### PR TITLE
fix(ingest): the trade tier reaches the warehouse instead of waiting forever

### DIFF
--- a/scrapex/ingest.py
+++ b/scrapex/ingest.py
@@ -565,13 +565,37 @@ def _observation_values(r: dict, observed_at: str) -> dict:
     stock_raw = r["stock_quantity"]
     stock_dec = parse_money(stock_raw) if stock_raw else None
     stock = _to_float(stock_dec)
-    # record_hash keeps its original composition — it is the dedupe key on
-    # ux_price_obs_dedupe and part of the frozen cross-engine contract, so
-    # changing it would silently re-key every existing warehouse.
+    trade_dec = parse_money(r.get("price_trade", "")) if r.get("price_trade") else None
+    # record_hash decides whether this observation is NEW. Its composition is the
+    # dedupe key on ux_price_obs_dedupe and part of the frozen cross-engine
+    # contract, so a key added unconditionally would re-hash every observation of
+    # every source and append a duplicate for all 73,000 of them on the next
+    # crawl. `trade` is therefore added ONLY when the shop published one.
+    #
+    # THE ABSENT FIELD CONTRIBUTES NOTHING — the rule pricekey.py already states
+    # and the reason this is safe: a source with no trade price hashes exactly
+    # what it hashed yesterday, so nothing moves for it, ever.
+    #
+    # WHY IT HAD TO GO IN. 0052 moved the trade tier out of the details bag into
+    # price_observation.price_trade and left it out of every hash, writing down
+    # the cost: "a run where ONLY the trade price moved appends no observation".
+    # The real cost was larger. An observation is only ever WRITTEN when the hash
+    # differs, so an offer whose retail price had not moved never got a new row
+    # at all — and the column stayed NULL on the rows that already existed.
+    # Measured on the live warehouse: two successful sikaegshop crawls after
+    # 0052, 2,461 rows each, and 0 of 73,084 observations carried a trade price;
+    # the newest sikaegshop observation was still dated two days BEFORE the
+    # migration. The values 0052 promised would "be re-fetched on the next crawl"
+    # could not arrive, because nothing asked the warehouse to write a row.
+    #
+    # It is NOT added to the price key, and that stays deliberate: this is a
+    # different customer's price, so it must not split the retail timeline. It
+    # answers "is this row new", not "did the price change".
     content_hash = record_hash({
         "effective": _canon_amount(effective), "regular": _canon_amount(regular),
         "sale": _canon_amount(sale), "currency": r["currency"], "vat": vat,
         "availability": availability, "stock": _canon_amount(stock_dec),
+        **({"trade": _canon_amount(trade_dec)} if trade_dec is not None else {}),
     })
     # price_hash answers a different question: is this the SAME PRICE? It leaves
     # availability and stock out — the owner wants the latest stock state, not
@@ -606,13 +630,10 @@ def _observation_values(r: dict, observed_at: str) -> dict:
         "price_before": _to_float(regular),
         "price_sale": _to_float(sale),
         "price": _to_float(effective),
-        # NOT in record_hash or the price key: it is a DIFFERENT customer's
-        # price, so hashing it would split one product's timeline on a number
-        # the owner is never charged — and record_hash is the frozen
-        # cross-engine dedupe key. The cost is stated in migration 0052: a run
-        # where ONLY this moved appends no observation.
-        "price_trade": _to_float(parse_money(r.get("price_trade", ""))
-                                 if r.get("price_trade") else None),
+        # In record_hash when the shop publishes one (see above), never in the
+        # PRICE key: it is a different customer's price, so it must not split
+        # the retail timeline this warehouse exists to track.
+        "price_trade": _to_float(trade_dec),
         "currency": r["currency"],
         "tax_included": vat,
         "availability": availability,
@@ -975,8 +996,34 @@ def _still_the_same_price(conn: sqlite3.Connection, offer_id: int, v: dict) -> b
         return False
     if open_period["price_hash"] != v["price_hash"]:
         return False
