### PR TITLE
fix(storage): say superseded when superseded, and refresh the statistics claimed

### DIFF
--- a/scrapex/storage.py
+++ b/scrapex/storage.py
@@ -272,21 +272,35 @@ def resolve_db_path() -> Path:
         # Nothing at the default path, but a sealed sibling means this machine
         # HAS a warehouse — it moved. Starting an empty one here would leave the
         # real history sitting somewhere the owner is never told about.
-        moved_to = _successor_recorded_nearby(fallback)
-        if moved_to:
+        why, went_to = _successor_recorded_nearby(fallback)
+        if went_to:
+            # A compaction and a move leave the same absence behind and mean two
+            # different things. Saying "moved" for a compaction sends the owner
+            # looking for a decision they never made.
+            became = ("was superseded by a compacted database at" if why == "sealed"
+                      else "was moved to")
             raise StorageUnavailableError(
                 f"There is no database at {fallback}, but this machine's warehouse "
-                f"was moved to {moved_to}. ScrapeX will not start an empty one in "
+                f"{became} {went_to}. ScrapeX will not start an empty one in "
                 "its place. Reconnect that location, or point ScrapeX at it."
             )
     return fallback
 
 
-def _successor_recorded_nearby(fallback: Path) -> str:
-    """Where a retired sibling says the warehouse went, if one is there."""
+def _successor_recorded_nearby(fallback: Path) -> tuple[str, str]:
+    """(why, where) a retired sibling says the warehouse went, if one is there.
+
+    The REASON is returned, not discarded. `mark_sealed` stores it as
+    "{reason} -> {successor}" and there are two that reach here: `moved`, a
+    deliberate relocation the owner asked for, and `sealed`, a compaction that
+    replaced this file with a smaller successor. Reading only the target made
+    both of them read as "was moved to", so a compacted-away warehouse told the
+    owner something that had not happened — and a compaction genuinely is not a
+    move.
+    """
     folder = fallback.parent
     if not folder.is_dir():
-        return ""
+        return "", ""
     for candidate in sorted(folder.glob(f"{base_stem(fallback)}.*-*{fallback.suffix}"),
                             reverse=True):
         if not sealed_at(candidate):
@@ -303,8 +317,9 @@ def _successor_recorded_nearby(fallback: Path) -> str:
         finally:
             conn.close()
         if row and " -> " in row[0]:
-            return row[0].split(" -> ", 1)[1]
-    return ""
+            reason, target = row[0].split(" -> ", 1)
+            return reason.strip(), target
+    return "", ""
 
 
 # ---- measuring and checking --------------------------------------------------
@@ -784,6 +799,18 @@ def repair(db_path: Path | str) -> RunResult:
     try:
         conn.execute("REINDEX")
         conn.execute("PRAGMA optimize")
+        # `PRAGMA optimize` only analyses tables THIS connection has queried,
+        # and before SQLite 3.46 it never analyses one that has no statistics
+        # yet. This connection has issued no queries, so on SQLite 3.45 —
+        # ubuntu-24.04's, which is what CI runs — it analysed nothing at all,
+        # and the "statistics refreshed" reported below was simply not true.
+        #
+        # ANALYZE is the unconditional form. Run it only when optimize left
+        # nothing behind, so a newer SQLite keeps its cheaper incremental path
+        # and this costs nothing where it is already correct.
+        if not conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE name = 'sqlite_stat1'").fetchone():
+            conn.execute("ANALYZE")
         conn.commit()
     finally:
         conn.close()

--- a/tests/test_phase6_review_fixes.py
+++ b/tests/test_phase6_review_fixes.py
@@ -475,3 +475,73 @@ def test_backups_survive_every_lineage_suffix_the_product_writes(db_path):
     twice = db_path.with_name(
         f"{db_path.stem}.compact-{stamp}.compact-{stamp}{db_path.suffix}")
     assert storage.base_stem(twice) == db_path.stem
