### PR TITLE
Redesign settings UI across extension and workspace

### DIFF
--- a/extension/app.html
+++ b/extension/app.html
@@ -59,7 +59,7 @@
   /* Each task tab has one visible purpose, followed by clearly separated
      sections. The side panel is too narrow for a flat stream of unrelated
      cards: hierarchy has to come from spacing and headings, not extra chrome. */
-  #view-run, #view-data { display: flex; flex-direction: column; gap: var(--sp-3); }
+  #view-run, #view-data, #view-settings { display: flex; flex-direction: column; gap: var(--sp-3); }
   .view-heading { display: flex; flex-direction: column; gap: 2px; }
   .view-heading h1 { margin: 0; font-size: var(--fs-lg); font-weight: var(--fw-bold); }
   .view-heading p { margin: 0; color: var(--muted); font-size: var(--fs-xs); }
@@ -80,6 +80,46 @@
   .output-group-head { margin-bottom: var(--sp-2); }
   .output-group-head h3 { margin: 0; font-size: var(--fs-sm); font-weight: var(--fw-bold); }
   .output-group-head p { margin: 2px 0 0; color: var(--muted); font-size: var(--fs-xs); }
+  /* Settings is an information architecture, not a stack of identical cards.
+     Related controls share one surface and the disclosure rows explain what is
+     behind them before the owner commits to opening a long form. */
+  .settings-principle { display: flex; align-items: flex-start; gap: var(--sp-2);
+                        padding: var(--sp-3); border: 1px solid var(--line);
+                        border-radius: var(--radius-lg); background: var(--accent-weak); }
+  .settings-principle .dot { margin-top: 5px; background: var(--accent); flex: none; }
+  .settings-principle strong { display: block; color: var(--accent-ink);
+                               font-size: var(--fs-sm); }
+  .settings-principle p { margin: 1px 0 0; color: var(--muted); font-size: var(--fs-xs); }
+  .settings-group { display: flex; flex-direction: column; gap: var(--sp-2); }
+  .settings-group-head { display: flex; align-items: baseline; justify-content: space-between;
+                         gap: var(--sp-2); padding: 0 var(--sp-1); }
+  .settings-group-head h2 { margin: 0; }
+  .settings-group-head p { margin: 0; color: var(--muted); font-size: var(--fs-xs);
+                           text-align: right; }
+  .settings-list { overflow: hidden; border: 1px solid var(--line);
+                   border-radius: var(--radius-lg); background: var(--surface); }
+  .settings-item + .settings-item { border-top: 1px solid var(--line); }
+  #view-settings .settings-toggle { display: grid; grid-template-columns: 24px minmax(0,1fr) auto;
+                                    align-items: center; gap: var(--sp-3); width: 100%;
+                                    padding: var(--sp-3) var(--sp-4); }
+  .settings-index { width: 24px; height: 24px; display: grid; place-items: center;
+                    border-radius: var(--radius-sm); background: var(--chip); color: var(--muted);
+                    font-size: 10px; font-variant-numeric: tabular-nums; }
+  .settings-toggle-copy { display: flex; flex-direction: column; gap: 1px; }
+  .settings-title { color: var(--text); font-size: var(--fs-sm); font-weight: var(--fw-bold); }
+  .settings-description { color: var(--muted); font-size: var(--fs-xs); font-weight: var(--fw-regular); }
+  .settings-chevron { color: var(--muted); font-size: var(--fs-lg); line-height: 1;
+                      transition: transform var(--dur); }
+  #view-settings .settings-toggle:hover .settings-index,
+  #view-settings .settings-toggle[aria-expanded="true"] .settings-index {
+    background: var(--accent-weak); color: var(--accent-ink);
+  }
+  #view-settings .settings-toggle[aria-expanded="true"] .settings-chevron {
+    transform: rotate(90deg); color: var(--accent-ink);
+  }
+  .settings-panel { padding: var(--sp-3) var(--sp-4) var(--sp-4);
+                    border-top: 1px solid var(--line); background: var(--bg); }
+  .settings-panel > :first-child { margin-top: 0; }
   .fieldset { display: flex; flex-direction: column; gap: var(--sp-1); }
   .fieldset > label { font-size: var(--fs-xs); color: var(--muted); }
   /* Two columns only when there is room; one column at 320px. */
