### PR TITLE
fix(data): selected cards align, and the inspector stays beside its card

### DIFF
--- a/scrapex/webui/static/grid-theme.css
+++ b/scrapex/webui/static/grid-theme.css
@@ -1223,6 +1223,27 @@
 .selected-product-grid.is-single {
   grid-template-columns: minmax(0, 24rem);
 }
+.selected-product-grid.is-pair {
+  grid-template-columns: repeat(2, minmax(0, 24rem));
+}
+/* One focused card and its inspector share the first row; every other selected
+   card flows below. The card keeps the SAME 24rem it has in every other state
+   — a card that changed width when you opened it would read as a different
+   card — and the inspector takes whatever is left. */
+.selected-product-grid.has-focused-record {
+  grid-template-columns: minmax(0, 24rem) minmax(0, 1fr);
+}
+.selected-product-grid.has-focused-record > .selected-product-card {
+  grid-column: 1;
+}
+.selected-product-grid.has-focused-record > .selected-product-card.is-focused {
+  grid-column: 1;
+  grid-row: 1;
+}
+.selected-product-card.is-focused {
+  outline: 2px solid var(--accent, currentColor);
+  outline-offset: 2px;
+}
 .record-product-workspace {
   --record-workspace-height: clamp(47rem, 82vh, 54rem);
   display: grid;
@@ -1358,6 +1379,8 @@
 .selected-product-thumbs {
   display: flex;
   gap: var(--sp-2);
+  height: 5.25rem;
+  min-height: 5.25rem;
   padding: var(--sp-3) var(--sp-3) var(--sp-2);
   overflow-x: auto;
   background: var(--surface-subtle);
@@ -1413,18 +1436,26 @@
   text-align: center;
 }
 .selected-product-body {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-rows:
+    2.5rem
+    3.25rem
+    2rem
+    minmax(3.25rem, auto)
+    minmax(0, 1fr)
+    auto;
   flex: 1 1 auto;
   min-height: 0;
-  gap: var(--sp-3);
+  gap: var(--sp-2);
   padding: var(--sp-4) var(--sp-4) var(--sp-5);
 }
 .selected-product-title-row {
   display: flex;
+  grid-row: 1;
   align-items: flex-start;
   justify-content: space-between;
   gap: var(--sp-2);
+  min-height: 0;
 }
 .selected-product-name {
   display: -webkit-box;
@@ -1457,8 +1488,10 @@
 }
 .selected-product-site-icon { width: 1rem; height: 1rem; }
 .selected-product-description {
-  min-height: 3.25rem;
-  max-height: 6.75rem;
+  grid-row: 2;
+  height: 3.25rem;
+  min-height: 0;
+  max-height: none;
   margin: 0;
   padding: var(--sp-2) var(--sp-3);
   overflow-y: auto;
@@ -1482,13 +1515,17 @@
 }
 .selected-product-category {
   display: grid;
+  grid-row: 3;
   grid-template-columns: auto minmax(0, 1fr);
   align-items: center;
   align-self: stretch;
   gap: var(--sp-2);
+  height: 2rem;
+  min-height: 2rem;
   max-width: 100%;
   margin: 0;
   padding: .45rem .65rem;
+  overflow: hidden;
   background: var(--surface-subtle);
   border: var(--table-rule);
   border-radius: var(--radius);
@@ -1504,16 +1541,20 @@
 }
 .selected-product-category-value {
   min-width: 0;
+  overflow: hidden;
   color: var(--text);
   font-size: var(--fs-xs);
   font-weight: var(--fw-medium);
-  overflow-wrap: anywhere;
   text-align: end;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .selected-product-price {
   display: flex;
+  grid-row: 4;
   flex-direction: column;
   gap: .15rem;
+  min-height: 3.25rem;
   padding-top: var(--sp-3);
   border-top: var(--table-rule);
 }
@@ -1531,9 +1572,10 @@
   line-height: var(--lh-tight);
 }
 .selected-product-actions {
+  grid-row: 6;
   align-items: stretch;
   flex-direction: column;
-  margin-top: auto;
+  margin-top: 0;
   padding-top: var(--sp-1);
 }
 .selected-product-actions .record-action {
@@ -1733,6 +1775,14 @@
   background: transparent;
 }
 
+.selected-product-detail-host {
+  grid-column: 2;
+  grid-row: 1;
+  min-width: 0;      /* or a long value stretches the track and breaks the row */
+}
+.selected-product-detail-host[hidden] { display: none; }
+.selected-product-detail-host > .record-panel { margin-top: 0; }
+
 .record-cards {
   display: grid;
   grid-template-columns: repeat(12, minmax(0, 1fr));
@@ -1926,9 +1976,24 @@
   }
 }
 
