### PR TITLE
feat(panel): the crawl pace moves to where the owner actually works

### DIFF
--- a/extension/app.html
+++ b/extension/app.html
@@ -860,6 +860,51 @@
               <div id="outputs" class="output-groups"><div class="skeleton"></div></div>
             </div>
           </article>
+          <!-- The crawl's pace and the engine itself. These existed only on the
+               engine's own web page, which is display-only — so from here, where
+               the owner actually works, they did not exist at all. -->
+          <article class="settings-item">
+            <button class="link sect settings-toggle" data-sect="s-crawl" aria-expanded="false">
+              <span class="settings-index" aria-hidden="true">05</span>
+              <span class="settings-toggle-copy">
+                <span class="settings-title">Crawl pace and engine</span>
+                <span class="settings-description">Pace, log retention and engine restart</span>
+              </span>
+              <svg class="settings-chevron sx-icon" aria-hidden="true">
+                <use href="icons/material-icons.svg#chevron-right"></use>
+              </svg>
+            </button>
+            <div id="s-crawl" class="settings-panel hidden">
+              <p class="muted hint">
+                A site can ask for a pace in its robots.txt. Honouring it is the
+                default and the polite choice; turning it off is yours to make,
+                and every run records which pace it used.</p>
+              <label class="row" for="crawl_honour_delay">
+                <input id="crawl_honour_delay" type="checkbox">
+                <span>Honour each site's requested crawl delay</span>
+              </label>
+              <p class="muted text-xs" id="crawl-pace-effect">&nbsp;</p>
+
+              <label for="crawl_min_interval_s">Minimum seconds between requests</label>
+              <input id="crawl_min_interval_s" type="number" step="0.1" min="0.1" dir="ltr">
+
+              <label for="crawl_timeout_s">Request timeout in seconds</label>
+              <input id="crawl_timeout_s" type="number" min="1" dir="ltr">
+
+              <label for="crawl_user_agent">User agent</label>
+              <input id="crawl_user_agent" type="text" dir="ltr" spellcheck="false"
+                     placeholder="leave empty for the built-in honest agent">
+
+              <label for="log_retention_days">Keep job logs for (days)</label>
+              <input id="log_retention_days" type="number" min="1" dir="ltr">
+
+              <div class="row mt-2">
+                <button id="crawl-save" class="primary">Save</button>
+                <button id="engine-restart" class="link">Restart engine</button>
+              </div>
+              <div id="crawl-msg" class="muted text-sm" role="status" aria-live="polite"></div>
+            </div>
+          </article>
         </div>
       </section>
 
@@ -871,7 +916,7 @@
         <div class="settings-list">
           <article class="settings-item">
             <button class="link sect settings-toggle" data-sect="s-about" aria-expanded="false">
-              <span class="settings-index" aria-hidden="true">05</span>
+              <span class="settings-index" aria-hidden="true">06</span>
               <span class="settings-toggle-copy">
                 <span class="settings-title">About</span>
                 <span class="settings-description">Version and product details</span>

--- a/extension/app.js
+++ b/extension/app.js
@@ -230,6 +230,76 @@ function setStatus(engine) {
   renderRuntime(engine);
 }
 