@@ -237,7 +277,7 @@
   @media (prefers-reduced-motion: reduce) {
     .skeleton { animation: none; }
     .source-choice, .source-choice-label, .source-choice-icon, .source-choice-check,
-    .source-choice-panel, .source-choice-panel-inner { transition: none; }
+    .source-choice-panel, .source-choice-panel-inner, .settings-chevron { transition: none; }
   }
 </style>
 </head>
@@ -656,52 +696,126 @@
 
     <!-- ========================== SETTINGS ========================== -->
     <section id="view-settings" class="hidden">
-      <div class="card">
-        <button class="link sect" data-sect="s-engine" aria-expanded="false">Local runtime ›</button>
-        <div id="s-engine" class="hidden" style="margin-top:var(--sp-2)">
-          <label class="muted" for="backend" style="font-size:var(--fs-xs)">Engine URL</label>
-          <div class="field"><input id="backend" placeholder="http://127.0.0.1:8000" class="tech">
-            <button id="save" class="ghost">Save</button></div>
-          <div class="muted" style="font-size:var(--fs-xs);margin-top:var(--sp-1)">
-            Your data stays on this machine. Nothing is sent to any server.</div>
+      <header class="view-heading">
+        <h1>Settings</h1>
+        <p>Configure how ScrapeX runs, stores data, and sends results.</p>
+      </header>
+
+      <aside class="settings-principle" aria-label="Privacy summary">
+        <span class="dot on" aria-hidden="true"></span>
+        <div>
+          <strong>Local-first by default</strong>
+          <p>External destinations stay off until you configure them.</p>
         </div>
-      </div>
-      <div class="card">
-        <button class="link sect" data-sect="s-sched" aria-expanded="false">Jobs and scheduling ›</button>
-        <div id="s-sched" class="hidden" style="margin-top:var(--sp-2)">
-          <div id="schedules" class="muted" style="font-size:var(--fs-sm)">Loading…</div>
-          <div class="muted" style="font-size:var(--fs-xs);margin-top:var(--sp-2)" id="sched-note"></div>
+      </aside>
+
+      <section class="settings-group" aria-labelledby="settings-workspace-heading">
+        <div class="settings-group-head">
+          <h2 id="settings-workspace-heading">Workspace</h2>
+          <p>Engine and local data</p>
         </div>
