### PR TITLE
fix(ui): refine the dataset export control

### DIFF
--- a/scrapex/webui/static/grid-theme.css
+++ b/scrapex/webui/static/grid-theme.css
@@ -620,50 +620,65 @@
   justify-content: space-between;
   gap: 1rem;
   margin-top: .75rem;
-  padding: .7rem 1rem;
+  padding: .8rem 1rem;
   border-top: var(--table-rule);
   border-radius: 0;
-  background: var(--bg);
+  background: var(--surface-container-low);
 }
 .data-grid-export-copy { min-width: 0; }
-.data-grid-export-copy strong { display: block; font-size: .76rem; }
-.data-grid-export-copy span { display: block; margin-top: .08rem; color: var(--muted); font-size: .64rem; }
+.data-grid-export-copy strong {
+  display: block;
+  color: var(--text);
+  font-size: var(--fs-sm);
+  line-height: 1.3;
+}
+.data-grid-export-copy span {
+  display: block;
+  max-width: 42rem;
+  margin-top: var(--sp-1);
+  color: var(--muted);
+  font-size: var(--fs-xs);
+  line-height: 1.45;
+}
 .data-grid-exportbar #grid-toolbar { flex: none; justify-content: flex-end; margin: 0; }
 .grid-export-split {
   display: inline-flex;
   align-items: stretch;
+  border: 1px solid var(--line-strong);
   border-radius: var(--radius);
-  box-shadow: var(--shadow-sm);
+  background: var(--surface);
+  box-shadow: var(--shadow-xs);
 }
 .grid-export-primary,
 .grid-export-trigger {
   min-height: var(--control-height);
-  border-color: var(--button-bg);
-  background: var(--button-bg);
-  color: var(--button-text);
+  border: 0;
+  background: transparent;
+  color: var(--text);
 }
 .grid-export-primary {
   display: inline-flex;
   align-items: center;
   gap: var(--sp-2);
   padding-inline: var(--sp-4);
-  border-radius: var(--radius) 0 0 var(--radius);
+  border-start-start-radius: calc(var(--radius) - 1px);
+  border-end-start-radius: calc(var(--radius) - 1px);
+  font-weight: var(--fw-heavy);
 }
 .grid-export-primary .sx-icon {
   width: 1.05rem;
   height: 1.05rem;
+  color: var(--accent-ink);
 }
 #grid-toolbar .grid-export-primary:hover:not(:disabled),
 #grid-toolbar .grid-export-trigger:hover {
-  border-color: var(--button-hover);
-  background: var(--button-hover);
-  color: var(--button-hover-text);
+  background: var(--control-hover);
+  color: var(--text);
 }
 #grid-toolbar .grid-export-primary:active:not(:disabled),
 #grid-toolbar .grid-export-trigger:active {