-    return pricekey.comparable(pricekey.parse_fields(open_period["price_fields"]),
-                               pricekey.parse_fields(v["price_fields"]))
+    if not pricekey.comparable(pricekey.parse_fields(open_period["price_fields"]),
+                               pricekey.parse_fields(v["price_fields"])):
+        return False
+
+    # SAME PRICE PERIOD, BUT IS THERE ANYTHING NEW TO RECORD? Two questions were
+    # collapsed into one here, and the second was never asked.
+    #
+    # The retail price key deliberately excludes the trade tier (0052: it is a
+    # different customer's price and must not split this product's timeline).
+    # But this function is also the gate on whether an observation is APPENDED
+    # AT ALL — so a shop that moved only its trade price was confirmed, nothing
+    # was written, and the column stayed NULL forever. Measured on the live
+    # warehouse: two sikaegshop crawls after 0052, 0 of 73,084 observations
+    # carrying a trade price, and the newest sikaegshop row still dated two days
+    # BEFORE the migration that introduced the column.
+    #
+    # So the period stays keyed on the price — a trade move opens no new period —
+    # while a trade move that is genuinely new still lands as an observation
+    # INSIDE that period. The retail timeline is unchanged; the fact is recorded.
+    if v.get("price_trade") is not None:
+        latest = conn.execute(
+            "SELECT price_trade FROM price_observation "
+            "WHERE offer_id = ? AND provenance = 'observed' "
+            "ORDER BY observed_at DESC, price_observation_id DESC LIMIT 1",
+            (offer_id,)).fetchone()
+        if latest is None or latest["price_trade"] != v["price_trade"]:
+            return False
+    return True
 
 
 def _derive_seen(conn: sqlite3.Connection, result: IngestResult) -> None:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -406,3 +406,67 @@ def test_the_retirement_sweep_speaks_through_notices_not_errors():
     assert result.errors == []
     assert result.contained == []
     assert len(result.notices) == 1 and "retired 3" in result.notices[0]
+
+
+# ---- the trade tier has to REACH the warehouse -------------------------------
+
+def test_a_published_trade_price_lands_on_the_observation(conn):
+    """0052 moved the trade tier into price_observation.price_trade and left it
+    out of every hash. An observation is only ever WRITTEN when record_hash
+    differs, so an offer whose retail price had not moved never got a new row —
+    and the column stayed NULL on the rows that already existed. Measured on the
+    live warehouse: two sikaegshop crawls after 0052, and 0 of 73,084
+    observations carried a trade price."""
+    ingest_payloads(conn, make_entry(), [make_payload([
+        one_row(price="1252.50", price_trade="939.38")])])
+    stored = conn.execute(
+        "SELECT price, price_trade FROM price_observation").fetchone()
+    assert stored[0] == 1252.50
+    assert stored[1] == 939.38, "the shop published a trade price and it was dropped"
+
+
+def test_the_trade_price_moving_alone_is_a_new_observation(conn):
+    """The failure 0052 wrote down and accepted. It is now a real change: the
+    retail price is identical, only the trade tier moved, and that IS news."""
+    ingest_payloads(conn, make_entry(), [make_payload([
+        one_row(price="1252.50", price_trade="939.38")])])
+    ingest_payloads(conn, make_entry(), [make_payload([
+        one_row(price="1252.50", price_trade="900.00")])])
+
+    rows = conn.execute(
+        "SELECT price, price_trade FROM price_observation"
+        " ORDER BY price_observation_id").fetchall()
+    assert len(rows) == 2, "a trade price that moved was swallowed as a duplicate"
+    assert [r[1] for r in rows] == [939.38, 900.00]
+    assert {r[0] for r in rows} == {1252.50}, "the retail price must not have moved"
+
+
+def test_a_source_with_no_trade_price_is_hashed_exactly_as_before(conn):
+    """The reason this change is safe for 73,000 rows. `trade` enters the hash
+    ONLY when the shop published one — the rule pricekey.py already states, that
+    an absent field contributes nothing. Added unconditionally it would re-key
+    every observation of every source and append a duplicate for all of them on
+    the next crawl."""
+    ingest_payloads(conn, make_entry(), [make_payload([one_row(price="100.00")])])
+    first = conn.execute("SELECT record_hash FROM price_observation").fetchone()[0]
+
+    # The same row again: a shop that publishes no trade price must produce the
+    # very same hash, so nothing is appended.
+    result = ingest_payloads(conn, make_entry(), [make_payload([one_row(price="100.00")])])
+    again = conn.execute("SELECT record_hash FROM price_observation").fetchall()
+    assert len(again) == 1, "an unchanged row without a trade price was re-appended"
+    assert again[0][0] == first
+    assert result.observations == 0, "an unchanged row was appended again"
+
+
+def test_the_trade_price_does_not_open_a_price_period(conn):
+    """It is a DIFFERENT customer's price. It must be recorded, and it must not
+    split the retail timeline — the distinction 0052 got right and this keeps."""
+    ingest_payloads(conn, make_entry(), [make_payload([
+        one_row(price="1252.50", price_trade="939.38")])])
+    ingest_payloads(conn, make_entry(), [make_payload([
+        one_row(price="1252.50", price_trade="900.00")])])
+
+    hashes = {row[0] for row in conn.execute(
+        "SELECT price_hash FROM price_observation")}
+    assert len(hashes) == 1, "a trade-price move opened a new retail price period"


