### PR TITLE
G1: add the generic dataset catalog foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ publishing curated data to the Google Sheet the mbiX Excel add-in reads.
 
 Rules: [ENGINEERING.md](ENGINEERING.md) ·
 Compatibility contract: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md) ·
+Generic catalogue: [docs/GENERIC_CATALOG.md](docs/GENERIC_CATALOG.md) ·
 Architecture plan: owner's plan doc.
 
 ```

--- a/db/migrations/0012_generic_dataset_catalog.sql
+++ b/db/migrations/0012_generic_dataset_catalog.sql
@@ -1,0 +1,168 @@
+-- ============================================================================
+-- Migration 0012 — generic site, dataset, field and relationship catalogue.
+--
+-- This is an additive seam beside the price warehouse. It records what a site
+-- appears to contain without repurposing source_site, source_product or the
+-- append-only price tables. Discovery may suggest relationships, but only a
+-- later, explicit review action may confirm them.
+--
+-- Catalogue identities and original names are immutable. Retirement uses
+-- valid_to; no catalogue row needs to be deleted when a site changes shape.
+-- ============================================================================
+
+CREATE TABLE site_profile (
+    site_profile_id INTEGER PRIMARY KEY,
+    site_key        TEXT NOT NULL UNIQUE,
+    display_name    TEXT NOT NULL,
+    base_url        TEXT NOT NULL,
+    price_source_id INTEGER REFERENCES source_site(source_id),
+    lifecycle       TEXT NOT NULL DEFAULT 'draft'
+        CHECK (lifecycle IN ('draft','active','paused')),
+    created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    updated_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    valid_to        TEXT
+);
+
+CREATE INDEX ix_site_profile_page ON site_profile(site_profile_id, valid_to);
+
+CREATE TABLE dataset_definition (
+    dataset_definition_id INTEGER PRIMARY KEY,
+    site_profile_id       INTEGER NOT NULL REFERENCES site_profile(site_profile_id),
+    dataset_key           TEXT NOT NULL,
+    original_name         TEXT NOT NULL,
+    display_name          TEXT,
+    dataset_kind          TEXT NOT NULL DEFAULT 'unknown'
+        CHECK (dataset_kind IN ('table','list','detail','tree','stream','unknown')),
+    discovery_method      TEXT NOT NULL
+        CHECK (discovery_method IN (
+            'manual','html_table','repeating_dom','json','api','inferred')),
+    locator_json          TEXT NOT NULL DEFAULT '{}',
+    first_seen_at         TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    last_seen_at          TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    valid_to              TEXT,
+    UNIQUE (site_profile_id, dataset_key)
+);
+
+CREATE INDEX ix_dataset_definition_site
+    ON dataset_definition(site_profile_id, dataset_definition_id, valid_to);
+
+CREATE TABLE field_definition (
+    field_definition_id   INTEGER PRIMARY KEY,
+    dataset_definition_id INTEGER NOT NULL
+        REFERENCES dataset_definition(dataset_definition_id),
+    field_key             TEXT NOT NULL,
+    original_name         TEXT NOT NULL,
+    display_name          TEXT,
+    data_type             TEXT NOT NULL DEFAULT 'unknown'
+        CHECK (data_type IN (
+            'text','integer','decimal','boolean','date','datetime','url','json','unknown')),
+    is_nullable           INTEGER NOT NULL DEFAULT 1 CHECK (is_nullable IN (0,1)),
+    identity_role         TEXT NOT NULL DEFAULT 'none'
+        CHECK (identity_role IN ('none','candidate','key_part')),
+    display_order         INTEGER NOT NULL DEFAULT 0 CHECK (display_order >= 0),
+    first_seen_at         TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    last_seen_at          TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    valid_to              TEXT,
+    UNIQUE (dataset_definition_id, field_key)
+);
+
+CREATE INDEX ix_field_definition_dataset
+    ON field_definition(dataset_definition_id, display_order, field_definition_id);
+
+CREATE TABLE dataset_relationship (
+    dataset_relationship_id INTEGER PRIMARY KEY,
+    site_profile_id         INTEGER NOT NULL REFERENCES site_profile(site_profile_id),
+    relationship_key        TEXT NOT NULL,
+    parent_dataset_id       INTEGER NOT NULL
+        REFERENCES dataset_definition(dataset_definition_id),
+    child_dataset_id        INTEGER NOT NULL
+        REFERENCES dataset_definition(dataset_definition_id),
+    cardinality             TEXT NOT NULL DEFAULT 'unknown'
+        CHECK (cardinality IN (
+            'one_to_one','one_to_many','many_to_one','many_to_many','unknown')),
+    review_status           TEXT NOT NULL DEFAULT 'suggested'
+        CHECK (review_status IN ('suggested','confirmed','rejected')),
+    confidence              REAL NOT NULL DEFAULT 0.0
+        CHECK (confidence >= 0.0 AND confidence <= 1.0),
+    evidence_json           TEXT NOT NULL DEFAULT '{}',
+    created_at              TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    updated_at              TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    valid_to                TEXT,
+    CHECK (parent_dataset_id <> child_dataset_id),
+    UNIQUE (site_profile_id, relationship_key)
+);
+
+CREATE INDEX ix_dataset_relationship_site
+    ON dataset_relationship(site_profile_id, dataset_relationship_id, valid_to);
+
+CREATE TABLE relationship_field_pair (
+    relationship_field_pair_id INTEGER PRIMARY KEY,
+    dataset_relationship_id    INTEGER NOT NULL
+        REFERENCES dataset_relationship(dataset_relationship_id),
+    parent_field_id             INTEGER NOT NULL REFERENCES field_definition(field_definition_id),
+    child_field_id              INTEGER NOT NULL REFERENCES field_definition(field_definition_id),
+    pair_order                  INTEGER NOT NULL DEFAULT 0 CHECK (pair_order >= 0),
+    UNIQUE (dataset_relationship_id, parent_field_id, child_field_id),
+    UNIQUE (dataset_relationship_id, pair_order)
+);
+
+CREATE INDEX ix_relationship_field_pair_relationship
+    ON relationship_field_pair(dataset_relationship_id, pair_order);
+
+-- SQL-level guards make it impossible for a direct caller to build a relation
+-- across sites or map a field that belongs to another dataset.
+CREATE TRIGGER trg_dataset_relationship_same_site_insert
+BEFORE INSERT ON dataset_relationship
+FOR EACH ROW
+WHEN (SELECT site_profile_id FROM dataset_definition
+      WHERE dataset_definition_id = NEW.parent_dataset_id) <> NEW.site_profile_id
+  OR (SELECT site_profile_id FROM dataset_definition
+      WHERE dataset_definition_id = NEW.child_dataset_id) <> NEW.site_profile_id
+BEGIN
+    SELECT RAISE(ABORT, 'relationship datasets must belong to the same site profile');
+END;
+
+CREATE TRIGGER trg_dataset_relationship_same_site_update
+BEFORE UPDATE OF site_profile_id, parent_dataset_id, child_dataset_id
+ON dataset_relationship
+FOR EACH ROW
+WHEN (SELECT site_profile_id FROM dataset_definition
+      WHERE dataset_definition_id = NEW.parent_dataset_id) <> NEW.site_profile_id
+  OR (SELECT site_profile_id FROM dataset_definition
+      WHERE dataset_definition_id = NEW.child_dataset_id) <> NEW.site_profile_id
+BEGIN
+    SELECT RAISE(ABORT, 'relationship datasets must belong to the same site profile');
+END;
+
+CREATE TRIGGER trg_relationship_field_pair_matches_insert
+BEFORE INSERT ON relationship_field_pair
+FOR EACH ROW
+WHEN (SELECT dataset_definition_id FROM field_definition
+      WHERE field_definition_id = NEW.parent_field_id) <>
+     (SELECT parent_dataset_id FROM dataset_relationship
+      WHERE dataset_relationship_id = NEW.dataset_relationship_id)
+  OR (SELECT dataset_definition_id FROM field_definition
+      WHERE field_definition_id = NEW.child_field_id) <>
+     (SELECT child_dataset_id FROM dataset_relationship
+      WHERE dataset_relationship_id = NEW.dataset_relationship_id)
+BEGIN
+    SELECT RAISE(ABORT, 'relationship fields must belong to their mapped datasets');
+END;
+
+CREATE TRIGGER trg_relationship_field_pair_matches_update
+BEFORE UPDATE OF dataset_relationship_id, parent_field_id, child_field_id
+ON relationship_field_pair
+FOR EACH ROW
+WHEN (SELECT dataset_definition_id FROM field_definition
+      WHERE field_definition_id = NEW.parent_field_id) <>
+     (SELECT parent_dataset_id FROM dataset_relationship
+      WHERE dataset_relationship_id = NEW.dataset_relationship_id)
+  OR (SELECT dataset_definition_id FROM field_definition
+      WHERE field_definition_id = NEW.child_field_id) <>
+     (SELECT child_dataset_id FROM dataset_relationship
+      WHERE dataset_relationship_id = NEW.dataset_relationship_id)
+BEGIN
+    SELECT RAISE(ABORT, 'relationship fields must belong to their mapped datasets');
+END;
+
+PRAGMA user_version = 12;

--- a/docs/GENERIC_CATALOG.md
+++ b/docs/GENERIC_CATALOG.md
@@ -1,0 +1,48 @@
+# Generic Dataset Catalogue (G1 Foundation)
+
+G1 introduces persistent definitions for arbitrary websites without changing
+the existing product and price warehouse. It is deliberately a foundation, not
+a claim that generic crawling or row extraction is finished.
+
+## Model
+
+- `site_profile` identifies one website and may optionally link to an existing
+  price `source_site`.
+- `dataset_definition` identifies each table, list, detail record, tree, stream,
+  or still-unknown structure discovered on that site.
+- `field_definition` gives every dataset its own dynamic field set, stable keys,
+  preserved original names, inferred data types, and discovery order.
+- `dataset_relationship` stores a directed relationship between two datasets on
+  the same site.
+- `relationship_field_pair` supports single-column and composite joins.
+
+Definitions are additive. A disappeared definition is retired with `valid_to`;
+it is never deleted or reused for a different meaning. Display labels are
+separate from immutable original names and stable keys.
+
+## Relationship safety
+
+Discovery can only create relationships with `review_status = suggested`.
+There is intentionally no automatic-confirmation endpoint in G1. Database
+triggers reject cross-site relationships and field mappings whose fields do not
+belong to the parent and child datasets.
+
+## API
+
+The typed local API is rooted at `/api/catalog`:
+
+- `POST/GET /sites`
+- `POST/GET /sites/{site_key}/datasets`
+- `POST/GET /datasets/{dataset_id}/fields`
+- `POST/GET /sites/{site_key}/relationships`
+
+Every collection read is cursor-paginated with `after_id` and a `limit` capped
+at 200. Repeating an identical discovery is idempotent. Reusing a stable key for
+a different URL, original name, type, locator, or relationship is a conflict,
+not a silent rewrite.
+
+## Capability state
+
+`generic_dataset_catalog` reports stage `foundation` but remains disabled. It
+may only be enabled after a later vertical slice adds generic row storage and a
+complete user-facing catalogue workflow with recovery and compatibility tests.

--- a/scrapex/catalog.py
+++ b/scrapex/catalog.py
@@ -1,0 +1,287 @@
+"""Persistent definitions for generic sites, datasets, fields and relations.
+
+This module is catalogue-only: it describes arbitrary structures without
+pretending that generic extraction or row storage has shipped. Price tables are
+never reused, inferred relations remain suggestions, and repeat discovery is
+idempotent unless a stable identity changes meaning.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+from .catalog_models import (
+    DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, CatalogConflict, CatalogNotFound,
+    DatasetCreate, FieldCreate, SiteCreate,
+)
+
+
+def _json(value: dict[str, Any]) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _page_limit(limit: int) -> int:
+    if limit < 1 or limit > MAX_PAGE_SIZE:
+        raise ValueError(f"limit must be between 1 and {MAX_PAGE_SIZE}")
+    return limit
+
+
+def _site_row(conn: sqlite3.Connection, site_key: str) -> sqlite3.Row:
+    row = conn.execute(
+        "SELECT * FROM site_profile WHERE site_key = ? AND valid_to IS NULL",
+        (site_key,),
+    ).fetchone()
+    if row is None:
+        raise CatalogNotFound(f"unknown active site profile {site_key!r}")
+    return row
+
+
+def _dataset_row(conn: sqlite3.Connection, dataset_id: int) -> sqlite3.Row:
+    row = conn.execute(
+        "SELECT * FROM dataset_definition "
+        "WHERE dataset_definition_id = ? AND valid_to IS NULL",
+        (dataset_id,),
+    ).fetchone()
+    if row is None:
+        raise CatalogNotFound(f"unknown active dataset {dataset_id}")
+    return row
+
+
+def _site_public(row: sqlite3.Row) -> dict[str, Any]:
+    return {
+        "site_profile_id": row["site_profile_id"],
+        "site_key": row["site_key"],
+        "display_name": row["display_name"],
+        "base_url": row["base_url"],
+        "price_source_id": row["price_source_id"],
+        "lifecycle": row["lifecycle"],
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+    }
+
+
+def _dataset_public(row: sqlite3.Row) -> dict[str, Any]:
+    return {
+        "dataset_definition_id": row["dataset_definition_id"],
+        "site_profile_id": row["site_profile_id"],
+        "dataset_key": row["dataset_key"],
+        "original_name": row["original_name"],
+        "display_name": row["display_name"],
+        "label": row["display_name"] or row["original_name"],
+        "dataset_kind": row["dataset_kind"],
+        "discovery_method": row["discovery_method"],
+        "locator": json.loads(row["locator_json"]),
+        "first_seen_at": row["first_seen_at"],
+        "last_seen_at": row["last_seen_at"],
+    }
+
+
+def _field_public(row: sqlite3.Row) -> dict[str, Any]:
+    return {
+        "field_definition_id": row["field_definition_id"],
+        "dataset_definition_id": row["dataset_definition_id"],
+        "field_key": row["field_key"],
+        "original_name": row["original_name"],
+        "display_name": row["display_name"],
+        "label": row["display_name"] or row["original_name"],
+        "data_type": row["data_type"],
+        "is_nullable": bool(row["is_nullable"]),
+        "identity_role": row["identity_role"],
+        "display_order": row["display_order"],
+        "first_seen_at": row["first_seen_at"],
+        "last_seen_at": row["last_seen_at"],
+    }
+
+
+def register_site(conn: sqlite3.Connection, request: SiteCreate) -> dict[str, Any]:
+    """Register a site idempotently without overwriting its stable identity."""
+    base_url = str(request.base_url)
+    existing = conn.execute(
+        "SELECT * FROM site_profile WHERE site_key = ?", (request.site_key,)
+    ).fetchone()
+    if existing is not None:
+        if existing["valid_to"] is not None:
+            raise CatalogConflict(
+                f"site_key {request.site_key!r} is retired; reactivate it explicitly"
+            )
+        if existing["base_url"] != base_url:
+            raise CatalogConflict(
+                f"site_key {request.site_key!r} already belongs to "
+                f"{existing['base_url']!r}"
+            )
+        return _site_public(existing)
+    cursor = conn.execute(
+        "INSERT INTO site_profile "
+        "(site_key, display_name, base_url, price_source_id, lifecycle) "
+        "VALUES (?,?,?,?,?)",
+        (
+            request.site_key,
+            request.display_name,
+            base_url,
+            request.price_source_id,
+            request.lifecycle.value,
+        ),
+    )
+    return _site_public(conn.execute(
+        "SELECT * FROM site_profile WHERE site_profile_id = ?", (cursor.lastrowid,)
+    ).fetchone())
+
+
+def list_sites(
+    conn: sqlite3.Connection, *, after_id: int = 0, limit: int = DEFAULT_PAGE_SIZE
+) -> dict[str, Any]:
+    limit = _page_limit(limit)
+    rows = conn.execute(
+        "SELECT * FROM site_profile WHERE valid_to IS NULL AND site_profile_id > ? "
+        "ORDER BY site_profile_id LIMIT ?",
+        (max(0, after_id), limit + 1),
+    ).fetchall()
+    has_more = len(rows) > limit
+    page = rows[:limit]
+    return {
+        "sites": [_site_public(row) for row in page],
+        "next_after_id": page[-1]["site_profile_id"] if has_more else None,
+    }
+
+
+def register_dataset(
+    conn: sqlite3.Connection, site_key: str, request: DatasetCreate
+) -> dict[str, Any]:
+    site = _site_row(conn, site_key)
+    locator_json = _json(request.locator)
+    existing = conn.execute(
+        "SELECT * FROM dataset_definition "
+        "WHERE site_profile_id = ? AND dataset_key = ?",
+        (site["site_profile_id"], request.dataset_key),
+    ).fetchone()
+    if existing is not None:
+        if existing["valid_to"] is not None:
+            raise CatalogConflict(
+                f"dataset_key {request.dataset_key!r} is retired; "
+                "reactivate it explicitly"
+            )
+        identity = (
+            existing["original_name"], existing["dataset_kind"],
+            existing["discovery_method"], existing["locator_json"],
+        )
+        proposed = (
+            request.original_name, request.dataset_kind.value,
+            request.discovery_method.value, locator_json,
+        )
+        if identity != proposed:
+            raise CatalogConflict(
+                f"dataset_key {request.dataset_key!r} already has another definition"
+            )
+        conn.execute(
+            "UPDATE dataset_definition SET last_seen_at = "
+            "strftime('%Y-%m-%dT%H:%M:%SZ','now') "
+            "WHERE dataset_definition_id = ?",
+            (existing["dataset_definition_id"],),
+        )
+        return _dataset_public(_dataset_row(conn, existing["dataset_definition_id"]))
+    cursor = conn.execute(
+        "INSERT INTO dataset_definition "
+        "(site_profile_id, dataset_key, original_name, dataset_kind, "
+        "discovery_method, locator_json) VALUES (?,?,?,?,?,?)",
+        (
+            site["site_profile_id"], request.dataset_key, request.original_name,
+            request.dataset_kind.value, request.discovery_method.value, locator_json,
+        ),
+    )
+    return _dataset_public(_dataset_row(conn, int(cursor.lastrowid)))
+
+
+def list_datasets(
+    conn: sqlite3.Connection, site_key: str, *, after_id: int = 0,
+    limit: int = DEFAULT_PAGE_SIZE,
+) -> dict[str, Any]:
+    limit = _page_limit(limit)
+    site = _site_row(conn, site_key)
+    rows = conn.execute(
+        "SELECT * FROM dataset_definition WHERE site_profile_id = ? "
+        "AND valid_to IS NULL AND dataset_definition_id > ? "
+        "ORDER BY dataset_definition_id LIMIT ?",
+        (site["site_profile_id"], max(0, after_id), limit + 1),
+    ).fetchall()
+    has_more = len(rows) > limit
+    page = rows[:limit]
+    return {
+        "datasets": [_dataset_public(row) for row in page],
+        "next_after_id": page[-1]["dataset_definition_id"] if has_more else None,
+    }
+
+
+def register_field(
+    conn: sqlite3.Connection, dataset_id: int, request: FieldCreate
+) -> dict[str, Any]:
+    dataset = _dataset_row(conn, dataset_id)
+    existing = conn.execute(
+        "SELECT * FROM field_definition "
+        "WHERE dataset_definition_id = ? AND field_key = ?",
+        (dataset["dataset_definition_id"], request.field_key),
+    ).fetchone()
+    if existing is not None:
+        if existing["valid_to"] is not None:
+            raise CatalogConflict(
+                f"field_key {request.field_key!r} is retired; reactivate it explicitly"
+            )
+        identity = (
+            existing["original_name"], existing["data_type"],
+            bool(existing["is_nullable"]), existing["identity_role"],
+        )
+        proposed = (
+            request.original_name, request.data_type.value,
+            request.is_nullable, request.identity_role.value,
+        )
+        if identity != proposed:
+            raise CatalogConflict(
+                f"field_key {request.field_key!r} already has another definition"
+            )
+        conn.execute(
+            "UPDATE field_definition SET last_seen_at = "
+            "strftime('%Y-%m-%dT%H:%M:%SZ','now') "
+            "WHERE field_definition_id = ?",
+            (existing["field_definition_id"],),
+        )
+        row = conn.execute(
+            "SELECT * FROM field_definition WHERE field_definition_id = ?",
+            (existing["field_definition_id"],),
+        ).fetchone()
+        return _field_public(row)
+    cursor = conn.execute(
+        "INSERT INTO field_definition "
+        "(dataset_definition_id, field_key, original_name, data_type, "
+        "is_nullable, identity_role, display_order) VALUES (?,?,?,?,?,?,?)",
+        (
+            dataset["dataset_definition_id"], request.field_key,
+            request.original_name, request.data_type.value,
+            int(request.is_nullable), request.identity_role.value,
+            request.display_order,
+        ),
+    )
+    row = conn.execute(
+        "SELECT * FROM field_definition WHERE field_definition_id = ?",
+        (cursor.lastrowid,),
+    ).fetchone()
+    return _field_public(row)
+
+
+def list_fields(
+    conn: sqlite3.Connection, dataset_id: int, *, after_id: int = 0,
+    limit: int = DEFAULT_PAGE_SIZE,
+) -> dict[str, Any]:
+    limit = _page_limit(limit)
+    dataset = _dataset_row(conn, dataset_id)
+    rows = conn.execute(
+        "SELECT * FROM field_definition WHERE dataset_definition_id = ? "
+        "AND valid_to IS NULL AND field_definition_id > ? "
+        "ORDER BY field_definition_id LIMIT ?",
+        (dataset["dataset_definition_id"], max(0, after_id), limit + 1),
+    ).fetchall()
+    has_more = len(rows) > limit
+    page = rows[:limit]
+    return {
+        "fields": [_field_public(row) for row in page],
+        "next_after_id": page[-1]["field_definition_id"] if has_more else None,
+    }

--- a/scrapex/catalog_models.py
+++ b/scrapex/catalog_models.py
@@ -1,0 +1,223 @@
+"""Typed vocabulary and boundary DTOs for the generic dataset catalogue."""
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated, Any
+
+from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field, field_validator
+
+MAX_PAGE_SIZE = 200
+DEFAULT_PAGE_SIZE = 50
+KEY_PATTERN = r"^[a-z][a-z0-9_]{1,63}$"
+CatalogKey = Annotated[str, Field(pattern=KEY_PATTERN)]
+
+
+class SiteLifecycle(StrEnum):
+    DRAFT = "draft"
+    ACTIVE = "active"
+    PAUSED = "paused"
+
+
+class DatasetKind(StrEnum):
+    TABLE = "table"
+    LIST = "list"
+    DETAIL = "detail"
+    TREE = "tree"
+    STREAM = "stream"
+    UNKNOWN = "unknown"
+
+
+class DiscoveryMethod(StrEnum):
+    MANUAL = "manual"
+    HTML_TABLE = "html_table"
+    REPEATING_DOM = "repeating_dom"
+    JSON = "json"
+    API = "api"
+    INFERRED = "inferred"
+
+
+class FieldType(StrEnum):
+    TEXT = "text"
+    INTEGER = "integer"
+    DECIMAL = "decimal"
+    BOOLEAN = "boolean"
+    DATE = "date"
+    DATETIME = "datetime"
+    URL = "url"
+    JSON = "json"
+    UNKNOWN = "unknown"
+
+
+class IdentityRole(StrEnum):
+    NONE = "none"
+    CANDIDATE = "candidate"
+    KEY_PART = "key_part"
+
+
+class Cardinality(StrEnum):
+    ONE_TO_ONE = "one_to_one"
+    ONE_TO_MANY = "one_to_many"
+    MANY_TO_ONE = "many_to_one"
+    MANY_TO_MANY = "many_to_many"
+    UNKNOWN = "unknown"
+
+
+class RelationshipReviewStatus(StrEnum):
+    SUGGESTED = "suggested"
+    CONFIRMED = "confirmed"
+    REJECTED = "rejected"
+
+
+class SiteCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    site_key: CatalogKey
+    display_name: str = Field(min_length=1, max_length=200)
+    base_url: AnyHttpUrl
+    lifecycle: SiteLifecycle = SiteLifecycle.DRAFT
+    price_source_id: int | None = Field(default=None, gt=0)
+
+
+class DatasetCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    dataset_key: CatalogKey
+    original_name: str = Field(min_length=1, max_length=500)
+    dataset_kind: DatasetKind = DatasetKind.UNKNOWN
+    discovery_method: DiscoveryMethod
+    locator: dict[str, Any] = Field(default_factory=dict)
+
+
+class FieldCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    field_key: CatalogKey
+    original_name: str = Field(min_length=1, max_length=500)
+    data_type: FieldType = FieldType.UNKNOWN
+    is_nullable: bool = True
+    identity_role: IdentityRole = IdentityRole.NONE
+    display_order: int = Field(default=0, ge=0)
+
+
+class RelationshipFieldPairCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    parent_field_id: int = Field(gt=0)
+    child_field_id: int = Field(gt=0)
+
+
+class RelationshipCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    relationship_key: CatalogKey
+    parent_dataset_id: int = Field(gt=0)
+    child_dataset_id: int = Field(gt=0)
+    cardinality: Cardinality = Cardinality.UNKNOWN
+    confidence: float = Field(default=0.0, ge=0.0, le=1.0)
+    evidence: dict[str, Any] = Field(default_factory=dict)
+    field_pairs: list[RelationshipFieldPairCreate] = Field(min_length=1, max_length=32)
+
+    @field_validator("field_pairs")
+    @classmethod
+    def _pairs_are_unique(
+        cls, pairs: list[RelationshipFieldPairCreate]
+    ) -> list[RelationshipFieldPairCreate]:
+        keys = {(pair.parent_field_id, pair.child_field_id) for pair in pairs}
+        if len(keys) != len(pairs):
+            raise ValueError("field_pairs must not contain duplicates")
+        return pairs
+
+
+class SiteView(BaseModel):
+    site_profile_id: int
+    site_key: str
+    display_name: str
+    base_url: AnyHttpUrl
+    price_source_id: int | None
+    lifecycle: SiteLifecycle
+    created_at: str
+    updated_at: str
+
+
+class DatasetView(BaseModel):
+    dataset_definition_id: int
+    site_profile_id: int
+    dataset_key: str
+    original_name: str
+    display_name: str | None
+    label: str
+    dataset_kind: DatasetKind
+    discovery_method: DiscoveryMethod
+    locator: dict[str, Any]
+    first_seen_at: str
+    last_seen_at: str
+
+
+class FieldView(BaseModel):
+    field_definition_id: int
+    dataset_definition_id: int
+    field_key: str
+    original_name: str
+    display_name: str | None
+    label: str
+    data_type: FieldType
+    is_nullable: bool
+    identity_role: IdentityRole
+    display_order: int
+    first_seen_at: str
+    last_seen_at: str
+
+
+class RelationshipFieldPairView(BaseModel):
+    parent_field_id: int
+    parent_field_key: str
+    child_field_id: int
+    child_field_key: str
+    pair_order: int
+
+
+class RelationshipView(BaseModel):
+    dataset_relationship_id: int
+    site_profile_id: int
+    relationship_key: str
+    parent_dataset_id: int
+    child_dataset_id: int
+    cardinality: Cardinality
+    review_status: RelationshipReviewStatus
+    confidence: float
+    evidence: dict[str, Any]
+    field_pairs: list[RelationshipFieldPairView]
+    created_at: str
+    updated_at: str
+
+
+class SitePage(BaseModel):
+    sites: list[SiteView]
+    next_after_id: int | None
+
+
+class DatasetPage(BaseModel):
+    datasets: list[DatasetView]
+    next_after_id: int | None
+
+
+class FieldPage(BaseModel):
+    fields: list[FieldView]
+    next_after_id: int | None
+
+
+class RelationshipPage(BaseModel):
+    relationships: list[RelationshipView]
+    next_after_id: int | None
+
+
+class CatalogError(ValueError):
+    """A safe, user-facing catalogue refusal."""
+
+
+class CatalogNotFound(CatalogError):
+    pass
+
+
+class CatalogConflict(CatalogError):
+    pass

--- a/scrapex/catalog_relations.py
+++ b/scrapex/catalog_relations.py
@@ -1,0 +1,183 @@
+"""Suggested relationships between generic datasets and their field pairs."""
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+from .catalog import _dataset_row, _json, _page_limit, _site_row
+from .catalog_models import (
+    DEFAULT_PAGE_SIZE, CatalogConflict, RelationshipCreate, RelationshipReviewStatus,
+)
+
+
+def _relationship_pairs(
+    conn: sqlite3.Connection, relationship_ids: list[int]
+) -> dict[int, list[dict[str, Any]]]:
+    pairs = {relationship_id: [] for relationship_id in relationship_ids}
+    if not relationship_ids:
+        return pairs
+    # Placeholder count is derived from bounded database IDs; all values remain
+    # parameterized, and the second query avoids one query per relationship.
+    placeholders = ",".join("?" for _ in relationship_ids)
+    rows = conn.execute(
+        "SELECT rfp.dataset_relationship_id, rfp.parent_field_id, "
+        "rfp.child_field_id, rfp.pair_order, pf.field_key AS parent_field_key, "
+        "cf.field_key AS child_field_key "
+        "FROM relationship_field_pair rfp "
+        "JOIN field_definition pf ON pf.field_definition_id = rfp.parent_field_id "
+        "JOIN field_definition cf ON cf.field_definition_id = rfp.child_field_id "
+        f"WHERE rfp.dataset_relationship_id IN ({placeholders}) "
+        "ORDER BY rfp.dataset_relationship_id, rfp.pair_order",
+        relationship_ids,
+    ).fetchall()
+    for row in rows:
+        pairs[row["dataset_relationship_id"]].append({
+            "parent_field_id": row["parent_field_id"],
+            "parent_field_key": row["parent_field_key"],
+            "child_field_id": row["child_field_id"],
+            "child_field_key": row["child_field_key"],
+            "pair_order": row["pair_order"],
+        })
+    return pairs
+
+
+def _relationship_public(
+    row: sqlite3.Row, pairs: list[dict[str, Any]]
+) -> dict[str, Any]:
+    return {
+        "dataset_relationship_id": row["dataset_relationship_id"],
+        "site_profile_id": row["site_profile_id"],
+        "relationship_key": row["relationship_key"],
+        "parent_dataset_id": row["parent_dataset_id"],
+        "child_dataset_id": row["child_dataset_id"],
+        "cardinality": row["cardinality"],
+        "review_status": row["review_status"],
+        "confidence": row["confidence"],
+        "evidence": json.loads(row["evidence_json"]),
+        "field_pairs": pairs,
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+    }
+
+
+def propose_relationship(
+    conn: sqlite3.Connection, site_key: str, request: RelationshipCreate
+) -> dict[str, Any]:
+    """Persist an inference as ``suggested``; this path can never confirm it."""
+    site = _site_row(conn, site_key)
+    parent = _dataset_row(conn, request.parent_dataset_id)
+    child = _dataset_row(conn, request.child_dataset_id)
+    if request.parent_dataset_id == request.child_dataset_id:
+        raise CatalogConflict("a relationship must connect two different datasets")
+    if parent["site_profile_id"] != site["site_profile_id"] or \
+            child["site_profile_id"] != site["site_profile_id"]:
+        raise CatalogConflict("relationship datasets must belong to the requested site")
+
+    pair_keys = [
+        (pair.parent_field_id, pair.child_field_id) for pair in request.field_pairs
+    ]
+    field_ids = {field_id for pair in pair_keys for field_id in pair}
+    placeholders = ",".join("?" for _ in field_ids)
+    rows = conn.execute(
+        "SELECT field_definition_id, dataset_definition_id FROM field_definition "
+        f"WHERE valid_to IS NULL AND field_definition_id IN ({placeholders})",
+        sorted(field_ids),
+    ).fetchall()
+    owners = {row["field_definition_id"]: row["dataset_definition_id"] for row in rows}
+    for parent_field_id, child_field_id in pair_keys:
+        if owners.get(parent_field_id) != request.parent_dataset_id or \
+                owners.get(child_field_id) != request.child_dataset_id:
+            raise CatalogConflict(
+                "relationship fields must belong to their mapped datasets"
+            )
+
+    evidence_json = _json(request.evidence)
+    existing = conn.execute(
+        "SELECT * FROM dataset_relationship "
+        "WHERE site_profile_id = ? AND relationship_key = ?",
+        (site["site_profile_id"], request.relationship_key),
+    ).fetchone()
+    if existing is not None:
+        if existing["valid_to"] is not None:
+            raise CatalogConflict(
+                f"relationship_key {request.relationship_key!r} is retired; "
+                "reactivate it explicitly"
+            )
+        existing_pairs = _relationship_pairs(
+            conn, [existing["dataset_relationship_id"]]
+        )[existing["dataset_relationship_id"]]
+        existing_keys = [
+            (pair["parent_field_id"], pair["child_field_id"])
+            for pair in existing_pairs
+        ]
+        identity = (
+            existing["parent_dataset_id"], existing["child_dataset_id"],
+            existing["cardinality"], existing["confidence"],
+            existing["evidence_json"], existing_keys,
+        )
+        proposed = (
+            request.parent_dataset_id, request.child_dataset_id,
+            request.cardinality.value, request.confidence, evidence_json, pair_keys,
+        )
+        if identity != proposed:
+            raise CatalogConflict(
+                f"relationship_key {request.relationship_key!r} already has "
+                "another definition"
+            )
+        return _relationship_public(existing, existing_pairs)
+
+    cursor = conn.execute(
+        "INSERT INTO dataset_relationship "
+        "(site_profile_id, relationship_key, parent_dataset_id, child_dataset_id, "
+        "cardinality, review_status, confidence, evidence_json) "
+        "VALUES (?,?,?,?,?,?,?,?)",
+        (
+            site["site_profile_id"], request.relationship_key,
+            request.parent_dataset_id, request.child_dataset_id,
+            request.cardinality.value, RelationshipReviewStatus.SUGGESTED.value,
+            request.confidence, evidence_json,
+        ),
+    )
+    relationship_id = int(cursor.lastrowid)
+    conn.executemany(
+        "INSERT INTO relationship_field_pair "
+        "(dataset_relationship_id, parent_field_id, child_field_id, pair_order) "
+        "VALUES (?,?,?,?)",
+        [
+            (relationship_id, parent_field_id, child_field_id, order)
+            for order, (parent_field_id, child_field_id) in enumerate(pair_keys)
+        ],
+    )
+    row = conn.execute(
+        "SELECT * FROM dataset_relationship WHERE dataset_relationship_id = ?",
+        (relationship_id,),
+    ).fetchone()
+    return _relationship_public(
+        row, _relationship_pairs(conn, [relationship_id])[relationship_id]
+    )
+
+
+def list_relationships(
+    conn: sqlite3.Connection, site_key: str, *, after_id: int = 0,
+    limit: int = DEFAULT_PAGE_SIZE,
+) -> dict[str, Any]:
+    limit = _page_limit(limit)
+    site = _site_row(conn, site_key)
+    rows = conn.execute(
+        "SELECT * FROM dataset_relationship WHERE site_profile_id = ? "
+        "AND valid_to IS NULL AND dataset_relationship_id > ? "
+        "ORDER BY dataset_relationship_id LIMIT ?",
+        (site["site_profile_id"], max(0, after_id), limit + 1),
+    ).fetchall()
+    has_more = len(rows) > limit
+    page = rows[:limit]
+    ids = [row["dataset_relationship_id"] for row in page]
+    pairs = _relationship_pairs(conn, ids)
+    return {
+        "relationships": [
+            _relationship_public(row, pairs[row["dataset_relationship_id"]])
+            for row in page
+        ],
+        "next_after_id": page[-1]["dataset_relationship_id"] if has_more else None,
+    }

--- a/scrapex/features.py
+++ b/scrapex/features.py
@@ -50,8 +50,8 @@ _FEATURES = (
     FeatureState(
         FeatureKey.GENERIC_DATASET_CATALOG,
         False,
-        DeliveryStage.NOT_STARTED,
-        "Enabled only after G1 stores and displays an arbitrary dataset end to end.",
+        DeliveryStage.FOUNDATION,
+        "Definitions and API exist; enable only after generic rows and the catalogue UI ship.",
     ),
     FeatureState(
         FeatureKey.GENERIC_EXTRACTION,

--- a/scrapex/storage.py
+++ b/scrapex/storage.py
@@ -628,17 +628,29 @@ def migrate_location(db_path: Path | str, new_dir: Path | str, *,
 
 
 def _same_contents(src: Path, dst: Path) -> bool:
-    """Row counts agree on the tables that matter. Cheap, and catches a truncated
-    copy — which is the failure a byte-size check misses on a WAL database."""
-    tables = ("price_observation", "source_offer", "source_product", "source_site")
+    """Every user table and row count agrees, including future generic data.
+
+    A fixed table allowlist silently stopped protecting data as soon as a new
+    migration added a first-class dataset. Schema names come from SQLite itself;
+    values remain parameterized and identifiers are quoted before use.
+    """
     try:
         a, b = sqlite3.connect(str(src)), sqlite3.connect(str(dst))
     except sqlite3.DatabaseError:
         return False
     try:
-        for table in tables:
-            if a.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0] != \
-               b.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]:
+        table_sql = (
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name NOT LIKE 'sqlite_%' ORDER BY name"
+        )
+        tables_a = [row[0] for row in a.execute(table_sql)]
+        tables_b = [row[0] for row in b.execute(table_sql)]
+        if tables_a != tables_b:
+            return False
+        for table in tables_a:
+            quoted = table.replace('"', '""')
+            count_sql = f'SELECT COUNT(*) FROM "{quoted}"'
+            if a.execute(count_sql).fetchone()[0] != b.execute(count_sql).fetchone()[0]:
                 return False
         return a.execute("PRAGMA user_version").fetchone()[0] == \
             b.execute("PRAGMA user_version").fetchone()[0]

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -58,6 +58,7 @@ from ..vocab import (
     Authority, Cadence, ConnectorFamily, ExtractKind, ExtractScope, Fetcher,
     JobControl, MissedRunPolicy, OverlapPolicy, RunMode, ScheduleFrequency, VatMode,
 )
+from .catalog_api import create_catalog_router
 
 TEMPLATES = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
 STATIC_DIR = Path(__file__).parent / "static"
@@ -386,6 +387,10 @@ def create_app(db_path: Path | str, manifest_path: Path | str = MANIFEST_FILE,
             raise HTTPException(
                 status_code=409,
                 detail="a crawl is currently writing to the database — try again shortly")
+
+    # G1 foundation: typed persistence and API only. The feature stays disabled
+    # until a later slice adds a complete user-facing catalogue workflow.
+    app.include_router(create_catalog_router(read_conn, _write))
 
     @app.get("/api/fields/{source_key}")
     def api_fields(source_key: str):

--- a/scrapex/webui/catalog_api.py
+++ b/scrapex/webui/catalog_api.py
@@ -1,0 +1,112 @@
+"""Typed, cursor-paginated HTTP boundary for the generic catalogue."""
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable
+from typing import Annotated, Any
+
+from fastapi import APIRouter, HTTPException, Path, Query, status
+
+from .. import catalog, catalog_relations
+from .. import catalog_models as models
+from ..catalog_models import DatasetCreate, FieldCreate, RelationshipCreate, SiteCreate
+
+ReadConnection = Callable[[], sqlite3.Connection]
+WriteAction = Callable[[Callable[[sqlite3.Connection], Any]], Any]
+SiteKeyPath = Annotated[str, Path(pattern=models.KEY_PATTERN)]
+PageAfter = Annotated[int, Query(ge=0)]
+PageLimit = Annotated[int, Query(ge=1, le=models.MAX_PAGE_SIZE)]
+
+
+def create_catalog_router(
+    read_connection: ReadConnection, write_action: WriteAction
+) -> APIRouter:
+    router = APIRouter(prefix="/api/catalog", tags=["generic-catalog"])
+
+    def read(run: Callable[[sqlite3.Connection], Any]) -> Any:
+        conn = read_connection()
+        try:
+            return run(conn)
+        except models.CatalogNotFound as exc:
+            raise HTTPException(status_code=404, detail=str(exc))
+        finally:
+            conn.close()
+
+    def write(run: Callable[[sqlite3.Connection], Any]) -> Any:
+        try:
+            return write_action(run)
+        except models.CatalogNotFound as exc:
+            raise HTTPException(status_code=404, detail=str(exc))
+        except models.CatalogConflict as exc:
+            raise HTTPException(status_code=409, detail=str(exc))
+        except sqlite3.IntegrityError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+
+    @router.post(
+        "/sites", status_code=status.HTTP_201_CREATED,
+        response_model=models.SiteView,
+    )
+    def create_site(request: SiteCreate):
+        return write(lambda conn: catalog.register_site(conn, request))
+
+    @router.get("/sites", response_model=models.SitePage)
+    def sites(after_id: PageAfter = 0, limit: PageLimit = models.DEFAULT_PAGE_SIZE):
+        return read(lambda conn: catalog.list_sites(
+            conn, after_id=after_id, limit=limit
+        ))
+
+    @router.post(
+        "/sites/{site_key}/datasets", status_code=status.HTTP_201_CREATED,
+        response_model=models.DatasetView,
+    )
+    def create_dataset(site_key: SiteKeyPath, request: DatasetCreate):
+        return write(lambda conn: catalog.register_dataset(conn, site_key, request))
+
+    @router.get("/sites/{site_key}/datasets", response_model=models.DatasetPage)
+    def datasets(
+        site_key: SiteKeyPath, after_id: PageAfter = 0,
+        limit: PageLimit = models.DEFAULT_PAGE_SIZE,
+    ):
+        return read(lambda conn: catalog.list_datasets(
+            conn, site_key, after_id=after_id, limit=limit
+        ))
+
+    @router.post(
+        "/datasets/{dataset_id}/fields", status_code=status.HTTP_201_CREATED,
+        response_model=models.FieldView,
+    )
+    def create_field(
+        dataset_id: Annotated[int, Path(gt=0)], request: FieldCreate
+    ):
+        return write(lambda conn: catalog.register_field(conn, dataset_id, request))
+
+    @router.get("/datasets/{dataset_id}/fields", response_model=models.FieldPage)
+    def fields(
+        dataset_id: Annotated[int, Path(gt=0)], after_id: PageAfter = 0,
+        limit: PageLimit = models.DEFAULT_PAGE_SIZE,
+    ):
+        return read(lambda conn: catalog.list_fields(
+            conn, dataset_id, after_id=after_id, limit=limit
+        ))
+
+    @router.post(
+        "/sites/{site_key}/relationships", status_code=status.HTTP_201_CREATED,
+        response_model=models.RelationshipView,
+    )
+    def create_relationship(site_key: SiteKeyPath, request: RelationshipCreate):
+        return write(lambda conn: catalog_relations.propose_relationship(
+            conn, site_key, request
+        ))
+
+    @router.get(
+        "/sites/{site_key}/relationships", response_model=models.RelationshipPage
+    )
+    def relationships(
+        site_key: SiteKeyPath, after_id: PageAfter = 0,
+        limit: PageLimit = models.DEFAULT_PAGE_SIZE,
+    ):
+        return read(lambda conn: catalog_relations.list_relationships(
+            conn, site_key, after_id=after_id, limit=limit
+        ))
+
+    return router

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,0 +1,249 @@
+"""G1 generic catalogue: additive identities, dynamic fields and safe relations."""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scrapex import catalog, catalog_relations
+from scrapex import db as dbmod
+from scrapex import catalog_models as models
+
+
+@pytest.fixture()
+def conn(tmp_path: Path):
+    connection = dbmod.connect(tmp_path / "catalog.db")
+    dbmod.migrate(connection)
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def site(key: str = "example_site", url: str = "https://example.com"):
+    return models.SiteCreate(site_key=key, display_name="Example", base_url=url)
+
+
+def dataset(key: str, name: str, method: str = "html_table"):
+    return models.DatasetCreate(
+        dataset_key=key,
+        original_name=name,
+        dataset_kind="table",
+        discovery_method=method,
+        locator={"selector": f"#{key}"},
+    )
+
+
+def field(key: str, name: str, order: int = 0, data_type: str = "text"):
+    return models.FieldCreate(
+        field_key=key,
+        original_name=name,
+        display_order=order,
+        data_type=data_type,
+    )
+
+
+def test_migration_creates_the_catalogue_and_integrity_triggers(conn):
+    objects = {
+        row["name"]: row["type"] for row in conn.execute(
+            "SELECT name, type FROM sqlite_master WHERE type IN ('table','trigger')"
+        )
+    }
+    assert objects["site_profile"] == "table"
+    assert objects["dataset_definition"] == "table"
+    assert objects["field_definition"] == "table"
+    assert objects["dataset_relationship"] == "table"
+    assert objects["relationship_field_pair"] == "table"
+    assert objects["trg_dataset_relationship_same_site_insert"] == "trigger"
+    assert objects["trg_relationship_field_pair_matches_insert"] == "trigger"
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 12
+
+
+def test_one_site_can_hold_multiple_tables_with_different_dynamic_columns(conn):
+    catalog.register_site(conn, site())
+    orders = catalog.register_dataset(conn, "example_site", dataset("orders", "Orders"))
+    customers = catalog.register_dataset(
+        conn, "example_site", dataset("customers", "Customers")
+    )
+    for order, key in enumerate(("order_id", "customer_id", "total")):
+        catalog.register_field(
+            conn, orders["dataset_definition_id"], field(key, key.title(), order)
+        )
+    for order, key in enumerate(("customer_id", "name")):
+        catalog.register_field(
+            conn, customers["dataset_definition_id"], field(key, key.title(), order)
+        )
+
+    datasets = catalog.list_datasets(conn, "example_site")["datasets"]
+    assert [item["dataset_key"] for item in datasets] == ["orders", "customers"]
+    assert len(catalog.list_fields(
+        conn, orders["dataset_definition_id"]
+    )["fields"]) == 3
+    assert len(catalog.list_fields(
+        conn, customers["dataset_definition_id"]
+    )["fields"]) == 2
+
+
+def test_repeat_discovery_is_idempotent_and_preserves_original_names(conn):
+    first_site = catalog.register_site(conn, site())
+    second_site = catalog.register_site(conn, site())
+    first_dataset = catalog.register_dataset(
+        conn, "example_site", dataset("orders", "Orders table")
+    )
+    second_dataset = catalog.register_dataset(
+        conn, "example_site", dataset("orders", "Orders table")
+    )
+    first_field = catalog.register_field(
+        conn, first_dataset["dataset_definition_id"], field("order_id", "Order ID")
+    )
+    second_field = catalog.register_field(
+        conn, first_dataset["dataset_definition_id"], field("order_id", "Order ID")
+    )
+
+    assert first_site["site_profile_id"] == second_site["site_profile_id"]
+    assert first_dataset["dataset_definition_id"] == second_dataset["dataset_definition_id"]
+    assert first_field["field_definition_id"] == second_field["field_definition_id"]
+    assert conn.execute("SELECT COUNT(*) FROM site_profile").fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM dataset_definition").fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM field_definition").fetchone()[0] == 1
+
+    with pytest.raises(models.CatalogConflict, match="another definition"):
+        catalog.register_field(
+            conn, first_dataset["dataset_definition_id"],
+            field("order_id", "A different original name"),
+        )
+    stored = conn.execute(
+        "SELECT original_name FROM field_definition"
+    ).fetchone()[0]
+    assert stored == "Order ID"
+
+
+def test_retired_identities_are_never_silently_reused(conn):
+    registered = catalog.register_site(conn, site())
+    conn.execute(
+        "UPDATE site_profile SET valid_to='2026-07-19T00:00:00Z' "
+        "WHERE site_profile_id=?",
+        (registered["site_profile_id"],),
+    )
+    with pytest.raises(models.CatalogConflict, match="reactivate it explicitly"):
+        catalog.register_site(conn, site())
+    assert catalog.list_sites(conn)["sites"] == []
+
+
+def test_every_unbounded_catalogue_read_is_cursor_paginated(conn):
+    for number in range(4):
+        catalog.register_site(conn, site(
+            key=f"site_{number}", url=f"https://site-{number}.example"
+        ))
+    first = catalog.list_sites(conn, limit=2)
+    second = catalog.list_sites(conn, after_id=first["next_after_id"], limit=2)
+    assert [item["site_key"] for item in first["sites"]] == ["site_0", "site_1"]
+    assert [item["site_key"] for item in second["sites"]] == ["site_2", "site_3"]
+    assert first["next_after_id"] is not None
+    assert second["next_after_id"] is None
+    with pytest.raises(ValueError, match="between 1 and"):
+        catalog.list_sites(conn, limit=models.MAX_PAGE_SIZE + 1)
+
+
+def _related_catalogue(conn):
+    catalog.register_site(conn, site())
+    parents = catalog.register_dataset(conn, "example_site", dataset("orders", "Orders"))
+    children = catalog.register_dataset(
+        conn, "example_site", dataset("lines", "Order lines")
+    )
+    parent_field = catalog.register_field(
+        conn, parents["dataset_definition_id"],
+        field("order_id", "Order ID", data_type="integer"),
+    )
+    child_field = catalog.register_field(
+        conn, children["dataset_definition_id"],
+        field("order_id", "Order ID", data_type="integer"),
+    )
+    return parents, children, parent_field, child_field
+
+
+def test_relationships_stay_suggestions_and_carry_explicit_field_pairs(conn):
+    parents, children, parent_field, child_field = _related_catalogue(conn)
+    request = models.RelationshipCreate(
+        relationship_key="orders_to_lines",
+        parent_dataset_id=parents["dataset_definition_id"],
+        child_dataset_id=children["dataset_definition_id"],
+        cardinality="one_to_many",
+        confidence=0.91,
+        evidence={"matching_values": 42},
+        field_pairs=[{
+            "parent_field_id": parent_field["field_definition_id"],
+            "child_field_id": child_field["field_definition_id"],
+        }],
+    )
+    first = catalog_relations.propose_relationship(conn, "example_site", request)
+    second = catalog_relations.propose_relationship(conn, "example_site", request)
+    assert first["dataset_relationship_id"] == second["dataset_relationship_id"]
+    assert first["review_status"] == "suggested"
+    assert first["field_pairs"][0]["parent_field_key"] == "order_id"
+    assert catalog_relations.list_relationships(
+        conn, "example_site"
+    )["relationships"] == [first]
+
+
+def test_cross_site_relationships_are_refused_by_code_and_sql(conn):
+    parents, _, parent_field, _ = _related_catalogue(conn)
+    catalog.register_site(conn, site("other_site", "https://other.example"))
+    other = catalog.register_dataset(conn, "other_site", dataset("other_rows", "Other"))
+    other_field = catalog.register_field(
+        conn, other["dataset_definition_id"], field("order_id", "Order ID")
+    )
+    request = models.RelationshipCreate(
+        relationship_key="invalid_relation",
+        parent_dataset_id=parents["dataset_definition_id"],
+        child_dataset_id=other["dataset_definition_id"],
+        field_pairs=[{
+            "parent_field_id": parent_field["field_definition_id"],
+            "child_field_id": other_field["field_definition_id"],
+        }],
+    )
+    with pytest.raises(models.CatalogConflict, match="requested site"):
+        catalog_relations.propose_relationship(conn, "example_site", request)
+
+    example_id = conn.execute(
+        "SELECT site_profile_id FROM site_profile WHERE site_key='example_site'"
+    ).fetchone()[0]
+    with pytest.raises(sqlite3.IntegrityError, match="same site profile"):
+        conn.execute(
+            "INSERT INTO dataset_relationship "
+            "(site_profile_id, relationship_key, parent_dataset_id, child_dataset_id) "
+            "VALUES (?,?,?,?)",
+            (
+                example_id, "direct_invalid", parents["dataset_definition_id"],
+                other["dataset_definition_id"],
+            ),
+        )
+
+
+def test_relationship_field_trigger_rejects_a_field_from_the_wrong_dataset(conn):
+    parents, children, parent_field, child_field = _related_catalogue(conn)
+    cursor = conn.execute(
+        "INSERT INTO dataset_relationship "
+        "(site_profile_id, relationship_key, parent_dataset_id, child_dataset_id) "
+        "VALUES ((SELECT site_profile_id FROM site_profile WHERE site_key=?),?,?,?)",
+        (
+            "example_site", "orders_to_lines", parents["dataset_definition_id"],
+            children["dataset_definition_id"],
+        ),
+    )
+    with pytest.raises(sqlite3.IntegrityError, match="mapped datasets"):
+        conn.execute(
+            "INSERT INTO relationship_field_pair "
+            "(dataset_relationship_id, parent_field_id, child_field_id) VALUES (?,?,?)",
+            (
+                cursor.lastrowid, child_field["field_definition_id"],
+                parent_field["field_definition_id"],
+            ),
+        )
+
+
+def test_catalogue_services_have_no_delete_path():
+    for module in (catalog, catalog_relations):
+        source = Path(module.__file__).read_text(encoding="utf-8")
+        assert "DELETE FROM" not in source

--- a/tests/test_catalog_api.py
+++ b/tests/test_catalog_api.py
@@ -1,0 +1,146 @@
+"""G1 HTTP boundary: arbitrary catalogue definitions without generic-data claims."""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from scrapex import db as dbmod  # noqa: E402
+from scrapex.config import MANIFEST_FILE  # noqa: E402
+from scrapex.webui.app import create_app  # noqa: E402
+
+
+@pytest.fixture()
+def client(tmp_path: Path):
+    db_path = tmp_path / "catalog-api.db"
+    conn = dbmod.connect(db_path)
+    dbmod.migrate(conn)
+    conn.close()
+    manifest = tmp_path / "sources.yaml"
+    shutil.copy(MANIFEST_FILE, manifest)
+    return TestClient(create_app(db_path, manifest_path=manifest))
+
+
+def _post_site(client, key="example_site", url="https://example.com"):
+    response = client.post("/api/catalog/sites", json={
+        "site_key": key,
+        "display_name": "Example",
+        "base_url": url,
+    })
+    assert response.status_code == 201
+    return response.json()
+
+
+def _post_dataset(client, site_key, key, name):
+    response = client.post(f"/api/catalog/sites/{site_key}/datasets", json={
+        "dataset_key": key,
+        "original_name": name,
+        "dataset_kind": "table",
+        "discovery_method": "html_table",
+        "locator": {"selector": f"#{key}"},
+    })
+    assert response.status_code == 201
+    return response.json()
+
+
+def _post_field(client, dataset_id, key, name):
+    response = client.post(f"/api/catalog/datasets/{dataset_id}/fields", json={
+        "field_key": key,
+        "original_name": name,
+        "data_type": "integer" if key.endswith("id") else "text",
+    })
+    assert response.status_code == 201
+    return response.json()
+
+
+def test_api_builds_two_dynamic_tables_and_a_suggested_relation(client):
+    _post_site(client)
+    orders = _post_dataset(client, "example_site", "orders", "Orders")
+    lines = _post_dataset(client, "example_site", "lines", "Order lines")
+    order_id = _post_field(
+        client, orders["dataset_definition_id"], "order_id", "Order ID"
+    )
+    _post_field(client, orders["dataset_definition_id"], "total", "Total")
+    line_order_id = _post_field(
+        client, lines["dataset_definition_id"], "order_id", "Order ID"
+    )
+
+    relation = client.post(
+        "/api/catalog/sites/example_site/relationships",
+        json={
+            "relationship_key": "orders_to_lines",
+            "parent_dataset_id": orders["dataset_definition_id"],
+            "child_dataset_id": lines["dataset_definition_id"],
+            "cardinality": "one_to_many",
+            "confidence": 0.8,
+            "evidence": {"source": "matching_values"},
+            "field_pairs": [{
+                "parent_field_id": order_id["field_definition_id"],
+                "child_field_id": line_order_id["field_definition_id"],
+            }],
+        },
+    )
+    assert relation.status_code == 201
+    assert relation.json()["review_status"] == "suggested"
+
+    datasets = client.get("/api/catalog/sites/example_site/datasets").json()
+    assert [row["dataset_key"] for row in datasets["datasets"]] == ["orders", "lines"]
+    assert len(client.get(
+        f"/api/catalog/datasets/{orders['dataset_definition_id']}/fields"
+    ).json()["fields"]) == 2
+    assert len(client.get(
+        f"/api/catalog/datasets/{lines['dataset_definition_id']}/fields"
+    ).json()["fields"]) == 1
+    assert len(client.get(
+        "/api/catalog/sites/example_site/relationships"
+    ).json()["relationships"]) == 1
+
+
+def test_api_rejects_untyped_or_ambiguous_catalogue_input(client):
+    assert client.post("/api/catalog/sites", json={
+        "site_key": "Not Stable",
+        "display_name": "Bad",
+        "base_url": "not a url",
+    }).status_code == 422
+
+    _post_site(client)
+    dataset = _post_dataset(client, "example_site", "orders", "Orders")
+    bad_type = client.post(
+        f"/api/catalog/datasets/{dataset['dataset_definition_id']}/fields",
+        json={
+            "field_key": "total",
+            "original_name": "Total",
+            "data_type": "whatever-the-source-said",
+        },
+    )
+    assert bad_type.status_code == 422
+
+
+def test_api_is_cursor_paginated_and_unknown_parents_are_404(client):
+    for number in range(3):
+        _post_site(client, f"site_{number}", f"https://site-{number}.example")
+    first = client.get("/api/catalog/sites", params={"limit": 2}).json()
+    second = client.get("/api/catalog/sites", params={
+        "limit": 2, "after_id": first["next_after_id"]
+    }).json()
+    assert len(first["sites"]) == 2
+    assert [row["site_key"] for row in second["sites"]] == ["site_2"]
+    assert client.get(
+        "/api/catalog/datasets/999/fields"
+    ).status_code == 404
+    assert client.get(
+        "/api/catalog/sites/no_such_site/datasets"
+    ).status_code == 404
+
+
+def test_feature_manifest_reports_foundation_without_enabling_the_ui(client):
+    features = {
+        item["key"]: item for item in client.get("/api/features").json()["features"]
+    }
+    catalog_feature = features["generic_dataset_catalog"]
+    assert catalog_feature["stage"] == "foundation"
+    assert catalog_feature["enabled"] is False

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -27,12 +27,12 @@ def test_migrate_is_idempotent(tmp_path: Path):
         second = dbmod.migrate(conn)
     finally:
         conn.close()
-    assert first == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]  # +0011 retention
+    assert first == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     assert second == []  # T4: running again applies nothing
 
 
 def test_latest_schema_version_matches_the_migration_chain():
-    assert dbmod.latest_schema_version() == 11
+    assert dbmod.latest_schema_version() == 12
 
 
 def test_foreign_keys_actually_enforced(tmp_path: Path):

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -12,6 +12,14 @@ def test_price_tracking_is_the_enabled_compatibility_baseline():
     assert price["stage"] == DeliveryStage.PRODUCTION_READY.value
 
 
+def test_generic_catalogue_foundation_is_visible_but_not_enabled():
+    feature = next(
+        f for f in manifest()["features"] if f["key"] == "generic_dataset_catalog"
+    )
+    assert feature["stage"] == DeliveryStage.FOUNDATION.value
+    assert feature["enabled"] is False
+
+
 @pytest.mark.parametrize("feature", [
     FeatureKey.GENERIC_DATASET_CATALOG,
     FeatureKey.GENERIC_EXTRACTION,

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -62,7 +62,7 @@ def _insert_observation(conn, ids, price: float = 168.78, hash_: str = "h1") -> 
 
 
 def test_migration_reaches_latest_version(conn):
-    assert dbmod.schema_version(conn) == 11  # +0011 retention
+    assert dbmod.schema_version(conn) == 12  # +0012 generic dataset catalogue
 
 
 def test_all_owner_tables_exist(conn):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -244,6 +244,34 @@ def test_restore_validates_the_copy_before_moving_the_live_database(conn, db_pat
     assert not db_path.with_name(db_path.name + ".restore-incoming").exists()
 
 
+def test_copy_verification_includes_generic_catalogue_tables(db_path, tmp_path):
+    source = db_path
+    copied = tmp_path / "copied.db"
+    source_conn = dbmod.connect(source)
+    try:
+        source_conn.execute(
+            "INSERT INTO site_profile (site_key, display_name, base_url) VALUES (?,?,?)",
+            ("example_site", "Example", "https://example.com/"),
+        )
+        source_conn.commit()
+        destination_conn = sqlite3.connect(str(copied))
+        try:
+            source_conn.backup(destination_conn)
+        finally:
+            destination_conn.close()
+    finally:
+        source_conn.close()
+
+    assert storage._same_contents(source, copied) is True
+    copied_conn = sqlite3.connect(str(copied))
+    try:
+        copied_conn.execute("DELETE FROM site_profile")
+        copied_conn.commit()
+    finally:
+        copied_conn.close()
+    assert storage._same_contents(source, copied) is False
+
+
 # ---- maintenance -------------------------------------------------------------
 
 def test_compacting_keeps_every_row(conn, db_path):


### PR DESCRIPTION
## What changed

- Added migration 0012 with additive `site_profile`, `dataset_definition`, `field_definition`, `dataset_relationship`, and composite `relationship_field_pair` tables.
- Added typed DTOs and separate catalogue definition/relationship services.
- Added cursor-paginated `/api/catalog` endpoints for sites, datasets, dynamic fields, and suggested relationships.
- Added SQL triggers and service checks that reject cross-site relationships and mismatched field maps.
- Preserved immutable keys/original names, represented retirement with `valid_to`, and made repeat discovery idempotent.
- Extended storage-copy verification to compare every user table, so generic catalogue data receives the same restore/move protection as price data.
- Documented the G1 model and exposed its feature stage as `foundation` while keeping it disabled.

## Why

ScrapeX needs to model arbitrary sites with multiple tables and different column sets before generic crawl and extraction code can safely persist rows. The existing price tables are a working compatibility contract and must not be repurposed.

The relationship path intentionally creates only `suggested` records. Automatic discovery is evidence, not approval; a later reviewed workflow will own confirmation or rejection.

## Impact

- Existing product and price tables and routes are unchanged.
- Schema version advances from 11 to 12 through a forward-only migration.
- Generic catalogue APIs are available for foundation testing, but no generic UI/navigation is advertised and `generic_dataset_catalog.enabled` remains false.
- Collection reads are cursor-paginated and capped at 200 records.

## Validation

- 560 project tests passed.
- 132 focused storage, schema, compaction, API, and catalogue safety tests passed during development.
- `git diff --check` passed.
- New service modules are each below 400 lines.
- One existing Starlette/httpx deprecation warning remains; no test failures.

## Known limitations and next slice

G1 stores definitions, not generic extracted rows. Automatic table detection, schema reconciliation, crawl frontier persistence, user-facing catalogue screens, and relationship review actions remain disabled future slices.

## Review and rollback

This is a stacked Draft PR targeting `codex/generic-platform-g0`; its diff is limited to G1. Review G0 first, then this migration and catalogue contract.

Rollback is a normal commit revert before migration. After a database has migrated to v12, use the pre-migration backup for a full downgrade; do not manually drop catalogue tables. No code path deletes price history or catalogue definitions.
