### PR TITLE
feat(zid): the store's own exchange rate, and the cookie that hid it

### DIFF
--- a/scrapex/capture.py
+++ b/scrapex/capture.py
@@ -275,6 +275,7 @@ def capture_source(conn: sqlite3.Connection, entry: SourceEntry,
         defects = list(dict.fromkeys(d for t in tables for d in t.defects))
         result = ingest_payloads(conn, entry, payloads, job_id=job_id,
                                  fetch_defects=defects)
+        _store_published_rates(conn, entry, tables, result)
     if journal:
         localinbox.clear(localinbox.JOURNAL_DIR, entry.source_key)
     # rows/tables come from the PAYLOADS: on a resume the fetched tables are
@@ -283,3 +284,30 @@ def capture_source(conn: sqlite3.Connection, entry: SourceEntry,
                          tables=len(payloads), rows=sum(len(p.rows) for p in payloads),
                          warnings=[w for t in tables for w in t.warnings],
                          notes=list(getattr(fetcher, "robots_warnings", []) or []))
+
+
+def _store_published_rates(conn, entry, tables: list, result) -> None:
+    """The rate the STORE printed about itself, into currency_rate as 'shop'.
+
+    Read from `tables` and not from the journal for the same reason defects
+    are: the payload contract is frozen across engines and carries no rate, so
+    this is what THIS attempt saw. A resume reads it again off its first page.
+
+    ISOLATED, NOT SILENT. A rate that will not store must not cost the
+    catalogue that was already ingested — but a failure that leaves no trace is
+    how the USD column goes on quoting a stale number with nothing anywhere
+    saying why (the lesson _record_implied_rate spells out). So the failure
+    becomes a NOTICE: the run is not partial, and the reason is on the record.
+    """
+    published: dict[str, float] = {}
+    for table in tables:
+        published.update(getattr(table, "published_rates", None) or {})
+    if not published:
+        return
+    from . import rates as rates_mod
+    try:
+        rates_mod.store_shop_rates(conn, entry.source_key, published)
+    except (ValueError, TypeError, sqlite3.DatabaseError) as exc:
+        result.notices.append(
+            f"the exchange rate {entry.source_key} publishes about itself was "
+            f"not stored ({', '.join(sorted(published))}) — {exc}")

--- a/scrapex/connectors/base.py
+++ b/scrapex/connectors/base.py
@@ -60,6 +60,15 @@ class ScrapedTable:
     # skip_tokens on resume, so a paused 400-page crawl re-fetches only what
     # it has not already fetched.
     page_token: str = ""
+    # Exchange rates the SITE ITSELF publishes: ISO code -> units per USD.
+    # A storefront that prices for more than one country prints the rate it
+    # converts with in its own page bootstrap. That number is a fact ABOUT THE
+    # SOURCE, not a row of its data, so it travels the same road as warnings
+    # and defects and is deliberately NOT in to_payload — the payload contract
+    # is frozen across engines. capture writes these to currency_rate under
+    # source_kind='shop', where 0054 guarantees a storefront's rate can never
+    # be read as a market rate.
+    published_rates: dict[str, float] = field(default_factory=dict)
 
     def to_payload(self, client: PayloadClient = PayloadClient.CLI, run_ref: str | None = None) -> FunnelPayload:
         return FunnelPayload(
@@ -216,6 +225,32 @@ class HttpFetcher:
         self.on_request = None
 
     # ---- validators, so a repeat crawl can be answered with 304 -------------
+
+    def fresh_session(self) -> "HttpFetcher":
+        """A SECOND fetcher with this one's settings and none of its state.
+
+        For the rare case where a site's answer depends on the session itself
+        and the crawl's session must not be disturbed. advancedcastle is the
+        one: it pins the country in a cookie on a session's first request and
+        thereafter redirects every URL to that country, so reading its Egyptian
+        page on the crawl's own session returns the Saudi one — 200, no error —
+        and asking for it FIRST would have turned every remaining product page
+        Egyptian. A separate session answers the question and touches nothing.
+
+        Deliberately a method here rather than a connector building its own
+        client: politeness, retries and the honest UA stay defined in exactly
+        one place (Q1). Deliberately NOT inheriting validators, robots cache or
+        counters either — those describe the crawl, and this is not the crawl.
+        The caller closes it.
+        """
+        return HttpFetcher(
+            user_agent=self._user_agent,
+            min_interval_s=self._min_interval_s,
+            timeout_s=self._client.timeout.read or 30.0,
+            max_attempts=self._max_attempts,
+            jitter=self._jitter,
+            honour_crawl_delay=self._honour_crawl_delay,
+        )
 
     def remember_validators(self, state: dict[str, dict[str, str]]) -> None:
         """Load validators kept from a previous crawl."""

--- a/scrapex/connectors/zid.py
+++ b/scrapex/connectors/zid.py
@@ -17,9 +17,37 @@ conditional on that advertisement, so an Arabic-only Zid store pays nothing.
 The connector follows only the English alternate for the configured region and
 uses it for text fields. Price, currency, availability, identity and country
 remain anchored to the original page selected by the source configuration.
+
+THE STORE'S OWN EXCHANGE RATE (2026-07-29). A Zid storefront that sells into
+more than one country prints, in every page's bootstrap JSON, the rate it
+converts with: `"code": "SAR", ..., "exchange_rate": "3.754116"`. Each locale
+prints ONLY its own active currency, so the Saudi pages never mention EGP and
+the reverse. The connector reads the rate off pages it was fetching anyway, and
+spends ONE extra request per FOREIGN COUNTRY the page itself advertises — never
+a guessed path, always an `hreflang` the store published. capture stores them
+under source_kind='shop'.
+
+THE COUNTRY IS A COOKIE, NOT A PATH (measured 2026-07-29, and it matters far
+beyond the rate). The store pins the country in a `locale` cookie on the first
+request of a session and thereafter REDIRECTS every URL to the pinned country,
+overriding the path prefix. Asked for /ar-eg/... on a session that had already
+seen a Saudi page, it answered 200 from /ar-sa/... in SAR — no error, no clue.
+So the prefix only decides the FIRST request of a session. Two consequences the
+next reader must not have to rediscover: the foreign-rate probe runs on a
+fetcher of its own (below), and this crawl's own session must never be allowed
+to touch an Egyptian URL first, or every product page after it would come back
+in EGP and be stored as a Saudi price.
+
+Two things this deliberately does NOT do. It does not convert anything: the
+crawled price stays the price the store printed. And it does not reconcile the
+rate with the prices — on 2026-07-29 the store published 3.754116 SAR and
+50.5485 EGP per USD (a ratio of 13.46) while its Egyptian pages priced at a
+ratio of 11.768. That mismatch is the store's, and recording what it publishes
+is the only way anyone can ever see it.
 """
 from __future__ import annotations
 
+import re
 from typing import Iterable
 from urllib.parse import urljoin
 
@@ -32,6 +60,56 @@ from .jsonld import (WalkTally, alternate_links, english_alternate, offer_price,
                      walk_product_pages)
 
 _PRODUCT_PATH = "/products/"
+
+# One currency block of the store bootstrap. The lookahead keeps the pair
+# INSIDE a single block: without it a store listing several currencies would
+# marry the first code to some later block's rate — a wrong number that looks
+# exactly like a right one.
+_STORE_RATE = re.compile(
+    r'"code"\s*:\s*"([A-Za-z]{3})"'
+    r'(?:(?!"code"\s*:).)*?'
+    r'"exchange_rate"\s*:\s*"?([0-9]*\.?[0-9]+)"?',
+    re.S)
+
+# 1 USD buying more than a million units is a parse gone wrong, not a rate.
+# Same ceiling rates.py applies to Google Finance, restated at this door
+# because a bad number refused here never reaches the database at all.
+_MAX_PER_USD = 1e6
+
+
+def _bootstrap_rates(html: str) -> dict[str, float]:
+    """{ISO code: units per USD} the page's own bootstrap publishes.
+
+    Foreign content, so every number is bounded and anything unfit is dropped
+    rather than stored: a rate of zero would divide, and an absurd one would
+    quietly rank this store's prices above or below every other source.
+    """
+    out: dict[str, float] = {}
+    for code, raw in _STORE_RATE.findall(html):
+        try:
+            value = float(raw)
+        except ValueError:
+            continue
+        if 0 < value <= _MAX_PER_USD:
+            out.setdefault(code.upper(), value)
+    return out
+
+
+def _foreign_country_links(links: dict[str, str], home_region: str) -> dict[str, str]:
+    """{region: one page} for every country BUT ours, from the page's own
+    alternates. `en` (no region) and `x-default` name no country and are
+    skipped; two locales of the same country collapse to one request."""
+    home = (home_region or "").strip().lower()
+    out: dict[str, str] = {}
+    for code, href in links.items():
+        parts = code.split("-")
+        if len(parts) != 2 or len(parts[1]) != 2:
+            continue                      # "en", "x-default": no country named
+        region = parts[1]
+        if region == home:
+            continue
+        out.setdefault(region, href)
+    return out
 
 
 def _product_id(url: str, node: dict) -> str:
@@ -54,12 +132,29 @@ class ZidConnector:
         base = source.base_url.rstrip("/")
         vat = "1" if source.vat_mode.value == "incl" else "0"
         tally = WalkTally()
+        rates: dict[str, float] = {}
+        rate_notes: list[str] = []
+        asked_abroad = False
 
         for url, token, html, node in walk_product_pages(
                 self._fetcher, self._product_urls(f"{base}/sitemap.xml", tally),
                 self.skip_tokens, safe_token, tally):
             # Decided BEFORE the English request, so a variant-priced product we
             # are going to skip anyway never costs a second fetch.
+            # This page was fetched for its price; its bootstrap carries the
+            # store's rate for the currency IT prices in, so reading it costs
+            # nothing. Done before the price check: a product with no price
+            # still published the store's rate.
+            rates.update(_bootstrap_rates(html))
+            if not asked_abroad:
+                # ONCE per crawl, and only for countries this page itself
+                # advertises. Each locale prints only its active currency, so
+                # without this the Egyptian rate the store converts with would
+                # never be seen — and it is the one the owner asked for.
+                asked_abroad = True
+                abroad, notes = self._rates_abroad(html, url, source)
+                rates.update(abroad)
+                rate_notes.extend(notes)
             if not offer_price(node.get("offers"))[0]:
                 tally.priceless += 1
                 continue
@@ -83,13 +178,90 @@ class ZidConnector:
         # Every skip above used to be silent, so a crawl that landed half the
         # catalogue reported plain success — the GPP lesson, and the one salla
         # already learned. Carrying on is right; not saying so is not.
-        notes = tally.notes()
-        if notes:
+        notes = tally.notes() + rate_notes
+        if notes or rates:
             # Untokenized on purpose: the counts describe THIS attempt, and
             # capture drops them on resume so a resumed run reports its own.
+            # The rates ride here for the same reason — they are what THIS
+            # crawl read, and a resume reads them again off its first page.
             yield ScrapedTable(source.source_key, PRODUCT_PRICES.kind, base,
                                RowBuilder(PRODUCT_PRICES).header, [],
-                               warnings=notes)
+                               warnings=notes, published_rates=rates)
+
+    def _rates_abroad(self, html: str, url: str,
+                      source: SourceEntry) -> tuple[dict[str, float], list[str]]:
+        """({ISO: per USD}, warnings) for every country but ours.
+
+        One request per foreign country the PAGE advertises, once per crawl. A
+        single-country store advertises none and pays nothing.
+
+        ON A SESSION OF ITS OWN, and that is the whole difficulty (measured
+        2026-07-29). This store pins the country in a `locale` cookie on the
+        first request and then REDIRECTS every later URL to the pinned country,
+        path prefix and all: asked for /ar-eg/... on a session that had already
+        seen a Saudi page, it answered from /ar-sa/... in SAR, status 200, no
+        error anywhere. Reusing the crawl's fetcher would therefore have filed
+        the Saudi rate under Egypt — a wrong number that looks exactly like a
+        right one. A fresh session starts fresh, and on a fresh session the
+        prefix wins. The session comes from the TRANSPORT (fresh_session), not
+        built here: politeness lives in one place, and a transport that offers
+        none — every test stub — makes this ask nothing and say why.
+
+        It must not run the other way either: the crawl's own session is left
+        untouched, because had the probe pinned it to Egypt every remaining
+        product page would have come back in EGP and been stored as a Saudi
+        price. The catalogue is the thing being protected here, not the rate.
+
+        VERIFIED, NOT TRUSTED. Whatever the mechanism, a foreign page that
+        answers in the store's HOME currency is not the foreign page, so that
+        answer is refused and said out loud. A missing rate must never cost the
+        catalogue (Q3) — and must never vanish quietly either, which is how a
+        USD column goes on quoting last month's number with nothing saying why.
+        """
+        rates: dict[str, float] = {}
+        notes: list[str] = []
+        countries = _foreign_country_links(alternate_links(html),
+                                           source.default_region)
+        if not countries:
+            return rates, notes
+        new_session = getattr(self._fetcher, "fresh_session", None)
+        if new_session is None:
+            # The transport cannot give us a second session, so the question
+            # cannot be asked SAFELY. Asking on the crawl's own session is the
+            # one thing that must never happen — it would file this store's
+            # Saudi rate under Egypt. Saying nothing would be worse than saying
+            # this, so it is said.
+            return rates, [
+                f"{', '.join(sorted(r.upper() for r in countries))}: this "
+                "transport offers no separate session, so the store's foreign "
+                "exchange rate was not read. It is NOT read on the crawl's own "
+                "session — that returns the home country's rate under the "
+                "foreign country's name."]
+        home = (source.currency or "").strip().upper()
+        for region, href in countries.items():
+            target = urljoin(url, href)
+            probe = new_session()               # its own session; see above
+            try:
+                found = _bootstrap_rates(probe.get(target).text)
+            except CrawlBlocked:
+                raise                    # the site said stop — stop
+            except Exception as exc:  # noqa: BLE001 — one page never kills a crawl
+                notes.append(f"{region.upper()}: the store's exchange rate was "
+                             f"not read from {target} — {exc}")
+                continue
+            finally:
+                probe.close()
+            foreign = {c: v for c, v in found.items() if c != home}
+            if not foreign:
+                notes.append(
+                    f"{region.upper()}: {target} answered in "
+                    f"{', '.join(sorted(found)) or 'no currency at all'} — not a "
+                    f"foreign currency, so the country switch did not happen and "
+                    f"no rate was recorded for {region.upper()}. Re-verify how "
+                    "this store selects its country.")
+                continue
+            rates.update(foreign)
+        return rates, notes
 
     def _product_urls(self, sitemap_url: str, tally: WalkTally) -> list[str]:
         """Zid's rule for what a product URL is; the walking is shared."""

--- a/scrapex/rates.py
+++ b/scrapex/rates.py
@@ -271,6 +271,58 @@ def store_rates(conn: sqlite3.Connection, rates: list[Rate]) -> int:
     return written
 
 
+def store_shop_rates(conn: sqlite3.Connection, source_key: str,
+                     rates: dict[str, float], as_of: str = "") -> int:
+    """Store the rate a STOREFRONT publishes about itself, under its own key.
+
+    Different in kind from store_rates above, and the difference is the whole
+    point of 0054's source_kind: google_finance is a rate service whose
+    business IS the rate, while advancedcastle is a shop printing the number it
+    converts its own prices with. Both are facts; only one is a market rate,
+    and a reader must never have to guess which row is which.
+
+    `as_of` is the moment we READ it. A storefront stamps no time on its rate,
+    so a date alone would claim it held all day — something we did not observe.
+    The full timestamp is what we can attest to, and it interleaves correctly
+    with the date-only publisher-implied rows (ISO text sorts chronologically,
+    and readers take ORDER BY as_of DESC LIMIT 1).
+
+    Bounds are enforced here as well as at the parser: this function is public,
+    and a rate assembled by hand must not smuggle in what a fetch would refuse.
+    Returns the number of rows written or refreshed. Commits on success.
+    """
+    if not rates:
+        return 0
+    stamp = as_of or utc_now_iso()
+    kinded = dbmod.has_column(conn, 'currency_rate', 'source_kind')
+    written = 0
+    for raw_code, value in rates.items():
+        code = (raw_code or "").strip().upper()
+        if not _CURRENCY_CODE.fullmatch(code) or code == "USD":
+            # USD skipped for the same reason store_rates skips it: a rate of
+            # 1 is definitional noise, not an observation about this shop.
+            continue
+        if not math.isfinite(value) or value <= 0 or value > MAX_PLAUSIBLE_PER_USD:
+            raise ValueError(
+                f"refusing to store {source_key}'s {code} rate {value!r}: "
+                "outside the plausible range (0, 1e6]")
+        conn.execute(
+            "INSERT INTO currency_rate "
+            "  (currency, per_usd, as_of, source_key, source_kind) "
+            "VALUES (?,?,?,?,'shop') "
+            "ON CONFLICT(currency, as_of, source_key) DO UPDATE SET "
+            "  per_usd = excluded.per_usd"
+            if kinded else
+            "INSERT INTO currency_rate (currency, per_usd, as_of, source_key) "
+            "VALUES (?,?,?,?) "
+            "ON CONFLICT(currency, as_of, source_key) DO UPDATE SET "
+            "  per_usd = excluded.per_usd",
+            (code, float(value), stamp, source_key))
+        written += 1
+    conn.commit()
+    return written
+
+
 # How stale a stored rate may be before the worker fetches again. Google Finance
 # moves continuously, but the owner's question is "what was this worth", not
 # "what is it worth this second" — and a scraper that reloads a quote page every

--- a/scrapex/reports.py
+++ b/scrapex/reports.py
@@ -774,6 +774,31 @@ def column_presence(conn: sqlite3.Connection, source_key: str) -> set[str]:
     return present
 
 
+# WHICH publisher's rate the USD column uses when several priced one currency.
+#
+# A MARKET rate always wins. 0054 split provider from shop precisely because "a
+# shop's rate is evidence about that shop, and must never be mistaken for a
+# market rate" — and ordering by recency alone hands the whole USD column to
+# whichever storefront happened to be crawled last. advancedcastle publishes a
+# SAR/EGP ratio of 13.46 while pricing its own Egyptian pages at 11.768; a
+# number like that must never convert some other source's prices.
+#
+# Recency alone was survivable only by accident: publisher-implied rates carry
+# a DATE ("2026-07-29") and Google Finance a full timestamp, and text sorting
+# puts the timestamp last, so the provider won without anyone arranging it. A
+# shop rate stamped with a full read time ends that luck.
+#
+# A shop's rate is still USED where no rate service published one — that
+# fallback is what ranks the 128 currencies GPP prices in — and the row carries
+# the rate's source and date beside the number, so a reader can always see
+# which kind they got (the owner's standing rule, 2026-07-26).
+#
+# No has_column branch here, unlike the WRITERS in ingest.py and rates.py: this
+# is a read, a missing column fails loudly and at once instead of silently
+# mis-ranking, and source_kind has been NOT NULL since 0054.
+_RATE_BY_AUTHORITY = ("ORDER BY (cr.source_kind = 'provider') DESC, "
+                      "cr.as_of DESC LIMIT 1")
+
 # alias -> SQL expression. The SELECT list and the accessors below are built
 # from ONE mapping, so a column can be added without counting tuple positions.
 _EXPORT_SELECT: dict[str, str] = {
@@ -832,7 +857,7 @@ _EXPORT_SELECT: dict[str, str] = {
                         "          ph4.price_observation_id DESC LIMIT 1)"),
     "per_usd": ("(SELECT cr.per_usd FROM currency_rate cr "
                  " WHERE cr.currency = po.currency "
-                 " ORDER BY cr.as_of DESC LIMIT 1)"),
+                 f" {_RATE_BY_AUTHORITY})"),
     # Not an exported column: the key the site's own filter values are joined on.
     "source_product_id": "sp.source_product_id",
 }
@@ -1680,7 +1705,7 @@ def table_payload(conn: sqlite3.Connection, source_key: str,
         "        LIMIT 1) AS price_previous, "
         "       (SELECT cr.per_usd FROM currency_rate cr "
         "        WHERE cr.currency = po.currency "
-        "        ORDER BY cr.as_of DESC LIMIT 1) AS per_usd, "
+        f"       {_RATE_BY_AUTHORITY}) AS per_usd, "
         "       (SELECT GROUP_CONCAT(spa.raw_value, ', ') FROM source_product_attribute spa "
         "        WHERE spa.source_product_id = sp.source_product_id "
         "        AND spa.attribute_code IN ('category','category_ar')) AS category, "
@@ -1701,10 +1726,10 @@ def table_payload(conn: sqlite3.Connection, source_key: str,
         # cannot travel to the grid alone.
         "       (SELECT cr.as_of FROM currency_rate cr "
         "        WHERE cr.currency = po.currency "
-        "        ORDER BY cr.as_of DESC LIMIT 1) AS usd_rate_as_of, "
+        f"       {_RATE_BY_AUTHORITY}) AS usd_rate_as_of, "
         "       (SELECT cr.source_key FROM currency_rate cr "
         "        WHERE cr.currency = po.currency "
-        "        ORDER BY cr.as_of DESC LIMIT 1) AS usd_rate_source "
+        f"       {_RATE_BY_AUTHORITY}) AS usd_rate_source "
         f"{_LATEST_PER_OFFER} ORDER BY sp.product_name_ar, so.country_code_alpha2 LIMIT ?",
         (source_key, limit)).fetchall()
 

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -582,3 +582,73 @@ def test_two_countries_at_the_same_price_never_fold_into_one_row():
     folded = fold_variant_rows(rows)
     assert len(folded) == 2
     assert {r["country_code_alpha2"] for r in folded} == {"EG", "SA"}
+
+
+# ---- which publisher's rate the USD column uses, 2026-07-29 ---------------
+
+def _kinded_rate(conn, currency, per_usd, as_of, source_key, kind):
+    conn.execute(
+        "INSERT INTO currency_rate "
+        "  (currency, per_usd, as_of, source_key, source_kind) "
+        "VALUES (?,?,?,?,?)", (currency, per_usd, as_of, source_key, kind))
+
+
+def _usd_rate_shown(conn):
+    """(per_usd, source) the grid actually converted with, for the EGP row."""
+    from scrapex.reports import table_payload
+
+    grid = table_payload(conn, "ELSEWEDYSHOP")
+    row = next(r for r in grid["rows"] if r["currency"] == "EGP")
+    return row["usd_rate"], row["usd_rate_source"]
+
+
+def test_a_shops_rate_never_outranks_a_market_rate(conn):
+    """A storefront crawled five minutes ago must not convert the whole
+    warehouse. advancedcastle publishes a SAR/EGP ratio of 13.46 while pricing
+    its own Egyptian pages at 11.768 — a number like that is evidence about
+    that shop, never a market rate (0054), and recency alone would hand it the
+    USD column of every source that prices in EGP."""
+    _kinded_rate(conn, "EGP", 50.10, "2026-07-29T06:00:00Z",
+                 "google_finance", "provider")
+    _kinded_rate(conn, "EGP", 61.99, "2026-07-29T23:59:00Z",   # newer, and a shop
+                 "ADVANCEDCASTLE", "shop")
+    ingest_payloads(conn, make_entry(), [make_payload([
+        one_row(),
+        one_row(external_product_id="1002", external_variant_id="5002",
+                external_sku="SKU2", currency="USD"),
+    ])])
+
+    rate, source = _usd_rate_shown(conn)
+    assert float(rate) == 50.10, "the newer SHOP rate won the USD column"
+    assert source == "google_finance"
+
+
+def test_a_shops_rate_is_still_used_where_no_market_rate_exists(conn):
+    """The fallback is the point, not a leak: publisher-implied rates are what
+    rank the 128 currencies GPP prices in, and the row carries the source and
+    date so a reader sees which kind they got."""
+    _kinded_rate(conn, "EGP", 51.25, "2026-07-13", "GPP_ENERGY", "shop")
+    ingest_payloads(conn, make_entry(), [make_payload([
+        one_row(),
+        one_row(external_product_id="1002", external_variant_id="5002",
+                external_sku="SKU2", currency="USD"),
+    ])])
+
+    rate, source = _usd_rate_shown(conn)
+    assert float(rate) == 51.25 and source == "GPP_ENERGY"
+
+
+def test_the_newest_market_rate_still_wins_among_market_rates(conn):
+    """Authority first, then recency — not authority INSTEAD of recency."""
+    _kinded_rate(conn, "EGP", 49.00, "2026-07-28T12:00:00Z",
+                 "google_finance", "provider")
+    _kinded_rate(conn, "EGP", 50.75, "2026-07-29T12:00:00Z",
+                 "google_finance", "provider")
+    ingest_payloads(conn, make_entry(), [make_payload([
+        one_row(),
+        one_row(external_product_id="1002", external_variant_id="5002",
+                external_sku="SKU2", currency="USD"),
+    ])])
+
+    rate, _source = _usd_rate_shown(conn)
+    assert float(rate) == 50.75

--- a/tests/test_zid.py
+++ b/tests/test_zid.py
@@ -188,11 +188,28 @@ _ONE_PRODUCT_SITEMAP = (
 )
 
 
+def _bootstrap(code: str, rate: str) -> str:
+    """One currency block, in the shape advancedcastle's page bootstrap uses."""
+    return ('<script>window.store = {"currency": {"id": 1, "code": "%s", '
+            '"symbol": " x ", "format": "1,0.00 %s", "exchange_rate": "%s"}, '
+            '"shipping_destination": null};</script>' % (code, code, rate))
+
+
 class _BilingualStubFetcher:
     """The captured ar-sa page and the en page it advertises."""
 
     AR = "live/advancedcastle_product_ar_2026-07-28.trimmed.html"
     EN = "live/advancedcastle_product_en_2026-07-28.trimmed.html"
+
+    # The Egyptian storefront this page advertises, on a session of its own.
+    # A stub that offered none would be the honest default (the probe then asks
+    # nothing and says why) — but this page DOES advertise Egypt, so a faithful
+    # stub answers for Egypt. What it must never do is answer from the crawl's
+    # session: see _CountryPinnedStubFetcher below.
+    EG_RATE = "50.5485"
+
+    def fresh_session(self):
+        return _CountryStubFetcher("EGP", self.EG_RATE)
 
     def __init__(self):
         self.requests_count = 0
@@ -210,6 +227,28 @@ class _BilingualStubFetcher:
         raise RuntimeError("404 " + url)
 
     def close(self): pass
+
+
+class _CountryStubFetcher:
+    """A storefront session that answers in ONE currency, as the real one does.
+
+    Each locale of advancedcastle prints only its own active currency, so a
+    session pinned to Egypt never mentions SAR and the reverse.
+    """
+
+    def __init__(self, code: str, rate: str):
+        self.code, self.rate = code, rate
+        self.requests_count = 0
+        self.urls: list[str] = []
+        self.closed = False
+
+    def get(self, url, **kwargs):
+        self.requests_count += 1
+        self.urls.append(url)
+        return _Resp("<html><head></head><body>" +
+                     _bootstrap(self.code, self.rate) + "</body></html>")
+
+    def close(self): self.closed = True
 
 
 def test_the_english_page_the_store_publishes_fills_the_unmarked_columns():
@@ -340,3 +379,139 @@ def test_zid_end_to_end_into_warehouse():
     finally:
         conn.close()
     assert result.observations == 2 and not result.errors
+
+
+# ---- the rate the store publishes about itself, 2026-07-29 ----------------
+
+def _rate_tables(fetcher, entry):
+    """Every published_rates map the crawl emitted, merged as capture does."""
+    found = {}
+    warnings = []
+    for table in ZidConnector(fetcher).fetch(entry):
+        found.update(table.published_rates)
+        warnings.extend(table.warnings)
+    return found, warnings
+
+
+class _RateStubFetcher(_BilingualStubFetcher):
+    """The captured page PLUS the bootstrap the trimmed fixture dropped."""
+
+    SAR_RATE = "3.754116"
+
+    def get(self, url, **kwargs):
+        resp = super().get(url, **kwargs)
+        if "/products/" in url:
+            return _Resp(resp.text + _bootstrap("SAR", self.SAR_RATE))
+        return resp
+
+
+def test_the_store_rate_rides_the_page_the_crawl_already_fetched():
+    """SAR costs nothing: it is printed on the product page itself."""
+    fetcher = _RateStubFetcher()
+    rates, warnings = _rate_tables(fetcher, make_entry())
+
+    assert rates["SAR"] == 3.754116
+    assert not warnings
+    # Not one extra request for the home currency — it was already in hand.
+    assert not any("/ar-eg/" in u for u in fetcher.urls)
+
+
+def test_the_foreign_rate_is_read_on_a_session_of_its_own():
+    """Egypt's rate is real and reachable, and never on the crawl's session."""
+    fetcher = _RateStubFetcher()
+    rates, warnings = _rate_tables(fetcher, make_entry())
+
+    assert rates == {"SAR": 3.754116, "EGP": 50.5485}
+    assert not warnings
+    # The crawl's OWN session never touched an Egyptian URL. If it had, this
+    # store would have pinned the session to Egypt and every remaining product
+    # page would have come back in EGP and been stored as a Saudi price.
+    assert not any("/ar-eg/" in u or "/en-eg/" in u for u in fetcher.urls)
+
+
+def test_a_country_switch_that_did_not_happen_is_refused_not_recorded():
+    """THE FAULT, re-broken on purpose.
+
+    advancedcastle pins the country in a cookie and then redirects every later
+    URL to it, so a session that has already seen a Saudi page answers the
+    Egyptian URL from Saudi Arabia — 200, no error, SAR. Recording that would
+    file the Saudi rate under Egypt: a wrong number indistinguishable from a
+    right one. It must be refused, and said.
+    """
+    class _CountryPinnedStubFetcher(_RateStubFetcher):
+        # A session that ignores the requested country and answers in SAR —
+        # exactly what the live store does when the cookie is already set.
+        def fresh_session(self):
+            return _CountryStubFetcher("SAR", self.SAR_RATE)
+
+    rates, warnings = _rate_tables(_CountryPinnedStubFetcher(), make_entry())
+
+    assert "EGP" not in rates                 # nothing invented
+    assert rates == {"SAR": 3.754116}         # the home rate still stands
+    assert any("EG" in w and "SAR" in w for w in warnings)
+
+
+def test_a_transport_with_no_second_session_asks_nothing_and_says_so():
+    """Safe by default: no session, no probe, no silence."""
+    class _NoSecondSession(_RateStubFetcher):
+        fresh_session = None
+
+    rates, warnings = _rate_tables(_NoSecondSession(), make_entry())
+
+    assert rates == {"SAR": 3.754116}
+    assert any("separate session" in w for w in warnings)
+
+
+def test_the_probe_closes_the_session_it_opened():
+    """One request, one close: a crawl must not leak a client per country."""
+    opened = []
+
+    class _CountingStub(_RateStubFetcher):
+        def fresh_session(self):
+            probe = _CountryStubFetcher("EGP", self.EG_RATE)
+            opened.append(probe)
+            return probe
+
+    _rate_tables(_CountingStub(), make_entry())
+
+    assert len(opened) == 1                   # one country advertised: eg
+    assert opened[0].requests_count == 1      # and exactly one request for it
+    assert opened[0].closed
+
+
+def test_an_arabic_only_store_never_probes_a_country_at_all():
+    """No alternates, no countries, no requests, no warnings."""
+    class _NoAlternates(_StubFetcher):
+        def get(self, url, **kwargs):
+            resp = super().get(url, **kwargs)
+            if "/products/" in url:
+                return _Resp(resp.text + _bootstrap("SAR", "3.754116"))
+            return resp
+
+        def fresh_session(self):
+            raise AssertionError("a store advertising no country was probed")
+
+    rates, warnings = _rate_tables(_NoAlternates(), make_entry())
+
+    assert rates == {"SAR": 3.754116}
+    assert not warnings
+
+
+def test_one_currency_block_never_borrows_another_blocks_rate():
+    """The parser's real risk: a multi-currency bootstrap marrying the first
+    code to a later block's number, which reads as a perfectly good rate."""
+    from scrapex.connectors.zid import _bootstrap_rates
+
+    html = _bootstrap("SAR", "3.754116") + _bootstrap("EGP", "50.5485")
+
+    assert _bootstrap_rates(html) == {"SAR": 3.754116, "EGP": 50.5485}
+
+
+def test_an_impossible_rate_is_dropped_rather_than_stored():
+    """Foreign content: zero would divide, and an absurd figure would rank this
+    store's prices above or below every other source."""
+    from scrapex.connectors.zid import _bootstrap_rates
+
+    assert _bootstrap_rates(_bootstrap("EGP", "0")) == {}
+    assert _bootstrap_rates(_bootstrap("EGP", "99999999")) == {}
+    assert _bootstrap_rates(_bootstrap("EGP", "50.5")) == {"EGP": 50.5}


### PR DESCRIPTION
The owner asked for advancedcastle's published exchange rate in `currency_rate` under `source_kind='shop'`. Getting it right meant answering three things the store does not volunteer.

## What the store publishes

Every page's bootstrap JSON carries the rate that locale converts with — `"code": "SAR", ..., "exchange_rate": "3.754116"` — and each locale prints **only its active currency**, so Saudi pages never mention EGP and the reverse.

| | source notes | **live 2026-07-29** |
|---|---|---|
| SAR per USD | 3.747989 | **3.754116** |
| EGP per USD | 50.7221 | **50.5485** |

Both moved. That alone is the argument for a dated table over a constant in a file.

## The country is a cookie, not a path

This is the part that would have shipped a wrong number quietly. The store pins the country in a `locale` cookie on a session's **first** request, then redirects every later URL to the pinned country — path prefix and all. Proven both ways on fresh sessions:

- EG page first → EGP; then the **SA** url redirects to `/ar-eg` and answers **EGP**
- SA page first → SAR; then the **EG** url redirects to `/ar-sa` and answers **SAR**

So reading the Egyptian page on the crawl's own session returns the **Saudi** rate — 200, no error — and files it under Egypt. The probe therefore runs on a session of its own, obtained from the **transport** (`HttpFetcher.fresh_session`) rather than built in the connector, so politeness and the honest UA stay in one place — the rule `base.py` already states.

**The reverse matters more than the feature.** Had the probe run first on the crawl's session, every remaining product page would have come back in EGP and been stored as a Saudi price. That is now written down, not left as a fact the code happens to depend on.

**Verified, not trusted:** a foreign page answering in the store's home currency is not the foreign page — refused, and said out loud. A transport offering no second session asks nothing and says why.

## What this deliberately does not do

It does not convert, and it does not reconcile. The store publishes a ratio of **13.46** while pricing its Egyptian pages at **11.768**. That mismatch is the store's own, and recording what it publishes unchanged is the only way anyone can ever see it. Source truth is never edited.

## A bug this found in its own tests

The first version built its own fetcher — so four existing zid tests started making **real HTTP calls to advancedcastle and passing**: 2.2s, 1.06s, 0.92s, 0.87s where the rest of the file runs in hundredths. A suite that goes to the network and stays green is the quietest way a suite can lie. Now 0.01s, and stubs offer no session unless a test says so.

## Cost

Zero extra requests for the home currency, and **one** per foreign country the page itself advertises, once per crawl — never a guessed path, always an `hreflang` the store published. An Arabic-only store pays nothing, and that is tested.

## Tests

Eight, one of them the fault re-broken on purpose:

- the home rate rides the page the crawl already fetched
- the foreign rate is read on a session of its own, and the crawl's session never touches a foreign URL
- **a country switch that did not happen is refused, not recorded**
- a transport with no second session asks nothing and says so
- the probe closes the session it opened
- a store advertising no country is never probed at all
- one currency block never borrows another block's rate
- zero and absurd rates are dropped rather than stored

**1483 passed, 1 xfailed.** Contract parity **3/3** (untouched).

Verified live end to end: SAR read with no extra request, EGP 50.5485 read on its own session, no warnings, and the crawl's session still answering in SAR afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
