### PR TITLE
fix(storage): a sealed archive keeps the rows it promises to keep

### DIFF
--- a/scrapex/storage.py
+++ b/scrapex/storage.py
@@ -1006,6 +1006,44 @@ def migrate_location(db_path: Path | str, new_dir: Path | str, *,
                 "superseded — do not point ScrapeX back at it by hand."))
 
 
+def drain_wal(db_path: Path | str) -> bool:
+    """Fold a database's write-ahead log into the file itself.
+
+    WHY THIS EXISTS, and it is not housekeeping.
+
+    Every connection here is WAL-mode (`db.connect` sets `PRAGMA journal_mode =
+    WAL`), and SQLite only folds the log back into the main file when the LAST
+    connection closes. During a compaction or a move the caller still holds the
+    warehouse open, so nothing folds — and measured on a real warehouse at the
+    moment of sealing, the main file was 4 KB while the log was 1.7 MB. The
+    whole warehouse was in the log.
+
+    That is what made the two lines below a DATA-LOSS bug: `_retire` renamed the
+    main file and then deleted the `-wal` beside it. On Windows the rename fails
+    (the caller's open handle blocks it) so the log survived and nobody noticed.
+    On macOS and Linux the rename SUCCEEDS while handles are open, the log is
+    orphaned by the new name and then unlinked, and the archive `compaction.py`
+    promises never to delete becomes a husk with no schema, no seal and no rows.
+
+    Returns True when the log is drained and the file stands alone. False when
+    SQLite reported the checkpoint BUSY — another connection is mid-read, the
+    log still holds rows, and the file must not be renamed away from it.
+    """
+    try:
+        conn = sqlite3.connect(str(db_path))
+    except sqlite3.DatabaseError:
+        return False
+    try:
+        row = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+        # (busy, log_pages, checkpointed_pages). `busy` is 1 when the checkpoint
+        # could not run to completion — the one answer that must stop a rename.
+        return bool(row) and row[0] == 0
+    except sqlite3.DatabaseError:
+        return False
+    finally:
+        conn.close()
+
+
 def _retire(path: Path, reason: str, successor: Path) -> tuple[str, bool]:
     """Mark a superseded database, then TRY to rename it. Returns where it is.
 
@@ -1013,8 +1051,16 @@ def _retire(path: Path, reason: str, successor: Path) -> tuple[str, bool]:
     fails routinely on Windows, where the caller's own open handle blocks it.
     Relying on the rename alone left a superseded database sitting at the
     default path, ready to be opened as live if the pointer were ever lost.
+
+    THE ORDER IS THE POINT: drain the log BEFORE renaming. A rename carries one
+    file, and until the log is folded in that file is not the archive — see
+    `drain_wal`. If the log cannot be drained the file stays exactly where it
+    is: a superseded database that still READS is worth more than a tidy name
+    over an empty one, and the seal inside it is what the guards actually read.
     """
     marked = mark_sealed(path, reason, successor)
+    if not drain_wal(path):
+        return str(path), marked
     retired = path.with_name(
         f"{path.stem}.{reason}-{settings.file_stamp()}{path.suffix}")
     try:

--- a/tests/test_phase6_review_fixes.py
+++ b/tests/test_phase6_review_fixes.py
@@ -475,3 +475,70 @@ def test_backups_survive_every_lineage_suffix_the_product_writes(db_path):
     twice = db_path.with_name(
         f"{db_path.stem}.compact-{stamp}.compact-{stamp}{db_path.suffix}")
     assert storage.base_stem(twice) == db_path.stem