-      </div>
-      <div class="card">
-        <button class="link sect" data-sect="s-output" aria-expanded="false">Data output settings ›</button>
-        <div id="s-output" class="hidden" style="margin-top:var(--sp-3)">
-          <p class="muted hint" style="margin-top:0">
-            Local destinations stay separate from external sync services.</p>
-          <div id="outputs" class="output-groups"><div class="skeleton"></div></div>
+        <div class="settings-list">
+          <article class="settings-item">
+            <button class="link sect settings-toggle" data-sect="s-engine" aria-expanded="false">
+              <span class="settings-index" aria-hidden="true">01</span>
+              <span class="settings-toggle-copy">
+                <span class="settings-title">Local runtime</span>
+                <span class="settings-description">Connection and privacy</span>
+              </span>
+              <span class="settings-chevron" aria-hidden="true">›</span>
+            </button>
+            <div id="s-engine" class="settings-panel hidden">
+              <label class="muted" for="backend" style="font-size:var(--fs-xs)">Engine URL</label>
+              <div class="field"><input id="backend" placeholder="http://127.0.0.1:8000" class="tech">
+                <button id="save" class="ghost">Save</button></div>
+              <div class="muted" style="font-size:var(--fs-xs);margin-top:var(--sp-1)">
+                Your data stays on this machine. Nothing is sent to any server.</div>
+            </div>
+          </article>
+          <article class="settings-item">
+            <button class="link sect settings-toggle" data-sect="s-storage" aria-expanded="false">
+              <span class="settings-index" aria-hidden="true">02</span>
+              <span class="settings-toggle-copy">
+                <span class="settings-title">Storage and data</span>
+                <span class="settings-description">Database health and source management</span>
+              </span>
+              <span class="settings-chevron" aria-hidden="true">›</span>
+            </button>
+            <div id="s-storage" class="settings-panel hidden">
+              <!-- Read-only on purpose. Every control that can rewrite the database
+                   lives in the workspace, so a destructive action is never one
+                   stray tap away in a panel used while browsing. -->
+              <div id="storage-info" class="muted" style="font-size:var(--fs-sm)">Loading…</div>
+              <div class="links">
+                <button type="button" class="link" id="open-storage">Manage storage ↗</button>
+                <button type="button" class="link" id="open-browse">Browse all data ↗</button>
+                <button type="button" class="link" id="open-manage">Manage sources ↗</button>
+              </div>
+            </div>
+          </article>
         </div>
-      </div>
-      <div class="card">
-        <button class="link sect" data-sect="s-storage" aria-expanded="false">Storage and data ›</button>
-        <div id="s-storage" class="hidden" style="margin-top:var(--sp-2)">
-          <!-- Read-only on purpose. Every control that can rewrite the database
-               lives in the workspace, so a destructive action is never one
-               stray tap away in a panel used while browsing. -->
-          <div id="storage-info" class="muted" style="font-size:var(--fs-sm)">Loading…</div>
-          <div class="links">
-            <button type="button" class="link" id="open-storage">Manage storage ↗</button>
-            <button type="button" class="link" id="open-browse">Browse all data ↗</button>
-            <button type="button" class="link" id="open-manage">Manage sources ↗</button>
-          </div>
+      </section>
+
+      <section class="settings-group" aria-labelledby="settings-operations-heading">
+        <div class="settings-group-head">
+          <h2 id="settings-operations-heading">Automation &amp; output</h2>
+          <p>Schedules and destinations</p>
         </div>
-      </div>
-      <div class="card">
-        <button class="link sect" data-sect="s-about" aria-expanded="false">About ›</button>
-        <div id="s-about" class="hidden muted" style="margin-top:var(--sp-2);font-size:var(--fs-sm)">
-          ScrapeX — local-first price tracking.
-          Engine <span id="about-version" class="tech">—</span>
+        <div class="settings-list">
+          <article class="settings-item">
+            <button class="link sect settings-toggle" data-sect="s-sched" aria-expanded="false">
+              <span class="settings-index" aria-hidden="true">03</span>
+              <span class="settings-toggle-copy">
+                <span class="settings-title">Jobs and scheduling</span>
+                <span class="settings-description">Run cadence and worker availability</span>
+              </span>
+              <span class="settings-chevron" aria-hidden="true">›</span>
+            </button>
+            <div id="s-sched" class="settings-panel hidden">
+              <div id="schedules" class="muted" style="font-size:var(--fs-sm)">Loading…</div>
+              <div class="muted" style="font-size:var(--fs-xs);margin-top:var(--sp-2)" id="sched-note"></div>
+            </div>
+          </article>
+          <article class="settings-item">
+            <button class="link sect settings-toggle" data-sect="s-output" aria-expanded="false">
+              <span class="settings-index" aria-hidden="true">04</span>
+              <span class="settings-toggle-copy">
+                <span class="settings-title">Data output settings</span>
+                <span class="settings-description">Local exports and external sync</span>
+              </span>
+              <span class="settings-chevron" aria-hidden="true">›</span>
+            </button>
+            <div id="s-output" class="settings-panel hidden">
+              <p class="muted hint">
+                Local destinations stay separate from external sync services.</p>
+              <div id="outputs" class="output-groups"><div class="skeleton"></div></div>
+            </div>
+          </article>
         </div>
