### PR TITLE
fix(archive): close the compaction cluster - four faults, one green suite

### DIFF
--- a/scrapex/capture.py
+++ b/scrapex/capture.py
@@ -32,6 +32,18 @@ def _refuse_if_superseded(conn: sqlite3.Connection) -> None:
 
     Checked HERE, inside the lock and immediately before the insert, because
     that is the only point where the answer cannot go stale again.
+
+    THE SEAL IS READ THROUGH THIS CRAWL'S OWN HANDLE, not by reopening a path.
+    `PRAGMA database_list` reports the file as it was named when the connection
+    opened, and a compaction RENAMES it: on macOS and Linux that rename succeeds
+    while handles are open, so the recorded path no longer exists. The previous
+    version passed that stale path to `storage.sealed_at`, whose first line
+    returns "" for a path that is not there — so the guard saw no seal, said
+    nothing, and let the crawl write into the sealed archive. Exactly the
+    disaster the paragraphs above describe, produced by the guard against it.
+
+    The handle does not care what the file is called. It is attached to the
+    database itself, and a seal another connection committed is visible to it.
     """
     from . import storage
 
@@ -39,7 +51,14 @@ def _refuse_if_superseded(conn: sqlite3.Connection) -> None:
     path = row[2] if row is not None else ""
     if not path:
         return                              # in-memory database: nothing to seal
-    when = storage.sealed_at(path)
+    try:
+        found = conn.execute("SELECT value FROM scrapex_meta WHERE key = ?",
+                             (storage.SEALED_KEY,)).fetchone()
+    except sqlite3.DatabaseError:
+        # Older than migration 0002: no scrapex_meta to read, so nothing can
+        # have sealed it. Silence here is the truth, not a swallowed error.
+        return
+    when = found[0] if found else ""
     if when:
         raise WarehouseSupersededError(
             f"The warehouse was replaced at {when} while this crawl was running, "

--- a/scrapex/storage.py
+++ b/scrapex/storage.py
@@ -272,21 +272,35 @@ def resolve_db_path() -> Path:
         # Nothing at the default path, but a sealed sibling means this machine
         # HAS a warehouse — it moved. Starting an empty one here would leave the
         # real history sitting somewhere the owner is never told about.
-        moved_to = _successor_recorded_nearby(fallback)
-        if moved_to:
+        why, went_to = _successor_recorded_nearby(fallback)
+        if went_to:
+            # A compaction and a move leave the same absence behind and mean two
+            # different things. Saying "moved" for a compaction sends the owner
+            # looking for a decision they never made.
+            became = ("was superseded by a compacted database at" if why == "sealed"
+                      else "was moved to")
             raise StorageUnavailableError(
                 f"There is no database at {fallback}, but this machine's warehouse "
-                f"was moved to {moved_to}. ScrapeX will not start an empty one in "
+                f"{became} {went_to}. ScrapeX will not start an empty one in "
                 "its place. Reconnect that location, or point ScrapeX at it."
             )
     return fallback
 
 
-def _successor_recorded_nearby(fallback: Path) -> str:
-    """Where a retired sibling says the warehouse went, if one is there."""
+def _successor_recorded_nearby(fallback: Path) -> tuple[str, str]:
+    """(why, where) a retired sibling says the warehouse went, if one is there.
+
+    The REASON is returned, not discarded. `mark_sealed` stores it as
+    "{reason} -> {successor}" and there are two that reach here: `moved`, a
+    deliberate relocation the owner asked for, and `sealed`, a compaction that
+    replaced this file with a smaller successor. Reading only the target made
+    both of them read as "was moved to", so a compacted-away warehouse told the
+    owner something that had not happened — and a compaction genuinely is not a
+    move.
+    """
     folder = fallback.parent
     if not folder.is_dir():
-        return ""
+        return "", ""
     for candidate in sorted(folder.glob(f"{base_stem(fallback)}.*-*{fallback.suffix}"),
                             reverse=True):
         if not sealed_at(candidate):
@@ -303,8 +317,9 @@ def _successor_recorded_nearby(fallback: Path) -> str:
         finally:
             conn.close()
         if row and " -> " in row[0]:
-            return row[0].split(" -> ", 1)[1]
-    return ""
+            reason, target = row[0].split(" -> ", 1)
+            return reason.strip(), target
+    return "", ""
 
 
 # ---- measuring and checking --------------------------------------------------
@@ -784,6 +799,18 @@ def repair(db_path: Path | str) -> RunResult:
     try:
         conn.execute("REINDEX")
         conn.execute("PRAGMA optimize")
+        # `PRAGMA optimize` only analyses tables THIS connection has queried,
+        # and before SQLite 3.46 it never analyses one that has no statistics
+        # yet. This connection has issued no queries, so on SQLite 3.45 —
+        # ubuntu-24.04's, which is what CI runs — it analysed nothing at all,
+        # and the "statistics refreshed" reported below was simply not true.
+        #
+        # ANALYZE is the unconditional form. Run it only when optimize left
+        # nothing behind, so a newer SQLite keeps its cheaper incremental path
+        # and this costs nothing where it is already correct.
+        if not conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE name = 'sqlite_stat1'").fetchone():
+            conn.execute("ANALYZE")
         conn.commit()
     finally:
         conn.close()

--- a/scrapex/storage.py
+++ b/scrapex/storage.py
@@ -1006,6 +1006,44 @@ def migrate_location(db_path: Path | str, new_dir: Path | str, *,
                 "superseded — do not point ScrapeX back at it by hand."))
 
 
+def drain_wal(db_path: Path | str) -> bool:
+    """Fold a database's write-ahead log into the file itself.
+
+    WHY THIS EXISTS, and it is not housekeeping.
+
+    Every connection here is WAL-mode (`db.connect` sets `PRAGMA journal_mode =
+    WAL`), and SQLite only folds the log back into the main file when the LAST
+    connection closes. During a compaction or a move the caller still holds the
+    warehouse open, so nothing folds — and measured on a real warehouse at the
+    moment of sealing, the main file was 4 KB while the log was 1.7 MB. The
+    whole warehouse was in the log.
+
+    That is what made the two lines below a DATA-LOSS bug: `_retire` renamed the
+    main file and then deleted the `-wal` beside it. On Windows the rename fails
+    (the caller's open handle blocks it) so the log survived and nobody noticed.
+    On macOS and Linux the rename SUCCEEDS while handles are open, the log is
+    orphaned by the new name and then unlinked, and the archive `compaction.py`
+    promises never to delete becomes a husk with no schema, no seal and no rows.
+
+    Returns True when the log is drained and the file stands alone. False when
+    SQLite reported the checkpoint BUSY — another connection is mid-read, the
+    log still holds rows, and the file must not be renamed away from it.
+    """
+    try:
+        conn = sqlite3.connect(str(db_path))
+    except sqlite3.DatabaseError:
+        return False
+    try:
+        row = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+        # (busy, log_pages, checkpointed_pages). `busy` is 1 when the checkpoint
+        # could not run to completion — the one answer that must stop a rename.
+        return bool(row) and row[0] == 0
+    except sqlite3.DatabaseError:
+        return False
+    finally:
+        conn.close()
+
+
 def _retire(path: Path, reason: str, successor: Path) -> tuple[str, bool]:
     """Mark a superseded database, then TRY to rename it. Returns where it is.
 
@@ -1013,8 +1051,16 @@ def _retire(path: Path, reason: str, successor: Path) -> tuple[str, bool]:
     fails routinely on Windows, where the caller's own open handle blocks it.
     Relying on the rename alone left a superseded database sitting at the
     default path, ready to be opened as live if the pointer were ever lost.
+
+    THE ORDER IS THE POINT: drain the log BEFORE renaming. A rename carries one
+    file, and until the log is folded in that file is not the archive — see
+    `drain_wal`. If the log cannot be drained the file stays exactly where it
+    is: a superseded database that still READS is worth more than a tidy name
+    over an empty one, and the seal inside it is what the guards actually read.
     """
     marked = mark_sealed(path, reason, successor)
+    if not drain_wal(path):
+        return str(path), marked
     retired = path.with_name(
         f"{path.stem}.{reason}-{settings.file_stamp()}{path.suffix}")
     try:

--- a/tests/test_phase6_review_fixes.py
+++ b/tests/test_phase6_review_fixes.py
@@ -542,3 +542,54 @@ def test_a_busy_checkpoint_leaves_the_database_where_it_is(tmp_path):
     finally:
         probe.close()
         holder.close()
+# ---- the in-flight guard must not depend on a filename ----------------------
+
+def test_the_inflight_guard_does_not_depend_on_the_path_it_opened(conn, db_path,
+                                                                  monkeypatch):
+    """The guard asked `storage.sealed_at(path)` with the name
+    `PRAGMA database_list` reports — the name the file had when the connection
+    OPENED. A compaction renames that file, and on macOS and Linux the rename
+    succeeds while handles are still open, so the recorded path stops existing.
+    `sealed_at` returns "" for a path that is not there, so the guard saw no
+    seal, said nothing, and let the crawl write into the sealed archive: the
+    exact disaster it exists to prevent, produced by the guard against it.
+
+    Windows cannot reproduce that by renaming — it refuses to move a file a
+    handle holds, which is the whole reason this went unseen. So the test asks
+    the PROPERTY instead of the mechanic, and asks it on every platform: with
+    `sealed_at` answering exactly as it does for a path that no longer exists,
+    the guard must still refuse. It can only do that by reading through its own
+    handle.
+    """
+    from scrapex.capture import WarehouseSupersededError, _refuse_if_superseded
+
+    storage.mark_sealed(db_path, "sealed", db_path.with_name("successor.db"))
+
+    def gone(_path):
+        return ""                      # what a vanished path answers
+    monkeypatch.setattr(storage, "sealed_at", gone)
+
+    with pytest.raises(WarehouseSupersededError, match="replaced"):
+        _refuse_if_superseded(conn)
+
+
+def test_the_inflight_guard_stays_silent_on_a_live_warehouse(conn):
+    """The other half: a warehouse nobody sealed must not be refused."""
+    from scrapex.capture import _refuse_if_superseded
+
+    _refuse_if_superseded(conn)          # no exception is the assertion
+
+
+def test_the_inflight_guard_says_nothing_about_a_database_too_old_to_have_a_seal(tmp_path):
+    """A database older than migration 0002 has no scrapex_meta at all. Nothing
+    can have sealed it, so the guard must pass — not raise, and not crash."""
+    from scrapex.capture import _refuse_if_superseded
+
+    plain = tmp_path / "ancient.db"
+    old = sqlite3.connect(str(plain))
+    try:
+        old.execute("CREATE TABLE price_observation (price_observation_id INTEGER)")
+        old.commit()
+        _refuse_if_superseded(old)       # no exception is the assertion
+    finally:
+        old.close()

--- a/tests/test_phase6_review_fixes.py
+++ b/tests/test_phase6_review_fixes.py
@@ -475,3 +475,70 @@ def test_backups_survive_every_lineage_suffix_the_product_writes(db_path):
     twice = db_path.with_name(
         f"{db_path.stem}.compact-{stamp}.compact-{stamp}{db_path.suffix}")
     assert storage.base_stem(twice) == db_path.stem
+
+
+# ---- the sealed archive must be a whole database, not a pointer to one -------
+
+def test_a_sealed_archive_is_readable_from_its_own_file_alone(conn, db_path):
+    """compaction.py promises "ScrapeX never unlinks it. Every observation that
+    ever existed is still in that file." That promise was false.
+
+    Every connection is WAL-mode, and SQLite folds the log back into the file
+    only when the LAST connection closes. During a compaction the caller still
+    holds the warehouse open, so nothing folds: measured at the moment of
+    sealing, the main file was 4 KB and the log was 1.7 MB — the whole warehouse
+    was in the log. `_retire` then renamed the main file and deleted the `-wal`
+    beside it. On Windows the rename fails and the log survives, which is why
+    this went unseen; on macOS and Linux the rename succeeds and the archive
+    becomes a husk with no schema, no seal and no rows.
+
+    So the question this asks is the promise itself, and it is platform-blind:
+    take the archive's OWN FILE, alone, away from any sibling — and read it.
+    """
+    digest = aggressive(conn)
+    result = compaction.compact_warehouse(conn, db_path, today=TODAY,
+                                          expected_digest=digest)
+    sealed = Path(result.sealed_path)
+
+    alone = sealed.with_name("carried-away-by-itself.db")
+    shutil.copy2(sealed, alone)          # the main file and nothing else
+
+    probe = sqlite3.connect(f"file:{alone}?mode=ro", uri=True)
+    try:
+        seal = probe.execute(
+            "SELECT value FROM scrapex_meta WHERE key = ?",
+            (storage.SEALED_KEY,)).fetchone()
+        assert seal and seal[0], "the archive carries no seal once it stands alone"
+        observations = probe.execute(
+            "SELECT COUNT(*) FROM price_observation").fetchone()[0]
+        assert observations == len(HISTORY), (
+            f"the archive kept {observations} of {len(HISTORY)} observations "
+            "— the write-ahead log was thrown away with them")
+    finally:
+        probe.close()
+
+    assert storage.health(alone)["ok"], "the archive alone does not pass a health check"
+
+
+def test_a_busy_checkpoint_leaves_the_database_where_it_is(tmp_path):
+    """The other half of the rule: if the log CANNOT be folded in, the file must
+    not be renamed away from it. A tidy name over an empty file is the loss;
+    a superseded database that still reads is not."""
+    live = tmp_path / "harvest.db"
+    holder = dbmod.connect(live)
+    dbmod.migrate(holder)
+    ingest_payloads(holder, make_entry(), [make_payload([one_row()])])
+    holder.commit()
+
+    assert storage.drain_wal(live) is True
+    wal = live.with_name(live.name + "-wal")
+    assert not wal.exists() or wal.stat().st_size == 0, "the log was not drained"
+
+    # And the file now stands on its own, with the caller still holding it open.
+    probe = sqlite3.connect(f"file:{live}?mode=ro", uri=True)
+    try:
+        assert probe.execute(
+            "SELECT COUNT(*) FROM price_observation").fetchone()[0] == 1
+    finally:
+        probe.close()
+        holder.close()

--- a/tests/test_phase6_review_fixes.py
+++ b/tests/test_phase6_review_fixes.py
@@ -593,3 +593,71 @@ def test_the_inflight_guard_says_nothing_about_a_database_too_old_to_have_a_seal
         _refuse_if_superseded(old)       # no exception is the assertion
     finally:
         old.close()
+# ---- a compaction is not a move, and must not be reported as one ------------
+
+def _sealed_sibling(folder, reason, successor):
+    """A retired warehouse beside an absent default path, as _retire leaves it."""
+    retired = folder / f"harvest.{reason}-20260729T000000Z.db"
+    conn = dbmod.connect(retired)
+    dbmod.migrate(conn)
+    conn.close()
+    storage.mark_sealed(retired, reason, successor)
+    return retired
+
+
+def test_a_compacted_warehouse_is_reported_as_superseded_not_moved(tmp_path,
+                                                                   monkeypatch):
+    """mark_sealed stores "{reason} -> {successor}" and there are two reasons:
+    `moved`, a relocation the owner asked for, and `sealed`, a compaction that
+    replaced the file with a smaller successor. _successor_recorded_nearby read
+    only the target and threw the reason away, so BOTH were reported as "was
+    moved to" — sending the owner to look for a decision they never made."""
+    home = tmp_path / "home"
+    home.mkdir()
+    absent = home / "harvest.db"
+    _sealed_sibling(home, "sealed", home / "harvest.compacted.db")
+
+    monkeypatch.setattr(dbmod, "DEFAULT_DB_PATH", absent)
+    monkeypatch.setattr(storage, "POINTER_FILE", tmp_path / "location.json")
+
+    with pytest.raises(storage.StorageUnavailableError, match="superseded"):
+        storage.resolve_db_path()
+
+
+def test_a_moved_warehouse_is_still_reported_as_moved(tmp_path, monkeypatch):
+    """The other half: a relocation must keep saying so. One wording for two
+    different events is what this fixes, not a rename of the other."""
+    home = tmp_path / "home"
+    home.mkdir()
+    absent = home / "harvest.db"
+    _sealed_sibling(home, "moved", tmp_path / "elsewhere" / "harvest.db")
+
+    monkeypatch.setattr(dbmod, "DEFAULT_DB_PATH", absent)
+    monkeypatch.setattr(storage, "POINTER_FILE", tmp_path / "location.json")
+
+    with pytest.raises(storage.StorageUnavailableError, match="moved to"):
+        storage.resolve_db_path()
+
+
+# ---- repair must keep the promise it prints ---------------------------------
+
+def test_repair_refreshes_statistics_on_every_sqlite_version(conn, db_path):
+    """repair() reports "statistics refreshed". `PRAGMA optimize` only analyses
+    tables THIS connection has queried, and before SQLite 3.46 it never analyses
+    one with no statistics yet — and repair's connection has issued no queries.
+    On ubuntu-24.04's SQLite 3.45, which is what CI runs, it analysed nothing
+    and the sentence was false. Asserted on the OUTCOME, so it holds on both."""
+    conn.close()
+
+    result = storage.repair(db_path)
+    assert result.ok, result.detail
+
+    check = dbmod.connect(db_path)
+    try:
+        assert check.execute(
+            "SELECT COUNT(*) FROM sqlite_master WHERE name = 'sqlite_stat1'"
+        ).fetchone()[0] == 1, (
+            "repair reported refreshed statistics but produced none — "
+            f"SQLite {sqlite3.sqlite_version}")
+    finally:
+        check.close()


### PR DESCRIPTION
**The integration of #7 (A), #8 (C) and #9 (B+D).** Each of those PRs fixes exactly its own fault and no more — which is why none of them can be green alone. CI proved that precisely:

- **#7** (Fault A) leaves 2 failures: C's guard and D's repair.
- **#8** (Fault C) leaves 4 failures: A's three and D's repair.

This branch carries all three so the cluster can be judged as one. Same three commits, cherry-picked; the only resolution was positional — all three append tests to the end of one file, so both sides were kept in order.

## The four faults

| | What was untrue | Where |
|---|---|---|
| **A** | `compaction.py` promises the archive keeps every observation. On POSIX it became a husk: the rename orphaned a 1.7 MB write-ahead log holding the whole warehouse, then unlinked it. | `storage.py` `_retire` |
| **C** | The in-flight guard identified the warehouse by a path a rename destroys, read *not sealed*, and let a crawl write **into** the sealed archive — the disaster it exists to prevent. | `capture.py` |
| **B** | A compaction was reported to the owner as a *move* they never made. | `storage.py` `resolve_db_path` |
| **D** | `repair()` reported *statistics refreshed* while producing none on SQLite < 3.46 — which is what CI runs. | `storage.py` `repair` |

**A and C are data-safety faults**, not red tests. Both were invisible on Windows because `os.replace` refuses to move a file an open handle holds — the code was accidentally safe on one platform through a coupling the other two do not provide.

## Verification

Every fix was **re-broken on purpose** and its test observed failing — except D, where local SQLite is 3.50.4 and the fault cannot reproduce. I did not pretend otherwise; CI's 3.45 is the judge there.

Local: **1466 passed, 1 xfailed, 0 failures.** Archive surface alone: 95 passed.

If CI is green here, this is the **first green `main` in over 60 runs** — the suite has been red since 2026-07-25.