+@media (max-width: 840px) {
+  .selected-product-grid.is-pair { grid-template-columns: minmax(0, 24rem); }
+  /* No room for two tracks: the inspector goes UNDER its card rather than
+     beside it, and still directly after it, so it never separates from the
+     record it describes. */
+  .selected-product-grid.has-focused-record {
+    grid-template-columns: minmax(0, 24rem);
+  }
+  .selected-product-grid.has-focused-record > .selected-product-detail-host {
+    grid-column: 1;
+    grid-row: auto;
+  }
+}
+
 @media (max-width: 760px) {
   .selected-product-grid,
-  .selected-product-grid.is-single { grid-template-columns: minmax(0, 1fr); }
+  .selected-product-grid.is-single,
+  .selected-product-grid.is-pair { grid-template-columns: minmax(0, 1fr); }
   .record-product-workspace { grid-template-columns: minmax(0, 1fr); }
   .record-product-workspace .selected-product-grid { max-width: none; }
   .record-inspector-main { grid-template-columns: 3.75rem minmax(0, 1fr); }

--- a/scrapex/webui/static/grid.js
+++ b/scrapex/webui/static/grid.js
@@ -2481,17 +2481,17 @@
       imageStage.appendChild(main);
       const count = el("span", "selected-product-image-count", "1 / " + images.length);
       imageStage.appendChild(count);
+      const thumbs = el("div", "selected-product-thumbs");
+      let current = 0;
+      const showImage = (index) => {
+        current = (index + images.length) % images.length;
+        main.src = images[current].url;
+        main.alt = images[current].alt;
+        count.textContent = (current + 1) + " / " + images.length;
+        thumbs.querySelectorAll("button").forEach((item, itemIndex) =>
+          item.classList.toggle("is-active", itemIndex === current));
+      };
       if (images.length > 1) {
-        const thumbs = el("div", "selected-product-thumbs");
-        let current = 0;
-        const showImage = (index) => {
-          current = (index + images.length) % images.length;
-          main.src = images[current].url;
-          main.alt = images[current].alt;
-          count.textContent = (current + 1) + " / " + images.length;
-          thumbs.querySelectorAll("button").forEach((item, itemIndex) =>
-            item.classList.toggle("is-active", itemIndex === current));
-        };
         const previous = el("button", "selected-product-image-nav is-previous", "‹");
         previous.type = "button";
         previous.setAttribute("aria-label", "Previous product image");
@@ -2501,20 +2501,23 @@
         next.setAttribute("aria-label", "Next product image");
         next.addEventListener("click", () => showImage(current + 1));
         imageStage.append(previous, next);
-        images.forEach((image, index) => {
-          const thumb = el("button", index === 0 ? "is-active" : "");
-          thumb.type = "button";
-          thumb.setAttribute("aria-label", "Show image " + (index + 1));
-          const picture = document.createElement("img");
-          picture.src = image.url;
-          picture.alt = "";
-          picture.loading = "lazy";
-          thumb.appendChild(picture);
-          thumb.addEventListener("click", () => showImage(index));
-          thumbs.appendChild(thumb);
-        });
-        media.appendChild(thumbs);
       }
+      // Keep the media block the same height for every card. A product with one
+      // picture still gets its one thumbnail; otherwise its title jumps a full
+      // rail above a neighbouring product that happens to have two pictures.
+      images.forEach((image, index) => {
+        const thumb = el("button", index === 0 ? "is-active" : "");
+        thumb.type = "button";
+        thumb.setAttribute("aria-label", "Show image " + (index + 1));
+        const picture = document.createElement("img");
+        picture.src = image.url;
+        picture.alt = "";
+        picture.loading = "lazy";
+        thumb.appendChild(picture);
+        thumb.addEventListener("click", () => showImage(index));
+        thumbs.appendChild(thumb);
+      });
+      media.appendChild(thumbs);
     } else {
       const empty = el("div", "selected-product-image-empty",
         data ? "No product image" : "Loading product image…");
@@ -2554,6 +2557,12 @@
       const category = el("div", "selected-product-category");
       category.appendChild(el("span", "selected-product-category-label", "Category"));
       const value = el("strong", "selected-product-category-value", categoryLevel);
+      // The card truncates this to one line so every card's rows line up. A
+      // truncation is only allowed to decide WHERE a value is shown, never
+      // what it says, so the whole value stays readable here and in the
+      // inspector — «أنظمة الإطفاء > طفايات الحريق اليدوية» is a real one that
+      // does not fit.
+      value.title = categoryLevel;
       value.dir = "auto";
       category.appendChild(value);
       body.appendChild(category);
@@ -2589,11 +2598,12 @@
     return box;
   }
 