-  border-color: var(--button-active);
-  background: var(--button-active);
-  color: var(--button-hover-text);
+  background: var(--accent-weak);
+  color: var(--accent-ink);
   transform: none;
 }
 .grid-export-menu {
@@ -682,8 +697,9 @@
   min-width: var(--control-height);
   padding: 0;
   place-items: center;
-  border-inline-start-color: color-mix(in srgb, var(--button-text) 24%, transparent);
-  border-radius: 0 var(--radius) var(--radius) 0;
+  border-inline-start: 1px solid var(--line);
+  border-start-end-radius: calc(var(--radius) - 1px);
+  border-end-end-radius: calc(var(--radius) - 1px);
   cursor: pointer;
 }
 .grid-export-trigger .sx-icon {
@@ -697,35 +713,52 @@
 .grid-export-menu[open] .grid-export-chevron {
   transform: rotate(180deg);
 }
+.grid-export-menu[open] .grid-export-trigger {
+  background: var(--accent-weak);
+  color: var(--accent-ink);
+}
 .grid-export-options {
   position: absolute;
   z-index: 120;
   inset-inline-end: 0;
   bottom: calc(100% + var(--sp-2));
   display: grid;
-  gap: 0;
-  width: min(15rem, calc(100vw - 2rem));
-  padding: var(--sp-1);
+  gap: var(--sp-1);
+  width: min(20rem, calc(100vw - 2rem));
+  padding: var(--sp-2);
   background: var(--surface);
-  border: var(--table-rule);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  transform-origin: bottom right;
+  animation: grid-export-options-in var(--dur-fast) var(--ease);
 }
-.grid-export-options-title {
-  padding: var(--sp-2) var(--sp-3);
+@keyframes grid-export-options-in {
+  from { opacity: 0; transform: translateY(.35rem) scale(.98); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+.grid-export-options-head {
+  display: grid;
+  gap: var(--sp-1);
+  padding: var(--sp-2) var(--sp-3) var(--sp-3);
+  border-bottom: 1px solid var(--line);
+}
+.grid-export-options-head strong {
+  color: var(--text);
+  font-size: var(--fs-sm);
+}
+.grid-export-options-head span {
   color: var(--muted);
-  font-size: var(--fs-2xs);
-  font-weight: var(--fw-heavy);
-  letter-spacing: .06em;
-  text-transform: uppercase;
+  font-size: var(--fs-xs);
+  line-height: 1.4;
 }
 .grid-export-option {
   display: grid;
-  grid-template-columns: 2rem minmax(0, 1fr);
+  grid-template-columns: 2rem minmax(0, 1fr) auto;
   align-items: center;
-  gap: var(--sp-2);
+  gap: var(--sp-3);
   width: 100%;
-  min-height: 3rem;
+  min-height: 3.5rem;
   padding: var(--sp-2) var(--sp-3);
   color: var(--text);
   background: transparent;
@@ -748,15 +781,19 @@
 .grid-export-option-icon {
   display: grid;
   place-items: center;
-  width: 1.15rem;
-  height: 1.15rem;
+  width: 2rem;
+  height: 2rem;
+  border-radius: var(--radius);
+  background: var(--accent-weak);
   color: var(--accent-ink);
 }
+.grid-export-option-icon .sx-icon {
+  width: 1.05rem;
+  height: 1.05rem;
+}
 .grid-export-option-copy {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: var(--sp-3);
+  display: grid;
+  gap: var(--sp-1);
   min-width: 0;
 }
 .grid-export-option-copy strong {
@@ -764,18 +801,34 @@
 }
 .grid-export-option-copy small {
   color: var(--muted);
-  font-family: var(--font-mono);
   font-size: var(--fs-2xs);
   font-weight: var(--fw-regular);
+  line-height: 1.35;
+}
+.grid-export-extension {
+  padding: .15rem .35rem;
+  border-radius: var(--radius-xs);
+  background: var(--surface-container-low);
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-2xs);
+  line-height: 1.4;
 }
 
 @media (max-width: 640px) {
   .data-grid-exportbar { align-items: flex-start; flex-direction: column; }
-  .data-grid-exportbar #grid-toolbar { justify-content: flex-start; }
+  .data-grid-exportbar #grid-toolbar,
+  .grid-export-split { width: 100%; }
+  .grid-export-primary { flex: 1; justify-content: center; }
   .grid-export-options {
-    inset-inline-start: 0;
-    inset-inline-end: auto;
+    inset-inline-start: auto;
+    inset-inline-end: 0;
+    width: min(20rem, calc(100vw - 3rem));
   }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .grid-export-options { animation: none; }
 }
 
 .grid-feature-popover {

--- a/scrapex/webui/templates/datasets.html
+++ b/scrapex/webui/templates/datasets.html
@@ -6,7 +6,7 @@
    fail exactly when the owner is offline. See static/vendor/README.md. #}
   <link rel="stylesheet" href="/static/vendor/tabulator.min.css">
   {# Loaded AFTER the library so the project's own table appearance wins. #}
-  <link rel="stylesheet" href="/static/grid-theme.css?v=design-system-42">
+  <link rel="stylesheet" href="/static/grid-theme.css?v=design-system-43">
   <link rel="stylesheet" href="/static/pages/datasets.css">
   <script src="/static/vendor/tabulator.min.js" defer></script>
 {% endblock %}

--- a/scrapex/webui/templates/source.html
+++ b/scrapex/webui/templates/source.html
@@ -8,14 +8,14 @@
    the owner is offline. See static/vendor/README.md. #}
   <link rel="stylesheet" href="/static/vendor/tabulator.min.css">
   {# Loaded AFTER the library so the project's own table appearance wins. #}
-  <link rel="stylesheet" href="/static/grid-theme.css?v=design-system-42">
+  <link rel="stylesheet" href="/static/grid-theme.css?v=design-system-43">
   <link rel="stylesheet" href="/static/pages/data-workspace.css?v=source-ui-8">
   <script src="/static/vendor/tabulator.min.js" defer></script>
   <script src="/static/datasets-browser.js?v=source-ui-8" defer></script>
 {# StaticFiles supplies validators but no Cache-Control policy. A new URL is
    therefore intentional when grid behaviour changes: an already-cached script
    must not keep the old sorting persistence or header controls after update. #}
-  <script src="/static/grid.js?v=design-system-42" defer></script>
+  <script src="/static/grid.js?v=design-system-43" defer></script>
 {% endblock %}
 {% block content %}
 {# Interface language is English only (spec 1). Scraped values are DATA: they
@@ -275,41 +275,50 @@
            button called a browser-side writer whose library was never
            vendored, so it produced nothing at all. #}
         <div class="data-grid-export-copy">
-          <strong>Export</strong>
-          <span>CSV and JSON carry this view — your filters, column order and
-                hidden columns. Excel carries the whole record: prices,
-                details, price history and where each figure came from.</span>
+          <strong>Export data</strong>
+          <span>Excel includes the complete record. CSV and JSON follow the
+                current table view.</span>
         </div>
         <div id="grid-toolbar" class="toolbar" aria-label="Export">
           <div class="grid-export-split" role="group" aria-label="Export data">
             <button type="button" class="grid-export-primary" data-export="xlsx"
-                    title="Export the complete record as an Excel workbook">
+                    aria-label="Export complete record as an Excel workbook"
+                    title="Export complete record as an Excel workbook">
               {{ icon("file-download") }}
-              <span>Export Excel</span>
+              <span>Excel workbook</span>
             </button>
             <details class="grid-export-menu">
               <summary class="grid-export-trigger" aria-haspopup="menu"
-                       aria-expanded="false" aria-label="Choose another export format"
-                       title="Choose another export format">
+                       aria-expanded="false" aria-label="Other export formats"
+                       title="Other export formats">
                 {{ icon("expand-more", "grid-export-chevron") }}
               </summary>
               <div class="grid-export-options" role="menu" aria-label="Export format">
-                <span class="grid-export-options-title">Export current table as</span>
+                <div class="grid-export-options-head">
+                  <strong>Other formats</strong>
+                  <span>Uses visible columns, filters and their current order.</span>
+                </div>
                 <button type="button" class="grid-export-option" data-export="csv"
                         role="menuitem">
-                  {{ icon("description", "grid-export-option-icon") }}
+                  <span class="grid-export-option-icon">
+                    {{ icon("description") }}
+                  </span>
                   <span class="grid-export-option-copy">
                     <strong>CSV table</strong>
-                    <small>.csv</small>
+                    <small>Filtered rows in a spreadsheet-friendly file.</small>
                   </span>
+                  <span class="grid-export-extension">.csv</span>
                 </button>
                 <button type="button" class="grid-export-option" data-export="json"
                         role="menuitem">
-                  {{ icon("insert-drive-file", "grid-export-option-icon") }}
+                  <span class="grid-export-option-icon">
+                    {{ icon("insert-drive-file") }}
+                  </span>
                   <span class="grid-export-option-copy">
                     <strong>JSON data</strong>
-                    <small>.json</small>
+                    <small>Structured data from the current table view.</small>
                   </span>
+                  <span class="grid-export-extension">.json</span>
                 </button>
               </div>
             </details>

--- a/tests/test_vendor.py
+++ b/tests/test_vendor.py
@@ -308,9 +308,11 @@ def test_grid_behaviour_changes_bust_the_browser_cache():
     # stay together in its compact, accessible format menu.
     # design-system-42: header filter/menu controls gained keyboard semantics
     # and a visible token-based focus state.
-    assert '/static/grid.js?v=design-system-42' in page
-    assert '/static/grid-theme.css?v=design-system-42' in page
-    assert '/static/grid-theme.css?v=design-system-42' in (
+    # design-system-43: the export split control gained a quieter hierarchy
+    # and a structured, descriptive menu without changing export behaviour.
+    assert '/static/grid.js?v=design-system-43' in page
+    assert '/static/grid-theme.css?v=design-system-43' in page
+    assert '/static/grid-theme.css?v=design-system-43' in (
         TEMPLATES / "datasets.html").read_text(encoding="utf-8")
 
 
@@ -369,13 +371,19 @@ def test_export_actions_follow_the_grid_instead_of_sitting_above_it():
     assert 'class="grid-export-primary" data-export="xlsx"' in page
     assert 'class="grid-export-menu"' in page
     assert 'class="grid-export-trigger"' in page
+    assert '<span>Excel workbook</span>' in page
+    assert 'class="grid-export-options-head"' in page
     assert page.count('class="grid-export-option"') == 2
+    assert page.count('class="grid-export-extension"') == 2
     assert page.count("data-export=") == 3
     assert 'class="chip" data-export=' not in page
     assert 'role="menu" aria-label="Export format"' in page
     assert 'if (event.key !== "Escape" || !menu.open) return;' in script
     assert 'if (menu.open && !menu.contains(event.target)) closeMenu();' in script
     assert ".grid-export-split" in css
+    split_rule = css.split(".grid-export-split {", 1)[1].split("}", 1)[0]
+    assert "overflow: hidden" not in split_rule, "the split must not clip its menu"
+    assert ".grid-export-menu[open] .grid-export-trigger" in css
     assert "#grid-toolbar .grid-export-primary:active:not(:disabled)" in css
     assert ".grid-export-options" in css
     assert "#grid-toolbar .grid-export-option:active:not(:disabled)" in css


### PR DESCRIPTION
Review of `eef4fe6` from `codex/export-control-design-review`, rebased onto the post-cluster `main`. **Approved.**

## What I checked, and why

Three branches reviewed today asked to be merged while already being on `main` by content, and two of them would have **reverted** `main` had they landed. So this one was checked against the same three questions before approval:

**1. Is it already on main?** No. One commit, one ahead / zero behind. `main`'s `190bf24` was a different pass at the same control; this builds on it.

**2. Does it revert anything?** No — and this is the check that failed for `review-fixes`. The asset cache version moves **42 → 43**, forward. Nothing on `main` is undone.

**3. Does it change export behaviour, as it claims not to?** No, and this is structural rather than a matter of trust: the diff touches `grid-theme.css`, two templates and `test_vendor.py` — **no `.py` and no `.js` at all**. The `data-export` attributes and the script that reads them are untouched, so export behaviour cannot change.

## What it does

A quieter hierarchy for the split control: Excel is the primary action, the other two formats sit in its menu. `aria-label` added to the primary button and the trigger, so both announce themselves.

## One observation, not a blocker

The helper text is shortened:

> **before** — CSV and JSON carry this view — your filters, column order and hidden columns. Excel carries the whole record: prices, details, price history and where each figure came from.
> **after** — Excel includes the complete record. CSV and JSON follow the current table view.

Still true, and terser reads better in a control. What it drops is the *enumeration* — which filters travel, and what "the whole record" contains. If that detail is wanted it belongs in the tooltip rather than the panel.

## Verification

`tests/test_vendor.py` + `tests/test_grid_dom.py` + `tests/test_phase6_review_fixes.py`: **107 passed** on the rebased base.