+// ---- crawl pace and engine control -----------------------------------------
+// These settings were built, plumbed all the way to the fetcher, and rendered
+// ONLY on the engine's own web page — which is display-only. So from the side
+// panel, where the work actually happens, they did not exist: the owner asked
+// for a feature that had been shipped weeks earlier. Settings belong here.
+
+const CRAWL_KEYS = ["crawl_honour_delay", "crawl_min_interval_s",
+                    "crawl_timeout_s", "crawl_user_agent"];
+
+function crawlPaceEffect() {
+  // What the choice MEANS, in the units the owner thinks in. A checkbox that
+  // silently decides whether a crawl takes one hour or eleven should say so.
+  const honour = $("crawl_honour_delay").checked;
+  const every = parseFloat($("crawl_min_interval_s").value) || 0;
+  $("crawl-pace-effect").textContent = honour
+    ? "Each site's own delay wins when it asks for more than " + every + "s."
+    : "Our pace only: " + every + "s between requests, whatever a site asks for.";
+}
+
+async function loadCrawlSettings() {
+  let settings;
+  try { settings = (await api("/api/settings")).settings || {}; }
+  catch (err) { out("crawl-msg", "could not read settings: " + err.message, "err"); return; }
+  const value = (key) => {
+    const raw = settings[key];
+    return raw && typeof raw === "object" ? raw.value : raw;
+  };
+  $("crawl_honour_delay").checked = !["0", "false", false].includes(value("crawl_honour_delay"));
+  $("crawl_min_interval_s").value = value("crawl_min_interval_s") || "1.0";
+  $("crawl_timeout_s").value = value("crawl_timeout_s") || "30";
+  $("crawl_user_agent").value = value("crawl_user_agent") || "";
+  $("log_retention_days").value = value("log_retention_days") || "30";
+  crawlPaceEffect();
+}
+
+async function saveCrawlSettings() {
+  const interval = parseFloat($("crawl_min_interval_s").value);
+  if (!(interval > 0)) {
+    // Refused HERE, not at the server: zero seconds between requests is not a
+    // pace, it is a flood, and the site that gets it blocks us for good.
+    out("crawl-msg", "seconds between requests must be greater than zero", "err");
+    return;
+  }
+  out("crawl-msg", "saving…");
+  try {
+    await post("/api/settings", {
+      crawl_honour_delay: $("crawl_honour_delay").checked ? "1" : "0",
+      crawl_min_interval_s: String(interval),
+      crawl_timeout_s: String(parseInt($("crawl_timeout_s").value, 10) || 30),
+      crawl_user_agent: $("crawl_user_agent").value.trim(),
+      log_retention_days: String(parseInt($("log_retention_days").value, 10) || 30),
+    });
+  } catch (err) { out("crawl-msg", "not saved: " + err.message, "err"); return; }
+  out("crawl-msg", "saved — it applies to the next crawl, not one already running", "ok");
+  crawlPaceEffect();
+}
+
+async function restartEngineFromPanel() {
+  out("crawl-msg", "restarting the engine…");
+  try { await post("/api/engine/restart", {}); }
+  catch (err) {
+    // A restart tears down the very connection carrying its own reply, so a
+    // dropped request here is the SUCCESS case as often as the failure case.
+    // Claiming failure would be a lie; the status dot settles it either way.
+    out("crawl-msg", "restart requested — watch the status dot (" + err.message + ")");
+    return;
+  }
+  out("crawl-msg", "restart requested — the status dot turns green when it is back", "ok");
+}
+
 // ---- sites -----------------------------------------------------------------
 function hostOf(url) { try { return new URL(url).host; } catch (_) { return url || ""; } }
 