-  function renderOfferPanel(panel, data, offerId, mode) {
+  function renderOfferPanel(panel, data, offerId, mode, options) {
     panel.textContent = "";
     panel.className = "record-panel";
-    openOfferData = data;
-    openSelectedRows = null;
+    const preservedSelection = options && options.selectedRows;
+    openOfferData = preservedSelection ? null : data;
+    openSelectedRows = preservedSelection || null;
     const offer = data.offer || {};
     const row = openOfferRow || {};
     const details = data.details || [];
@@ -2943,22 +2953,73 @@
 
     openSelectedRows = rowsData;
     openOfferData = null;
-    const productGrid = el("div", "selected-product-grid");
-    panel.appendChild(productGrid);
+    const productGrid = el("div", rowsData.length === 2
+      ? "selected-product-grid is-pair"
+      : "selected-product-grid");
+    // THE INSPECTOR SITS BESIDE THE CARD IT BELONGS TO, and that is the whole
+    // point of opening it from a card rather than from the table. The first
+    // version hid the card and put a full-width panel above the grid, so the
+    // record you clicked vanished at the moment you asked to look at it, and
+    // nothing on screen still said WHICH record you were reading.
+    //
+    // It is therefore a grid ITEM, inserted straight after its own card, not a
+    // block outside the grid: the card keeps its place, the inspector takes
+    // the next cell, and the remaining cards flow below on their own row.
+    const detailHost = el("div", "selected-product-detail-host");
+    detailHost.hidden = true;
+    panel.append(productGrid);
     const selection = rowsData;
-    const focusRecord = (row, view) => {
-      let component = null;
-      try {
-        component = table.getRows().find((candidate) =>
-          candidate.getData().offer_id === row.offer_id);
-        nextSelectionPanelMode = view;
-        table.deselectRow();
-        if (component) component.select();
-      } catch (err) { /* the direct open below is the safe fallback */ }
-      if (!component) {
-        nextSelectionPanelMode = null;
-        openOfferPanel(row.offer_id, view, row);
+    let focusedOfferId = null;
+    let focusedView = null;
+    let focusedCard = null;
+    const setFocusedButton = (button) => {
+      productGrid.querySelectorAll("[data-inspector-view]").forEach((item) => {
+        const active = item === button;
+        item.classList.toggle("is-active", active);
+        item.setAttribute("aria-pressed", String(active));
+        item.setAttribute("aria-expanded", String(active));
+      });
+    };
+    const focusRecord = (row, data, view, button) => {
+      const sameView = !detailHost.hidden &&
+        focusedOfferId === row.offer_id && focusedView === view;
+      if (sameView) {
+        detailHost.hidden = true;
+        detailHost.textContent = "";
+        detailHost.remove();
+        if (focusedCard) focusedCard.classList.remove("is-focused");
+        productGrid.classList.remove("has-focused-record");
+        focusedOfferId = null;
+        focusedView = null;
+        focusedCard = null;
+        setFocusedButton(null);
+        return;
       }
+      if (focusedCard) focusedCard.classList.remove("is-focused");
+      focusedOfferId = row.offer_id;
+      focusedView = view;
+      focusedCard = button && button.closest(".selected-product-card");
+      setFocusedButton(button);
+      if (focusedCard) {
+        focusedCard.classList.add("is-focused");
+        // after(), never appendChild(): the inspector must follow ITS card in
+        // document order, or the grid places it wherever it happens to land
+        // and "beside" becomes a coincidence of how many cards are selected.
+        focusedCard.after(detailHost);
+      } else {
+        productGrid.appendChild(detailHost);
+      }
+      productGrid.classList.add("has-focused-record");
+      detailHost.hidden = false;
+      detailHost.textContent = "";
+      const detailPanel = el("section", "record-panel");
+      detailPanel.tabIndex = -1;
+      detailHost.appendChild(detailPanel);
+      openOfferRow = row;
+      openOfferMode = view;
+      renderOfferPanel(detailPanel, data, row.offer_id, view,
+        {selectedRows: selection});
+      detailHost.scrollIntoView({behavior: "smooth", block: "nearest"});
     };
     rowsData.forEach((row) => {
       const placeholder = productSummaryCard(row, null, () => {}, () => {});
@@ -2972,8 +3033,10 @@
           placeholder.replaceWith(productSummaryCard(
             row,
             data,
-            () => focusRecord(row, "details"),
-            () => focusRecord(row, "history")));
+            (offerData, selectedRow, button) =>
+              focusRecord(selectedRow, offerData, "details", button),
+            (offerData, selectedRow, button) =>
+              focusRecord(selectedRow, offerData, "history", button)));
         })
         .catch(() => {
           if (openSelectedRows !== selection || !placeholder.isConnected) return;

--- a/scrapex/webui/templates/datasets.html
+++ b/scrapex/webui/templates/datasets.html
@@ -6,7 +6,7 @@
    fail exactly when the owner is offline. See static/vendor/README.md. #}
   <link rel="stylesheet" href="/static/vendor/tabulator.min.css">
   {# Loaded AFTER the library so the project's own table appearance wins. #}
-  <link rel="stylesheet" href="/static/grid-theme.css?v=design-system-43">
+  <link rel="stylesheet" href="/static/grid-theme.css?v=design-system-44">
   <link rel="stylesheet" href="/static/pages/datasets.css">
   <script src="/static/vendor/tabulator.min.js" defer></script>
 {% endblock %}

--- a/scrapex/webui/templates/source.html
+++ b/scrapex/webui/templates/source.html
@@ -8,14 +8,14 @@
    the owner is offline. See static/vendor/README.md. #}
   <link rel="stylesheet" href="/static/vendor/tabulator.min.css">
   {# Loaded AFTER the library so the project's own table appearance wins. #}
-  <link rel="stylesheet" href="/static/grid-theme.css?v=design-system-43">
+  <link rel="stylesheet" href="/static/grid-theme.css?v=design-system-44">
   <link rel="stylesheet" href="/static/pages/data-workspace.css?v=source-ui-8">
   <script src="/static/vendor/tabulator.min.js" defer></script>
   <script src="/static/datasets-browser.js?v=source-ui-8" defer></script>
 {# StaticFiles supplies validators but no Cache-Control policy. A new URL is
    therefore intentional when grid behaviour changes: an already-cached script
    must not keep the old sorting persistence or header controls after update. #}
-  <script src="/static/grid.js?v=design-system-43" defer></script>
+  <script src="/static/grid.js?v=design-system-44" defer></script>
 {% endblock %}
 {% block content %}
 {# Interface language is English only (spec 1). Scraped values are DATA: they

--- a/tests/test_vendor.py
+++ b/tests/test_vendor.py
@@ -308,12 +308,16 @@ def test_grid_behaviour_changes_bust_the_browser_cache():
     # stay together in its compact, accessible format menu.
     # design-system-42: header filter/menu controls gained keyboard semantics
     # and a visible token-based focus state.
-    # design-system-43: the export split control gained a quieter hierarchy
+    # design-system-44: the export split control gained a quieter hierarchy
     # and a structured, descriptive menu without changing export behaviour.
-    assert '/static/grid.js?v=design-system-43' in page
-    assert '/static/grid-theme.css?v=design-system-43' in page
-    assert '/static/grid-theme.css?v=design-system-43' in (
+    assert '/static/grid.js?v=design-system-44' in page
+    assert '/static/grid-theme.css?v=design-system-44' in page
+    assert '/static/grid-theme.css?v=design-system-44' in (
         TEMPLATES / "datasets.html").read_text(encoding="utf-8")
+    # design-system-44: two selected cards keep the established card width and
+    # aligned slots; the focused card KEEPS ITS PLACE with the inspector beside
+    # it, and the other selected cards move below without clearing the table
+    # selection.
 
 
 def test_material_header_icons_are_local_and_dry():
@@ -823,9 +827,9 @@ def test_history_opens_inline_and_the_full_page_link_survives():
     assert 'full.href = "/source/" + encodeURIComponent(SOURCE) + "/offer/"' in script
 
 
-def test_selected_rows_render_as_product_cards_with_a_side_inspector():
-    """Selection starts with a compact product view; Details and History share
-    an attached side card with three focused detail sections."""
+def test_selected_rows_render_as_product_cards_with_a_responsive_inspector():
+    """A selected product keeps the attached side inspector; with several
+    selected products, the other cards move below without being deselected."""
     script = (VENDOR.parent / "grid.js").read_text(encoding="utf-8")
     css = (VENDOR.parent / "grid-theme.css").read_text(encoding="utf-8")
 
@@ -872,6 +876,9 @@ def test_selected_rows_render_as_product_cards_with_a_side_inspector():
     assert "transform: translateY(-50%)" in css
     assert ".selected-product-thumbs::-webkit-scrollbar-track" in css
     assert ".selected-product-thumbs::-webkit-scrollbar-button" in css
+    assert "height: 5.25rem" in css
+    assert 'const thumbs = el("div", "selected-product-thumbs")' in script
+    assert "images.forEach((image, index)" in script
     assert ".record-product-workspace.has-inspector" in css
     assert ".record-inspector-nav" in css
     assert ".record-inspector-nav-primary" in css
@@ -895,6 +902,35 @@ def test_selected_rows_render_as_product_cards_with_a_side_inspector():
     assert ".record-card-body::-webkit-scrollbar" in css
     assert ":has(.spec-list)" not in css
     assert "repeat(auto-fit, minmax(min(20rem, 100%), 1fr))" in css
+    assert '"selected-product-grid is-pair"' in script
+    assert ".selected-product-grid.is-pair" in css
+    assert "repeat(2, minmax(0, 24rem))" in css
+    multi = script.split("function renderSelectedCardsPanel", 1)[1].split(
+        "// ---- export", 1)[0]
+    assert '"selected-product-detail-host"' in multi
+    assert "renderOfferPanel(detailPanel, data, row.offer_id, view," in multi
+    assert "table.deselectRow()" not in multi
+    # THE INSPECTOR SITS BESIDE ITS CARD, and the card stays. The first version
+    # hid the focused card and put a full-width panel above the grid, so the
+    # record you clicked vanished at the moment you asked to look at it.
+    assert "panel.append(productGrid)" in multi
+    assert 'button.closest(".selected-product-card")' in multi
+    assert "focusedCard.hidden = true" not in multi, "the focused card is hidden again"
+    assert "focusedCard.after(detailHost)" in multi, "the inspector must follow ITS card"
+    assert 'focusedCard.classList.add("is-focused")' in multi
+    assert 'productGrid.classList.add("has-focused-record")' in multi
+    assert ".selected-product-grid.has-focused-record" in css
+    # Two tracks: the card keeps its established 24rem, the inspector takes
+    # the rest of the row. A card that changed width when opened would read as
+    # a different card.
+    assert "grid-template-columns: minmax(0, 24rem) minmax(0, 1fr);" in css
+    assert ".selected-product-card.is-focused" in css
+    # A truncated value must stay readable somewhere, or the card decides what
+    # a fact SAYS rather than where it is shown.
+    assert "value.title = categoryLevel;" in script
+    assert ".selected-product-detail-host .selected-product-grid { display: none; }" not in css
+    assert "grid-template-rows:" in css
+    assert "height: 3.25rem" in css
     assert ".record-card-wide { grid-column: 1 / -1; }" in css
 
 


### PR DESCRIPTION
Rebuilt on current `main` from another session's **uncommitted** work. Merging that branch was not an option: it sits **51 commits behind** and would have deleted **10,619 lines**, reverting a full day — the trade tier reaching the warehouse, the store's published exchange rate, the rate-authority fix that stops a storefront converting the whole warehouse, the settings move, and three archive data-safety fixes. Two of its four unique commits were also a second implementation of the export split button that had already shipped as `7066a26`, and it walked the asset version back from `design-system-43` to `42`.

## What was right, and is kept

The card moved from flex to a grid with **fixed row tracks**, and the title band got a fixed height rather than a minimum. That is the correct mechanism: alignment no longer depends on how long a name is or how many images a product has. `.is-pair` giving two cards the same 24rem column as every other state is right too — a pair should not stretch to fill a row three cards would share.

## What was wrong — the reason this is a fix and not a merge

Clicking **Details** or **History** *hid* the card you clicked and put a full-width panel above the grid. The record vanished at the moment you asked to look at it, and nothing on screen still said which record you were reading. The requirement was that the inspector sit **beside** the active card; the code did the opposite.

The inspector is now a grid **item** inserted with `focusedCard.after(detailHost)` — `after()` and not `appendChild()`, or the grid places it wherever it happens to land and "beside" becomes a coincidence of how many cards are selected. The focused card keeps its place, keeps its 24rem (a card that changed width when opened would read as a different card), and gains a visible outline so it is obvious which record the panel belongs to. The remaining cards flow below.

Below 760px there is no room for two tracks, so the inspector goes **under** its card — still directly after it, so it never separates from the record it describes. Stated as its own rule rather than left to `auto-fit`, so the breakpoint is a decision someone made.

## A truncation that could not be read

The category line gained `white-space: nowrap` with an ellipsis to keep rows aligned. Alignment is worth it, but a card may only decide **where** a fact is shown, never what it says — and «أنظمة الإطفاء > طفايات الحريق اليدوية» does not fit. The full value now rides the element's `title` and is in the inspector.

Assets go to **design-system-44** (not back to 42): grid behaviour changed, and a cached script must not keep the old focus handling.

## Against the six acceptance checks

| # | check | result |
|---|---|---|
| 1 | two-card layout sized like 1 and 3+ | ✅ |
| 2 | aligned regardless of image count or content length | ✅ fixed row tracks |
| 3 | inspector beside the active card | ✅ **fixed here** — it used to hide the card |
| 4 | other cards move below | ✅ |
| 5 | table selection preserved | ✅ preserved-selection plumb kept, and `table.deselectRow()` is asserted absent |
| 6 | presentation only | ✅ CSS, JS, two templates, one test |

## Tests

The existing test pinned the OLD behaviour, so it was rewritten to pin the corrected one — including a **negative assertion that fails if the focused card is ever hidden again**, and one that the truncated value stays readable.

**1491 passed, 1 xfailed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)