### PR DESCRIPTION
The owner reported that sika's Tier-02 prices exist in 13 archived databases and are absent from the live one. They are — and they were never coming back.

## Measured on the live warehouse

| | |
|---|---|
| observations carrying a trade price | **0 of 73,084** |
| `trade_tier_price` attribute rows left | 0 |
| successful sikaegshop crawls since 0052 | **2** (2,461 rows each) |
| newest sikaegshop observation | **2026-07-26** — two days *before* 0052 |

`0052` moved the trade tier into `price_observation.price_trade`, left it out of every hash, and wrote down the cost it thought it was accepting: *"a run where ONLY the trade price moved appends no observation."*

## Why it was worse than that

`_still_the_same_price` is not only the price-period test — it is **the gate on whether an observation is appended at all**. It answers with the price key, and the price key excludes the trade tier on purpose. So for every offer whose retail price had not moved, the run confirmed and returned, no row was written, and the column stayed NULL on the rows that already existed.

Sika's prices have not moved since 26 July. The values were not waiting for "something else to change" — they were waiting indefinitely.

Two questions had been collapsed into one: *is this the same price period?* and *is there anything new to record?* Only the first was ever asked.

## The fix

The period stays keyed on the price — a trade move opens **no** new period, which is 0052's ruling and it is right: a different customer's price must not split this product's timeline. But a trade price that is genuinely new now lands as an observation **inside** that period.

`trade` also joins `record_hash`, **and only when the shop published one**. That condition is the whole safety of this change: added unconditionally it would re-hash every observation of every source and append a duplicate for all 73,000 on the next crawl. An absent field contributes nothing — the rule `pricekey.py` already states.

The frozen cross-engine contract is untouched: `parity.test.mjs` hashes the vectors' own inputs, not ingest's. **3/3 pass.**

## What I got wrong first

The plan said *"put price_trade into record_hash and roll PRICE_KEY_VERSION"*. Half wrong, and recorded in the commit so the next reader does not repeat it: `record_hash` is the right destination but only conditionally, and the version roll belongs to the **other** key — `price_hash`, comparability — where a bump would have re-baselined every offer of every source for nothing. The actual gate was neither hash, but `_still_the_same_price` one level above both.

## Tests

Four. The second was **re-broken on purpose** — *"a trade price that moved was swallowed as a duplicate"* — then restored.

- a published trade price lands on the observation
- the trade price moving **alone** is a new observation
- a source with no trade price is hashed exactly as before, and appends nothing
- a trade-price move does **not** open a new price period

Full suite: **1475 passed, 1 xfailed, 0 failures.** Contract parity: **3/3**.

The 78 archived values are not restored by this — it makes the **next** sikaegshop crawl record them, which is what 0052 intended and could not deliver.