+
+
+# ---- a compaction is not a move, and must not be reported as one ------------
+
+def _sealed_sibling(folder, reason, successor):
+    """A retired warehouse beside an absent default path, as _retire leaves it."""
+    retired = folder / f"harvest.{reason}-20260729T000000Z.db"
+    conn = dbmod.connect(retired)
+    dbmod.migrate(conn)
+    conn.close()
+    storage.mark_sealed(retired, reason, successor)
+    return retired
+
+
+def test_a_compacted_warehouse_is_reported_as_superseded_not_moved(tmp_path,
+                                                                   monkeypatch):
+    """mark_sealed stores "{reason} -> {successor}" and there are two reasons:
+    `moved`, a relocation the owner asked for, and `sealed`, a compaction that
+    replaced the file with a smaller successor. _successor_recorded_nearby read
+    only the target and threw the reason away, so BOTH were reported as "was
+    moved to" — sending the owner to look for a decision they never made."""
+    home = tmp_path / "home"
+    home.mkdir()
+    absent = home / "harvest.db"
+    _sealed_sibling(home, "sealed", home / "harvest.compacted.db")
+
+    monkeypatch.setattr(dbmod, "DEFAULT_DB_PATH", absent)
+    monkeypatch.setattr(storage, "POINTER_FILE", tmp_path / "location.json")
+
+    with pytest.raises(storage.StorageUnavailableError, match="superseded"):
+        storage.resolve_db_path()
+
+
+def test_a_moved_warehouse_is_still_reported_as_moved(tmp_path, monkeypatch):
+    """The other half: a relocation must keep saying so. One wording for two
+    different events is what this fixes, not a rename of the other."""
+    home = tmp_path / "home"
+    home.mkdir()
+    absent = home / "harvest.db"
+    _sealed_sibling(home, "moved", tmp_path / "elsewhere" / "harvest.db")
+
+    monkeypatch.setattr(dbmod, "DEFAULT_DB_PATH", absent)
+    monkeypatch.setattr(storage, "POINTER_FILE", tmp_path / "location.json")
+
+    with pytest.raises(storage.StorageUnavailableError, match="moved to"):
+        storage.resolve_db_path()
+
+
+# ---- repair must keep the promise it prints ---------------------------------
+
+def test_repair_refreshes_statistics_on_every_sqlite_version(conn, db_path):
+    """repair() reports "statistics refreshed". `PRAGMA optimize` only analyses
+    tables THIS connection has queried, and before SQLite 3.46 it never analyses
+    one with no statistics yet — and repair's connection has issued no queries.
+    On ubuntu-24.04's SQLite 3.45, which is what CI runs, it analysed nothing
+    and the sentence was false. Asserted on the OUTCOME, so it holds on both."""
+    conn.close()
+
+    result = storage.repair(db_path)
+    assert result.ok, result.detail
+
+    check = dbmod.connect(db_path)
+    try:
+        assert check.execute(
+            "SELECT COUNT(*) FROM sqlite_master WHERE name = 'sqlite_stat1'"
+        ).fetchone()[0] == 1, (
+            "repair reported refreshed statistics but produced none — "
+            f"SQLite {sqlite3.sqlite_version}")
+    finally:
+        check.close()


### PR DESCRIPTION
Faults **B** and **D**, the last two of the archive/compaction cluster. Both are small; both are the code saying something that is not true.

## B — a compaction is not a move

`mark_sealed` stores `"{reason} -> {successor}"`, and two reasons reach the reader: `moved`, a relocation the owner asked for, and `sealed`, a compaction that replaced the file with a smaller successor. `_successor_recorded_nearby` split on `" -> "`, returned the target and **threw the reason away** — so `resolve_db_path` worded both as *this machine's warehouse was moved to …*.

An owner who never moved anything is told their warehouse was moved, and sent looking for a decision they did not make. The reason now travels with the target and the sentence follows it.

This surfaces precisely **because Fault A (#7) was fixed**: with the log drained the rename now succeeds on POSIX, so the default path really is absent and this branch is the one that answers.

## D — "statistics refreshed" was not always true

`repair()` runs `REINDEX` then `PRAGMA optimize` and reports *Indexes rebuilt and statistics refreshed*. `PRAGMA optimize` only analyses tables the **connection** has queried, and before SQLite 3.46 it never analyses one that has no statistics yet — and `repair`'s connection has issued no queries. On ubuntu-24.04's SQLite **3.45**, which is what CI runs, it analysed nothing, produced no `sqlite_stat1`, and the sentence was false.

`ANALYZE` is the unconditional form, and it now runs **only when optimize left nothing behind**, so a newer SQLite keeps its cheaper incremental path.

Fixed in the **product**, not the test. The failing test was asserting something true — that Repair produces planner statistics — and weakening it would have kept a false sentence in the interface.

## Tests

- `test_a_compacted_warehouse_is_reported_as_superseded_not_moved`, with a counterpart holding that a real move still says *moved to*. **Re-broken on purpose**: the compaction case reports *was moved to* and the test fails.
- `test_repair_refreshes_statistics_on_every_sqlite_version` asserts the **outcome** rather than the mechanism, so it holds on both versions.

**Stated plainly:** I could not make D's test fail on this machine and did not pretend to — local SQLite is 3.50.4, where optimize behaves; CI's 3.45 is where the fault bites. B's test was re-broken and observed failing.

Full suite: **1466 passed, 1 xfailed, 0 failures.**

Closes the cluster with #7 (A) and #8 (C). Independent of both.