-      </div>
+      </section>
+
+      <section class="settings-group" aria-labelledby="settings-product-heading">
+        <div class="settings-group-head">
+          <h2 id="settings-product-heading">Product</h2>
+          <p>Build information</p>
+        </div>
+        <div class="settings-list">
+          <article class="settings-item">
+            <button class="link sect settings-toggle" data-sect="s-about" aria-expanded="false">
+              <span class="settings-index" aria-hidden="true">05</span>
+              <span class="settings-toggle-copy">
+                <span class="settings-title">About</span>
+                <span class="settings-description">Version and product details</span>
+              </span>
+              <span class="settings-chevron" aria-hidden="true">›</span>
+            </button>
+            <div id="s-about" class="settings-panel hidden muted" style="font-size:var(--fs-sm)">
+              ScrapeX — local-first price tracking.
+              Engine <span id="about-version" class="tech">—</span>
+            </div>
+          </article>
+        </div>
+      </section>
     </section>
   </main>
 

--- a/scrapex/webui/templates/base.html
+++ b/scrapex/webui/templates/base.html
@@ -143,23 +143,64 @@
     .step-body h3{margin:.1rem 0 .3rem;font-size:.95rem;font-weight:600}
     pre.script{direction:ltr;max-height:260px;overflow:auto;background:var(--chip);
       border-radius:10px;padding:.8rem;font-size:.8rem;margin:.5rem 0}
-    /* Settings sections (spec 33): progressive disclosure. The open/closed state
-       is carried by the marker AND by the summary, never by colour alone. */
-    .settings{display:flex;flex-direction:column;gap:.6rem;margin-top:1rem}
+    /* Settings sections (spec 33): a grouped information architecture with
+       progressive disclosure. The open/closed state is carried by the marker
+       and by the summary, never by colour alone. */
+    .settings-hero{display:grid;grid-template-columns:minmax(0,1fr) minmax(240px,330px);
+      align-items:end;gap:2rem;padding:.35rem 0 1.5rem;border-bottom:1px solid var(--line)}
+    .settings-eyebrow{display:block;margin-bottom:.35rem;color:var(--accent-ink);
+      font-size:.72rem;font-weight:600;letter-spacing:.08em;text-transform:uppercase}
+    .settings-hero h1{margin:0 0 .35rem;font-size:1.7rem;line-height:1.2}
+    .settings-hero p{max-width:650px;margin:0;color:var(--muted)}
+    .settings-assurance{display:flex;gap:.7rem;align-items:flex-start;padding:.85rem 1rem;
+      border:1px solid var(--line);border-radius:12px;background:var(--surface);box-shadow:var(--shadow)}
+    .settings-assurance-mark{width:26px;height:26px;flex:none;display:grid;place-items:center;
+      border-radius:8px;background:var(--accent-weak);color:var(--accent-ink);font-weight:600}
+    .settings-assurance strong{display:block;font-size:.88rem}
+    .settings-assurance span:last-child{display:block;color:var(--muted);font-size:.78rem}
+    .settings{display:flex;flex-direction:column;gap:2rem;margin-top:1.5rem}
+    .settings-category{display:grid;grid-template-columns:minmax(165px,220px) minmax(0,1fr);
+      gap:1.5rem;align-items:start}
+    .settings-category-head{position:sticky;top:calc(var(--sticky-tabs) + 72px)}
+    .settings-category-head h2{margin:0 0 .25rem;font-size:1rem}
+    .settings-category-head p{margin:0;color:var(--muted);font-size:.82rem}
+    .settings-list{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.7rem}
     /* The topbar and tab bar are both sticky, so an anchor jump lands the target
        UNDER them. Reserving their combined height means a link to a section
        shows that section instead of the row above it. */
