### PR TITLE
DB1: isolate General and MarketLens databases

### DIFF
--- a/db/general/schema.sql
+++ b/db/general/schema.sql
@@ -1,0 +1,176 @@
+-- General database baseline 0001: generic catalogue definitions only.
+-- Generic snapshots, jobs, schedules and records arrive in their owning slices.
+
+PRAGMA foreign_keys = ON;
+PRAGMA application_id = 1398294350;
+
+CREATE TABLE scrapex_meta (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+INSERT INTO scrapex_meta (key, value) VALUES
+    ('database_kind', 'general'),
+    ('migration_stream', 'general');
+
+CREATE TABLE database_migration (
+    migration_number INTEGER PRIMARY KEY,
+    migration_name   TEXT NOT NULL,
+    sha256            TEXT NOT NULL,
+    applied_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+);
+
+CREATE TABLE site_profile (
+    site_profile_id      INTEGER PRIMARY KEY,
+    site_key             TEXT NOT NULL UNIQUE,
+    display_name         TEXT NOT NULL,
+    base_url             TEXT NOT NULL,
+    marketlens_source_key TEXT,
+    lifecycle            TEXT NOT NULL DEFAULT 'draft'
+        CHECK (lifecycle IN ('draft','active','paused')),
+    created_at           TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    updated_at           TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    valid_to             TEXT
+);
+
+CREATE INDEX ix_site_profile_page ON site_profile(valid_to, site_profile_id);
+
+CREATE TABLE dataset_definition (
+    dataset_definition_id INTEGER PRIMARY KEY,
+    site_profile_id       INTEGER NOT NULL REFERENCES site_profile(site_profile_id),
+    dataset_key           TEXT NOT NULL,
+    original_name         TEXT NOT NULL,
+    display_name          TEXT,
+    dataset_kind          TEXT NOT NULL DEFAULT 'unknown'
+        CHECK (dataset_kind IN ('table','list','detail','tree','stream','unknown')),
+    discovery_method      TEXT NOT NULL
+        CHECK (discovery_method IN (
+            'manual','html_table','repeating_dom','json','api','inferred')),
+    locator_json          TEXT NOT NULL DEFAULT '{}',
+    first_seen_at         TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    last_seen_at          TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    valid_to              TEXT,
+    UNIQUE (site_profile_id, dataset_key)
+);
+
+CREATE INDEX ix_dataset_definition_site
+    ON dataset_definition(site_profile_id, dataset_definition_id, valid_to);
+
+CREATE TABLE field_definition (
+    field_definition_id   INTEGER PRIMARY KEY,
+    dataset_definition_id INTEGER NOT NULL
+        REFERENCES dataset_definition(dataset_definition_id),
+    field_key             TEXT NOT NULL,
+    original_name         TEXT NOT NULL,
+    display_name          TEXT,
+    data_type             TEXT NOT NULL DEFAULT 'unknown'
+        CHECK (data_type IN (
+            'text','integer','decimal','boolean','date','datetime','url','json','unknown')),
+    is_nullable           INTEGER NOT NULL DEFAULT 1 CHECK (is_nullable IN (0,1)),
+    identity_role         TEXT NOT NULL DEFAULT 'none'
+        CHECK (identity_role IN ('none','candidate','key_part')),
+    display_order         INTEGER NOT NULL DEFAULT 0 CHECK (display_order >= 0),
+    first_seen_at         TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    last_seen_at          TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    valid_to              TEXT,
+    UNIQUE (dataset_definition_id, field_key)
+);
+
+CREATE INDEX ix_field_definition_dataset
+    ON field_definition(dataset_definition_id, display_order, field_definition_id);
+
+CREATE TABLE dataset_relationship (
+    dataset_relationship_id INTEGER PRIMARY KEY,
+    site_profile_id         INTEGER NOT NULL REFERENCES site_profile(site_profile_id),
+    relationship_key        TEXT NOT NULL,
+    parent_dataset_id       INTEGER NOT NULL
+        REFERENCES dataset_definition(dataset_definition_id),
+    child_dataset_id        INTEGER NOT NULL
+        REFERENCES dataset_definition(dataset_definition_id),
+    cardinality             TEXT NOT NULL DEFAULT 'unknown'
+        CHECK (cardinality IN (
+            'one_to_one','one_to_many','many_to_one','many_to_many','unknown')),
+    review_status           TEXT NOT NULL DEFAULT 'suggested'
+        CHECK (review_status IN ('suggested','confirmed','rejected')),
+    confidence              REAL NOT NULL DEFAULT 0.0
+        CHECK (confidence >= 0.0 AND confidence <= 1.0),
+    evidence_json           TEXT NOT NULL DEFAULT '{}',
+    created_at              TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    updated_at              TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    valid_to                TEXT,
+    CHECK (parent_dataset_id <> child_dataset_id),
+    UNIQUE (site_profile_id, relationship_key)
+);
+
+CREATE INDEX ix_dataset_relationship_site
+    ON dataset_relationship(site_profile_id, dataset_relationship_id, valid_to);
+
+CREATE TABLE relationship_field_pair (
+    relationship_field_pair_id INTEGER PRIMARY KEY,
+    dataset_relationship_id    INTEGER NOT NULL
+        REFERENCES dataset_relationship(dataset_relationship_id),
+    parent_field_id             INTEGER NOT NULL REFERENCES field_definition(field_definition_id),
+    child_field_id              INTEGER NOT NULL REFERENCES field_definition(field_definition_id),
+    pair_order                  INTEGER NOT NULL DEFAULT 0 CHECK (pair_order >= 0),
+    UNIQUE (dataset_relationship_id, parent_field_id, child_field_id),
+    UNIQUE (dataset_relationship_id, pair_order)
+);
+
+CREATE INDEX ix_relationship_field_pair_relationship
+    ON relationship_field_pair(dataset_relationship_id, pair_order);
+
+CREATE TRIGGER trg_dataset_relationship_same_site_insert
+BEFORE INSERT ON dataset_relationship
+FOR EACH ROW
+WHEN (SELECT site_profile_id FROM dataset_definition
+      WHERE dataset_definition_id = NEW.parent_dataset_id LIMIT 1) <> NEW.site_profile_id
+  OR (SELECT site_profile_id FROM dataset_definition
+      WHERE dataset_definition_id = NEW.child_dataset_id LIMIT 1) <> NEW.site_profile_id
+BEGIN
+    SELECT RAISE(ABORT, 'relationship datasets must belong to the same site profile');
+END;
+
+CREATE TRIGGER trg_dataset_relationship_same_site_update
+BEFORE UPDATE OF site_profile_id, parent_dataset_id, child_dataset_id
+ON dataset_relationship
+FOR EACH ROW
+WHEN (SELECT site_profile_id FROM dataset_definition
+      WHERE dataset_definition_id = NEW.parent_dataset_id LIMIT 1) <> NEW.site_profile_id
+  OR (SELECT site_profile_id FROM dataset_definition
+      WHERE dataset_definition_id = NEW.child_dataset_id LIMIT 1) <> NEW.site_profile_id
+BEGIN
+    SELECT RAISE(ABORT, 'relationship datasets must belong to the same site profile');
+END;
+
+CREATE TRIGGER trg_relationship_field_pair_matches_insert
+BEFORE INSERT ON relationship_field_pair
+FOR EACH ROW
+WHEN (SELECT dataset_definition_id FROM field_definition
+      WHERE field_definition_id = NEW.parent_field_id LIMIT 1) <>
+     (SELECT parent_dataset_id FROM dataset_relationship
+      WHERE dataset_relationship_id = NEW.dataset_relationship_id LIMIT 1)
+  OR (SELECT dataset_definition_id FROM field_definition
+      WHERE field_definition_id = NEW.child_field_id LIMIT 1) <>
+     (SELECT child_dataset_id FROM dataset_relationship
+      WHERE dataset_relationship_id = NEW.dataset_relationship_id LIMIT 1)
+BEGIN
+    SELECT RAISE(ABORT, 'relationship fields must belong to their mapped datasets');
+END;
+
+CREATE TRIGGER trg_relationship_field_pair_matches_update
+BEFORE UPDATE OF dataset_relationship_id, parent_field_id, child_field_id
+ON relationship_field_pair
+FOR EACH ROW
+WHEN (SELECT dataset_definition_id FROM field_definition
+      WHERE field_definition_id = NEW.parent_field_id LIMIT 1) <>
+     (SELECT parent_dataset_id FROM dataset_relationship
+      WHERE dataset_relationship_id = NEW.dataset_relationship_id LIMIT 1)
+  OR (SELECT dataset_definition_id FROM field_definition
+      WHERE field_definition_id = NEW.child_field_id LIMIT 1) <>
+     (SELECT child_dataset_id FROM dataset_relationship
+      WHERE dataset_relationship_id = NEW.dataset_relationship_id LIMIT 1)
+BEGIN
+    SELECT RAISE(ABORT, 'relationship fields must belong to their mapped datasets');
+END;
+
+PRAGMA user_version = 1;

--- a/db/marketlens/migrations/0013_marketlens_database_identity.sql
+++ b/db/marketlens/migrations/0013_marketlens_database_identity.sql
@@ -1,0 +1,18 @@
+-- MarketLens migration 0013: identify the independent price database stream.
+-- Versions 0001-0012 reuse the immutable price-warehouse history. The legacy
+-- stream's unrelated 0013 generic catalogue migration is deliberately excluded.
+
+PRAGMA application_id = 1398295884;
+
+CREATE TABLE database_migration (
+    migration_number INTEGER PRIMARY KEY,
+    migration_name   TEXT NOT NULL,
+    sha256            TEXT NOT NULL,
+    applied_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+);
+
+INSERT INTO scrapex_meta (key, value) VALUES
+    ('database_kind', 'marketlens'),
+    ('migration_stream', 'marketlens');
+
+PRAGMA user_version = 13;

--- a/docs/db1-domain-database-isolation.md
+++ b/docs/db1-domain-database-isolation.md
@@ -1,0 +1,79 @@
+# DB1 domain database isolation
+
+DB1 separates ScrapeX's operational data into two SQLite files:
+
+- `~/.scrapex/general/general.db` owns generic site and dataset definitions.
+- `~/.scrapex/marketlens/marketlens.db` owns the existing product and price path.
+
+The files have different SQLite `application_id` values, required
+`database_kind` markers, independent migration ledgers and checksums, and
+independent lock, health, backup, and restore operations. ScrapeX refuses a
+General file at a MarketLens boundary and vice versa. It never uses `ATTACH`, a
+cross-database foreign key, or a distributed transaction.
+
+## Fresh installation
+
+Run:
+
+```text
+scrapex init-db
+scrapex database-status
+```
+
+Initialization creates both files and commits `~/.scrapex/databases.json` only
+after both pass health checks.
+
+## Split an existing unified warehouse
+
+First stop the worker and any other process using the warehouse. Then run:
+
+```text
+scrapex init-db --db <legacy-harvest.db>
+scrapex split-databases --legacy-db <legacy-harvest.db>
+scrapex database-status
+```
+
+The split takes a pre-split backup, copies each domain to an incoming file,
+verifies bounded row counts and checksums, verifies foreign keys, promotes both
+files, switches the registry pointer, and seals the legacy file. It does not
+delete or update a `price_observation` row. A failure before the pointer switch
+leaves the legacy database authoritative; fix the reported cause and retry.
+
+## Backup and restore
+
+Create a bundle containing one independently restorable backup per domain:
+
+```text
+scrapex backup-databases --folder <backup-folder>
+```
+
+Restore only the affected domain:
+
+```text
+scrapex restore-database general <general-backup.db>
+scrapex restore-database marketlens <marketlens-backup.db>
+scrapex database-status
+```
+
+A restore verifies the domain identity and checksum ledger before moving the
+live file. The replaced file remains beside it for recovery.
+
+## Rollback
+
+Run:
+
+```text
+scrapex rollback-databases
+scrapex ui --db <legacy-harvest.db>
+```
+
+Rollback unseals the legacy file and switches the registry to explicit legacy
+mode. It does not alter or delete either split database. Retry
+`split-databases --legacy-db <legacy-harvest.db>` when ready to switch forward.
+
+## Compatibility boundary
+
+The explicit `--db` option remains the temporary unified-database compatibility
+path for rollback and migration. Normal commands use the typed registry. The
+old `/api/catalog` route remains an alias while G2 rebases; the authoritative
+generic route is `/api/general/catalog`.

--- a/scrapex/catalog.py
+++ b/scrapex/catalog.py
@@ -49,12 +49,16 @@ def _dataset_row(conn: sqlite3.Connection, dataset_id: int) -> sqlite3.Row:
 
 
 def _site_public(row: sqlite3.Row) -> dict[str, Any]:
+    keys = set(row.keys())
     return {
         "site_profile_id": row["site_profile_id"],
         "site_key": row["site_key"],
         "display_name": row["display_name"],
         "base_url": row["base_url"],
-        "price_source_id": row["price_source_id"],
+        "marketlens_source_key": (
+            row["marketlens_source_key"] if "marketlens_source_key" in keys else None
+        ),
+        "price_source_id": row["price_source_id"] if "price_source_id" in keys else None,
         "lifecycle": row["lifecycle"],
         "created_at": row["created_at"],
         "updated_at": row["updated_at"],
@@ -97,6 +101,18 @@ def _field_public(row: sqlite3.Row) -> dict[str, Any]:
 def register_site(conn: sqlite3.Connection, request: SiteCreate) -> dict[str, Any]:
     """Register a site idempotently without overwriting its stable identity."""
     base_url = str(request.base_url)
+    try:
+        conn.execute("SELECT marketlens_source_key FROM site_profile LIMIT 0")
+        general_schema = True
+    except sqlite3.OperationalError as exc:
+        if "marketlens_source_key" not in str(exc):
+            raise
+        general_schema = False
+    if general_schema and request.price_source_id is not None:
+        raise CatalogConflict(
+            "General cannot store a MarketLens row id; provide "
+            "marketlens_source_key instead"
+        )
     existing = conn.execute(
         "SELECT * FROM site_profile WHERE site_key = ?", (request.site_key,)
     ).fetchone()
@@ -110,19 +126,54 @@ def register_site(conn: sqlite3.Connection, request: SiteCreate) -> dict[str, An
                 f"site_key {request.site_key!r} already belongs to "
                 f"{existing['base_url']!r}"
             )
+        existing_keys = set(existing.keys())
+        if (
+            request.marketlens_source_key is not None
+            and "marketlens_source_key" in existing_keys
+            and existing["marketlens_source_key"] != request.marketlens_source_key
+        ):
+            raise CatalogConflict(
+                f"site_key {request.site_key!r} already links to another "
+                "MarketLens source key"
+            )
         return _site_public(existing)
-    cursor = conn.execute(
-        "INSERT INTO site_profile "
-        "(site_key, display_name, base_url, price_source_id, lifecycle) "
-        "VALUES (?,?,?,?,?)",
-        (
-            request.site_key,
-            request.display_name,
-            base_url,
-            request.price_source_id,
-            request.lifecycle.value,
-        ),
-    )
+    if general_schema:
+        cursor = conn.execute(
+            "INSERT INTO site_profile "
+            "(site_key, display_name, base_url, marketlens_source_key, lifecycle) "
+            "VALUES (?,?,?,?,?)",
+            (
+                request.site_key,
+                request.display_name,
+                base_url,
+                request.marketlens_source_key,
+                request.lifecycle.value,
+            ),
+        )
+    else:
+        legacy_source_id = request.price_source_id
+        if legacy_source_id is None and request.marketlens_source_key is not None:
+            linked = conn.execute(
+                "SELECT source_id FROM source_site WHERE source_key = ? LIMIT 1",
+                (request.marketlens_source_key,),
+            ).fetchone()
+            if linked is None:
+                raise CatalogConflict(
+                    f"unknown legacy price source {request.marketlens_source_key!r}"
+                )
+            legacy_source_id = int(linked[0])
+        cursor = conn.execute(
+            "INSERT INTO site_profile "
+            "(site_key, display_name, base_url, price_source_id, lifecycle) "
+            "VALUES (?,?,?,?,?)",
+            (
+                request.site_key,
+                request.display_name,
+                base_url,
+                legacy_source_id,
+                request.lifecycle.value,
+            ),
+        )
     return _site_public(conn.execute(
         "SELECT * FROM site_profile WHERE site_profile_id = ?", (cursor.lastrowid,)
     ).fetchone())

--- a/scrapex/catalog_models.py
+++ b/scrapex/catalog_models.py
@@ -75,6 +75,11 @@ class SiteCreate(BaseModel):
     display_name: str = Field(min_length=1, max_length=200)
     base_url: AnyHttpUrl
     lifecycle: SiteLifecycle = SiteLifecycle.DRAFT
+    marketlens_source_key: str | None = Field(
+        default=None, pattern=r"^[A-Z][A-Z0-9_]{2,63}$"
+    )
+    # Accepted only while a legacy unified catalogue is being migrated. New
+    # General records link across domains by stable source key, never an FK/id.
     price_source_id: int | None = Field(default=None, gt=0)
 
 
@@ -133,6 +138,7 @@ class SiteView(BaseModel):
     site_key: str
     display_name: str
     base_url: AnyHttpUrl
+    marketlens_source_key: str | None = None
     price_source_id: int | None
     lifecycle: SiteLifecycle
     created_at: str

--- a/scrapex/cli.py
+++ b/scrapex/cli.py
@@ -21,6 +21,11 @@ from . import db as dbmod
 from . import localinbox
 from .config import MANIFEST_FILE, load_manifest
 from .connectors.factory import build_connector
+from .databases import DatabaseRegistry
+from .databases.registry import (
+    DEFAULT_GENERAL_PATH, DEFAULT_MARKETLENS_PATH, REGISTRY_FILE,
+)
+from .databases.split import rollback_to_legacy, split_legacy_database
 from .funnel import FunnelClient
 from .ingest import ingest_payloads
 from .reports import recent_observations, source_summary
@@ -35,8 +40,26 @@ from .vocab import ExtractKind, PayloadClient
 CONTRACTS_DIR = Path(__file__).resolve().parent.parent / "contracts"
 
 
+def _marketlens_path(args: argparse.Namespace) -> Path:
+    explicit = getattr(args, "db", None)
+    if explicit:
+        return Path(explicit)
+    registry = DatabaseRegistry.defaults()
+    registry.verify()
+    return registry.marketlens.path
+
+
 def _cmd_init_db(args: argparse.Namespace) -> int:
-    db_path = Path(args.db) if args.db else dbmod.DEFAULT_DB_PATH
+    if not args.db:
+        registry = DatabaseRegistry.defaults()
+        applied = registry.initialize()
+        print(f"General database at {registry.general.path}: applied {applied['general'] or 'none'}")
+        print(
+            f"MarketLens database at {registry.marketlens.path}: "
+            f"applied {applied['marketlens'] or 'none'}"
+        )
+        return 0
+    db_path = Path(args.db)
     with dbmod.write_lock(db_path):
         conn = dbmod.connect(db_path)
         try:
@@ -47,6 +70,57 @@ def _cmd_init_db(args: argparse.Namespace) -> int:
         print(f"harvest.db at {db_path}: applied migrations {applied}")
     else:
         print(f"harvest.db at {db_path}: already at version — nothing to apply")
+    return 0
+
+
+def _cmd_split_databases(args: argparse.Namespace) -> int:
+    from .storage import resolve_db_path
+
+    legacy_path = Path(args.legacy_db) if args.legacy_db else resolve_db_path()
+    result = split_legacy_database(
+        legacy_path,
+        general_path=Path(args.general_db) if args.general_db else DEFAULT_GENERAL_PATH,
+        marketlens_path=(
+            Path(args.marketlens_db) if args.marketlens_db else DEFAULT_MARKETLENS_PATH
+        ),
+        pointer_file=Path(args.registry) if args.registry else REGISTRY_FILE,
+    )
+    print(json.dumps(result.public(), indent=2, ensure_ascii=False))
+    return 0
+
+
+def _cmd_rollback_databases(args: argparse.Namespace) -> int:
+    legacy = rollback_to_legacy(Path(args.registry) if args.registry else REGISTRY_FILE)
+    print(
+        f"Rolled back to the sealed legacy database at {legacy}. The split databases "
+        "remain unchanged. Start a legacy session with --db, then retry the split "
+        "when ready."
+    )
+    return 0
+
+
+def _cmd_database_status(args: argparse.Namespace) -> int:
+    registry = DatabaseRegistry.read(Path(args.registry) if args.registry else REGISTRY_FILE)
+    health = registry.health()
+    print(json.dumps(health, indent=2, ensure_ascii=False))
+    return 0 if all(item["ok"] for item in health.values()) else 1
+
+
+def _cmd_backup_databases(args: argparse.Namespace) -> int:
+    registry = DatabaseRegistry.read(Path(args.registry) if args.registry else REGISTRY_FILE)
+    result = registry.backup_bundle(Path(args.folder))
+    print(json.dumps({"status": "Succeeded", "backups": result}, indent=2))
+    return 0
+
+
+def _cmd_restore_database(args: argparse.Namespace) -> int:
+    registry = DatabaseRegistry.read(Path(args.registry) if args.registry else REGISTRY_FILE)
+    database = registry.general if args.kind == "general" else registry.marketlens
+    displaced = database.restore(Path(args.backup))
+    print(
+        f"Restored {args.kind} from {args.backup}. The replaced database remains at "
+        f"{displaced}. Restart ScrapeX, then run database-status."
+    )
     return 0
 
 
@@ -113,7 +187,7 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
     if not payloads:
         print(f"no payloads in local inbox for {entry.source_key} — run: scrapex crawl {entry.source_key}")
         return 1
-    db_path = Path(args.db) if args.db else dbmod.DEFAULT_DB_PATH
+    db_path = _marketlens_path(args)
     with dbmod.write_lock(db_path):
         conn = dbmod.connect(db_path)
         try:
@@ -135,7 +209,7 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
 
 
 def _cmd_peek(args: argparse.Namespace) -> int:
-    db_path = Path(args.db) if args.db else dbmod.DEFAULT_DB_PATH
+    db_path = _marketlens_path(args)
     if not Path(db_path).exists():
         print("harvest.db not initialized — run: scrapex init-db")
         return 1
@@ -185,7 +259,7 @@ def _cmd_native_host(args: argparse.Namespace) -> int:
     """Chrome launches this; it speaks framed JSON on stdio, not to a human."""
     from .native import serve
 
-    db_path = Path(args.db) if args.db else dbmod.DEFAULT_DB_PATH
+    db_path = _marketlens_path(args)
     return serve(db_path)
 
 
@@ -209,7 +283,7 @@ def _publish_with(args: argparse.Namespace, sink, verb: str) -> int:
     arrangement, different sink."""
     from .publish import publish_source
 
-    db_path = Path(args.db) if args.db else dbmod.DEFAULT_DB_PATH
+    db_path = _marketlens_path(args)
     if not Path(db_path).exists():
         print("harvest.db not initialized — crawl + ingest first", file=sys.stderr)
         return 1
@@ -260,13 +334,20 @@ def _cmd_ui(args: argparse.Namespace) -> int:
     except ImportError:
         print("the UI needs the ui extra: pip install -e .[ui]", file=sys.stderr)
         return 1
-    db_path = Path(args.db) if args.db else dbmod.DEFAULT_DB_PATH
+    registry = None if args.db else DatabaseRegistry.defaults()
+    if registry is not None:
+        registry.verify()
+    db_path = Path(args.db) if args.db else registry.marketlens.path
     if not Path(db_path).exists():
         print("harvest.db not initialized — run: scrapex init-db, then crawl + ingest", file=sys.stderr)
         return 1
     # start_worker: the local runtime owns job execution, so a queued job runs
     # (and keeps running) whether or not the side panel is open (spec 4/23).
-    app = create_app(db_path, start_worker=True)
+    app = create_app(
+        db_path if registry is None else None,
+        start_worker=True,
+        databases=registry,
+    )
     url = f"http://{args.host}:{args.port}"
     print(f"ScrapeX UI → {url}   (Ctrl+C to stop)")
     if not args.no_open:
@@ -280,7 +361,7 @@ def _cmd_ui(args: argparse.Namespace) -> int:
 def _cmd_status(args: argparse.Namespace) -> int:
     # S8 watchdog: fleshed out when ingest lands (Phase 1); the surface exists
     # now so the owner's habit starts on day one.
-    db_path = Path(args.db) if args.db else dbmod.DEFAULT_DB_PATH
+    db_path = _marketlens_path(args)
     if not Path(db_path).exists():
         print("harvest.db not initialized — run: scrapex init-db")
         return 1
@@ -305,9 +386,43 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="scrapex", description=__doc__)
     sub = parser.add_subparsers(dest="command", required=True)
 
-    p = sub.add_parser("init-db", help="create/upgrade harvest.db")
-    p.add_argument("--db", help="database path (default: env SCRAPEX_DB_PATH or ~/.scrapex/harvest.db)")
+    p = sub.add_parser("init-db", help="create/upgrade both isolated databases")
+    p.add_argument(
+        "--db",
+        help="legacy unified database path (only for migration or rollback)",
+    )
     p.set_defaults(func=_cmd_init_db)
+
+    p = sub.add_parser(
+        "split-databases",
+        help="copy a unified warehouse into isolated General and MarketLens databases",
+    )
+    p.add_argument("--legacy-db", help="unified harvest.db path")
+    p.add_argument("--general-db", help="General target path")
+    p.add_argument("--marketlens-db", help="MarketLens target path")
+    p.add_argument("--registry", help="database registry path")
+    p.set_defaults(func=_cmd_split_databases)
+
+    p = sub.add_parser(
+        "rollback-databases", help="switch the runtime pointer back to the legacy database"
+    )
+    p.add_argument("--registry", help="database registry path")
+    p.set_defaults(func=_cmd_rollback_databases)
+
+    p = sub.add_parser("database-status", help="show independent database health")
+    p.add_argument("--registry", help="database registry path")
+    p.set_defaults(func=_cmd_database_status)
+
+    p = sub.add_parser("backup-databases", help="back up General and MarketLens independently")
+    p.add_argument("--folder", required=True, help="folder that will receive both backups")
+    p.add_argument("--registry", help="database registry path")
+    p.set_defaults(func=_cmd_backup_databases)
+
+    p = sub.add_parser("restore-database", help="restore one isolated database from backup")
+    p.add_argument("kind", choices=("general", "marketlens"))
+    p.add_argument("backup", help="verified backup path")
+    p.add_argument("--registry", help="database registry path")
+    p.set_defaults(func=_cmd_restore_database)
 
     p = sub.add_parser("validate-manifest", help="validate sources.yaml")
     p.add_argument("--manifest", help="manifest path (default: scraper/sources.yaml)")

--- a/scrapex/contract.py
+++ b/scrapex/contract.py
@@ -74,7 +74,9 @@ def stamp_contract(conn) -> None:
 
 
 def stored_contract_version(conn) -> int | None:
-    row = conn.execute("SELECT value FROM scrapex_meta WHERE key = 'contract_version'").fetchone()
+    row = conn.execute(
+        "SELECT value FROM scrapex_meta WHERE key = 'contract_version' LIMIT 1"
+    ).fetchone()
     return int(row[0]) if row else None
 
 

--- a/scrapex/database_ids.py
+++ b/scrapex/database_ids.py
@@ -1,0 +1,7 @@
+"""Stable physical identities for ScrapeX operational databases."""
+
+GENERAL_APPLICATION_ID = 0x5358474E  # "SXGN"
+MARKETLENS_APPLICATION_ID = 0x53584D4C  # "SXML"
+
+GENERAL_DATABASE_KIND = "general"
+MARKETLENS_DATABASE_KIND = "marketlens"

--- a/scrapex/databases/__init__.py
+++ b/scrapex/databases/__init__.py
@@ -1,0 +1,22 @@
+"""Typed access to ScrapeX's physically isolated operational databases."""
+
+from .domain import (
+    DatabaseHealth,
+    DatabaseKindError,
+    DatabaseMigrationError,
+    DatabaseUnavailableError,
+    GeneralDatabase,
+    MarketLensDatabase,
+)
+from .registry import DatabaseRegistry, LegacyDatabaseRequiresSplit
+
+__all__ = [
+    "DatabaseHealth",
+    "DatabaseKindError",
+    "DatabaseMigrationError",
+    "DatabaseRegistry",
+    "DatabaseUnavailableError",
+    "GeneralDatabase",
+    "LegacyDatabaseRequiresSplit",
+    "MarketLensDatabase",
+]

--- a/scrapex/databases/domain.py
+++ b/scrapex/databases/domain.py
@@ -1,0 +1,421 @@
+"""Typed SQLite boundaries for General and MarketLens.
+
+Each type owns a migration stream, application id, lock, health check, backup,
+and restore path. Callers cannot accidentally pass one domain to the other.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import sqlite3
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable, Generic, TypeVar
+
+from .. import db as legacy_db
+from ..database_ids import (
+    GENERAL_APPLICATION_ID,
+    GENERAL_DATABASE_KIND,
+    MARKETLENS_APPLICATION_ID,
+    MARKETLENS_DATABASE_KIND,
+)
+
+ROOT_DB_DIR = Path(__file__).resolve().parents[2] / "db"
+GENERAL_SCHEMA = ROOT_DB_DIR / "general" / "schema.sql"
+GENERAL_MIGRATIONS = ROOT_DB_DIR / "general" / "migrations"
+MARKETLENS_IDENTITY = (
+    ROOT_DB_DIR / "marketlens" / "migrations" / "0013_marketlens_database_identity.sql"
+)
+
+T = TypeVar("T")
+
+
+class DatabaseUnavailableError(RuntimeError):
+    """A requested operational database is missing or unreadable."""
+
+
+class DatabaseKindError(RuntimeError):
+    """A typed boundary was given the other domain's database."""
+
+
+class DatabaseMigrationError(RuntimeError):
+    """A migration stream is incomplete, newer, or has been edited in place."""
+
+
+@dataclass(frozen=True)
+class Migration:
+    number: int
+    path: Path
+
+    @property
+    def name(self) -> str:
+        return self.path.name
+
+    @property
+    def sha256(self) -> str:
+        return hashlib.sha256(self.path.read_bytes()).hexdigest()
+
+
+@dataclass(frozen=True)
+class DatabaseHealth:
+    kind: str
+    path: str
+    ok: bool
+    status: str
+    action: str
+    schema_version: int | None
+    application_id: int | None
+
+    def public(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _utc_stamp() -> str:
+    return datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
+
+
+def _sqlite_connect(path: Path, *, create: bool) -> sqlite3.Connection:
+    if not create and not path.is_file():
+        raise DatabaseUnavailableError(
+            f"database not found at {path}; reconnect its storage and try again"
+        )
+    if create:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA busy_timeout = 5000")
+    return conn
+
+
+def _folder_migrations(folder: Path, start: int = 2) -> list[Migration]:
+    if not folder.is_dir():
+        return []
+    result: list[Migration] = []
+    for path in sorted(folder.glob("[0-9][0-9][0-9][0-9]_*.sql")):
+        number = int(path.name[:4])
+        if number < start:
+            continue
+        result.append(Migration(number, path))
+    return result
+
+
+def _general_plan() -> tuple[Migration, ...]:
+    return tuple([Migration(1, GENERAL_SCHEMA), *_folder_migrations(GENERAL_MIGRATIONS)])
+
+
+def _marketlens_plan() -> tuple[Migration, ...]:
+    immutable_price_history = [Migration(1, legacy_db.SCHEMA_FILE)]
+    immutable_price_history.extend(
+        Migration(number, path)
+        for number, path in legacy_db._migration_files()  # noqa: SLF001 - selected legacy history
+        if 2 <= number <= 12
+    )
+    immutable_price_history.append(Migration(13, MARKETLENS_IDENTITY))
+    return tuple(immutable_price_history)
+
+
+class DomainDatabase(Generic[T]):
+    """Base implementation; concrete domain types are the public capability."""
+
+    kind: str
+    application_id: int
+
+    def __init__(self, path: Path | str, migrations: tuple[Migration, ...]):
+        self.path = Path(path)
+        self._migrations = migrations
+        numbers = [item.number for item in migrations]
+        if numbers != list(range(1, len(numbers) + 1)):
+            raise DatabaseMigrationError(
+                f"{self.kind} migrations must be gapless from 1, got {numbers}"
+            )
+
+    @property
+    def latest_schema_version(self) -> int:
+        return self._migrations[-1].number
+
+    def initialize(self) -> list[int]:
+        """Create or advance this database, then verify its physical identity."""
+        with legacy_db.write_lock(self.path):
+            existed = self.path.exists() and self.path.stat().st_size > 0
+            conn = _sqlite_connect(self.path, create=True)
+            try:
+                if existed:
+                    self._assert_not_other_kind(conn)
+                applied = self._migrate(conn)
+                self._verify(conn)
+                return applied
+            except Exception:
+                conn.close()
+                if not existed:
+                    self._remove_new_database_files()
+                raise
+            finally:
+                try:
+                    conn.close()
+                except sqlite3.Error:
+                    pass
+
+    def connect(self) -> sqlite3.Connection:
+        conn = _sqlite_connect(self.path, create=False)
+        try:
+            self._verify(conn)
+        except Exception:
+            conn.close()
+            raise
+        return conn
+
+    def write(self, action: Callable[[sqlite3.Connection], T]) -> T:
+        with legacy_db.write_lock(self.path):
+            conn = self.connect()
+            try:
+                result = action(conn)
+                conn.commit()
+                return result
+            except Exception:
+                conn.rollback()
+                raise
+            finally:
+                conn.close()
+
+    def health(self) -> DatabaseHealth:
+        if not self.path.is_file():
+            return DatabaseHealth(
+                self.kind, str(self.path), False, "Missing",
+                "Reconnect the storage containing this database, then retry.",
+                None, None,
+            )
+        try:
+            conn = self.connect()
+            try:
+                quick = conn.execute("PRAGMA quick_check(1)").fetchone()[0]
+                fk_problem = conn.execute(
+                    "SELECT 1 FROM pragma_foreign_key_check LIMIT 1"
+                ).fetchone()
+                version = int(conn.execute("PRAGMA user_version").fetchone()[0])
+                app_id = int(conn.execute("PRAGMA application_id").fetchone()[0])
+            finally:
+                conn.close()
+            if quick != "ok" or fk_problem is not None:
+                return DatabaseHealth(
+                    self.kind, str(self.path), False, "Failed",
+                    "Restore this database from a verified backup, then retry.",
+                    version, app_id,
+                )
+            return DatabaseHealth(
+                self.kind, str(self.path), True, "Healthy",
+                "No action is required.", version, app_id,
+            )
+        except (sqlite3.DatabaseError, DatabaseUnavailableError,
+                DatabaseKindError, DatabaseMigrationError) as exc:
+            return DatabaseHealth(
+                self.kind, str(self.path), False, "Failed",
+                f"Choose the correct {self.kind} database or restore a verified backup, "
+                f"then retry. ({exc})",
+                None, None,
+            )
+
+    def backup(self, folder: Path | str | None = None) -> Path:
+        target_folder = Path(folder) if folder else self.path.parent / "backups"
+        target_folder.mkdir(parents=True, exist_ok=True)
+        target = target_folder / f"{self.path.stem}.{self.kind}-{_utc_stamp()}.db"
+        incoming = target.with_suffix(".db.incoming")
+        with legacy_db.write_lock(self.path):
+            source = self.connect()
+            destination = _sqlite_connect(incoming, create=True)
+            try:
+                source.backup(destination)
+                destination.close()
+                destination = None
+                copied = self.__class__(incoming).connect()
+                copied.close()
+                os.replace(incoming, target)
+            finally:
+                source.close()
+                if destination is not None:
+                    destination.close()
+                incoming.unlink(missing_ok=True)
+        return target
+
+    def restore(self, backup_path: Path | str) -> Path:
+        backup = Path(backup_path)
+        check = self.__class__(backup).connect()
+        check.close()
+        incoming = self.path.with_suffix(self.path.suffix + ".restore-incoming")
+        displaced = self.path.with_name(
+            f"{self.path.stem}.replaced-{_utc_stamp()}{self.path.suffix}"
+        )
+        with legacy_db.write_lock(self.path):
+            try:
+                source = self.__class__(backup).connect()
+                try:
+                    destination = _sqlite_connect(incoming, create=True)
+                    try:
+                        source.backup(destination)
+                    finally:
+                        destination.close()
+                finally:
+                    source.close()
+                verified = self.__class__(incoming).connect()
+                verified.close()
+                try:
+                    os.replace(self.path, displaced)
+                    os.replace(incoming, self.path)
+                except Exception:
+                    if displaced.exists() and not self.path.exists():
+                        os.replace(displaced, self.path)
+                    raise
+            finally:
+                for suffix in ("", "-wal", "-shm"):
+                    Path(str(incoming) + suffix).unlink(missing_ok=True)
+        return displaced
+
+    def _migrate(self, conn: sqlite3.Connection) -> list[int]:
+        current = int(conn.execute("PRAGMA user_version").fetchone()[0])
+        if current > self.latest_schema_version:
+            raise DatabaseMigrationError(
+                f"{self.kind} database schema v{current} is newer than this engine's "
+                f"v{self.latest_schema_version}; upgrade ScrapeX and retry"
+            )
+        applied: list[int] = []
+        for migration in self._migrations:
+            if migration.number <= current:
+                continue
+            sql = migration.path.read_text(encoding="utf-8")
+            try:
+                conn.executescript(f"BEGIN IMMEDIATE;\n{sql}\nCOMMIT;")
+            except Exception:
+                if conn.in_transaction:
+                    conn.rollback()
+                raise
+            if int(conn.execute("PRAGMA user_version").fetchone()[0]) != migration.number:
+                raise DatabaseMigrationError(
+                    f"{self.kind} migration {migration.name} did not set schema "
+                    f"version {migration.number}; fix the migration and retry"
+                )
+            current = migration.number
+            applied.append(current)
+        self._stamp_and_verify_checksums(conn)
+        return applied
+
+    def _stamp_and_verify_checksums(self, conn: sqlite3.Connection) -> None:
+        for migration in self._migrations:
+            stored = conn.execute(
+                "SELECT sha256 FROM database_migration WHERE migration_number = ? LIMIT 1",
+                (migration.number,),
+            ).fetchone()
+            if stored is not None and stored[0] != migration.sha256:
+                raise DatabaseMigrationError(
+                    f"{self.kind} migration {migration.name} checksum changed; restore "
+                    "the original migration file and retry"
+                )
+            if stored is None:
+                conn.execute(
+                    "INSERT INTO database_migration "
+                    "(migration_number, migration_name, sha256) VALUES (?,?,?)",
+                    (migration.number, migration.name, migration.sha256),
+                )
+        conn.commit()
+
+    def _assert_not_other_kind(self, conn: sqlite3.Connection) -> None:
+        app_id = int(conn.execute("PRAGMA application_id").fetchone()[0])
+        version = int(conn.execute("PRAGMA user_version").fetchone()[0])
+        if app_id == 0 and version > 0:
+            raise DatabaseKindError(
+                f"{self.path} is an unmarked legacy database; run "
+                "'scrapex split-databases' and retry"
+            )
+        if app_id not in (0, self.application_id):
+            raise DatabaseKindError(
+                f"expected a {self.kind} database at {self.path}, but its application id "
+                f"is {app_id}; select the correct database and retry"
+            )
+
+    def _verify_checksums(self, conn: sqlite3.Connection) -> None:
+        for migration in self._migrations:
+            stored = conn.execute(
+                "SELECT sha256 FROM database_migration WHERE migration_number = ? LIMIT 1",
+                (migration.number,),
+            ).fetchone()
+            if stored is None:
+                raise DatabaseMigrationError(
+                    f"{self.kind} migration ledger is incomplete at {migration.name}; "
+                    "run database initialization and retry"
+                )
+            if stored[0] != migration.sha256:
+                raise DatabaseMigrationError(
+                    f"{self.kind} migration {migration.name} checksum changed; restore "
+                    "the original migration file and retry"
+                )
+
+    def _verify(self, conn: sqlite3.Connection) -> None:
+        app_id = int(conn.execute("PRAGMA application_id").fetchone()[0])
+        if app_id != self.application_id:
+            raise DatabaseKindError(
+                f"expected a {self.kind} database at {self.path}, but its application id "
+                f"is {app_id}; select the correct database and retry"
+            )
+        try:
+            row = conn.execute(
+                "SELECT value FROM scrapex_meta WHERE key = 'database_kind' LIMIT 1"
+            ).fetchone()
+        except sqlite3.DatabaseError as exc:
+            raise DatabaseKindError(
+                f"{self.path} has no ScrapeX database marker; select the correct "
+                f"{self.kind} database and retry"
+            ) from exc
+        if row is None or row[0] != self.kind:
+            actual = row[0] if row else "unmarked"
+            raise DatabaseKindError(
+                f"expected database kind {self.kind!r}, found {actual!r}; select the "
+                "correct database and retry"
+            )
+        current = int(conn.execute("PRAGMA user_version").fetchone()[0])
+        if current != self.latest_schema_version:
+            raise DatabaseMigrationError(
+                f"{self.kind} database is at schema v{current}, expected "
+                f"v{self.latest_schema_version}; run database initialization and retry"
+            )
+        self._verify_checksums(conn)
+
+    def _remove_new_database_files(self) -> None:
+        for suffix in ("", "-wal", "-shm"):
+            Path(str(self.path) + suffix).unlink(missing_ok=True)
+
+
+class GeneralDatabase(DomainDatabase[T]):
+    kind = GENERAL_DATABASE_KIND
+    application_id = GENERAL_APPLICATION_ID
+
+    def __init__(self, path: Path | str):
+        super().__init__(path, _general_plan())
+
+
+class MarketLensDatabase(DomainDatabase[T]):
+    kind = MARKETLENS_DATABASE_KIND
+    application_id = MARKETLENS_APPLICATION_ID
+
+    def __init__(self, path: Path | str):
+        super().__init__(path, _marketlens_plan())
+
+    def _migrate(self, conn: sqlite3.Connection) -> list[int]:
+        applied = super()._migrate(conn)
+        from ..contract import stamp_contract
+
+        with conn:
+            stamp_contract(conn)
+        return applied
+
+    def _verify(self, conn: sqlite3.Connection) -> None:
+        super()._verify(conn)
+        from ..contract import CONTRACT_VERSION, stored_contract_version
+
+        stored = stored_contract_version(conn)
+        if stored != CONTRACT_VERSION:
+            raise DatabaseMigrationError(
+                f"MarketLens contract marker is {stored!r}, expected "
+                f"{CONTRACT_VERSION}; run database initialization or restore a "
+                "compatible backup and retry"
+            )

--- a/scrapex/databases/registry.py
+++ b/scrapex/databases/registry.py
@@ -1,0 +1,145 @@
+"""Persistent registry for the two operational database capabilities."""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from .domain import GeneralDatabase, MarketLensDatabase
+
+DATABASE_ROOT = Path(
+    os.environ.get("SCRAPEX_DATA_ROOT", str(Path.home() / ".scrapex"))
+)
+REGISTRY_FILE = Path(
+    os.environ.get("SCRAPEX_DATABASE_REGISTRY", str(DATABASE_ROOT / "databases.json"))
+)
+DEFAULT_GENERAL_PATH = DATABASE_ROOT / "general" / "general.db"
+DEFAULT_MARKETLENS_PATH = DATABASE_ROOT / "marketlens" / "marketlens.db"
+DEFAULT_LEGACY_PATH = DATABASE_ROOT / "harvest.db"
+
+
+class LegacyDatabaseRequiresSplit(RuntimeError):
+    """A unified warehouse exists and must be explicitly split by the owner."""
+
+
+@dataclass(frozen=True)
+class DatabaseRegistry:
+    general: GeneralDatabase
+    marketlens: MarketLensDatabase
+    legacy_path: Path | None = None
+    pointer_file: Path = REGISTRY_FILE
+
+    def __post_init__(self) -> None:
+        paths = {
+            self.general.path.resolve(),
+            self.marketlens.path.resolve(),
+            self.pointer_file.resolve(),
+        }
+        if len(paths) != 3:
+            raise ValueError(
+                "General, MarketLens, and the registry must use three different paths"
+            )
+
+    @classmethod
+    def defaults(cls, *, pointer_file: Path | str = REGISTRY_FILE) -> "DatabaseRegistry":
+        pointer = Path(pointer_file)
+        if pointer.is_file():
+            return cls.read(pointer)
+        if DEFAULT_LEGACY_PATH.is_file():
+            raise LegacyDatabaseRequiresSplit(
+                f"the unified database still exists at {DEFAULT_LEGACY_PATH}; run "
+                "'scrapex split-databases' and retry, or use --db for a temporary "
+                "legacy session"
+            )
+        return cls(
+            GeneralDatabase(DEFAULT_GENERAL_PATH),
+            MarketLensDatabase(DEFAULT_MARKETLENS_PATH),
+            pointer_file=pointer,
+        )
+
+    @classmethod
+    def read(cls, pointer_file: Path | str = REGISTRY_FILE) -> "DatabaseRegistry":
+        pointer = Path(pointer_file)
+        try:
+            data = json.loads(pointer.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise LegacyDatabaseRequiresSplit(
+                f"database registry {pointer} is unreadable; restore it from backup "
+                "or run database recovery and retry"
+            ) from exc
+        mode = data.get("mode")
+        if mode == "legacy":
+            legacy = Path(str(data.get("legacy_path") or ""))
+            raise LegacyDatabaseRequiresSplit(
+                f"rollback mode is active at {legacy}; use --db {legacy} for the "
+                "legacy session, then run 'scrapex split-databases' to switch forward"
+            )
+        if mode != "split":
+            raise LegacyDatabaseRequiresSplit(
+                f"database registry {pointer} has an unknown mode; restore it from "
+                "backup and retry"
+            )
+        general_raw = str(data.get("general_path") or "").strip()
+        marketlens_raw = str(data.get("marketlens_path") or "").strip()
+        if not general_raw or not marketlens_raw:
+            raise LegacyDatabaseRequiresSplit(
+                f"database registry {pointer} is incomplete; restore it and retry"
+            )
+        general_path = Path(general_raw)
+        marketlens_path = Path(marketlens_raw)
+        legacy_raw = str(data.get("legacy_path") or "").strip()
+        return cls(
+            GeneralDatabase(general_path),
+            MarketLensDatabase(marketlens_path),
+            Path(legacy_raw) if legacy_raw else None,
+            pointer,
+        )
+
+    def initialize(self) -> dict[str, list[int]]:
+        result = {
+            "general": self.general.initialize(),
+            "marketlens": self.marketlens.initialize(),
+        }
+        self.write()
+        return result
+
+    def verify(self) -> None:
+        for database in (self.general, self.marketlens):
+            health = database.health()
+            if not health.ok:
+                raise RuntimeError(
+                    f"{health.kind} database is {health.status.lower()}: "
+                    f"{health.action}"
+                )
+
+    def write(self) -> None:
+        self.verify()
+        self.pointer_file.parent.mkdir(parents=True, exist_ok=True)
+        incoming = self.pointer_file.with_suffix(self.pointer_file.suffix + ".incoming")
+        payload = {
+            "format_version": 1,
+            "mode": "split",
+            "general_path": str(self.general.path),
+            "marketlens_path": str(self.marketlens.path),
+            "legacy_path": str(self.legacy_path) if self.legacy_path else None,
+        }
+        incoming.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        os.replace(incoming, self.pointer_file)
+
+    def backup_bundle(self, folder: Path | str) -> dict[str, str]:
+        destination = Path(folder)
+        general_backup = self.general.backup(destination / "general")
+        marketlens_backup = self.marketlens.backup(destination / "marketlens")
+        return {
+            "general": str(general_backup),
+            "marketlens": str(marketlens_backup),
+        }
+
+    def health(self) -> dict[str, dict]:
+        return {
+            "general": self.general.health().public(),
+            "marketlens": self.marketlens.health().public(),
+        }

--- a/scrapex/databases/split.py
+++ b/scrapex/databases/split.py
@@ -1,0 +1,428 @@
+"""Reversible migration from the unified warehouse to two domain databases."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import stat
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Iterable
+
+from .. import db as legacy_db
+from .. import storage
+from .domain import GeneralDatabase, MarketLensDatabase
+from .registry import DatabaseRegistry, REGISTRY_FILE
+
+BATCH_SIZE = 500
+GENERIC_TABLES = (
+    "site_profile",
+    "dataset_definition",
+    "field_definition",
+    "dataset_relationship",
+    "relationship_field_pair",
+)
+GENERIC_COPY_COLUMNS = {
+    "dataset_definition": (
+        "dataset_definition_id", "site_profile_id", "dataset_key", "original_name",
+        "display_name", "dataset_kind", "discovery_method", "locator_json",
+        "first_seen_at", "last_seen_at", "valid_to",
+    ),
+    "field_definition": (
+        "field_definition_id", "dataset_definition_id", "field_key", "original_name",
+        "display_name", "data_type", "is_nullable", "identity_role", "display_order",
+        "first_seen_at", "last_seen_at", "valid_to",
+    ),
+    "dataset_relationship": (
+        "dataset_relationship_id", "site_profile_id", "relationship_key",
+        "parent_dataset_id", "child_dataset_id", "cardinality", "review_status",
+        "confidence", "evidence_json", "created_at", "updated_at", "valid_to",
+    ),
+    "relationship_field_pair": (
+        "relationship_field_pair_id", "dataset_relationship_id", "parent_field_id",
+        "child_field_id", "pair_order",
+    ),
+}
+
+
+class DatabaseSplitError(RuntimeError):
+    """The split was refused or failed before the runtime pointer switched."""
+
+
+@dataclass(frozen=True)
+class SplitResult:
+    legacy_path: str
+    legacy_backup: str
+    general_path: str
+    marketlens_path: str
+    registry_path: str
+    generic_rows: int
+    marketlens_tables_verified: int
+    status: str
+    recovery: str
+
+    def public(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _stamp() -> str:
+    return datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
+
+
+def _quote(identifier: str) -> str:
+    if not identifier.replace("_", "").isalnum():
+        raise DatabaseSplitError(f"unsafe SQLite identifier {identifier!r}")
+    return f'"{identifier}"'
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    return conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1",
+        (table,),
+    ).fetchone() is not None
+
+
+def _count(conn: sqlite3.Connection, table: str) -> int:
+    return int(conn.execute(
+        f"SELECT COUNT(*) FROM {_quote(table)} LIMIT 1"
+    ).fetchone()[0])
+
+
+def _iter_rows(
+    conn: sqlite3.Connection, table: str, columns: Iterable[str]
+) -> Iterable[sqlite3.Row]:
+    names = tuple(columns)
+    selected = ", ".join(_quote(name) for name in names)
+    cursor: int | None = None
+    while True:
+        if cursor is None:
+            rows = conn.execute(
+                f"SELECT rowid AS _copy_rowid, {selected} FROM {_quote(table)} "
+                "ORDER BY rowid LIMIT ?",
+                (BATCH_SIZE,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                f"SELECT rowid AS _copy_rowid, {selected} FROM {_quote(table)} "
+                "WHERE rowid > ? ORDER BY rowid LIMIT ?",
+                (cursor, BATCH_SIZE),
+            ).fetchall()
+        if not rows:
+            return
+        for row in rows:
+            yield row
+        cursor = int(rows[-1]["_copy_rowid"])
+
+
+def _remove_sqlite_files(path: Path) -> None:
+    for suffix in ("", "-wal", "-shm"):
+        Path(str(path) + suffix).unlink(missing_ok=True)
+
+
+def _table_hash(conn: sqlite3.Connection, table: str) -> str:
+    columns = [
+        row[0] for row in conn.execute(
+            "SELECT name FROM pragma_table_info(?) ORDER BY cid LIMIT 200", (table,)
+        ).fetchall()
+    ]
+    digest = hashlib.sha256()
+    for row in _iter_rows(conn, table, columns):
+        payload = [row[name] for name in columns]
+        digest.update(
+            json.dumps(payload, ensure_ascii=False, separators=(",", ":"),
+                       default=str).encode("utf-8")
+        )
+        digest.update(b"\n")
+    return digest.hexdigest()
+
+
+def _legacy_tables(conn: sqlite3.Connection) -> list[str]:
+    return [
+        str(row[0]) for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' "
+            "AND name NOT LIKE 'sqlite_%' ORDER BY name LIMIT 200"
+        ).fetchall()
+    ]
+
+
+def _backup_legacy(source: sqlite3.Connection, legacy_path: Path) -> Path:
+    folder = legacy_path.parent / "backups"
+    folder.mkdir(parents=True, exist_ok=True)
+    target = folder / f"{legacy_path.stem}.pre-split-{_stamp()}.db"
+    destination = sqlite3.connect(str(target))
+    try:
+        source.backup(destination)
+    finally:
+        destination.close()
+    check = sqlite3.connect(str(target))
+    try:
+        if check.execute("PRAGMA quick_check(1)").fetchone()[0] != "ok":
+            raise DatabaseSplitError(
+                "the pre-split backup failed verification; free disk space and retry"
+            )
+    finally:
+        check.close()
+    return target
+
+
+def _build_marketlens(
+    legacy: sqlite3.Connection, legacy_tables: list[str], incoming_path: Path
+) -> int:
+    target = sqlite3.connect(str(incoming_path))
+    target.row_factory = sqlite3.Row
+    try:
+        legacy.backup(target)
+        target.execute("PRAGMA foreign_keys = OFF")
+        with target:
+            for table in reversed(GENERIC_TABLES):
+                target.execute(f"DROP TABLE IF EXISTS {_quote(table)}")
+            target.executescript(
+                MarketLensDatabase(incoming_path)._migrations[-1].path.read_text(  # noqa: SLF001
+                    encoding="utf-8"
+                )
+            )
+        marketlens = MarketLensDatabase(incoming_path)
+        marketlens._stamp_and_verify_checksums(target)  # noqa: SLF001
+        target.execute("PRAGMA foreign_keys = ON")
+        if target.execute(
+            "SELECT 1 FROM pragma_foreign_key_check LIMIT 1"
+        ).fetchone() is not None:
+            raise DatabaseSplitError(
+                "the MarketLens copy has a foreign-key error; keep using the legacy "
+                "database and retry after repairing it"
+            )
+        verified = 0
+        for table in legacy_tables:
+            if table in GENERIC_TABLES or table in {"database_migration", "scrapex_meta"}:
+                continue
+            if not _table_exists(target, table):
+                raise DatabaseSplitError(f"MarketLens copy is missing table {table}")
+            if _count(legacy, table) != _count(target, table):
+                raise DatabaseSplitError(f"MarketLens row count changed for {table}")
+            if _table_hash(legacy, table) != _table_hash(target, table):
+                raise DatabaseSplitError(f"MarketLens row checksum changed for {table}")
+            verified += 1
+    finally:
+        target.close()
+    check = MarketLensDatabase(incoming_path).connect()
+    check.close()
+    return verified
+
+
+def _insert_rows(
+    source: sqlite3.Connection,
+    destination: sqlite3.Connection,
+    table: str,
+    columns: tuple[str, ...],
+) -> int:
+    placeholders = ",".join("?" for _ in columns)
+    names = ",".join(_quote(name) for name in columns)
+    written = 0
+    for row in _iter_rows(source, table, columns):
+        destination.execute(
+            f"INSERT INTO {_quote(table)} ({names}) VALUES ({placeholders})",
+            tuple(row[name] for name in columns),
+        )
+        written += 1
+    return written
+
+
+def _copy_general(legacy: sqlite3.Connection, incoming_path: Path) -> int:
+    general = GeneralDatabase(incoming_path)
+    general.initialize()
+    if not _table_exists(legacy, "site_profile"):
+        return 0
+    destination = general.connect()
+    written = 0
+    try:
+        with destination:
+            site_columns = (
+                "site_profile_id", "site_key", "display_name", "base_url",
+                "price_source_id", "lifecycle", "created_at", "updated_at", "valid_to",
+            )
+            for row in _iter_rows(legacy, "site_profile", site_columns):
+                source_key = None
+                if row["price_source_id"] is not None:
+                    linked = legacy.execute(
+                        "SELECT source_key FROM source_site WHERE source_id = ? LIMIT 1",
+                        (row["price_source_id"],),
+                    ).fetchone()
+                    source_key = linked[0] if linked else None
+                destination.execute(
+                    "INSERT INTO site_profile "
+                    "(site_profile_id, site_key, display_name, base_url, "
+                    "marketlens_source_key, lifecycle, created_at, updated_at, valid_to) "
+                    "VALUES (?,?,?,?,?,?,?,?,?)",
+                    (
+                        row["site_profile_id"], row["site_key"], row["display_name"],
+                        row["base_url"], source_key, row["lifecycle"], row["created_at"],
+                        row["updated_at"], row["valid_to"],
+                    ),
+                )
+                written += 1
+            for table in GENERIC_TABLES[1:]:
+                written += _insert_rows(
+                    legacy, destination, table, GENERIC_COPY_COLUMNS[table]
+                )
+        for table in GENERIC_TABLES:
+            if _count(legacy, table) != _count(destination, table):
+                raise DatabaseSplitError(f"General row count changed for {table}")
+        if destination.execute(
+            "SELECT 1 FROM pragma_foreign_key_check LIMIT 1"
+        ).fetchone() is not None:
+            raise DatabaseSplitError(
+                "the General copy has a foreign-key error; keep using the legacy "
+                "database and retry after repairing it"
+            )
+    finally:
+        destination.close()
+    return written
+
+
+def split_legacy_database(
+    legacy_path: Path | str,
+    *,
+    general_path: Path | str,
+    marketlens_path: Path | str,
+    pointer_file: Path | str = REGISTRY_FILE,
+) -> SplitResult:
+    """Copy, verify, switch, and seal without deleting or rewriting the legacy file."""
+    legacy_path = Path(legacy_path).resolve()
+    general_path = Path(general_path).resolve()
+    marketlens_path = Path(marketlens_path).resolve()
+    pointer_file = Path(pointer_file).resolve()
+    if not legacy_path.is_file():
+        raise DatabaseSplitError(
+            f"legacy database not found at {legacy_path}; reconnect its storage and retry"
+        )
+    if len({legacy_path, general_path, marketlens_path, pointer_file}) != 4:
+        raise DatabaseSplitError(
+            "legacy, General, MarketLens, and registry paths must be different files"
+        )
+    for target in (general_path, marketlens_path):
+        if target.exists():
+            raise DatabaseSplitError(
+                f"target {target} already exists; choose an empty target or restore the "
+                "existing domain database intentionally"
+            )
+        target.parent.mkdir(parents=True, exist_ok=True)
+
+    general_incoming = general_path.with_suffix(general_path.suffix + ".split-incoming")
+    marketlens_incoming = marketlens_path.with_suffix(
+        marketlens_path.suffix + ".split-incoming"
+    )
+    for incoming in (general_incoming, marketlens_incoming):
+        if incoming.exists():
+            raise DatabaseSplitError(
+                f"recovery file {incoming} already exists; inspect it, move it aside, "
+                "and retry the split"
+            )
+
+    with legacy_db.write_lock(legacy_path):
+        legacy = legacy_db.connect(legacy_path)
+        try:
+            if legacy_db.schema_version(legacy) != legacy_db.latest_schema_version():
+                raise DatabaseSplitError(
+                    "the legacy database is not at the latest schema; run "
+                    "'scrapex init-db --db <path>' and retry"
+                )
+            if legacy.execute("PRAGMA quick_check(1)").fetchone()[0] != "ok":
+                raise DatabaseSplitError(
+                    "the legacy database failed its integrity check; restore or repair "
+                    "it before retrying"
+                )
+            tables = _legacy_tables(legacy)
+            legacy_backup = _backup_legacy(legacy, legacy_path)
+            verified = _build_marketlens(legacy, tables, marketlens_incoming)
+            generic_rows = _copy_general(legacy, general_incoming)
+        except Exception:
+            for incoming in (general_incoming, marketlens_incoming):
+                _remove_sqlite_files(incoming)
+            raise
+        finally:
+            legacy.close()
+
+    registry = DatabaseRegistry(
+        GeneralDatabase(general_path), MarketLensDatabase(marketlens_path),
+        legacy_path, pointer_file,
+    )
+    promoted: list[tuple[Path, Path]] = []
+    try:
+        os.replace(general_incoming, general_path)
+        promoted.append((general_path, general_incoming))
+        os.replace(marketlens_incoming, marketlens_path)
+        promoted.append((marketlens_path, marketlens_incoming))
+        registry.verify()
+        if not storage.mark_sealed(
+            legacy_path, "split into isolated General and MarketLens databases",
+            f"{general_path}; {marketlens_path}",
+        ):
+            raise DatabaseSplitError(
+                "the new databases passed verification but the legacy database could "
+                "not be sealed; restore write access to it and retry"
+            )
+        registry.write()
+        try:
+            os.chmod(legacy_path, stat.S_IREAD)
+        except OSError:
+            pass
+    except Exception:
+        try:
+            os.chmod(legacy_path, stat.S_IREAD | stat.S_IWRITE)
+            storage.unseal(legacy_path)
+        except OSError:
+            pass
+        for live, incoming in reversed(promoted):
+            if live.exists() and not incoming.exists():
+                os.replace(live, incoming)
+        raise
+
+    return SplitResult(
+        str(legacy_path), str(legacy_backup), str(general_path), str(marketlens_path),
+        str(pointer_file), generic_rows, verified, "Succeeded",
+        "To recover, run 'scrapex rollback-databases'; the legacy file and backup "
+        "remain on disk.",
+    )
+
+
+def rollback_to_legacy(pointer_file: Path | str = REGISTRY_FILE) -> Path:
+    """Switch the runtime pointer back; split files remain untouched for recovery."""
+    pointer = Path(pointer_file)
+    registry = DatabaseRegistry.read(pointer)
+    if registry.legacy_path is None or not registry.legacy_path.is_file():
+        raise DatabaseSplitError(
+            "the recorded legacy database is unavailable; reconnect its storage and retry"
+        )
+    legacy = registry.legacy_path
+    try:
+        os.chmod(legacy, stat.S_IREAD | stat.S_IWRITE)
+    except OSError:
+        pass
+    storage.unseal(legacy)
+    if storage.sealed_at(legacy):
+        raise DatabaseSplitError(
+            "the legacy database could not be unsealed; restore write access and retry"
+        )
+    incoming = pointer.with_suffix(pointer.suffix + ".incoming")
+    try:
+        incoming.write_text(
+            json.dumps({
+                "format_version": 1,
+                "mode": "legacy",
+                "legacy_path": str(legacy),
+                "general_path": str(registry.general.path),
+                "marketlens_path": str(registry.marketlens.path),
+            }, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        os.replace(incoming, pointer)
+    except Exception:
+        incoming.unlink(missing_ok=True)
+        storage.mark_sealed(
+            legacy, "rollback pointer update failed; split databases remain active",
+            registry.marketlens.path,
+        )
+        raise
+    return legacy

--- a/scrapex/db.py
+++ b/scrapex/db.py
@@ -17,6 +17,8 @@ import time
 from contextlib import contextmanager
 from pathlib import Path
 
+from .database_ids import GENERAL_APPLICATION_ID
+
 # db/ lives next to the package; schema.sql is the single DDL truth (Q1).
 DB_DIR = Path(__file__).resolve().parent.parent / "db"
 SCHEMA_FILE = DB_DIR / "schema.sql"
@@ -33,13 +35,26 @@ class DbLockedError(RuntimeError):
     """Another scrapex command holds the write lock (A10)."""
 
 
+class WrongDatabaseKindError(RuntimeError):
+    """The legacy MarketLens facade was pointed at the General database."""
+
+
 def connect(db_path: Path | str = DEFAULT_DB_PATH) -> sqlite3.Connection:
-    """Open harvest.db with the mandated pragmas. Creates parent dirs."""
+    """Open the legacy/MarketLens price database with the mandated pragmas.
+
+    This compatibility facade remains for price-domain modules while they move
+    behind repositories. It explicitly refuses the General database.
+    """
     path = Path(db_path)
     if str(path) != ":memory:":
         path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(str(path))
     conn.row_factory = sqlite3.Row
+    if int(conn.execute("PRAGMA application_id").fetchone()[0]) == GENERAL_APPLICATION_ID:
+        conn.close()
+        raise WrongDatabaseKindError(
+            f"{path} is the General database; choose the MarketLens database and retry"
+        )
     conn.execute("PRAGMA foreign_keys = ON")
     conn.execute("PRAGMA journal_mode = WAL")
     conn.execute("PRAGMA busy_timeout = 5000")

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -24,6 +24,7 @@ from ..capture import capture_source
 from ..changes import change_summary, recent_changes
 from ..config import MANIFEST_FILE, SourceEntry, load_manifest
 from ..connectors.factory import _BUILDERS
+from ..databases import DatabaseRegistry, GeneralDatabase, MarketLensDatabase
 from ..jobs import JobRunner, create_job, get_job, job_logs, list_jobs, set_control
 from ..fields import (
     delete_view, ensure_fields, list_fields, list_views, reorder, reset_view, save_view,
@@ -59,6 +60,7 @@ from ..vocab import (
     JobControl, MissedRunPolicy, OverlapPolicy, RunMode, ScheduleFrequency, VatMode,
 )
 from .catalog_api import create_catalog_router
+from .database_api import create_database_router, create_domain_health_router
 
 TEMPLATES = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
 STATIC_DIR = Path(__file__).parent / "static"
@@ -66,10 +68,30 @@ PAGE_SIZE = 50
 AVAILABILITY_OPTIONS = ("in_stock", "out_of_stock", "unknown")
 
 
-def create_app(db_path: Path | str, manifest_path: Path | str = MANIFEST_FILE,
-               start_worker: bool = False) -> FastAPI:
+def create_app(
+    db_path: Path | str | None = None,
+    manifest_path: Path | str = MANIFEST_FILE,
+    start_worker: bool = False,
+    *,
+    databases: DatabaseRegistry | None = None,
+    general_db_path: Path | str | None = None,
+) -> FastAPI:
+    if databases is None and db_path is None:
+        databases = DatabaseRegistry.defaults()
+        databases.verify()
+    if databases is not None:
+        databases.verify()
+        price_path = databases.marketlens.path
+        general_database = databases.general
+    else:
+        price_path = Path(db_path)  # explicit legacy-compatible test/session path
+        general_database = GeneralDatabase(general_db_path) if general_db_path else None
+        if general_database is not None:
+            general_database.initialize()
     app = FastAPI(title="ScrapeX", docs_url=None, redoc_url=None)
-    app.state.db_path = str(db_path)
+    app.state.db_path = str(price_path)
+    app.state.databases = databases
+    app.state.general_database = general_database
     app.state.manifest_path = str(manifest_path)
     app.state.manifest = load_manifest(manifest_path)
     # The job worker owns ALL long-running crawls (spec 4). Tests drive the
@@ -78,7 +100,7 @@ def create_app(db_path: Path | str, manifest_path: Path | str = MANIFEST_FILE,
     # app.state.db_path, and a worker still holding the old file would crawl
     # into a database nothing else reads.
     app.state.runner = JobRunner(
-        str(db_path), lambda: app.state.manifest,
+        str(price_path), lambda: app.state.manifest,
         path_provider=lambda: app.state.db_path) if start_worker else None
     if app.state.runner is not None:
         app.state.runner.start()
@@ -91,8 +113,19 @@ def create_app(db_path: Path | str, manifest_path: Path | str = MANIFEST_FILE,
         CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"],
     )
 
+    if databases is not None:
+        app.include_router(create_database_router(lambda: app.state.databases))
+        app.include_router(create_domain_health_router(lambda: app.state.databases))
+
     def read_conn():
+        if app.state.databases is not None:
+            return app.state.databases.marketlens.connect()
         return dbmod.connect(app.state.db_path)
+
+    def general_read_conn():
+        if app.state.general_database is None:
+            return read_conn()
+        return app.state.general_database.connect()
 
     # ---- HTML browse UI ----------------------------------------------------
 
@@ -393,9 +426,25 @@ def create_app(db_path: Path | str, manifest_path: Path | str = MANIFEST_FILE,
                 status_code=409,
                 detail="a crawl is currently writing to the database — try again shortly")
 
-    # G1 foundation: typed persistence and API only. The feature stays disabled
-    # until a later slice adds a complete user-facing catalogue workflow.
-    app.include_router(create_catalog_router(read_conn, _write))
+    def _general_write(fn):
+        if app.state.general_database is None:
+            return _write(fn)
+        try:
+            return app.state.general_database.write(fn)
+        except dbmod.DbLockedError:
+            raise HTTPException(
+                status_code=409,
+                detail="the General database is busy — try again shortly",
+            )
+
+    # The namespaced route is authoritative. The old catalogue path stays as a
+    # compatibility alias during G2's rebase and writes to the same General DB.
+    app.include_router(create_catalog_router(
+        general_read_conn, _general_write, prefix="/api/general/catalog"
+    ))
+    app.include_router(create_catalog_router(
+        general_read_conn, _general_write, prefix="/api/catalog"
+    ))
 
     @app.get("/api/fields/{source_key}")
     def api_fields(source_key: str):
@@ -525,7 +574,7 @@ def create_app(db_path: Path | str, manifest_path: Path | str = MANIFEST_FILE,
 
     def _write_conn():
         """A connection for routes that persist settings or run status."""
-        return dbmod.connect(app.state.db_path)
+        return read_conn()
 
     def _integration(fn, *args, state_after=None, **kwargs):
         """Run one integration action under the write lock, mapping the
@@ -837,6 +886,14 @@ def create_app(db_path: Path | str, manifest_path: Path | str = MANIFEST_FILE,
         # The pointer moved, so this process follows it. Otherwise the server
         # keeps writing to a file the owner has been told is no longer live.
         app.state.db_path = str(resolve_db_path())
+        if app.state.databases is not None:
+            app.state.databases = DatabaseRegistry(
+                app.state.databases.general,
+                MarketLensDatabase(app.state.db_path),
+                app.state.databases.legacy_path,
+                app.state.databases.pointer_file,
+            )
+            app.state.databases.write()
         return result
 
     @app.get("/api/retention")
@@ -906,6 +963,14 @@ def create_app(db_path: Path | str, manifest_path: Path | str = MANIFEST_FILE,
             finally:
                 conn.close()
         app.state.db_path = str(resolve_db_path())
+        if app.state.databases is not None:
+            app.state.databases = DatabaseRegistry(
+                app.state.databases.general,
+                MarketLensDatabase(app.state.db_path),
+                app.state.databases.legacy_path,
+                app.state.databases.pointer_file,
+            )
+            app.state.databases.write()
         return {**result.as_state(), "sealed_path": result.sealed_path,
                 "observations_after": result.observations_after}
 

--- a/scrapex/webui/catalog_api.py
+++ b/scrapex/webui/catalog_api.py
@@ -19,9 +19,10 @@ PageLimit = Annotated[int, Query(ge=1, le=models.MAX_PAGE_SIZE)]
 
 
 def create_catalog_router(
-    read_connection: ReadConnection, write_action: WriteAction
+    read_connection: ReadConnection, write_action: WriteAction,
+    *, prefix: str = "/api/catalog",
 ) -> APIRouter:
-    router = APIRouter(prefix="/api/catalog", tags=["generic-catalog"])
+    router = APIRouter(prefix=prefix, tags=["generic-catalog"])
 
     def read(run: Callable[[sqlite3.Connection], Any]) -> Any:
         conn = read_connection()

--- a/scrapex/webui/database_api.py
+++ b/scrapex/webui/database_api.py
@@ -1,0 +1,51 @@
+"""Read-only health API for the isolated operational databases."""
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from fastapi import APIRouter
+
+from ..databases import DatabaseRegistry
+
+
+def create_database_router(
+    databases: DatabaseRegistry | Callable[[], DatabaseRegistry]
+) -> APIRouter:
+    router = APIRouter(prefix="/api/databases", tags=["databases"])
+
+    def current() -> DatabaseRegistry:
+        return databases() if callable(databases) else databases
+
+    @router.get("/health")
+    def health() -> dict:
+        states = current().health()
+        return {
+            "status": "Healthy" if all(item["ok"] for item in states.values()) else "Failed",
+            "databases": states,
+            "action": (
+                "No action is required."
+                if all(item["ok"] for item in states.values())
+                else "Follow the action shown for each failed database, then retry."
+            ),
+        }
+
+    return router
+
+
+def create_domain_health_router(
+    databases: DatabaseRegistry | Callable[[], DatabaseRegistry]
+) -> APIRouter:
+    router = APIRouter(tags=["databases"])
+
+    def current() -> DatabaseRegistry:
+        return databases() if callable(databases) else databases
+
+    @router.get("/api/general/health")
+    def general_health() -> dict:
+        return current().general.health().public()
+
+    @router.get("/api/marketlens/health")
+    def marketlens_health() -> dict:
+        return current().marketlens.health().public()
+
+    return router

--- a/tests/test_database_isolation.py
+++ b/tests/test_database_isolation.py
@@ -1,0 +1,318 @@
+"""DB1: physical General/MarketLens isolation, migration, and recovery."""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scrapex import catalog
+from scrapex import catalog_models as models
+from scrapex import db as legacy_db
+from scrapex.databases import (
+    DatabaseKindError,
+    DatabaseRegistry,
+    GeneralDatabase,
+    MarketLensDatabase,
+)
+from scrapex.databases.split import (
+    DatabaseSplitError,
+    rollback_to_legacy,
+    split_legacy_database,
+)
+from scrapex.ingest import ingest_payloads
+from scrapex.webui.app import create_app
+from tests.test_ingest import make_entry, make_payload, one_row
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+
+def _legacy_with_both_domains(path: Path) -> None:
+    conn = legacy_db.connect(path)
+    legacy_db.migrate(conn)
+    result = ingest_payloads(conn, make_entry(), [make_payload([one_row()])])
+    source_id = conn.execute(
+        "SELECT source_id FROM source_site WHERE source_key = ? LIMIT 1",
+        (result.source_key,),
+    ).fetchone()[0]
+    catalog.register_site(conn, models.SiteCreate(
+        site_key="example_site",
+        display_name="Example",
+        base_url="https://example.com",
+        price_source_id=source_id,
+    ))
+    catalog.register_dataset(conn, "example_site", models.DatasetCreate(
+        dataset_key="rates",
+        original_name="Reference rates",
+        dataset_kind="table",
+        discovery_method="html_table",
+        locator={"selector": "#rates"},
+    ))
+    conn.commit()
+    conn.close()
+
+
+def test_fresh_registry_creates_two_typed_databases_without_domain_tables_crossing(
+    tmp_path: Path,
+):
+    registry = DatabaseRegistry(
+        GeneralDatabase(tmp_path / "general" / "general.db"),
+        MarketLensDatabase(tmp_path / "marketlens" / "marketlens.db"),
+        pointer_file=tmp_path / "databases.json",
+    )
+    applied = registry.initialize()
+
+    assert applied["general"] == [1]
+    assert applied["marketlens"] == list(range(1, 14))
+    assert registry.health()["general"]["status"] == "Healthy"
+    assert registry.health()["marketlens"]["status"] == "Healthy"
+
+    general = registry.general.connect()
+    marketlens = registry.marketlens.connect()
+    try:
+        assert general.execute(
+            "SELECT 1 FROM sqlite_master WHERE name = 'price_observation' LIMIT 1"
+        ).fetchone() is None
+        assert marketlens.execute(
+            "SELECT 1 FROM sqlite_master WHERE name = 'site_profile' LIMIT 1"
+        ).fetchone() is None
+        assert general.execute(
+            "SELECT value FROM scrapex_meta WHERE key = 'database_kind' LIMIT 1"
+        ).fetchone()[0] == "general"
+        assert marketlens.execute(
+            "SELECT value FROM scrapex_meta WHERE key = 'database_kind' LIMIT 1"
+        ).fetchone()[0] == "marketlens"
+    finally:
+        general.close()
+        marketlens.close()
+
+    with pytest.raises(DatabaseKindError, match="expected a general database"):
+        GeneralDatabase(registry.marketlens.path).connect()
+    with pytest.raises(legacy_db.WrongDatabaseKindError, match="General database"):
+        legacy_db.connect(registry.general.path)
+
+    ingested = registry.marketlens.write(
+        lambda conn: ingest_payloads(conn, make_entry(), [make_payload([one_row()])])
+    )
+    assert ingested.observations == 1
+    price_check = registry.marketlens.connect()
+    try:
+        assert price_check.execute(
+            "SELECT COUNT(*) FROM price_observation LIMIT 1"
+        ).fetchone()[0] == 1
+    finally:
+        price_check.close()
+
+
+def test_split_preserves_price_history_and_moves_catalogue_to_general(tmp_path: Path):
+    legacy = tmp_path / "harvest.db"
+    _legacy_with_both_domains(legacy)
+    pointer = tmp_path / "databases.json"
+
+    result = split_legacy_database(
+        legacy,
+        general_path=tmp_path / "general" / "general.db",
+        marketlens_path=tmp_path / "marketlens" / "marketlens.db",
+        pointer_file=pointer,
+    )
+
+    assert result.status == "Succeeded"
+    assert Path(result.legacy_backup).is_file()
+    registry = DatabaseRegistry.read(pointer)
+    general = registry.general.connect()
+    marketlens = registry.marketlens.connect()
+    try:
+        site = general.execute(
+            "SELECT site_key, marketlens_source_key FROM site_profile LIMIT 1"
+        ).fetchone()
+        assert tuple(site) == ("example_site", "ELSEWEDYSHOP")
+        assert marketlens.execute(
+            "SELECT COUNT(*) FROM price_observation LIMIT 1"
+        ).fetchone()[0] == 1
+        assert marketlens.execute(
+            "SELECT 1 FROM sqlite_master WHERE name = 'site_profile' LIMIT 1"
+        ).fetchone() is None
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            marketlens.execute("DELETE FROM price_observation")
+    finally:
+        general.close()
+        marketlens.close()
+
+    legacy_conn = sqlite3.connect(str(legacy))
+    try:
+        assert legacy_conn.execute(
+            "SELECT value FROM scrapex_meta WHERE key = 'sealed_at' LIMIT 1"
+        ).fetchone() is not None
+    finally:
+        legacy_conn.close()
+
+
+def test_failed_split_keeps_legacy_live_and_a_retry_recovers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+):
+    legacy = tmp_path / "harvest.db"
+    _legacy_with_both_domains(legacy)
+    pointer = tmp_path / "databases.json"
+    general = tmp_path / "general.db"
+    marketlens = tmp_path / "marketlens.db"
+
+    from scrapex.databases import split as split_module
+    real_copy = split_module._copy_general
+
+    def fail_copy(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(split_module, "_copy_general", fail_copy)
+    with pytest.raises(OSError, match="disk full"):
+        split_legacy_database(
+            legacy, general_path=general, marketlens_path=marketlens,
+            pointer_file=pointer,
+        )
+    assert not pointer.exists()
+    assert not general.exists()
+    assert not marketlens.exists()
+    check = legacy_db.connect(legacy)
+    try:
+        assert check.execute(
+            "SELECT COUNT(*) FROM price_observation LIMIT 1"
+        ).fetchone()[0] == 1
+    finally:
+        check.close()
+
+    monkeypatch.setattr(split_module, "_copy_general", real_copy)
+    recovered = split_legacy_database(
+        legacy, general_path=general, marketlens_path=marketlens,
+        pointer_file=pointer,
+    )
+    assert recovered.status == "Succeeded"
+
+
+def test_rollback_switches_pointer_without_deleting_split_databases(tmp_path: Path):
+    legacy = tmp_path / "harvest.db"
+    _legacy_with_both_domains(legacy)
+    pointer = tmp_path / "databases.json"
+    general = tmp_path / "general.db"
+    marketlens = tmp_path / "marketlens.db"
+    split_legacy_database(
+        legacy, general_path=general, marketlens_path=marketlens,
+        pointer_file=pointer,
+    )
+
+    restored = rollback_to_legacy(pointer)
+
+    assert restored == legacy.resolve()
+    assert general.exists() and marketlens.exists()
+    payload = json.loads(pointer.read_text(encoding="utf-8"))
+    assert payload["mode"] == "legacy"
+    check = legacy_db.connect(legacy)
+    try:
+        assert check.execute(
+            "SELECT value FROM scrapex_meta WHERE key = 'sealed_at' LIMIT 1"
+        ).fetchone() is None
+    finally:
+        check.close()
+
+
+def test_restore_refuses_the_other_database_kind_without_displacing_live_data(
+    tmp_path: Path,
+):
+    general = GeneralDatabase(tmp_path / "general.db")
+    marketlens = MarketLensDatabase(tmp_path / "marketlens.db")
+    general.initialize()
+    marketlens.initialize()
+    original = general.path.read_bytes()
+
+    with pytest.raises(DatabaseKindError, match="expected a general database"):
+        general.restore(marketlens.path)
+
+    assert general.path.read_bytes() == original
+    assert not list(tmp_path.glob("general.replaced-*.db"))
+
+
+def test_backup_restore_and_locks_are_independent_per_domain(tmp_path: Path):
+    general = GeneralDatabase(tmp_path / "general.db")
+    marketlens = MarketLensDatabase(tmp_path / "marketlens.db")
+    general.initialize()
+    marketlens.initialize()
+    general.write(lambda conn: catalog.register_site(conn, models.SiteCreate(
+        site_key="before_backup", display_name="Before", base_url="https://before.example"
+    )))
+    backup = general.backup(tmp_path / "backups")
+    general.write(lambda conn: catalog.register_site(conn, models.SiteCreate(
+        site_key="after_backup", display_name="After", base_url="https://after.example"
+    )))
+
+    with legacy_db.write_lock(general.path, timeout_s=0.1):
+        with legacy_db.write_lock(marketlens.path, timeout_s=0.1):
+            pass
+
+    displaced = general.restore(backup)
+    restored = general.connect()
+    try:
+        keys = [row[0] for row in restored.execute(
+            "SELECT site_key FROM site_profile ORDER BY site_profile_id LIMIT 10"
+        ).fetchall()]
+    finally:
+        restored.close()
+    assert keys == ["before_backup"]
+    assert displaced.is_file()
+    assert marketlens.health().ok is True
+
+
+def test_workspace_uses_general_catalogue_across_restart_and_reports_both_health_states(
+    tmp_path: Path,
+):
+    registry = DatabaseRegistry(
+        GeneralDatabase(tmp_path / "general.db"),
+        MarketLensDatabase(tmp_path / "marketlens.db"),
+        pointer_file=tmp_path / "databases.json",
+    )
+    registry.initialize()
+    first = TestClient(create_app(databases=registry))
+    created = first.post("/api/general/catalog/sites", json={
+        "site_key": "example_site",
+        "display_name": "Example",
+        "base_url": "https://example.com",
+        "marketlens_source_key": "ELSEWEDYSHOP",
+    })
+    assert created.status_code == 201
+
+    restarted = TestClient(create_app(databases=DatabaseRegistry.read(registry.pointer_file)))
+    sites = restarted.get("/api/general/catalog/sites", params={"limit": 10})
+    health = restarted.get("/api/databases/health")
+    price_health = restarted.get("/api/health")
+    general_health = restarted.get("/api/general/health")
+    marketlens_health = restarted.get("/api/marketlens/health")
+
+    assert sites.json()["sites"][0]["site_key"] == "example_site"
+    assert price_health.status_code == 200
+    assert health.json()["status"] == "Healthy"
+    assert set(health.json()["databases"]) == {"general", "marketlens"}
+    assert general_health.json()["kind"] == "general"
+    assert marketlens_health.json()["kind"] == "marketlens"
+
+
+def test_workspace_move_changes_only_marketlens_location(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+):
+    from scrapex import storage
+
+    monkeypatch.setattr(storage, "POINTER_FILE", tmp_path / "legacy-location.json")
+    registry = DatabaseRegistry(
+        GeneralDatabase(tmp_path / "general" / "general.db"),
+        MarketLensDatabase(tmp_path / "marketlens" / "marketlens.db"),
+        pointer_file=tmp_path / "databases.json",
+    )
+    registry.initialize()
+    original_general = registry.general.path
+    client = TestClient(create_app(databases=registry))
+
+    response = client.post("/api/storage/move", json={"folder": str(tmp_path / "moved")})
+
+    assert response.status_code == 200, response.text
+    followed = DatabaseRegistry.read(registry.pointer_file)
+    assert followed.general.path == original_general
+    assert followed.marketlens.path == tmp_path / "moved" / "marketlens.db"
+    assert followed.health()["marketlens"]["status"] == "Healthy"


### PR DESCRIPTION
## Status

Draft for Tech Lead review. This is the DB1 prerequisite introduced by the owner decision in spec section 40. It does not mark DB1, G2, or the generic platform complete, and it must not be merged without review.

## What this reuses

- The immutable price-warehouse schema and migrations 0001-0012 as the MarketLens migration history.
- The merged G1 catalogue services and DTOs.
- The existing SQLite online-backup and single-writer lock behavior.
- The existing unified `harvest.db` as a preserved migration and rollback source.

## What this adds

- Typed `GeneralDatabase`, `MarketLensDatabase`, and `DatabaseRegistry` capabilities.
- Physical defaults at `~/.scrapex/general/general.db` and `~/.scrapex/marketlens/marketlens.db`.
- Different SQLite `application_id` values, required `database_kind` markers, independent schema versions, and per-stream SHA-256 migration ledgers.
- Independent locks, health checks, backup, restore, and combined backup-bundle commands.
- A reversible `split-databases` workflow that takes a pre-split backup, creates and verifies incoming copies, switches one atomic registry pointer, and seals the legacy database.
- Explicit rollback mode that leaves both split databases untouched.
- Authoritative generic API namespace `/api/general/catalog`, compatibility alias `/api/catalog`, and domain health endpoints under `/api/general` and `/api/marketlens`.
- Stable cross-domain catalogue linking by `marketlens_source_key`, with no cross-database foreign key.

## Migration design

There is no new unified migration and reserved migration 0014 remains untouched.

- General starts its independent stream at `db/general/schema.sql` version 1 and contains only G1 catalogue definitions in this PR.
- MarketLens reuses immutable unified versions 0001-0012, excludes the unrelated unified 0013 catalogue migration, and applies its own independent `db/marketlens/migrations/0013_marketlens_database_identity.sql`.
- The split copies the legacy file to MarketLens, removes only copied G1 catalogue tables from that copy, and verifies bounded row counts and SHA-256 row hashes for every operational MarketLens table.
- G1 rows are copied to General with IDs preserved; a legacy numeric price source link is converted to the stable source key.
- The legacy database and its pre-split backup remain on disk. No `price_observation` row is updated or deleted.

## Compatibility impact

- Normal CLI and UI startup use the split registry.
- Explicit `--db` remains the temporary unified-database path for migration and rollback.
- Existing price ingestion, browsing, jobs, schedules, retention, and storage routes continue to use MarketLens.
- MarketLens storage movement and compaction update only the MarketLens registry entry; General stays at its own location.
- The legacy `/api/catalog` route remains available while G2 rebases.
- The legacy `scrapex.db` facade refuses a General database but remains as a transitional MarketLens facade for existing price modules.

## Tests added

`tests/test_database_isolation.py` covers:

- fresh physical isolation and independent versions;
- unchanged price ingestion in MarketLens;
- wrong-kind refusal;
- successful legacy split with price history and catalogue preservation;
- simulated disk failure, unchanged legacy state, and successful retry;
- rollback without deletion;
- wrong-kind restore refusal without displacement;
- independent backups, restore, and locks;
- restart persistence and namespaced health;
- MarketLens-only storage movement.

Full validation:

- `python -m pytest`: **598 passed**, 2 pre-existing environment/deprecation warnings.
- `node contract/parity/parity.test.mjs`: **16/16 passed**.
- `python -m scrapex.cli validate-manifest`: **OK, 12 sources**.
- `python -m compileall -q scrapex`: passed.
- `git diff --check`: passed.

## G2 and G3 dependency

G2 must be rebased onto this branch after DB1 review. Its generic snapshot and record migration must become General migration 0002, and its extraction router must use the General database capability. Unified migration 0014 remains only for the legacy compatibility path.

G3 has not been started because section 40 requires the DB1 gate to be reviewed and satisfied before G3.

## Known limitations

- General contains G1 definitions only until the adapted G2 slice adds approved generic records.
- Database management is currently exposed through CLI commands and health APIs; there is no new combined database-management screen in this prerequisite.
- Rollback mode is intentionally explicit and requires `--db <legacy-harvest.db>`; ScrapeX does not silently resume writes to a unified file.
- Existing price modules still use the guarded compatibility facade internally; repository-by-repository cleanup is future work and is not required to achieve physical isolation.
- There are no dual writes, cross-database foreign keys, SQLite `ATTACH`, or distributed transactions.
