### PR TITLE
fix(capture): the in-flight guard reads the seal, not a filename

### DIFF
--- a/scrapex/capture.py
+++ b/scrapex/capture.py
@@ -32,6 +32,18 @@ def _refuse_if_superseded(conn: sqlite3.Connection) -> None:
 
     Checked HERE, inside the lock and immediately before the insert, because
     that is the only point where the answer cannot go stale again.
+
+    THE SEAL IS READ THROUGH THIS CRAWL'S OWN HANDLE, not by reopening a path.
+    `PRAGMA database_list` reports the file as it was named when the connection
+    opened, and a compaction RENAMES it: on macOS and Linux that rename succeeds
+    while handles are open, so the recorded path no longer exists. The previous
+    version passed that stale path to `storage.sealed_at`, whose first line
+    returns "" for a path that is not there — so the guard saw no seal, said
+    nothing, and let the crawl write into the sealed archive. Exactly the
+    disaster the paragraphs above describe, produced by the guard against it.
+
+    The handle does not care what the file is called. It is attached to the
+    database itself, and a seal another connection committed is visible to it.
     """
     from . import storage
 
@@ -39,7 +51,14 @@ def _refuse_if_superseded(conn: sqlite3.Connection) -> None:
     path = row[2] if row is not None else ""
     if not path:
         return                              # in-memory database: nothing to seal
-    when = storage.sealed_at(path)
+    try:
+        found = conn.execute("SELECT value FROM scrapex_meta WHERE key = ?",
+                             (storage.SEALED_KEY,)).fetchone()
+    except sqlite3.DatabaseError:
+        # Older than migration 0002: no scrapex_meta to read, so nothing can
+        # have sealed it. Silence here is the truth, not a swallowed error.
+        return
+    when = found[0] if found else ""
     if when:
         raise WarehouseSupersededError(
             f"The warehouse was replaced at {when} while this crawl was running, "

--- a/tests/test_phase6_review_fixes.py
+++ b/tests/test_phase6_review_fixes.py
@@ -475,3 +475,56 @@ def test_backups_survive_every_lineage_suffix_the_product_writes(db_path):
     twice = db_path.with_name(
         f"{db_path.stem}.compact-{stamp}.compact-{stamp}{db_path.suffix}")
     assert storage.base_stem(twice) == db_path.stem
+
+
+# ---- the in-flight guard must not depend on a filename ----------------------
+
+def test_the_inflight_guard_does_not_depend_on_the_path_it_opened(conn, db_path,
+                                                                  monkeypatch):
+    """The guard asked `storage.sealed_at(path)` with the name
+    `PRAGMA database_list` reports — the name the file had when the connection
+    OPENED. A compaction renames that file, and on macOS and Linux the rename
+    succeeds while handles are still open, so the recorded path stops existing.
+    `sealed_at` returns "" for a path that is not there, so the guard saw no
+    seal, said nothing, and let the crawl write into the sealed archive: the
+    exact disaster it exists to prevent, produced by the guard against it.
+
+    Windows cannot reproduce that by renaming — it refuses to move a file a
+    handle holds, which is the whole reason this went unseen. So the test asks
+    the PROPERTY instead of the mechanic, and asks it on every platform: with
+    `sealed_at` answering exactly as it does for a path that no longer exists,
+    the guard must still refuse. It can only do that by reading through its own
+    handle.
+    """
+    from scrapex.capture import WarehouseSupersededError, _refuse_if_superseded
+
+    storage.mark_sealed(db_path, "sealed", db_path.with_name("successor.db"))
+
+    def gone(_path):
+        return ""                      # what a vanished path answers
+    monkeypatch.setattr(storage, "sealed_at", gone)
+
+    with pytest.raises(WarehouseSupersededError, match="replaced"):
+        _refuse_if_superseded(conn)
+
+
+def test_the_inflight_guard_stays_silent_on_a_live_warehouse(conn):
+    """The other half: a warehouse nobody sealed must not be refused."""
+    from scrapex.capture import _refuse_if_superseded
+
+    _refuse_if_superseded(conn)          # no exception is the assertion
+
+
+def test_the_inflight_guard_says_nothing_about_a_database_too_old_to_have_a_seal(tmp_path):
+    """A database older than migration 0002 has no scrapex_meta at all. Nothing
+    can have sealed it, so the guard must pass — not raise, and not crash."""
+    from scrapex.capture import _refuse_if_superseded
+
+    plain = tmp_path / "ancient.db"
+    old = sqlite3.connect(str(plain))
+    try:
+        old.execute("CREATE TABLE price_observation (price_observation_id INTEGER)")
+        old.commit()
+        _refuse_if_superseded(old)       # no exception is the assertion
+    finally:
+        old.close()


### PR DESCRIPTION
Fault C of four in the archive/compaction cluster. **The guard was defeated by the thing it guards against.**

## What was happening

`_refuse_if_superseded` exists for one scenario, and its own docstring states it: `connector.fetch` runs for minutes holding no lock, so a crawl can return to a handle on a database that was sealed and replaced while it worked. Those rows would land in the archive and be invisible to the live warehouse forever.

It identified the warehouse by `PRAGMA database_list` — which reports the path as it was when the **connection opened** — and passed that path to `storage.sealed_at`. A compaction **renames** that file. On macOS and Linux the rename succeeds while handles are open, so the recorded path stops existing, and `sealed_at` opens with:

```python
if not Path(db_path).exists():
    return ""
```

So the guard read *not sealed*, said nothing, and let the crawl write into the sealed archive. Windows hid it: there the rename fails while a handle is open, so the path still resolves.

## The fix

Ask this crawl's **own handle**:

```sql
SELECT value FROM scrapex_meta WHERE key = 'sealed_at'
```

The handle is attached to the database, not to a name, so a rename cannot blind it — and a seal another connection committed is visible to it. A database older than migration 0002 has no `scrapex_meta`; nothing can have sealed it, so that case returns quietly. The path is still used in the message, where it belongs — it tells the owner where the rows would have gone.

## Tests

`test_the_inflight_guard_does_not_depend_on_the_path_it_opened` asks the **property**, not the mechanic, because Windows cannot reproduce the mechanic — it refuses to rename a file a handle holds, which is exactly why this went unseen. With `sealed_at` stubbed to answer as it does for a vanished path, the guard must still refuse; it can only do that by reading through its own handle.

**Re-broken on purpose** by restoring the path-based read — *DID NOT RAISE WarehouseSupersededError* — then restored. Two more tests hold the edges: a live warehouse is not refused, and a pre-0002 database passes without raising or crashing.

Full suite: **1466 passed, 1 xfailed, 0 failures.**

Independent of #7 (Fault A). Faults B and D are separate and not in this PR.
