### PR TITLE
G0: establish a safe generic-platform compatibility baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Contract-driven web data collection into a SQLite price-tracking warehouse,
 publishing curated data to the Google Sheet the mbiX Excel add-in reads.
 **The add-in is never touched** — the two systems meet only at the sheets.
 
-Rules: [ENGINEERING.md](ENGINEERING.md) · Architecture plan: owner's plan doc.
+Rules: [ENGINEERING.md](ENGINEERING.md) ·
+Compatibility contract: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md) ·
+Architecture plan: owner's plan doc.
 
 ```
 {connectors, extension} → funnel (Apps Script) → staging sheet (_INBOX/_RUNS)

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,0 +1,93 @@
+# ScrapeX Compatibility Contract
+
+This document is the Phase G0 baseline for evolving ScrapeX into a generic
+crawling and data-modeling platform without replacing the working product.
+
+The repository behavior and its tests are authoritative. A later roadmap item
+does not override a working compatibility guarantee by itself.
+
+## Protected behavior
+
+The following behavior must remain operational while generic capabilities are
+introduced:
+
+- Product and price ingestion continues to use the current normalized contract.
+- `price_observation` remains append-only and protected by database triggers.
+- Existing warehouse files remain readable and migratable.
+- Contract-version mismatches continue to refuse writes.
+- Existing connectors, manifests, jobs, schedules, reports, and exports keep
+  their current public behavior unless a reviewed change explicitly replaces it.
+- A crawl job belongs to the Local Runtime, not to the Side Panel lifecycle.
+- Pause, resume, cancellation, checkpoint recovery, and bounded log reads remain
+  persistent runtime responsibilities.
+- Native Messaging remains versioned and cursor-paginated; localhost HTTP remains
+  a compatibility fallback.
+- Arabic scraped content remains data with automatic direction; interface and
+  code language remain English.
+- Original Schema and Current View remain separate concepts; presentation changes
+  never delete source data.
+- Backup, restore, move, retention, and compaction never silently destroy the
+  current warehouse or append-only price history.
+
+## Additive evolution rules
+
+Generic-platform work must use additive seams:
+
+1. Database changes use numbered, forward-only migrations.
+2. New generic tables do not repurpose existing price columns.
+3. The price workflow remains the reference domain until a generic path proves
+   end-to-end parity where the two intentionally overlap.
+4. New APIs are added beside existing APIs before any compatibility route is
+   retired.
+5. Old data is migrated by explicit, tested code; it is never rewritten merely
+   to make an internal model look cleaner.
+6. A replacement path must have rollback instructions before it may become the
+   default.
+
+## Warehouse identity and restore safety
+
+A healthy SQLite file is not automatically a ScrapeX warehouse.
+
+Before restore or migration, storage code must verify:
+
+- A supported `PRAGMA user_version`.
+- Required core warehouse tables.
+- Append-only observation triggers.
+- The ScrapeX contract marker for schema version 2 and later.
+- SQLite integrity and foreign-key checks.
+
+Restore copies into a staging file and verifies that copy while the current
+warehouse remains live. Only the verified staging file may be switched into
+place; the previous warehouse is moved aside and never deleted automatically.
+
+## Feature-gate policy
+
+`scrapex.features` is the single public manifest of shipped and planned
+capabilities. A generic capability remains disabled until its vertical slice has:
+
+- Persistent storage.
+- A real API path.
+- A usable UI workflow when the capability is user-facing.
+- Failure and recovery behavior.
+- Automated tests.
+- Compatibility verification against price workflows.
+
+Disabled capabilities must not appear as functional navigation or static mock
+controls. `/api/features` allows the extension and Workspace to make the same
+decision from one source of truth.
+
+## Human review gates
+
+Programmer approval is required before:
+
+- Destructive or irreversible migration.
+- Record-identity behavior changes.
+- Automatic approval of inferred schema renames or dataset relationships.
+- Retirement of an existing API, CLI command, transport, or output path.
+- Changing the database that acts as the source of truth.
+- Enabling remotely updated adapter configurations.
+
+Each implementation slice is delivered on its own branch and Draft Pull Request.
+The PR must include compatibility impact, migrations, tests, visual evidence when
+applicable, known limitations, and rollback behavior. Codex may address review
+feedback, but the programmer owns approval and merge.

--- a/scrapex/db.py
+++ b/scrapex/db.py
@@ -72,6 +72,16 @@ def _migration_files() -> list[tuple[int, Path]]:
     return migrations
 
 
+def latest_schema_version() -> int:
+    """The newest warehouse schema this engine understands.
+
+    Storage restore uses this as a downgrade guard: a database produced by a
+    newer ScrapeX may be perfectly healthy SQLite, but this engine must not make
+    it live and then guess at a schema it does not understand.
+    """
+    return _migration_files()[-1][0]
+
+
 def migrate(conn: sqlite3.Connection) -> list[int]:
     """Apply every migration above the current user_version. Returns applied numbers."""
     applied: list[int] = []

--- a/scrapex/features.py
+++ b/scrapex/features.py
@@ -1,0 +1,84 @@
+"""One honest manifest for shipped and planned product capabilities.
+
+The generic-platform work lands in vertical slices. Until a slice has a real
+storage path, API, UI, recovery behavior, and tests, its flag stays disabled and
+no navigation may advertise it as available. This avoids scattering optimistic
+``if experimental`` checks across the extension and workspace.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from enum import StrEnum
+
+
+class DeliveryStage(StrEnum):
+    NOT_STARTED = "not_started"
+    FOUNDATION = "foundation"
+    PARTIAL = "partial"
+    PRODUCTION_READY = "production_ready"
+
+
+class FeatureKey(StrEnum):
+    PRICE_TRACKING = "price_tracking"
+    GENERIC_DATASET_CATALOG = "generic_dataset_catalog"
+    GENERIC_EXTRACTION = "generic_extraction"
+    CRAWL_FRONTIER = "crawl_frontier"
+    SITE_DATA_MODEL = "site_data_model"
+
+
+@dataclass(frozen=True)
+class FeatureState:
+    key: FeatureKey
+    enabled: bool
+    stage: DeliveryStage
+    detail: str
+
+    def public(self) -> dict:
+        value = asdict(self)
+        value["key"] = self.key.value
+        value["stage"] = self.stage.value
+        return value
+
+
+_FEATURES = (
+    FeatureState(
+        FeatureKey.PRICE_TRACKING,
+        True,
+        DeliveryStage.PRODUCTION_READY,
+        "Existing product and price workflows remain the compatibility baseline.",
+    ),
+    FeatureState(
+        FeatureKey.GENERIC_DATASET_CATALOG,
+        False,
+        DeliveryStage.NOT_STARTED,
+        "Enabled only after G1 stores and displays an arbitrary dataset end to end.",
+    ),
+    FeatureState(
+        FeatureKey.GENERIC_EXTRACTION,
+        False,
+        DeliveryStage.NOT_STARTED,
+        "Enabled only after an approved non-product extraction reaches generic storage.",
+    ),
+    FeatureState(
+        FeatureKey.CRAWL_FRONTIER,
+        False,
+        DeliveryStage.NOT_STARTED,
+        "Enabled only after persistent discovery, limits, and checkpoint recovery ship.",
+    ),
+    FeatureState(
+        FeatureKey.SITE_DATA_MODEL,
+        False,
+        DeliveryStage.NOT_STARTED,
+        "Enabled only after reviewed dataset relationships are persistent and navigable.",
+    ),
+)
+
+
+def manifest() -> dict:
+    """Public, deterministic feature state for UI and integration clients."""
+    return {"features": [feature.public() for feature in _FEATURES]}
+
+
+def is_enabled(key: FeatureKey) -> bool:
+    """The single gate future routes and navigation must call."""
+    return next(feature.enabled for feature in _FEATURES if feature.key == key)

--- a/scrapex/storage.py
+++ b/scrapex/storage.py
@@ -43,6 +43,18 @@ FREE_SPACE_MARGIN = 1.2
 # Windows drive types (winbase.h). Used only to warn, never to refuse.
 _DRIVE_REMOVABLE, _DRIVE_REMOTE = 2, 4
 
+# A readable SQLite file is not necessarily a ScrapeX warehouse. These objects
+# are the smallest durable identity shared by the original schema and every
+# migration since: accepting a foreign SQLite file during restore would move the
+# real warehouse aside and put unrelated data in its place.
+_WAREHOUSE_TABLES = frozenset({
+    "source_site", "source_product", "source_variant", "source_offer",
+    "price_observation", "crawl_run", "raw_snapshot",
+})
+_WAREHOUSE_TRIGGERS = frozenset({
+    "trg_price_obs_no_update", "trg_price_obs_no_delete",
+})
+
 
 class StorageUnavailableError(RuntimeError):
     """The recorded database location cannot be reached right now.
@@ -169,6 +181,71 @@ def drive_kind(folder: Path | str) -> str:
     return {_DRIVE_REMOVABLE: "removable", _DRIVE_REMOTE: "network"}.get(kind, "fixed")
 
 
+def _warehouse_identity(conn: sqlite3.Connection) -> tuple[str, str] | None:
+    """Return ``(status, reason)`` when this is not a compatible warehouse.
+
+    Integrity and identity are deliberately separate checks. ``quick_check``
+    answers whether SQLite can read the file; this answers whether ScrapeX may
+    safely interpret and restore it.
+    """
+    version = int(conn.execute("PRAGMA user_version").fetchone()[0])
+    if version <= 0:
+        return (
+            "not_scrapex",
+            "The file is SQLite, but it is not a ScrapeX warehouse; it has no "
+            "ScrapeX schema version.",
+        )
+    latest = dbmod.latest_schema_version()
+    if version > latest:
+        return (
+            "incompatible",
+            f"The file uses ScrapeX schema v{version}, but this engine only "
+            f"understands through v{latest}. Update ScrapeX before restoring it.",
+        )
+
+    objects = {
+        row[0]: row[1]
+        for row in conn.execute(
+            "SELECT name, type FROM sqlite_master WHERE type IN ('table','trigger')"
+        )
+    }
+    missing_tables = sorted(name for name in _WAREHOUSE_TABLES
+                            if objects.get(name) != "table")
+    missing_triggers = sorted(name for name in _WAREHOUSE_TRIGGERS
+                              if objects.get(name) != "trigger")
+    if missing_tables or missing_triggers:
+        missing = missing_tables + missing_triggers
+        return (
+            "not_scrapex",
+            "The file is SQLite, but it is not a ScrapeX warehouse; required "
+            f"objects are missing: {', '.join(missing)}.",
+        )
+
+    # Migration 0002 introduced the contract marker. A v1 warehouse is a valid
+    # legacy ScrapeX database and can be migrated after restore; v2+ without the
+    # marker is either foreign or incomplete and must be refused.
+    if version >= 2:
+        if objects.get("scrapex_meta") != "table":
+            return "not_scrapex", "The ScrapeX contract marker table is missing."
+        row = conn.execute(
+            "SELECT value FROM scrapex_meta WHERE key = 'contract_version'"
+        ).fetchone()
+        if row is None:
+            return "not_scrapex", "The ScrapeX contract version marker is missing."
+        from .contract import CONTRACT_VERSION
+        try:
+            stored_contract = int(row[0])
+        except (TypeError, ValueError):
+            return "not_scrapex", "The ScrapeX contract version marker is invalid."
+        if stored_contract != CONTRACT_VERSION:
+            return (
+                "incompatible",
+                f"The warehouse uses contract v{stored_contract}, but this engine "
+                f"uses v{CONTRACT_VERSION}. Use a compatible engine or migrate it.",
+            )
+    return None
+
+
 def health(db_path: Path | str) -> dict:
     """SQLite's own verdict, reported as a word plus the raw findings.
 
@@ -181,6 +258,11 @@ def health(db_path: Path | str) -> dict:
         return {"status": "missing", "ok": False,
                 "detail": "There is no database at this location yet.",
                 "problems": [], "foreign_key_problems": 0}
+    if _size(path) == 0:
+        return {"status": "not_scrapex", "ok": False,
+                "detail": "The file is empty and is not a ScrapeX warehouse.",
+                "problems": ["empty file"], "foreign_key_problems": 0,
+                "reclaimable_bytes": 0}
     conn = sqlite3.connect(str(path))
     try:
         problems = [r[0] for r in conn.execute("PRAGMA quick_check")]
@@ -188,6 +270,7 @@ def health(db_path: Path | str) -> dict:
         fk = conn.execute("PRAGMA foreign_key_check").fetchall()
         freelist = conn.execute("PRAGMA freelist_count").fetchone()[0]
         page_size = conn.execute("PRAGMA page_size").fetchone()[0]
+        identity_problem = _warehouse_identity(conn)
     except sqlite3.DatabaseError as exc:
         return {"status": "unreadable", "ok": False,
                 "detail": f"SQLite could not read this file: {exc}",
@@ -200,6 +283,11 @@ def health(db_path: Path | str) -> dict:
         return {"status": "damaged", "ok": False, "problems": problems,
                 "foreign_key_problems": len(fk),
                 "detail": "SQLite reported problems. Back up first, then run Repair."}
+    if identity_problem is not None:
+        status, detail = identity_problem
+        return {"status": status, "ok": False, "problems": [detail],
+                "foreign_key_problems": 0, "reclaimable_bytes": reclaimable,
+                "detail": detail}
     return {
         "status": "healthy", "ok": True, "problems": [], "foreign_key_problems": 0,
         "reclaimable_bytes": reclaimable,
@@ -277,6 +365,11 @@ def restore(db_path: Path | str, backup_path: Path | str) -> RunResult:
     path, source = Path(db_path), Path(backup_path)
     if not source.exists():
         raise StorageRefused(f"That backup is no longer at {source}.")
+    try:
+        if source.resolve() == path.resolve():
+            raise StorageRefused("The selected backup is already the live database.")
+    except OSError:
+        pass
     verdict = health(source)
     if not verdict["ok"]:
         raise StorageRefused(
@@ -285,16 +378,34 @@ def restore(db_path: Path | str, backup_path: Path | str) -> RunResult:
     if free_space(path.parent) < _size(source) * FREE_SPACE_MARGIN:
         raise StorageRefused(f"Not enough free space in {path.parent} to restore.")
 
+    # Copy and validate while the current warehouse remains authoritative. Only
+    # a fully copied, re-checked file is allowed to reach the switch below.
+    incoming = path.with_name(path.name + ".restore-incoming")
+    incoming.unlink(missing_ok=True)
+    try:
+        shutil.copy2(source, incoming)
+    except OSError:
+        incoming.unlink(missing_ok=True)
+        raise
+    copied_verdict = health(incoming)
+    if not copied_verdict["ok"] or not _same_contents(source, incoming):
+        incoming.unlink(missing_ok=True)
+        raise StorageRefused(
+            "The copied backup did not pass verification, so the live database "
+            "was not changed. Try an older backup or another storage device."
+        )
+
     displaced = ""
     if path.exists():
         displaced = str(path.with_name(
             f"{path.stem}.replaced-{settings.utc_now().replace(':', '')}{path.suffix}"))
         os.replace(path, displaced)
     try:
-        shutil.copy2(source, path)
+        os.replace(incoming, path)
     except OSError:
         if displaced:                      # put the original back, then re-raise
             os.replace(displaced, path)
+        incoming.unlink(missing_ok=True)
         raise
     # The WAL of the replaced database describes a file that is no longer there.
     for suffix in ("-wal", "-shm"):
@@ -318,6 +429,10 @@ def repair(db_path: Path | str) -> RunResult:
     """
     path = Path(db_path)
     verdict = health(path)
+    if verdict["status"] in {"missing", "unreadable", "not_scrapex", "incompatible"}:
+        raise StorageRefused(
+            f"Refusing to repair {path.name}: {verdict['detail']}"
+        )
     conn = dbmod.connect(path)
     try:
         conn.execute("REINDEX")

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -29,6 +29,7 @@ from ..fields import (
     delete_view, ensure_fields, list_fields, list_views, reorder, reset_view, save_view,
     set_display_name, set_visibility,
 )
+from ..features import manifest as feature_manifest
 from ..manifest_io import DuplicateSourceError, add_source
 from ..matching import (
     ConflictError, Decision, decide, pending_reviews, suggest_for_source, undo_decision,
@@ -248,6 +249,11 @@ def create_app(db_path: Path | str, manifest_path: Path | str = MANIFEST_FILE,
         finally:
             conn.close()
         return {"ok": True, "app": "scrapex", "version": __version__, "sources_with_data": n}
+
+    @app.get("/api/features")
+    def api_features():
+        """What is genuinely usable, separate from what the roadmap names."""
+        return feature_manifest()
 
     @app.get("/api/sources")
     def api_sources():
@@ -772,7 +778,16 @@ def create_app(db_path: Path | str, manifest_path: Path | str = MANIFEST_FILE,
         backup_path = (body or {}).get("backup_path", "")
         if not backup_path:
             raise HTTPException(status_code=400, detail="backup_path is required")
-        return _storage_action(lambda conn: restore(app.state.db_path, backup_path))
+        # Unlike normal storage actions, restore replaces the database file.
+        # Keeping a SQLite connection open while doing that fails on Windows and
+        # risks letting the old WAL describe the new file. Hold the writer lock,
+        # but deliberately open no database connection during the switch.
+        with dbmod.write_lock(app.state.db_path):
+            try:
+                result = restore(app.state.db_path, backup_path)
+            except StorageRefused as exc:
+                raise HTTPException(status_code=400, detail=str(exc))
+        return result.as_state()
 
     @app.post("/api/storage/repair")
     def api_storage_repair():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -48,6 +48,15 @@ def test_health(client):
     assert r.status_code == 200 and r.json()["ok"] is True
 
 
+def test_feature_manifest_is_honest_about_the_generic_roadmap(client):
+    response = client.get("/api/features")
+    assert response.status_code == 200
+    features = {item["key"]: item for item in response.json()["features"]}
+    assert features["price_tracking"]["enabled"] is True
+    assert features["generic_dataset_catalog"]["enabled"] is False
+    assert features["generic_extraction"]["stage"] == "not_started"
+
+
 def test_sources_lists_manifest_with_counts(client):
     data = client.get("/api/sources").json()["sources"]
     keys = {s["source_key"] for s in data}

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -240,6 +240,25 @@ def test_a_failed_verification_leaves_the_warehouse_alone(conn, db_path, monkeyp
     assert not list(db_path.parent.glob("*.compact-*")), "the rejected build was kept"
 
 
+def test_a_stale_pin_blocks_compaction_instead_of_silently_losing_the_mark(conn, db_path):
+    """A pin may become stale after manual recovery or imported metadata.
+
+    The safe result is an explicit verification refusal. Treating a missing pin
+    target as irrelevant would let compaction claim every protected observation
+    survived when it did not carry the owner's exact protected set forward.
+    """
+    set_aggressive(conn)
+    offer_id = conn.execute("SELECT offer_id FROM price_observation LIMIT 1").fetchone()[0]
+    retention.pin(conn, offer_id, "2026-01-01", "hash-that-matches-no-row")
+    conn.commit()
+    digest = retention.policy_digest(retention.get_policies(conn))
+
+    assert retention.protected_keys(conn) == retention.protected_keys_independently(conn)
+    with pytest.raises(compaction.CompactionAborted, match="did not pass verification"):
+        compaction.compact_warehouse(conn, db_path, today=TODAY, expected_digest=digest)
+    assert storage.read_pointer() is None
+
+
 def test_the_audit_row_lands_in_the_database_that_is_now_live(conn, db_path):
     """Writing it before the run would leave a row stuck at 'running' inside the
     file being sealed, and the live warehouse would report a run that never ended."""

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -31,6 +31,10 @@ def test_migrate_is_idempotent(tmp_path: Path):
     assert second == []  # T4: running again applies nothing
 
 
+def test_latest_schema_version_matches_the_migration_chain():
+    assert dbmod.latest_schema_version() == 11
+
+
 def test_foreign_keys_actually_enforced(tmp_path: Path):
     conn = dbmod.connect(tmp_path / "t.db")
     try:

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,29 @@
+"""G0 feature gates: planned generic work is never advertised as shipped."""
+from __future__ import annotations
+
+import pytest
+
+from scrapex.features import DeliveryStage, FeatureKey, is_enabled, manifest
+
+
+def test_price_tracking_is_the_enabled_compatibility_baseline():
+    assert is_enabled(FeatureKey.PRICE_TRACKING) is True
+    price = next(f for f in manifest()["features"] if f["key"] == "price_tracking")
+    assert price["stage"] == DeliveryStage.PRODUCTION_READY.value
+
+
+@pytest.mark.parametrize("feature", [
+    FeatureKey.GENERIC_DATASET_CATALOG,
+    FeatureKey.GENERIC_EXTRACTION,
+    FeatureKey.CRAWL_FRONTIER,
+    FeatureKey.SITE_DATA_MODEL,
+])
+def test_unfinished_generic_capabilities_are_disabled(feature):
+    assert is_enabled(feature) is False
+
+
+def test_the_public_manifest_uses_stable_strings_not_python_enums():
+    payload = manifest()
+    assert payload["features"]
+    assert all(isinstance(item["key"], str) and isinstance(item["stage"], str)
+               for item in payload["features"])

--- a/tests/test_settings_page.py
+++ b/tests/test_settings_page.py
@@ -104,6 +104,31 @@ def test_every_storage_control_the_spec_names_is_offered(client):
         assert label in body, f"the {label} control is missing"
 
 
+def test_restore_api_refuses_a_foreign_sqlite_file(client, db_path, tmp_path):
+    import sqlite3
+
+    foreign = tmp_path / "foreign.db"
+    conn = sqlite3.connect(str(foreign))
+    try:
+        conn.execute("CREATE TABLE notes(body TEXT)")
+        conn.commit()
+    finally:
+        conn.close()
+
+    response = client.post("/api/storage/restore", json={"backup_path": str(foreign)})
+    assert response.status_code == 400
+    assert "health check" in response.json()["detail"]
+    assert storage.health(db_path)["ok"], "the live warehouse must remain untouched"
+
+
+def test_restore_api_can_switch_to_a_verified_backup(client, db_path):
+    backup = client.post("/api/storage/backup").json()["location"]
+    response = client.post("/api/storage/restore", json={"backup_path": backup})
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    assert storage.health(db_path)["ok"] is True
+
+
 def test_moving_is_disabled_until_a_folder_has_been_checked(client):
     """A move must never be the first thing a stray click does."""
     body = client.get("/settings").text

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -97,6 +97,69 @@ def test_health_reports_an_unreadable_file_as_a_word_not_a_crash(tmp_path):
     assert verdict["ok"] is False and verdict["status"] == "unreadable"
 
 
+def test_health_refuses_an_empty_sqlite_file(tmp_path):
+    empty = tmp_path / "empty.db"
+    empty.write_bytes(b"")
+    verdict = storage.health(empty)
+    assert verdict["ok"] is False and verdict["status"] == "not_scrapex"
+    assert "empty" in verdict["detail"].lower()
+
+
+def test_health_distinguishes_foreign_sqlite_from_a_scrapex_warehouse(tmp_path):
+    foreign = tmp_path / "foreign.db"
+    conn = sqlite3.connect(str(foreign))
+    try:
+        conn.execute("CREATE TABLE contacts(name TEXT)")
+        conn.commit()
+    finally:
+        conn.close()
+    verdict = storage.health(foreign)
+    assert verdict["ok"] is False and verdict["status"] == "not_scrapex"
+    assert "not a ScrapeX warehouse" in verdict["detail"]
+
+
+def test_repair_refuses_a_foreign_sqlite_database(tmp_path):
+    foreign = tmp_path / "foreign.db"
+    conn = sqlite3.connect(str(foreign))
+    conn.execute("CREATE TABLE contacts(name TEXT)")
+    conn.execute("INSERT INTO contacts VALUES ('Ada')")
+    conn.commit()
+    conn.close()
+
+    with pytest.raises(storage.StorageRefused, match="Refusing to repair"):
+        storage.repair(foreign)
+
+    check = sqlite3.connect(str(foreign))
+    try:
+        assert check.execute("SELECT name FROM contacts").fetchall() == [("Ada",)]
+    finally:
+        check.close()
+
+
+def test_health_accepts_a_legacy_v1_scrapex_warehouse_for_migration(tmp_path):
+    legacy = tmp_path / "legacy.db"
+    conn = sqlite3.connect(str(legacy))
+    try:
+        conn.executescript(dbmod.SCHEMA_FILE.read_text(encoding="utf-8"))
+        conn.commit()
+    finally:
+        conn.close()
+    verdict = storage.health(legacy)
+    assert verdict["ok"] is True and verdict["status"] == "healthy"
+
+
+def test_health_refuses_a_warehouse_from_a_newer_engine(db_path):
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("PRAGMA user_version = 999")
+        conn.commit()
+    finally:
+        conn.close()
+    verdict = storage.health(db_path)
+    assert verdict["ok"] is False and verdict["status"] == "incompatible"
+    assert "Update ScrapeX" in verdict["detail"]
+
+
 # ---- backups -----------------------------------------------------------------
 
 def test_a_backup_is_a_usable_database_not_a_torn_copy(conn, db_path):
@@ -139,6 +202,46 @@ def test_an_unhealthy_backup_is_never_put_in_place(db_path, tmp_path):
     with pytest.raises(storage.StorageRefused, match="health check"):
         storage.restore(db_path, junk)
     assert storage.health(db_path)["ok"], "the live database must be untouched"
+
+
+def test_a_foreign_but_healthy_sqlite_file_is_never_restored(db_path, tmp_path):
+    foreign = tmp_path / "someone-elses.db"
+    conn = sqlite3.connect(str(foreign))
+    try:
+        conn.execute("CREATE TABLE contacts(name TEXT)")
+        conn.commit()
+    finally:
+        conn.close()
+
+    with pytest.raises(storage.StorageRefused, match="health check"):
+        storage.restore(db_path, foreign)
+
+    assert storage.health(db_path)["ok"], "the live warehouse must remain in place"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        triggers = {r[0] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'trigger'")}
+    finally:
+        conn.close()
+    assert "trg_price_obs_no_update" in triggers
+
+
+def test_restore_validates_the_copy_before_moving_the_live_database(conn, db_path,
+                                                                    tmp_path, monkeypatch):
+    backup = Path(storage.backup_now(conn, db_path).location)
+    conn.close()
+    real_copy = storage.shutil.copy2
+
+    def corrupt_copy(source, destination):
+        real_copy(source, destination)
+        Path(destination).write_bytes(b"copy failed partway")
+
+    monkeypatch.setattr(storage.shutil, "copy2", corrupt_copy)
+    with pytest.raises(storage.StorageRefused, match="copied backup"):
+        storage.restore(db_path, backup)
+
+    assert storage.health(db_path)["ok"], "validation happens before the live switch"
+    assert not db_path.with_name(db_path.name + ".restore-incoming").exists()
 
 
 # ---- maintenance -------------------------------------------------------------


### PR DESCRIPTION
## What changed

- Added a written compatibility contract for incremental generic-platform evolution.
- Added one public feature manifest and `/api/features` endpoint; price tracking remains enabled while unfinished generic capabilities remain disabled.
- Added ScrapeX warehouse identity validation using schema version, core tables, append-only triggers, and the contract marker.
- Made restore copy and validate an incoming database before switching the live warehouse, and avoided keeping a SQLite connection open during the Windows file replacement.
- Refused repair/restore for foreign, empty, or newer incompatible SQLite databases.
- Added regression coverage for storage identity, restore safety, feature gates, and stale retention pins.

## Why

ScrapeX is evolving beyond product/price scraping. G0 establishes additive compatibility and recovery rules before generic tables, crawling, and data-model inference are introduced.

The storage fix addresses a concrete root cause: SQLite integrity checks prove that a file is readable, but do not prove that it is a ScrapeX warehouse. A valid foreign SQLite file could previously pass the health check and replace the live database.

## Impact

Existing product and price workflows remain the compatibility baseline. No existing tables are repurposed and no migration is added in this slice. Generic navigation remains hidden until an end-to-end capability is genuinely available.

## Validation

- 110 focused tests passed, including the supplied restore probes.
- 545 tracked project tests passed.
- `git diff --check` passed.
- One existing Starlette/httpx deprecation warning remains; no test failures.

## Review and rollback

This is a stacked Draft PR targeting `codex/current-product-baseline` because four existing local product phases are not yet on `origin/main`. That keeps this review limited to G0.

Rollback is a normal commit revert. Restore keeps the displaced live database on disk and never deletes it automatically. No destructive migration is included.
