### PR TITLE
feat(extract): add approved HTML table ingestion

### DIFF
--- a/db/general/migrations/0002_generic_html_table_extraction.sql
+++ b/db/general/migrations/0002_generic_html_table_extraction.sql
@@ -1,0 +1,212 @@
+-- General migration 0002: owner-approved HTML table extraction storage.
+-- Detection candidates remain transient. Only saved evidence and approved
+-- datasets, schemas, records, and revisions are persisted in General.
+
+CREATE TABLE generic_page_snapshot (
+    page_snapshot_id INTEGER PRIMARY KEY,
+    source_url       TEXT NOT NULL,
+    content_type     TEXT NOT NULL DEFAULT 'text/html'
+        CHECK (content_type = 'text/html'),
+    html_content     TEXT NOT NULL,
+    content_hash     TEXT NOT NULL,
+    captured_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+);
+
+CREATE INDEX ix_generic_page_snapshot_page
+    ON generic_page_snapshot(page_snapshot_id, captured_at);
+CREATE INDEX ix_generic_page_snapshot_hash
+    ON generic_page_snapshot(content_hash, page_snapshot_id);
+
+CREATE TRIGGER trg_generic_page_snapshot_immutable_update
+BEFORE UPDATE ON generic_page_snapshot
+BEGIN
+    SELECT RAISE(ABORT, 'saved HTML snapshots are immutable');
+END;
+
+CREATE TRIGGER trg_generic_page_snapshot_immutable_delete
+BEFORE DELETE ON generic_page_snapshot
+BEGIN
+    SELECT RAISE(ABORT, 'saved HTML snapshots are immutable');
+END;
+
+CREATE TABLE dataset_schema_version (
+    schema_version_id     INTEGER PRIMARY KEY,
+    dataset_definition_id INTEGER NOT NULL
+        REFERENCES dataset_definition(dataset_definition_id),
+    version_number        INTEGER NOT NULL CHECK (version_number >= 1),
+    schema_hash           TEXT NOT NULL,
+    status                TEXT NOT NULL DEFAULT 'approved'
+        CHECK (status IN ('approved','retired')),
+    approved_at           TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    valid_to              TEXT,
+    UNIQUE (dataset_definition_id, version_number),
+    UNIQUE (dataset_definition_id, schema_hash)
+);
+
+CREATE UNIQUE INDEX ux_dataset_schema_version_active
+    ON dataset_schema_version(dataset_definition_id)
+    WHERE valid_to IS NULL;
+
+CREATE TABLE schema_version_field (
+    schema_version_id   INTEGER NOT NULL
+        REFERENCES dataset_schema_version(schema_version_id),
+    field_definition_id INTEGER NOT NULL
+        REFERENCES field_definition(field_definition_id),
+    field_order         INTEGER NOT NULL CHECK (field_order >= 0),
+    PRIMARY KEY (schema_version_id, field_definition_id),
+    UNIQUE (schema_version_id, field_order)
+);
+
+CREATE INDEX ix_schema_version_field_order
+    ON schema_version_field(schema_version_id, field_order);
+
+CREATE TABLE generic_record (
+    generic_record_id     INTEGER PRIMARY KEY,
+    dataset_definition_id INTEGER NOT NULL
+        REFERENCES dataset_definition(dataset_definition_id),
+    record_key            TEXT NOT NULL,
+    schema_version_id     INTEGER NOT NULL
+        REFERENCES dataset_schema_version(schema_version_id),
+    data_json             TEXT NOT NULL
+        CHECK (json_valid(data_json) AND json_type(data_json) = 'object'),
+    source_snapshot_id    INTEGER NOT NULL
+        REFERENCES generic_page_snapshot(page_snapshot_id),
+    source_locator        TEXT NOT NULL,
+    content_hash          TEXT NOT NULL,
+    first_seen_at         TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    last_seen_at          TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    status                TEXT NOT NULL DEFAULT 'active'
+        CHECK (status IN ('active','unavailable','retired')),
+    UNIQUE (dataset_definition_id, record_key)
+);
+
+CREATE INDEX ix_generic_record_page
+    ON generic_record(dataset_definition_id, generic_record_id);
+CREATE INDEX ix_generic_record_snapshot
+    ON generic_record(source_snapshot_id, generic_record_id);
+
+CREATE TABLE generic_record_revision (
+    record_revision_id INTEGER PRIMARY KEY,
+    generic_record_id  INTEGER NOT NULL REFERENCES generic_record(generic_record_id),
+    schema_version_id  INTEGER NOT NULL
+        REFERENCES dataset_schema_version(schema_version_id),
+    source_snapshot_id INTEGER NOT NULL
+        REFERENCES generic_page_snapshot(page_snapshot_id),
+    data_json          TEXT NOT NULL
+        CHECK (json_valid(data_json) AND json_type(data_json) = 'object'),
+    content_hash       TEXT NOT NULL,
+    observed_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    UNIQUE (generic_record_id, source_snapshot_id, content_hash)
+);
+
+CREATE INDEX ix_generic_record_revision_record
+    ON generic_record_revision(generic_record_id, record_revision_id);
+
+CREATE TRIGGER trg_generic_record_revision_append_only_update
+BEFORE UPDATE ON generic_record_revision
+BEGIN
+    SELECT RAISE(ABORT, 'generic record revisions are append-only');
+END;
+
+CREATE TRIGGER trg_generic_record_revision_append_only_delete
+BEFORE DELETE ON generic_record_revision
+BEGIN
+    SELECT RAISE(ABORT, 'generic record revisions are append-only');
+END;
+
+CREATE TABLE generic_ingestion (
+    generic_ingestion_id  INTEGER PRIMARY KEY,
+    dataset_definition_id INTEGER NOT NULL
+        REFERENCES dataset_definition(dataset_definition_id),
+    schema_version_id     INTEGER NOT NULL
+        REFERENCES dataset_schema_version(schema_version_id),
+    source_snapshot_id    INTEGER NOT NULL
+        REFERENCES generic_page_snapshot(page_snapshot_id),
+    source_locator        TEXT NOT NULL,
+    record_count          INTEGER NOT NULL CHECK (record_count >= 0),
+    status                TEXT NOT NULL DEFAULT 'success'
+        CHECK (status = 'success'),
+    ingested_at           TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    UNIQUE (source_snapshot_id, source_locator)
+);
+
+CREATE INDEX ix_generic_ingestion_dataset
+    ON generic_ingestion(dataset_definition_id, generic_ingestion_id);
+
+CREATE TRIGGER trg_generic_ingestion_append_only_update
+BEFORE UPDATE ON generic_ingestion
+BEGIN
+    SELECT RAISE(ABORT, 'generic ingestions are append-only');
+END;
+
+CREATE TRIGGER trg_generic_ingestion_append_only_delete
+BEFORE DELETE ON generic_ingestion
+BEGIN
+    SELECT RAISE(ABORT, 'generic ingestions are append-only');
+END;
+
+-- Cross-table guards keep approved schema state inside one General dataset.
+CREATE TRIGGER trg_schema_version_field_matches_insert
+BEFORE INSERT ON schema_version_field
+FOR EACH ROW
+WHEN (SELECT dataset_definition_id FROM field_definition
+      WHERE field_definition_id = NEW.field_definition_id LIMIT 1) <>
+     (SELECT dataset_definition_id FROM dataset_schema_version
+      WHERE schema_version_id = NEW.schema_version_id LIMIT 1)
+BEGIN
+    SELECT RAISE(ABORT, 'schema fields must belong to the schema dataset');
+END;
+
+CREATE TRIGGER trg_schema_version_field_matches_update
+BEFORE UPDATE OF schema_version_id, field_definition_id ON schema_version_field
+FOR EACH ROW
+WHEN (SELECT dataset_definition_id FROM field_definition
+      WHERE field_definition_id = NEW.field_definition_id LIMIT 1) <>
+     (SELECT dataset_definition_id FROM dataset_schema_version
+      WHERE schema_version_id = NEW.schema_version_id LIMIT 1)
+BEGIN
+    SELECT RAISE(ABORT, 'schema fields must belong to the schema dataset');
+END;
+
+CREATE TRIGGER trg_generic_record_schema_matches_insert
+BEFORE INSERT ON generic_record
+FOR EACH ROW
+WHEN NEW.dataset_definition_id <>
+     (SELECT dataset_definition_id FROM dataset_schema_version
+      WHERE schema_version_id = NEW.schema_version_id LIMIT 1)
+BEGIN
+    SELECT RAISE(ABORT, 'generic record schema must belong to its dataset');
+END;
+
+CREATE TRIGGER trg_generic_record_schema_matches_update
+BEFORE UPDATE OF dataset_definition_id, schema_version_id ON generic_record
+FOR EACH ROW
+WHEN NEW.dataset_definition_id <>
+     (SELECT dataset_definition_id FROM dataset_schema_version
+      WHERE schema_version_id = NEW.schema_version_id LIMIT 1)
+BEGIN
+    SELECT RAISE(ABORT, 'generic record schema must belong to its dataset');
+END;
+
+CREATE TRIGGER trg_generic_record_revision_matches_insert
+BEFORE INSERT ON generic_record_revision
+FOR EACH ROW
+WHEN (SELECT dataset_definition_id FROM dataset_schema_version
+      WHERE schema_version_id = NEW.schema_version_id LIMIT 1) <>
+     (SELECT dataset_definition_id FROM generic_record
+      WHERE generic_record_id = NEW.generic_record_id LIMIT 1)
+BEGIN
+    SELECT RAISE(ABORT, 'generic record revision schema must belong to its dataset');
+END;
+
+CREATE TRIGGER trg_generic_ingestion_matches_insert
+BEFORE INSERT ON generic_ingestion
+FOR EACH ROW
+WHEN NEW.dataset_definition_id <>
+     (SELECT dataset_definition_id FROM dataset_schema_version
+      WHERE schema_version_id = NEW.schema_version_id LIMIT 1)
+BEGIN
+    SELECT RAISE(ABORT, 'generic ingestion schema must belong to its dataset');
+END;
+
+PRAGMA user_version = 2;

--- a/db/migrations/0014_generic_html_table_extraction.sql
+++ b/db/migrations/0014_generic_html_table_extraction.sql
@@ -1,0 +1,219 @@
+-- ============================================================================
+-- Migration 0014 - first generic HTML-table extraction slice.
+--
+-- These tables sit beside the price warehouse. A saved page is immutable raw
+-- evidence; approved schemas describe arbitrary fields; generic records keep
+-- canonical JSON rather than creating one physical table per discovered table.
+-- Discovery candidates remain in memory and therefore cannot pollute this
+-- permanent store before an owner approves one.
+-- ============================================================================
+
+CREATE TABLE generic_page_snapshot (
+    page_snapshot_id INTEGER PRIMARY KEY,
+    source_url       TEXT NOT NULL,
+    content_type     TEXT NOT NULL DEFAULT 'text/html'
+        CHECK (content_type = 'text/html'),
+    html_content     TEXT NOT NULL,
+    content_hash     TEXT NOT NULL,
+    captured_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+);
+
+CREATE INDEX ix_generic_page_snapshot_page
+    ON generic_page_snapshot(page_snapshot_id, captured_at);
+CREATE INDEX ix_generic_page_snapshot_hash
+    ON generic_page_snapshot(content_hash, page_snapshot_id);
+
+CREATE TRIGGER trg_generic_page_snapshot_immutable_update
+BEFORE UPDATE ON generic_page_snapshot
+BEGIN
+    SELECT RAISE(ABORT, 'saved HTML snapshots are immutable');
+END;
+
+CREATE TRIGGER trg_generic_page_snapshot_immutable_delete
+BEFORE DELETE ON generic_page_snapshot
+BEGIN
+    SELECT RAISE(ABORT, 'saved HTML snapshots are immutable');
+END;
+
+CREATE TABLE dataset_schema_version (
+    schema_version_id     INTEGER PRIMARY KEY,
+    dataset_definition_id INTEGER NOT NULL
+        REFERENCES dataset_definition(dataset_definition_id),
+    version_number        INTEGER NOT NULL CHECK (version_number >= 1),
+    schema_hash           TEXT NOT NULL,
+    status                TEXT NOT NULL DEFAULT 'approved'
+        CHECK (status IN ('approved','retired')),
+    approved_at           TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    valid_to              TEXT,
+    UNIQUE (dataset_definition_id, version_number),
+    UNIQUE (dataset_definition_id, schema_hash)
+);
+
+CREATE UNIQUE INDEX ux_dataset_schema_version_active
+    ON dataset_schema_version(dataset_definition_id)
+    WHERE valid_to IS NULL;
+
+CREATE TABLE schema_version_field (
+    schema_version_id   INTEGER NOT NULL
+        REFERENCES dataset_schema_version(schema_version_id),
+    field_definition_id INTEGER NOT NULL
+        REFERENCES field_definition(field_definition_id),
+    field_order         INTEGER NOT NULL CHECK (field_order >= 0),
+    PRIMARY KEY (schema_version_id, field_definition_id),
+    UNIQUE (schema_version_id, field_order)
+);
+
+CREATE INDEX ix_schema_version_field_order
+    ON schema_version_field(schema_version_id, field_order);
+
+CREATE TABLE generic_record (
+    generic_record_id    INTEGER PRIMARY KEY,
+    dataset_definition_id INTEGER NOT NULL
+        REFERENCES dataset_definition(dataset_definition_id),
+    record_key           TEXT NOT NULL,
+    schema_version_id    INTEGER NOT NULL
+        REFERENCES dataset_schema_version(schema_version_id),
+    data_json            TEXT NOT NULL
+        CHECK (json_valid(data_json) AND json_type(data_json) = 'object'),
+    source_snapshot_id   INTEGER NOT NULL
+        REFERENCES generic_page_snapshot(page_snapshot_id),
+    source_locator       TEXT NOT NULL,
+    content_hash         TEXT NOT NULL,
+    first_seen_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    last_seen_at         TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    status               TEXT NOT NULL DEFAULT 'active'
+        CHECK (status IN ('active','unavailable','retired')),
+    UNIQUE (dataset_definition_id, record_key)
+);
+
+CREATE INDEX ix_generic_record_page
+    ON generic_record(dataset_definition_id, generic_record_id);
+CREATE INDEX ix_generic_record_snapshot
+    ON generic_record(source_snapshot_id, generic_record_id);
+
+CREATE TABLE generic_record_revision (
+    record_revision_id INTEGER PRIMARY KEY,
+    generic_record_id  INTEGER NOT NULL REFERENCES generic_record(generic_record_id),
+    schema_version_id  INTEGER NOT NULL
+        REFERENCES dataset_schema_version(schema_version_id),
+    source_snapshot_id INTEGER NOT NULL
+        REFERENCES generic_page_snapshot(page_snapshot_id),
+    data_json          TEXT NOT NULL
+        CHECK (json_valid(data_json) AND json_type(data_json) = 'object'),
+    content_hash       TEXT NOT NULL,
+    observed_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    UNIQUE (generic_record_id, source_snapshot_id, content_hash)
+);
+
+CREATE INDEX ix_generic_record_revision_record
+    ON generic_record_revision(generic_record_id, record_revision_id);
+
+CREATE TRIGGER trg_generic_record_revision_append_only_update
+BEFORE UPDATE ON generic_record_revision
+BEGIN
+    SELECT RAISE(ABORT, 'generic record revisions are append-only');
+END;
+
+CREATE TRIGGER trg_generic_record_revision_append_only_delete
+BEFORE DELETE ON generic_record_revision
+BEGIN
+    SELECT RAISE(ABORT, 'generic record revisions are append-only');
+END;
+
+CREATE TABLE generic_ingestion (
+    generic_ingestion_id  INTEGER PRIMARY KEY,
+    dataset_definition_id INTEGER NOT NULL
+        REFERENCES dataset_definition(dataset_definition_id),
+    schema_version_id     INTEGER NOT NULL
+        REFERENCES dataset_schema_version(schema_version_id),
+    source_snapshot_id    INTEGER NOT NULL
+        REFERENCES generic_page_snapshot(page_snapshot_id),
+    source_locator        TEXT NOT NULL,
+    record_count          INTEGER NOT NULL CHECK (record_count >= 0),
+    status                TEXT NOT NULL DEFAULT 'success'
+        CHECK (status = 'success'),
+    ingested_at           TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    UNIQUE (source_snapshot_id, source_locator)
+);
+
+CREATE INDEX ix_generic_ingestion_dataset
+    ON generic_ingestion(dataset_definition_id, generic_ingestion_id);
+
+CREATE TRIGGER trg_generic_ingestion_append_only_update
+BEFORE UPDATE ON generic_ingestion
+BEGIN
+    SELECT RAISE(ABORT, 'generic ingestions are append-only');
+END;
+
+CREATE TRIGGER trg_generic_ingestion_append_only_delete
+BEFORE DELETE ON generic_ingestion
+BEGIN
+    SELECT RAISE(ABORT, 'generic ingestions are append-only');
+END;
+
+-- Cross-table guards keep a schema, its fields, and its records inside one
+-- dataset even when SQL is called directly instead of through the service.
+CREATE TRIGGER trg_schema_version_field_matches_insert
+BEFORE INSERT ON schema_version_field
+FOR EACH ROW
+WHEN (SELECT dataset_definition_id FROM field_definition
+      WHERE field_definition_id = NEW.field_definition_id LIMIT 1) <>
+     (SELECT dataset_definition_id FROM dataset_schema_version
+      WHERE schema_version_id = NEW.schema_version_id LIMIT 1)
+BEGIN
+    SELECT RAISE(ABORT, 'schema fields must belong to the schema dataset');
+END;
+
+CREATE TRIGGER trg_schema_version_field_matches_update
+BEFORE UPDATE OF schema_version_id, field_definition_id ON schema_version_field
+FOR EACH ROW
+WHEN (SELECT dataset_definition_id FROM field_definition
+      WHERE field_definition_id = NEW.field_definition_id LIMIT 1) <>
+     (SELECT dataset_definition_id FROM dataset_schema_version
+      WHERE schema_version_id = NEW.schema_version_id LIMIT 1)
+BEGIN
+    SELECT RAISE(ABORT, 'schema fields must belong to the schema dataset');
+END;
+
+CREATE TRIGGER trg_generic_record_schema_matches_insert
+BEFORE INSERT ON generic_record
+FOR EACH ROW
+WHEN NEW.dataset_definition_id <>
+     (SELECT dataset_definition_id FROM dataset_schema_version
+      WHERE schema_version_id = NEW.schema_version_id LIMIT 1)
+BEGIN
+    SELECT RAISE(ABORT, 'generic record schema must belong to its dataset');
+END;
+
+CREATE TRIGGER trg_generic_record_schema_matches_update
+BEFORE UPDATE OF dataset_definition_id, schema_version_id ON generic_record
+FOR EACH ROW
+WHEN NEW.dataset_definition_id <>
+     (SELECT dataset_definition_id FROM dataset_schema_version
+      WHERE schema_version_id = NEW.schema_version_id LIMIT 1)
+BEGIN
+    SELECT RAISE(ABORT, 'generic record schema must belong to its dataset');
+END;
+
+CREATE TRIGGER trg_generic_record_revision_matches_insert
+BEFORE INSERT ON generic_record_revision
+FOR EACH ROW
+WHEN (SELECT dataset_definition_id FROM dataset_schema_version
+      WHERE schema_version_id = NEW.schema_version_id LIMIT 1) <>
+     (SELECT dataset_definition_id FROM generic_record
+      WHERE generic_record_id = NEW.generic_record_id LIMIT 1)
+BEGIN
+    SELECT RAISE(ABORT, 'generic record revision schema must belong to its dataset');
+END;
+
+CREATE TRIGGER trg_generic_ingestion_matches_insert
+BEFORE INSERT ON generic_ingestion
+FOR EACH ROW
+WHEN NEW.dataset_definition_id <>
+     (SELECT dataset_definition_id FROM dataset_schema_version
+      WHERE schema_version_id = NEW.schema_version_id LIMIT 1)
+BEGIN
+    SELECT RAISE(ABORT, 'generic ingestion schema must belong to its dataset');
+END;
+
+PRAGMA user_version = 14;

--- a/docs/CLAUDE-after-database-separation-20260720.md
+++ b/docs/CLAUDE-after-database-separation-20260720.md
@@ -1,0 +1,2526 @@
+You are a senior product designer, UX architect, browser-extension engineer, local-runtime engineer, and data-platform architect.
+
+Your mission is to design and implement a production-quality browser Side Panel Extension for resilient website crawling, scraping, structured local storage, dataset management, historical change tracking, price monitoring, Excel export, Google Sheets synchronization, and background job scheduling.
+
+This is not a generic scraper dashboard. It is a local-first, multi-engine data collection and synchronization product.
+
+# 1. Mandatory communication and language rules
+
+These rules are non-negotiable:
+
+1. Always communicate with me, explain your decisions, report progress, and provide final summaries in Arabic.
+2. The entire product interface must be written in English only.
+3. English-only interface content includes:
+   - Navigation
+   - Buttons
+   - Labels
+   - Forms
+   - Status messages
+   - Errors
+   - Warnings
+   - Empty states
+   - Tooltips
+   - Dialogs
+   - Setup instructions
+   - Logs
+   - Notifications
+   - Generated integration instructions
+4. Arabic is supported only as user-entered data, site names, or scraped content.
+5. Do not place Arabic text inside the product interface itself.
+6. Scraped Arabic data must render correctly with RTL support.
+7. Use automatic text-direction detection for user-entered and scraped values.
+8. URLs, file paths, IDs, versions, source keys, code, and technical logs must always remain LTR.
+9. All source-code comments, docstrings, variable names, function names, test descriptions, commit messages, and technical documentation must be written in English.
+10. Do not propose or create a color palette.
+11. Focus on:
+    - Layout
+    - Spacing
+    - Typography
+    - Hierarchy
+    - Responsive behavior
+    - Component structure
+    - Interaction design
+    - Loading, empty, success, warning, and failure states
+12. Reuse the existing project theme and design tokens when available.
+13. Never rely only on color to communicate status.
+
+# 2. Working approach
+
+Before making changes:
+
+1. Inspect the existing project.
+2. Understand its architecture, framework, components, conventions, and design system.
+3. Reuse the current stack where practical.
+4. Do not replace the existing architecture without a clear technical reason.
+5. Preserve existing user work.
+6. Explain important assumptions to me in Arabic.
+7. Make sensible decisions without asking unnecessary questions.
+
+Do not stop at a conceptual description.
+
+If a repository is available, implement a polished and functional solution.
+
+If some backend capability is unavailable, create a well-structured adapter or realistic mock implementation and clearly distinguish mock behavior from production behavior.
+
+If no implementation environment is available, produce:
+
+- High-fidelity interface specifications.
+- Component specifications.
+- State models.
+- Data models.
+- User flows.
+- Technical architecture.
+- Implementation-ready acceptance criteria.
+
+# 3. Product vision
+
+The product must:
+
+- Run as a browser Side Panel Extension.
+- Support multiple crawling and scraping engines.
+- Support multiple programming runtimes and strategies.
+- Support local Python.
+- Support JavaScript-based processing.
+- Support browser automation.
+- Support static HTTP extraction.
+- Support structured API extraction when legitimately available.
+- Support site-specific adapters.
+- Support automatic engine selection.
+- Support ordered fallback engines.
+- Use a locally installed runtime/helper on the user’s device.
+- Detect whether local components are installed, running, compatible, and ready.
+- Crawl a site for the first time.
+- Update previously collected datasets.
+- Detect field-level changes.
+- Track product prices over time.
+- Identify new, changed, unavailable, returned, and removed records.
+- Rebuild datasets when explicitly requested.
+- Store data locally by default.
+- Export data to Excel.
+- Synchronize data through Apps Script.
+- Connect directly to Google Drive and Google Sheets.
+- Schedule automatic runs.
+- Continue background jobs when the Side Panel is closed.
+- Restore the current job state when the Side Panel is opened again.
+- Handle different schemas for different websites.
+- Allow users to customize data presentation without altering original collected fields.
+
+Handle legitimate crawling challenges through:
+
+- Retry policies.
+- Pagination detection.
+- Browser rendering.
+- Session management.
+- Rate limiting.
+- Throttling.
+- Timeouts.
+- Engine fallback.
+- Checkpoints.
+- Structured error recovery.
+- Network interruption recovery.
+
+Never silently bypass access controls.
+
+Detect and report:
+
+- Authentication requirements.
+- Blocked access.
+- CAPTCHA challenges.
+- Permission problems.
+- Rate limits.
+- Robots or policy restrictions.
+- Unsupported website behavior.
+
+# 4. Required system architecture
+
+The Side Panel must never own or directly execute a long-running crawl.
+
+Use this responsibility model:
+
+```text
+SIDE PANEL
+- Remote control
+- Site selection
+- Run configuration
+- Progress summary
+- Job controls
+- Runtime status
+- Quick data preview
+
+FULL WORKSPACE TAB
+- Dynamic datasets
+- Full tables
+- Column management
+- Comparisons
+- Change history
+- Review queue
+- Jobs and schedules
+- Detailed logs
+- Advanced settings
+
+EXTENSION SERVICE WORKER
+- Extension event handling
+- Native Messaging bridge
+- Browser permissions
+- Authentication coordination
+- Alarm coordination
+- UI notifications
+
+LOCAL RUNTIME
+- Crawling engines
+- Job execution
+- Job queue
+- Persistent checkpoints
+- SQLite database
+- Full technical logs
+- Scheduling
+- Excel generation
+- Synchronization workers
+- Backups and recovery
+```
+
+The Local Runtime must continue jobs independently from the Side Panel.
+
+If the Side Panel closes and reopens, it must request the current job state and reconnect to live updates.
+
+Use persistent Job IDs and database-backed job state.
+
+Do not depend on a Manifest V3 Service Worker remaining alive for a long-running crawl.
+
+
+# Service Worker Lifecycle and MV3 Constraints
+
+The architecture must explicitly handle Chrome Manifest V3 (MV3) Service Worker hibernation. 
+Do not assume the Service Worker will remain active for longer than 30 seconds.
+
+Ensure:
+- The Local Runtime functions independently regardless of the Service Worker's state.
+- The Side Panel communicates directly with the Local Runtime when open, using the Service Worker only as a coordination bridge when necessary.
+- Use Chrome Offscreen Documents or explicit heartbeat pings to maintain the Native Messaging host connection only during critical background UI notifications.
+- Re-establish lost Native Messaging connections automatically and request the latest missed job events upon waking.
+
+# Local Runtime Distribution and Updates
+
+The Local Runtime must be frictionless for non-technical users. 
+Do not require end-users to use the command line, install Python manually, or manage dependencies via `pip`.
+
+Require:
+- A bundled, standalone executable installer (e.g., a single `.exe` or `.dmg`).
+- Over-The-Air (OTA) silent background updates for the runtime and its dependencies.
+- Version parity checks between the browser extension and the Local Runtime.
+
+The extension must prompt users gracefully when an OTA update requires a runtime restart.
+
+
+# 5. Local domain databases as the sources of truth
+
+Use separate local SQL databases as the canonical sources of truth for their
+own operational domains.
+
+Prefer SQLite unless the existing architecture already uses another appropriate local SQL database.
+
+```text
+Website
+   ↓
+Crawling and Extraction Engines
+   ↓
+Local Runtime
+   ├── General Scrape SQLite Database — generic crawling and datasets
+   └── MarketLens SQLite Database — products, offers, and price tracking
+           ↓
+      Domain-owned Excel / Apps Script / Google Drive and Sheets outputs
+```
+
+OPFS or browser storage may be used for temporary UI state or cache, but not as the only canonical database.
+
+The Local Runtime must own and manage both database files. Each database is the
+source of truth only for its own domain. Do not introduce a third operational
+database in the first separation slice; a small workspace manifest file may
+record both locations without owning business data.
+
+Use:
+
+- Transactions.
+- WAL mode when appropriate.
+- Safe schema migrations.
+- Integrity checks.
+- Recoverable backups.
+- Job checkpoints.
+- Database versioning.
+- Compaction and maintenance.
+- Storage-health monitoring.
+
+# 6. Native Messaging constraints
+
+Use Native Messaging as a command and status bridge between the extension and Local Runtime.
+
+Do not send entire datasets or full logs through one message.
+
+Native Messaging responses from the Local Runtime must remain small and paginated.
+
+Use:
+
+- Cursor-based pagination.
+- Small command responses.
+- Structured job events.
+- Aggregated progress.
+- Log tails.
+- Explicit acknowledgements.
+- Reconnection support.
+
+Example:
+
+```text
+GET_RECORDS
+
+datasetId
+cursor
+limit
+visibleFields
+filters
+sort
+```
+
+The Local Runtime must return a limited page and a new cursor.
+
+# 7. Core domain model
+
+Adapt the exact implementation to the project, but support concepts equivalent to:
+
+- Site
+- Site Profile
+- Site Adapter
+- Runtime Component
+- Crawling Engine
+- Engine Capability
+- Dataset
+- Dataset Field
+- Record Entity
+- Source Identity
+- Identity Alias
+- Crawl Job
+- Crawl Snapshot
+- Change Event
+- Identity Conflict
+- Review Decision
+- Output Destination
+- Sync Session
+- Sync Batch
+- Schedule
+- Saved View
+- Export Job
+- Backup
+- Runtime Log
+
+# 8. Side Panel information architecture
+
+The primary Side Panel must contain:
+
+1. Product header.
+2. Local Runtime status.
+3. Sites section.
+4. Add Site action.
+5. Site search and checklist.
+6. Selected site cards.
+7. Run mode.
+8. Output summary.
+9. Main run action.
+10. Activity summary.
+11. Persistent active-job mini-player.
+12. Bottom navigation.
+
+Bottom navigation:
+
+```text
+Run
+Browse Data
+Settings
+```
+
+Do not add a complex full-width data table to the Side Panel.
+
+# 9. Header and Local Runtime status
+
+Place the product logo and extension name at the top.
+
+Directly below the product name, add a thin interactive status row.
+
+Possible states:
+
+```text
+Local Runtime Ready                         ›
+Setup Required                              ›
+Connection Failed                           ›
+Checking Components...
+Update Required                             ›
+Runtime Stopped                             ›
+```
+
+The status represents the complete runtime, not Python alone.
+
+When selected, expand:
+
+```text
+LOCAL RUNTIME
+
+Core Service                         Running
+Python Runtime                       Ready
+JavaScript Runtime                   Ready
+Browser Automation                  Ready
+Network Tools                        Ready
+Site Adapters                  24 installed
+
+Run Diagnostics
+Manage Components                            ›
+```
+
+Support:
+
+- Installed.
+- Not Installed.
+- Running.
+- Stopped.
+- Ready.
+- Update Required.
+- Incompatible.
+- Connection Failed.
+- Checking.
+
+If components are missing, provide:
+
+```text
+SET UP LOCAL RUNTIME
+
+1. Download the local helper
+2. Run the installer
+3. Install required runtimes
+4. Verify the connection
+```
+
+Actions:
+
+- Download.
+- Continue Setup.
+- Recheck Status.
+- Run Diagnostics.
+- Manage Components.
+- Open Runtime Logs.
+- Check for Updates.
+
+# 10. Sites section
+
+Use:
+
+```text
+SITES                               + Add Site
+```
+
+Provide:
+
+- Search by site name or URL.
+- Select All.
+- Clear.
+- Selected count.
+- Scrollable checklist.
+- Empty state.
+- Loading state.
+- Error state.
+
+Site format:
+
+```text
+example.com (Example Website)
+news-site.com (موقع الأخبار)
+```
+
+The interface remains English and LTR, while Arabic names are treated as data and render correctly.
+
+Allow one or multiple sites to be selected.
+
+Unavailable sites remain visible but disabled with an English explanation.
+
+# 11. Add Site flow
+
+Selecting Add Site must open an internal Side Panel screen or drawer.
+
+Include:
+
+```text
+ADD SITE
+
+Site URL
+Display Name
+Scraping Profile
+Extraction Type
+Preferred Engine
+Fallback Engines
+Authentication Requirements
+Output Defaults
+Schedule
+Advanced Settings
+
+Test Site
+Add Site
+```
+
+The flow must:
+
+- Validate the URL.
+- Test connectivity.
+- Inspect basic capabilities.
+- Detect likely browser-rendering requirements.
+- Recommend an engine.
+- Allow advanced engine override.
+- Display a small discovered-data sample.
+- Save a reusable Site Profile.
+
+Under Advanced Settings, add:
+
+```text
+IDENTITY RULES
+
+Primary Match
+Fallback Match
+Composite Fields
+Canonical URL Rules
+Ambiguous Match Behavior
+```
+
+Default behavior should be automatic and simple. Advanced identity controls must not overwhelm a new user.
+
+# 12. Selected site cards
+
+Every selected site appears below the checklist as a compact card.
+
+Show:
+
+- Display name.
+- URL.
+- Engine.
+- Fallback availability.
+- Extraction profile.
+- Dataset state.
+- Readiness status.
+- Site Settings.
+- Remove-from-current-selection action.
+
+Example:
+
+```text
+Example Website                              ×
+example.com
+
+Engine              Playwright
+Extraction          Products
+Dataset             1,842 records
+Status              Ready
+
+Site Settings                                ›
+```
+
+Removing a selected card must not delete the saved site.
+
+# 13. Run modes
+
+Support three explicit modes:
+
+```text
+INITIAL CRAWL
+Collect and save this site for the first time.
+
+UPDATE EXISTING DATA
+Collect current data and detect differences.
+
+FULL REBUILD
+Archive the current dataset and crawl the site again.
+```
+
+## Initial Crawl
+
+- Create the first dataset.
+- Discover the initial schema.
+- Create stable Record Entity IDs.
+- Save the initial snapshot.
+- Record the source identity strategy.
+
+## Update Existing Data
+
+- Match incoming records against stable entities.
+- Detect new records.
+- Detect changed records.
+- Detect unavailable records.
+- Detect returned records.
+- Preserve previous values.
+- Create field-level Change Events.
+- Update current state.
+- Save a Crawl Snapshot.
+- Preserve full history.
+
+## Full Rebuild
+
+- Show a clear warning.
+- Create a backup or archive.
+- Let the user choose Archive or Replace.
+- Never destroy old data silently.
+- Provide a rollback path.
+
+# 14. Record identity and conflict resolution
+
+Separate the internal entity from its current source identity.
+
+```text
+Record Entity ID
+A permanent internal identity.
+
+Source Identity
+URL, SKU, source ID, canonical URL, or composite key.
+
+Identity Aliases
+Previous URLs, SKUs, IDs, and known identities.
+```
+
+Matching priority may include:
+
+1. Stable source ID.
+2. SKU.
+3. Canonical URL.
+4. Composite key.
+5. Known identity aliases.
+6. Similarity matching.
+7. Requires Review.
+
+Composite keys must be configurable.
+
+If the system suspects that an incoming record matches an existing entity but cannot safely confirm it, create a `Requires Review` item.
+
+Provide a Review Queue:
+
+```text
+POSSIBLE MATCH
+
+Existing Record
+Incoming Record
+Match Confidence
+Matched Fields
+Conflicting Fields
+
+Keep Separate
+Merge Records
+Review Later
+```
+
+Manual merges must:
+
+- Preserve price history.
+- Preserve previous identities.
+- Create aliases.
+- Create an audit record.
+- Support Undo Merge.
+- Prevent the same conflict from repeatedly returning.
+
+# 15. Historical changes and price monitoring
+
+Maintain separate current-state and historical-change layers.
+
+```text
+CURRENT RECORD
+
+Record Entity ID
+Current Values
+Current Availability
+First Seen
+Last Seen
+Last Updated
+```
+
+```text
+CHANGE EVENT
+
+Record Entity ID
+Field Key
+Previous Value
+New Value
+Detected At
+Crawl Job ID
+Change Type
+```
+
+## Price-history storage semantics
+
+The owner-facing price history is a timeline of real price changes, not a daily
+copy of an unchanged price row.
+
+For each source-scoped offer identity, including its product, variant, region,
+branch, customer segment, selling unit, currency, and VAT basis:
+
+- Store the first detected price.
+- Compute a normalized `price_hash` from the comparable price, currency, and VAT
+  basis.
+- When a successful refresh sees the same `price_hash`, do not append a price
+  observation, price-history row, or price change event. Update only the current
+  state's `last_seen_at` and the active price period's `last_confirmed_at`.
+- When the `price_hash` changes, append exactly one immutable price observation
+  and change event, close the previous price period, and open a new price period.
+- Track availability and stock with a separate state hash so that a stock change
+  does not create a false price change.
+- Failed, partial, cancelled, or out-of-scope runs must not advance
+  `last_confirmed_at` and must not mark products unavailable.
+- If an offer disappears and later returns, open a new price period even when the
+  returned price equals the old price; continuity during the absence is unknown.
+
+The permanent price model must distinguish:
+
+```text
+CURRENT OFFER STATE
+Latest price and availability for fast reads.
+Updated in place after a successful refresh.
+
+PRICE PERIOD
+One row per continuous confirmed price period.
+Contains first_detected_at and last_confirmed_at.
+
+PRICE OBSERVATION / CHANGE EVENT
+Append-only evidence for the first price and each real change.
+Existing rows are never updated or deleted.
+
+SCRAPE RUN
+One audit row per refresh, including scope, completion status, row counts, and
+errors.
+
+ABSENCE PERIOD
+Created only when a successfully completed full-scope run does not see an
+expected offer. It records disappearance and return transitions, not unchanged
+daily confirmations.
+```
+
+Do not persist a full per-offer seen row for every successful daily refresh.
+The run may use a staging table or an in-memory seen set while finalizing. After
+the run has updated current state, price periods, and absence transitions, the
+staging seen set may be discarded. Raw snapshots remain the recoverable source
+evidence under their configured retention policy.
+
+Exact-date price lookup must behave as follows:
+
+- If a successful in-scope run confirms the offer on the requested date, return
+  the price period that covered that confirmation.
+- If no reliable observation exists on that date, say so explicitly and return
+  the last known price before that date together with its observation date.
+- If the requested date is before tracking began, report the first tracking date.
+- If the relevant run failed or was partial, report that the date has no reliable
+  observation rather than assuming the previous price remained valid.
+
+The product price-history view must list only the first detected price and each
+subsequent real price change, ordered from the beginning of tracking through the
+last confirmed price. Daily unchanged confirmations must not appear as duplicate
+history rows.
+
+Support:
+
+- New records.
+- Updated records.
+- Price increases.
+- Price decreases.
+- Unchanged records as current-state confirmations without duplicate historical rows.
+- Unavailable records.
+- Returned records.
+- Removed records.
+- Crawl errors.
+- Comparison between any two snapshots.
+- First recorded price.
+- Current price.
+- Minimum price.
+- Maximum price.
+- Absolute change.
+- Percentage change.
+- Exact-date price lookup with an explicit last-known fallback.
+- A change-only price timeline from first detection through last confirmation.
+
+# 16. Output destinations
+
+The Local Database must be enabled by default.
+
+Allow multiple destinations for the same run:
+
+```text
+DATA OUTPUT
+
+Domain-owned Local Database
+Excel Files
+Google Sheets via Apps Script
+Google Drive and Sheets
+```
+
+The domain-owned local databases remain the sources of truth.
+
+# 17. Local storage settings
+
+Provide separately for General Scrape and MarketLens:
+
+- Current database locations.
+- Change Storage Location.
+- Open Storage Folder.
+- Database size.
+- Database health.
+- Backup.
+- Restore.
+- Repair.
+- Compact Database.
+- Export Database.
+- Storage migration progress.
+
+Also provide a full Workspace Backup that packages two independently restorable
+database snapshots plus a manifest and checksums. Restoring one domain must not
+roll back or replace the other domain.
+
+When changing storage location:
+
+- Validate permissions.
+- Detect unavailable or removable drives.
+- Explain whether existing data will move.
+- Never overwrite a database silently.
+- Create a recoverable backup.
+- Provide rollback.
+- Report migration progress.
+- Move only the selected domain database and its domain-owned evidence files.
+- Never silently repoint the other domain.
+
+# 18. Data retention
+
+Provide configurable retention policies:
+
+```text
+CHANGE HISTORY RETENTION
+
+Keep detailed history for:
+90 days
+
+After that:
+Keep daily summaries
+Keep weekly summaries
+Archive old history
+Delete permanently
+```
+
+Always allow preserving:
+
+- First recorded value.
+- Latest value.
+- Minimum price.
+- Maximum price.
+- Important user-marked events.
+
+Provide:
+
+- Retention preview.
+- Estimated recovered space.
+- Dataset-level exclusions.
+- Backup before destructive cleanup.
+- Storage usage warnings.
+- Automatic database maintenance.
+
+# 19. Excel output
+
+Excel is an optional output destination.
+
+Support:
+
+```text
+WORKBOOK STRUCTURE
+
+One workbook for all sites
+Separate workbook for each site
+```
+
+For a combined workbook, use separate sheets where schemas differ.
+
+Support:
+
+```text
+UPDATE BEHAVIOR
+
+Update existing rows
+Create a new snapshot sheet
+Create a new dated workbook
+```
+
+Provide:
+
+- Change Save Location.
+- Open Output Folder.
+- Export Current View.
+- Export Original Schema.
+- Export Change History.
+- Last Export Status.
+
+Preserve Arabic data correctly.
+
+# 20. Browse Data inside the Side Panel
+
+Browse Data in the Side Panel is a compact preview, not a full analytics table.
+
+Show:
+
+- Dataset list.
+- Record count.
+- Last update.
+- Change summary.
+- Recent records.
+- Compact Card View.
+- Basic search.
+- Basic filters.
+- Open in Workspace.
+
+Example:
+
+```text
+DATASETS
+
+Example Store
+1,842 records
+Updated 12 minutes ago
+34 changed · 15 new · 3 unavailable
+
+Open Dataset
+```
+
+When a dataset is opened inside the Side Panel, use compact cards and limited fields.
+
+Use virtualization for long lists.
+
+# 21. Full-page Workspace
+
+Provide an `Open in Workspace` action that opens a full extension page in a browser tab.
+
+The Workspace must contain:
+
+- Overview.
+- Data.
+- Changes.
+- Crawl History.
+- Review Queue.
+- Jobs.
+- Schedules.
+- Sync.
+- Exports.
+- Logs.
+
+The Data area must support:
+
+- Dynamic table schemas.
+- Search.
+- Filters.
+- Sorting.
+- Pagination or virtualization.
+- Column resizing.
+- Column reordering.
+- Manage Columns.
+- Show Hidden Columns.
+- Saved Views.
+- Snapshot comparison.
+- Export.
+- Sync.
+- Full-page horizontal scrolling when genuinely required.
+
+# 22. Schema and column safety
+
+Never treat a presentation change as a destructive schema change.
+
+Every field must support:
+
+```text
+Source Key
+Original Name
+Display Name
+Data Type
+Visibility
+Display Order
+```
+
+Rules:
+
+- Source Key is stable and immutable.
+- Original Name is preserved.
+- Display Name is user-editable.
+- Selecting X sets the field to Hidden.
+- Selecting X never deletes the field or its data.
+- Hidden fields continue receiving future updates.
+- Users can show hidden fields again.
+- Users can reset names.
+- Users can reset layout.
+- Users can restore the default view.
+- Users can save multiple views.
+- Export and sync can use either Original Schema or Current View.
+- Destructive deletion requires explicit confirmation.
+
+# 23. Job execution and lifecycle
+
+Persist every job in the database.
+
+Support states equivalent to:
+
+- Scheduled.
+- Queued.
+- Preparing.
+- Running.
+- Pausing.
+- Paused.
+- Resuming.
+- Cancelling.
+- Cancelled.
+- Completed.
+- Partially Completed.
+- Failed.
+- Requires Review.
+
+Persist:
+
+- Job ID.
+- Site IDs.
+- Run mode.
+- Current stage.
+- Progress.
+- Counters.
+- Checkpoint.
+- Started time.
+- Last heartbeat.
+- Retry count.
+- Output status.
+- Error summary.
+
+Closing the Side Panel must not stop the job.
+
+Reopening the Side Panel must retrieve and display the current state.
+
+# 24. Active Job mini-player
+
+Add a persistent mini-player above bottom navigation when a job is active.
+
+Example:
+
+```text
+Amazon Update                         63%
+Processing 8,420 of 10,000
+1 running · 2 queued
+
+View Job
+Pause
+```
+
+The mini-player remains visible while the user moves between:
+
+- Run.
+- Browse Data.
+- Settings.
+- Add Site.
+
+Selecting it opens the full job details.
+
+# 25. Activity and logging
+
+Do not add one UI row for every processed product.
+
+The Local Runtime must store the complete technical log.
+
+The Side Panel displays:
+
+- Aggregated progress.
+- Current step.
+- Current site.
+- Current counters.
+- Last 200 log entries only.
+
+Use a fixed-size Ring Buffer for UI logs.
+
+Use virtualization for visible log rows.
+
+Throttle UI progress updates instead of rendering every internal event.
+
+Show:
+
+- Overall percentage.
+- Current site.
+- Current stage.
+- Records discovered.
+- Records processed.
+- Records created.
+- Records updated.
+- Records unchanged.
+- Warnings.
+- Errors.
+- Elapsed time.
+- Per-site progress.
+
+Include:
+
+- Show Technical Details.
+- Pause Auto-scroll.
+- Copy Visible Logs.
+- Download Full Logs.
+- Open Logs Folder.
+- Pause.
+- Resume.
+- Cancel Run.
+- Retry Failed Step.
+- Open Dataset after completion.
+
+# 26. Scheduling
+
+Provide scheduling inside Site Settings.
+
+Support:
+
+- Manual.
+- Daily.
+- Weekly.
+- Custom schedule when appropriate.
+- Time selection.
+- Time zone.
+- Offline behavior.
+- Missed-run behavior.
+- Overlapping-run policy.
+- Retry policy.
+- Completion notifications.
+- Failure notifications.
+- Change-detected notifications.
+
+Example:
+
+```text
+SCHEDULE
+
+Frequency
+Daily
+
+Run At
+09:00 AM
+
+Time Zone
+Asia/Riyadh
+
+If Device Was Offline
+Run when available
+
+Overlapping Runs
+Queue new run
+```
+
+Use the Local Runtime scheduler for reliable scheduling.
+
+Use `chrome.alarms` only as browser-side coordination or fallback.
+
+Do not claim that browser alarms can wake a sleeping or powered-off device.
+
+If scheduling must work while Chrome is closed, implement an explicit user-approved Local Runtime background service or OS-level scheduling integration.
+
+Clearly explain the behavior to the user in English.
+
+# OS Resource and Hardware Management
+
+Background jobs must not freeze the user's operating system or aggressively drain device batteries.
+
+Implement:
+- Hardware-aware concurrency limits (detect available CPU cores and RAM).
+- Eco Mode: Automatically pause or throttle intensive jobs (like browser automation) when the device is running on battery power.
+- System wake/sleep awareness to safely checkpoint and suspend running jobs when the OS goes to sleep.
+
+
+# 27. Apps Script integration
+
+Generate Apps Script code that users can copy into Google Sheets.
+
+Setup interface:
+
+```text
+GOOGLE SHEETS — APPS SCRIPT
+
+1. Create or open a Google Sheet
+2. Open Extensions → Apps Script
+3. Paste the generated code
+4. Run the setup function
+5. Deploy the script
+6. Paste the deployment URL below
+```
+
+Include:
+
+- Copy Script.
+- Deployment URL.
+- Test Connection.
+- Save Connection.
+- Regenerate Secret.
+- Revoke Connection.
+- Last Sync.
+- Sync Now.
+- Connection Logs.
+
+The generated Apps Script must:
+
+- Create required sheets.
+- Create and update headers.
+- Insert new records.
+- Update existing records.
+- Preserve supported user customizations.
+- Read existing sheet data when required.
+- Synchronize current data.
+- Synchronize change history optionally.
+- Resume interrupted synchronization.
+- Prevent duplicate records.
+- Support explicit full recreation.
+
+All generated code and comments must be written in English.
+
+# 28. Apps Script security
+
+Do not rely on a permanent hard-coded bearer token.
+
+Use a cryptographically secure connection secret.
+
+Prefer:
+
+- A 256-bit random secret.
+- Secure local storage managed by Local Runtime.
+- Apps Script `Script Properties`.
+- HMAC request signing.
+- Timestamp.
+- Nonce.
+- Replay protection.
+- Revocation.
+- Regeneration.
+- Rate limiting.
+- Constant-time signature comparison when possible.
+
+Do not place secrets in URLs.
+
+If standard HTTP authorization headers are not reliably available to Apps Script `doPost`, include the signature metadata inside the JSON request body.
+
+# 29. Apps Script batching and recovery
+
+Never send an entire large dataset in one request.
+
+Use adaptive batching based on:
+
+- Encoded payload size.
+- Row count.
+- Column count.
+- Remaining execution time.
+- Previous response time.
+- Retry history.
+
+Do not assume that 1,000 records are always an appropriate batch.
+
+Persist:
+
+```text
+Sync Session ID
+Dataset ID
+Snapshot ID
+Batch Number
+Total Batches
+Cursor
+Checksum
+Attempt Number
+Status
+Acknowledged At
+```
+
+The synchronization process must be:
+
+- Resumable.
+- Idempotent.
+- Checkpointed.
+- Retryable.
+- Duplicate-safe.
+- Observable.
+
+Use:
+
+- Batch acknowledgements.
+- Checksums.
+- Exponential backoff.
+- Time-budget guards.
+- Concurrency control.
+- Partial-failure reporting.
+- Resume from the last acknowledged batch.
+
+Verify current official Google limits during implementation rather than relying on permanently hard-coded quota assumptions.
+
+# 30. Direct Google integration
+
+Provide a separate direct integration using:
+
+- Continue with Google.
+- Google Drive API.
+- Google Sheets API.
+
+Allow users to:
+
+- Connect a Google account.
+- View the connected account.
+- Select or create a Drive folder.
+- Create spreadsheets.
+- Organize files.
+- Synchronize existing datasets.
+- Create missing headers.
+- Update existing rows.
+- Create snapshots.
+- View the last sync result.
+- Reconnect after authorization expires.
+- Disconnect the account.
+
+Organization options:
+
+```text
+FILE ORGANIZATION
+
+One spreadsheet per site
+One spreadsheet per crawl
+Combined spreadsheet
+```
+
+Request only required permissions.
+
+Store OAuth credentials securely.
+
+Implement:
+
+- Adaptive request batching.
+- Quota awareness.
+- Exponential backoff.
+- Resumable synchronization.
+- Clear error reporting.
+
+# 31. Google Sheet conflict policy
+
+The Local Database remains the source of truth by default.
+
+Provide explicit sync policies:
+
+```text
+SYNC DIRECTION
+
+Local Database to Google Sheets
+Two-way Sync
+```
+
+For two-way sync, define:
+
+- System-owned fields.
+- User-editable fields.
+- Conflict detection.
+- Local wins.
+- Google Sheet wins.
+- Requires Review.
+- Last-write metadata.
+- Audit history.
+
+Never overwrite a manual Google Sheet edit silently when two-way sync is enabled.
+
+# 32. Multi-engine orchestration
+
+Do not hard-code a single engine.
+
+Support:
+
+- Automatic engine recommendation.
+- Preferred engine.
+- Ordered fallback engines.
+- Capability detection.
+- Dependency checks.
+- Per-site engine profiles.
+- Per-step retries.
+- Manual override.
+- Structured failure reasons.
+
+The execution log must show:
+
+- Selected engine.
+- Why it was selected.
+- Engine switches.
+- Fallback reasons.
+- Retry attempts.
+- Final failure reason.
+
+# Proxy and Anti-Bot Management
+
+Engine orchestration must handle anti-bot detection intelligently without causing permanent IP bans.
+
+Support:
+- Proxy configuration per site or globally.
+- Residential and Datacenter proxy types.
+- Automatic IP rotation per request or per session.
+- Advanced browser fingerprint spoofing (e.g., modifying User-Agent, WebGL, canvas, and timezone metadata when using automated browsers).
+- Rate-limit awareness and automatic cooldowns.
+
+Do not permanently burn user IP addresses through aggressive retries on blocked access.
+
+# Adapter Drift and Dynamic Maintenance
+
+Website DOM structures and internal APIs change frequently, breaking hard-coded Site Adapters. 
+
+The system must:
+- Detect Adapter Breakdown: Identify when a previously successful site adapter experiences a sudden, extreme drop in success rates.
+- Display an explicit `Adapter Outdated` status instead of a generic `Failed` error.
+- Support dynamic fetching of updated adapter rules or configurations without requiring a full application update.
+- Allow users to report broken adapters directly from the Side Panel.
+
+# 33. Settings structure
+
+Organize Settings into:
+
+- General.
+- Local Runtime.
+- Storage.
+- Crawling.
+- Engines.
+- Jobs and Scheduling.
+- Excel.
+- Apps Script.
+- Google Account.
+- Data and History.
+- Privacy and Security.
+- Logs and Diagnostics.
+- About.
+
+Use progressive disclosure.
+
+Do not place every setting on one long screen.
+
+# 34. Security and data safety
+
+Treat all scraped content as untrusted.
+
+Implement:
+
+- Output sanitization.
+- XSS prevention.
+- Message validation.
+- Command authorization.
+- Native host origin restrictions.
+- Secure secret storage.
+- Path validation.
+- Safe file creation.
+- Database transactions.
+- Backup before destructive operations.
+- Audit logs.
+- Runtime version compatibility checks.
+- Protection against duplicate jobs.
+- Concurrency limits.
+- Safe cancellation.
+
+Never execute remotely downloaded code inside the extension.
+
+Comply with current browser-extension platform requirements.
+
+# 35. Required UX states
+
+Design and implement:
+
+- First launch.
+- Runtime not installed.
+- Runtime checking.
+- Runtime ready.
+- Runtime update required.
+- Runtime disconnected.
+- Empty site list.
+- Add Site.
+- Site test running.
+- Site test failed.
+- No selected sites.
+- Initial crawl.
+- Update existing data.
+- Full rebuild warning.
+- Multi-site run.
+- Scheduled run.
+- Queued job.
+- Paused job.
+- Cancelled job.
+- Partial success.
+- Complete success.
+- Failed run.
+- Requires Review.
+- Empty dataset.
+- Dataset loading.
+- Dynamic schema.
+- Hidden columns.
+- No detected changes.
+- Sync pending.
+- Sync running.
+- Sync partially completed.
+- Sync successful.
+- Sync failed.
+- Google disconnected.
+- Apps Script not configured.
+- Storage location unavailable.
+- Database migration.
+- Database backup.
+- Database recovery.
+
+# 36. Accessibility and responsive behavior
+
+- Optimize the Side Panel for approximately 320px–400px widths.
+- Avoid horizontal scrolling in the main Side Panel.
+- Use Card View or compact previews for records.
+- Use the Full Workspace for complex tables.
+- Use keyboard navigation.
+- Use accessible names and labels.
+- Use visible focus states from the existing theme.
+- Keep primary actions discoverable.
+- Do not rely only on icons.
+- Use confirmation dialogs only for destructive actions.
+- Preserve scroll position where appropriate.
+- Handle long URLs safely.
+- Use `dir="auto"` or equivalent for scraped values.
+- Force technical content to LTR.
+- Test mixed Arabic and English data.
+
+# 37. Testing requirements
+
+Add tests for:
+
+- Closing and reopening the Side Panel during a job.
+- Runtime disconnection and reconnection.
+- Job checkpoint recovery.
+- Initial Crawl.
+- Update Existing Data.
+- Full Rebuild backup.
+- Composite identity matching.
+- Requires Review.
+- Merge and Undo Merge.
+- Price history preservation.
+- Column rename without source-key mutation.
+- Column hiding without data deletion.
+- Apps Script batch retry.
+- Duplicate batch prevention.
+- Interrupted sync resume.
+- Google authorization expiration.
+- Storage migration failure.
+- Scheduled-run recovery.
+- Arabic data rendering.
+- Native Messaging pagination.
+- Log Ring Buffer behavior.
+- Large dataset virtualization.
+- XSS sanitization.
+
+# 38. Expected implementation quality
+
+- Use reusable components.
+- Use typed domain models.
+- Use explicit state machines where helpful.
+- Separate UI, domain logic, execution, storage, and synchronization.
+- Do not hard-code site schemas.
+- Do not hard-code one engine.
+- Do not hard-code one output.
+- Do not store complete datasets in UI state.
+- Do not stream one UI log event per product.
+- Do not couple jobs to the Side Panel lifecycle.
+- Clearly identify mock and production integrations.
+- Add validation and structured recovery.
+- Preserve existing project conventions.
+- Verify realistic Side Panel dimensions.
+- Verify the Full Workspace separately.
+- Keep code comments in English.
+
+# 39. Final implementation phases
+
+Complete the work in these phases:
+
+1. Inspect the existing project.
+2. Explain your understanding to me in Arabic.
+3. Present the implementation plan in Arabic.
+4. Define the architecture and responsibility boundaries.
+5. Define the domain and state models.
+6. Implement Local Runtime communication abstractions.
+7. Implement the Side Panel.
+8. Implement the active-job mini-player.
+9. Implement the Full Workspace.
+10. Implement dataset and schema customization.
+11. Implement job persistence and lifecycle recovery.
+12. Implement scheduling.
+13. Implement Excel output.
+14. Implement Apps Script synchronization.
+15. Implement direct Google integration.
+16. Implement identity conflict review.
+17. Implement logging, retention, backup, and recovery.
+18. Test critical workflows.
+19. Visually inspect realistic Side Panel and Workspace dimensions.
+20. Report completed work, assumptions, limitations, test results, and next steps to me in Arabic.
+
+The final product must feel like a focused, reliable, local-first crawling and data synchronization platform specifically designed around a browser Side Panel and a full data-management Workspace.
+
+# 40. Incremental Evolution into a Generic Crawling and Data-Modeling Platform
+
+## Mission
+
+Evolve ScrapeX incrementally from its current product-and-price tracking system into a generic, metadata-driven crawling, extraction, and data-modeling platform.
+
+The final platform should be capable of:
+
+- Crawling broadly different website structures.
+- Discovering multiple datasets within the same site or page.
+- Extracting HTML tables, repeated DOM structures, structured data, embedded JSON, REST APIs, GraphQL responses, and browser-observed network data.
+- Inferring dynamic schemas whose columns may appear, disappear, change names, or change types over time.
+- Detecting and managing multiple datasets per site.
+- Inferring and reviewing relationships between datasets.
+- Building a versioned site-specific data model.
+- Preserving raw source evidence, historical revisions, provenance, and schema history.
+- Presenting dynamic datasets, columns, relationships, and crawl state through the Side Panel and Full Workspace.
+- Exporting either the original discovered schema or a user-customized view.
+- Keeping the existing price-tracking domain fully operational throughout the evolution.
+
+This is an evolutionary program, not a rewrite.
+
+## Prime Directive: Extend, Preserve, and Migrate Incrementally
+
+Never destroy and rebuild the existing product merely to obtain a cleaner architecture.
+
+Before implementing any capability:
+
+1. Inspect the current repository and identify existing components that already solve part of the problem.
+2. Reuse or extend those components wherever doing so preserves correctness.
+3. Introduce a compatibility seam when the existing design is too specialized.
+4. Move one vertical slice at a time through the new seam.
+5. Keep the old path operational until the replacement path has proven behavioral parity.
+6. Remove or retire an old path only after:
+   - Its replacement is complete.
+   - Migration is tested.
+   - Existing data remains readable.
+   - Rollback is possible.
+   - The user has explicitly approved retirement.
+
+Do not perform speculative large-scale refactoring.
+
+Do not rename, relocate, or rewrite stable modules unless the current increment genuinely requires it.
+
+Do not mix architectural cleanup with unrelated feature work.
+
+Every increment must leave the application runnable, testable, and recoverable.
+
+Repository behavior and tests are the ground truth. If this plan conflicts with proven repository behavior, report the conflict before changing the behavior.
+
+## Existing Capabilities That Must Be Preserved
+
+Treat the following as valuable working assets rather than temporary code:
+
+- Existing product and price ingestion.
+- Append-only price observation history. Existing observations are immutable;
+  the optimized price path may reduce future write frequency by appending only
+  the first price and real changes, as defined in section 15, but it must never
+  rewrite or delete legacy observations.
+- Current connectors and fetchers.
+- Job persistence, pause, resume, cancellation, and checkpoint recovery.
+- Native Messaging and localhost communication.
+- Side Panel and active-job mini-player.
+- Full Workspace.
+- Storage, backup, restore, migration, and retention mechanisms.
+- Column customization and saved views.
+- Excel, Apps Script, and direct Google output paths.
+- Review Queue and identity conflict decisions.
+- Arabic content normalization and bidirectional rendering.
+- Existing tests, fixtures, screenshots, and public contracts.
+
+The price engine must become the first specialized domain built on, or interoperating with, the generic platform. It must not be discarded.
+
+The price-history optimization in section 15 is the owner-approved target for
+that specialized domain. It must be introduced through additive schema,
+backfilled projections, compatibility tests, and a reversible cutover. Generic
+phases do not have implicit permission to repurpose `generic_record`, rewrite
+`price_observation`, or weaken existing price workflows while implementing this
+optimization.
+
+## Honest Definition of “Generic”
+
+Do not claim that ScrapeX can scrape literally every website.
+
+A generic platform means:
+
+- It supports several reusable extraction patterns.
+- It can describe site-specific behavior through versioned metadata.
+- It provides an adapter mechanism for exceptional sites.
+- It reports unsupported, blocked, ambiguous, or authentication-dependent cases honestly.
+- It never silently returns incomplete or structurally incorrect data.
+- It distinguishes crawler failure, extractor failure, schema drift, access denial, and unsupported structure.
+
+CAPTCHAs, strong anti-bot systems, inaccessible authenticated content, legal restrictions, and highly interactive applications may still require user intervention or a specialized adapter.
+
+## Architectural Direction
+
+Separate the following responsibilities:
+
+```text
+Site Project
+    ↓
+Crawl Plan
+    ↓
+URL Frontier
+    ↓
+Fetcher
+    ↓
+Page Snapshot
+    ↓
+Dataset Discovery
+    ↓
+Extraction Plan
+    ↓
+Schema Inference
+    ↓
+Generic Records
+    ↓
+Identity Resolution
+    ↓
+Relationship Inference
+    ↓
+Versioned Site Data Model
+    ↓
+Workspace / Export / Sync
+```
+
+### Crawl and Scrape Are Different Operations
+
+`Crawl` discovers and revisits pages.
+
+`Scrape` extracts one or more datasets from a page or response.
+
+Do not couple URL discovery to product extraction.
+
+The crawler must be able to discover pages even when no extraction rule has been approved yet.
+
+The extractor must be able to run against a saved page snapshot without repeating a network request.
+
+### Domain Type and Extraction Method Are Different Concepts
+
+Do not use one enum to represent both what the data means and how it was obtained.
+
+Keep separate concepts such as:
+
+```text
+Domain:
+- generic
+- prices
+- listings
+- documents
+- user-defined
+
+Extraction Method:
+- html_table
+- repeated_dom
+- json_array
+- json_path
+- json_ld
+- embedded_json
+- rest_api
+- graphql
+- browser_network
+- custom_adapter
+```
+
+A dataset may use any extraction method without being classified as product or price data.
+
+## Operational Database Isolation — Owner Decision
+
+General Scrape and the specialized price-tracking domain, named `MarketLens`,
+must use physically separate SQLite database files.
+
+```text
+Local Runtime / Workspace
+    ├── GeneralScrapeService
+    │       └── GeneralRepository
+    │               └── ~/.scrapex/general/general.db
+    └── MarketLensService
+            └── MarketLensRepository
+                    └── ~/.scrapex/marketlens/marketlens.db
+```
+
+The Local Runtime and Workspace may be shared. Operational tables, migration
+streams, connections, locks, jobs, schedules, and retention state must not be
+shared.
+
+### General Scrape Ownership
+
+The General Scrape database owns only generic crawling and data-modeling state,
+including concepts equivalent to:
+
+```text
+SiteProject
+CrawlPlan
+URLFrontier
+GenericCrawlRun
+CrawlPage
+GenericPageSnapshot
+PageType
+DatasetDefinition
+DatasetCandidate
+DatasetSchemaVersion
+FieldDefinition
+ExtractionRule
+GenericRecord
+RecordRevision
+RelationshipDefinition
+RecordRelationship
+AdapterDefinition
+AdapterVersion
+SchemaChange
+GenericJob
+GenericSchedule
+GenericExportRun
+GenericSyncRun
+```
+
+It must not own MarketLens products, variants, offers, current prices, price
+periods, price changes, price absence state, or price retention rules.
+
+### MarketLens Ownership
+
+The MarketLens database owns only price-tracking operational state, including
+concepts equivalent to:
+
+```text
+Store
+StoreProduct
+StoreVariant
+StoreOffer
+OfferCurrentState
+PricePeriod
+PriceObservation
+PriceChangeEvent
+AbsencePeriod
+ProductIdentityAlias
+MarketLensCrawlRun
+MarketLensJob
+MarketLensSchedule
+PriceReviewDecision
+PriceRetentionPolicy
+PriceRetentionPin
+MarketLensExportRun
+MarketLensSyncRun
+```
+
+The offer remains the price-tracking grain. Product, variant, branch, region,
+customer segment, selling unit, currency, and VAT basis must not be collapsed
+into a product-only price key.
+
+### Hard Isolation Rules
+
+- Do not place General Scrape and MarketLens operational tables in the same
+  SQLite file.
+- Do not use SQLite `ATTACH` as an application integration mechanism.
+- Do not create cross-database foreign keys or depend on matching integer row
+  identifiers across the two domains.
+- Do not pass an untyped generic `sqlite3.Connection` into both domains.
+- Use explicit `GeneralDatabase`, `MarketLensDatabase`, `GeneralRepository`, and
+  `MarketLensRepository` boundaries.
+- Give each database a different SQLite `application_id`, a required
+  `database_kind` marker, an independent schema checksum, and an independent
+  migration version. Refuse to open a database through the wrong domain type.
+- Use separate write locks, backup folders, raw-evidence namespaces, retention
+  policies, and storage-health status.
+- A failed migration, repair, restore, compaction, crawl, or long write in one
+  domain must not block, roll back, or corrupt the other domain.
+
+### Shared Code, Independent Instances
+
+The domains may share genuinely cross-cutting libraries such as HTTP clients,
+browser fetchers, scheduler primitives, structured logging helpers, hashing,
+normalization, backup utilities, UI design tokens, and error models.
+
+Shared libraries must be instantiated separately for each domain:
+
+```text
+GeneralScheduler instance  → General database and lock
+MarketLensScheduler instance → MarketLens database and lock
+```
+
+MarketLens owns its business rules, repositories, job definitions, schedules,
+configuration, operational logs, and recovery behavior even when their
+implementation uses shared infrastructure libraries.
+
+### Site Identity Across Domains
+
+The same website may exist independently in both databases. A stable string
+such as `site_key` may be shown consistently in the Workspace, but it is not a
+cross-database foreign key.
+
+```text
+general.db:    SiteProject(site_key = example_store)
+marketlens.db: Store(site_key = example_store)
+```
+
+Deleting, rebuilding, restoring, or disabling one definition must not mutate the
+other. If the owner chooses `Track prices` for a generic dataset, General Scrape
+must produce a versioned import payload. MarketLens validates and imports that
+payload idempotently into its own identities and tables.
+
+### Cross-Domain Communication
+
+Do not attempt a distributed transaction across both SQLite files. Use explicit,
+versioned import/export payloads with idempotency keys and an outbox or receipt
+when acknowledgement is required.
+
+```text
+General dataset
+    → versioned transfer payload
+    → MarketLens import validation
+    → MarketLens-owned product and offer identities
+    → import receipt
+```
+
+A transfer failure must remain retryable without leaving either database in a
+half-committed state.
+
+### API and Workspace Boundaries
+
+Namespace the APIs and route every request through the correct repository:
+
+```text
+/api/general/sites
+/api/general/datasets
+/api/general/crawls
+
+/api/marketlens/products
+/api/marketlens/prices
+/api/marketlens/history
+/api/marketlens/runs
+```
+
+The Workspace may present one product, but its General Scrape and MarketLens
+screens must remain visibly distinct. A combined dashboard is an application-
+layer composition of bounded API results, never a cross-database SQL join.
+
+### Independent Backup and Restore
+
+Use domain-owned locations equivalent to:
+
+```text
+~/.scrapex/backups/general/
+~/.scrapex/backups/marketlens/
+~/.scrapex/evidence/general/
+~/.scrapex/evidence/marketlens/
+```
+
+A full Workspace Backup is a package containing two verified SQLite snapshots,
+their evidence manifests, schema versions, and checksums. Each snapshot remains
+independently restorable. The UI must state exactly which domain a storage action
+will affect before it runs.
+
+### Migration from the Unified Warehouse
+
+The split must be additive, verified, reversible, and must not delete or update
+an existing `price_observation`:
+
+1. Create the empty General Scrape and MarketLens databases beside the current
+   unified warehouse.
+2. Give each database its own migration runner, lock, kind marker, application
+   ID, schema checksum, and backup lineage.
+3. Copy generic catalogue, schema, snapshot, record, revision, relationship, and
+   generic workflow data into General Scrape while preserving domain IDs.
+4. Copy stores, products, variants, offers, identity aliases, price observations,
+   price changes, price workflow state, and price retention data into MarketLens
+   while preserving all historical relationships.
+5. Rebuild derived current-state and price-period projections from immutable
+   observations; never make the copied projection the only migration evidence.
+6. Validate row counts, foreign keys, hashes, first/latest/minimum/maximum prices,
+   current price per offer, change timelines, job lineage, and snapshot references.
+7. Run shadow reads through both the legacy and separated repositories and refuse
+   cutover on any mismatch.
+8. Pause new jobs, take a final consistent backup, copy the final delta, switch
+   domain routes and workers, and run smoke tests.
+9. Keep a reversible pointer or feature-flag cutover. A rollback must restore both
+   old routing and job ownership without rewriting history.
+10. Seal the unified warehouse read-only after verification and retain it as a
+    recoverable archive. Never delete it automatically.
+
+Do not introduce dual writes to both the unified and separated operational
+schemas as the long-term design. Use a short, explicit cutover window instead.
+
+## Generic Metadata Model
+
+Introduce the generic model through additive migrations owned exclusively by the
+General Scrape database.
+
+At minimum, support concepts equivalent to:
+
+```text
+SiteProject
+CrawlPlan
+CrawlRun
+CrawlPage
+PageSnapshot
+PageType
+DatasetDefinition
+DatasetCandidate
+DatasetSchemaVersion
+FieldDefinition
+ExtractionRule
+GenericRecord
+RecordRevision
+RelationshipDefinition
+RecordRelationship
+AdapterDefinition
+AdapterVersion
+SchemaChange
+```
+
+### Dataset Definition
+
+A dataset definition should identify:
+
+- Stable dataset key.
+- User-facing name.
+- Source page type.
+- Extraction method.
+- Source selector, JSON path, or response path.
+- Cardinality.
+- Pagination strategy.
+- Identity strategy.
+- Current schema version.
+- Adapter version.
+- Dataset status.
+- Provenance and timestamps.
+
+### Field Definition
+
+A field definition should preserve:
+
+```text
+field_key
+source_name
+display_name
+source_path
+data_type
+nullable
+repeated
+key_role
+position
+confidence
+first_seen_at
+last_seen_at
+status
+```
+
+Rules:
+
+- `field_key` is stable and internal.
+- `source_name` preserves the exact source label or property name.
+- `display_name` is a presentation preference.
+- Renaming a display name never changes source identity.
+- Hiding a field never deletes it.
+- Missing fields remain in schema history.
+- New fields create a new schema version.
+- Type changes are recorded, not silently overwritten.
+- Automatic widening is allowed only through safe rules such as `integer → decimal → text`.
+- Automatic narrowing is forbidden.
+- Objects and arrays must remain representable without flattening away information.
+
+### Generic Record Storage
+
+Do not create an uncontrolled physical SQL table for every detected HTML table.
+
+Prefer a hybrid model:
+
+- Metadata tables describe datasets, fields, schemas, and relationships.
+- Each record stores its canonical values as validated JSON.
+- Frequently searched or indexed fields may receive explicit projections.
+- Record revisions preserve historical changes.
+- Raw snapshots remain available for re-extraction and audit.
+- Materialized views may be created for performance, but they are derived and rebuildable.
+
+Every record must preserve:
+
+```text
+record_id
+dataset_id
+record_key
+schema_version_id
+data
+source_page_id
+source_locator
+content_hash
+first_seen_at
+last_seen_at
+status
+```
+
+## Dataset Discovery
+
+Dataset discovery must return candidates, not immediately create permanent datasets.
+
+Initial reusable detectors should include:
+
+1. Semantic HTML tables.
+2. Repeated DOM structures such as cards, rows, listings, and definition blocks.
+3. JSON arrays and nested object collections.
+4. JSON-LD, Microdata, and embedded structured data.
+5. REST and GraphQL response collections.
+6. Browser-observed fetch/XHR responses.
+
+Each candidate should report:
+
+```text
+candidate name
+source type
+source locator
+estimated row count
+sample records
+detected fields
+candidate identity fields
+pagination evidence
+confidence
+warnings
+```
+
+The user must be able to:
+
+- Preview the candidate.
+- Accept or reject it.
+- Rename it.
+- Edit field names and types.
+- Select or define identity fields.
+- Configure pagination.
+- Approve the dataset before persistent ingestion.
+
+Discovery must never pollute the permanent dataset store.
+
+## Dynamic Schema and Schema Drift
+
+Every dataset must have versioned schemas.
+
+When a later crawl differs from the approved schema, classify the difference:
+
+```text
+field_added
+field_missing
+field_renamed_candidate
+field_type_widened
+field_type_conflict
+structure_changed
+identity_field_missing
+relationship_broken
+extractor_failed
+adapter_outdated
+```
+
+Safe additions may be accepted automatically according to dataset policy.
+
+Destructive or ambiguous changes must enter a Schema Review Queue.
+
+Never delete historical values because a field disappeared from the latest page.
+
+Never reuse an old field key for a semantically different field.
+
+Store enough provenance to explain why two fields are believed to represent the same source field.
+
+## Identity Inference
+
+Infer candidate record keys using this order:
+
+1. Explicit source ID.
+2. Stable API identifier.
+3. Declared primary key.
+4. Canonical detail URL.
+5. Highly unique non-null field.
+6. Composite key.
+7. Deterministic fingerprint.
+
+For every suggested key, calculate and display:
+
+- Uniqueness percentage.
+- Null percentage.
+- Duplicate examples.
+- Stability across snapshots.
+- Confidence.
+- Fields used.
+
+Ambiguous identity must enter review.
+
+Never merge records solely because names are similar.
+
+Existing price identity behavior must remain unchanged until the generic identity system proves parity for that domain.
+
+## Relationship Inference
+
+Support relationships between datasets:
+
+```text
+one_to_one
+one_to_many
+many_to_one
+many_to_many
+hierarchical
+```
+
+Use evidence such as:
+
+- Matching primary and foreign-key candidates.
+- Nested JSON ownership.
+- Shared stable identifiers.
+- Detail-page URLs.
+- Parent-child DOM structure.
+- Link targets.
+- Repeated uniqueness and cardinality evidence.
+- User-defined mapping.
+
+A relationship suggestion must include:
+
+```text
+from_dataset
+from_fields
+to_dataset
+to_fields
+cardinality
+confidence
+evidence
+sample_matches
+orphan_count
+conflict_count
+status
+```
+
+Low-confidence relationships must never be activated automatically.
+
+Many-to-many relationships must use an explicit logical junction dataset.
+
+Relationships must be versioned and reviewed when schema drift invalidates their fields.
+
+## Declarative Adapter System
+
+Implement generic extraction first, then use site adapters only for exceptions.
+
+Adapters should preferably be declarative and versioned.
+
+An adapter may define:
+
+- Page-type matching.
+- Crawl scope.
+- URL normalization.
+- Dataset selectors.
+- Field selectors.
+- JSON paths.
+- Pagination rules.
+- Identity rules.
+- Relationship hints.
+- Validation rules.
+- Expected-volume canaries.
+
+Never execute remotely downloaded Python or JavaScript.
+
+Remote updates may provide validated configuration only.
+
+Adapter updates must support:
+
+- Signature or trust verification.
+- Versioning.
+- Compatibility checks.
+- Rollback.
+- Test-fixture validation.
+- Drift detection.
+- Explicit `Adapter Outdated` state.
+
+## User Experience Evolution
+
+Extend the existing Side Panel and Workspace; do not replace them.
+
+The generic Add Site flow should evolve into:
+
+```text
+1. Enter site URL
+2. Configure crawl boundaries
+3. Discover pages
+4. Detect dataset candidates
+5. Preview candidate data
+6. Approve datasets
+7. Review dynamic schemas
+8. Select identity keys
+9. Review relationships
+10. Save the site model
+11. Start the crawl
+```
+
+Add Workspace areas for:
+
+- Pages.
+- Datasets.
+- Schema.
+- Relationships.
+- Data Model.
+- Extraction Rules.
+- Schema Changes.
+- Failed Pages.
+- Raw Snapshots.
+- Crawl Runs.
+
+The Data Model screen should visualize approved datasets and relationships.
+
+Large datasets must use pagination or virtualization.
+
+The table renderer must be generated from the active schema version rather than from hard-coded price columns.
+
+## Incremental Implementation Protocol
+
+Work in small vertical slices.
+
+A vertical slice must include, where applicable:
+
+- Domain model.
+- Database migration.
+- Repository/service logic.
+- API.
+- UI.
+- Tests.
+- Error states.
+- Migration or compatibility behavior.
+- Visual verification.
+- Documentation.
+
+Do not implement a large backend subsystem without one minimal user-visible workflow proving that it works.
+
+For every slice:
+
+1. Inspect current behavior and tests.
+2. State what will be reused.
+3. State the smallest new seam required.
+4. Implement the database change additively.
+5. Implement the domain logic independently of the UI.
+6. Add API boundaries.
+7. Add one usable UI path.
+8. Add happy-path, failure-path, recovery, and migration tests.
+9. Run the full existing test suite.
+10. Verify existing price workflows remain unchanged.
+11. Visually inspect relevant Side Panel and Workspace states.
+12. Report completed work, remaining limitations, and the next smallest slice.
+
+If a slice breaks an existing test, treat it as a regression unless the user explicitly approved the behavioral change.
+
+## Delivery Phases
+
+### Phase G0 — Baseline and Compatibility Contract
+
+- Record current database, API, CLI, Native Messaging, UI, and export behavior.
+- Fix failing storage-safety regressions before adding generic ingestion.
+- Add tests protecting existing price workflows.
+- Define the compatibility boundary between price-specific and generic behavior.
+- Add feature flags for unfinished generic screens.
+
+Exit condition: current behavior is protected and the repository is green.
+
+### Phase G1 — Generic Dataset Catalog
+
+- Add SiteProject, DatasetDefinition, SchemaVersion, and FieldDefinition.
+- Add generic record and revision storage.
+- Implement additive migrations.
+- Add repository APIs and tests.
+- Expose a minimal read-only Dataset Catalog in the Workspace.
+
+Exit condition: a manually defined generic dataset can store and display arbitrary records without affecting price tables.
+
+### Phase G2 — First Generic Extraction Slice
+
+Implement one complete extraction path:
+
+```text
+Saved HTML snapshot
+→ HTML table detection
+→ candidate preview
+→ schema inference
+→ user approval
+→ generic ingestion
+→ dynamic Workspace table
+```
+
+Exit condition: a non-product HTML table can be extracted and browsed end to end.
+
+### Cross-Cutting Gate DB1 — General Scrape / MarketLens Database Separation
+
+This gate must be satisfied before Phase G2 is approved for merge and before
+Phase G3 begins:
+
+- Introduce typed General Scrape and MarketLens database registries.
+- Create independent database locations, kind markers, application IDs,
+  migrations, locks, health checks, backups, and restore paths.
+- Route G1/G2 catalogue, snapshot, schema, generic record, and revision writes
+  exclusively to the General Scrape database.
+- Route all product, variant, offer, price, price-change, and price-retention
+  writes exclusively to the MarketLens database.
+- Migrate and validate the unified warehouse using the reversible procedure in
+  `Operational Database Isolation — Owner Decision`.
+- Prove through tests that a generic migration or failed generic crawl cannot
+  mutate or block MarketLens, and that a MarketLens migration or failed price run
+  cannot mutate or block General Scrape.
+- Prove independent backup, restore, repair, compaction, and storage relocation.
+- Keep the legacy unified database as a sealed, readable rollback archive.
+
+Exit condition: General Scrape and MarketLens operate through physically separate
+SQLite files, each domain refuses the wrong database kind, existing price history
+is intact, G2 persists only to General Scrape, and no cross-database operational
+foreign key or distributed transaction exists.
+
+### Phase G3 — Repeated DOM and JSON Extraction
+
+- Add repeated-card/list extraction.
+- Add JSON array and JSONPath extraction.
+- Add embedded JSON and JSON-LD extraction.
+- Preserve source paths and raw evidence.
+- Add fixture-driven conformance tests.
+
+Exit condition: structurally different datasets use the same generic ingest and UI path.
+
+### Phase G4 — Crawl Frontier
+
+- Add persistent URL frontier.
+- Add canonicalization and deduplication.
+- Add scope, depth, page, and time limits.
+- Add sitemap and link discovery.
+- Add checkpoint recovery.
+- Separate discovery status from extraction status.
+
+Exit condition: a crawl can discover and resume pages without requiring product semantics.
+
+### Phase G5 — Multi-Dataset Sites
+
+- Detect several datasets from the same site.
+- Allow independent approval and scheduling.
+- Support dataset-specific extraction and pagination rules.
+- Show dataset-level progress and failures.
+
+Exit condition: one site can own several separately browsable datasets.
+
+### Phase G6 — Relationships and Site Data Model
+
+- Add key profiling.
+- Add relationship suggestions.
+- Add relationship review.
+- Add one-to-many and many-to-many support.
+- Add Data Model visualization.
+- Add orphan and conflict reporting.
+
+Exit condition: approved related datasets can be navigated and exported as a coherent site model.
+
+### Phase G7 — Schema and Adapter Drift
+
+- Detect schema changes.
+- Add Schema Review Queue.
+- Add adapter versioning.
+- Add volume and structural canaries.
+- Add rollback and re-extraction from saved snapshots.
+
+Exit condition: site changes are explicit, explainable, and recoverable.
+
+### Phase G8 — Dynamic Outputs and Synchronization
+
+- Export any dataset using Original Schema or Current View.
+- Preserve dataset relationships in export metadata.
+- Support multi-sheet/workbook strategies.
+- Apply dynamic schemas to Apps Script and Google synchronization.
+- Resume interrupted multi-dataset synchronization.
+- Report partial failures per dataset.
+
+Exit condition: generic datasets no longer depend on price-specific export columns.
+
+### Phase G9 — Hardening and Public Readiness
+
+- Large crawl tests.
+- Large dynamic-schema tests.
+- Multi-dataset and relationship tests.
+- Arabic and mixed-direction data tests.
+- XSS and untrusted-content tests.
+- Recovery after shutdown, sleep, disconnection, and migration failure.
+- Performance profiling.
+- Adapter-drift tests.
+- Documentation and onboarding.
+
+Exit condition: generic functionality is reliable without weakening existing price functionality.
+
+## Definition of Done for Every Increment
+
+An increment is not complete merely because classes or database tables exist.
+
+It is complete only when:
+
+- The feature is reachable through a real workflow.
+- State is persistent.
+- Failures are visible and actionable.
+- Recovery behavior is defined.
+- Existing data remains safe.
+- Existing price workflows still pass.
+- Tests cover success, failure, retry, and migration.
+- The UI includes empty, loading, running, partial, success, and failure states where applicable.
+- Side Panel and Workspace layouts are visually verified.
+- Documentation distinguishes implemented behavior from planned behavior.
+- No static mock is presented as a production integration.
+
+## Decision Rules
+
+Ask for user direction before:
+
+- Removing or replacing a working compatibility path.
+- Performing a destructive migration.
+- Changing record identity behavior.
+- Automatically approving inferred relationships.
+- Automatically accepting an ambiguous schema rename.
+- Expanding crawl scope beyond the configured site boundaries.
+- Introducing remote adapter updates.
+- Changing which database is the source of truth.
+
+For ordinary additive implementation details, make the safest reasonable decision and continue.
+
+## Required Progress Report
+
+After every completed slice, report in Arabic:
+
+```text
+Slice
+What existed before
+What was reused
+What was added
+Database migrations
+Compatibility impact
+Tests added
+Full test result
+Visual evidence
+Known limitations
+Next recommended slice
+```
+
+Maintain a living implementation matrix with:
+
+```text
+Capability
+Not Started
+Foundation
+Partial
+Production Ready
+Evidence
+Known Limitations
+Next Action
+```
+
+Never inflate progress because a model, API route, or static screen exists.
+
+Measure progress using complete end-to-end workflows.
+
+## Final Principle
+
+ScrapeX must become generic by adding stable metadata-driven capabilities around its proven core, not by erasing the core.
+
+The desired end state is:
+
+```text
+Generic crawling and extraction platform
+    ├── Generic datasets
+    ├── Dynamic schemas
+    ├── Dataset relationships
+    ├── Site-specific data models
+    ├── Declarative adapters
+    ├── Dynamic exports and synchronization
+    └── Price tracking as the first specialized domain
+```
+
+At every stage, prefer:
+
+```text
+working old path + tested new path
+```
+
+over:
+
+```text
+unfinished replacement + removed old path
+```

--- a/docs/CLAUDE-after-price-history-20260720.md
+++ b/docs/CLAUDE-after-price-history-20260720.md
@@ -1,0 +1,2273 @@
+You are a senior product designer, UX architect, browser-extension engineer, local-runtime engineer, and data-platform architect.
+
+Your mission is to design and implement a production-quality browser Side Panel Extension for resilient website crawling, scraping, structured local storage, dataset management, historical change tracking, price monitoring, Excel export, Google Sheets synchronization, and background job scheduling.
+
+This is not a generic scraper dashboard. It is a local-first, multi-engine data collection and synchronization product.
+
+# 1. Mandatory communication and language rules
+
+These rules are non-negotiable:
+
+1. Always communicate with me, explain your decisions, report progress, and provide final summaries in Arabic.
+2. The entire product interface must be written in English only.
+3. English-only interface content includes:
+   - Navigation
+   - Buttons
+   - Labels
+   - Forms
+   - Status messages
+   - Errors
+   - Warnings
+   - Empty states
+   - Tooltips
+   - Dialogs
+   - Setup instructions
+   - Logs
+   - Notifications
+   - Generated integration instructions
+4. Arabic is supported only as user-entered data, site names, or scraped content.
+5. Do not place Arabic text inside the product interface itself.
+6. Scraped Arabic data must render correctly with RTL support.
+7. Use automatic text-direction detection for user-entered and scraped values.
+8. URLs, file paths, IDs, versions, source keys, code, and technical logs must always remain LTR.
+9. All source-code comments, docstrings, variable names, function names, test descriptions, commit messages, and technical documentation must be written in English.
+10. Do not propose or create a color palette.
+11. Focus on:
+    - Layout
+    - Spacing
+    - Typography
+    - Hierarchy
+    - Responsive behavior
+    - Component structure
+    - Interaction design
+    - Loading, empty, success, warning, and failure states
+12. Reuse the existing project theme and design tokens when available.
+13. Never rely only on color to communicate status.
+
+# 2. Working approach
+
+Before making changes:
+
+1. Inspect the existing project.
+2. Understand its architecture, framework, components, conventions, and design system.
+3. Reuse the current stack where practical.
+4. Do not replace the existing architecture without a clear technical reason.
+5. Preserve existing user work.
+6. Explain important assumptions to me in Arabic.
+7. Make sensible decisions without asking unnecessary questions.
+
+Do not stop at a conceptual description.
+
+If a repository is available, implement a polished and functional solution.
+
+If some backend capability is unavailable, create a well-structured adapter or realistic mock implementation and clearly distinguish mock behavior from production behavior.
+
+If no implementation environment is available, produce:
+
+- High-fidelity interface specifications.
+- Component specifications.
+- State models.
+- Data models.
+- User flows.
+- Technical architecture.
+- Implementation-ready acceptance criteria.
+
+# 3. Product vision
+
+The product must:
+
+- Run as a browser Side Panel Extension.
+- Support multiple crawling and scraping engines.
+- Support multiple programming runtimes and strategies.
+- Support local Python.
+- Support JavaScript-based processing.
+- Support browser automation.
+- Support static HTTP extraction.
+- Support structured API extraction when legitimately available.
+- Support site-specific adapters.
+- Support automatic engine selection.
+- Support ordered fallback engines.
+- Use a locally installed runtime/helper on the user’s device.
+- Detect whether local components are installed, running, compatible, and ready.
+- Crawl a site for the first time.
+- Update previously collected datasets.
+- Detect field-level changes.
+- Track product prices over time.
+- Identify new, changed, unavailable, returned, and removed records.
+- Rebuild datasets when explicitly requested.
+- Store data locally by default.
+- Export data to Excel.
+- Synchronize data through Apps Script.
+- Connect directly to Google Drive and Google Sheets.
+- Schedule automatic runs.
+- Continue background jobs when the Side Panel is closed.
+- Restore the current job state when the Side Panel is opened again.
+- Handle different schemas for different websites.
+- Allow users to customize data presentation without altering original collected fields.
+
+Handle legitimate crawling challenges through:
+
+- Retry policies.
+- Pagination detection.
+- Browser rendering.
+- Session management.
+- Rate limiting.
+- Throttling.
+- Timeouts.
+- Engine fallback.
+- Checkpoints.
+- Structured error recovery.
+- Network interruption recovery.
+
+Never silently bypass access controls.
+
+Detect and report:
+
+- Authentication requirements.
+- Blocked access.
+- CAPTCHA challenges.
+- Permission problems.
+- Rate limits.
+- Robots or policy restrictions.
+- Unsupported website behavior.
+
+# 4. Required system architecture
+
+The Side Panel must never own or directly execute a long-running crawl.
+
+Use this responsibility model:
+
+```text
+SIDE PANEL
+- Remote control
+- Site selection
+- Run configuration
+- Progress summary
+- Job controls
+- Runtime status
+- Quick data preview
+
+FULL WORKSPACE TAB
+- Dynamic datasets
+- Full tables
+- Column management
+- Comparisons
+- Change history
+- Review queue
+- Jobs and schedules
+- Detailed logs
+- Advanced settings
+
+EXTENSION SERVICE WORKER
+- Extension event handling
+- Native Messaging bridge
+- Browser permissions
+- Authentication coordination
+- Alarm coordination
+- UI notifications
+
+LOCAL RUNTIME
+- Crawling engines
+- Job execution
+- Job queue
+- Persistent checkpoints
+- SQLite database
+- Full technical logs
+- Scheduling
+- Excel generation
+- Synchronization workers
+- Backups and recovery
+```
+
+The Local Runtime must continue jobs independently from the Side Panel.
+
+If the Side Panel closes and reopens, it must request the current job state and reconnect to live updates.
+
+Use persistent Job IDs and database-backed job state.
+
+Do not depend on a Manifest V3 Service Worker remaining alive for a long-running crawl.
+
+
+# Service Worker Lifecycle and MV3 Constraints
+
+The architecture must explicitly handle Chrome Manifest V3 (MV3) Service Worker hibernation. 
+Do not assume the Service Worker will remain active for longer than 30 seconds.
+
+Ensure:
+- The Local Runtime functions independently regardless of the Service Worker's state.
+- The Side Panel communicates directly with the Local Runtime when open, using the Service Worker only as a coordination bridge when necessary.
+- Use Chrome Offscreen Documents or explicit heartbeat pings to maintain the Native Messaging host connection only during critical background UI notifications.
+- Re-establish lost Native Messaging connections automatically and request the latest missed job events upon waking.
+
+# Local Runtime Distribution and Updates
+
+The Local Runtime must be frictionless for non-technical users. 
+Do not require end-users to use the command line, install Python manually, or manage dependencies via `pip`.
+
+Require:
+- A bundled, standalone executable installer (e.g., a single `.exe` or `.dmg`).
+- Over-The-Air (OTA) silent background updates for the runtime and its dependencies.
+- Version parity checks between the browser extension and the Local Runtime.
+
+The extension must prompt users gracefully when an OTA update requires a runtime restart.
+
+
+# 5. Local database as the source of truth
+
+Use the local SQL database as the canonical source of truth.
+
+Prefer SQLite unless the existing architecture already uses another appropriate local SQL database.
+
+```text
+Website
+   ↓
+Crawling and Extraction Engines
+   ↓
+Local SQLite Database — Source of Truth
+   ├── Excel Output
+   ├── Google Sheets via Apps Script
+   └── Google Drive and Sheets APIs
+```
+
+OPFS or browser storage may be used for temporary UI state or cache, but not as the only canonical database.
+
+The Local Runtime must own and manage the database file.
+
+Use:
+
+- Transactions.
+- WAL mode when appropriate.
+- Safe schema migrations.
+- Integrity checks.
+- Recoverable backups.
+- Job checkpoints.
+- Database versioning.
+- Compaction and maintenance.
+- Storage-health monitoring.
+
+# 6. Native Messaging constraints
+
+Use Native Messaging as a command and status bridge between the extension and Local Runtime.
+
+Do not send entire datasets or full logs through one message.
+
+Native Messaging responses from the Local Runtime must remain small and paginated.
+
+Use:
+
+- Cursor-based pagination.
+- Small command responses.
+- Structured job events.
+- Aggregated progress.
+- Log tails.
+- Explicit acknowledgements.
+- Reconnection support.
+
+Example:
+
+```text
+GET_RECORDS
+
+datasetId
+cursor
+limit
+visibleFields
+filters
+sort
+```
+
+The Local Runtime must return a limited page and a new cursor.
+
+# 7. Core domain model
+
+Adapt the exact implementation to the project, but support concepts equivalent to:
+
+- Site
+- Site Profile
+- Site Adapter
+- Runtime Component
+- Crawling Engine
+- Engine Capability
+- Dataset
+- Dataset Field
+- Record Entity
+- Source Identity
+- Identity Alias
+- Crawl Job
+- Crawl Snapshot
+- Change Event
+- Identity Conflict
+- Review Decision
+- Output Destination
+- Sync Session
+- Sync Batch
+- Schedule
+- Saved View
+- Export Job
+- Backup
+- Runtime Log
+
+# 8. Side Panel information architecture
+
+The primary Side Panel must contain:
+
+1. Product header.
+2. Local Runtime status.
+3. Sites section.
+4. Add Site action.
+5. Site search and checklist.
+6. Selected site cards.
+7. Run mode.
+8. Output summary.
+9. Main run action.
+10. Activity summary.
+11. Persistent active-job mini-player.
+12. Bottom navigation.
+
+Bottom navigation:
+
+```text
+Run
+Browse Data
+Settings
+```
+
+Do not add a complex full-width data table to the Side Panel.
+
+# 9. Header and Local Runtime status
+
+Place the product logo and extension name at the top.
+
+Directly below the product name, add a thin interactive status row.
+
+Possible states:
+
+```text
+Local Runtime Ready                         ›
+Setup Required                              ›
+Connection Failed                           ›
+Checking Components...
+Update Required                             ›
+Runtime Stopped                             ›
+```
+
+The status represents the complete runtime, not Python alone.
+
+When selected, expand:
+
+```text
+LOCAL RUNTIME
+
+Core Service                         Running
+Python Runtime                       Ready
+JavaScript Runtime                   Ready
+Browser Automation                  Ready
+Network Tools                        Ready
+Site Adapters                  24 installed
+
+Run Diagnostics
+Manage Components                            ›
+```
+
+Support:
+
+- Installed.
+- Not Installed.
+- Running.
+- Stopped.
+- Ready.
+- Update Required.
+- Incompatible.
+- Connection Failed.
+- Checking.
+
+If components are missing, provide:
+
+```text
+SET UP LOCAL RUNTIME
+
+1. Download the local helper
+2. Run the installer
+3. Install required runtimes
+4. Verify the connection
+```
+
+Actions:
+
+- Download.
+- Continue Setup.
+- Recheck Status.
+- Run Diagnostics.
+- Manage Components.
+- Open Runtime Logs.
+- Check for Updates.
+
+# 10. Sites section
+
+Use:
+
+```text
+SITES                               + Add Site
+```
+
+Provide:
+
+- Search by site name or URL.
+- Select All.
+- Clear.
+- Selected count.
+- Scrollable checklist.
+- Empty state.
+- Loading state.
+- Error state.
+
+Site format:
+
+```text
+example.com (Example Website)
+news-site.com (موقع الأخبار)
+```
+
+The interface remains English and LTR, while Arabic names are treated as data and render correctly.
+
+Allow one or multiple sites to be selected.
+
+Unavailable sites remain visible but disabled with an English explanation.
+
+# 11. Add Site flow
+
+Selecting Add Site must open an internal Side Panel screen or drawer.
+
+Include:
+
+```text
+ADD SITE
+
+Site URL
+Display Name
+Scraping Profile
+Extraction Type
+Preferred Engine
+Fallback Engines
+Authentication Requirements
+Output Defaults
+Schedule
+Advanced Settings
+
+Test Site
+Add Site
+```
+
+The flow must:
+
+- Validate the URL.
+- Test connectivity.
+- Inspect basic capabilities.
+- Detect likely browser-rendering requirements.
+- Recommend an engine.
+- Allow advanced engine override.
+- Display a small discovered-data sample.
+- Save a reusable Site Profile.
+
+Under Advanced Settings, add:
+
+```text
+IDENTITY RULES
+
+Primary Match
+Fallback Match
+Composite Fields
+Canonical URL Rules
+Ambiguous Match Behavior
+```
+
+Default behavior should be automatic and simple. Advanced identity controls must not overwhelm a new user.
+
+# 12. Selected site cards
+
+Every selected site appears below the checklist as a compact card.
+
+Show:
+
+- Display name.
+- URL.
+- Engine.
+- Fallback availability.
+- Extraction profile.
+- Dataset state.
+- Readiness status.
+- Site Settings.
+- Remove-from-current-selection action.
+
+Example:
+
+```text
+Example Website                              ×
+example.com
+
+Engine              Playwright
+Extraction          Products
+Dataset             1,842 records
+Status              Ready
+
+Site Settings                                ›
+```
+
+Removing a selected card must not delete the saved site.
+
+# 13. Run modes
+
+Support three explicit modes:
+
+```text
+INITIAL CRAWL
+Collect and save this site for the first time.
+
+UPDATE EXISTING DATA
+Collect current data and detect differences.
+
+FULL REBUILD
+Archive the current dataset and crawl the site again.
+```
+
+## Initial Crawl
+
+- Create the first dataset.
+- Discover the initial schema.
+- Create stable Record Entity IDs.
+- Save the initial snapshot.
+- Record the source identity strategy.
+
+## Update Existing Data
+
+- Match incoming records against stable entities.
+- Detect new records.
+- Detect changed records.
+- Detect unavailable records.
+- Detect returned records.
+- Preserve previous values.
+- Create field-level Change Events.
+- Update current state.
+- Save a Crawl Snapshot.
+- Preserve full history.
+
+## Full Rebuild
+
+- Show a clear warning.
+- Create a backup or archive.
+- Let the user choose Archive or Replace.
+- Never destroy old data silently.
+- Provide a rollback path.
+
+# 14. Record identity and conflict resolution
+
+Separate the internal entity from its current source identity.
+
+```text
+Record Entity ID
+A permanent internal identity.
+
+Source Identity
+URL, SKU, source ID, canonical URL, or composite key.
+
+Identity Aliases
+Previous URLs, SKUs, IDs, and known identities.
+```
+
+Matching priority may include:
+
+1. Stable source ID.
+2. SKU.
+3. Canonical URL.
+4. Composite key.
+5. Known identity aliases.
+6. Similarity matching.
+7. Requires Review.
+
+Composite keys must be configurable.
+
+If the system suspects that an incoming record matches an existing entity but cannot safely confirm it, create a `Requires Review` item.
+
+Provide a Review Queue:
+
+```text
+POSSIBLE MATCH
+
+Existing Record
+Incoming Record
+Match Confidence
+Matched Fields
+Conflicting Fields
+
+Keep Separate
+Merge Records
+Review Later
+```
+
+Manual merges must:
+
+- Preserve price history.
+- Preserve previous identities.
+- Create aliases.
+- Create an audit record.
+- Support Undo Merge.
+- Prevent the same conflict from repeatedly returning.
+
+# 15. Historical changes and price monitoring
+
+Maintain separate current-state and historical-change layers.
+
+```text
+CURRENT RECORD
+
+Record Entity ID
+Current Values
+Current Availability
+First Seen
+Last Seen
+Last Updated
+```
+
+```text
+CHANGE EVENT
+
+Record Entity ID
+Field Key
+Previous Value
+New Value
+Detected At
+Crawl Job ID
+Change Type
+```
+
+## Price-history storage semantics
+
+The owner-facing price history is a timeline of real price changes, not a daily
+copy of an unchanged price row.
+
+For each source-scoped offer identity, including its product, variant, region,
+branch, customer segment, selling unit, currency, and VAT basis:
+
+- Store the first detected price.
+- Compute a normalized `price_hash` from the comparable price, currency, and VAT
+  basis.
+- When a successful refresh sees the same `price_hash`, do not append a price
+  observation, price-history row, or price change event. Update only the current
+  state's `last_seen_at` and the active price period's `last_confirmed_at`.
+- When the `price_hash` changes, append exactly one immutable price observation
+  and change event, close the previous price period, and open a new price period.
+- Track availability and stock with a separate state hash so that a stock change
+  does not create a false price change.
+- Failed, partial, cancelled, or out-of-scope runs must not advance
+  `last_confirmed_at` and must not mark products unavailable.
+- If an offer disappears and later returns, open a new price period even when the
+  returned price equals the old price; continuity during the absence is unknown.
+
+The permanent price model must distinguish:
+
+```text
+CURRENT OFFER STATE
+Latest price and availability for fast reads.
+Updated in place after a successful refresh.
+
+PRICE PERIOD
+One row per continuous confirmed price period.
+Contains first_detected_at and last_confirmed_at.
+
+PRICE OBSERVATION / CHANGE EVENT
+Append-only evidence for the first price and each real change.
+Existing rows are never updated or deleted.
+
+SCRAPE RUN
+One audit row per refresh, including scope, completion status, row counts, and
+errors.
+
+ABSENCE PERIOD
+Created only when a successfully completed full-scope run does not see an
+expected offer. It records disappearance and return transitions, not unchanged
+daily confirmations.
+```
+
+Do not persist a full per-offer seen row for every successful daily refresh.
+The run may use a staging table or an in-memory seen set while finalizing. After
+the run has updated current state, price periods, and absence transitions, the
+staging seen set may be discarded. Raw snapshots remain the recoverable source
+evidence under their configured retention policy.
+
+Exact-date price lookup must behave as follows:
+
+- If a successful in-scope run confirms the offer on the requested date, return
+  the price period that covered that confirmation.
+- If no reliable observation exists on that date, say so explicitly and return
+  the last known price before that date together with its observation date.
+- If the requested date is before tracking began, report the first tracking date.
+- If the relevant run failed or was partial, report that the date has no reliable
+  observation rather than assuming the previous price remained valid.
+
+The product price-history view must list only the first detected price and each
+subsequent real price change, ordered from the beginning of tracking through the
+last confirmed price. Daily unchanged confirmations must not appear as duplicate
+history rows.
+
+Support:
+
+- New records.
+- Updated records.
+- Price increases.
+- Price decreases.
+- Unchanged records as current-state confirmations without duplicate historical rows.
+- Unavailable records.
+- Returned records.
+- Removed records.
+- Crawl errors.
+- Comparison between any two snapshots.
+- First recorded price.
+- Current price.
+- Minimum price.
+- Maximum price.
+- Absolute change.
+- Percentage change.
+- Exact-date price lookup with an explicit last-known fallback.
+- A change-only price timeline from first detection through last confirmation.
+
+# 16. Output destinations
+
+The Local Database must be enabled by default.
+
+Allow multiple destinations for the same run:
+
+```text
+DATA OUTPUT
+
+Local Database
+Excel Files
+Google Sheets via Apps Script
+Google Drive and Sheets
+```
+
+The local database remains the source of truth.
+
+# 17. Local storage settings
+
+Provide:
+
+- Current database location.
+- Change Storage Location.
+- Open Storage Folder.
+- Database size.
+- Database health.
+- Backup.
+- Restore.
+- Repair.
+- Compact Database.
+- Export Database.
+- Storage migration progress.
+
+When changing storage location:
+
+- Validate permissions.
+- Detect unavailable or removable drives.
+- Explain whether existing data will move.
+- Never overwrite a database silently.
+- Create a recoverable backup.
+- Provide rollback.
+- Report migration progress.
+
+# 18. Data retention
+
+Provide configurable retention policies:
+
+```text
+CHANGE HISTORY RETENTION
+
+Keep detailed history for:
+90 days
+
+After that:
+Keep daily summaries
+Keep weekly summaries
+Archive old history
+Delete permanently
+```
+
+Always allow preserving:
+
+- First recorded value.
+- Latest value.
+- Minimum price.
+- Maximum price.
+- Important user-marked events.
+
+Provide:
+
+- Retention preview.
+- Estimated recovered space.
+- Dataset-level exclusions.
+- Backup before destructive cleanup.
+- Storage usage warnings.
+- Automatic database maintenance.
+
+# 19. Excel output
+
+Excel is an optional output destination.
+
+Support:
+
+```text
+WORKBOOK STRUCTURE
+
+One workbook for all sites
+Separate workbook for each site
+```
+
+For a combined workbook, use separate sheets where schemas differ.
+
+Support:
+
+```text
+UPDATE BEHAVIOR
+
+Update existing rows
+Create a new snapshot sheet
+Create a new dated workbook
+```
+
+Provide:
+
+- Change Save Location.
+- Open Output Folder.
+- Export Current View.
+- Export Original Schema.
+- Export Change History.
+- Last Export Status.
+
+Preserve Arabic data correctly.
+
+# 20. Browse Data inside the Side Panel
+
+Browse Data in the Side Panel is a compact preview, not a full analytics table.
+
+Show:
+
+- Dataset list.
+- Record count.
+- Last update.
+- Change summary.
+- Recent records.
+- Compact Card View.
+- Basic search.
+- Basic filters.
+- Open in Workspace.
+
+Example:
+
+```text
+DATASETS
+
+Example Store
+1,842 records
+Updated 12 minutes ago
+34 changed · 15 new · 3 unavailable
+
+Open Dataset
+```
+
+When a dataset is opened inside the Side Panel, use compact cards and limited fields.
+
+Use virtualization for long lists.
+
+# 21. Full-page Workspace
+
+Provide an `Open in Workspace` action that opens a full extension page in a browser tab.
+
+The Workspace must contain:
+
+- Overview.
+- Data.
+- Changes.
+- Crawl History.
+- Review Queue.
+- Jobs.
+- Schedules.
+- Sync.
+- Exports.
+- Logs.
+
+The Data area must support:
+
+- Dynamic table schemas.
+- Search.
+- Filters.
+- Sorting.
+- Pagination or virtualization.
+- Column resizing.
+- Column reordering.
+- Manage Columns.
+- Show Hidden Columns.
+- Saved Views.
+- Snapshot comparison.
+- Export.
+- Sync.
+- Full-page horizontal scrolling when genuinely required.
+
+# 22. Schema and column safety
+
+Never treat a presentation change as a destructive schema change.
+
+Every field must support:
+
+```text
+Source Key
+Original Name
+Display Name
+Data Type
+Visibility
+Display Order
+```
+
+Rules:
+
+- Source Key is stable and immutable.
+- Original Name is preserved.
+- Display Name is user-editable.
+- Selecting X sets the field to Hidden.
+- Selecting X never deletes the field or its data.
+- Hidden fields continue receiving future updates.
+- Users can show hidden fields again.
+- Users can reset names.
+- Users can reset layout.
+- Users can restore the default view.
+- Users can save multiple views.
+- Export and sync can use either Original Schema or Current View.
+- Destructive deletion requires explicit confirmation.
+
+# 23. Job execution and lifecycle
+
+Persist every job in the database.
+
+Support states equivalent to:
+
+- Scheduled.
+- Queued.
+- Preparing.
+- Running.
+- Pausing.
+- Paused.
+- Resuming.
+- Cancelling.
+- Cancelled.
+- Completed.
+- Partially Completed.
+- Failed.
+- Requires Review.
+
+Persist:
+
+- Job ID.
+- Site IDs.
+- Run mode.
+- Current stage.
+- Progress.
+- Counters.
+- Checkpoint.
+- Started time.
+- Last heartbeat.
+- Retry count.
+- Output status.
+- Error summary.
+
+Closing the Side Panel must not stop the job.
+
+Reopening the Side Panel must retrieve and display the current state.
+
+# 24. Active Job mini-player
+
+Add a persistent mini-player above bottom navigation when a job is active.
+
+Example:
+
+```text
+Amazon Update                         63%
+Processing 8,420 of 10,000
+1 running · 2 queued
+
+View Job
+Pause
+```
+
+The mini-player remains visible while the user moves between:
+
+- Run.
+- Browse Data.
+- Settings.
+- Add Site.
+
+Selecting it opens the full job details.
+
+# 25. Activity and logging
+
+Do not add one UI row for every processed product.
+
+The Local Runtime must store the complete technical log.
+
+The Side Panel displays:
+
+- Aggregated progress.
+- Current step.
+- Current site.
+- Current counters.
+- Last 200 log entries only.
+
+Use a fixed-size Ring Buffer for UI logs.
+
+Use virtualization for visible log rows.
+
+Throttle UI progress updates instead of rendering every internal event.
+
+Show:
+
+- Overall percentage.
+- Current site.
+- Current stage.
+- Records discovered.
+- Records processed.
+- Records created.
+- Records updated.
+- Records unchanged.
+- Warnings.
+- Errors.
+- Elapsed time.
+- Per-site progress.
+
+Include:
+
+- Show Technical Details.
+- Pause Auto-scroll.
+- Copy Visible Logs.
+- Download Full Logs.
+- Open Logs Folder.
+- Pause.
+- Resume.
+- Cancel Run.
+- Retry Failed Step.
+- Open Dataset after completion.
+
+# 26. Scheduling
+
+Provide scheduling inside Site Settings.
+
+Support:
+
+- Manual.
+- Daily.
+- Weekly.
+- Custom schedule when appropriate.
+- Time selection.
+- Time zone.
+- Offline behavior.
+- Missed-run behavior.
+- Overlapping-run policy.
+- Retry policy.
+- Completion notifications.
+- Failure notifications.
+- Change-detected notifications.
+
+Example:
+
+```text
+SCHEDULE
+
+Frequency
+Daily
+
+Run At
+09:00 AM
+
+Time Zone
+Asia/Riyadh
+
+If Device Was Offline
+Run when available
+
+Overlapping Runs
+Queue new run
+```
+
+Use the Local Runtime scheduler for reliable scheduling.
+
+Use `chrome.alarms` only as browser-side coordination or fallback.
+
+Do not claim that browser alarms can wake a sleeping or powered-off device.
+
+If scheduling must work while Chrome is closed, implement an explicit user-approved Local Runtime background service or OS-level scheduling integration.
+
+Clearly explain the behavior to the user in English.
+
+# OS Resource and Hardware Management
+
+Background jobs must not freeze the user's operating system or aggressively drain device batteries.
+
+Implement:
+- Hardware-aware concurrency limits (detect available CPU cores and RAM).
+- Eco Mode: Automatically pause or throttle intensive jobs (like browser automation) when the device is running on battery power.
+- System wake/sleep awareness to safely checkpoint and suspend running jobs when the OS goes to sleep.
+
+
+# 27. Apps Script integration
+
+Generate Apps Script code that users can copy into Google Sheets.
+
+Setup interface:
+
+```text
+GOOGLE SHEETS — APPS SCRIPT
+
+1. Create or open a Google Sheet
+2. Open Extensions → Apps Script
+3. Paste the generated code
+4. Run the setup function
+5. Deploy the script
+6. Paste the deployment URL below
+```
+
+Include:
+
+- Copy Script.
+- Deployment URL.
+- Test Connection.
+- Save Connection.
+- Regenerate Secret.
+- Revoke Connection.
+- Last Sync.
+- Sync Now.
+- Connection Logs.
+
+The generated Apps Script must:
+
+- Create required sheets.
+- Create and update headers.
+- Insert new records.
+- Update existing records.
+- Preserve supported user customizations.
+- Read existing sheet data when required.
+- Synchronize current data.
+- Synchronize change history optionally.
+- Resume interrupted synchronization.
+- Prevent duplicate records.
+- Support explicit full recreation.
+
+All generated code and comments must be written in English.
+
+# 28. Apps Script security
+
+Do not rely on a permanent hard-coded bearer token.
+
+Use a cryptographically secure connection secret.
+
+Prefer:
+
+- A 256-bit random secret.
+- Secure local storage managed by Local Runtime.
+- Apps Script `Script Properties`.
+- HMAC request signing.
+- Timestamp.
+- Nonce.
+- Replay protection.
+- Revocation.
+- Regeneration.
+- Rate limiting.
+- Constant-time signature comparison when possible.
+
+Do not place secrets in URLs.
+
+If standard HTTP authorization headers are not reliably available to Apps Script `doPost`, include the signature metadata inside the JSON request body.
+
+# 29. Apps Script batching and recovery
+
+Never send an entire large dataset in one request.
+
+Use adaptive batching based on:
+
+- Encoded payload size.
+- Row count.
+- Column count.
+- Remaining execution time.
+- Previous response time.
+- Retry history.
+
+Do not assume that 1,000 records are always an appropriate batch.
+
+Persist:
+
+```text
+Sync Session ID
+Dataset ID
+Snapshot ID
+Batch Number
+Total Batches
+Cursor
+Checksum
+Attempt Number
+Status
+Acknowledged At
+```
+
+The synchronization process must be:
+
+- Resumable.
+- Idempotent.
+- Checkpointed.
+- Retryable.
+- Duplicate-safe.
+- Observable.
+
+Use:
+
+- Batch acknowledgements.
+- Checksums.
+- Exponential backoff.
+- Time-budget guards.
+- Concurrency control.
+- Partial-failure reporting.
+- Resume from the last acknowledged batch.
+
+Verify current official Google limits during implementation rather than relying on permanently hard-coded quota assumptions.
+
+# 30. Direct Google integration
+
+Provide a separate direct integration using:
+
+- Continue with Google.
+- Google Drive API.
+- Google Sheets API.
+
+Allow users to:
+
+- Connect a Google account.
+- View the connected account.
+- Select or create a Drive folder.
+- Create spreadsheets.
+- Organize files.
+- Synchronize existing datasets.
+- Create missing headers.
+- Update existing rows.
+- Create snapshots.
+- View the last sync result.
+- Reconnect after authorization expires.
+- Disconnect the account.
+
+Organization options:
+
+```text
+FILE ORGANIZATION
+
+One spreadsheet per site
+One spreadsheet per crawl
+Combined spreadsheet
+```
+
+Request only required permissions.
+
+Store OAuth credentials securely.
+
+Implement:
+
+- Adaptive request batching.
+- Quota awareness.
+- Exponential backoff.
+- Resumable synchronization.
+- Clear error reporting.
+
+# 31. Google Sheet conflict policy
+
+The Local Database remains the source of truth by default.
+
+Provide explicit sync policies:
+
+```text
+SYNC DIRECTION
+
+Local Database to Google Sheets
+Two-way Sync
+```
+
+For two-way sync, define:
+
+- System-owned fields.
+- User-editable fields.
+- Conflict detection.
+- Local wins.
+- Google Sheet wins.
+- Requires Review.
+- Last-write metadata.
+- Audit history.
+
+Never overwrite a manual Google Sheet edit silently when two-way sync is enabled.
+
+# 32. Multi-engine orchestration
+
+Do not hard-code a single engine.
+
+Support:
+
+- Automatic engine recommendation.
+- Preferred engine.
+- Ordered fallback engines.
+- Capability detection.
+- Dependency checks.
+- Per-site engine profiles.
+- Per-step retries.
+- Manual override.
+- Structured failure reasons.
+
+The execution log must show:
+
+- Selected engine.
+- Why it was selected.
+- Engine switches.
+- Fallback reasons.
+- Retry attempts.
+- Final failure reason.
+
+# Proxy and Anti-Bot Management
+
+Engine orchestration must handle anti-bot detection intelligently without causing permanent IP bans.
+
+Support:
+- Proxy configuration per site or globally.
+- Residential and Datacenter proxy types.
+- Automatic IP rotation per request or per session.
+- Advanced browser fingerprint spoofing (e.g., modifying User-Agent, WebGL, canvas, and timezone metadata when using automated browsers).
+- Rate-limit awareness and automatic cooldowns.
+
+Do not permanently burn user IP addresses through aggressive retries on blocked access.
+
+# Adapter Drift and Dynamic Maintenance
+
+Website DOM structures and internal APIs change frequently, breaking hard-coded Site Adapters. 
+
+The system must:
+- Detect Adapter Breakdown: Identify when a previously successful site adapter experiences a sudden, extreme drop in success rates.
+- Display an explicit `Adapter Outdated` status instead of a generic `Failed` error.
+- Support dynamic fetching of updated adapter rules or configurations without requiring a full application update.
+- Allow users to report broken adapters directly from the Side Panel.
+
+# 33. Settings structure
+
+Organize Settings into:
+
+- General.
+- Local Runtime.
+- Storage.
+- Crawling.
+- Engines.
+- Jobs and Scheduling.
+- Excel.
+- Apps Script.
+- Google Account.
+- Data and History.
+- Privacy and Security.
+- Logs and Diagnostics.
+- About.
+
+Use progressive disclosure.
+
+Do not place every setting on one long screen.
+
+# 34. Security and data safety
+
+Treat all scraped content as untrusted.
+
+Implement:
+
+- Output sanitization.
+- XSS prevention.
+- Message validation.
+- Command authorization.
+- Native host origin restrictions.
+- Secure secret storage.
+- Path validation.
+- Safe file creation.
+- Database transactions.
+- Backup before destructive operations.
+- Audit logs.
+- Runtime version compatibility checks.
+- Protection against duplicate jobs.
+- Concurrency limits.
+- Safe cancellation.
+
+Never execute remotely downloaded code inside the extension.
+
+Comply with current browser-extension platform requirements.
+
+# 35. Required UX states
+
+Design and implement:
+
+- First launch.
+- Runtime not installed.
+- Runtime checking.
+- Runtime ready.
+- Runtime update required.
+- Runtime disconnected.
+- Empty site list.
+- Add Site.
+- Site test running.
+- Site test failed.
+- No selected sites.
+- Initial crawl.
+- Update existing data.
+- Full rebuild warning.
+- Multi-site run.
+- Scheduled run.
+- Queued job.
+- Paused job.
+- Cancelled job.
+- Partial success.
+- Complete success.
+- Failed run.
+- Requires Review.
+- Empty dataset.
+- Dataset loading.
+- Dynamic schema.
+- Hidden columns.
+- No detected changes.
+- Sync pending.
+- Sync running.
+- Sync partially completed.
+- Sync successful.
+- Sync failed.
+- Google disconnected.
+- Apps Script not configured.
+- Storage location unavailable.
+- Database migration.
+- Database backup.
+- Database recovery.
+
+# 36. Accessibility and responsive behavior
+
+- Optimize the Side Panel for approximately 320px–400px widths.
+- Avoid horizontal scrolling in the main Side Panel.
+- Use Card View or compact previews for records.
+- Use the Full Workspace for complex tables.
+- Use keyboard navigation.
+- Use accessible names and labels.
+- Use visible focus states from the existing theme.
+- Keep primary actions discoverable.
+- Do not rely only on icons.
+- Use confirmation dialogs only for destructive actions.
+- Preserve scroll position where appropriate.
+- Handle long URLs safely.
+- Use `dir="auto"` or equivalent for scraped values.
+- Force technical content to LTR.
+- Test mixed Arabic and English data.
+
+# 37. Testing requirements
+
+Add tests for:
+
+- Closing and reopening the Side Panel during a job.
+- Runtime disconnection and reconnection.
+- Job checkpoint recovery.
+- Initial Crawl.
+- Update Existing Data.
+- Full Rebuild backup.
+- Composite identity matching.
+- Requires Review.
+- Merge and Undo Merge.
+- Price history preservation.
+- Column rename without source-key mutation.
+- Column hiding without data deletion.
+- Apps Script batch retry.
+- Duplicate batch prevention.
+- Interrupted sync resume.
+- Google authorization expiration.
+- Storage migration failure.
+- Scheduled-run recovery.
+- Arabic data rendering.
+- Native Messaging pagination.
+- Log Ring Buffer behavior.
+- Large dataset virtualization.
+- XSS sanitization.
+
+# 38. Expected implementation quality
+
+- Use reusable components.
+- Use typed domain models.
+- Use explicit state machines where helpful.
+- Separate UI, domain logic, execution, storage, and synchronization.
+- Do not hard-code site schemas.
+- Do not hard-code one engine.
+- Do not hard-code one output.
+- Do not store complete datasets in UI state.
+- Do not stream one UI log event per product.
+- Do not couple jobs to the Side Panel lifecycle.
+- Clearly identify mock and production integrations.
+- Add validation and structured recovery.
+- Preserve existing project conventions.
+- Verify realistic Side Panel dimensions.
+- Verify the Full Workspace separately.
+- Keep code comments in English.
+
+# 39. Final implementation phases
+
+Complete the work in these phases:
+
+1. Inspect the existing project.
+2. Explain your understanding to me in Arabic.
+3. Present the implementation plan in Arabic.
+4. Define the architecture and responsibility boundaries.
+5. Define the domain and state models.
+6. Implement Local Runtime communication abstractions.
+7. Implement the Side Panel.
+8. Implement the active-job mini-player.
+9. Implement the Full Workspace.
+10. Implement dataset and schema customization.
+11. Implement job persistence and lifecycle recovery.
+12. Implement scheduling.
+13. Implement Excel output.
+14. Implement Apps Script synchronization.
+15. Implement direct Google integration.
+16. Implement identity conflict review.
+17. Implement logging, retention, backup, and recovery.
+18. Test critical workflows.
+19. Visually inspect realistic Side Panel and Workspace dimensions.
+20. Report completed work, assumptions, limitations, test results, and next steps to me in Arabic.
+
+The final product must feel like a focused, reliable, local-first crawling and data synchronization platform specifically designed around a browser Side Panel and a full data-management Workspace.
+
+# 40. Incremental Evolution into a Generic Crawling and Data-Modeling Platform
+
+## Mission
+
+Evolve ScrapeX incrementally from its current product-and-price tracking system into a generic, metadata-driven crawling, extraction, and data-modeling platform.
+
+The final platform should be capable of:
+
+- Crawling broadly different website structures.
+- Discovering multiple datasets within the same site or page.
+- Extracting HTML tables, repeated DOM structures, structured data, embedded JSON, REST APIs, GraphQL responses, and browser-observed network data.
+- Inferring dynamic schemas whose columns may appear, disappear, change names, or change types over time.
+- Detecting and managing multiple datasets per site.
+- Inferring and reviewing relationships between datasets.
+- Building a versioned site-specific data model.
+- Preserving raw source evidence, historical revisions, provenance, and schema history.
+- Presenting dynamic datasets, columns, relationships, and crawl state through the Side Panel and Full Workspace.
+- Exporting either the original discovered schema or a user-customized view.
+- Keeping the existing price-tracking domain fully operational throughout the evolution.
+
+This is an evolutionary program, not a rewrite.
+
+## Prime Directive: Extend, Preserve, and Migrate Incrementally
+
+Never destroy and rebuild the existing product merely to obtain a cleaner architecture.
+
+Before implementing any capability:
+
+1. Inspect the current repository and identify existing components that already solve part of the problem.
+2. Reuse or extend those components wherever doing so preserves correctness.
+3. Introduce a compatibility seam when the existing design is too specialized.
+4. Move one vertical slice at a time through the new seam.
+5. Keep the old path operational until the replacement path has proven behavioral parity.
+6. Remove or retire an old path only after:
+   - Its replacement is complete.
+   - Migration is tested.
+   - Existing data remains readable.
+   - Rollback is possible.
+   - The user has explicitly approved retirement.
+
+Do not perform speculative large-scale refactoring.
+
+Do not rename, relocate, or rewrite stable modules unless the current increment genuinely requires it.
+
+Do not mix architectural cleanup with unrelated feature work.
+
+Every increment must leave the application runnable, testable, and recoverable.
+
+Repository behavior and tests are the ground truth. If this plan conflicts with proven repository behavior, report the conflict before changing the behavior.
+
+## Existing Capabilities That Must Be Preserved
+
+Treat the following as valuable working assets rather than temporary code:
+
+- Existing product and price ingestion.
+- Append-only price observation history. Existing observations are immutable;
+  the optimized price path may reduce future write frequency by appending only
+  the first price and real changes, as defined in section 15, but it must never
+  rewrite or delete legacy observations.
+- Current connectors and fetchers.
+- Job persistence, pause, resume, cancellation, and checkpoint recovery.
+- Native Messaging and localhost communication.
+- Side Panel and active-job mini-player.
+- Full Workspace.
+- Storage, backup, restore, migration, and retention mechanisms.
+- Column customization and saved views.
+- Excel, Apps Script, and direct Google output paths.
+- Review Queue and identity conflict decisions.
+- Arabic content normalization and bidirectional rendering.
+- Existing tests, fixtures, screenshots, and public contracts.
+
+The price engine must become the first specialized domain built on, or interoperating with, the generic platform. It must not be discarded.
+
+The price-history optimization in section 15 is the owner-approved target for
+that specialized domain. It must be introduced through additive schema,
+backfilled projections, compatibility tests, and a reversible cutover. Generic
+phases do not have implicit permission to repurpose `generic_record`, rewrite
+`price_observation`, or weaken existing price workflows while implementing this
+optimization.
+
+## Honest Definition of “Generic”
+
+Do not claim that ScrapeX can scrape literally every website.
+
+A generic platform means:
+
+- It supports several reusable extraction patterns.
+- It can describe site-specific behavior through versioned metadata.
+- It provides an adapter mechanism for exceptional sites.
+- It reports unsupported, blocked, ambiguous, or authentication-dependent cases honestly.
+- It never silently returns incomplete or structurally incorrect data.
+- It distinguishes crawler failure, extractor failure, schema drift, access denial, and unsupported structure.
+
+CAPTCHAs, strong anti-bot systems, inaccessible authenticated content, legal restrictions, and highly interactive applications may still require user intervention or a specialized adapter.
+
+## Architectural Direction
+
+Separate the following responsibilities:
+
+```text
+Site Project
+    ↓
+Crawl Plan
+    ↓
+URL Frontier
+    ↓
+Fetcher
+    ↓
+Page Snapshot
+    ↓
+Dataset Discovery
+    ↓
+Extraction Plan
+    ↓
+Schema Inference
+    ↓
+Generic Records
+    ↓
+Identity Resolution
+    ↓
+Relationship Inference
+    ↓
+Versioned Site Data Model
+    ↓
+Workspace / Export / Sync
+```
+
+### Crawl and Scrape Are Different Operations
+
+`Crawl` discovers and revisits pages.
+
+`Scrape` extracts one or more datasets from a page or response.
+
+Do not couple URL discovery to product extraction.
+
+The crawler must be able to discover pages even when no extraction rule has been approved yet.
+
+The extractor must be able to run against a saved page snapshot without repeating a network request.
+
+### Domain Type and Extraction Method Are Different Concepts
+
+Do not use one enum to represent both what the data means and how it was obtained.
+
+Keep separate concepts such as:
+
+```text
+Domain:
+- generic
+- prices
+- listings
+- documents
+- user-defined
+
+Extraction Method:
+- html_table
+- repeated_dom
+- json_array
+- json_path
+- json_ld
+- embedded_json
+- rest_api
+- graphql
+- browser_network
+- custom_adapter
+```
+
+A dataset may use any extraction method without being classified as product or price data.
+
+## Generic Metadata Model
+
+Introduce the generic model through additive database migrations.
+
+At minimum, support concepts equivalent to:
+
+```text
+SiteProject
+CrawlPlan
+CrawlRun
+CrawlPage
+PageSnapshot
+PageType
+DatasetDefinition
+DatasetCandidate
+DatasetSchemaVersion
+FieldDefinition
+ExtractionRule
+GenericRecord
+RecordRevision
+RelationshipDefinition
+RecordRelationship
+AdapterDefinition
+AdapterVersion
+SchemaChange
+```
+
+### Dataset Definition
+
+A dataset definition should identify:
+
+- Stable dataset key.
+- User-facing name.
+- Source page type.
+- Extraction method.
+- Source selector, JSON path, or response path.
+- Cardinality.
+- Pagination strategy.
+- Identity strategy.
+- Current schema version.
+- Adapter version.
+- Dataset status.
+- Provenance and timestamps.
+
+### Field Definition
+
+A field definition should preserve:
+
+```text
+field_key
+source_name
+display_name
+source_path
+data_type
+nullable
+repeated
+key_role
+position
+confidence
+first_seen_at
+last_seen_at
+status
+```
+
+Rules:
+
+- `field_key` is stable and internal.
+- `source_name` preserves the exact source label or property name.
+- `display_name` is a presentation preference.
+- Renaming a display name never changes source identity.
+- Hiding a field never deletes it.
+- Missing fields remain in schema history.
+- New fields create a new schema version.
+- Type changes are recorded, not silently overwritten.
+- Automatic widening is allowed only through safe rules such as `integer → decimal → text`.
+- Automatic narrowing is forbidden.
+- Objects and arrays must remain representable without flattening away information.
+
+### Generic Record Storage
+
+Do not create an uncontrolled physical SQL table for every detected HTML table.
+
+Prefer a hybrid model:
+
+- Metadata tables describe datasets, fields, schemas, and relationships.
+- Each record stores its canonical values as validated JSON.
+- Frequently searched or indexed fields may receive explicit projections.
+- Record revisions preserve historical changes.
+- Raw snapshots remain available for re-extraction and audit.
+- Materialized views may be created for performance, but they are derived and rebuildable.
+
+Every record must preserve:
+
+```text
+record_id
+dataset_id
+record_key
+schema_version_id
+data
+source_page_id
+source_locator
+content_hash
+first_seen_at
+last_seen_at
+status
+```
+
+## Dataset Discovery
+
+Dataset discovery must return candidates, not immediately create permanent datasets.
+
+Initial reusable detectors should include:
+
+1. Semantic HTML tables.
+2. Repeated DOM structures such as cards, rows, listings, and definition blocks.
+3. JSON arrays and nested object collections.
+4. JSON-LD, Microdata, and embedded structured data.
+5. REST and GraphQL response collections.
+6. Browser-observed fetch/XHR responses.
+
+Each candidate should report:
+
+```text
+candidate name
+source type
+source locator
+estimated row count
+sample records
+detected fields
+candidate identity fields
+pagination evidence
+confidence
+warnings
+```
+
+The user must be able to:
+
+- Preview the candidate.
+- Accept or reject it.
+- Rename it.
+- Edit field names and types.
+- Select or define identity fields.
+- Configure pagination.
+- Approve the dataset before persistent ingestion.
+
+Discovery must never pollute the permanent dataset store.
+
+## Dynamic Schema and Schema Drift
+
+Every dataset must have versioned schemas.
+
+When a later crawl differs from the approved schema, classify the difference:
+
+```text
+field_added
+field_missing
+field_renamed_candidate
+field_type_widened
+field_type_conflict
+structure_changed
+identity_field_missing
+relationship_broken
+extractor_failed
+adapter_outdated
+```
+
+Safe additions may be accepted automatically according to dataset policy.
+
+Destructive or ambiguous changes must enter a Schema Review Queue.
+
+Never delete historical values because a field disappeared from the latest page.
+
+Never reuse an old field key for a semantically different field.
+
+Store enough provenance to explain why two fields are believed to represent the same source field.
+
+## Identity Inference
+
+Infer candidate record keys using this order:
+
+1. Explicit source ID.
+2. Stable API identifier.
+3. Declared primary key.
+4. Canonical detail URL.
+5. Highly unique non-null field.
+6. Composite key.
+7. Deterministic fingerprint.
+
+For every suggested key, calculate and display:
+
+- Uniqueness percentage.
+- Null percentage.
+- Duplicate examples.
+- Stability across snapshots.
+- Confidence.
+- Fields used.
+
+Ambiguous identity must enter review.
+
+Never merge records solely because names are similar.
+
+Existing price identity behavior must remain unchanged until the generic identity system proves parity for that domain.
+
+## Relationship Inference
+
+Support relationships between datasets:
+
+```text
+one_to_one
+one_to_many
+many_to_one
+many_to_many
+hierarchical
+```
+
+Use evidence such as:
+
+- Matching primary and foreign-key candidates.
+- Nested JSON ownership.
+- Shared stable identifiers.
+- Detail-page URLs.
+- Parent-child DOM structure.
+- Link targets.
+- Repeated uniqueness and cardinality evidence.
+- User-defined mapping.
+
+A relationship suggestion must include:
+
+```text
+from_dataset
+from_fields
+to_dataset
+to_fields
+cardinality
+confidence
+evidence
+sample_matches
+orphan_count
+conflict_count
+status
+```
+
+Low-confidence relationships must never be activated automatically.
+
+Many-to-many relationships must use an explicit logical junction dataset.
+
+Relationships must be versioned and reviewed when schema drift invalidates their fields.
+
+## Declarative Adapter System
+
+Implement generic extraction first, then use site adapters only for exceptions.
+
+Adapters should preferably be declarative and versioned.
+
+An adapter may define:
+
+- Page-type matching.
+- Crawl scope.
+- URL normalization.
+- Dataset selectors.
+- Field selectors.
+- JSON paths.
+- Pagination rules.
+- Identity rules.
+- Relationship hints.
+- Validation rules.
+- Expected-volume canaries.
+
+Never execute remotely downloaded Python or JavaScript.
+
+Remote updates may provide validated configuration only.
+
+Adapter updates must support:
+
+- Signature or trust verification.
+- Versioning.
+- Compatibility checks.
+- Rollback.
+- Test-fixture validation.
+- Drift detection.
+- Explicit `Adapter Outdated` state.
+
+## User Experience Evolution
+
+Extend the existing Side Panel and Workspace; do not replace them.
+
+The generic Add Site flow should evolve into:
+
+```text
+1. Enter site URL
+2. Configure crawl boundaries
+3. Discover pages
+4. Detect dataset candidates
+5. Preview candidate data
+6. Approve datasets
+7. Review dynamic schemas
+8. Select identity keys
+9. Review relationships
+10. Save the site model
+11. Start the crawl
+```
+
+Add Workspace areas for:
+
+- Pages.
+- Datasets.
+- Schema.
+- Relationships.
+- Data Model.
+- Extraction Rules.
+- Schema Changes.
+- Failed Pages.
+- Raw Snapshots.
+- Crawl Runs.
+
+The Data Model screen should visualize approved datasets and relationships.
+
+Large datasets must use pagination or virtualization.
+
+The table renderer must be generated from the active schema version rather than from hard-coded price columns.
+
+## Incremental Implementation Protocol
+
+Work in small vertical slices.
+
+A vertical slice must include, where applicable:
+
+- Domain model.
+- Database migration.
+- Repository/service logic.
+- API.
+- UI.
+- Tests.
+- Error states.
+- Migration or compatibility behavior.
+- Visual verification.
+- Documentation.
+
+Do not implement a large backend subsystem without one minimal user-visible workflow proving that it works.
+
+For every slice:
+
+1. Inspect current behavior and tests.
+2. State what will be reused.
+3. State the smallest new seam required.
+4. Implement the database change additively.
+5. Implement the domain logic independently of the UI.
+6. Add API boundaries.
+7. Add one usable UI path.
+8. Add happy-path, failure-path, recovery, and migration tests.
+9. Run the full existing test suite.
+10. Verify existing price workflows remain unchanged.
+11. Visually inspect relevant Side Panel and Workspace states.
+12. Report completed work, remaining limitations, and the next smallest slice.
+
+If a slice breaks an existing test, treat it as a regression unless the user explicitly approved the behavioral change.
+
+## Delivery Phases
+
+### Phase G0 — Baseline and Compatibility Contract
+
+- Record current database, API, CLI, Native Messaging, UI, and export behavior.
+- Fix failing storage-safety regressions before adding generic ingestion.
+- Add tests protecting existing price workflows.
+- Define the compatibility boundary between price-specific and generic behavior.
+- Add feature flags for unfinished generic screens.
+
+Exit condition: current behavior is protected and the repository is green.
+
+### Phase G1 — Generic Dataset Catalog
+
+- Add SiteProject, DatasetDefinition, SchemaVersion, and FieldDefinition.
+- Add generic record and revision storage.
+- Implement additive migrations.
+- Add repository APIs and tests.
+- Expose a minimal read-only Dataset Catalog in the Workspace.
+
+Exit condition: a manually defined generic dataset can store and display arbitrary records without affecting price tables.
+
+### Phase G2 — First Generic Extraction Slice
+
+Implement one complete extraction path:
+
+```text
+Saved HTML snapshot
+→ HTML table detection
+→ candidate preview
+→ schema inference
+→ user approval
+→ generic ingestion
+→ dynamic Workspace table
+```
+
+Exit condition: a non-product HTML table can be extracted and browsed end to end.
+
+### Phase G3 — Repeated DOM and JSON Extraction
+
+- Add repeated-card/list extraction.
+- Add JSON array and JSONPath extraction.
+- Add embedded JSON and JSON-LD extraction.
+- Preserve source paths and raw evidence.
+- Add fixture-driven conformance tests.
+
+Exit condition: structurally different datasets use the same generic ingest and UI path.
+
+### Phase G4 — Crawl Frontier
+
+- Add persistent URL frontier.
+- Add canonicalization and deduplication.
+- Add scope, depth, page, and time limits.
+- Add sitemap and link discovery.
+- Add checkpoint recovery.
+- Separate discovery status from extraction status.
+
+Exit condition: a crawl can discover and resume pages without requiring product semantics.
+
+### Phase G5 — Multi-Dataset Sites
+
+- Detect several datasets from the same site.
+- Allow independent approval and scheduling.
+- Support dataset-specific extraction and pagination rules.
+- Show dataset-level progress and failures.
+
+Exit condition: one site can own several separately browsable datasets.
+
+### Phase G6 — Relationships and Site Data Model
+
+- Add key profiling.
+- Add relationship suggestions.
+- Add relationship review.
+- Add one-to-many and many-to-many support.
+- Add Data Model visualization.
+- Add orphan and conflict reporting.
+
+Exit condition: approved related datasets can be navigated and exported as a coherent site model.
+
+### Phase G7 — Schema and Adapter Drift
+
+- Detect schema changes.
+- Add Schema Review Queue.
+- Add adapter versioning.
+- Add volume and structural canaries.
+- Add rollback and re-extraction from saved snapshots.
+
+Exit condition: site changes are explicit, explainable, and recoverable.
+
+### Phase G8 — Dynamic Outputs and Synchronization
+
+- Export any dataset using Original Schema or Current View.
+- Preserve dataset relationships in export metadata.
+- Support multi-sheet/workbook strategies.
+- Apply dynamic schemas to Apps Script and Google synchronization.
+- Resume interrupted multi-dataset synchronization.
+- Report partial failures per dataset.
+
+Exit condition: generic datasets no longer depend on price-specific export columns.
+
+### Phase G9 — Hardening and Public Readiness
+
+- Large crawl tests.
+- Large dynamic-schema tests.
+- Multi-dataset and relationship tests.
+- Arabic and mixed-direction data tests.
+- XSS and untrusted-content tests.
+- Recovery after shutdown, sleep, disconnection, and migration failure.
+- Performance profiling.
+- Adapter-drift tests.
+- Documentation and onboarding.
+
+Exit condition: generic functionality is reliable without weakening existing price functionality.
+
+## Definition of Done for Every Increment
+
+An increment is not complete merely because classes or database tables exist.
+
+It is complete only when:
+
+- The feature is reachable through a real workflow.
+- State is persistent.
+- Failures are visible and actionable.
+- Recovery behavior is defined.
+- Existing data remains safe.
+- Existing price workflows still pass.
+- Tests cover success, failure, retry, and migration.
+- The UI includes empty, loading, running, partial, success, and failure states where applicable.
+- Side Panel and Workspace layouts are visually verified.
+- Documentation distinguishes implemented behavior from planned behavior.
+- No static mock is presented as a production integration.
+
+## Decision Rules
+
+Ask for user direction before:
+
+- Removing or replacing a working compatibility path.
+- Performing a destructive migration.
+- Changing record identity behavior.
+- Automatically approving inferred relationships.
+- Automatically accepting an ambiguous schema rename.
+- Expanding crawl scope beyond the configured site boundaries.
+- Introducing remote adapter updates.
+- Changing which database is the source of truth.
+
+For ordinary additive implementation details, make the safest reasonable decision and continue.
+
+## Required Progress Report
+
+After every completed slice, report in Arabic:
+
+```text
+Slice
+What existed before
+What was reused
+What was added
+Database migrations
+Compatibility impact
+Tests added
+Full test result
+Visual evidence
+Known limitations
+Next recommended slice
+```
+
+Maintain a living implementation matrix with:
+
+```text
+Capability
+Not Started
+Foundation
+Partial
+Production Ready
+Evidence
+Known Limitations
+Next Action
+```
+
+Never inflate progress because a model, API route, or static screen exists.
+
+Measure progress using complete end-to-end workflows.
+
+## Final Principle
+
+ScrapeX must become generic by adding stable metadata-driven capabilities around its proven core, not by erasing the core.
+
+The desired end state is:
+
+```text
+Generic crawling and extraction platform
+    ├── Generic datasets
+    ├── Dynamic schemas
+    ├── Dataset relationships
+    ├── Site-specific data models
+    ├── Declarative adapters
+    ├── Dynamic exports and synchronization
+    └── Price tracking as the first specialized domain
+```
+
+At every stage, prefer:
+
+```text
+working old path + tested new path
+```
+
+over:
+
+```text
+unfinished replacement + removed old path
+```

--- a/docs/CLAUDE-before-database-separation-20260720.md
+++ b/docs/CLAUDE-before-database-separation-20260720.md
@@ -1,0 +1,2273 @@
+You are a senior product designer, UX architect, browser-extension engineer, local-runtime engineer, and data-platform architect.
+
+Your mission is to design and implement a production-quality browser Side Panel Extension for resilient website crawling, scraping, structured local storage, dataset management, historical change tracking, price monitoring, Excel export, Google Sheets synchronization, and background job scheduling.
+
+This is not a generic scraper dashboard. It is a local-first, multi-engine data collection and synchronization product.
+
+# 1. Mandatory communication and language rules
+
+These rules are non-negotiable:
+
+1. Always communicate with me, explain your decisions, report progress, and provide final summaries in Arabic.
+2. The entire product interface must be written in English only.
+3. English-only interface content includes:
+   - Navigation
+   - Buttons
+   - Labels
+   - Forms
+   - Status messages
+   - Errors
+   - Warnings
+   - Empty states
+   - Tooltips
+   - Dialogs
+   - Setup instructions
+   - Logs
+   - Notifications
+   - Generated integration instructions
+4. Arabic is supported only as user-entered data, site names, or scraped content.
+5. Do not place Arabic text inside the product interface itself.
+6. Scraped Arabic data must render correctly with RTL support.
+7. Use automatic text-direction detection for user-entered and scraped values.
+8. URLs, file paths, IDs, versions, source keys, code, and technical logs must always remain LTR.
+9. All source-code comments, docstrings, variable names, function names, test descriptions, commit messages, and technical documentation must be written in English.
+10. Do not propose or create a color palette.
+11. Focus on:
+    - Layout
+    - Spacing
+    - Typography
+    - Hierarchy
+    - Responsive behavior
+    - Component structure
+    - Interaction design
+    - Loading, empty, success, warning, and failure states
+12. Reuse the existing project theme and design tokens when available.
+13. Never rely only on color to communicate status.
+
+# 2. Working approach
+
+Before making changes:
+
+1. Inspect the existing project.
+2. Understand its architecture, framework, components, conventions, and design system.
+3. Reuse the current stack where practical.
+4. Do not replace the existing architecture without a clear technical reason.
+5. Preserve existing user work.
+6. Explain important assumptions to me in Arabic.
+7. Make sensible decisions without asking unnecessary questions.
+
+Do not stop at a conceptual description.
+
+If a repository is available, implement a polished and functional solution.
+
+If some backend capability is unavailable, create a well-structured adapter or realistic mock implementation and clearly distinguish mock behavior from production behavior.
+
+If no implementation environment is available, produce:
+
+- High-fidelity interface specifications.
+- Component specifications.
+- State models.
+- Data models.
+- User flows.
+- Technical architecture.
+- Implementation-ready acceptance criteria.
+
+# 3. Product vision
+
+The product must:
+
+- Run as a browser Side Panel Extension.
+- Support multiple crawling and scraping engines.
+- Support multiple programming runtimes and strategies.
+- Support local Python.
+- Support JavaScript-based processing.
+- Support browser automation.
+- Support static HTTP extraction.
+- Support structured API extraction when legitimately available.
+- Support site-specific adapters.
+- Support automatic engine selection.
+- Support ordered fallback engines.
+- Use a locally installed runtime/helper on the user’s device.
+- Detect whether local components are installed, running, compatible, and ready.
+- Crawl a site for the first time.
+- Update previously collected datasets.
+- Detect field-level changes.
+- Track product prices over time.
+- Identify new, changed, unavailable, returned, and removed records.
+- Rebuild datasets when explicitly requested.
+- Store data locally by default.
+- Export data to Excel.
+- Synchronize data through Apps Script.
+- Connect directly to Google Drive and Google Sheets.
+- Schedule automatic runs.
+- Continue background jobs when the Side Panel is closed.
+- Restore the current job state when the Side Panel is opened again.
+- Handle different schemas for different websites.
+- Allow users to customize data presentation without altering original collected fields.
+
+Handle legitimate crawling challenges through:
+
+- Retry policies.
+- Pagination detection.
+- Browser rendering.
+- Session management.
+- Rate limiting.
+- Throttling.
+- Timeouts.
+- Engine fallback.
+- Checkpoints.
+- Structured error recovery.
+- Network interruption recovery.
+
+Never silently bypass access controls.
+
+Detect and report:
+
+- Authentication requirements.
+- Blocked access.
+- CAPTCHA challenges.
+- Permission problems.
+- Rate limits.
+- Robots or policy restrictions.
+- Unsupported website behavior.
+
+# 4. Required system architecture
+
+The Side Panel must never own or directly execute a long-running crawl.
+
+Use this responsibility model:
+
+```text
+SIDE PANEL
+- Remote control
+- Site selection
+- Run configuration
+- Progress summary
+- Job controls
+- Runtime status
+- Quick data preview
+
+FULL WORKSPACE TAB
+- Dynamic datasets
+- Full tables
+- Column management
+- Comparisons
+- Change history
+- Review queue
+- Jobs and schedules
+- Detailed logs
+- Advanced settings
+
+EXTENSION SERVICE WORKER
+- Extension event handling
+- Native Messaging bridge
+- Browser permissions
+- Authentication coordination
+- Alarm coordination
+- UI notifications
+
+LOCAL RUNTIME
+- Crawling engines
+- Job execution
+- Job queue
+- Persistent checkpoints
+- SQLite database
+- Full technical logs
+- Scheduling
+- Excel generation
+- Synchronization workers
+- Backups and recovery
+```
+
+The Local Runtime must continue jobs independently from the Side Panel.
+
+If the Side Panel closes and reopens, it must request the current job state and reconnect to live updates.
+
+Use persistent Job IDs and database-backed job state.
+
+Do not depend on a Manifest V3 Service Worker remaining alive for a long-running crawl.
+
+
+# Service Worker Lifecycle and MV3 Constraints
+
+The architecture must explicitly handle Chrome Manifest V3 (MV3) Service Worker hibernation. 
+Do not assume the Service Worker will remain active for longer than 30 seconds.
+
+Ensure:
+- The Local Runtime functions independently regardless of the Service Worker's state.
+- The Side Panel communicates directly with the Local Runtime when open, using the Service Worker only as a coordination bridge when necessary.
+- Use Chrome Offscreen Documents or explicit heartbeat pings to maintain the Native Messaging host connection only during critical background UI notifications.
+- Re-establish lost Native Messaging connections automatically and request the latest missed job events upon waking.
+
+# Local Runtime Distribution and Updates
+
+The Local Runtime must be frictionless for non-technical users. 
+Do not require end-users to use the command line, install Python manually, or manage dependencies via `pip`.
+
+Require:
+- A bundled, standalone executable installer (e.g., a single `.exe` or `.dmg`).
+- Over-The-Air (OTA) silent background updates for the runtime and its dependencies.
+- Version parity checks between the browser extension and the Local Runtime.
+
+The extension must prompt users gracefully when an OTA update requires a runtime restart.
+
+
+# 5. Local database as the source of truth
+
+Use the local SQL database as the canonical source of truth.
+
+Prefer SQLite unless the existing architecture already uses another appropriate local SQL database.
+
+```text
+Website
+   ↓
+Crawling and Extraction Engines
+   ↓
+Local SQLite Database — Source of Truth
+   ├── Excel Output
+   ├── Google Sheets via Apps Script
+   └── Google Drive and Sheets APIs
+```
+
+OPFS or browser storage may be used for temporary UI state or cache, but not as the only canonical database.
+
+The Local Runtime must own and manage the database file.
+
+Use:
+
+- Transactions.
+- WAL mode when appropriate.
+- Safe schema migrations.
+- Integrity checks.
+- Recoverable backups.
+- Job checkpoints.
+- Database versioning.
+- Compaction and maintenance.
+- Storage-health monitoring.
+
+# 6. Native Messaging constraints
+
+Use Native Messaging as a command and status bridge between the extension and Local Runtime.
+
+Do not send entire datasets or full logs through one message.
+
+Native Messaging responses from the Local Runtime must remain small and paginated.
+
+Use:
+
+- Cursor-based pagination.
+- Small command responses.
+- Structured job events.
+- Aggregated progress.
+- Log tails.
+- Explicit acknowledgements.
+- Reconnection support.
+
+Example:
+
+```text
+GET_RECORDS
+
+datasetId
+cursor
+limit
+visibleFields
+filters
+sort
+```
+
+The Local Runtime must return a limited page and a new cursor.
+
+# 7. Core domain model
+
+Adapt the exact implementation to the project, but support concepts equivalent to:
+
+- Site
+- Site Profile
+- Site Adapter
+- Runtime Component
+- Crawling Engine
+- Engine Capability
+- Dataset
+- Dataset Field
+- Record Entity
+- Source Identity
+- Identity Alias
+- Crawl Job
+- Crawl Snapshot
+- Change Event
+- Identity Conflict
+- Review Decision
+- Output Destination
+- Sync Session
+- Sync Batch
+- Schedule
+- Saved View
+- Export Job
+- Backup
+- Runtime Log
+
+# 8. Side Panel information architecture
+
+The primary Side Panel must contain:
+
+1. Product header.
+2. Local Runtime status.
+3. Sites section.
+4. Add Site action.
+5. Site search and checklist.
+6. Selected site cards.
+7. Run mode.
+8. Output summary.
+9. Main run action.
+10. Activity summary.
+11. Persistent active-job mini-player.
+12. Bottom navigation.
+
+Bottom navigation:
+
+```text
+Run
+Browse Data
+Settings
+```
+
+Do not add a complex full-width data table to the Side Panel.
+
+# 9. Header and Local Runtime status
+
+Place the product logo and extension name at the top.
+
+Directly below the product name, add a thin interactive status row.
+
+Possible states:
+
+```text
+Local Runtime Ready                         ›
+Setup Required                              ›
+Connection Failed                           ›
+Checking Components...
+Update Required                             ›
+Runtime Stopped                             ›
+```
+
+The status represents the complete runtime, not Python alone.
+
+When selected, expand:
+
+```text
+LOCAL RUNTIME
+
+Core Service                         Running
+Python Runtime                       Ready
+JavaScript Runtime                   Ready
+Browser Automation                  Ready
+Network Tools                        Ready
+Site Adapters                  24 installed
+
+Run Diagnostics
+Manage Components                            ›
+```
+
+Support:
+
+- Installed.
+- Not Installed.
+- Running.
+- Stopped.
+- Ready.
+- Update Required.
+- Incompatible.
+- Connection Failed.
+- Checking.
+
+If components are missing, provide:
+
+```text
+SET UP LOCAL RUNTIME
+
+1. Download the local helper
+2. Run the installer
+3. Install required runtimes
+4. Verify the connection
+```
+
+Actions:
+
+- Download.
+- Continue Setup.
+- Recheck Status.
+- Run Diagnostics.
+- Manage Components.
+- Open Runtime Logs.
+- Check for Updates.
+
+# 10. Sites section
+
+Use:
+
+```text
+SITES                               + Add Site
+```
+
+Provide:
+
+- Search by site name or URL.
+- Select All.
+- Clear.
+- Selected count.
+- Scrollable checklist.
+- Empty state.
+- Loading state.
+- Error state.
+
+Site format:
+
+```text
+example.com (Example Website)
+news-site.com (موقع الأخبار)
+```
+
+The interface remains English and LTR, while Arabic names are treated as data and render correctly.
+
+Allow one or multiple sites to be selected.
+
+Unavailable sites remain visible but disabled with an English explanation.
+
+# 11. Add Site flow
+
+Selecting Add Site must open an internal Side Panel screen or drawer.
+
+Include:
+
+```text
+ADD SITE
+
+Site URL
+Display Name
+Scraping Profile
+Extraction Type
+Preferred Engine
+Fallback Engines
+Authentication Requirements
+Output Defaults
+Schedule
+Advanced Settings
+
+Test Site
+Add Site
+```
+
+The flow must:
+
+- Validate the URL.
+- Test connectivity.
+- Inspect basic capabilities.
+- Detect likely browser-rendering requirements.
+- Recommend an engine.
+- Allow advanced engine override.
+- Display a small discovered-data sample.
+- Save a reusable Site Profile.
+
+Under Advanced Settings, add:
+
+```text
+IDENTITY RULES
+
+Primary Match
+Fallback Match
+Composite Fields
+Canonical URL Rules
+Ambiguous Match Behavior
+```
+
+Default behavior should be automatic and simple. Advanced identity controls must not overwhelm a new user.
+
+# 12. Selected site cards
+
+Every selected site appears below the checklist as a compact card.
+
+Show:
+
+- Display name.
+- URL.
+- Engine.
+- Fallback availability.
+- Extraction profile.
+- Dataset state.
+- Readiness status.
+- Site Settings.
+- Remove-from-current-selection action.
+
+Example:
+
+```text
+Example Website                              ×
+example.com
+
+Engine              Playwright
+Extraction          Products
+Dataset             1,842 records
+Status              Ready
+
+Site Settings                                ›
+```
+
+Removing a selected card must not delete the saved site.
+
+# 13. Run modes
+
+Support three explicit modes:
+
+```text
+INITIAL CRAWL
+Collect and save this site for the first time.
+
+UPDATE EXISTING DATA
+Collect current data and detect differences.
+
+FULL REBUILD
+Archive the current dataset and crawl the site again.
+```
+
+## Initial Crawl
+
+- Create the first dataset.
+- Discover the initial schema.
+- Create stable Record Entity IDs.
+- Save the initial snapshot.
+- Record the source identity strategy.
+
+## Update Existing Data
+
+- Match incoming records against stable entities.
+- Detect new records.
+- Detect changed records.
+- Detect unavailable records.
+- Detect returned records.
+- Preserve previous values.
+- Create field-level Change Events.
+- Update current state.
+- Save a Crawl Snapshot.
+- Preserve full history.
+
+## Full Rebuild
+
+- Show a clear warning.
+- Create a backup or archive.
+- Let the user choose Archive or Replace.
+- Never destroy old data silently.
+- Provide a rollback path.
+
+# 14. Record identity and conflict resolution
+
+Separate the internal entity from its current source identity.
+
+```text
+Record Entity ID
+A permanent internal identity.
+
+Source Identity
+URL, SKU, source ID, canonical URL, or composite key.
+
+Identity Aliases
+Previous URLs, SKUs, IDs, and known identities.
+```
+
+Matching priority may include:
+
+1. Stable source ID.
+2. SKU.
+3. Canonical URL.
+4. Composite key.
+5. Known identity aliases.
+6. Similarity matching.
+7. Requires Review.
+
+Composite keys must be configurable.
+
+If the system suspects that an incoming record matches an existing entity but cannot safely confirm it, create a `Requires Review` item.
+
+Provide a Review Queue:
+
+```text
+POSSIBLE MATCH
+
+Existing Record
+Incoming Record
+Match Confidence
+Matched Fields
+Conflicting Fields
+
+Keep Separate
+Merge Records
+Review Later
+```
+
+Manual merges must:
+
+- Preserve price history.
+- Preserve previous identities.
+- Create aliases.
+- Create an audit record.
+- Support Undo Merge.
+- Prevent the same conflict from repeatedly returning.
+
+# 15. Historical changes and price monitoring
+
+Maintain separate current-state and historical-change layers.
+
+```text
+CURRENT RECORD
+
+Record Entity ID
+Current Values
+Current Availability
+First Seen
+Last Seen
+Last Updated
+```
+
+```text
+CHANGE EVENT
+
+Record Entity ID
+Field Key
+Previous Value
+New Value
+Detected At
+Crawl Job ID
+Change Type
+```
+
+## Price-history storage semantics
+
+The owner-facing price history is a timeline of real price changes, not a daily
+copy of an unchanged price row.
+
+For each source-scoped offer identity, including its product, variant, region,
+branch, customer segment, selling unit, currency, and VAT basis:
+
+- Store the first detected price.
+- Compute a normalized `price_hash` from the comparable price, currency, and VAT
+  basis.
+- When a successful refresh sees the same `price_hash`, do not append a price
+  observation, price-history row, or price change event. Update only the current
+  state's `last_seen_at` and the active price period's `last_confirmed_at`.
+- When the `price_hash` changes, append exactly one immutable price observation
+  and change event, close the previous price period, and open a new price period.
+- Track availability and stock with a separate state hash so that a stock change
+  does not create a false price change.
+- Failed, partial, cancelled, or out-of-scope runs must not advance
+  `last_confirmed_at` and must not mark products unavailable.
+- If an offer disappears and later returns, open a new price period even when the
+  returned price equals the old price; continuity during the absence is unknown.
+
+The permanent price model must distinguish:
+
+```text
+CURRENT OFFER STATE
+Latest price and availability for fast reads.
+Updated in place after a successful refresh.
+
+PRICE PERIOD
+One row per continuous confirmed price period.
+Contains first_detected_at and last_confirmed_at.
+
+PRICE OBSERVATION / CHANGE EVENT
+Append-only evidence for the first price and each real change.
+Existing rows are never updated or deleted.
+
+SCRAPE RUN
+One audit row per refresh, including scope, completion status, row counts, and
+errors.
+
+ABSENCE PERIOD
+Created only when a successfully completed full-scope run does not see an
+expected offer. It records disappearance and return transitions, not unchanged
+daily confirmations.
+```
+
+Do not persist a full per-offer seen row for every successful daily refresh.
+The run may use a staging table or an in-memory seen set while finalizing. After
+the run has updated current state, price periods, and absence transitions, the
+staging seen set may be discarded. Raw snapshots remain the recoverable source
+evidence under their configured retention policy.
+
+Exact-date price lookup must behave as follows:
+
+- If a successful in-scope run confirms the offer on the requested date, return
+  the price period that covered that confirmation.
+- If no reliable observation exists on that date, say so explicitly and return
+  the last known price before that date together with its observation date.
+- If the requested date is before tracking began, report the first tracking date.
+- If the relevant run failed or was partial, report that the date has no reliable
+  observation rather than assuming the previous price remained valid.
+
+The product price-history view must list only the first detected price and each
+subsequent real price change, ordered from the beginning of tracking through the
+last confirmed price. Daily unchanged confirmations must not appear as duplicate
+history rows.
+
+Support:
+
+- New records.
+- Updated records.
+- Price increases.
+- Price decreases.
+- Unchanged records as current-state confirmations without duplicate historical rows.
+- Unavailable records.
+- Returned records.
+- Removed records.
+- Crawl errors.
+- Comparison between any two snapshots.
+- First recorded price.
+- Current price.
+- Minimum price.
+- Maximum price.
+- Absolute change.
+- Percentage change.
+- Exact-date price lookup with an explicit last-known fallback.
+- A change-only price timeline from first detection through last confirmation.
+
+# 16. Output destinations
+
+The Local Database must be enabled by default.
+
+Allow multiple destinations for the same run:
+
+```text
+DATA OUTPUT
+
+Local Database
+Excel Files
+Google Sheets via Apps Script
+Google Drive and Sheets
+```
+
+The local database remains the source of truth.
+
+# 17. Local storage settings
+
+Provide:
+
+- Current database location.
+- Change Storage Location.
+- Open Storage Folder.
+- Database size.
+- Database health.
+- Backup.
+- Restore.
+- Repair.
+- Compact Database.
+- Export Database.
+- Storage migration progress.
+
+When changing storage location:
+
+- Validate permissions.
+- Detect unavailable or removable drives.
+- Explain whether existing data will move.
+- Never overwrite a database silently.
+- Create a recoverable backup.
+- Provide rollback.
+- Report migration progress.
+
+# 18. Data retention
+
+Provide configurable retention policies:
+
+```text
+CHANGE HISTORY RETENTION
+
+Keep detailed history for:
+90 days
+
+After that:
+Keep daily summaries
+Keep weekly summaries
+Archive old history
+Delete permanently
+```
+
+Always allow preserving:
+
+- First recorded value.
+- Latest value.
+- Minimum price.
+- Maximum price.
+- Important user-marked events.
+
+Provide:
+
+- Retention preview.
+- Estimated recovered space.
+- Dataset-level exclusions.
+- Backup before destructive cleanup.
+- Storage usage warnings.
+- Automatic database maintenance.
+
+# 19. Excel output
+
+Excel is an optional output destination.
+
+Support:
+
+```text
+WORKBOOK STRUCTURE
+
+One workbook for all sites
+Separate workbook for each site
+```
+
+For a combined workbook, use separate sheets where schemas differ.
+
+Support:
+
+```text
+UPDATE BEHAVIOR
+
+Update existing rows
+Create a new snapshot sheet
+Create a new dated workbook
+```
+
+Provide:
+
+- Change Save Location.
+- Open Output Folder.
+- Export Current View.
+- Export Original Schema.
+- Export Change History.
+- Last Export Status.
+
+Preserve Arabic data correctly.
+
+# 20. Browse Data inside the Side Panel
+
+Browse Data in the Side Panel is a compact preview, not a full analytics table.
+
+Show:
+
+- Dataset list.
+- Record count.
+- Last update.
+- Change summary.
+- Recent records.
+- Compact Card View.
+- Basic search.
+- Basic filters.
+- Open in Workspace.
+
+Example:
+
+```text
+DATASETS
+
+Example Store
+1,842 records
+Updated 12 minutes ago
+34 changed · 15 new · 3 unavailable
+
+Open Dataset
+```
+
+When a dataset is opened inside the Side Panel, use compact cards and limited fields.
+
+Use virtualization for long lists.
+
+# 21. Full-page Workspace
+
+Provide an `Open in Workspace` action that opens a full extension page in a browser tab.
+
+The Workspace must contain:
+
+- Overview.
+- Data.
+- Changes.
+- Crawl History.
+- Review Queue.
+- Jobs.
+- Schedules.
+- Sync.
+- Exports.
+- Logs.
+
+The Data area must support:
+
+- Dynamic table schemas.
+- Search.
+- Filters.
+- Sorting.
+- Pagination or virtualization.
+- Column resizing.
+- Column reordering.
+- Manage Columns.
+- Show Hidden Columns.
+- Saved Views.
+- Snapshot comparison.
+- Export.
+- Sync.
+- Full-page horizontal scrolling when genuinely required.
+
+# 22. Schema and column safety
+
+Never treat a presentation change as a destructive schema change.
+
+Every field must support:
+
+```text
+Source Key
+Original Name
+Display Name
+Data Type
+Visibility
+Display Order
+```
+
+Rules:
+
+- Source Key is stable and immutable.
+- Original Name is preserved.
+- Display Name is user-editable.
+- Selecting X sets the field to Hidden.
+- Selecting X never deletes the field or its data.
+- Hidden fields continue receiving future updates.
+- Users can show hidden fields again.
+- Users can reset names.
+- Users can reset layout.
+- Users can restore the default view.
+- Users can save multiple views.
+- Export and sync can use either Original Schema or Current View.
+- Destructive deletion requires explicit confirmation.
+
+# 23. Job execution and lifecycle
+
+Persist every job in the database.
+
+Support states equivalent to:
+
+- Scheduled.
+- Queued.
+- Preparing.
+- Running.
+- Pausing.
+- Paused.
+- Resuming.
+- Cancelling.
+- Cancelled.
+- Completed.
+- Partially Completed.
+- Failed.
+- Requires Review.
+
+Persist:
+
+- Job ID.
+- Site IDs.
+- Run mode.
+- Current stage.
+- Progress.
+- Counters.
+- Checkpoint.
+- Started time.
+- Last heartbeat.
+- Retry count.
+- Output status.
+- Error summary.
+
+Closing the Side Panel must not stop the job.
+
+Reopening the Side Panel must retrieve and display the current state.
+
+# 24. Active Job mini-player
+
+Add a persistent mini-player above bottom navigation when a job is active.
+
+Example:
+
+```text
+Amazon Update                         63%
+Processing 8,420 of 10,000
+1 running · 2 queued
+
+View Job
+Pause
+```
+
+The mini-player remains visible while the user moves between:
+
+- Run.
+- Browse Data.
+- Settings.
+- Add Site.
+
+Selecting it opens the full job details.
+
+# 25. Activity and logging
+
+Do not add one UI row for every processed product.
+
+The Local Runtime must store the complete technical log.
+
+The Side Panel displays:
+
+- Aggregated progress.
+- Current step.
+- Current site.
+- Current counters.
+- Last 200 log entries only.
+
+Use a fixed-size Ring Buffer for UI logs.
+
+Use virtualization for visible log rows.
+
+Throttle UI progress updates instead of rendering every internal event.
+
+Show:
+
+- Overall percentage.
+- Current site.
+- Current stage.
+- Records discovered.
+- Records processed.
+- Records created.
+- Records updated.
+- Records unchanged.
+- Warnings.
+- Errors.
+- Elapsed time.
+- Per-site progress.
+
+Include:
+
+- Show Technical Details.
+- Pause Auto-scroll.
+- Copy Visible Logs.
+- Download Full Logs.
+- Open Logs Folder.
+- Pause.
+- Resume.
+- Cancel Run.
+- Retry Failed Step.
+- Open Dataset after completion.
+
+# 26. Scheduling
+
+Provide scheduling inside Site Settings.
+
+Support:
+
+- Manual.
+- Daily.
+- Weekly.
+- Custom schedule when appropriate.
+- Time selection.
+- Time zone.
+- Offline behavior.
+- Missed-run behavior.
+- Overlapping-run policy.
+- Retry policy.
+- Completion notifications.
+- Failure notifications.
+- Change-detected notifications.
+
+Example:
+
+```text
+SCHEDULE
+
+Frequency
+Daily
+
+Run At
+09:00 AM
+
+Time Zone
+Asia/Riyadh
+
+If Device Was Offline
+Run when available
+
+Overlapping Runs
+Queue new run
+```
+
+Use the Local Runtime scheduler for reliable scheduling.
+
+Use `chrome.alarms` only as browser-side coordination or fallback.
+
+Do not claim that browser alarms can wake a sleeping or powered-off device.
+
+If scheduling must work while Chrome is closed, implement an explicit user-approved Local Runtime background service or OS-level scheduling integration.
+
+Clearly explain the behavior to the user in English.
+
+# OS Resource and Hardware Management
+
+Background jobs must not freeze the user's operating system or aggressively drain device batteries.
+
+Implement:
+- Hardware-aware concurrency limits (detect available CPU cores and RAM).
+- Eco Mode: Automatically pause or throttle intensive jobs (like browser automation) when the device is running on battery power.
+- System wake/sleep awareness to safely checkpoint and suspend running jobs when the OS goes to sleep.
+
+
+# 27. Apps Script integration
+
+Generate Apps Script code that users can copy into Google Sheets.
+
+Setup interface:
+
+```text
+GOOGLE SHEETS — APPS SCRIPT
+
+1. Create or open a Google Sheet
+2. Open Extensions → Apps Script
+3. Paste the generated code
+4. Run the setup function
+5. Deploy the script
+6. Paste the deployment URL below
+```
+
+Include:
+
+- Copy Script.
+- Deployment URL.
+- Test Connection.
+- Save Connection.
+- Regenerate Secret.
+- Revoke Connection.
+- Last Sync.
+- Sync Now.
+- Connection Logs.
+
+The generated Apps Script must:
+
+- Create required sheets.
+- Create and update headers.
+- Insert new records.
+- Update existing records.
+- Preserve supported user customizations.
+- Read existing sheet data when required.
+- Synchronize current data.
+- Synchronize change history optionally.
+- Resume interrupted synchronization.
+- Prevent duplicate records.
+- Support explicit full recreation.
+
+All generated code and comments must be written in English.
+
+# 28. Apps Script security
+
+Do not rely on a permanent hard-coded bearer token.
+
+Use a cryptographically secure connection secret.
+
+Prefer:
+
+- A 256-bit random secret.
+- Secure local storage managed by Local Runtime.
+- Apps Script `Script Properties`.
+- HMAC request signing.
+- Timestamp.
+- Nonce.
+- Replay protection.
+- Revocation.
+- Regeneration.
+- Rate limiting.
+- Constant-time signature comparison when possible.
+
+Do not place secrets in URLs.
+
+If standard HTTP authorization headers are not reliably available to Apps Script `doPost`, include the signature metadata inside the JSON request body.
+
+# 29. Apps Script batching and recovery
+
+Never send an entire large dataset in one request.
+
+Use adaptive batching based on:
+
+- Encoded payload size.
+- Row count.
+- Column count.
+- Remaining execution time.
+- Previous response time.
+- Retry history.
+
+Do not assume that 1,000 records are always an appropriate batch.
+
+Persist:
+
+```text
+Sync Session ID
+Dataset ID
+Snapshot ID
+Batch Number
+Total Batches
+Cursor
+Checksum
+Attempt Number
+Status
+Acknowledged At
+```
+
+The synchronization process must be:
+
+- Resumable.
+- Idempotent.
+- Checkpointed.
+- Retryable.
+- Duplicate-safe.
+- Observable.
+
+Use:
+
+- Batch acknowledgements.
+- Checksums.
+- Exponential backoff.
+- Time-budget guards.
+- Concurrency control.
+- Partial-failure reporting.
+- Resume from the last acknowledged batch.
+
+Verify current official Google limits during implementation rather than relying on permanently hard-coded quota assumptions.
+
+# 30. Direct Google integration
+
+Provide a separate direct integration using:
+
+- Continue with Google.
+- Google Drive API.
+- Google Sheets API.
+
+Allow users to:
+
+- Connect a Google account.
+- View the connected account.
+- Select or create a Drive folder.
+- Create spreadsheets.
+- Organize files.
+- Synchronize existing datasets.
+- Create missing headers.
+- Update existing rows.
+- Create snapshots.
+- View the last sync result.
+- Reconnect after authorization expires.
+- Disconnect the account.
+
+Organization options:
+
+```text
+FILE ORGANIZATION
+
+One spreadsheet per site
+One spreadsheet per crawl
+Combined spreadsheet
+```
+
+Request only required permissions.
+
+Store OAuth credentials securely.
+
+Implement:
+
+- Adaptive request batching.
+- Quota awareness.
+- Exponential backoff.
+- Resumable synchronization.
+- Clear error reporting.
+
+# 31. Google Sheet conflict policy
+
+The Local Database remains the source of truth by default.
+
+Provide explicit sync policies:
+
+```text
+SYNC DIRECTION
+
+Local Database to Google Sheets
+Two-way Sync
+```
+
+For two-way sync, define:
+
+- System-owned fields.
+- User-editable fields.
+- Conflict detection.
+- Local wins.
+- Google Sheet wins.
+- Requires Review.
+- Last-write metadata.
+- Audit history.
+
+Never overwrite a manual Google Sheet edit silently when two-way sync is enabled.
+
+# 32. Multi-engine orchestration
+
+Do not hard-code a single engine.
+
+Support:
+
+- Automatic engine recommendation.
+- Preferred engine.
+- Ordered fallback engines.
+- Capability detection.
+- Dependency checks.
+- Per-site engine profiles.
+- Per-step retries.
+- Manual override.
+- Structured failure reasons.
+
+The execution log must show:
+
+- Selected engine.
+- Why it was selected.
+- Engine switches.
+- Fallback reasons.
+- Retry attempts.
+- Final failure reason.
+
+# Proxy and Anti-Bot Management
+
+Engine orchestration must handle anti-bot detection intelligently without causing permanent IP bans.
+
+Support:
+- Proxy configuration per site or globally.
+- Residential and Datacenter proxy types.
+- Automatic IP rotation per request or per session.
+- Advanced browser fingerprint spoofing (e.g., modifying User-Agent, WebGL, canvas, and timezone metadata when using automated browsers).
+- Rate-limit awareness and automatic cooldowns.
+
+Do not permanently burn user IP addresses through aggressive retries on blocked access.
+
+# Adapter Drift and Dynamic Maintenance
+
+Website DOM structures and internal APIs change frequently, breaking hard-coded Site Adapters. 
+
+The system must:
+- Detect Adapter Breakdown: Identify when a previously successful site adapter experiences a sudden, extreme drop in success rates.
+- Display an explicit `Adapter Outdated` status instead of a generic `Failed` error.
+- Support dynamic fetching of updated adapter rules or configurations without requiring a full application update.
+- Allow users to report broken adapters directly from the Side Panel.
+
+# 33. Settings structure
+
+Organize Settings into:
+
+- General.
+- Local Runtime.
+- Storage.
+- Crawling.
+- Engines.
+- Jobs and Scheduling.
+- Excel.
+- Apps Script.
+- Google Account.
+- Data and History.
+- Privacy and Security.
+- Logs and Diagnostics.
+- About.
+
+Use progressive disclosure.
+
+Do not place every setting on one long screen.
+
+# 34. Security and data safety
+
+Treat all scraped content as untrusted.
+
+Implement:
+
+- Output sanitization.
+- XSS prevention.
+- Message validation.
+- Command authorization.
+- Native host origin restrictions.
+- Secure secret storage.
+- Path validation.
+- Safe file creation.
+- Database transactions.
+- Backup before destructive operations.
+- Audit logs.
+- Runtime version compatibility checks.
+- Protection against duplicate jobs.
+- Concurrency limits.
+- Safe cancellation.
+
+Never execute remotely downloaded code inside the extension.
+
+Comply with current browser-extension platform requirements.
+
+# 35. Required UX states
+
+Design and implement:
+
+- First launch.
+- Runtime not installed.
+- Runtime checking.
+- Runtime ready.
+- Runtime update required.
+- Runtime disconnected.
+- Empty site list.
+- Add Site.
+- Site test running.
+- Site test failed.
+- No selected sites.
+- Initial crawl.
+- Update existing data.
+- Full rebuild warning.
+- Multi-site run.
+- Scheduled run.
+- Queued job.
+- Paused job.
+- Cancelled job.
+- Partial success.
+- Complete success.
+- Failed run.
+- Requires Review.
+- Empty dataset.
+- Dataset loading.
+- Dynamic schema.
+- Hidden columns.
+- No detected changes.
+- Sync pending.
+- Sync running.
+- Sync partially completed.
+- Sync successful.
+- Sync failed.
+- Google disconnected.
+- Apps Script not configured.
+- Storage location unavailable.
+- Database migration.
+- Database backup.
+- Database recovery.
+
+# 36. Accessibility and responsive behavior
+
+- Optimize the Side Panel for approximately 320px–400px widths.
+- Avoid horizontal scrolling in the main Side Panel.
+- Use Card View or compact previews for records.
+- Use the Full Workspace for complex tables.
+- Use keyboard navigation.
+- Use accessible names and labels.
+- Use visible focus states from the existing theme.
+- Keep primary actions discoverable.
+- Do not rely only on icons.
+- Use confirmation dialogs only for destructive actions.
+- Preserve scroll position where appropriate.
+- Handle long URLs safely.
+- Use `dir="auto"` or equivalent for scraped values.
+- Force technical content to LTR.
+- Test mixed Arabic and English data.
+
+# 37. Testing requirements
+
+Add tests for:
+
+- Closing and reopening the Side Panel during a job.
+- Runtime disconnection and reconnection.
+- Job checkpoint recovery.
+- Initial Crawl.
+- Update Existing Data.
+- Full Rebuild backup.
+- Composite identity matching.
+- Requires Review.
+- Merge and Undo Merge.
+- Price history preservation.
+- Column rename without source-key mutation.
+- Column hiding without data deletion.
+- Apps Script batch retry.
+- Duplicate batch prevention.
+- Interrupted sync resume.
+- Google authorization expiration.
+- Storage migration failure.
+- Scheduled-run recovery.
+- Arabic data rendering.
+- Native Messaging pagination.
+- Log Ring Buffer behavior.
+- Large dataset virtualization.
+- XSS sanitization.
+
+# 38. Expected implementation quality
+
+- Use reusable components.
+- Use typed domain models.
+- Use explicit state machines where helpful.
+- Separate UI, domain logic, execution, storage, and synchronization.
+- Do not hard-code site schemas.
+- Do not hard-code one engine.
+- Do not hard-code one output.
+- Do not store complete datasets in UI state.
+- Do not stream one UI log event per product.
+- Do not couple jobs to the Side Panel lifecycle.
+- Clearly identify mock and production integrations.
+- Add validation and structured recovery.
+- Preserve existing project conventions.
+- Verify realistic Side Panel dimensions.
+- Verify the Full Workspace separately.
+- Keep code comments in English.
+
+# 39. Final implementation phases
+
+Complete the work in these phases:
+
+1. Inspect the existing project.
+2. Explain your understanding to me in Arabic.
+3. Present the implementation plan in Arabic.
+4. Define the architecture and responsibility boundaries.
+5. Define the domain and state models.
+6. Implement Local Runtime communication abstractions.
+7. Implement the Side Panel.
+8. Implement the active-job mini-player.
+9. Implement the Full Workspace.
+10. Implement dataset and schema customization.
+11. Implement job persistence and lifecycle recovery.
+12. Implement scheduling.
+13. Implement Excel output.
+14. Implement Apps Script synchronization.
+15. Implement direct Google integration.
+16. Implement identity conflict review.
+17. Implement logging, retention, backup, and recovery.
+18. Test critical workflows.
+19. Visually inspect realistic Side Panel and Workspace dimensions.
+20. Report completed work, assumptions, limitations, test results, and next steps to me in Arabic.
+
+The final product must feel like a focused, reliable, local-first crawling and data synchronization platform specifically designed around a browser Side Panel and a full data-management Workspace.
+
+# 40. Incremental Evolution into a Generic Crawling and Data-Modeling Platform
+
+## Mission
+
+Evolve ScrapeX incrementally from its current product-and-price tracking system into a generic, metadata-driven crawling, extraction, and data-modeling platform.
+
+The final platform should be capable of:
+
+- Crawling broadly different website structures.
+- Discovering multiple datasets within the same site or page.
+- Extracting HTML tables, repeated DOM structures, structured data, embedded JSON, REST APIs, GraphQL responses, and browser-observed network data.
+- Inferring dynamic schemas whose columns may appear, disappear, change names, or change types over time.
+- Detecting and managing multiple datasets per site.
+- Inferring and reviewing relationships between datasets.
+- Building a versioned site-specific data model.
+- Preserving raw source evidence, historical revisions, provenance, and schema history.
+- Presenting dynamic datasets, columns, relationships, and crawl state through the Side Panel and Full Workspace.
+- Exporting either the original discovered schema or a user-customized view.
+- Keeping the existing price-tracking domain fully operational throughout the evolution.
+
+This is an evolutionary program, not a rewrite.
+
+## Prime Directive: Extend, Preserve, and Migrate Incrementally
+
+Never destroy and rebuild the existing product merely to obtain a cleaner architecture.
+
+Before implementing any capability:
+
+1. Inspect the current repository and identify existing components that already solve part of the problem.
+2. Reuse or extend those components wherever doing so preserves correctness.
+3. Introduce a compatibility seam when the existing design is too specialized.
+4. Move one vertical slice at a time through the new seam.
+5. Keep the old path operational until the replacement path has proven behavioral parity.
+6. Remove or retire an old path only after:
+   - Its replacement is complete.
+   - Migration is tested.
+   - Existing data remains readable.
+   - Rollback is possible.
+   - The user has explicitly approved retirement.
+
+Do not perform speculative large-scale refactoring.
+
+Do not rename, relocate, or rewrite stable modules unless the current increment genuinely requires it.
+
+Do not mix architectural cleanup with unrelated feature work.
+
+Every increment must leave the application runnable, testable, and recoverable.
+
+Repository behavior and tests are the ground truth. If this plan conflicts with proven repository behavior, report the conflict before changing the behavior.
+
+## Existing Capabilities That Must Be Preserved
+
+Treat the following as valuable working assets rather than temporary code:
+
+- Existing product and price ingestion.
+- Append-only price observation history. Existing observations are immutable;
+  the optimized price path may reduce future write frequency by appending only
+  the first price and real changes, as defined in section 15, but it must never
+  rewrite or delete legacy observations.
+- Current connectors and fetchers.
+- Job persistence, pause, resume, cancellation, and checkpoint recovery.
+- Native Messaging and localhost communication.
+- Side Panel and active-job mini-player.
+- Full Workspace.
+- Storage, backup, restore, migration, and retention mechanisms.
+- Column customization and saved views.
+- Excel, Apps Script, and direct Google output paths.
+- Review Queue and identity conflict decisions.
+- Arabic content normalization and bidirectional rendering.
+- Existing tests, fixtures, screenshots, and public contracts.
+
+The price engine must become the first specialized domain built on, or interoperating with, the generic platform. It must not be discarded.
+
+The price-history optimization in section 15 is the owner-approved target for
+that specialized domain. It must be introduced through additive schema,
+backfilled projections, compatibility tests, and a reversible cutover. Generic
+phases do not have implicit permission to repurpose `generic_record`, rewrite
+`price_observation`, or weaken existing price workflows while implementing this
+optimization.
+
+## Honest Definition of “Generic”
+
+Do not claim that ScrapeX can scrape literally every website.
+
+A generic platform means:
+
+- It supports several reusable extraction patterns.
+- It can describe site-specific behavior through versioned metadata.
+- It provides an adapter mechanism for exceptional sites.
+- It reports unsupported, blocked, ambiguous, or authentication-dependent cases honestly.
+- It never silently returns incomplete or structurally incorrect data.
+- It distinguishes crawler failure, extractor failure, schema drift, access denial, and unsupported structure.
+
+CAPTCHAs, strong anti-bot systems, inaccessible authenticated content, legal restrictions, and highly interactive applications may still require user intervention or a specialized adapter.
+
+## Architectural Direction
+
+Separate the following responsibilities:
+
+```text
+Site Project
+    ↓
+Crawl Plan
+    ↓
+URL Frontier
+    ↓
+Fetcher
+    ↓
+Page Snapshot
+    ↓
+Dataset Discovery
+    ↓
+Extraction Plan
+    ↓
+Schema Inference
+    ↓
+Generic Records
+    ↓
+Identity Resolution
+    ↓
+Relationship Inference
+    ↓
+Versioned Site Data Model
+    ↓
+Workspace / Export / Sync
+```
+
+### Crawl and Scrape Are Different Operations
+
+`Crawl` discovers and revisits pages.
+
+`Scrape` extracts one or more datasets from a page or response.
+
+Do not couple URL discovery to product extraction.
+
+The crawler must be able to discover pages even when no extraction rule has been approved yet.
+
+The extractor must be able to run against a saved page snapshot without repeating a network request.
+
+### Domain Type and Extraction Method Are Different Concepts
+
+Do not use one enum to represent both what the data means and how it was obtained.
+
+Keep separate concepts such as:
+
+```text
+Domain:
+- generic
+- prices
+- listings
+- documents
+- user-defined
+
+Extraction Method:
+- html_table
+- repeated_dom
+- json_array
+- json_path
+- json_ld
+- embedded_json
+- rest_api
+- graphql
+- browser_network
+- custom_adapter
+```
+
+A dataset may use any extraction method without being classified as product or price data.
+
+## Generic Metadata Model
+
+Introduce the generic model through additive database migrations.
+
+At minimum, support concepts equivalent to:
+
+```text
+SiteProject
+CrawlPlan
+CrawlRun
+CrawlPage
+PageSnapshot
+PageType
+DatasetDefinition
+DatasetCandidate
+DatasetSchemaVersion
+FieldDefinition
+ExtractionRule
+GenericRecord
+RecordRevision
+RelationshipDefinition
+RecordRelationship
+AdapterDefinition
+AdapterVersion
+SchemaChange
+```
+
+### Dataset Definition
+
+A dataset definition should identify:
+
+- Stable dataset key.
+- User-facing name.
+- Source page type.
+- Extraction method.
+- Source selector, JSON path, or response path.
+- Cardinality.
+- Pagination strategy.
+- Identity strategy.
+- Current schema version.
+- Adapter version.
+- Dataset status.
+- Provenance and timestamps.
+
+### Field Definition
+
+A field definition should preserve:
+
+```text
+field_key
+source_name
+display_name
+source_path
+data_type
+nullable
+repeated
+key_role
+position
+confidence
+first_seen_at
+last_seen_at
+status
+```
+
+Rules:
+
+- `field_key` is stable and internal.
+- `source_name` preserves the exact source label or property name.
+- `display_name` is a presentation preference.
+- Renaming a display name never changes source identity.
+- Hiding a field never deletes it.
+- Missing fields remain in schema history.
+- New fields create a new schema version.
+- Type changes are recorded, not silently overwritten.
+- Automatic widening is allowed only through safe rules such as `integer → decimal → text`.
+- Automatic narrowing is forbidden.
+- Objects and arrays must remain representable without flattening away information.
+
+### Generic Record Storage
+
+Do not create an uncontrolled physical SQL table for every detected HTML table.
+
+Prefer a hybrid model:
+
+- Metadata tables describe datasets, fields, schemas, and relationships.
+- Each record stores its canonical values as validated JSON.
+- Frequently searched or indexed fields may receive explicit projections.
+- Record revisions preserve historical changes.
+- Raw snapshots remain available for re-extraction and audit.
+- Materialized views may be created for performance, but they are derived and rebuildable.
+
+Every record must preserve:
+
+```text
+record_id
+dataset_id
+record_key
+schema_version_id
+data
+source_page_id
+source_locator
+content_hash
+first_seen_at
+last_seen_at
+status
+```
+
+## Dataset Discovery
+
+Dataset discovery must return candidates, not immediately create permanent datasets.
+
+Initial reusable detectors should include:
+
+1. Semantic HTML tables.
+2. Repeated DOM structures such as cards, rows, listings, and definition blocks.
+3. JSON arrays and nested object collections.
+4. JSON-LD, Microdata, and embedded structured data.
+5. REST and GraphQL response collections.
+6. Browser-observed fetch/XHR responses.
+
+Each candidate should report:
+
+```text
+candidate name
+source type
+source locator
+estimated row count
+sample records
+detected fields
+candidate identity fields
+pagination evidence
+confidence
+warnings
+```
+
+The user must be able to:
+
+- Preview the candidate.
+- Accept or reject it.
+- Rename it.
+- Edit field names and types.
+- Select or define identity fields.
+- Configure pagination.
+- Approve the dataset before persistent ingestion.
+
+Discovery must never pollute the permanent dataset store.
+
+## Dynamic Schema and Schema Drift
+
+Every dataset must have versioned schemas.
+
+When a later crawl differs from the approved schema, classify the difference:
+
+```text
+field_added
+field_missing
+field_renamed_candidate
+field_type_widened
+field_type_conflict
+structure_changed
+identity_field_missing
+relationship_broken
+extractor_failed
+adapter_outdated
+```
+
+Safe additions may be accepted automatically according to dataset policy.
+
+Destructive or ambiguous changes must enter a Schema Review Queue.
+
+Never delete historical values because a field disappeared from the latest page.
+
+Never reuse an old field key for a semantically different field.
+
+Store enough provenance to explain why two fields are believed to represent the same source field.
+
+## Identity Inference
+
+Infer candidate record keys using this order:
+
+1. Explicit source ID.
+2. Stable API identifier.
+3. Declared primary key.
+4. Canonical detail URL.
+5. Highly unique non-null field.
+6. Composite key.
+7. Deterministic fingerprint.
+
+For every suggested key, calculate and display:
+
+- Uniqueness percentage.
+- Null percentage.
+- Duplicate examples.
+- Stability across snapshots.
+- Confidence.
+- Fields used.
+
+Ambiguous identity must enter review.
+
+Never merge records solely because names are similar.
+
+Existing price identity behavior must remain unchanged until the generic identity system proves parity for that domain.
+
+## Relationship Inference
+
+Support relationships between datasets:
+
+```text
+one_to_one
+one_to_many
+many_to_one
+many_to_many
+hierarchical
+```
+
+Use evidence such as:
+
+- Matching primary and foreign-key candidates.
+- Nested JSON ownership.
+- Shared stable identifiers.
+- Detail-page URLs.
+- Parent-child DOM structure.
+- Link targets.
+- Repeated uniqueness and cardinality evidence.
+- User-defined mapping.
+
+A relationship suggestion must include:
+
+```text
+from_dataset
+from_fields
+to_dataset
+to_fields
+cardinality
+confidence
+evidence
+sample_matches
+orphan_count
+conflict_count
+status
+```
+
+Low-confidence relationships must never be activated automatically.
+
+Many-to-many relationships must use an explicit logical junction dataset.
+
+Relationships must be versioned and reviewed when schema drift invalidates their fields.
+
+## Declarative Adapter System
+
+Implement generic extraction first, then use site adapters only for exceptions.
+
+Adapters should preferably be declarative and versioned.
+
+An adapter may define:
+
+- Page-type matching.
+- Crawl scope.
+- URL normalization.
+- Dataset selectors.
+- Field selectors.
+- JSON paths.
+- Pagination rules.
+- Identity rules.
+- Relationship hints.
+- Validation rules.
+- Expected-volume canaries.
+
+Never execute remotely downloaded Python or JavaScript.
+
+Remote updates may provide validated configuration only.
+
+Adapter updates must support:
+
+- Signature or trust verification.
+- Versioning.
+- Compatibility checks.
+- Rollback.
+- Test-fixture validation.
+- Drift detection.
+- Explicit `Adapter Outdated` state.
+
+## User Experience Evolution
+
+Extend the existing Side Panel and Workspace; do not replace them.
+
+The generic Add Site flow should evolve into:
+
+```text
+1. Enter site URL
+2. Configure crawl boundaries
+3. Discover pages
+4. Detect dataset candidates
+5. Preview candidate data
+6. Approve datasets
+7. Review dynamic schemas
+8. Select identity keys
+9. Review relationships
+10. Save the site model
+11. Start the crawl
+```
+
+Add Workspace areas for:
+
+- Pages.
+- Datasets.
+- Schema.
+- Relationships.
+- Data Model.
+- Extraction Rules.
+- Schema Changes.
+- Failed Pages.
+- Raw Snapshots.
+- Crawl Runs.
+
+The Data Model screen should visualize approved datasets and relationships.
+
+Large datasets must use pagination or virtualization.
+
+The table renderer must be generated from the active schema version rather than from hard-coded price columns.
+
+## Incremental Implementation Protocol
+
+Work in small vertical slices.
+
+A vertical slice must include, where applicable:
+
+- Domain model.
+- Database migration.
+- Repository/service logic.
+- API.
+- UI.
+- Tests.
+- Error states.
+- Migration or compatibility behavior.
+- Visual verification.
+- Documentation.
+
+Do not implement a large backend subsystem without one minimal user-visible workflow proving that it works.
+
+For every slice:
+
+1. Inspect current behavior and tests.
+2. State what will be reused.
+3. State the smallest new seam required.
+4. Implement the database change additively.
+5. Implement the domain logic independently of the UI.
+6. Add API boundaries.
+7. Add one usable UI path.
+8. Add happy-path, failure-path, recovery, and migration tests.
+9. Run the full existing test suite.
+10. Verify existing price workflows remain unchanged.
+11. Visually inspect relevant Side Panel and Workspace states.
+12. Report completed work, remaining limitations, and the next smallest slice.
+
+If a slice breaks an existing test, treat it as a regression unless the user explicitly approved the behavioral change.
+
+## Delivery Phases
+
+### Phase G0 — Baseline and Compatibility Contract
+
+- Record current database, API, CLI, Native Messaging, UI, and export behavior.
+- Fix failing storage-safety regressions before adding generic ingestion.
+- Add tests protecting existing price workflows.
+- Define the compatibility boundary between price-specific and generic behavior.
+- Add feature flags for unfinished generic screens.
+
+Exit condition: current behavior is protected and the repository is green.
+
+### Phase G1 — Generic Dataset Catalog
+
+- Add SiteProject, DatasetDefinition, SchemaVersion, and FieldDefinition.
+- Add generic record and revision storage.
+- Implement additive migrations.
+- Add repository APIs and tests.
+- Expose a minimal read-only Dataset Catalog in the Workspace.
+
+Exit condition: a manually defined generic dataset can store and display arbitrary records without affecting price tables.
+
+### Phase G2 — First Generic Extraction Slice
+
+Implement one complete extraction path:
+
+```text
+Saved HTML snapshot
+→ HTML table detection
+→ candidate preview
+→ schema inference
+→ user approval
+→ generic ingestion
+→ dynamic Workspace table
+```
+
+Exit condition: a non-product HTML table can be extracted and browsed end to end.
+
+### Phase G3 — Repeated DOM and JSON Extraction
+
+- Add repeated-card/list extraction.
+- Add JSON array and JSONPath extraction.
+- Add embedded JSON and JSON-LD extraction.
+- Preserve source paths and raw evidence.
+- Add fixture-driven conformance tests.
+
+Exit condition: structurally different datasets use the same generic ingest and UI path.
+
+### Phase G4 — Crawl Frontier
+
+- Add persistent URL frontier.
+- Add canonicalization and deduplication.
+- Add scope, depth, page, and time limits.
+- Add sitemap and link discovery.
+- Add checkpoint recovery.
+- Separate discovery status from extraction status.
+
+Exit condition: a crawl can discover and resume pages without requiring product semantics.
+
+### Phase G5 — Multi-Dataset Sites
+
+- Detect several datasets from the same site.
+- Allow independent approval and scheduling.
+- Support dataset-specific extraction and pagination rules.
+- Show dataset-level progress and failures.
+
+Exit condition: one site can own several separately browsable datasets.
+
+### Phase G6 — Relationships and Site Data Model
+
+- Add key profiling.
+- Add relationship suggestions.
+- Add relationship review.
+- Add one-to-many and many-to-many support.
+- Add Data Model visualization.
+- Add orphan and conflict reporting.
+
+Exit condition: approved related datasets can be navigated and exported as a coherent site model.
+
+### Phase G7 — Schema and Adapter Drift
+
+- Detect schema changes.
+- Add Schema Review Queue.
+- Add adapter versioning.
+- Add volume and structural canaries.
+- Add rollback and re-extraction from saved snapshots.
+
+Exit condition: site changes are explicit, explainable, and recoverable.
+
+### Phase G8 — Dynamic Outputs and Synchronization
+
+- Export any dataset using Original Schema or Current View.
+- Preserve dataset relationships in export metadata.
+- Support multi-sheet/workbook strategies.
+- Apply dynamic schemas to Apps Script and Google synchronization.
+- Resume interrupted multi-dataset synchronization.
+- Report partial failures per dataset.
+
+Exit condition: generic datasets no longer depend on price-specific export columns.
+
+### Phase G9 — Hardening and Public Readiness
+
+- Large crawl tests.
+- Large dynamic-schema tests.
+- Multi-dataset and relationship tests.
+- Arabic and mixed-direction data tests.
+- XSS and untrusted-content tests.
+- Recovery after shutdown, sleep, disconnection, and migration failure.
+- Performance profiling.
+- Adapter-drift tests.
+- Documentation and onboarding.
+
+Exit condition: generic functionality is reliable without weakening existing price functionality.
+
+## Definition of Done for Every Increment
+
+An increment is not complete merely because classes or database tables exist.
+
+It is complete only when:
+
+- The feature is reachable through a real workflow.
+- State is persistent.
+- Failures are visible and actionable.
+- Recovery behavior is defined.
+- Existing data remains safe.
+- Existing price workflows still pass.
+- Tests cover success, failure, retry, and migration.
+- The UI includes empty, loading, running, partial, success, and failure states where applicable.
+- Side Panel and Workspace layouts are visually verified.
+- Documentation distinguishes implemented behavior from planned behavior.
+- No static mock is presented as a production integration.
+
+## Decision Rules
+
+Ask for user direction before:
+
+- Removing or replacing a working compatibility path.
+- Performing a destructive migration.
+- Changing record identity behavior.
+- Automatically approving inferred relationships.
+- Automatically accepting an ambiguous schema rename.
+- Expanding crawl scope beyond the configured site boundaries.
+- Introducing remote adapter updates.
+- Changing which database is the source of truth.
+
+For ordinary additive implementation details, make the safest reasonable decision and continue.
+
+## Required Progress Report
+
+After every completed slice, report in Arabic:
+
+```text
+Slice
+What existed before
+What was reused
+What was added
+Database migrations
+Compatibility impact
+Tests added
+Full test result
+Visual evidence
+Known limitations
+Next recommended slice
+```
+
+Maintain a living implementation matrix with:
+
+```text
+Capability
+Not Started
+Foundation
+Partial
+Production Ready
+Evidence
+Known Limitations
+Next Action
+```
+
+Never inflate progress because a model, API route, or static screen exists.
+
+Measure progress using complete end-to-end workflows.
+
+## Final Principle
+
+ScrapeX must become generic by adding stable metadata-driven capabilities around its proven core, not by erasing the core.
+
+The desired end state is:
+
+```text
+Generic crawling and extraction platform
+    ├── Generic datasets
+    ├── Dynamic schemas
+    ├── Dataset relationships
+    ├── Site-specific data models
+    ├── Declarative adapters
+    ├── Dynamic exports and synchronization
+    └── Price tracking as the first specialized domain
+```
+
+At every stage, prefer:
+
+```text
+working old path + tested new path
+```
+
+over:
+
+```text
+unfinished replacement + removed old path
+```

--- a/docs/CLAUDE-before-price-history-20260720.md
+++ b/docs/CLAUDE-before-price-history-20260720.md
@@ -1,0 +1,2192 @@
+You are a senior product designer, UX architect, browser-extension engineer, local-runtime engineer, and data-platform architect.
+
+Your mission is to design and implement a production-quality browser Side Panel Extension for resilient website crawling, scraping, structured local storage, dataset management, historical change tracking, price monitoring, Excel export, Google Sheets synchronization, and background job scheduling.
+
+This is not a generic scraper dashboard. It is a local-first, multi-engine data collection and synchronization product.
+
+# 1. Mandatory communication and language rules
+
+These rules are non-negotiable:
+
+1. Always communicate with me, explain your decisions, report progress, and provide final summaries in Arabic.
+2. The entire product interface must be written in English only.
+3. English-only interface content includes:
+   - Navigation
+   - Buttons
+   - Labels
+   - Forms
+   - Status messages
+   - Errors
+   - Warnings
+   - Empty states
+   - Tooltips
+   - Dialogs
+   - Setup instructions
+   - Logs
+   - Notifications
+   - Generated integration instructions
+4. Arabic is supported only as user-entered data, site names, or scraped content.
+5. Do not place Arabic text inside the product interface itself.
+6. Scraped Arabic data must render correctly with RTL support.
+7. Use automatic text-direction detection for user-entered and scraped values.
+8. URLs, file paths, IDs, versions, source keys, code, and technical logs must always remain LTR.
+9. All source-code comments, docstrings, variable names, function names, test descriptions, commit messages, and technical documentation must be written in English.
+10. Do not propose or create a color palette.
+11. Focus on:
+    - Layout
+    - Spacing
+    - Typography
+    - Hierarchy
+    - Responsive behavior
+    - Component structure
+    - Interaction design
+    - Loading, empty, success, warning, and failure states
+12. Reuse the existing project theme and design tokens when available.
+13. Never rely only on color to communicate status.
+
+# 2. Working approach
+
+Before making changes:
+
+1. Inspect the existing project.
+2. Understand its architecture, framework, components, conventions, and design system.
+3. Reuse the current stack where practical.
+4. Do not replace the existing architecture without a clear technical reason.
+5. Preserve existing user work.
+6. Explain important assumptions to me in Arabic.
+7. Make sensible decisions without asking unnecessary questions.
+
+Do not stop at a conceptual description.
+
+If a repository is available, implement a polished and functional solution.
+
+If some backend capability is unavailable, create a well-structured adapter or realistic mock implementation and clearly distinguish mock behavior from production behavior.
+
+If no implementation environment is available, produce:
+
+- High-fidelity interface specifications.
+- Component specifications.
+- State models.
+- Data models.
+- User flows.
+- Technical architecture.
+- Implementation-ready acceptance criteria.
+
+# 3. Product vision
+
+The product must:
+
+- Run as a browser Side Panel Extension.
+- Support multiple crawling and scraping engines.
+- Support multiple programming runtimes and strategies.
+- Support local Python.
+- Support JavaScript-based processing.
+- Support browser automation.
+- Support static HTTP extraction.
+- Support structured API extraction when legitimately available.
+- Support site-specific adapters.
+- Support automatic engine selection.
+- Support ordered fallback engines.
+- Use a locally installed runtime/helper on the user’s device.
+- Detect whether local components are installed, running, compatible, and ready.
+- Crawl a site for the first time.
+- Update previously collected datasets.
+- Detect field-level changes.
+- Track product prices over time.
+- Identify new, changed, unavailable, returned, and removed records.
+- Rebuild datasets when explicitly requested.
+- Store data locally by default.
+- Export data to Excel.
+- Synchronize data through Apps Script.
+- Connect directly to Google Drive and Google Sheets.
+- Schedule automatic runs.
+- Continue background jobs when the Side Panel is closed.
+- Restore the current job state when the Side Panel is opened again.
+- Handle different schemas for different websites.
+- Allow users to customize data presentation without altering original collected fields.
+
+Handle legitimate crawling challenges through:
+
+- Retry policies.
+- Pagination detection.
+- Browser rendering.
+- Session management.
+- Rate limiting.
+- Throttling.
+- Timeouts.
+- Engine fallback.
+- Checkpoints.
+- Structured error recovery.
+- Network interruption recovery.
+
+Never silently bypass access controls.
+
+Detect and report:
+
+- Authentication requirements.
+- Blocked access.
+- CAPTCHA challenges.
+- Permission problems.
+- Rate limits.
+- Robots or policy restrictions.
+- Unsupported website behavior.
+
+# 4. Required system architecture
+
+The Side Panel must never own or directly execute a long-running crawl.
+
+Use this responsibility model:
+
+```text
+SIDE PANEL
+- Remote control
+- Site selection
+- Run configuration
+- Progress summary
+- Job controls
+- Runtime status
+- Quick data preview
+
+FULL WORKSPACE TAB
+- Dynamic datasets
+- Full tables
+- Column management
+- Comparisons
+- Change history
+- Review queue
+- Jobs and schedules
+- Detailed logs
+- Advanced settings
+
+EXTENSION SERVICE WORKER
+- Extension event handling
+- Native Messaging bridge
+- Browser permissions
+- Authentication coordination
+- Alarm coordination
+- UI notifications
+
+LOCAL RUNTIME
+- Crawling engines
+- Job execution
+- Job queue
+- Persistent checkpoints
+- SQLite database
+- Full technical logs
+- Scheduling
+- Excel generation
+- Synchronization workers
+- Backups and recovery
+```
+
+The Local Runtime must continue jobs independently from the Side Panel.
+
+If the Side Panel closes and reopens, it must request the current job state and reconnect to live updates.
+
+Use persistent Job IDs and database-backed job state.
+
+Do not depend on a Manifest V3 Service Worker remaining alive for a long-running crawl.
+
+
+# Service Worker Lifecycle and MV3 Constraints
+
+The architecture must explicitly handle Chrome Manifest V3 (MV3) Service Worker hibernation. 
+Do not assume the Service Worker will remain active for longer than 30 seconds.
+
+Ensure:
+- The Local Runtime functions independently regardless of the Service Worker's state.
+- The Side Panel communicates directly with the Local Runtime when open, using the Service Worker only as a coordination bridge when necessary.
+- Use Chrome Offscreen Documents or explicit heartbeat pings to maintain the Native Messaging host connection only during critical background UI notifications.
+- Re-establish lost Native Messaging connections automatically and request the latest missed job events upon waking.
+
+# Local Runtime Distribution and Updates
+
+The Local Runtime must be frictionless for non-technical users. 
+Do not require end-users to use the command line, install Python manually, or manage dependencies via `pip`.
+
+Require:
+- A bundled, standalone executable installer (e.g., a single `.exe` or `.dmg`).
+- Over-The-Air (OTA) silent background updates for the runtime and its dependencies.
+- Version parity checks between the browser extension and the Local Runtime.
+
+The extension must prompt users gracefully when an OTA update requires a runtime restart.
+
+
+# 5. Local database as the source of truth
+
+Use the local SQL database as the canonical source of truth.
+
+Prefer SQLite unless the existing architecture already uses another appropriate local SQL database.
+
+```text
+Website
+   ↓
+Crawling and Extraction Engines
+   ↓
+Local SQLite Database — Source of Truth
+   ├── Excel Output
+   ├── Google Sheets via Apps Script
+   └── Google Drive and Sheets APIs
+```
+
+OPFS or browser storage may be used for temporary UI state or cache, but not as the only canonical database.
+
+The Local Runtime must own and manage the database file.
+
+Use:
+
+- Transactions.
+- WAL mode when appropriate.
+- Safe schema migrations.
+- Integrity checks.
+- Recoverable backups.
+- Job checkpoints.
+- Database versioning.
+- Compaction and maintenance.
+- Storage-health monitoring.
+
+# 6. Native Messaging constraints
+
+Use Native Messaging as a command and status bridge between the extension and Local Runtime.
+
+Do not send entire datasets or full logs through one message.
+
+Native Messaging responses from the Local Runtime must remain small and paginated.
+
+Use:
+
+- Cursor-based pagination.
+- Small command responses.
+- Structured job events.
+- Aggregated progress.
+- Log tails.
+- Explicit acknowledgements.
+- Reconnection support.
+
+Example:
+
+```text
+GET_RECORDS
+
+datasetId
+cursor
+limit
+visibleFields
+filters
+sort
+```
+
+The Local Runtime must return a limited page and a new cursor.
+
+# 7. Core domain model
+
+Adapt the exact implementation to the project, but support concepts equivalent to:
+
+- Site
+- Site Profile
+- Site Adapter
+- Runtime Component
+- Crawling Engine
+- Engine Capability
+- Dataset
+- Dataset Field
+- Record Entity
+- Source Identity
+- Identity Alias
+- Crawl Job
+- Crawl Snapshot
+- Change Event
+- Identity Conflict
+- Review Decision
+- Output Destination
+- Sync Session
+- Sync Batch
+- Schedule
+- Saved View
+- Export Job
+- Backup
+- Runtime Log
+
+# 8. Side Panel information architecture
+
+The primary Side Panel must contain:
+
+1. Product header.
+2. Local Runtime status.
+3. Sites section.
+4. Add Site action.
+5. Site search and checklist.
+6. Selected site cards.
+7. Run mode.
+8. Output summary.
+9. Main run action.
+10. Activity summary.
+11. Persistent active-job mini-player.
+12. Bottom navigation.
+
+Bottom navigation:
+
+```text
+Run
+Browse Data
+Settings
+```
+
+Do not add a complex full-width data table to the Side Panel.
+
+# 9. Header and Local Runtime status
+
+Place the product logo and extension name at the top.
+
+Directly below the product name, add a thin interactive status row.
+
+Possible states:
+
+```text
+Local Runtime Ready                         ›
+Setup Required                              ›
+Connection Failed                           ›
+Checking Components...
+Update Required                             ›
+Runtime Stopped                             ›
+```
+
+The status represents the complete runtime, not Python alone.
+
+When selected, expand:
+
+```text
+LOCAL RUNTIME
+
+Core Service                         Running
+Python Runtime                       Ready
+JavaScript Runtime                   Ready
+Browser Automation                  Ready
+Network Tools                        Ready
+Site Adapters                  24 installed
+
+Run Diagnostics
+Manage Components                            ›
+```
+
+Support:
+
+- Installed.
+- Not Installed.
+- Running.
+- Stopped.
+- Ready.
+- Update Required.
+- Incompatible.
+- Connection Failed.
+- Checking.
+
+If components are missing, provide:
+
+```text
+SET UP LOCAL RUNTIME
+
+1. Download the local helper
+2. Run the installer
+3. Install required runtimes
+4. Verify the connection
+```
+
+Actions:
+
+- Download.
+- Continue Setup.
+- Recheck Status.
+- Run Diagnostics.
+- Manage Components.
+- Open Runtime Logs.
+- Check for Updates.
+
+# 10. Sites section
+
+Use:
+
+```text
+SITES                               + Add Site
+```
+
+Provide:
+
+- Search by site name or URL.
+- Select All.
+- Clear.
+- Selected count.
+- Scrollable checklist.
+- Empty state.
+- Loading state.
+- Error state.
+
+Site format:
+
+```text
+example.com (Example Website)
+news-site.com (موقع الأخبار)
+```
+
+The interface remains English and LTR, while Arabic names are treated as data and render correctly.
+
+Allow one or multiple sites to be selected.
+
+Unavailable sites remain visible but disabled with an English explanation.
+
+# 11. Add Site flow
+
+Selecting Add Site must open an internal Side Panel screen or drawer.
+
+Include:
+
+```text
+ADD SITE
+
+Site URL
+Display Name
+Scraping Profile
+Extraction Type
+Preferred Engine
+Fallback Engines
+Authentication Requirements
+Output Defaults
+Schedule
+Advanced Settings
+
+Test Site
+Add Site
+```
+
+The flow must:
+
+- Validate the URL.
+- Test connectivity.
+- Inspect basic capabilities.
+- Detect likely browser-rendering requirements.
+- Recommend an engine.
+- Allow advanced engine override.
+- Display a small discovered-data sample.
+- Save a reusable Site Profile.
+
+Under Advanced Settings, add:
+
+```text
+IDENTITY RULES
+
+Primary Match
+Fallback Match
+Composite Fields
+Canonical URL Rules
+Ambiguous Match Behavior
+```
+
+Default behavior should be automatic and simple. Advanced identity controls must not overwhelm a new user.
+
+# 12. Selected site cards
+
+Every selected site appears below the checklist as a compact card.
+
+Show:
+
+- Display name.
+- URL.
+- Engine.
+- Fallback availability.
+- Extraction profile.
+- Dataset state.
+- Readiness status.
+- Site Settings.
+- Remove-from-current-selection action.
+
+Example:
+
+```text
+Example Website                              ×
+example.com
+
+Engine              Playwright
+Extraction          Products
+Dataset             1,842 records
+Status              Ready
+
+Site Settings                                ›
+```
+
+Removing a selected card must not delete the saved site.
+
+# 13. Run modes
+
+Support three explicit modes:
+
+```text
+INITIAL CRAWL
+Collect and save this site for the first time.
+
+UPDATE EXISTING DATA
+Collect current data and detect differences.
+
+FULL REBUILD
+Archive the current dataset and crawl the site again.
+```
+
+## Initial Crawl
+
+- Create the first dataset.
+- Discover the initial schema.
+- Create stable Record Entity IDs.
+- Save the initial snapshot.
+- Record the source identity strategy.
+
+## Update Existing Data
+
+- Match incoming records against stable entities.
+- Detect new records.
+- Detect changed records.
+- Detect unavailable records.
+- Detect returned records.
+- Preserve previous values.
+- Create field-level Change Events.
+- Update current state.
+- Save a Crawl Snapshot.
+- Preserve full history.
+
+## Full Rebuild
+
+- Show a clear warning.
+- Create a backup or archive.
+- Let the user choose Archive or Replace.
+- Never destroy old data silently.
+- Provide a rollback path.
+
+# 14. Record identity and conflict resolution
+
+Separate the internal entity from its current source identity.
+
+```text
+Record Entity ID
+A permanent internal identity.
+
+Source Identity
+URL, SKU, source ID, canonical URL, or composite key.
+
+Identity Aliases
+Previous URLs, SKUs, IDs, and known identities.
+```
+
+Matching priority may include:
+
+1. Stable source ID.
+2. SKU.
+3. Canonical URL.
+4. Composite key.
+5. Known identity aliases.
+6. Similarity matching.
+7. Requires Review.
+
+Composite keys must be configurable.
+
+If the system suspects that an incoming record matches an existing entity but cannot safely confirm it, create a `Requires Review` item.
+
+Provide a Review Queue:
+
+```text
+POSSIBLE MATCH
+
+Existing Record
+Incoming Record
+Match Confidence
+Matched Fields
+Conflicting Fields
+
+Keep Separate
+Merge Records
+Review Later
+```
+
+Manual merges must:
+
+- Preserve price history.
+- Preserve previous identities.
+- Create aliases.
+- Create an audit record.
+- Support Undo Merge.
+- Prevent the same conflict from repeatedly returning.
+
+# 15. Historical changes and price monitoring
+
+Maintain separate current-state and historical-change layers.
+
+```text
+CURRENT RECORD
+
+Record Entity ID
+Current Values
+Current Availability
+First Seen
+Last Seen
+Last Updated
+```
+
+```text
+CHANGE EVENT
+
+Record Entity ID
+Field Key
+Previous Value
+New Value
+Detected At
+Crawl Job ID
+Change Type
+```
+
+Support:
+
+- New records.
+- Updated records.
+- Price increases.
+- Price decreases.
+- Unchanged records.
+- Unavailable records.
+- Returned records.
+- Removed records.
+- Crawl errors.
+- Comparison between any two snapshots.
+- First recorded price.
+- Current price.
+- Minimum price.
+- Maximum price.
+- Absolute change.
+- Percentage change.
+
+# 16. Output destinations
+
+The Local Database must be enabled by default.
+
+Allow multiple destinations for the same run:
+
+```text
+DATA OUTPUT
+
+Local Database
+Excel Files
+Google Sheets via Apps Script
+Google Drive and Sheets
+```
+
+The local database remains the source of truth.
+
+# 17. Local storage settings
+
+Provide:
+
+- Current database location.
+- Change Storage Location.
+- Open Storage Folder.
+- Database size.
+- Database health.
+- Backup.
+- Restore.
+- Repair.
+- Compact Database.
+- Export Database.
+- Storage migration progress.
+
+When changing storage location:
+
+- Validate permissions.
+- Detect unavailable or removable drives.
+- Explain whether existing data will move.
+- Never overwrite a database silently.
+- Create a recoverable backup.
+- Provide rollback.
+- Report migration progress.
+
+# 18. Data retention
+
+Provide configurable retention policies:
+
+```text
+CHANGE HISTORY RETENTION
+
+Keep detailed history for:
+90 days
+
+After that:
+Keep daily summaries
+Keep weekly summaries
+Archive old history
+Delete permanently
+```
+
+Always allow preserving:
+
+- First recorded value.
+- Latest value.
+- Minimum price.
+- Maximum price.
+- Important user-marked events.
+
+Provide:
+
+- Retention preview.
+- Estimated recovered space.
+- Dataset-level exclusions.
+- Backup before destructive cleanup.
+- Storage usage warnings.
+- Automatic database maintenance.
+
+# 19. Excel output
+
+Excel is an optional output destination.
+
+Support:
+
+```text
+WORKBOOK STRUCTURE
+
+One workbook for all sites
+Separate workbook for each site
+```
+
+For a combined workbook, use separate sheets where schemas differ.
+
+Support:
+
+```text
+UPDATE BEHAVIOR
+
+Update existing rows
+Create a new snapshot sheet
+Create a new dated workbook
+```
+
+Provide:
+
+- Change Save Location.
+- Open Output Folder.
+- Export Current View.
+- Export Original Schema.
+- Export Change History.
+- Last Export Status.
+
+Preserve Arabic data correctly.
+
+# 20. Browse Data inside the Side Panel
+
+Browse Data in the Side Panel is a compact preview, not a full analytics table.
+
+Show:
+
+- Dataset list.
+- Record count.
+- Last update.
+- Change summary.
+- Recent records.
+- Compact Card View.
+- Basic search.
+- Basic filters.
+- Open in Workspace.
+
+Example:
+
+```text
+DATASETS
+
+Example Store
+1,842 records
+Updated 12 minutes ago
+34 changed · 15 new · 3 unavailable
+
+Open Dataset
+```
+
+When a dataset is opened inside the Side Panel, use compact cards and limited fields.
+
+Use virtualization for long lists.
+
+# 21. Full-page Workspace
+
+Provide an `Open in Workspace` action that opens a full extension page in a browser tab.
+
+The Workspace must contain:
+
+- Overview.
+- Data.
+- Changes.
+- Crawl History.
+- Review Queue.
+- Jobs.
+- Schedules.
+- Sync.
+- Exports.
+- Logs.
+
+The Data area must support:
+
+- Dynamic table schemas.
+- Search.
+- Filters.
+- Sorting.
+- Pagination or virtualization.
+- Column resizing.
+- Column reordering.
+- Manage Columns.
+- Show Hidden Columns.
+- Saved Views.
+- Snapshot comparison.
+- Export.
+- Sync.
+- Full-page horizontal scrolling when genuinely required.
+
+# 22. Schema and column safety
+
+Never treat a presentation change as a destructive schema change.
+
+Every field must support:
+
+```text
+Source Key
+Original Name
+Display Name
+Data Type
+Visibility
+Display Order
+```
+
+Rules:
+
+- Source Key is stable and immutable.
+- Original Name is preserved.
+- Display Name is user-editable.
+- Selecting X sets the field to Hidden.
+- Selecting X never deletes the field or its data.
+- Hidden fields continue receiving future updates.
+- Users can show hidden fields again.
+- Users can reset names.
+- Users can reset layout.
+- Users can restore the default view.
+- Users can save multiple views.
+- Export and sync can use either Original Schema or Current View.
+- Destructive deletion requires explicit confirmation.
+
+# 23. Job execution and lifecycle
+
+Persist every job in the database.
+
+Support states equivalent to:
+
+- Scheduled.
+- Queued.
+- Preparing.
+- Running.
+- Pausing.
+- Paused.
+- Resuming.
+- Cancelling.
+- Cancelled.
+- Completed.
+- Partially Completed.
+- Failed.
+- Requires Review.
+
+Persist:
+
+- Job ID.
+- Site IDs.
+- Run mode.
+- Current stage.
+- Progress.
+- Counters.
+- Checkpoint.
+- Started time.
+- Last heartbeat.
+- Retry count.
+- Output status.
+- Error summary.
+
+Closing the Side Panel must not stop the job.
+
+Reopening the Side Panel must retrieve and display the current state.
+
+# 24. Active Job mini-player
+
+Add a persistent mini-player above bottom navigation when a job is active.
+
+Example:
+
+```text
+Amazon Update                         63%
+Processing 8,420 of 10,000
+1 running · 2 queued
+
+View Job
+Pause
+```
+
+The mini-player remains visible while the user moves between:
+
+- Run.
+- Browse Data.
+- Settings.
+- Add Site.
+
+Selecting it opens the full job details.
+
+# 25. Activity and logging
+
+Do not add one UI row for every processed product.
+
+The Local Runtime must store the complete technical log.
+
+The Side Panel displays:
+
+- Aggregated progress.
+- Current step.
+- Current site.
+- Current counters.
+- Last 200 log entries only.
+
+Use a fixed-size Ring Buffer for UI logs.
+
+Use virtualization for visible log rows.
+
+Throttle UI progress updates instead of rendering every internal event.
+
+Show:
+
+- Overall percentage.
+- Current site.
+- Current stage.
+- Records discovered.
+- Records processed.
+- Records created.
+- Records updated.
+- Records unchanged.
+- Warnings.
+- Errors.
+- Elapsed time.
+- Per-site progress.
+
+Include:
+
+- Show Technical Details.
+- Pause Auto-scroll.
+- Copy Visible Logs.
+- Download Full Logs.
+- Open Logs Folder.
+- Pause.
+- Resume.
+- Cancel Run.
+- Retry Failed Step.
+- Open Dataset after completion.
+
+# 26. Scheduling
+
+Provide scheduling inside Site Settings.
+
+Support:
+
+- Manual.
+- Daily.
+- Weekly.
+- Custom schedule when appropriate.
+- Time selection.
+- Time zone.
+- Offline behavior.
+- Missed-run behavior.
+- Overlapping-run policy.
+- Retry policy.
+- Completion notifications.
+- Failure notifications.
+- Change-detected notifications.
+
+Example:
+
+```text
+SCHEDULE
+
+Frequency
+Daily
+
+Run At
+09:00 AM
+
+Time Zone
+Asia/Riyadh
+
+If Device Was Offline
+Run when available
+
+Overlapping Runs
+Queue new run
+```
+
+Use the Local Runtime scheduler for reliable scheduling.
+
+Use `chrome.alarms` only as browser-side coordination or fallback.
+
+Do not claim that browser alarms can wake a sleeping or powered-off device.
+
+If scheduling must work while Chrome is closed, implement an explicit user-approved Local Runtime background service or OS-level scheduling integration.
+
+Clearly explain the behavior to the user in English.
+
+# OS Resource and Hardware Management
+
+Background jobs must not freeze the user's operating system or aggressively drain device batteries.
+
+Implement:
+- Hardware-aware concurrency limits (detect available CPU cores and RAM).
+- Eco Mode: Automatically pause or throttle intensive jobs (like browser automation) when the device is running on battery power.
+- System wake/sleep awareness to safely checkpoint and suspend running jobs when the OS goes to sleep.
+
+
+# 27. Apps Script integration
+
+Generate Apps Script code that users can copy into Google Sheets.
+
+Setup interface:
+
+```text
+GOOGLE SHEETS — APPS SCRIPT
+
+1. Create or open a Google Sheet
+2. Open Extensions → Apps Script
+3. Paste the generated code
+4. Run the setup function
+5. Deploy the script
+6. Paste the deployment URL below
+```
+
+Include:
+
+- Copy Script.
+- Deployment URL.
+- Test Connection.
+- Save Connection.
+- Regenerate Secret.
+- Revoke Connection.
+- Last Sync.
+- Sync Now.
+- Connection Logs.
+
+The generated Apps Script must:
+
+- Create required sheets.
+- Create and update headers.
+- Insert new records.
+- Update existing records.
+- Preserve supported user customizations.
+- Read existing sheet data when required.
+- Synchronize current data.
+- Synchronize change history optionally.
+- Resume interrupted synchronization.
+- Prevent duplicate records.
+- Support explicit full recreation.
+
+All generated code and comments must be written in English.
+
+# 28. Apps Script security
+
+Do not rely on a permanent hard-coded bearer token.
+
+Use a cryptographically secure connection secret.
+
+Prefer:
+
+- A 256-bit random secret.
+- Secure local storage managed by Local Runtime.
+- Apps Script `Script Properties`.
+- HMAC request signing.
+- Timestamp.
+- Nonce.
+- Replay protection.
+- Revocation.
+- Regeneration.
+- Rate limiting.
+- Constant-time signature comparison when possible.
+
+Do not place secrets in URLs.
+
+If standard HTTP authorization headers are not reliably available to Apps Script `doPost`, include the signature metadata inside the JSON request body.
+
+# 29. Apps Script batching and recovery
+
+Never send an entire large dataset in one request.
+
+Use adaptive batching based on:
+
+- Encoded payload size.
+- Row count.
+- Column count.
+- Remaining execution time.
+- Previous response time.
+- Retry history.
+
+Do not assume that 1,000 records are always an appropriate batch.
+
+Persist:
+
+```text
+Sync Session ID
+Dataset ID
+Snapshot ID
+Batch Number
+Total Batches
+Cursor
+Checksum
+Attempt Number
+Status
+Acknowledged At
+```
+
+The synchronization process must be:
+
+- Resumable.
+- Idempotent.
+- Checkpointed.
+- Retryable.
+- Duplicate-safe.
+- Observable.
+
+Use:
+
+- Batch acknowledgements.
+- Checksums.
+- Exponential backoff.
+- Time-budget guards.
+- Concurrency control.
+- Partial-failure reporting.
+- Resume from the last acknowledged batch.
+
+Verify current official Google limits during implementation rather than relying on permanently hard-coded quota assumptions.
+
+# 30. Direct Google integration
+
+Provide a separate direct integration using:
+
+- Continue with Google.
+- Google Drive API.
+- Google Sheets API.
+
+Allow users to:
+
+- Connect a Google account.
+- View the connected account.
+- Select or create a Drive folder.
+- Create spreadsheets.
+- Organize files.
+- Synchronize existing datasets.
+- Create missing headers.
+- Update existing rows.
+- Create snapshots.
+- View the last sync result.
+- Reconnect after authorization expires.
+- Disconnect the account.
+
+Organization options:
+
+```text
+FILE ORGANIZATION
+
+One spreadsheet per site
+One spreadsheet per crawl
+Combined spreadsheet
+```
+
+Request only required permissions.
+
+Store OAuth credentials securely.
+
+Implement:
+
+- Adaptive request batching.
+- Quota awareness.
+- Exponential backoff.
+- Resumable synchronization.
+- Clear error reporting.
+
+# 31. Google Sheet conflict policy
+
+The Local Database remains the source of truth by default.
+
+Provide explicit sync policies:
+
+```text
+SYNC DIRECTION
+
+Local Database to Google Sheets
+Two-way Sync
+```
+
+For two-way sync, define:
+
+- System-owned fields.
+- User-editable fields.
+- Conflict detection.
+- Local wins.
+- Google Sheet wins.
+- Requires Review.
+- Last-write metadata.
+- Audit history.
+
+Never overwrite a manual Google Sheet edit silently when two-way sync is enabled.
+
+# 32. Multi-engine orchestration
+
+Do not hard-code a single engine.
+
+Support:
+
+- Automatic engine recommendation.
+- Preferred engine.
+- Ordered fallback engines.
+- Capability detection.
+- Dependency checks.
+- Per-site engine profiles.
+- Per-step retries.
+- Manual override.
+- Structured failure reasons.
+
+The execution log must show:
+
+- Selected engine.
+- Why it was selected.
+- Engine switches.
+- Fallback reasons.
+- Retry attempts.
+- Final failure reason.
+
+# Proxy and Anti-Bot Management
+
+Engine orchestration must handle anti-bot detection intelligently without causing permanent IP bans.
+
+Support:
+- Proxy configuration per site or globally.
+- Residential and Datacenter proxy types.
+- Automatic IP rotation per request or per session.
+- Advanced browser fingerprint spoofing (e.g., modifying User-Agent, WebGL, canvas, and timezone metadata when using automated browsers).
+- Rate-limit awareness and automatic cooldowns.
+
+Do not permanently burn user IP addresses through aggressive retries on blocked access.
+
+# Adapter Drift and Dynamic Maintenance
+
+Website DOM structures and internal APIs change frequently, breaking hard-coded Site Adapters. 
+
+The system must:
+- Detect Adapter Breakdown: Identify when a previously successful site adapter experiences a sudden, extreme drop in success rates.
+- Display an explicit `Adapter Outdated` status instead of a generic `Failed` error.
+- Support dynamic fetching of updated adapter rules or configurations without requiring a full application update.
+- Allow users to report broken adapters directly from the Side Panel.
+
+# 33. Settings structure
+
+Organize Settings into:
+
+- General.
+- Local Runtime.
+- Storage.
+- Crawling.
+- Engines.
+- Jobs and Scheduling.
+- Excel.
+- Apps Script.
+- Google Account.
+- Data and History.
+- Privacy and Security.
+- Logs and Diagnostics.
+- About.
+
+Use progressive disclosure.
+
+Do not place every setting on one long screen.
+
+# 34. Security and data safety
+
+Treat all scraped content as untrusted.
+
+Implement:
+
+- Output sanitization.
+- XSS prevention.
+- Message validation.
+- Command authorization.
+- Native host origin restrictions.
+- Secure secret storage.
+- Path validation.
+- Safe file creation.
+- Database transactions.
+- Backup before destructive operations.
+- Audit logs.
+- Runtime version compatibility checks.
+- Protection against duplicate jobs.
+- Concurrency limits.
+- Safe cancellation.
+
+Never execute remotely downloaded code inside the extension.
+
+Comply with current browser-extension platform requirements.
+
+# 35. Required UX states
+
+Design and implement:
+
+- First launch.
+- Runtime not installed.
+- Runtime checking.
+- Runtime ready.
+- Runtime update required.
+- Runtime disconnected.
+- Empty site list.
+- Add Site.
+- Site test running.
+- Site test failed.
+- No selected sites.
+- Initial crawl.
+- Update existing data.
+- Full rebuild warning.
+- Multi-site run.
+- Scheduled run.
+- Queued job.
+- Paused job.
+- Cancelled job.
+- Partial success.
+- Complete success.
+- Failed run.
+- Requires Review.
+- Empty dataset.
+- Dataset loading.
+- Dynamic schema.
+- Hidden columns.
+- No detected changes.
+- Sync pending.
+- Sync running.
+- Sync partially completed.
+- Sync successful.
+- Sync failed.
+- Google disconnected.
+- Apps Script not configured.
+- Storage location unavailable.
+- Database migration.
+- Database backup.
+- Database recovery.
+
+# 36. Accessibility and responsive behavior
+
+- Optimize the Side Panel for approximately 320px–400px widths.
+- Avoid horizontal scrolling in the main Side Panel.
+- Use Card View or compact previews for records.
+- Use the Full Workspace for complex tables.
+- Use keyboard navigation.
+- Use accessible names and labels.
+- Use visible focus states from the existing theme.
+- Keep primary actions discoverable.
+- Do not rely only on icons.
+- Use confirmation dialogs only for destructive actions.
+- Preserve scroll position where appropriate.
+- Handle long URLs safely.
+- Use `dir="auto"` or equivalent for scraped values.
+- Force technical content to LTR.
+- Test mixed Arabic and English data.
+
+# 37. Testing requirements
+
+Add tests for:
+
+- Closing and reopening the Side Panel during a job.
+- Runtime disconnection and reconnection.
+- Job checkpoint recovery.
+- Initial Crawl.
+- Update Existing Data.
+- Full Rebuild backup.
+- Composite identity matching.
+- Requires Review.
+- Merge and Undo Merge.
+- Price history preservation.
+- Column rename without source-key mutation.
+- Column hiding without data deletion.
+- Apps Script batch retry.
+- Duplicate batch prevention.
+- Interrupted sync resume.
+- Google authorization expiration.
+- Storage migration failure.
+- Scheduled-run recovery.
+- Arabic data rendering.
+- Native Messaging pagination.
+- Log Ring Buffer behavior.
+- Large dataset virtualization.
+- XSS sanitization.
+
+# 38. Expected implementation quality
+
+- Use reusable components.
+- Use typed domain models.
+- Use explicit state machines where helpful.
+- Separate UI, domain logic, execution, storage, and synchronization.
+- Do not hard-code site schemas.
+- Do not hard-code one engine.
+- Do not hard-code one output.
+- Do not store complete datasets in UI state.
+- Do not stream one UI log event per product.
+- Do not couple jobs to the Side Panel lifecycle.
+- Clearly identify mock and production integrations.
+- Add validation and structured recovery.
+- Preserve existing project conventions.
+- Verify realistic Side Panel dimensions.
+- Verify the Full Workspace separately.
+- Keep code comments in English.
+
+# 39. Final implementation phases
+
+Complete the work in these phases:
+
+1. Inspect the existing project.
+2. Explain your understanding to me in Arabic.
+3. Present the implementation plan in Arabic.
+4. Define the architecture and responsibility boundaries.
+5. Define the domain and state models.
+6. Implement Local Runtime communication abstractions.
+7. Implement the Side Panel.
+8. Implement the active-job mini-player.
+9. Implement the Full Workspace.
+10. Implement dataset and schema customization.
+11. Implement job persistence and lifecycle recovery.
+12. Implement scheduling.
+13. Implement Excel output.
+14. Implement Apps Script synchronization.
+15. Implement direct Google integration.
+16. Implement identity conflict review.
+17. Implement logging, retention, backup, and recovery.
+18. Test critical workflows.
+19. Visually inspect realistic Side Panel and Workspace dimensions.
+20. Report completed work, assumptions, limitations, test results, and next steps to me in Arabic.
+
+The final product must feel like a focused, reliable, local-first crawling and data synchronization platform specifically designed around a browser Side Panel and a full data-management Workspace.
+
+# 40. Incremental Evolution into a Generic Crawling and Data-Modeling Platform
+
+## Mission
+
+Evolve ScrapeX incrementally from its current product-and-price tracking system into a generic, metadata-driven crawling, extraction, and data-modeling platform.
+
+The final platform should be capable of:
+
+- Crawling broadly different website structures.
+- Discovering multiple datasets within the same site or page.
+- Extracting HTML tables, repeated DOM structures, structured data, embedded JSON, REST APIs, GraphQL responses, and browser-observed network data.
+- Inferring dynamic schemas whose columns may appear, disappear, change names, or change types over time.
+- Detecting and managing multiple datasets per site.
+- Inferring and reviewing relationships between datasets.
+- Building a versioned site-specific data model.
+- Preserving raw source evidence, historical revisions, provenance, and schema history.
+- Presenting dynamic datasets, columns, relationships, and crawl state through the Side Panel and Full Workspace.
+- Exporting either the original discovered schema or a user-customized view.
+- Keeping the existing price-tracking domain fully operational throughout the evolution.
+
+This is an evolutionary program, not a rewrite.
+
+## Prime Directive: Extend, Preserve, and Migrate Incrementally
+
+Never destroy and rebuild the existing product merely to obtain a cleaner architecture.
+
+Before implementing any capability:
+
+1. Inspect the current repository and identify existing components that already solve part of the problem.
+2. Reuse or extend those components wherever doing so preserves correctness.
+3. Introduce a compatibility seam when the existing design is too specialized.
+4. Move one vertical slice at a time through the new seam.
+5. Keep the old path operational until the replacement path has proven behavioral parity.
+6. Remove or retire an old path only after:
+   - Its replacement is complete.
+   - Migration is tested.
+   - Existing data remains readable.
+   - Rollback is possible.
+   - The user has explicitly approved retirement.
+
+Do not perform speculative large-scale refactoring.
+
+Do not rename, relocate, or rewrite stable modules unless the current increment genuinely requires it.
+
+Do not mix architectural cleanup with unrelated feature work.
+
+Every increment must leave the application runnable, testable, and recoverable.
+
+Repository behavior and tests are the ground truth. If this plan conflicts with proven repository behavior, report the conflict before changing the behavior.
+
+## Existing Capabilities That Must Be Preserved
+
+Treat the following as valuable working assets rather than temporary code:
+
+- Existing product and price ingestion.
+- Append-only price observation history.
+- Current connectors and fetchers.
+- Job persistence, pause, resume, cancellation, and checkpoint recovery.
+- Native Messaging and localhost communication.
+- Side Panel and active-job mini-player.
+- Full Workspace.
+- Storage, backup, restore, migration, and retention mechanisms.
+- Column customization and saved views.
+- Excel, Apps Script, and direct Google output paths.
+- Review Queue and identity conflict decisions.
+- Arabic content normalization and bidirectional rendering.
+- Existing tests, fixtures, screenshots, and public contracts.
+
+The price engine must become the first specialized domain built on, or interoperating with, the generic platform. It must not be discarded.
+
+## Honest Definition of “Generic”
+
+Do not claim that ScrapeX can scrape literally every website.
+
+A generic platform means:
+
+- It supports several reusable extraction patterns.
+- It can describe site-specific behavior through versioned metadata.
+- It provides an adapter mechanism for exceptional sites.
+- It reports unsupported, blocked, ambiguous, or authentication-dependent cases honestly.
+- It never silently returns incomplete or structurally incorrect data.
+- It distinguishes crawler failure, extractor failure, schema drift, access denial, and unsupported structure.
+
+CAPTCHAs, strong anti-bot systems, inaccessible authenticated content, legal restrictions, and highly interactive applications may still require user intervention or a specialized adapter.
+
+## Architectural Direction
+
+Separate the following responsibilities:
+
+```text
+Site Project
+    ↓
+Crawl Plan
+    ↓
+URL Frontier
+    ↓
+Fetcher
+    ↓
+Page Snapshot
+    ↓
+Dataset Discovery
+    ↓
+Extraction Plan
+    ↓
+Schema Inference
+    ↓
+Generic Records
+    ↓
+Identity Resolution
+    ↓
+Relationship Inference
+    ↓
+Versioned Site Data Model
+    ↓
+Workspace / Export / Sync
+```
+
+### Crawl and Scrape Are Different Operations
+
+`Crawl` discovers and revisits pages.
+
+`Scrape` extracts one or more datasets from a page or response.
+
+Do not couple URL discovery to product extraction.
+
+The crawler must be able to discover pages even when no extraction rule has been approved yet.
+
+The extractor must be able to run against a saved page snapshot without repeating a network request.
+
+### Domain Type and Extraction Method Are Different Concepts
+
+Do not use one enum to represent both what the data means and how it was obtained.
+
+Keep separate concepts such as:
+
+```text
+Domain:
+- generic
+- prices
+- listings
+- documents
+- user-defined
+
+Extraction Method:
+- html_table
+- repeated_dom
+- json_array
+- json_path
+- json_ld
+- embedded_json
+- rest_api
+- graphql
+- browser_network
+- custom_adapter
+```
+
+A dataset may use any extraction method without being classified as product or price data.
+
+## Generic Metadata Model
+
+Introduce the generic model through additive database migrations.
+
+At minimum, support concepts equivalent to:
+
+```text
+SiteProject
+CrawlPlan
+CrawlRun
+CrawlPage
+PageSnapshot
+PageType
+DatasetDefinition
+DatasetCandidate
+DatasetSchemaVersion
+FieldDefinition
+ExtractionRule
+GenericRecord
+RecordRevision
+RelationshipDefinition
+RecordRelationship
+AdapterDefinition
+AdapterVersion
+SchemaChange
+```
+
+### Dataset Definition
+
+A dataset definition should identify:
+
+- Stable dataset key.
+- User-facing name.
+- Source page type.
+- Extraction method.
+- Source selector, JSON path, or response path.
+- Cardinality.
+- Pagination strategy.
+- Identity strategy.
+- Current schema version.
+- Adapter version.
+- Dataset status.
+- Provenance and timestamps.
+
+### Field Definition
+
+A field definition should preserve:
+
+```text
+field_key
+source_name
+display_name
+source_path
+data_type
+nullable
+repeated
+key_role
+position
+confidence
+first_seen_at
+last_seen_at
+status
+```
+
+Rules:
+
+- `field_key` is stable and internal.
+- `source_name` preserves the exact source label or property name.
+- `display_name` is a presentation preference.
+- Renaming a display name never changes source identity.
+- Hiding a field never deletes it.
+- Missing fields remain in schema history.
+- New fields create a new schema version.
+- Type changes are recorded, not silently overwritten.
+- Automatic widening is allowed only through safe rules such as `integer → decimal → text`.
+- Automatic narrowing is forbidden.
+- Objects and arrays must remain representable without flattening away information.
+
+### Generic Record Storage
+
+Do not create an uncontrolled physical SQL table for every detected HTML table.
+
+Prefer a hybrid model:
+
+- Metadata tables describe datasets, fields, schemas, and relationships.
+- Each record stores its canonical values as validated JSON.
+- Frequently searched or indexed fields may receive explicit projections.
+- Record revisions preserve historical changes.
+- Raw snapshots remain available for re-extraction and audit.
+- Materialized views may be created for performance, but they are derived and rebuildable.
+
+Every record must preserve:
+
+```text
+record_id
+dataset_id
+record_key
+schema_version_id
+data
+source_page_id
+source_locator
+content_hash
+first_seen_at
+last_seen_at
+status
+```
+
+## Dataset Discovery
+
+Dataset discovery must return candidates, not immediately create permanent datasets.
+
+Initial reusable detectors should include:
+
+1. Semantic HTML tables.
+2. Repeated DOM structures such as cards, rows, listings, and definition blocks.
+3. JSON arrays and nested object collections.
+4. JSON-LD, Microdata, and embedded structured data.
+5. REST and GraphQL response collections.
+6. Browser-observed fetch/XHR responses.
+
+Each candidate should report:
+
+```text
+candidate name
+source type
+source locator
+estimated row count
+sample records
+detected fields
+candidate identity fields
+pagination evidence
+confidence
+warnings
+```
+
+The user must be able to:
+
+- Preview the candidate.
+- Accept or reject it.
+- Rename it.
+- Edit field names and types.
+- Select or define identity fields.
+- Configure pagination.
+- Approve the dataset before persistent ingestion.
+
+Discovery must never pollute the permanent dataset store.
+
+## Dynamic Schema and Schema Drift
+
+Every dataset must have versioned schemas.
+
+When a later crawl differs from the approved schema, classify the difference:
+
+```text
+field_added
+field_missing
+field_renamed_candidate
+field_type_widened
+field_type_conflict
+structure_changed
+identity_field_missing
+relationship_broken
+extractor_failed
+adapter_outdated
+```
+
+Safe additions may be accepted automatically according to dataset policy.
+
+Destructive or ambiguous changes must enter a Schema Review Queue.
+
+Never delete historical values because a field disappeared from the latest page.
+
+Never reuse an old field key for a semantically different field.
+
+Store enough provenance to explain why two fields are believed to represent the same source field.
+
+## Identity Inference
+
+Infer candidate record keys using this order:
+
+1. Explicit source ID.
+2. Stable API identifier.
+3. Declared primary key.
+4. Canonical detail URL.
+5. Highly unique non-null field.
+6. Composite key.
+7. Deterministic fingerprint.
+
+For every suggested key, calculate and display:
+
+- Uniqueness percentage.
+- Null percentage.
+- Duplicate examples.
+- Stability across snapshots.
+- Confidence.
+- Fields used.
+
+Ambiguous identity must enter review.
+
+Never merge records solely because names are similar.
+
+Existing price identity behavior must remain unchanged until the generic identity system proves parity for that domain.
+
+## Relationship Inference
+
+Support relationships between datasets:
+
+```text
+one_to_one
+one_to_many
+many_to_one
+many_to_many
+hierarchical
+```
+
+Use evidence such as:
+
+- Matching primary and foreign-key candidates.
+- Nested JSON ownership.
+- Shared stable identifiers.
+- Detail-page URLs.
+- Parent-child DOM structure.
+- Link targets.
+- Repeated uniqueness and cardinality evidence.
+- User-defined mapping.
+
+A relationship suggestion must include:
+
+```text
+from_dataset
+from_fields
+to_dataset
+to_fields
+cardinality
+confidence
+evidence
+sample_matches
+orphan_count
+conflict_count
+status
+```
+
+Low-confidence relationships must never be activated automatically.
+
+Many-to-many relationships must use an explicit logical junction dataset.
+
+Relationships must be versioned and reviewed when schema drift invalidates their fields.
+
+## Declarative Adapter System
+
+Implement generic extraction first, then use site adapters only for exceptions.
+
+Adapters should preferably be declarative and versioned.
+
+An adapter may define:
+
+- Page-type matching.
+- Crawl scope.
+- URL normalization.
+- Dataset selectors.
+- Field selectors.
+- JSON paths.
+- Pagination rules.
+- Identity rules.
+- Relationship hints.
+- Validation rules.
+- Expected-volume canaries.
+
+Never execute remotely downloaded Python or JavaScript.
+
+Remote updates may provide validated configuration only.
+
+Adapter updates must support:
+
+- Signature or trust verification.
+- Versioning.
+- Compatibility checks.
+- Rollback.
+- Test-fixture validation.
+- Drift detection.
+- Explicit `Adapter Outdated` state.
+
+## User Experience Evolution
+
+Extend the existing Side Panel and Workspace; do not replace them.
+
+The generic Add Site flow should evolve into:
+
+```text
+1. Enter site URL
+2. Configure crawl boundaries
+3. Discover pages
+4. Detect dataset candidates
+5. Preview candidate data
+6. Approve datasets
+7. Review dynamic schemas
+8. Select identity keys
+9. Review relationships
+10. Save the site model
+11. Start the crawl
+```
+
+Add Workspace areas for:
+
+- Pages.
+- Datasets.
+- Schema.
+- Relationships.
+- Data Model.
+- Extraction Rules.
+- Schema Changes.
+- Failed Pages.
+- Raw Snapshots.
+- Crawl Runs.
+
+The Data Model screen should visualize approved datasets and relationships.
+
+Large datasets must use pagination or virtualization.
+
+The table renderer must be generated from the active schema version rather than from hard-coded price columns.
+
+## Incremental Implementation Protocol
+
+Work in small vertical slices.
+
+A vertical slice must include, where applicable:
+
+- Domain model.
+- Database migration.
+- Repository/service logic.
+- API.
+- UI.
+- Tests.
+- Error states.
+- Migration or compatibility behavior.
+- Visual verification.
+- Documentation.
+
+Do not implement a large backend subsystem without one minimal user-visible workflow proving that it works.
+
+For every slice:
+
+1. Inspect current behavior and tests.
+2. State what will be reused.
+3. State the smallest new seam required.
+4. Implement the database change additively.
+5. Implement the domain logic independently of the UI.
+6. Add API boundaries.
+7. Add one usable UI path.
+8. Add happy-path, failure-path, recovery, and migration tests.
+9. Run the full existing test suite.
+10. Verify existing price workflows remain unchanged.
+11. Visually inspect relevant Side Panel and Workspace states.
+12. Report completed work, remaining limitations, and the next smallest slice.
+
+If a slice breaks an existing test, treat it as a regression unless the user explicitly approved the behavioral change.
+
+## Delivery Phases
+
+### Phase G0 — Baseline and Compatibility Contract
+
+- Record current database, API, CLI, Native Messaging, UI, and export behavior.
+- Fix failing storage-safety regressions before adding generic ingestion.
+- Add tests protecting existing price workflows.
+- Define the compatibility boundary between price-specific and generic behavior.
+- Add feature flags for unfinished generic screens.
+
+Exit condition: current behavior is protected and the repository is green.
+
+### Phase G1 — Generic Dataset Catalog
+
+- Add SiteProject, DatasetDefinition, SchemaVersion, and FieldDefinition.
+- Add generic record and revision storage.
+- Implement additive migrations.
+- Add repository APIs and tests.
+- Expose a minimal read-only Dataset Catalog in the Workspace.
+
+Exit condition: a manually defined generic dataset can store and display arbitrary records without affecting price tables.
+
+### Phase G2 — First Generic Extraction Slice
+
+Implement one complete extraction path:
+
+```text
+Saved HTML snapshot
+→ HTML table detection
+→ candidate preview
+→ schema inference
+→ user approval
+→ generic ingestion
+→ dynamic Workspace table
+```
+
+Exit condition: a non-product HTML table can be extracted and browsed end to end.
+
+### Phase G3 — Repeated DOM and JSON Extraction
+
+- Add repeated-card/list extraction.
+- Add JSON array and JSONPath extraction.
+- Add embedded JSON and JSON-LD extraction.
+- Preserve source paths and raw evidence.
+- Add fixture-driven conformance tests.
+
+Exit condition: structurally different datasets use the same generic ingest and UI path.
+
+### Phase G4 — Crawl Frontier
+
+- Add persistent URL frontier.
+- Add canonicalization and deduplication.
+- Add scope, depth, page, and time limits.
+- Add sitemap and link discovery.
+- Add checkpoint recovery.
+- Separate discovery status from extraction status.
+
+Exit condition: a crawl can discover and resume pages without requiring product semantics.
+
+### Phase G5 — Multi-Dataset Sites
+
+- Detect several datasets from the same site.
+- Allow independent approval and scheduling.
+- Support dataset-specific extraction and pagination rules.
+- Show dataset-level progress and failures.
+
+Exit condition: one site can own several separately browsable datasets.
+
+### Phase G6 — Relationships and Site Data Model
+
+- Add key profiling.
+- Add relationship suggestions.
+- Add relationship review.
+- Add one-to-many and many-to-many support.
+- Add Data Model visualization.
+- Add orphan and conflict reporting.
+
+Exit condition: approved related datasets can be navigated and exported as a coherent site model.
+
+### Phase G7 — Schema and Adapter Drift
+
+- Detect schema changes.
+- Add Schema Review Queue.
+- Add adapter versioning.
+- Add volume and structural canaries.
+- Add rollback and re-extraction from saved snapshots.
+
+Exit condition: site changes are explicit, explainable, and recoverable.
+
+### Phase G8 — Dynamic Outputs and Synchronization
+
+- Export any dataset using Original Schema or Current View.
+- Preserve dataset relationships in export metadata.
+- Support multi-sheet/workbook strategies.
+- Apply dynamic schemas to Apps Script and Google synchronization.
+- Resume interrupted multi-dataset synchronization.
+- Report partial failures per dataset.
+
+Exit condition: generic datasets no longer depend on price-specific export columns.
+
+### Phase G9 — Hardening and Public Readiness
+
+- Large crawl tests.
+- Large dynamic-schema tests.
+- Multi-dataset and relationship tests.
+- Arabic and mixed-direction data tests.
+- XSS and untrusted-content tests.
+- Recovery after shutdown, sleep, disconnection, and migration failure.
+- Performance profiling.
+- Adapter-drift tests.
+- Documentation and onboarding.
+
+Exit condition: generic functionality is reliable without weakening existing price functionality.
+
+## Definition of Done for Every Increment
+
+An increment is not complete merely because classes or database tables exist.
+
+It is complete only when:
+
+- The feature is reachable through a real workflow.
+- State is persistent.
+- Failures are visible and actionable.
+- Recovery behavior is defined.
+- Existing data remains safe.
+- Existing price workflows still pass.
+- Tests cover success, failure, retry, and migration.
+- The UI includes empty, loading, running, partial, success, and failure states where applicable.
+- Side Panel and Workspace layouts are visually verified.
+- Documentation distinguishes implemented behavior from planned behavior.
+- No static mock is presented as a production integration.
+
+## Decision Rules
+
+Ask for user direction before:
+
+- Removing or replacing a working compatibility path.
+- Performing a destructive migration.
+- Changing record identity behavior.
+- Automatically approving inferred relationships.
+- Automatically accepting an ambiguous schema rename.
+- Expanding crawl scope beyond the configured site boundaries.
+- Introducing remote adapter updates.
+- Changing which database is the source of truth.
+
+For ordinary additive implementation details, make the safest reasonable decision and continue.
+
+## Required Progress Report
+
+After every completed slice, report in Arabic:
+
+```text
+Slice
+What existed before
+What was reused
+What was added
+Database migrations
+Compatibility impact
+Tests added
+Full test result
+Visual evidence
+Known limitations
+Next recommended slice
+```
+
+Maintain a living implementation matrix with:
+
+```text
+Capability
+Not Started
+Foundation
+Partial
+Production Ready
+Evidence
+Known Limitations
+Next Action
+```
+
+Never inflate progress because a model, API route, or static screen exists.
+
+Measure progress using complete end-to-end workflows.
+
+## Final Principle
+
+ScrapeX must become generic by adding stable metadata-driven capabilities around its proven core, not by erasing the core.
+
+The desired end state is:
+
+```text
+Generic crawling and extraction platform
+    ├── Generic datasets
+    ├── Dynamic schemas
+    ├── Dataset relationships
+    ├── Site-specific data models
+    ├── Declarative adapters
+    ├── Dynamic exports and synchronization
+    └── Price tracking as the first specialized domain
+```
+
+At every stage, prefer:
+
+```text
+working old path + tested new path
+```
+
+over:
+
+```text
+unfinished replacement + removed old path
+```

--- a/scrapex/databases/split.py
+++ b/scrapex/databases/split.py
@@ -23,6 +23,12 @@ GENERIC_TABLES = (
     "field_definition",
     "dataset_relationship",
     "relationship_field_pair",
+    "generic_page_snapshot",
+    "dataset_schema_version",
+    "schema_version_field",
+    "generic_record",
+    "generic_record_revision",
+    "generic_ingestion",
 )
 GENERIC_COPY_COLUMNS = {
     "dataset_definition": (
@@ -43,6 +49,31 @@ GENERIC_COPY_COLUMNS = {
     "relationship_field_pair": (
         "relationship_field_pair_id", "dataset_relationship_id", "parent_field_id",
         "child_field_id", "pair_order",
+    ),
+    "generic_page_snapshot": (
+        "page_snapshot_id", "source_url", "content_type", "html_content",
+        "content_hash", "captured_at",
+    ),
+    "dataset_schema_version": (
+        "schema_version_id", "dataset_definition_id", "version_number",
+        "schema_hash", "status", "approved_at", "valid_to",
+    ),
+    "schema_version_field": (
+        "schema_version_id", "field_definition_id", "field_order",
+    ),
+    "generic_record": (
+        "generic_record_id", "dataset_definition_id", "record_key",
+        "schema_version_id", "data_json", "source_snapshot_id", "source_locator",
+        "content_hash", "first_seen_at", "last_seen_at", "status",
+    ),
+    "generic_record_revision": (
+        "record_revision_id", "generic_record_id", "schema_version_id",
+        "source_snapshot_id", "data_json", "content_hash", "observed_at",
+    ),
+    "generic_ingestion": (
+        "generic_ingestion_id", "dataset_definition_id", "schema_version_id",
+        "source_snapshot_id", "source_locator", "record_count", "status",
+        "ingested_at",
     ),
 }
 

--- a/scrapex/extract/__init__.py
+++ b/scrapex/extract/__init__.py
@@ -1,0 +1,1 @@
+"""Generic extraction seams that do not depend on product semantics."""

--- a/scrapex/extract/api.py
+++ b/scrapex/extract/api.py
@@ -82,17 +82,17 @@ def create_extraction_router(
         )
 
     @router.post(
-        "/api/extract/snapshots", status_code=status.HTTP_201_CREATED
+        "/api/general/extract/snapshots", status_code=status.HTTP_201_CREATED
     )
     def create_snapshot(request: SnapshotCreate):
         return write(lambda conn: service.save_snapshot(conn, request))
 
-    @router.get("/api/extract/snapshots/{snapshot_id}/candidates")
+    @router.get("/api/general/extract/snapshots/{snapshot_id}/candidates")
     def snapshot_candidates(snapshot_id: PositiveId):
         return read(lambda conn: service.discover_snapshot(conn, snapshot_id))
 
     @router.post(
-        "/api/extract/snapshots/{snapshot_id}/approve",
+        "/api/general/extract/snapshots/{snapshot_id}/approve",
         status_code=status.HTTP_201_CREATED,
     )
     def approve_snapshot_candidate(
@@ -102,7 +102,7 @@ def create_extraction_router(
             lambda conn: service.approve_candidate(conn, snapshot_id, request)
         )
 
-    @router.get("/api/extract/datasets")
+    @router.get("/api/general/extract/datasets")
     def approved_datasets(
         after_id: PageAfter = 0,
         limit: PageLimit = DEFAULT_RECORD_PAGE_SIZE,
@@ -113,7 +113,7 @@ def create_extraction_router(
             )
         )
 
-    @router.get("/api/extract/datasets/{dataset_id}/records")
+    @router.get("/api/general/extract/datasets/{dataset_id}/records")
     def dataset_records(
         dataset_id: PositiveId,
         after_id: PageAfter = 0,

--- a/scrapex/extract/api.py
+++ b/scrapex/extract/api.py
@@ -1,0 +1,128 @@
+"""Router for the first owner-approved generic extraction workflow."""
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable
+from pathlib import Path
+from typing import Annotated, Any
+
+from fastapi import APIRouter, HTTPException, Path as ApiPath, Query, Request, status
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+from ..catalog_models import CatalogConflict, CatalogNotFound
+from . import service
+from .models import (
+    DEFAULT_RECORD_PAGE_SIZE,
+    MAX_RECORD_PAGE_SIZE,
+    CandidateApproval,
+    CandidateNotApprovable,
+    ExtractionConflict,
+    ExtractionNotFound,
+    SnapshotCreate,
+)
+
+ReadConnection = Callable[[], sqlite3.Connection]
+WriteAction = Callable[[Callable[[sqlite3.Connection], Any]], Any]
+PositiveId = Annotated[int, ApiPath(gt=0)]
+PageAfter = Annotated[int, Query(ge=0)]
+PageLimit = Annotated[int, Query(ge=1, le=MAX_RECORD_PAGE_SIZE)]
+
+TEMPLATES = Jinja2Templates(
+    directory=str(Path(__file__).resolve().parent.parent / "webui" / "templates")
+)
+
+
+def create_extraction_router(
+    read_connection: ReadConnection, write_action: WriteAction
+) -> APIRouter:
+    """Create one isolated router so app.py only owns the mount point."""
+    router = APIRouter(tags=["generic-extraction"])
+
+    def read(run: Callable[[sqlite3.Connection], Any]) -> Any:
+        conn = read_connection()
+        try:
+            return run(conn)
+        except (ExtractionNotFound, CatalogNotFound) as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        finally:
+            conn.close()
+
+    def write(run: Callable[[sqlite3.Connection], Any]) -> Any:
+        try:
+            return write_action(run)
+        except (ExtractionNotFound, CatalogNotFound) as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except CandidateNotApprovable as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        except (ExtractionConflict, CatalogConflict) as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        except sqlite3.IntegrityError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "The generic dataset could not be saved safely. Review the "
+                    f"candidate and try again. ({exc})"
+                ),
+            ) from exc
+        except sqlite3.OperationalError as exc:
+            raise HTTPException(
+                status_code=409,
+                detail=f"The database is busy. Wait a moment and try again. ({exc})",
+            ) from exc
+
+    @router.get("/datasets", response_class=HTMLResponse)
+    def datasets_workspace(request: Request):
+        return TEMPLATES.TemplateResponse(
+            request=request,
+            name="datasets.html",
+            context={"tab": "datasets", "source_key": None},
+        )
+
+    @router.post(
+        "/api/extract/snapshots", status_code=status.HTTP_201_CREATED
+    )
+    def create_snapshot(request: SnapshotCreate):
+        return write(lambda conn: service.save_snapshot(conn, request))
+
+    @router.get("/api/extract/snapshots/{snapshot_id}/candidates")
+    def snapshot_candidates(snapshot_id: PositiveId):
+        return read(lambda conn: service.discover_snapshot(conn, snapshot_id))
+
+    @router.post(
+        "/api/extract/snapshots/{snapshot_id}/approve",
+        status_code=status.HTTP_201_CREATED,
+    )
+    def approve_snapshot_candidate(
+        snapshot_id: PositiveId, request: CandidateApproval
+    ):
+        return write(
+            lambda conn: service.approve_candidate(conn, snapshot_id, request)
+        )
+
+    @router.get("/api/extract/datasets")
+    def approved_datasets(
+        after_id: PageAfter = 0,
+        limit: PageLimit = DEFAULT_RECORD_PAGE_SIZE,
+    ):
+        return read(
+            lambda conn: service.list_datasets(
+                conn, after_id=after_id, limit=limit
+            )
+        )
+
+    @router.get("/api/extract/datasets/{dataset_id}/records")
+    def dataset_records(
+        dataset_id: PositiveId,
+        after_id: PageAfter = 0,
+        limit: PageLimit = DEFAULT_RECORD_PAGE_SIZE,
+    ):
+        return read(
+            lambda conn: service.browse_records(
+                conn, dataset_id, after_id=after_id, limit=limit
+            )
+        )
+
+    return router

--- a/scrapex/extract/html_table.py
+++ b/scrapex/extract/html_table.py
@@ -1,0 +1,314 @@
+"""Bounded semantic HTML-table discovery and schema inference."""
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any
+from urllib.parse import urlparse
+
+from bs4 import BeautifulSoup, Tag
+
+from .models import (
+    MAX_PREVIEW_ROWS, MAX_TABLE_COLUMNS, MAX_TABLE_ROWS, MAX_TABLES,
+)
+
+_INTEGER = re.compile(r"^[+-]?\d+$")
+_DECIMAL = re.compile(r"^[+-]?(?:\d+\.\d+|\d+\.)$")
+_SPACE = re.compile(r"\s+")
+_KEY_PARTS = re.compile(r"[^a-z0-9]+")
+
+
+@dataclass(frozen=True)
+class InferredField:
+    field_key: str
+    source_name: str
+    data_type: str
+    nullable: bool
+    position: int
+    confidence: float
+    uniqueness: float
+    null_fraction: float
+    identity_candidate: bool
+
+    def public(self) -> dict[str, Any]:
+        return {
+            "field_key": self.field_key,
+            "source_name": self.source_name,
+            "display_name": self.source_name,
+            "data_type": self.data_type,
+            "nullable": self.nullable,
+            "position": self.position,
+            "confidence": self.confidence,
+            "uniqueness": self.uniqueness,
+            "null_fraction": self.null_fraction,
+            "identity_candidate": self.identity_candidate,
+        }
+
+
+@dataclass(frozen=True)
+class TableCandidate:
+    table_index: int
+    name: str
+    locator: str
+    fields: tuple[InferredField, ...]
+    rows: tuple[dict[str, str | None], ...]
+    confidence: float
+    warnings: tuple[str, ...]
+    approvable: bool
+    truncated: bool
+
+    def public(self) -> dict[str, Any]:
+        suggested = [
+            field.field_key for field in self.fields if field.identity_candidate
+        ][:1]
+        return {
+            "candidate_id": f"html-table-{self.table_index}",
+            "table_index": self.table_index,
+            "name": self.name,
+            "source_type": "html_table",
+            "source_locator": self.locator,
+            "estimated_row_count": len(self.rows),
+            "sample_records": list(self.rows[:MAX_PREVIEW_ROWS]),
+            "fields": [field.public() for field in self.fields],
+            "candidate_identity_fields": suggested,
+            "pagination_evidence": None,
+            "confidence": self.confidence,
+            "warnings": list(self.warnings),
+            "approvable": self.approvable,
+            "truncated": self.truncated,
+        }
+
+
+def _clean(value: str) -> str:
+    return _SPACE.sub(" ", value).strip()
+
+
+def _field_key(name: str, position: int, used: set[str]) -> str:
+    ascii_name = unicodedata.normalize("NFKD", name).encode("ascii", "ignore").decode()
+    base = _KEY_PARTS.sub("_", ascii_name.lower()).strip("_") or f"field_{position + 1}"
+    if not base[0].isalpha():
+        base = f"field_{base}"
+    base = base[:64]
+    if len(base) < 2:
+        base = f"field_{position + 1}"
+    key = base
+    suffix = 2
+    while key in used:
+        tail = f"_{suffix}"
+        key = f"{base[:64 - len(tail)]}{tail}"
+        suffix += 1
+    used.add(key)
+    return key
+
+
+def _direct_rows(table: Tag) -> list[Tag]:
+    rows: list[Tag] = []
+    for row in table.find_all("tr", limit=MAX_TABLE_ROWS + 2):
+        if row.find_parent("table") is table:
+            rows.append(row)
+    return rows
+
+
+def _cells(row: Tag) -> list[Tag]:
+    return [cell for cell in row.find_all(["th", "td"], recursive=False)]
+
+
+def _infer_type(values: list[str | None]) -> tuple[str, float]:
+    present = [value for value in values if value not in (None, "")]
+    if not present:
+        return "unknown", 0.0
+    lowered = {value.casefold() for value in present}
+    if lowered <= {"true", "false", "yes", "no"}:
+        return "boolean", 1.0
+    if all(_INTEGER.fullmatch(value) for value in present):
+        return "integer", 1.0
+    if all(_INTEGER.fullmatch(value) or _DECIMAL.fullmatch(value) for value in present):
+        return "decimal", 1.0
+    if all(_is_datetime(value) for value in present):
+        return "datetime", 1.0
+    if all(_is_date(value) for value in present):
+        return "date", 1.0
+    if all(_is_url(value) for value in present):
+        return "url", 1.0
+    return "text", 1.0
+
+
+def _is_date(value: str) -> bool:
+    try:
+        date.fromisoformat(value)
+        return True
+    except ValueError:
+        return False
+
+
+def _is_datetime(value: str) -> bool:
+    if "T" not in value and " " not in value:
+        return False
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return True
+    except ValueError:
+        return False
+
+
+def _is_url(value: str) -> bool:
+    parsed = urlparse(value)
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+def _locator(table: Tag, table_index: int) -> str:
+    identifier = table.get("id")
+    if isinstance(identifier, str) and identifier:
+        safe_id = re.sub(r"[^a-zA-Z0-9_-]", "_", identifier)
+        return f"table#{safe_id}"
+    return f"table:nth-of-type({table_index + 1})"
+
+
+def _candidate(table: Tag, table_index: int) -> TableCandidate:
+    warnings: list[str] = []
+    rows = _direct_rows(table)
+    truncated = len(rows) > MAX_TABLE_ROWS + 1
+    if truncated:
+        rows = rows[:MAX_TABLE_ROWS + 1]
+        warnings.append(
+            f"The table exceeds {MAX_TABLE_ROWS:,} data rows. Narrow the saved HTML "
+            "before approval so no rows are silently omitted."
+        )
+
+    thead = table.find("thead")
+    header_row: Tag | None = None
+    header_rows: set[int] = set()
+    if isinstance(thead, Tag):
+        owned = [
+            row for row in thead.find_all("tr", limit=MAX_TABLE_ROWS + 2)
+            if row.find_parent("table") is table
+        ]
+        if owned:
+            header_row = owned[-1]
+            header_rows = {id(row) for row in owned}
+    if header_row is None and rows:
+        first_cells = _cells(rows[0])
+        if first_cells and any(cell.name == "th" for cell in first_cells):
+            header_row = rows[0]
+            header_rows = {id(rows[0])}
+
+    data_rows = [row for row in rows if id(row) not in header_rows]
+    raw_data = [[_clean(cell.get_text(" ", strip=True)) or None for cell in _cells(row)]
+                for row in data_rows]
+    raw_data = [row for row in raw_data if row]
+    width = max(
+        [len(_cells(header_row)) if header_row is not None else 0]
+        + [len(row) for row in raw_data]
+        + [0]
+    )
+    if width > MAX_TABLE_COLUMNS:
+        warnings.append(
+            f"The table has {width} columns; the approval limit is "
+            f"{MAX_TABLE_COLUMNS}. Reduce the table width and retry."
+        )
+
+    usable_width = min(width, MAX_TABLE_COLUMNS)
+    if header_row is not None:
+        source_names = [_clean(cell.get_text(" ", strip=True)) for cell in _cells(header_row)]
+    else:
+        source_names = []
+        if usable_width:
+            warnings.append(
+                "No semantic header row was found. Review the generated column names "
+                "before approval."
+            )
+    source_names += [f"Column {index + 1}" for index in range(len(source_names), usable_width)]
+    source_names = [name or f"Column {index + 1}" for index, name in enumerate(source_names)]
+
+    has_merged_cells = bool(
+        table.find(["td", "th"], attrs={"rowspan": True}) or table.find(
+        ["td", "th"], attrs={"colspan": True}
+        )
+    )
+    if has_merged_cells:
+        warnings.append(
+            "Merged cells are not expanded in this slice. Save a table with one cell "
+            "per field before approval."
+        )
+
+    used: set[str] = set()
+    keys = [_field_key(name, index, used) for index, name in enumerate(source_names)]
+    normalized_rows = [
+        {key: (row[index] if index < len(row) else None) for index, key in enumerate(keys)}
+        for row in raw_data[:MAX_TABLE_ROWS]
+    ]
+    fields: list[InferredField] = []
+    row_count = len(normalized_rows)
+    for position, (key, source_name) in enumerate(zip(keys, source_names, strict=True)):
+        values = [row[key] for row in normalized_rows]
+        present = [value for value in values if value not in (None, "")]
+        unique = len(set(present))
+        uniqueness = unique / len(present) if present else 0.0
+        null_fraction = (row_count - len(present)) / row_count if row_count else 1.0
+        data_type, confidence = _infer_type(values)
+        fields.append(InferredField(
+            field_key=key,
+            source_name=source_name,
+            data_type=data_type,
+            nullable=len(present) != row_count,
+            position=position,
+            confidence=confidence,
+            uniqueness=round(uniqueness, 4),
+            null_fraction=round(null_fraction, 4),
+            identity_candidate=bool(present) and uniqueness == 1.0 and null_fraction == 0.0,
+        ))
+
+    caption = table.find("caption")
+    aria_label = table.get("aria-label")
+    name = (
+        _clean(caption.get_text(" ", strip=True)) if isinstance(caption, Tag)
+        else _clean(aria_label) if isinstance(aria_label, str)
+        else f"Table {table_index + 1}"
+    )
+    semantic_header = header_row is not None
+    confidence = 0.95 if semantic_header and isinstance(caption, Tag) else (
+        0.88 if semantic_header else 0.7
+    )
+    approvable = (
+        bool(normalized_rows and fields)
+        and not truncated
+        and width <= MAX_TABLE_COLUMNS
+        and not has_merged_cells
+    )
+    if not normalized_rows:
+        warnings.append(
+            "No data rows were found. Add at least one row to the saved HTML and retry."
+        )
+    return TableCandidate(
+        table_index=table_index,
+        name=name[:500],
+        locator=_locator(table, table_index),
+        fields=tuple(fields),
+        rows=tuple(normalized_rows),
+        confidence=confidence,
+        warnings=tuple(warnings),
+        approvable=approvable,
+        truncated=truncated,
+    )
+
+
+def detect_html_tables(html_content: str) -> list[TableCandidate]:
+    """Return bounded candidates without writing catalogue or record state."""
+    soup = BeautifulSoup(html_content, "html.parser")
+    candidates: list[TableCandidate] = []
+    for table in soup.find_all("table", limit=MAX_TABLES * 10):
+        if not isinstance(table, Tag) or table.find_parent("table") is not None:
+            continue
+        candidates.append(_candidate(table, len(candidates)))
+        if len(candidates) == MAX_TABLES:
+            break
+    return candidates
+
+
+def candidate_by_index(html_content: str, table_index: int) -> TableCandidate:
+    for candidate in detect_html_tables(html_content):
+        if candidate.table_index == table_index:
+            return candidate
+    raise LookupError(table_index)

--- a/scrapex/extract/models.py
+++ b/scrapex/extract/models.py
@@ -1,0 +1,80 @@
+"""Typed HTTP and service boundaries for the first generic extraction slice."""
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import (
+    AnyHttpUrl, BaseModel, ConfigDict, Field, field_validator, model_validator,
+)
+
+from ..catalog_models import CatalogKey, FieldType
+
+MAX_HTML_BYTES = 2_000_000
+MAX_TABLES = 20
+MAX_TABLE_ROWS = 5_000
+MAX_TABLE_COLUMNS = 100
+MAX_PREVIEW_ROWS = 10
+MAX_RECORD_PAGE_SIZE = 100
+DEFAULT_RECORD_PAGE_SIZE = 50
+
+
+class SnapshotCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    source_url: AnyHttpUrl
+    html_content: str = Field(min_length=1, max_length=MAX_HTML_BYTES)
+
+
+class ApprovalField(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    field_key: CatalogKey
+    display_name: str = Field(min_length=1, max_length=500)
+    data_type: FieldType
+    identity: bool = False
+
+
+class CandidateApproval(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    table_index: int = Field(ge=0, lt=MAX_TABLES)
+    site_key: CatalogKey
+    site_display_name: str = Field(min_length=1, max_length=200)
+    dataset_key: CatalogKey
+    dataset_name: str = Field(min_length=1, max_length=500)
+    fields: list[ApprovalField] = Field(min_length=1, max_length=MAX_TABLE_COLUMNS)
+
+    @field_validator("fields")
+    @classmethod
+    def field_keys_are_unique(cls, fields: list[ApprovalField]) -> list[ApprovalField]:
+        keys = [field.field_key for field in fields]
+        if len(keys) != len(set(keys)):
+            raise ValueError("fields must not contain duplicate field_key values")
+        return fields
+
+    @model_validator(mode="after")
+    def has_identity_field(self) -> "CandidateApproval":
+        if not any(field.identity for field in self.fields):
+            raise ValueError(
+                "select at least one identity field before approving the dataset"
+            )
+        return self
+
+
+SnapshotIdPath = Annotated[int, Field(gt=0)]
+
+
+class ExtractionError(ValueError):
+    """A safe, actionable generic-extraction refusal."""
+
+
+class ExtractionNotFound(ExtractionError):
+    pass
+
+
+class ExtractionConflict(ExtractionError):
+    pass
+
+
+class CandidateNotApprovable(ExtractionError):
+    pass

--- a/scrapex/extract/service.py
+++ b/scrapex/extract/service.py
@@ -1,0 +1,512 @@
+"""Persistent approval and browsing for bounded HTML-table extraction."""
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
+from typing import Any
+from urllib.parse import urlparse
+
+from .. import catalog
+from ..catalog_models import DatasetCreate, FieldCreate, SiteCreate
+from .html_table import TableCandidate, candidate_by_index, detect_html_tables
+from .models import (
+    DEFAULT_RECORD_PAGE_SIZE,
+    MAX_HTML_BYTES,
+    MAX_RECORD_PAGE_SIZE,
+    CandidateApproval,
+    CandidateNotApprovable,
+    ExtractionConflict,
+    ExtractionNotFound,
+    SnapshotCreate,
+)
+
+
+def _canonical(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _digest(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _site_base_url(source_url: str) -> str:
+    parsed = urlparse(source_url)
+    return f"{parsed.scheme}://{parsed.netloc}/"
+
+
+def _snapshot_row(conn: sqlite3.Connection, snapshot_id: int) -> sqlite3.Row:
+    row = conn.execute(
+        "SELECT page_snapshot_id, source_url, content_type, html_content, "
+        "content_hash, captured_at FROM generic_page_snapshot "
+        "WHERE page_snapshot_id = ? LIMIT 1",
+        (snapshot_id,),
+    ).fetchone()
+    if row is None:
+        raise ExtractionNotFound(
+            "The saved HTML snapshot was not found. Save the HTML again and retry."
+        )
+    return row
+
+
+def _snapshot_public(row: sqlite3.Row) -> dict[str, Any]:
+    return {
+        "page_snapshot_id": row["page_snapshot_id"],
+        "source_url": row["source_url"],
+        "content_type": row["content_type"],
+        "content_hash": row["content_hash"],
+        "captured_at": row["captured_at"],
+    }
+
+
+def save_snapshot(conn: sqlite3.Connection, request: SnapshotCreate) -> dict[str, Any]:
+    """Persist immutable HTML evidence without creating a dataset candidate."""
+    html_bytes = request.html_content.encode("utf-8")
+    if len(html_bytes) > MAX_HTML_BYTES:
+        raise CandidateNotApprovable(
+            f"The saved HTML exceeds {MAX_HTML_BYTES:,} bytes. Save a smaller page "
+            "snapshot and try again."
+        )
+    source_url = str(request.source_url)
+    cursor = conn.execute(
+        "INSERT INTO generic_page_snapshot "
+        "(source_url, html_content, content_hash) VALUES (?,?,?)",
+        (source_url, request.html_content, _digest(request.html_content)),
+    )
+    return _snapshot_public(_snapshot_row(conn, int(cursor.lastrowid)))
+
+
+def discover_snapshot(conn: sqlite3.Connection, snapshot_id: int) -> dict[str, Any]:
+    """Recompute temporary candidates from saved evidence without catalogue writes."""
+    snapshot = _snapshot_row(conn, snapshot_id)
+    candidates = detect_html_tables(snapshot["html_content"])
+    return {
+        "snapshot": _snapshot_public(snapshot),
+        "candidates": [candidate.public() for candidate in candidates],
+    }
+
+
+def _candidate(snapshot: sqlite3.Row, table_index: int) -> TableCandidate:
+    try:
+        return candidate_by_index(snapshot["html_content"], table_index)
+    except LookupError:
+        raise ExtractionNotFound(
+            "The selected table candidate no longer exists in this snapshot. "
+            "Run detection again and choose one of the returned candidates."
+        ) from None
+
+
+def _convert(value: str | None, data_type: str, field_name: str) -> Any:
+    if value in (None, ""):
+        return None
+    try:
+        if data_type in {"text", "unknown"}:
+            return value
+        if data_type == "integer":
+            return int(value)
+        if data_type == "decimal":
+            number = Decimal(value)
+            if not number.is_finite():
+                raise ValueError
+            return float(number)
+        if data_type == "boolean":
+            lowered = value.casefold()
+            if lowered in {"true", "yes"}:
+                return True
+            if lowered in {"false", "no"}:
+                return False
+            raise ValueError
+        if data_type == "date":
+            return date.fromisoformat(value).isoformat()
+        if data_type == "datetime":
+            return datetime.fromisoformat(value.replace("Z", "+00:00")).isoformat()
+        if data_type == "url":
+            parsed = urlparse(value)
+            if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+                raise ValueError
+            return value
+        if data_type == "json":
+            return json.loads(value)
+    except (InvalidOperation, json.JSONDecodeError, ValueError):
+        pass
+    raise CandidateNotApprovable(
+        f"The value in {field_name!r} does not match the approved {data_type} "
+        "type. Change that field type or correct the saved HTML, then try again."
+    )
+
+
+def _validated_rows(
+    candidate: TableCandidate, approval: CandidateApproval
+) -> tuple[list[dict[str, Any]], list[str]]:
+    if len(approval.fields) != len(candidate.fields):
+        raise CandidateNotApprovable(
+            "The approved field list no longer matches the detected table. Run "
+            "detection again, review every field, and retry."
+        )
+    identity_keys = [field.field_key for field in approval.fields if field.identity]
+    rows: list[dict[str, Any]] = []
+    record_keys: list[str] = []
+    for source_row in candidate.rows:
+        converted: dict[str, Any] = {}
+        for inferred, approved in zip(candidate.fields, approval.fields, strict=True):
+            converted[approved.field_key] = _convert(
+                source_row.get(inferred.field_key),
+                approved.data_type.value,
+                approved.display_name,
+            )
+        identity = [converted[key] for key in identity_keys]
+        if any(value in (None, "") for value in identity):
+            raise CandidateNotApprovable(
+                "An approved identity field contains an empty value. Choose fields "
+                "that identify every row, then try again."
+            )
+        rows.append(converted)
+        record_keys.append(_digest(_canonical(identity)))
+    if len(record_keys) != len(set(record_keys)):
+        raise CandidateNotApprovable(
+            "The approved identity fields produce duplicate record keys. Select a "
+            "unique field or composite identity, then try again."
+        )
+    return rows, record_keys
+
+
+def _schema_payload(
+    candidate: TableCandidate, approval: CandidateApproval
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "field_key": approved.field_key,
+            "source_name": inferred.source_name,
+            "data_type": approved.data_type.value,
+            "nullable": inferred.nullable,
+            "identity": approved.identity,
+            "position": position,
+        }
+        for position, (inferred, approved) in enumerate(
+            zip(candidate.fields, approval.fields, strict=True)
+        )
+    ]
+
+
+def _approved_ingestion(
+    conn: sqlite3.Connection, snapshot_id: int, locator: str
+) -> sqlite3.Row | None:
+    return conn.execute(
+        "SELECT i.generic_ingestion_id, i.dataset_definition_id, "
+        "i.schema_version_id, s.site_key, d.dataset_key, v.schema_hash "
+        "FROM generic_ingestion AS i "
+        "JOIN dataset_definition AS d ON d.dataset_definition_id = i.dataset_definition_id "
+        "JOIN site_profile AS s ON s.site_profile_id = d.site_profile_id "
+        "JOIN dataset_schema_version AS v ON v.schema_version_id = i.schema_version_id "
+        "WHERE i.source_snapshot_id = ? AND i.source_locator = ? LIMIT 1",
+        (snapshot_id, locator),
+    ).fetchone()
+
+
+def _ensure_schema(
+    conn: sqlite3.Connection,
+    dataset_id: int,
+    candidate: TableCandidate,
+    approval: CandidateApproval,
+    schema_hash: str,
+) -> int:
+    existing = conn.execute(
+        "SELECT schema_version_id FROM dataset_schema_version "
+        "WHERE dataset_definition_id = ? AND schema_hash = ? LIMIT 1",
+        (dataset_id, schema_hash),
+    ).fetchone()
+    if existing is not None:
+        return int(existing["schema_version_id"])
+    active = conn.execute(
+        "SELECT schema_version_id FROM dataset_schema_version "
+        "WHERE dataset_definition_id = ? AND valid_to IS NULL LIMIT 1",
+        (dataset_id,),
+    ).fetchone()
+    if active is not None:
+        raise ExtractionConflict(
+            "This dataset already has a different approved schema. Use a new dataset "
+            "key, or wait for schema-drift review support before retrying."
+        )
+    version_row = conn.execute(
+        "SELECT COALESCE(MAX(version_number), 0) + 1 AS next_version "
+        "FROM dataset_schema_version WHERE dataset_definition_id = ? LIMIT 1",
+        (dataset_id,),
+    ).fetchone()
+    cursor = conn.execute(
+        "INSERT INTO dataset_schema_version "
+        "(dataset_definition_id, version_number, schema_hash) VALUES (?,?,?)",
+        (dataset_id, int(version_row["next_version"]), schema_hash),
+    )
+    schema_version_id = int(cursor.lastrowid)
+    for position, (inferred, approved) in enumerate(
+        zip(candidate.fields, approval.fields, strict=True)
+    ):
+        field = catalog.register_field(
+            conn,
+            dataset_id,
+            FieldCreate(
+                field_key=approved.field_key,
+                original_name=inferred.source_name,
+                data_type=approved.data_type,
+                is_nullable=inferred.nullable,
+                identity_role="key_part" if approved.identity else "none",
+                display_order=position,
+            ),
+        )
+        conn.execute(
+            "UPDATE field_definition SET display_name = ? "
+            "WHERE field_definition_id = ?",
+            (approved.display_name, field["field_definition_id"]),
+        )
+        conn.execute(
+            "INSERT INTO schema_version_field "
+            "(schema_version_id, field_definition_id, field_order) VALUES (?,?,?)",
+            (schema_version_id, field["field_definition_id"], position),
+        )
+    return schema_version_id
+
+
+def _dataset_row(conn: sqlite3.Connection, dataset_id: int) -> sqlite3.Row:
+    row = conn.execute(
+        "SELECT d.dataset_definition_id, d.dataset_key, d.original_name, "
+        "d.display_name, d.discovery_method, d.first_seen_at, d.last_seen_at, "
+        "s.site_key, s.display_name AS site_display_name "
+        "FROM dataset_definition AS d "
+        "JOIN site_profile AS s ON s.site_profile_id = d.site_profile_id "
+        "WHERE d.dataset_definition_id = ? AND d.valid_to IS NULL LIMIT 1",
+        (dataset_id,),
+    ).fetchone()
+    if row is None:
+        raise ExtractionNotFound(
+            "The approved dataset was not found. Return to Datasets and choose an "
+            "available dataset."
+        )
+    return row
+
+
+def _dataset_public(conn: sqlite3.Connection, dataset_id: int) -> dict[str, Any]:
+    row = _dataset_row(conn, dataset_id)
+    count_row = conn.execute(
+        "SELECT COUNT(*) AS record_count FROM generic_record "
+        "WHERE dataset_definition_id = ? LIMIT 1",
+        (dataset_id,),
+    ).fetchone()
+    ingestion = conn.execute(
+        "SELECT ingested_at FROM generic_ingestion "
+        "WHERE dataset_definition_id = ? ORDER BY generic_ingestion_id DESC LIMIT 1",
+        (dataset_id,),
+    ).fetchone()
+    return {
+        "dataset_definition_id": row["dataset_definition_id"],
+        "dataset_key": row["dataset_key"],
+        "original_name": row["original_name"],
+        "display_name": row["display_name"],
+        "label": row["display_name"] or row["original_name"],
+        "discovery_method": row["discovery_method"],
+        "site_key": row["site_key"],
+        "site_display_name": row["site_display_name"],
+        "record_count": int(count_row["record_count"]),
+        "last_ingested_at": ingestion["ingested_at"] if ingestion else None,
+    }
+
+
+def approve_candidate(
+    conn: sqlite3.Connection, snapshot_id: int, approval: CandidateApproval
+) -> dict[str, Any]:
+    """Atomically turn one reviewed candidate into definitions and generic rows."""
+    snapshot = _snapshot_row(conn, snapshot_id)
+    candidate = _candidate(snapshot, approval.table_index)
+    if not candidate.approvable:
+        reason = candidate.warnings[0] if candidate.warnings else "The table is incomplete."
+        raise CandidateNotApprovable(
+            f"This table cannot be approved: {reason} Correct the saved HTML and try again."
+        )
+    rows, record_keys = _validated_rows(candidate, approval)
+    schema_hash = _digest(_canonical(_schema_payload(candidate, approval)))
+    recovered = _approved_ingestion(conn, snapshot_id, candidate.locator)
+    if recovered is not None:
+        same_request = (
+            recovered["site_key"] == approval.site_key
+            and recovered["dataset_key"] == approval.dataset_key
+            and recovered["schema_hash"] == schema_hash
+        )
+        if not same_request:
+            raise ExtractionConflict(
+                "This table candidate was already approved with a different identity "
+                "or schema. Open the existing dataset instead of approving it again."
+            )
+        result = _dataset_public(conn, int(recovered["dataset_definition_id"]))
+        result.update({
+            "schema_version_id": int(recovered["schema_version_id"]),
+            "generic_ingestion_id": int(recovered["generic_ingestion_id"]),
+            "recovered": True,
+        })
+        return result
+
+    site = catalog.register_site(
+        conn,
+        SiteCreate(
+            site_key=approval.site_key,
+            display_name=approval.site_display_name,
+            base_url=_site_base_url(snapshot["source_url"]),
+        ),
+    )
+    dataset = catalog.register_dataset(
+        conn,
+        approval.site_key,
+        DatasetCreate(
+            dataset_key=approval.dataset_key,
+            original_name=candidate.name,
+            dataset_kind="table",
+            discovery_method="html_table",
+            locator={"selector": candidate.locator},
+        ),
+    )
+    dataset_id = int(dataset["dataset_definition_id"])
+    conn.execute(
+        "UPDATE dataset_definition SET display_name = ? "
+        "WHERE dataset_definition_id = ?",
+        (approval.dataset_name, dataset_id),
+    )
+    schema_version_id = _ensure_schema(
+        conn, dataset_id, candidate, approval, schema_hash
+    )
+    for row_position, (row, record_key) in enumerate(
+        zip(rows, record_keys, strict=True), start=1
+    ):
+        data_json = _canonical(row)
+        content_hash = _digest(data_json)
+        row_locator = f"{candidate.locator}::row({row_position})"
+        cursor = conn.execute(
+            "INSERT INTO generic_record "
+            "(dataset_definition_id, record_key, schema_version_id, data_json, "
+            "source_snapshot_id, source_locator, content_hash) VALUES (?,?,?,?,?,?,?) "
+            "ON CONFLICT(dataset_definition_id, record_key) DO UPDATE SET "
+            "schema_version_id=excluded.schema_version_id, "
+            "data_json=excluded.data_json, source_snapshot_id=excluded.source_snapshot_id, "
+            "source_locator=excluded.source_locator, content_hash=excluded.content_hash, "
+            "last_seen_at=strftime('%Y-%m-%dT%H:%M:%SZ','now'), status='active' "
+            "RETURNING generic_record_id",
+            (
+                dataset_id,
+                record_key,
+                schema_version_id,
+                data_json,
+                snapshot_id,
+                row_locator,
+                content_hash,
+            ),
+        )
+        record_id = int(cursor.fetchone()["generic_record_id"])
+        conn.execute(
+            "INSERT INTO generic_record_revision "
+            "(generic_record_id, schema_version_id, source_snapshot_id, data_json, "
+            "content_hash) VALUES (?,?,?,?,?)",
+            (record_id, schema_version_id, snapshot_id, data_json, content_hash),
+        )
+    ingestion = conn.execute(
+        "INSERT INTO generic_ingestion "
+        "(dataset_definition_id, schema_version_id, source_snapshot_id, "
+        "source_locator, record_count) VALUES (?,?,?,?,?)",
+        (dataset_id, schema_version_id, snapshot_id, candidate.locator, len(rows)),
+    )
+    result = _dataset_public(conn, dataset_id)
+    result.update({
+        "site_profile_id": int(site["site_profile_id"]),
+        "schema_version_id": schema_version_id,
+        "generic_ingestion_id": int(ingestion.lastrowid),
+        "recovered": False,
+    })
+    return result
+
+
+def list_datasets(
+    conn: sqlite3.Connection,
+    *,
+    after_id: int = 0,
+    limit: int = DEFAULT_RECORD_PAGE_SIZE,
+) -> dict[str, Any]:
+    if limit < 1 or limit > MAX_RECORD_PAGE_SIZE:
+        raise ValueError(f"limit must be between 1 and {MAX_RECORD_PAGE_SIZE}")
+    rows = conn.execute(
+        "SELECT DISTINCT d.dataset_definition_id FROM dataset_definition AS d "
+        "JOIN generic_ingestion AS i "
+        "ON i.dataset_definition_id = d.dataset_definition_id "
+        "WHERE d.valid_to IS NULL AND d.dataset_definition_id > ? "
+        "ORDER BY d.dataset_definition_id LIMIT ?",
+        (max(0, after_id), limit + 1),
+    ).fetchall()
+    has_more = len(rows) > limit
+    page = rows[:limit]
+    return {
+        "datasets": [
+            _dataset_public(conn, int(row["dataset_definition_id"])) for row in page
+        ],
+        "next_after_id": (
+            int(page[-1]["dataset_definition_id"]) if has_more else None
+        ),
+    }
+
+
+def browse_records(
+    conn: sqlite3.Connection,
+    dataset_id: int,
+    *,
+    after_id: int = 0,
+    limit: int = DEFAULT_RECORD_PAGE_SIZE,
+) -> dict[str, Any]:
+    if limit < 1 or limit > MAX_RECORD_PAGE_SIZE:
+        raise ValueError(f"limit must be between 1 and {MAX_RECORD_PAGE_SIZE}")
+    dataset = _dataset_public(conn, dataset_id)
+    fields = conn.execute(
+        "SELECT f.field_key, f.original_name, f.display_name, f.data_type, "
+        "f.identity_role, svf.field_order "
+        "FROM dataset_schema_version AS sv "
+        "JOIN schema_version_field AS svf "
+        "ON svf.schema_version_id = sv.schema_version_id "
+        "JOIN field_definition AS f "
+        "ON f.field_definition_id = svf.field_definition_id "
+        "WHERE sv.dataset_definition_id = ? AND sv.valid_to IS NULL "
+        "ORDER BY svf.field_order LIMIT ?",
+        (dataset_id, 100),
+    ).fetchall()
+    rows = conn.execute(
+        "SELECT generic_record_id, record_key, data_json, status, first_seen_at, "
+        "last_seen_at FROM generic_record "
+        "WHERE dataset_definition_id = ? AND generic_record_id > ? "
+        "ORDER BY generic_record_id LIMIT ?",
+        (dataset_id, max(0, after_id), limit + 1),
+    ).fetchall()
+    has_more = len(rows) > limit
+    page = rows[:limit]
+    return {
+        "dataset": dataset,
+        "fields": [
+            {
+                "field_key": row["field_key"],
+                "original_name": row["original_name"],
+                "display_name": row["display_name"],
+                "label": row["display_name"] or row["original_name"],
+                "data_type": row["data_type"],
+                "identity": row["identity_role"] == "key_part",
+                "position": row["field_order"],
+            }
+            for row in fields
+        ],
+        "records": [
+            {
+                "generic_record_id": row["generic_record_id"],
+                "record_key": row["record_key"],
+                "data": json.loads(row["data_json"]),
+                "status": row["status"],
+                "first_seen_at": row["first_seen_at"],
+                "last_seen_at": row["last_seen_at"],
+            }
+            for row in page
+        ],
+        "next_after_id": (
+            int(page[-1]["generic_record_id"]) if has_more else None
+        ),
+    }

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -30,6 +30,7 @@ from ..fields import (
     set_display_name, set_visibility,
 )
 from ..features import manifest as feature_manifest
+from ..extract.api import create_extraction_router
 from ..manifest_io import DuplicateSourceError, add_source
 from ..matching import (
     ConflictError, Decision, decide, pending_reviews, suggest_for_source, undo_decision,
@@ -396,6 +397,7 @@ def create_app(db_path: Path | str, manifest_path: Path | str = MANIFEST_FILE,
     # G1 foundation: typed persistence and API only. The feature stays disabled
     # until a later slice adds a complete user-facing catalogue workflow.
     app.include_router(create_catalog_router(read_conn, _write))
+    app.include_router(create_extraction_router(read_conn, _write))
 
     @app.get("/api/fields/{source_key}")
     def api_fields(source_key: str):

--- a/scrapex/webui/templates/datasets.html
+++ b/scrapex/webui/templates/datasets.html
@@ -331,7 +331,7 @@
         fields
       };
       try {
-        const approved = await requestJson(`/api/extract/snapshots/${snapshotId}/approve`, {
+        const approved = await requestJson(`/api/general/extract/snapshots/${snapshotId}/approve`, {
           method: "POST",
           headers: {"Content-Type": "application/json"},
           body: JSON.stringify(payload)
@@ -391,12 +391,12 @@
     setState(discoveryState, "loading", "Saving immutable HTML evidence and detecting bounded table candidates.");
     const form = new FormData(snapshotForm);
     try {
-      const snapshot = await requestJson("/api/extract/snapshots", {
+      const snapshot = await requestJson("/api/general/extract/snapshots", {
         method: "POST",
         headers: {"Content-Type": "application/json"},
         body: JSON.stringify({source_url: form.get("source_url"), html_content: form.get("html_content")})
       });
-      const candidates = await requestJson(`/api/extract/snapshots/${snapshot.page_snapshot_id}/candidates`);
+      const candidates = await requestJson(`/api/general/extract/snapshots/${snapshot.page_snapshot_id}/candidates`);
       renderCandidates(candidates);
     } catch (error) {
       setState(discoveryState, "failure", `${error.message} Correct the snapshot input and try detection again.`);
@@ -425,7 +425,7 @@
     setState(datasetsState, "loading", "Reading approved datasets from local storage.");
     moreDatasets.hidden = true;
     try {
-      const payload = await requestJson(`/api/extract/datasets?after_id=${after}&limit=50`);
+      const payload = await requestJson(`/api/general/extract/datasets?after_id=${after}&limit=50`);
       if (!append) datasetList.replaceChildren();
       payload.datasets.forEach(dataset => datasetList.append(datasetItem(dataset)));
       datasetAfter = payload.next_after_id || 0;
@@ -482,7 +482,7 @@
     previousRecords.disabled = true;
     nextRecords.disabled = true;
     try {
-      const payload = await requestJson(`/api/extract/datasets/${selectedDatasetId}/records?after_id=${after}&limit=50`);
+      const payload = await requestJson(`/api/general/extract/datasets/${selectedDatasetId}/records?after_id=${after}&limit=50`);
       recordNext = payload.next_after_id;
       renderRecords(payload);
       previousRecords.disabled = recordCursors.length === 1;

--- a/scrapex/webui/templates/datasets.html
+++ b/scrapex/webui/templates/datasets.html
@@ -1,0 +1,520 @@
+{% extends "base.html" %}
+{% block title %}Generic datasets · ScrapeX{% endblock %}
+{% block content %}
+<style>
+  .dataset-workflow{display:grid;gap:1rem}
+  .dataset-workflow section{background:var(--surface);border:1px solid var(--line);
+    border-radius:12px;padding:1rem 1.1rem;box-shadow:var(--shadow)}
+  .dataset-workflow h2{margin:.1rem 0 .5rem}
+  .state{border:1px solid var(--line);border-radius:9px;padding:.65rem .75rem;
+    margin:.75rem 0;font-size:.88rem}
+  .state[hidden]{display:none}
+  .state.failure{border-inline-start:4px solid var(--red)}
+  .state.success{border-inline-start:4px solid var(--accent)}
+  .state.loading{border-inline-start:4px solid var(--amber)}
+  .snapshot-form textarea{min-height:12rem;width:100%;direction:ltr;
+    font-family:ui-monospace,monospace;resize:vertical}
+  .candidate-list,.dataset-list{display:grid;gap:.75rem}
+  .candidate{border:1px solid var(--line);border-radius:10px;padding:.85rem}
+  .candidate h3{margin:0;font-size:1rem}
+  .candidate-meta{display:flex;gap:.5rem;flex-wrap:wrap;margin:.4rem 0}
+  .warnings{margin:.5rem 0;padding-inline-start:1.2rem}
+  .warnings li{margin:.2rem 0}
+  .schema-form{display:grid;gap:.75rem;margin-top:.8rem}
+  .schema-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.7rem}
+  .field-editor input,.field-editor select{min-width:9rem;width:100%}
+  .field-editor input[type=checkbox]{width:auto;min-width:0}
+  .candidate-preview,.records-table{max-height:28rem;overflow:auto}
+  .candidate-preview thead th,.records-table thead th{top:0}
+  .dataset-item{display:flex;align-items:center;justify-content:space-between;gap:.8rem;
+    border:1px solid var(--line);border-radius:10px;padding:.7rem .8rem}
+  .dataset-title{font-weight:600;unicode-bidi:plaintext}
+  .dataset-sub{font-size:.8rem;color:var(--muted)}
+  .value{unicode-bidi:plaintext;text-align:left;white-space:pre-wrap}
+  .approval-note{font-size:.82rem;color:var(--muted);margin:.35rem 0}
+  details.approval{border-top:1px solid var(--line);margin-top:.8rem;padding-top:.65rem}
+  details.approval summary{cursor:pointer;font-weight:600}
+  .toolbar{display:flex;align-items:center;justify-content:space-between;gap:.7rem;
+    flex-wrap:wrap;margin:.6rem 0}
+  @media (max-width:700px){.schema-grid{grid-template-columns:1fr}}
+</style>
+
+<div class="dataset-workflow">
+  <header>
+    <h1>Generic datasets</h1>
+    <p class="muted">Save HTML evidence, review detected tables, and approve only the dataset you want to keep.</p>
+  </header>
+
+  <section aria-labelledby="snapshot-heading">
+    <h2 id="snapshot-heading">1. Save an HTML snapshot</h2>
+    <p class="hint">Paste a previously captured page. Detection reads this saved snapshot and does not create a permanent dataset.</p>
+    <form id="snapshot-form" class="snapshot-form stack">
+      <div class="field">
+        <label for="source-url">Source URL</label>
+        <input id="source-url" name="source_url" type="url" required
+          placeholder="https://example.com/report" dir="ltr" autocomplete="url">
+      </div>
+      <div class="field">
+        <label for="html-content">Saved HTML</label>
+        <textarea id="html-content" name="html_content" required spellcheck="false"
+          placeholder="Paste the complete saved HTML here"></textarea>
+      </div>
+      <div class="row">
+        <button type="submit" id="discover-button">Save and detect tables</button>
+        <span class="hint">Maximum saved HTML size: 2 MB.</span>
+      </div>
+    </form>
+    <div id="discovery-state" class="state" role="status" aria-live="polite">Empty: No snapshot has been analyzed yet. Paste saved HTML above to begin.</div>
+    <div id="candidate-list" class="candidate-list" aria-live="polite"></div>
+  </section>
+
+  <section aria-labelledby="datasets-heading">
+    <div class="toolbar">
+      <div>
+        <h2 id="datasets-heading">2. Approved datasets</h2>
+        <p class="hint">Only owner-approved candidates appear here.</p>
+      </div>
+      <button id="refresh-datasets" class="ghost" type="button">Refresh datasets</button>
+    </div>
+    <div id="datasets-state" class="state loading" role="status" aria-live="polite">Loading: Reading approved datasets from local storage.</div>
+    <div id="dataset-list" class="dataset-list"></div>
+    <button id="more-datasets" class="ghost" type="button" hidden>Load more datasets</button>
+  </section>
+
+  <section id="records-section" aria-labelledby="records-heading">
+    <div class="toolbar">
+      <div>
+        <h2 id="records-heading">3. Dynamic table</h2>
+        <p id="records-context" class="hint">Choose an approved dataset to browse its inferred schema and records.</p>
+      </div>
+      <div class="row">
+        <button id="previous-records" class="ghost" type="button" disabled>Previous page</button>
+        <button id="next-records" class="ghost" type="button" disabled>Next page</button>
+      </div>
+    </div>
+    <div id="records-state" class="state" role="status" aria-live="polite">Empty: No approved dataset is selected.</div>
+    <div id="records-table" class="tablewrap records-table"></div>
+  </section>
+</div>
+
+<script>
+(() => {
+  "use strict";
+
+  const types = ["text", "integer", "decimal", "boolean", "date", "datetime", "url", "json", "unknown"];
+  const snapshotForm = document.querySelector("#snapshot-form");
+  const discoveryState = document.querySelector("#discovery-state");
+  const candidateList = document.querySelector("#candidate-list");
+  const discoverButton = document.querySelector("#discover-button");
+  const datasetsState = document.querySelector("#datasets-state");
+  const datasetList = document.querySelector("#dataset-list");
+  const moreDatasets = document.querySelector("#more-datasets");
+  const recordsState = document.querySelector("#records-state");
+  const recordsTable = document.querySelector("#records-table");
+  const recordsContext = document.querySelector("#records-context");
+  const previousRecords = document.querySelector("#previous-records");
+  const nextRecords = document.querySelector("#next-records");
+  let datasetAfter = 0;
+  let selectedDatasetId = null;
+  let recordCursors = [0];
+  let recordNext = null;
+
+  function setState(element, kind, message) {
+    element.hidden = false;
+    element.className = `state ${kind}`;
+    element.textContent = `${kind.charAt(0).toUpperCase()}${kind.slice(1)}: ${message}`;
+  }
+
+  function hideState(element) {
+    element.hidden = true;
+  }
+
+  function errorDetail(payload, fallback) {
+    if (!payload || !payload.detail) return fallback;
+    if (typeof payload.detail === "string") return payload.detail;
+    if (Array.isArray(payload.detail)) {
+      return payload.detail.map(item => item.msg || "Invalid input").join(" ");
+    }
+    return fallback;
+  }
+
+  async function requestJson(url, options = {}) {
+    let response;
+    try {
+      response = await fetch(url, options);
+    } catch (_error) {
+      throw new Error("The local runtime could not be reached. Confirm it is running, then try again.");
+    }
+    let payload = null;
+    try {
+      payload = await response.json();
+    } catch (_error) {
+      if (!response.ok) {
+        throw new Error("The local runtime returned an unreadable error. Restart it, then try again.");
+      }
+    }
+    if (!response.ok) {
+      throw new Error(errorDetail(payload, "The request failed. Review the input and try again."));
+    }
+    return payload;
+  }
+
+  function keyFrom(value, fallback) {
+    let key = value.normalize("NFKD").replace(/[\u0300-\u036f]/g, "")
+      .toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+    if (!/^[a-z]/.test(key)) key = `${fallback}_${key}`;
+    key = key.slice(0, 64).replace(/_+$/g, "");
+    if (key.length < 2) key = fallback;
+    return key;
+  }
+
+  function valueText(value) {
+    if (value === null || value === undefined || value === "") return "—";
+    if (typeof value === "object") return JSON.stringify(value);
+    return String(value);
+  }
+
+  function textElement(tag, text, className = "") {
+    const element = document.createElement(tag);
+    if (className) element.className = className;
+    element.textContent = text;
+    return element;
+  }
+
+  function previewTable(fields, records) {
+    const wrap = document.createElement("div");
+    wrap.className = "tablewrap candidate-preview";
+    const table = document.createElement("table");
+    const head = document.createElement("thead");
+    const headRow = document.createElement("tr");
+    fields.forEach(field => {
+      const th = textElement("th", field.source_name);
+      th.dir = "auto";
+      headRow.append(th);
+    });
+    head.append(headRow);
+    table.append(head);
+    const body = document.createElement("tbody");
+    records.forEach(record => {
+      const row = document.createElement("tr");
+      fields.forEach(field => {
+        const cell = textElement("td", valueText(record[field.field_key]), "value");
+        cell.dir = "auto";
+        row.append(cell);
+      });
+      body.append(row);
+    });
+    table.append(body);
+    wrap.append(table);
+    return wrap;
+  }
+
+  function labeledInput(labelText, value, name, required = true) {
+    const field = document.createElement("div");
+    field.className = "field";
+    const label = textElement("label", labelText);
+    const input = document.createElement("input");
+    input.name = name;
+    input.value = value;
+    input.required = required;
+    input.maxLength = labelText.includes("key") ? 64 : 500;
+    input.dir = labelText.includes("key") ? "ltr" : "auto";
+    label.append(input);
+    field.append(label);
+    return field;
+  }
+
+  function approvalEditor(candidate, snapshotId, sourceUrl) {
+    const details = document.createElement("details");
+    details.className = "approval";
+    details.append(textElement("summary", candidate.approvable ? "Review schema and approve" : "Approval unavailable"));
+    if (!candidate.approvable) {
+      details.append(textElement("p", "Correct the reported table issue in a new saved snapshot, then run detection again.", "approval-note"));
+      return details;
+    }
+    const form = document.createElement("form");
+    form.className = "schema-form";
+    const grid = document.createElement("div");
+    grid.className = "schema-grid";
+    const parsedUrl = new URL(sourceUrl);
+    const siteKey = keyFrom(parsedUrl.hostname.replace(/^www\./, ""), "site");
+    const siteName = parsedUrl.hostname.replace(/^www\./, "");
+    grid.append(
+      labeledInput("Site key", siteKey, "site_key"),
+      labeledInput("Site display name", siteName, "site_display_name"),
+      labeledInput("Dataset key", keyFrom(candidate.name, `table_${candidate.table_index + 1}`), "dataset_key"),
+      labeledInput("Dataset name", candidate.name, "dataset_name")
+    );
+    form.append(grid);
+    form.append(textElement("p", "Confirm field names and types, then select at least one identity field. Composite identities are supported.", "approval-note"));
+    const wrap = document.createElement("div");
+    wrap.className = "tablewrap field-editor";
+    const table = document.createElement("table");
+    const head = document.createElement("thead");
+    const headRow = document.createElement("tr");
+    ["Source field", "Field key", "Display name", "Type", "Identity"].forEach(label => headRow.append(textElement("th", label)));
+    head.append(headRow);
+    table.append(head);
+    const body = document.createElement("tbody");
+    const suggested = new Set(candidate.candidate_identity_fields || []);
+    candidate.fields.forEach(field => {
+      const row = document.createElement("tr");
+      const sourceCell = textElement("td", field.source_name, "value");
+      sourceCell.dir = "auto";
+      row.append(sourceCell);
+      const keyCell = document.createElement("td");
+      const keyInput = document.createElement("input");
+      keyInput.name = "field_key";
+      keyInput.value = field.field_key;
+      keyInput.pattern = "[a-z][a-z0-9_]{1,63}";
+      keyInput.maxLength = 64;
+      keyInput.required = true;
+      keyInput.dir = "ltr";
+      keyCell.append(keyInput);
+      row.append(keyCell);
+      const nameCell = document.createElement("td");
+      const nameInput = document.createElement("input");
+      nameInput.name = "display_name";
+      nameInput.value = field.display_name;
+      nameInput.maxLength = 500;
+      nameInput.required = true;
+      nameInput.dir = "auto";
+      nameCell.append(nameInput);
+      row.append(nameCell);
+      const typeCell = document.createElement("td");
+      const typeSelect = document.createElement("select");
+      typeSelect.name = "data_type";
+      types.forEach(type => {
+        const option = document.createElement("option");
+        option.value = type;
+        option.textContent = type;
+        option.selected = type === field.data_type;
+        typeSelect.append(option);
+      });
+      typeCell.append(typeSelect);
+      row.append(typeCell);
+      const identityCell = document.createElement("td");
+      const identity = document.createElement("input");
+      identity.type = "checkbox";
+      identity.name = "identity";
+      identity.checked = suggested.has(field.field_key);
+      identity.setAttribute("aria-label", `Use ${field.source_name} as identity`);
+      identityCell.append(identity);
+      row.append(identityCell);
+      body.append(row);
+    });
+    table.append(body);
+    wrap.append(table);
+    form.append(wrap);
+    const action = document.createElement("button");
+    action.type = "submit";
+    action.textContent = "Approve and ingest dataset";
+    form.append(action);
+    form.addEventListener("submit", async event => {
+      event.preventDefault();
+      action.disabled = true;
+      setState(discoveryState, "loading", "Approving the reviewed schema and ingesting generic records.");
+      const rows = [...body.querySelectorAll("tr")];
+      const fields = rows.map(row => ({
+        field_key: row.querySelector('[name="field_key"]').value,
+        display_name: row.querySelector('[name="display_name"]').value,
+        data_type: row.querySelector('[name="data_type"]').value,
+        identity: row.querySelector('[name="identity"]').checked
+      }));
+      const named = new FormData(form);
+      const payload = {
+        table_index: candidate.table_index,
+        site_key: named.get("site_key"),
+        site_display_name: named.get("site_display_name"),
+        dataset_key: named.get("dataset_key"),
+        dataset_name: named.get("dataset_name"),
+        fields
+      };
+      try {
+        const approved = await requestJson(`/api/extract/snapshots/${snapshotId}/approve`, {
+          method: "POST",
+          headers: {"Content-Type": "application/json"},
+          body: JSON.stringify(payload)
+        });
+        setState(discoveryState, "success", `${approved.label} was approved and ${approved.record_count} records were ingested. Opened the dynamic table below.`);
+        await loadDatasets(0, false);
+        await openDataset(approved.dataset_definition_id);
+        document.querySelector("#records-section").scrollIntoView({behavior: "smooth", block: "start"});
+      } catch (error) {
+        setState(discoveryState, "failure", `${error.message} Your reviewed values are still here; correct them and try approval again.`);
+      } finally {
+        action.disabled = false;
+      }
+    });
+    details.append(form);
+    return details;
+  }
+
+  function renderCandidates(payload) {
+    candidateList.replaceChildren();
+    if (!payload.candidates.length) {
+      setState(discoveryState, "empty", "No semantic HTML tables were detected. Paste a snapshot containing a table with rows and try again.");
+      return;
+    }
+    setState(discoveryState, "success", `${payload.candidates.length} table candidate${payload.candidates.length === 1 ? " was" : "s were"} detected. Review a candidate before permanent ingestion.`);
+    payload.candidates.forEach(candidate => {
+      const card = document.createElement("article");
+      card.className = "candidate";
+      const title = textElement("h3", candidate.name);
+      title.dir = "auto";
+      card.append(title);
+      const meta = document.createElement("div");
+      meta.className = "candidate-meta";
+      meta.append(
+        textElement("span", `${candidate.estimated_row_count} rows`, "chip"),
+        textElement("span", `${candidate.fields.length} fields`, "chip"),
+        textElement("span", `Confidence ${Math.round(candidate.confidence * 100)}%`, "chip"),
+        textElement("span", candidate.approvable ? "Status: Ready for review" : "Status: Needs correction", "chip")
+      );
+      card.append(meta);
+      if (candidate.warnings.length) {
+        const warnings = document.createElement("ul");
+        warnings.className = "warnings";
+        candidate.warnings.forEach(warning => warnings.append(textElement("li", warning)));
+        card.append(warnings);
+      }
+      card.append(previewTable(candidate.fields, candidate.sample_records));
+      card.append(approvalEditor(candidate, payload.snapshot.page_snapshot_id, payload.snapshot.source_url));
+      candidateList.append(card);
+    });
+  }
+
+  snapshotForm.addEventListener("submit", async event => {
+    event.preventDefault();
+    discoverButton.disabled = true;
+    candidateList.replaceChildren();
+    setState(discoveryState, "loading", "Saving immutable HTML evidence and detecting bounded table candidates.");
+    const form = new FormData(snapshotForm);
+    try {
+      const snapshot = await requestJson("/api/extract/snapshots", {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify({source_url: form.get("source_url"), html_content: form.get("html_content")})
+      });
+      const candidates = await requestJson(`/api/extract/snapshots/${snapshot.page_snapshot_id}/candidates`);
+      renderCandidates(candidates);
+    } catch (error) {
+      setState(discoveryState, "failure", `${error.message} Correct the snapshot input and try detection again.`);
+    } finally {
+      discoverButton.disabled = false;
+    }
+  });
+
+  function datasetItem(dataset) {
+    const item = document.createElement("article");
+    item.className = "dataset-item";
+    const summary = document.createElement("div");
+    const title = textElement("div", dataset.label, "dataset-title");
+    title.dir = "auto";
+    summary.append(title, textElement("div", `${dataset.site_display_name} · ${dataset.record_count} records · Status: Approved`, "dataset-sub"));
+    const open = document.createElement("button");
+    open.type = "button";
+    open.className = "ghost";
+    open.textContent = "Open table";
+    open.addEventListener("click", () => openDataset(dataset.dataset_definition_id));
+    item.append(summary, open);
+    return item;
+  }
+
+  async function loadDatasets(after = 0, append = false) {
+    setState(datasetsState, "loading", "Reading approved datasets from local storage.");
+    moreDatasets.hidden = true;
+    try {
+      const payload = await requestJson(`/api/extract/datasets?after_id=${after}&limit=50`);
+      if (!append) datasetList.replaceChildren();
+      payload.datasets.forEach(dataset => datasetList.append(datasetItem(dataset)));
+      datasetAfter = payload.next_after_id || 0;
+      moreDatasets.hidden = payload.next_after_id === null;
+      if (!datasetList.children.length) {
+        setState(datasetsState, "empty", "No candidate has been approved. Save HTML and approve one detected table above.");
+      } else {
+        setState(datasetsState, "success", `${datasetList.children.length} approved dataset${datasetList.children.length === 1 ? " is" : "s are"} available in this view.`);
+      }
+    } catch (error) {
+      setState(datasetsState, "failure", `${error.message} Use Refresh datasets to try again.`);
+    }
+  }
+
+  function renderRecords(payload) {
+    recordsTable.replaceChildren();
+    recordsContext.textContent = `${payload.dataset.label} · ${payload.dataset.site_display_name} · ${payload.dataset.record_count} total records`;
+    if (!payload.records.length) {
+      setState(recordsState, "empty", "This approved dataset has no records on this page. Return to the first page or approve a populated table.");
+      return;
+    }
+    hideState(recordsState);
+    const table = document.createElement("table");
+    const head = document.createElement("thead");
+    const headRow = document.createElement("tr");
+    payload.fields.forEach(field => {
+      const label = field.identity ? `${field.label} (Identity)` : field.label;
+      const th = textElement("th", label);
+      th.dir = "auto";
+      headRow.append(th);
+    });
+    head.append(headRow);
+    table.append(head);
+    const body = document.createElement("tbody");
+    payload.records.forEach(record => {
+      const row = document.createElement("tr");
+      payload.fields.forEach(field => {
+        const cell = textElement("td", valueText(record.data[field.field_key]), "value");
+        cell.dir = "auto";
+        row.append(cell);
+      });
+      body.append(row);
+    });
+    table.append(body);
+    recordsTable.append(table);
+    setState(recordsState, "success", `${payload.records.length} records are displayed from the approved dynamic schema.`);
+  }
+
+  async function loadRecordPage() {
+    if (!selectedDatasetId) return;
+    const after = recordCursors[recordCursors.length - 1];
+    recordsTable.replaceChildren();
+    setState(recordsState, "loading", "Reading a bounded page of generic records.");
+    previousRecords.disabled = true;
+    nextRecords.disabled = true;
+    try {
+      const payload = await requestJson(`/api/extract/datasets/${selectedDatasetId}/records?after_id=${after}&limit=50`);
+      recordNext = payload.next_after_id;
+      renderRecords(payload);
+      previousRecords.disabled = recordCursors.length === 1;
+      nextRecords.disabled = recordNext === null;
+    } catch (error) {
+      setState(recordsState, "failure", `${error.message} Choose the dataset again to retry.`);
+    }
+  }
+
+  async function openDataset(datasetId) {
+    selectedDatasetId = datasetId;
+    recordCursors = [0];
+    recordNext = null;
+    await loadRecordPage();
+  }
+
+  moreDatasets.addEventListener("click", () => loadDatasets(datasetAfter, true));
+  document.querySelector("#refresh-datasets").addEventListener("click", () => loadDatasets(0, false));
+  nextRecords.addEventListener("click", async () => {
+    if (recordNext !== null) {
+      recordCursors.push(recordNext);
+      await loadRecordPage();
+    }
+  });
+  previousRecords.addEventListener("click", async () => {
+    if (recordCursors.length > 1) {
+      recordCursors.pop();
+      await loadRecordPage();
+    }
+  });
+
+  loadDatasets();
+})();
+</script>
+{% endblock %}

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -57,7 +57,7 @@ def test_migration_creates_the_catalogue_and_integrity_triggers(conn):
     assert objects["relationship_field_pair"] == "table"
     assert objects["trg_dataset_relationship_same_site_insert"] == "trigger"
     assert objects["trg_relationship_field_pair_matches_insert"] == "trigger"
-    assert conn.execute("PRAGMA user_version").fetchone()[0] == 13
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 14
 
 
 def test_one_site_can_hold_multiple_tables_with_different_dynamic_columns(conn):

--- a/tests/test_database_isolation.py
+++ b/tests/test_database_isolation.py
@@ -64,7 +64,9 @@ def test_fresh_registry_creates_two_typed_databases_without_domain_tables_crossi
     )
     applied = registry.initialize()
 
-    assert applied["general"] == [1]
+    assert applied["general"] == list(
+        range(1, registry.general.latest_schema_version + 1)
+    )
     assert applied["marketlens"] == list(range(1, 14))
     assert registry.health()["general"]["status"] == "Healthy"
     assert registry.health()["marketlens"]["status"] == "Healthy"

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -27,12 +27,12 @@ def test_migrate_is_idempotent(tmp_path: Path):
         second = dbmod.migrate(conn)
     finally:
         conn.close()
-    assert first == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]  # +0013 generic catalogue
+    assert first == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
     assert second == []  # T4: running again applies nothing
 
 
 def test_latest_schema_version_matches_the_migration_chain():
-    assert dbmod.latest_schema_version() == 13
+    assert dbmod.latest_schema_version() == 14
 
 
 def test_foreign_keys_actually_enforced(tmp_path: Path):

--- a/tests/test_extract_api.py
+++ b/tests/test_extract_api.py
@@ -1,0 +1,195 @@
+"""End-to-end HTTP and Workspace coverage for generic HTML-table extraction."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from scrapex import db as dbmod  # noqa: E402
+from scrapex.webui.app import create_app  # noqa: E402
+
+
+HTML = """
+<table id="regional-offices">
+  <caption>Regional offices</caption>
+  <tr><th>Office code</th><th>Office name</th><th>Employees</th></tr>
+  <tr><td>RUH</td><td>الرياض</td><td>120</td></tr>
+  <tr><td>JED</td><td>Jeddah</td><td>85</td></tr>
+</table>
+"""
+
+
+@pytest.fixture()
+def workspace(tmp_path: Path):
+    db_path = tmp_path / "extract-api.db"
+    conn = dbmod.connect(db_path)
+    dbmod.migrate(conn)
+    conn.close()
+    with TestClient(create_app(db_path)) as client:
+        yield client, db_path
+
+
+def save_and_detect(client: TestClient, html: str = HTML):
+    saved = client.post("/api/extract/snapshots", json={
+        "source_url": "https://example.com/offices",
+        "html_content": html,
+    })
+    assert saved.status_code == 201
+    snapshot = saved.json()
+    detected = client.get(
+        f"/api/extract/snapshots/{snapshot['page_snapshot_id']}/candidates"
+    )
+    assert detected.status_code == 200
+    return snapshot, detected.json()["candidates"]
+
+
+def approval(candidate, identity_keys: set[str] | None = None):
+    identity_keys = identity_keys or set(candidate["candidate_identity_fields"])
+    return {
+        "table_index": candidate["table_index"],
+        "site_key": "example_site",
+        "site_display_name": "Example site",
+        "dataset_key": "regional_offices",
+        "dataset_name": "Regional offices",
+        "fields": [
+            {
+                "field_key": field["field_key"],
+                "display_name": field["display_name"],
+                "data_type": field["data_type"],
+                "identity": field["field_key"] in identity_keys,
+            }
+            for field in candidate["fields"]
+        ],
+    }
+
+
+def test_workspace_exposes_empty_loading_success_and_failure_states(workspace):
+    client, _ = workspace
+
+    response = client.get("/datasets")
+
+    assert response.status_code == 200
+    assert "Generic datasets" in response.text
+    assert "Empty:" in response.text
+    assert "Loading:" in response.text
+    assert 'setState(discoveryState, "success"' in response.text
+    assert 'setState(discoveryState, "failure"' in response.text
+    assert "Save and detect tables" in response.text
+    assert "Approve and ingest dataset" in response.text
+    assert "Dynamic table" in response.text
+
+
+def test_discovery_is_temporary_until_owner_approval(workspace):
+    client, _ = workspace
+
+    _, candidates = save_and_detect(client)
+
+    assert candidates[0]["name"] == "Regional offices"
+    assert client.get("/api/extract/datasets").json()["datasets"] == []
+
+
+def test_non_product_table_is_approved_ingested_and_browsed_end_to_end(workspace):
+    client, _ = workspace
+    snapshot, candidates = save_and_detect(client)
+    candidate = candidates[0]
+
+    approved = client.post(
+        f"/api/extract/snapshots/{snapshot['page_snapshot_id']}/approve",
+        json=approval(candidate),
+    )
+
+    assert approved.status_code == 201
+    dataset = approved.json()
+    assert dataset["record_count"] == 2
+    page = client.get(
+        f"/api/extract/datasets/{dataset['dataset_definition_id']}/records",
+        params={"limit": 1},
+    )
+    assert page.status_code == 200
+    payload = page.json()
+    assert [field["field_key"] for field in payload["fields"]] == [
+        "office_code", "office_name", "employees",
+    ]
+    assert payload["records"][0]["data"] == {
+        "office_code": "RUH", "office_name": "الرياض", "employees": 120,
+    }
+    assert payload["next_after_id"] is not None
+
+
+def test_failure_is_actionable_and_corrected_approval_recovers(workspace):
+    client, _ = workspace
+    html = """
+    <table><tr><th>Region</th><th>Code</th></tr>
+      <tr><td>North</td><td>N-1</td></tr>
+      <tr><td>North</td><td>N-2</td></tr>
+    </table>
+    """
+    snapshot, candidates = save_and_detect(client, html)
+    candidate = candidates[0]
+    endpoint = f"/api/extract/snapshots/{snapshot['page_snapshot_id']}/approve"
+
+    failed = client.post(endpoint, json=approval(candidate, {"region"}))
+
+    assert failed.status_code == 422
+    assert "duplicate record keys" in failed.json()["detail"]
+    assert "try again" in failed.json()["detail"]
+    assert client.get("/api/extract/datasets").json()["datasets"] == []
+
+    recovered = client.post(endpoint, json=approval(candidate, {"code"}))
+    assert recovered.status_code == 201
+    assert recovered.json()["record_count"] == 2
+
+
+def test_retry_and_restart_preserve_one_approved_ingestion(workspace):
+    client, db_path = workspace
+    snapshot, candidates = save_and_detect(client)
+    endpoint = f"/api/extract/snapshots/{snapshot['page_snapshot_id']}/approve"
+    request = approval(candidates[0])
+    first = client.post(endpoint, json=request)
+    assert first.status_code == 201
+
+    retry = client.post(endpoint, json=request)
+
+    assert retry.status_code == 201
+    assert retry.json()["recovered"] is True
+    dataset_id = first.json()["dataset_definition_id"]
+    with TestClient(create_app(db_path)) as restarted:
+        datasets = restarted.get("/api/extract/datasets").json()["datasets"]
+        records = restarted.get(
+            f"/api/extract/datasets/{dataset_id}/records"
+        ).json()["records"]
+    assert len(datasets) == 1
+    assert len(records) == 2
+
+
+def test_unknown_snapshot_and_invalid_page_limit_are_bounded_actionable_errors(workspace):
+    client, _ = workspace
+
+    missing = client.get("/api/extract/snapshots/999/candidates")
+    too_large = client.get("/api/extract/datasets", params={"limit": 101})
+
+    assert missing.status_code == 404
+    assert "Save the HTML again and retry" in missing.json()["detail"]
+    assert too_large.status_code == 422
+
+
+def test_untrusted_values_are_never_inserted_into_workspace_markup(workspace):
+    client, _ = workspace
+    malicious = (
+        "<table><tr><th>Payload</th></tr>"
+        "<tr><td>&lt;img src=x onerror=alert(1)&gt;</td></tr></table>"
+    )
+
+    _, candidates = save_and_detect(client, malicious)
+    page = client.get("/datasets")
+
+    assert candidates[0]["sample_records"][0]["payload"] == (
+        "<img src=x onerror=alert(1)>"
+    )
+    assert "<img src=x onerror=alert(1)>" not in page.text
+    assert ".innerHTML" not in page.text
+    assert "textContent" in page.text
+    assert 'cell.dir = "auto"' in page.text

--- a/tests/test_extract_api.py
+++ b/tests/test_extract_api.py
@@ -1,6 +1,7 @@
 """End-to-end HTTP and Workspace coverage for generic HTML-table extraction."""
 from __future__ import annotations
 
+from contextlib import closing
 from pathlib import Path
 
 import pytest
@@ -8,7 +9,11 @@ import pytest
 pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient  # noqa: E402
 
-from scrapex import db as dbmod  # noqa: E402
+from scrapex.databases import (  # noqa: E402
+    DatabaseRegistry,
+    GeneralDatabase,
+    MarketLensDatabase,
+)
 from scrapex.webui.app import create_app  # noqa: E402
 
 
@@ -24,23 +29,25 @@ HTML = """
 
 @pytest.fixture()
 def workspace(tmp_path: Path):
-    db_path = tmp_path / "extract-api.db"
-    conn = dbmod.connect(db_path)
-    dbmod.migrate(conn)
-    conn.close()
-    with TestClient(create_app(db_path)) as client:
-        yield client, db_path
+    registry = DatabaseRegistry(
+        GeneralDatabase(tmp_path / "general.db"),
+        MarketLensDatabase(tmp_path / "marketlens.db"),
+        pointer_file=tmp_path / "databases.json",
+    )
+    registry.initialize()
+    with TestClient(create_app(databases=registry)) as client:
+        yield client, registry
 
 
 def save_and_detect(client: TestClient, html: str = HTML):
-    saved = client.post("/api/extract/snapshots", json={
+    saved = client.post("/api/general/extract/snapshots", json={
         "source_url": "https://example.com/offices",
         "html_content": html,
     })
     assert saved.status_code == 201
     snapshot = saved.json()
     detected = client.get(
-        f"/api/extract/snapshots/{snapshot['page_snapshot_id']}/candidates"
+        f"/api/general/extract/snapshots/{snapshot['page_snapshot_id']}/candidates"
     )
     assert detected.status_code == 200
     return snapshot, detected.json()["candidates"]
@@ -88,16 +95,16 @@ def test_discovery_is_temporary_until_owner_approval(workspace):
     _, candidates = save_and_detect(client)
 
     assert candidates[0]["name"] == "Regional offices"
-    assert client.get("/api/extract/datasets").json()["datasets"] == []
+    assert client.get("/api/general/extract/datasets").json()["datasets"] == []
 
 
 def test_non_product_table_is_approved_ingested_and_browsed_end_to_end(workspace):
-    client, _ = workspace
+    client, registry = workspace
     snapshot, candidates = save_and_detect(client)
     candidate = candidates[0]
 
     approved = client.post(
-        f"/api/extract/snapshots/{snapshot['page_snapshot_id']}/approve",
+        f"/api/general/extract/snapshots/{snapshot['page_snapshot_id']}/approve",
         json=approval(candidate),
     )
 
@@ -105,7 +112,7 @@ def test_non_product_table_is_approved_ingested_and_browsed_end_to_end(workspace
     dataset = approved.json()
     assert dataset["record_count"] == 2
     page = client.get(
-        f"/api/extract/datasets/{dataset['dataset_definition_id']}/records",
+        f"/api/general/extract/datasets/{dataset['dataset_definition_id']}/records",
         params={"limit": 1},
     )
     assert page.status_code == 200
@@ -117,6 +124,14 @@ def test_non_product_table_is_approved_ingested_and_browsed_end_to_end(workspace
         "office_code": "RUH", "office_name": "الرياض", "employees": 120,
     }
     assert payload["next_after_id"] is not None
+    with closing(registry.general.connect()) as general:
+        assert general.execute(
+            "SELECT COUNT(*) FROM generic_record LIMIT 1"
+        ).fetchone()[0] == 2
+    with closing(registry.marketlens.connect()) as marketlens:
+        assert marketlens.execute(
+            "SELECT 1 FROM sqlite_master WHERE name = 'generic_record' LIMIT 1"
+        ).fetchone() is None
 
 
 def test_failure_is_actionable_and_corrected_approval_recovers(workspace):
@@ -129,14 +144,16 @@ def test_failure_is_actionable_and_corrected_approval_recovers(workspace):
     """
     snapshot, candidates = save_and_detect(client, html)
     candidate = candidates[0]
-    endpoint = f"/api/extract/snapshots/{snapshot['page_snapshot_id']}/approve"
+    endpoint = (
+        f"/api/general/extract/snapshots/{snapshot['page_snapshot_id']}/approve"
+    )
 
     failed = client.post(endpoint, json=approval(candidate, {"region"}))
 
     assert failed.status_code == 422
     assert "duplicate record keys" in failed.json()["detail"]
     assert "try again" in failed.json()["detail"]
-    assert client.get("/api/extract/datasets").json()["datasets"] == []
+    assert client.get("/api/general/extract/datasets").json()["datasets"] == []
 
     recovered = client.post(endpoint, json=approval(candidate, {"code"}))
     assert recovered.status_code == 201
@@ -144,9 +161,11 @@ def test_failure_is_actionable_and_corrected_approval_recovers(workspace):
 
 
 def test_retry_and_restart_preserve_one_approved_ingestion(workspace):
-    client, db_path = workspace
+    client, registry = workspace
     snapshot, candidates = save_and_detect(client)
-    endpoint = f"/api/extract/snapshots/{snapshot['page_snapshot_id']}/approve"
+    endpoint = (
+        f"/api/general/extract/snapshots/{snapshot['page_snapshot_id']}/approve"
+    )
     request = approval(candidates[0])
     first = client.post(endpoint, json=request)
     assert first.status_code == 201
@@ -156,10 +175,12 @@ def test_retry_and_restart_preserve_one_approved_ingestion(workspace):
     assert retry.status_code == 201
     assert retry.json()["recovered"] is True
     dataset_id = first.json()["dataset_definition_id"]
-    with TestClient(create_app(db_path)) as restarted:
-        datasets = restarted.get("/api/extract/datasets").json()["datasets"]
+    with TestClient(create_app(databases=registry)) as restarted:
+        datasets = restarted.get(
+            "/api/general/extract/datasets"
+        ).json()["datasets"]
         records = restarted.get(
-            f"/api/extract/datasets/{dataset_id}/records"
+            f"/api/general/extract/datasets/{dataset_id}/records"
         ).json()["records"]
     assert len(datasets) == 1
     assert len(records) == 2
@@ -168,8 +189,10 @@ def test_retry_and_restart_preserve_one_approved_ingestion(workspace):
 def test_unknown_snapshot_and_invalid_page_limit_are_bounded_actionable_errors(workspace):
     client, _ = workspace
 
-    missing = client.get("/api/extract/snapshots/999/candidates")
-    too_large = client.get("/api/extract/datasets", params={"limit": 101})
+    missing = client.get("/api/general/extract/snapshots/999/candidates")
+    too_large = client.get(
+        "/api/general/extract/datasets", params={"limit": 101}
+    )
 
     assert missing.status_code == 404
     assert "Save the HTML again and retry" in missing.json()["detail"]

--- a/tests/test_extract_html_table.py
+++ b/tests/test_extract_html_table.py
@@ -1,0 +1,84 @@
+"""Bounded, non-product HTML-table discovery and inference tests."""
+from __future__ import annotations
+
+from scrapex.extract.html_table import detect_html_tables
+
+
+REPORT_HTML = """
+<!doctype html>
+<html><body>
+  <table id="city-report">
+    <caption>City report</caption>
+    <thead><tr>
+      <th>City</th><th>Population</th><th>Coastal</th><th>Recorded</th>
+    </tr></thead>
+    <tbody>
+      <tr><td>الرياض</td><td>7000000</td><td>No</td><td>2026-07-19</td></tr>
+      <tr><td>Jeddah</td><td>4700000</td><td>Yes</td><td>2026-07-20</td></tr>
+    </tbody>
+  </table>
+</body></html>
+"""
+
+
+def test_detects_a_non_product_table_and_infers_dynamic_schema():
+    candidates = detect_html_tables(REPORT_HTML)
+
+    assert len(candidates) == 1
+    candidate = candidates[0].public()
+    assert candidate["name"] == "City report"
+    assert candidate["source_type"] == "html_table"
+    assert candidate["source_locator"] == "table#city-report"
+    assert candidate["estimated_row_count"] == 2
+    assert [field["data_type"] for field in candidate["fields"]] == [
+        "text", "integer", "boolean", "date",
+    ]
+    assert candidate["sample_records"][0]["city"] == "الرياض"
+    assert candidate["candidate_identity_fields"] == ["city"]
+    assert candidate["approvable"] is True
+
+
+def test_discovery_returns_candidates_without_interpreting_nested_tables_twice():
+    html = """
+    <table><tr><th>Name</th></tr><tr><td>
+      Outer<table><tr><th>Nested</th></tr><tr><td>Ignored</td></tr></table>
+    </td></tr></table>
+    """
+
+    candidates = detect_html_tables(html)
+
+    assert len(candidates) == 1
+    assert candidates[0].public()["estimated_row_count"] == 1
+
+
+def test_empty_and_headerless_tables_have_honest_actionable_results():
+    candidates = detect_html_tables(
+        "<table></table><table><tr><td>A</td><td>1</td></tr></table>"
+    )
+
+    assert candidates[0].approvable is False
+    assert "No data rows were found" in candidates[0].warnings[-1]
+    assert candidates[1].approvable is True
+    assert "No semantic header row" in candidates[1].warnings[0]
+    assert [field.source_name for field in candidates[1].fields] == [
+        "Column 1", "Column 2",
+    ]
+
+
+def test_merged_cells_are_previewed_but_refused_before_ingestion():
+    candidate = detect_html_tables(
+        "<table><tr><th colspan='2'>Heading</th></tr>"
+        "<tr><td>A</td><td>B</td></tr></table>"
+    )[0]
+
+    assert candidate.approvable is False
+    assert any("Merged cells" in warning for warning in candidate.warnings)
+
+
+def test_untrusted_markup_is_reduced_to_text_data():
+    candidate = detect_html_tables(
+        "<table><tr><th>Payload</th></tr>"
+        "<tr><td>&lt;img src=x onerror=alert(1)&gt;</td></tr></table>"
+    )[0]
+
+    assert candidate.rows[0]["payload"] == "<img src=x onerror=alert(1)>"

--- a/tests/test_extract_storage.py
+++ b/tests/test_extract_storage.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from contextlib import closing
 from pathlib import Path
 
 import pytest
 
 from scrapex import db as dbmod
+from scrapex.databases import DatabaseRegistry, GeneralDatabase, MarketLensDatabase
+from scrapex.databases.split import split_legacy_database
 from scrapex.extract import service
 from scrapex.extract.models import (
     CandidateApproval, CandidateNotApprovable, SnapshotCreate,
@@ -29,9 +32,19 @@ TABLE_HTML = """
 
 
 @pytest.fixture()
-def conn(tmp_path: Path):
-    connection = dbmod.connect(tmp_path / "generic.db")
-    dbmod.migrate(connection)
+def databases(tmp_path: Path):
+    registry = DatabaseRegistry(
+        GeneralDatabase(tmp_path / "general.db"),
+        MarketLensDatabase(tmp_path / "marketlens.db"),
+        pointer_file=tmp_path / "databases.json",
+    )
+    registry.initialize()
+    return registry
+
+
+@pytest.fixture()
+def conn(databases: DatabaseRegistry):
+    connection = databases.general.connect()
     try:
         yield connection
     finally:
@@ -64,8 +77,8 @@ def approval(candidate, identity: set[str] | None = None):
     )
 
 
-def test_0014_adds_separate_generic_storage_and_immutable_evidence(conn):
-    assert dbmod.schema_version(conn) == 14
+def test_general_0002_adds_generic_storage_and_immutable_evidence(conn):
+    assert dbmod.schema_version(conn) == 2
     objects = {
         row["name"]: row["type"]
         for row in conn.execute(
@@ -80,7 +93,7 @@ def test_0014_adds_separate_generic_storage_and_immutable_evidence(conn):
     assert objects["generic_ingestion"] == "table"
     assert objects["trg_generic_page_snapshot_immutable_update"] == "trigger"
     assert objects["trg_generic_record_revision_append_only_delete"] == "trigger"
-    assert objects["trg_price_obs_no_update"] == "trigger"
+    assert "trg_price_obs_no_update" not in objects
 
     snapshot = save(conn)
     with pytest.raises(sqlite3.IntegrityError, match="immutable"):
@@ -94,6 +107,69 @@ def test_0014_adds_separate_generic_storage_and_immutable_evidence(conn):
             "DELETE FROM generic_page_snapshot WHERE page_snapshot_id=?",
             (snapshot["page_snapshot_id"],),
         )
+
+
+def test_legacy_0014_remains_available_for_explicit_unified_sessions(tmp_path: Path):
+    legacy = dbmod.connect(tmp_path / "legacy.db")
+    try:
+        dbmod.migrate(legacy)
+        assert dbmod.schema_version(legacy) == 14
+        for table in ("price_observation", "generic_record"):
+            assert legacy.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1",
+                (table,),
+            ).fetchone() is not None
+    finally:
+        legacy.close()
+
+
+def test_split_moves_existing_g2_records_to_general_and_keeps_prices_in_marketlens(
+    tmp_path: Path,
+):
+    legacy_path = tmp_path / "legacy.db"
+    legacy = dbmod.connect(legacy_path)
+    dbmod.migrate(legacy)
+    snapshot = save(legacy)
+    candidate = service._candidate(
+        service._snapshot_row(legacy, snapshot["page_snapshot_id"]), 0
+    )
+    service.approve_candidate(
+        legacy, snapshot["page_snapshot_id"], approval(candidate)
+    )
+    ingest_payloads(legacy, make_entry(), [make_payload([one_row()])])
+    legacy.commit()
+    legacy.close()
+
+    general_path = tmp_path / "general.db"
+    marketlens_path = tmp_path / "marketlens.db"
+    split_legacy_database(
+        legacy_path,
+        general_path=general_path,
+        marketlens_path=marketlens_path,
+        pointer_file=tmp_path / "databases.json",
+    )
+
+    with closing(GeneralDatabase(general_path).connect()) as general:
+        assert general.execute(
+            "SELECT COUNT(*) FROM generic_page_snapshot LIMIT 1"
+        ).fetchone()[0] == 1
+        assert general.execute(
+            "SELECT COUNT(*) FROM generic_record LIMIT 1"
+        ).fetchone()[0] == 2
+        assert general.execute(
+            "SELECT COUNT(*) FROM generic_record_revision LIMIT 1"
+        ).fetchone()[0] == 2
+        assert general.execute(
+            "SELECT 1 FROM sqlite_master WHERE name = 'price_observation' LIMIT 1"
+        ).fetchone() is None
+
+    with closing(MarketLensDatabase(marketlens_path).connect()) as marketlens:
+        assert marketlens.execute(
+            "SELECT COUNT(*) FROM price_observation LIMIT 1"
+        ).fetchone()[0] == 1
+        assert marketlens.execute(
+            "SELECT 1 FROM sqlite_master WHERE name = 'generic_record' LIMIT 1"
+        ).fetchone() is None
 
 
 def test_discovery_returns_candidates_without_polluting_permanent_datasets(conn):
@@ -143,7 +219,9 @@ def test_owner_approval_atomically_creates_schema_and_typed_generic_records(conn
     ).fetchone()[0] == 2
 
 
-def test_failed_identity_approval_rolls_back_and_a_corrected_retry_recovers(conn):
+def test_failed_identity_approval_rolls_back_and_a_corrected_retry_recovers(
+    conn, databases: DatabaseRegistry,
+):
     html = """
     <table><tr><th>Region</th><th>Code</th></tr>
       <tr><td>North</td><td>N-1</td></tr>
@@ -162,6 +240,10 @@ def test_failed_identity_approval_rolls_back_and_a_corrected_retry_recovers(conn
     assert conn.execute(
         "SELECT COUNT(*) FROM dataset_definition LIMIT 1"
     ).fetchone()[0] == 0
+    with closing(databases.marketlens.connect()) as marketlens:
+        assert marketlens.execute(
+            "SELECT COUNT(*) FROM price_observation LIMIT 1"
+        ).fetchone()[0] == 0
 
     recovered = service.approve_candidate(
         conn, snapshot["page_snapshot_id"], approval(candidate, {"code"})
@@ -218,18 +300,34 @@ def test_later_snapshot_updates_current_record_and_appends_revision(conn):
     ).fetchone()[0] == 2
 
 
-def test_generic_ingestion_does_not_change_the_append_only_price_path(conn):
-    snapshot = save(conn)
-    candidate = service._candidate(
-        service._snapshot_row(conn, snapshot["page_snapshot_id"]), 0
-    )
-    service.approve_candidate(conn, snapshot["page_snapshot_id"], approval(candidate))
+def test_generic_ingestion_and_price_ingestion_stay_in_separate_databases(
+    databases: DatabaseRegistry,
+):
+    with closing(databases.general.connect()) as general:
+        snapshot = save(general)
+        candidate = service._candidate(
+            service._snapshot_row(general, snapshot["page_snapshot_id"]), 0
+        )
+        service.approve_candidate(
+            general, snapshot["page_snapshot_id"], approval(candidate)
+        )
+        general.commit()
+        assert general.execute(
+            "SELECT COUNT(*) FROM generic_record LIMIT 1"
+        ).fetchone()[0] == 2
+        with pytest.raises(sqlite3.OperationalError, match="no such table"):
+            general.execute("SELECT COUNT(*) FROM price_observation LIMIT 1")
 
-    result = ingest_payloads(conn, make_entry(), [make_payload([one_row()])])
-
-    assert result.observations == 1
-    assert conn.execute(
-        "SELECT COUNT(*) FROM price_observation LIMIT 1"
-    ).fetchone()[0] == 1
-    with pytest.raises(sqlite3.IntegrityError, match="append-only"):
-        conn.execute("UPDATE price_observation SET effective_price=1.0")
+    with closing(databases.marketlens.connect()) as marketlens:
+        assert marketlens.execute(
+            "SELECT 1 FROM sqlite_master WHERE name = 'generic_record' LIMIT 1"
+        ).fetchone() is None
+        result = ingest_payloads(
+            marketlens, make_entry(), [make_payload([one_row()])]
+        )
+        assert result.observations == 1
+        assert marketlens.execute(
+            "SELECT COUNT(*) FROM price_observation LIMIT 1"
+        ).fetchone()[0] == 1
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            marketlens.execute("UPDATE price_observation SET effective_price=1.0")

--- a/tests/test_extract_storage.py
+++ b/tests/test_extract_storage.py
@@ -1,0 +1,235 @@
+"""Persistent generic records, approval safety, recovery, and coexistence tests."""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scrapex import db as dbmod
+from scrapex.extract import service
+from scrapex.extract.models import (
+    CandidateApproval, CandidateNotApprovable, SnapshotCreate,
+)
+from scrapex.ingest import ingest_payloads
+from tests.test_ingest import make_entry, make_payload, one_row
+
+
+TABLE_HTML = """
+<table id="city-report">
+  <caption>City report</caption>
+  <thead><tr><th>City</th><th>Population</th><th>Coastal</th></tr></thead>
+  <tbody>
+    <tr><td>الرياض</td><td>7000000</td><td>No</td></tr>
+    <tr><td>Jeddah</td><td>4700000</td><td>Yes</td></tr>
+  </tbody>
+</table>
+"""
+
+
+@pytest.fixture()
+def conn(tmp_path: Path):
+    connection = dbmod.connect(tmp_path / "generic.db")
+    dbmod.migrate(connection)
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def save(conn, html: str = TABLE_HTML, url: str = "https://example.com/report"):
+    return service.save_snapshot(
+        conn, SnapshotCreate(source_url=url, html_content=html)
+    )
+
+
+def approval(candidate, identity: set[str] | None = None):
+    identity = identity or {candidate.fields[0].field_key}
+    return CandidateApproval(
+        table_index=candidate.table_index,
+        site_key="example_site",
+        site_display_name="Example site",
+        dataset_key="city_report",
+        dataset_name="City report",
+        fields=[
+            {
+                "field_key": field.field_key,
+                "display_name": field.source_name,
+                "data_type": field.data_type,
+                "identity": field.field_key in identity,
+            }
+            for field in candidate.fields
+        ],
+    )
+
+
+def test_0014_adds_separate_generic_storage_and_immutable_evidence(conn):
+    assert dbmod.schema_version(conn) == 14
+    objects = {
+        row["name"]: row["type"]
+        for row in conn.execute(
+            "SELECT name, type FROM sqlite_master "
+            "WHERE type IN ('table','trigger') LIMIT 500"
+        )
+    }
+    assert objects["generic_page_snapshot"] == "table"
+    assert objects["dataset_schema_version"] == "table"
+    assert objects["generic_record"] == "table"
+    assert objects["generic_record_revision"] == "table"
+    assert objects["generic_ingestion"] == "table"
+    assert objects["trg_generic_page_snapshot_immutable_update"] == "trigger"
+    assert objects["trg_generic_record_revision_append_only_delete"] == "trigger"
+    assert objects["trg_price_obs_no_update"] == "trigger"
+
+    snapshot = save(conn)
+    with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+        conn.execute(
+            "UPDATE generic_page_snapshot SET html_content='changed' "
+            "WHERE page_snapshot_id=?",
+            (snapshot["page_snapshot_id"],),
+        )
+    with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+        conn.execute(
+            "DELETE FROM generic_page_snapshot WHERE page_snapshot_id=?",
+            (snapshot["page_snapshot_id"],),
+        )
+
+
+def test_discovery_returns_candidates_without_polluting_permanent_datasets(conn):
+    snapshot = save(conn)
+
+    result = service.discover_snapshot(conn, snapshot["page_snapshot_id"])
+
+    assert result["candidates"][0]["name"] == "City report"
+    for table in (
+        "site_profile", "dataset_definition", "field_definition",
+        "dataset_schema_version", "generic_record", "generic_ingestion",
+    ):
+        assert conn.execute(f"SELECT COUNT(*) FROM {table} LIMIT 1").fetchone()[0] == 0
+
+
+def test_owner_approval_atomically_creates_schema_and_typed_generic_records(conn):
+    snapshot = save(conn)
+    candidate = service._candidate(
+        service._snapshot_row(conn, snapshot["page_snapshot_id"]), 0
+    )
+
+    result = service.approve_candidate(
+        conn, snapshot["page_snapshot_id"], approval(candidate)
+    )
+    conn.commit()
+    page = service.browse_records(conn, result["dataset_definition_id"], limit=1)
+
+    assert result["record_count"] == 2
+    assert result["recovered"] is False
+    assert [field["field_key"] for field in page["fields"]] == [
+        "city", "population", "coastal",
+    ]
+    assert page["fields"][0]["identity"] is True
+    assert page["records"][0]["data"] == {
+        "city": "الرياض", "population": 7000000, "coastal": False,
+    }
+    assert page["next_after_id"] is not None
+    stored = conn.execute(
+        "SELECT source_locator, data_json FROM generic_record "
+        "WHERE generic_record_id=? LIMIT 1",
+        (page["records"][0]["generic_record_id"],),
+    ).fetchone()
+    assert stored["source_locator"] == "table#city-report::row(1)"
+    assert json.loads(stored["data_json"])["population"] == 7000000
+    assert conn.execute(
+        "SELECT COUNT(*) FROM generic_record_revision LIMIT 1"
+    ).fetchone()[0] == 2
+
+
+def test_failed_identity_approval_rolls_back_and_a_corrected_retry_recovers(conn):
+    html = """
+    <table><tr><th>Region</th><th>Code</th></tr>
+      <tr><td>North</td><td>N-1</td></tr>
+      <tr><td>North</td><td>N-2</td></tr>
+    </table>
+    """
+    snapshot = save(conn, html)
+    candidate = service._candidate(
+        service._snapshot_row(conn, snapshot["page_snapshot_id"]), 0
+    )
+
+    with pytest.raises(CandidateNotApprovable, match="duplicate record keys"):
+        service.approve_candidate(
+            conn, snapshot["page_snapshot_id"], approval(candidate, {"region"})
+        )
+    assert conn.execute(
+        "SELECT COUNT(*) FROM dataset_definition LIMIT 1"
+    ).fetchone()[0] == 0
+
+    recovered = service.approve_candidate(
+        conn, snapshot["page_snapshot_id"], approval(candidate, {"code"})
+    )
+    conn.commit()
+    assert recovered["record_count"] == 2
+
+
+def test_retry_after_a_lost_success_response_is_idempotent(conn):
+    snapshot = save(conn)
+    candidate = service._candidate(
+        service._snapshot_row(conn, snapshot["page_snapshot_id"]), 0
+    )
+    request = approval(candidate)
+    first = service.approve_candidate(conn, snapshot["page_snapshot_id"], request)
+    conn.commit()
+
+    second = service.approve_candidate(conn, snapshot["page_snapshot_id"], request)
+    conn.commit()
+
+    assert second["dataset_definition_id"] == first["dataset_definition_id"]
+    assert second["recovered"] is True
+    assert conn.execute(
+        "SELECT COUNT(*) FROM generic_ingestion LIMIT 1"
+    ).fetchone()[0] == 1
+    assert conn.execute(
+        "SELECT COUNT(*) FROM generic_record_revision LIMIT 1"
+    ).fetchone()[0] == 2
+
+
+def test_later_snapshot_updates_current_record_and_appends_revision(conn):
+    first_snapshot = save(conn)
+    first_candidate = service._candidate(
+        service._snapshot_row(conn, first_snapshot["page_snapshot_id"]), 0
+    )
+    request = approval(first_candidate)
+    first = service.approve_candidate(
+        conn, first_snapshot["page_snapshot_id"], request
+    )
+    conn.commit()
+    changed_html = TABLE_HTML.replace("7000000", "7100000")
+    next_snapshot = save(conn, changed_html, "https://example.com/report?page=2")
+
+    service.approve_candidate(conn, next_snapshot["page_snapshot_id"], request)
+    conn.commit()
+    page = service.browse_records(conn, first["dataset_definition_id"])
+
+    assert page["records"][0]["data"]["population"] == 7100000
+    assert conn.execute(
+        "SELECT COUNT(*) FROM generic_record_revision LIMIT 1"
+    ).fetchone()[0] == 4
+    assert conn.execute(
+        "SELECT COUNT(*) FROM generic_ingestion LIMIT 1"
+    ).fetchone()[0] == 2
+
+
+def test_generic_ingestion_does_not_change_the_append_only_price_path(conn):
+    snapshot = save(conn)
+    candidate = service._candidate(
+        service._snapshot_row(conn, snapshot["page_snapshot_id"]), 0
+    )
+    service.approve_candidate(conn, snapshot["page_snapshot_id"], approval(candidate))
+
+    result = ingest_payloads(conn, make_entry(), [make_payload([one_row()])])
+
+    assert result.observations == 1
+    assert conn.execute(
+        "SELECT COUNT(*) FROM price_observation LIMIT 1"
+    ).fetchone()[0] == 1
+    with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+        conn.execute("UPDATE price_observation SET effective_price=1.0")

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -62,7 +62,7 @@ def _insert_observation(conn, ids, price: float = 168.78, hash_: str = "h1") -> 
 
 
 def test_migration_reaches_latest_version(conn):
-    assert dbmod.schema_version(conn) == 13  # +0013 generic catalogue
+    assert dbmod.schema_version(conn) == 14  # +0014 generic extraction storage
 
 
 def test_all_owner_tables_exist(conn):


### PR DESCRIPTION
## Draft status and dependency

This remains a Draft for Tech Lead review. It is intentionally stacked on DB1 PR #4 (`draft/db1-domain-database-isolation`) because section 40 requires physical database isolation before G2 can be approved. Do not merge G2 before DB1, and do not treat this description as declaring the slice complete.

## What this reuses

- The G1 catalogue definitions and repositories in `catalog.py`, `catalog_models.py`, and `catalog_relations.py`.
- DB1's typed `DatabaseRegistry`, `GeneralDatabase`, and `MarketLensDatabase` capabilities.
- DB1's independent locks, health checks, migration ledgers, backup/restore paths, and General catalogue API namespace.
- The existing legacy unified migration stream for explicit `--db` rollback-compatible sessions only.

## What this adds

- One complete production workflow: saved HTML snapshot -> semantic table detection -> candidate preview -> schema inference -> owner approval -> generic ingestion -> dynamic Workspace table.
- Immutable saved HTML evidence, approved schema versions, canonical JSON records, append-only revisions, and append-only ingestion receipts.
- Bounded candidate samples, dataset pages, field reads, and record pages.
- Actionable empty, loading, success, and failure states in the English Workspace UI.
- The authoritative General API namespace at `/api/general/extract`.
- Split migration support for existing G2 data: snapshots, schemas, generic records, revisions, and ingestion receipts move to General and are removed from the MarketLens copy.

Discovery still does not create permanent dataset definitions. The owner must review and approve a candidate before catalogue/schema/record ingestion occurs.

## Migrations

- `db/general/migrations/0002_generic_html_table_extraction.sql` is the production General migration. General advances from schema version 1 to 2.
- `db/migrations/0014_generic_html_table_extraction.sql` remains unchanged as reserved migration 0014 for explicit legacy unified sessions. It is not part of the MarketLens migration plan.
- MarketLens remains schema version 13 and receives no G2 tables.

## Compatibility impact

- Product, variant, offer, and price writes continue to use MarketLens exclusively.
- `price_observation` remains append-only; G2 neither updates nor deletes it.
- G1/G2 definitions, snapshots, schemas, generic records, revisions, and ingestions use General exclusively in split mode.
- The draft-only `/api/extract` path is replaced by `/api/general/extract`; the Workspace uses the new authoritative path. No released interface depended on the previous draft path.
- Explicit legacy `--db` sessions can still open a unified schema-14 database for rollback compatibility.
- Splitting a schema-14 legacy database now transfers all approved G2 state to General while preserving price history in MarketLens and sealing the legacy archive.

## Tests added or updated

- HTML table detection and schema inference fixtures.
- End-to-end HTTP and Workspace approval/ingestion/browsing.
- Physical proof that G2 records exist only in General and price observations exist only in MarketLens.
- Legacy schema-14 compatibility and a real split containing both approved generic records and price history.
- Discovery-without-approval, immutable evidence, bounded pagination, untrusted content rendering, idempotent retry, restart persistence, failure rollback, corrected recovery, and later snapshot revisions.
- DB1's fresh migration assertion now follows the General database's declared latest version instead of freezing it at version 1.

## Validation

- `python -m pytest` -> **619 passed**, 2 warnings (FastAPI TestClient deprecation and a pytest cache warning).
- `node contract/parity/parity.test.mjs` -> **16/16 passed**.
- `python -m scrapex.cli validate-manifest` -> **OK: 12 sources**.
- `python -m compileall -q scrapex tests` -> passed.
- `git diff --check` -> passed.
- Manual local browser workflow against separate General v2 and MarketLens v13 databases -> detection, owner approval, two-record ingestion, and dynamic table browsing succeeded with no browser console errors.

## Known limitations

- This slice supports semantic HTML tables only. Repeated DOM cards/lists, JSON arrays, JSONPath, embedded JSON, and JSON-LD remain G3 work and are not included here.
- Schema drift is intentionally refused after approval; the owner must use a new dataset key until a reviewed schema-drift workflow exists.
- Saved HTML is limited to 2 MB, previews and reads are bounded, and the UI browses records through cursor pages.
- Records use canonical JSON in one generic store rather than creating a physical SQL table per dataset.
- Review and merge approval remain the Tech Lead's responsibility.