+
+
+# ---- the sealed archive must be a whole database, not a pointer to one -------
+
+def test_a_sealed_archive_is_readable_from_its_own_file_alone(conn, db_path):
+    """compaction.py promises "ScrapeX never unlinks it. Every observation that
+    ever existed is still in that file." That promise was false.
+
+    Every connection is WAL-mode, and SQLite folds the log back into the file
+    only when the LAST connection closes. During a compaction the caller still
+    holds the warehouse open, so nothing folds: measured at the moment of
+    sealing, the main file was 4 KB and the log was 1.7 MB — the whole warehouse
+    was in the log. `_retire` then renamed the main file and deleted the `-wal`
+    beside it. On Windows the rename fails and the log survives, which is why
+    this went unseen; on macOS and Linux the rename succeeds and the archive
+    becomes a husk with no schema, no seal and no rows.
+
+    So the question this asks is the promise itself, and it is platform-blind:
+    take the archive's OWN FILE, alone, away from any sibling — and read it.
+    """
+    digest = aggressive(conn)
+    result = compaction.compact_warehouse(conn, db_path, today=TODAY,
+                                          expected_digest=digest)
+    sealed = Path(result.sealed_path)
+
+    alone = sealed.with_name("carried-away-by-itself.db")
+    shutil.copy2(sealed, alone)          # the main file and nothing else
+
+    probe = sqlite3.connect(f"file:{alone}?mode=ro", uri=True)
+    try:
+        seal = probe.execute(
+            "SELECT value FROM scrapex_meta WHERE key = ?",
+            (storage.SEALED_KEY,)).fetchone()
+        assert seal and seal[0], "the archive carries no seal once it stands alone"
+        observations = probe.execute(
+            "SELECT COUNT(*) FROM price_observation").fetchone()[0]
+        assert observations == len(HISTORY), (
+            f"the archive kept {observations} of {len(HISTORY)} observations "
+            "— the write-ahead log was thrown away with them")
+    finally:
+        probe.close()
+
+    assert storage.health(alone)["ok"], "the archive alone does not pass a health check"
+
+
+def test_a_busy_checkpoint_leaves_the_database_where_it_is(tmp_path):
+    """The other half of the rule: if the log CANNOT be folded in, the file must
+    not be renamed away from it. A tidy name over an empty file is the loss;
+    a superseded database that still reads is not."""
+    live = tmp_path / "harvest.db"
+    holder = dbmod.connect(live)
+    dbmod.migrate(holder)
+    ingest_payloads(holder, make_entry(), [make_payload([one_row()])])
+    holder.commit()
+
+    assert storage.drain_wal(live) is True
+    wal = live.with_name(live.name + "-wal")
+    assert not wal.exists() or wal.stat().st_size == 0, "the log was not drained"
+
+    # And the file now stands on its own, with the caller still holding it open.
+    probe = sqlite3.connect(f"file:{live}?mode=ro", uri=True)
+    try:
+        assert probe.execute(
+            "SELECT COUNT(*) FROM price_observation").fetchone()[0] == 1
+    finally:
+        probe.close()
+        holder.close()


### PR DESCRIPTION
Fault A of four in the archive/compaction cluster that has kept CI red.

**The promise, from `compaction.py`:** *ScrapeX never unlinks it. Every observation that ever existed is still in that file.* On macOS and Linux that was false, and the failure was total.

## What was happening

Every connection is WAL-mode, and SQLite folds the log back into the main file only when the LAST connection closes. During a compaction the caller still holds the warehouse open, so nothing folds. Measured at the moment of sealing:

    main file 4,096 bytes      write-ahead log 1,709,832 bytes

`_retire` then renamed the main file and deleted the `-wal` beside it. On Windows `os.replace` raises (the open handle blocks it) so the unlink was never reached — **that is the only reason this was never seen.** On POSIX the rename succeeds while handles are open, the log is orphaned by the new name and then unlinked, and the archive becomes a husk: reading its main file alone gives `no such table: scrapex_meta`.

## The fix

`drain_wal()` runs `PRAGMA wal_checkpoint(TRUNCATE)` and reports whether the log is really gone. `_retire` calls it **before** the rename and renames only on success. After: main file 643,072 bytes, log 0, and the file alone reads its seal, its rows and a healthy health check.

*Not deleting the -wal would NOT have fixed this* — the rename orphans the log by itself. The checkpoint is the fix.

When the checkpoint reports BUSY the file stays where it is: a superseded database that still reads beats a tidy name over an empty one, and the seal inside is what the guards read.

## Tests

`test_a_sealed_archive_is_readable_from_its_own_file_alone` asks the promise itself, platform-blind: copy the archive's own file away from every sibling, then read it. **Re-broken on purpose** — fails with *the archive carries no seal once it stands alone* — then restored.

Full suite on Windows: **1465 passed, 1 xfailed, 0 failures.** CI is the real test, because the fault only bites on Linux.

This fault also owns `test_the_seal_is_recorded_inside_the_file_not_only_in_its_name`, `test_undoing_a_compaction_makes_the_archive_live_again` and `test_compaction.py::test_a_compaction_can_be_undone_because_nothing_was_deleted`. Faults B, C and D of the cluster are separate and not in this PR.