@@ -1918,6 +1988,18 @@ async function init() {
   // The workspace opens with the Storage section already expanded, so the link
   // lands on what it promised rather than on a wall of closed rows.
   $("open-storage").addEventListener("click", () => openTab("/settings#s-storage"));
+
+  // Crawl pace and engine control. Loaded when the section is OPENED rather
+  // than at boot: the panel must not spend a request on a page the owner may
+  // never expand, and a stale value is worse than a late one.
+  $("crawl-save").addEventListener("click", saveCrawlSettings);
+  $("engine-restart").addEventListener("click", restartEngineFromPanel);
+  $("crawl_honour_delay").addEventListener("change", crawlPaceEffect);
+  $("crawl_min_interval_s").addEventListener("input", crawlPaceEffect);
+  document.querySelector('[data-sect="s-crawl"]')
+    .addEventListener("click", () => {
+      if (!$("s-crawl").classList.contains("hidden")) loadCrawlSettings();
+    });
 
   refreshMode();
   // The opening view must be ENTERED through showView like every other one.

--- a/scrapex/webui/templates/settings.html
+++ b/scrapex/webui/templates/settings.html
@@ -192,46 +192,25 @@
   <summary><span class="sect-name">Crawling</span>
     <span class="sect-sub">Politeness, timeouts and identification</span></summary>
   <div class="sect-body">
-    <p class="hint">These apply to every source that uses the shared HTTP fetcher.
-      A source that declares its own user agent keeps it.</p>
-    <form class="stack" onsubmit="return false">
-      <div class="field">
-        <label for="crawl_min_interval_s">Minimum seconds between requests</label>
-        <input id="crawl_min_interval_s" type="number" step="0.1" min="0.1"
-               value="{{ settings.crawl_min_interval_s.value }}">
-        <span class="hint">One request per second is the shipped default. Lowering it
-          puts more load on sites you do not own.</span>
-      </div>
-      <div class="field">
-        <label class="row" for="crawl_honour_delay">
-          <input id="crawl_honour_delay" type="checkbox"
-                 {% if settings.crawl_honour_delay.value not in ("0", "false") %}checked{% endif %}>
-          <span>Honour each site's own crawl delay</span>
-        </label>
-        <span class="hint">A site can publish a <code>Crawl-delay</code> in its
-          robots.txt asking for a pause between requests — elburoj.com asks for
-          10 seconds, which over its 6,720 products is about 25 hours. Unticking
-          this uses your interval above instead. The run says which pace it used
-          either way, and going faster than a site asked can get you rate-limited
-          or blocked.</span>
-      </div>
-      <div class="field">
-        <label for="crawl_timeout_s">Request timeout in seconds</label>
-        <input id="crawl_timeout_s" type="number" min="1" value="{{ settings.crawl_timeout_s.value }}">
-      </div>
-      <div class="field">
-        <label for="crawl_user_agent">User agent</label>
-        <input id="crawl_user_agent" dir="ltr" spellcheck="false"
-               value="{{ settings.crawl_user_agent.value }}"
-               placeholder="{{ about.default_user_agent }}">
-        <span class="hint">Leave empty to identify as ScrapeX. Pretending to be a
-          browser to get past a block is not what this field is for.</span>
-      </div>
-      <div class="row">
-        <button data-save="crawl_min_interval_s,crawl_honour_delay,crawl_timeout_s,crawl_user_agent">Save</button>
-        <span class="hint out" role="status" aria-live="polite"></span>
-      </div>
-    </form>
+    <!-- MOVED to the extension (owner's rule, 2026-07-29): every setting lives
+         in the side panel and this page is display-only. These four controls
+         had been built and plumbed all the way to the fetcher, and rendered
+         ONLY here — so from where the owner works they did not exist, and he
+         asked for a feature that had shipped weeks earlier. -->
+    <p class="hint">These settings now live in the ScrapeX side panel, under
+      <strong>Settings &rarr; Crawl pace and engine</strong>. This page shows
+      what the engine holds; it does not change it.</p>
+    <dl class="stack">
+      <dt>Minimum seconds between requests</dt>
+      <dd class="tech">{{ settings.crawl_min_interval_s.value }}</dd>
+      <dt>Honour each site's own crawl delay</dt>
+      <dd class="tech">
+        {% if settings.crawl_honour_delay.value not in ("0", "false") %}yes{% else %}no{% endif %}</dd>
+      <dt>Request timeout in seconds</dt>
+      <dd class="tech">{{ settings.crawl_timeout_s.value }}</dd>
+      <dt>User agent</dt>
+      <dd class="tech">{{ settings.crawl_user_agent.value or about.default_user_agent }}</dd>
+    </dl>
   </div>
 </details>
 
@@ -367,13 +346,12 @@
     <form class="stack" onsubmit="return false">
       <div class="field">
         <label for="log_retention_days">Keep job logs for (days)</label>
-        <input id="log_retention_days" type="number" min="1"
-               value="{{ settings.log_retention_days.value }}">
+        <span class="tech">{{ settings.log_retention_days.value }} days</span>
         <span class="hint">Job logs are diagnostics, not history: removing old ones
           destroys no price data.</span>
       </div>
       <div class="row">
-        <button data-save="log_retention_days">Save</button>
+        
         <span class="hint out" role="status" aria-live="polite"></span>
       </div>
     </form>

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -1056,3 +1056,42 @@ def test_a_key_in_the_wrong_spelling_is_refused_with_that_system_s_rule(open_pan
     page.click("#add-btn")
     page.wait_for_timeout(100)
     assert "lower_snake_case" in page.text_content("#err-key")
+
+
+# ---- the crawl pace is reachable from the panel, 2026-07-29 ---------------
+
+def test_the_crawl_pace_can_be_read_and_changed_from_the_panel(open_panel):
+    """It had been built, plumbed to the fetcher, and rendered ONLY on the
+    engine's own web page — so from here, where the work happens, it did not
+    exist and the owner asked for a feature that had already shipped."""
+    page = open_panel()
+    page.click(SETTINGS_TAB)
+    page.click('[data-sect="s-crawl"]')
+    page.wait_for_timeout(300)
+
+    assert page.is_visible("#s-crawl")
+    assert page.is_checked("#crawl_honour_delay")
+    assert page.input_value("#crawl_min_interval_s") == "1.0"
+    # The consequence is spelled out, not left as a bare checkbox: this one
+    # decides whether elburoj takes one hour or eleven.
+    assert "wins" in page.inner_text("#crawl-pace-effect")
+
+    page.uncheck("#crawl_honour_delay")
+    page.wait_for_timeout(100)
+    assert "Our pace only" in page.inner_text("#crawl-pace-effect")
+    assert not page.js_errors
+
+
+def test_a_pace_of_zero_is_refused_before_it_reaches_the_engine(open_panel):
+    """Zero seconds between requests is not a pace, it is a flood."""
+    page = open_panel()
+    page.click(SETTINGS_TAB)
+    page.click('[data-sect="s-crawl"]')
+    page.wait_for_timeout(300)
+    page.fill("#crawl_min_interval_s", "0")
+    page.click("#crawl-save")
+    page.wait_for_timeout(200)
+
+    assert "greater than zero" in page.inner_text("#crawl-msg")
+    posted = page.evaluate("window.__calls.filter(c => c.includes('/api/settings'))")
+    assert not [c for c in posted if "POST" in c], "the flood reached the engine"

--- a/tests/test_settings_live_in_the_extension.py
+++ b/tests/test_settings_live_in_the_extension.py
@@ -1,0 +1,62 @@
+"""The owner's rule, made mechanical: settings live in the extension.
+
+«لا اريد اى اعدادت على صفحة الويب — الاعدادت كلها على extension بينما صفحة
+الويب للعرض فقط» (2026-07-29).
+
+The rule earned itself. `crawl_honour_delay` and `crawl_min_interval_s` had
+been built, plumbed all the way to HttpFetcher, and rendered ONLY on the
+engine's web page — so from the side panel, where the work actually happens,
+they did not exist, and the owner asked for a feature that had shipped weeks
+earlier. A rule that lives only in a commit message is a rule that gets broken
+by the next person in a hurry; this one fails the build instead.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+WEB_SETTINGS = ROOT / "scrapex" / "webui" / "templates" / "settings.html"
+PANEL = ROOT / "extension" / "app.html"
+
+# The engine's OWN lifecycle is not a setting: restarting or upgrading the
+# runtime is a repair you may need precisely when the panel cannot reach it.
+# Named here so the exemption is a decision on the record, not a loophole.
+RUNTIME_REPAIR_IDS = {"runtime-restart", "runtime-upgrade"}
+
+
+def _control_ids(html: str) -> set[str]:
+    return {m.group(1) for m in re.finditer(
+        r'<(?:input|select|textarea)[^>]*\bid="([^"]+)"', html)}
+
+
+def test_the_web_page_offers_no_setting_to_change():
+    """It shows what the engine holds. It does not change it."""
+    stray = _control_ids(WEB_SETTINGS.read_text(encoding="utf-8")) - RUNTIME_REPAIR_IDS
+
+    assert not stray, (
+        "the engine's web page grew a control again: "
+        f"{sorted(stray)}. Settings belong in extension/app.html — a setting "
+        "the owner cannot reach from the side panel is a setting he does not "
+        "have.")
+
+
+def test_the_crawl_pace_is_reachable_from_the_panel():
+    """The specific controls that were unreachable, now where they belong."""
+    panel = PANEL.read_text(encoding="utf-8")
+
+    for control in ("crawl_honour_delay", "crawl_min_interval_s",
+                    "crawl_timeout_s", "crawl_user_agent"):
+        assert f'id="{control}"' in panel, f"{control} is not in the side panel"
+
+
+def test_the_web_page_still_shows_what_the_engine_holds():
+    """Display-only is not the same as blank: moving the controls must not
+    take the VALUES away, or the page stops being able to answer the one
+    question it exists for — what is this engine actually set to?"""
+    web = WEB_SETTINGS.read_text(encoding="utf-8")
+
+    for setting in ("crawl_min_interval_s", "crawl_honour_delay",
+                    "crawl_timeout_s", "crawl_user_agent"):
+        assert f"settings.{setting}.value" in web, (
+            f"{setting} stopped being displayed as well as editable")

--- a/tools/panel_harness.py
+++ b/tools/panel_harness.py
@@ -94,6 +94,14 @@ def stub(backend: str = DEFAULT_BACKEND, *, engine_up=True, sources=None, jobs=N
             "health": {"status": "healthy", "ok": True}},
         "/api/resolve": resolve if resolve is not None else {"matched": False},
         "/api/probe": probe if probe is not None else PROBE_RESULT,
+        # The crawl pace lives in the panel now (owner's rule, 2026-07-29:
+        # every setting in the extension, the web page display-only).
+        "/api/settings": {"settings": {
+            "crawl_honour_delay": {"value": "1"},
+            "crawl_min_interval_s": {"value": "1.0"},
+            "crawl_timeout_s": {"value": "30"},
+            "crawl_user_agent": {"value": ""},
+            "log_retention_days": {"value": "30"}}},
     }
     return f"""
 window.chrome = {{


### PR DESCRIPTION
The owner asked for a way to crawl at our own pace instead of the one a site requests. **It had shipped weeks earlier** — `crawl_honour_delay` and `crawl_min_interval_s` were declared in `settings.py`, read in `capture.py`, and plumbed all the way into `HttpFetcher`.

They were rendered **only** on the engine's own web page. The extension has never once called `/api/settings`. So from the side panel, which is where the work happens, the feature did not exist — and asking for it again was the correct response to what he could see.

## The rule that came out of it

> Every setting lives in the extension; the web page is display-only.

Now enforced by a test rather than by memory. `tests/test_settings_live_in_the_extension.py` fails the build if the web page grows an input, select or textarea again.

That guard **immediately found a second violation nobody had noticed** — `log_retention_days` was still editable on the web page — so it moved too. Which is the whole argument for making a rule mechanical: it audits the present, not just the future.

## What moved

`crawl_honour_delay`, `crawl_min_interval_s`, `crawl_timeout_s`, `crawl_user_agent`, `log_retention_days`, plus a **Restart engine** button, into a new *Crawl pace and engine* section of the panel's Settings tab.

The web page still **shows** every one of those values — display-only is not blank, and the page must still answer the one question it exists for: what is this engine actually set to? There is a test for that too.

Runtime repair buttons stay on the web page, named in the guard as a deliberate exemption: restarting or upgrading the runtime is a repair you may need *precisely when the panel cannot reach it*.

## The checkbox says what it costs

It decides whether elburoj takes **one hour or eleven** — measured today: 3,874 products, `Crawl-delay: 10`. A bare checkbox would hide that, so the panel writes the consequence underneath in the units the owner thinks in, and updates as he types.

A pace of **zero** is refused in the panel before it reaches the engine. Zero seconds between requests is not a pace, it is a flood.

## Mistake made and corrected

The first version collided with an existing id — the panel already had an *Engine connection* section using `s-engine`, so there were two and Playwright found the wrong one. Renamed to `s-crawl`. Cheap lesson: grep for the id before minting it.

## Tests

Five new, driven in a real browser:

- the pace can be read and changed from the panel, and the consequence line tracks the checkbox
- a pace of zero is refused before any request reaches the engine
- **the web page offers no control that changes a setting**
- the crawl pace controls are present in the panel
- the web page still *displays* every value it stopped editing

**1491 passed, 1 xfailed.** Contract parity **3/3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)