-    details.sect{background:var(--surface);border:1px solid var(--line);border-radius:12px;
-      scroll-margin-top:110px}
-    details.sect>summary{display:flex;flex-wrap:wrap;align-items:baseline;gap:.6rem;
-      padding:.85rem 1.1rem;cursor:pointer;border-radius:12px}
+    details.sect{min-width:0;background:var(--surface);border:1px solid var(--line);
+      border-radius:12px;scroll-margin-top:110px;box-shadow:var(--shadow);
+      transition:border-color .15s,box-shadow .15s}
+    details.sect[open]{grid-column:1/-1;border-color:var(--accent)}
+    details.sect>summary{display:grid;grid-template-columns:minmax(0,1fr) auto;
+      grid-template-rows:auto auto;column-gap:.8rem;align-items:center;min-height:78px;
+      padding:.85rem 1rem;cursor:pointer;border-radius:12px;list-style:none}
+    details.sect>summary::-webkit-details-marker{display:none}
+    details.sect>summary:focus{outline:none}
+    details.sect>summary:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+    details.sect>summary::after{content:"›";grid-column:2;grid-row:1/-1;align-self:center;
+      color:var(--muted);font-size:1.25rem;line-height:1;transition:transform .15s}
     details.sect>summary:hover{color:var(--accent-ink)}
-    details.sect[open]>summary{border-bottom:1px solid var(--line);
-      border-radius:12px 12px 0 0}
-    .sect-name{font-weight:600}
-    .sect-sub{color:var(--muted);font-size:.85rem}
-    .sect-body{padding:.4rem 1.1rem 1.1rem}
+    details.sect[open]>summary{border-bottom:1px solid var(--line);border-radius:12px 12px 0 0}
+    details.sect[open]>summary::after{transform:rotate(90deg);color:var(--accent-ink)}
+    .sect-name{grid-column:1;font-weight:600}
+    .sect-sub{grid-column:1;color:var(--muted);font-size:.8rem}
+    .sect-body{padding:.6rem 1.1rem 1.1rem}
+    .sect-body>table{table-layout:fixed}
+    .sect-body>table td,.sect-body code,.sect-body .tech{overflow-wrap:anywhere;word-break:break-word}
     .sect-body h3{font-size:.95rem;font-weight:600;margin:1.2rem 0 .5rem}
+    @media(max-width:900px){
+      .settings-hero{grid-template-columns:1fr;gap:1rem}
+      .settings-category{grid-template-columns:1fr;gap:.7rem}
+      .settings-category-head{position:static}
+    }
+    @media(max-width:640px){
+      .settings-list{grid-template-columns:1fr}
+      details.sect[open]{grid-column:auto}
+      .settings-hero h1{font-size:1.45rem}
+      .sect-body>table tbody>tr>th:first-child{width:7.5rem}
+    }
+    @media(prefers-reduced-motion:reduce){details.sect,details.sect>summary::after{transition:none}}
     .tech{direction:ltr;font-family:ui-monospace,monospace;font-size:.85em}
     progress{width:100%;height:.6rem}
     .banner.promise{background:var(--accent-weak)}

--- a/scrapex/webui/templates/settings.html
+++ b/scrapex/webui/templates/settings.html
@@ -1,17 +1,34 @@
 {% extends "base.html" %}
 {% block title %}Settings — ScrapeX{% endblock %}
 {% block content %}
-<h1>Settings</h1>
+<header class="settings-hero">
+  <div>
+    <span class="settings-eyebrow">Workspace configuration</span>
+    <h1>Settings</h1>
+    <p>Control the local runtime, collection rules, connected destinations, and
+      data safeguards from one organized workspace.</p>
+  </div>
+  <aside class="settings-assurance" aria-label="Saving behavior">
+    <span class="settings-assurance-mark" aria-hidden="true">✓</span>
+    <span><strong>Changes are explicit</strong>
+      <span>Nothing changes until you choose Save. Risky data actions explain
+        their effect before they run.</span></span>
+  </aside>
+</header>
 
 {# Spec 33/24: thirteen sections, every one closed by default. Progressive
    disclosure here is not decoration — Storage and Data and history hold the
    only controls in the product that can rewrite the warehouse, and they should
    take a deliberate act to reach, not scroll past under a thumb. #}
-<p class="muted small">Each section opens on its own. Nothing here changes until
-  you save it, and the two sections that can rewrite the database say exactly what
-  they will do before they do it.</p>
 
 <div class="settings">
+
+<section class="settings-category" aria-labelledby="settings-workspace-heading">
+  <div class="settings-category-head">
+    <h2 id="settings-workspace-heading">Workspace</h2>
+    <p>Core preferences, runtime health, and where local data lives.</p>
+  </div>
+  <div class="settings-list">
 
 <!-- 1 ------------------------------------------------------------------- -->
 <details class="sect" id="s-general">
@@ -61,6 +78,15 @@
 </details>
 
 <!-- 4 ------------------------------------------------------------------- -->
+  </div>
+</section>
+
+<section class="settings-category" aria-labelledby="settings-collection-heading">
+  <div class="settings-category-head">
+    <h2 id="settings-collection-heading">Collection</h2>
+    <p>How sources are crawled, which engines run, and when jobs start.</p>
+  </div>
+  <div class="settings-list">
 <details class="sect" id="s-crawling">
   <summary><span class="sect-name">Crawling</span>
     <span class="sect-sub">Politeness, timeouts and identification</span></summary>
@@ -133,6 +159,15 @@
 </details>
 
 <!-- 7, 8, 9 -------------------------------------------------------------- -->
+  </div>
+</section>
+
+<section class="settings-category" aria-labelledby="settings-connections-heading">
+  <div class="settings-category-head">
+    <h2 id="settings-connections-heading">Connections</h2>
+    <p>Optional destinations that send or synchronize data outside ScrapeX.</p>
+  </div>
+  <div class="settings-list">
 <details class="sect" id="s-excel">
   <summary><span class="sect-name">Excel</span>
     <span class="sect-sub">Workbook location and column schema</span></summary>
@@ -169,6 +204,15 @@
 </details>
 
 <!-- 10 ------------------------------------------------------------------ -->
+  </div>
+</section>
+
+<section class="settings-category" aria-labelledby="settings-governance-heading">
+  <div class="settings-category-head">
+    <h2 id="settings-governance-heading">Data &amp; trust</h2>
+    <p>Retention, privacy, diagnostics, and build information.</p>
+  </div>
+  <div class="settings-list">
 <details class="sect" id="s-data">
   <summary><span class="sect-name">Data and history</span>
     <span class="sect-sub">Retention policy, protected observations and compaction</span></summary>
@@ -238,6 +282,9 @@
     </table>
   </div>
 </details>
+
+  </div>
+</section>
 
 </div>
 


### PR DESCRIPTION
## Summary

- redesign the extension Settings tab with clear hierarchy, grouped disclosures, concise descriptions, and a local-first status panel
- reorganize the workspace Settings page into Workspace, Collection, Connections, and Data & trust sections
- add responsive two-column/one-column layouts, accessible focus states, reduced-motion support, and safe wrapping for long technical paths
- preserve all existing settings IDs, links, controls, save handlers, and progressive-disclosure behavior

## Visual review

- extension panel reviewed at 320px, 360px, and 400px, including the expanded Data output settings section
- workspace Settings reviewed in light and dark themes at 640px, 1024px, and desktop width
- confirmed the expanded Storage section has no horizontal page overflow at 640px

## Tests

- `python -m pytest tests/test_settings_page.py -q` (26 passed)
- `python -m pytest tests/test_panel_dom.py -q` (27 passed)
- `python -m pytest tests/test_database_notification.py -q` (7 passed)
