### PR TITLE
feat(madar): how the site shows it, and what one unit of the price buys

### DIFF
--- a/apps_script/StagingAppScript.txt
+++ b/apps_script/StagingAppScript.txt
@@ -251,7 +251,7 @@ const SYNC_MAX_ROWS = 40000;
 
 /* The payload contract this script speaks (payload.PAYLOAD_VERSION). A batch
  * announcing anything else is skipped loudly instead of parsed on a guess. */
-const SYNC_PAYLOAD_VERSION = 5;
+const SYNC_PAYLOAD_VERSION = 6;
 
 /* Cells are written as TEXT on purpose. Python already canonicalised every
  * value to a string (outputs._canonical_cell) so that 15 and 15.0 cannot fork

--- a/contracts/fixtures/payload_valid.json
+++ b/contracts/fixtures/payload_valid.json
@@ -1,5 +1,5 @@
 {
-  "payload_version": 5,
+  "payload_version": 6,
   "source_key": "MADAR",
   "kind": "product_prices",
   "client": "cli",

--- a/contracts/funnel-payload.schema.json
+++ b/contracts/funnel-payload.schema.json
@@ -43,10 +43,10 @@
     }
   },
   "additionalProperties": false,
-  "description": "Version 5. One contract for CLI + extension producers and the Apps Script consumer. See scraper/ENGINEERING.md T8.",
+  "description": "Version 6. One contract for CLI + extension producers and the Apps Script consumer. See scraper/ENGINEERING.md T8.",
   "properties": {
     "payload_version": {
-      "const": 5,
+      "const": 6,
       "title": "Payload Version",
       "type": "integer"
     },

--- a/db/migrations/0056_how_the_site_shows_it_and_what_one_unit_buys.sql
+++ b/db/migrations/0056_how_the_site_shows_it_and_what_one_unit_buys.sql
@@ -1,0 +1,117 @@
+-- =====================================================================
+-- 0056 — HOW THE SITE SHOWS IT, AND WHAT ONE UNIT BUYS
+--
+-- Two questions were being answered by one column, and badly.
+--
+-- THE DEFECT. A MADAR row could not be read. The prices themselves were
+-- never wrong — all 3,410 live prices matched the warehouse exactly on
+-- 2026-07-29, 0 mismatches — but every fact SURROUNDING the number was
+-- missing, and without them the number is unreadable:
+--
+--   the Ø8mm rebar member costs 4,830 and the Ø32mm costs 4,045
+--
+-- Per piece that is impossible: a 12 m Ø32 bar carries ~16x the steel of
+-- a Ø8 bar. Per TONNE it is exactly right — thin bars cost more per tonne
+-- to roll. The site says so in numbers: weight 1000, is_qty_decimal true,
+-- min_sale_qty 0.25, qty_increments 0.05. ScrapeX stored basis_quantity
+-- 1.0, no unit, no minimum — "the price of one thing".
+--
+-- WHAT THIS MIGRATION DOES NOT DO: it does not write «طن» anywhere. The
+-- shop never prints that word. Verified exhaustively 2026-07-29 against
+-- the live site — member attributes, parent attributes, description,
+-- short_description, every meta field, both category descriptions, both
+-- store views, and the full 932KB rendered page: «طن» 0 times, «الوحدة»
+-- 0 times, and the quantity box is labelled «الكمية» and nothing else.
+-- The owner ruled on it directly: «الحقائق الخام فقط» — raw facts only.
+-- So the site's NUMBERS are stored and the display layer renders "per
+-- 1,000 kg". An inferred unit would be a word the shop never said, which
+-- is the one thing this warehouse does not do.
+--
+-- THE KEY STRUCTURAL FINDING, and the reason this is TWO columns and not
+-- one: "sold by a bulk unit" is NOT a fourth Magento shape. It appears
+-- inside GroupedProduct (96 leaves) AND inside ConfigurableProduct (13 —
+-- the steel mesh, whose children carry per-child weights of 6.74..66.02
+-- kg, not a uniform 1000). Any design that models presentation as a
+-- single enum over __typename misses it. So:
+--
+--   source_product.display_method  — HOW THE SITE PRESENTS THE PRODUCT.
+--                                    A property of the PRODUCT, constant
+--                                    across every row it emits.
+--   source_offer.<quantity facts>  — WHAT ONE UNIT OF THE PRICE BUYS.
+--                                    A property of the OFFER, differing
+--                                    per member.
+--
+-- WHY NOT REUSE has_variants: it reads 1 for 763 of 763 MADAR products,
+-- and for every product of sources 1,2,3,4,7,8,9. ingest emitted
+-- `1 if external_variant_id or option_fingerprint`, and a simple product
+-- is emitted as row(uid, uid), so external_variant_id is never empty. The
+-- one column that looked like it answered "how is this product presented"
+-- answered 1 for everything. Its meaning is spent; a new column is
+-- cheaper than a re-interpretation nobody can see.
+--
+-- display_method's vocabulary is closed (scrapex.vocab.DisplayMethod) and
+-- deliberately has NO catch-all value. '' means "a shape nobody has
+-- studied", never "the nearest thing" — a BundleProduct arriving tomorrow
+-- files blank rather than wrong. Counted live 2026-07-29: 400 single, 36
+-- options_one_price, 292 options_priced, 33 member_list (161 leaves).
+--
+-- minimum_quantity already EXISTED and was never wired: it appeared
+-- exactly once in the whole repo, in db/schema.sql, with nothing reading
+-- or writing it and no column for it on the PRODUCT_PRICES contract, so
+-- no connector could have sent one. riyadh-cement child 70504010
+-- publishes min_sale_qty 450 with qty_increments 450 at 50 kg a bag —
+-- the price is only obtainable at 450 bags = 22.5 t per order, and the
+-- warehouse said NULL for all 3,417 MADAR offers.
+--
+-- NO BACKFILL IS POSSIBLE, and none is attempted: raw_snapshot holds 0
+-- rows, so there is nothing to re-read. Values arrive on the next crawl.
+-- Every default below ('' and 0 and NULL) reads as "the site did not
+-- say", which is precisely the truthful state of every existing row.
+--
+-- All three changes are ALTER TABLE ADD COLUMN with defaults: no table
+-- rebuild, no index touched, no view rewritten, no data loss. The offer
+-- identity index (ux_source_offer_identity) does NOT include any of these
+-- columns, so no existing offer changes identity and no offer is split.
+-- =====================================================================
+
+-- HOW THE SITE PRESENTS IT — one of vocab.DisplayMethod, or '' for a
+-- shape not yet studied. No CHECK constraint: the vocabulary lives in
+-- scrapex/vocab.py and test_schema.py asserts the two never drift, which
+-- is this repo's standing pattern for an enum that connectors extend.
+ALTER TABLE source_product ADD COLUMN display_method TEXT NOT NULL DEFAULT '';
+
+-- WHAT ONE UNIT OF THE PRICE BUYS. minimum_quantity is already on the
+-- table (schema.sql:177) and only needed wiring, so it is absent here.
+ALTER TABLE source_offer ADD COLUMN quantity_increment REAL;
+ALTER TABLE source_offer ADD COLUMN quantity_is_decimal INTEGER NOT NULL DEFAULT 0
+    CHECK (quantity_is_decimal IN (0,1));
+
+-- has_variants, CORRECTED IN PLACE — the one thing in this migration that is a
+-- backfill, and the only one that CAN be. The other columns describe facts the
+-- site publishes and we never asked for, so they must wait for a crawl. This
+-- one is derivable from rows the warehouse already holds: a product has
+-- variations when some variant of it is not simply ITSELF.
+--
+-- Without this the fix would be half a fix. ingest only ever wrote has_variants
+-- at INSERT, so correcting the rule there fixes products discovered from now
+-- on and leaves every existing one — all 763 MADAR products and every product
+-- of sources 1,2,3,4,7,8,9 — still reading 1. A column that is right for new
+-- rows and wrong for old ones is worse than one that is uniformly wrong,
+-- because nothing on screen says which kind of row you are looking at.
+--
+-- The rule is exactly the row-level one, aggregated: a variant whose
+-- external_variant_id differs from its product's external_product_id is a real
+-- variation, and so is any variant carrying an option fingerprint. A simple
+-- product is stored as one variant wearing the product's own id, which is
+-- precisely the case the old test could not see.
+UPDATE source_product SET has_variants = (
+    SELECT CASE WHEN EXISTS (
+        SELECT 1 FROM source_variant v
+        WHERE v.source_product_id = source_product.source_product_id
+          AND (COALESCE(v.option_fingerprint, '') <> ''
+               OR COALESCE(v.external_variant_id, '')
+                  NOT IN ('', source_product.external_product_id))
+    ) THEN 1 ELSE 0 END
+);
+
+PRAGMA user_version = 56;

--- a/scrapex/changes.py
+++ b/scrapex/changes.py
@@ -44,6 +44,15 @@ TRACKED_PRODUCT_FIELDS = (
     # renaming in either language is a recorded change, not a silent drift.
     ("product_name", "product_name"),
     ("product_name_lang", "lang"),
+    # HOW THE SITE PRESENTS THE PRODUCT (0056). Tracked, not INSERT-only, for
+    # two reasons. A shop really does re-shape a product — a simple item gains
+    # options and becomes a configurable — and that is a change worth recording
+    # rather than a fact frozen at first sight. And without it the 763 MADAR
+    # products that already exist could never learn the column at all: only the
+    # INSERT path writes it, and they were inserted long ago. The empty-value
+    # rule above protects the other direction — a connector that has not been
+    # taught display_method sends '' and never blanks a value already stored.
+    ("display_method", "display_method"),
 )
 
 # Fields whose OLD value is an identity worth remembering (spec 14): if a site

--- a/scrapex/connectors/magento.py
+++ b/scrapex/connectors/magento.py
@@ -37,7 +37,8 @@ from ..config import SourceEntry
 from ..normalize import (option_axes_json, option_fingerprint, selling_unit_from,
                          strip_markup)
 from ..rowspec import ENRICHMENT, PRODUCT_PRICES, RowBuilder
-from ..vocab import Availability, DetailGroup, ExtractKind, group_for_code
+from ..vocab import (Availability, DetailGroup, DisplayMethod, ExtractKind,
+                     group_for_code)
 from .base import CrawlBlocked, HttpFetcher, ScrapedTable
 
 PAGE_SIZE = 100
@@ -53,6 +54,23 @@ PAGE_SIZE = 100
 # knowing what a row is and assuming it. Study B1 (2026-07-25) enumerated the
 # whole madar census: 399 SimpleProduct, 328 ConfigurableProduct, 33
 # GroupedProduct, and the three do NOT share one price rule (see _product_rows).
+#
+# THE QUANTITY FACTS — is_qty_decimal, min_sale_qty, qty_increments — ride the
+# same request too, and their absence is what made 109 leaves unreadable. A
+# madar rebar member states weight 1000, a 0.25 minimum and a 0.05 step, and
+# the warehouse stored basis_quantity 1.0 with no unit and no minimum: "the
+# price of one thing", for a figure that is not the price of one thing. They
+# live on SimpleProduct in madar's schema (introspected 2026-07-29), so they
+# are asked for at the top level AND inside both child selections — a grouped
+# member and a configurable child are simple products, and that is where the
+# facts actually sit.
+#
+# only_x_left_in_stock is the shop's own count, non-null on 297 priced leaves.
+# rowspec has carried a stock_quantity column and ingest has stored it since
+# before this connector existed; nothing ever asked the site for it.
+_QUANTITY_FACTS = ("is_qty_decimal min_sale_qty qty_increments "
+                   "only_x_left_in_stock")
+
 _QUERY_TEMPLATE = """query($pageSize:Int!,$currentPage:Int!){{
   products(filter:{{price:{{from:"0"}}}},pageSize:$pageSize,currentPage:$currentPage){{
     page_info{{current_page total_pages}}
@@ -61,16 +79,20 @@ _QUERY_TEMPLATE = """query($pageSize:Int!,$currentPage:Int!){{
       categories{{uid name breadcrumbs{{category_name}}}}
       price_range{{minimum_price{{regular_price{{value}} final_price{{value}}}}
                   maximum_price{{final_price{{value}}}}}}
+      ... on SimpleProduct{{weight {quantity}}}
       {extra}
       ... on GroupedProduct{{
         items{{qty position product{{uid sku name stock_status
           ... on PhysicalProductInterface{{weight}}
+          ... on SimpleProduct{{{quantity}}}
           price_range{{minimum_price{{regular_price{{value}} final_price{{value}}}}}}}}}}
       }}
       ... on ConfigurableProduct{{
         configurable_options{{attribute_code label}}
         variants{{
-          product{{uid sku name stock_status weight price_range{{minimum_price{{regular_price{{value}} final_price{{value}}}}}}}}
+          product{{uid sku name stock_status weight
+            ... on SimpleProduct{{{quantity}}}
+            price_range{{minimum_price{{regular_price{{value}} final_price{{value}}}}}}}}
           attributes{{code label}}
         }}
       }}
@@ -78,7 +100,7 @@ _QUERY_TEMPLATE = """query($pageSize:Int!,$currentPage:Int!){{
   }}
 }}"""
 
-_QUERY = _QUERY_TEMPLATE.format(extra="")
+_QUERY = _QUERY_TEMPLATE.format(extra="", quantity=_QUANTITY_FACTS)
 # custom_attributesV2 IS the site's "More information" panel (verified live
 # 2026-07-23: manufacturer, country_of_manufacture, origin, size, material
 # type, coating, grade — the owner's list, code for code). Dropdown values
@@ -91,8 +113,20 @@ _QUERY = _QUERY_TEMPLATE.format(extra="")
 # products carry a real image, the other 49 answer with the shop's own
 # placeholder URL — which the reader already refuses, because a grey box where
 # a product belongs is worse than an honest blank.
+#
+# meta_title / meta_description / meta_keyword are asked for BY NAME because
+# custom_attributesV2 is filtered to is_visible_on_front:true and these are not
+# visible on the front — so the "take every visible attribute" reader could
+# never reach them, and the Site metadata group that exists for exactly this
+# kind of fact stayed half empty. They earn their place on live evidence: the
+# epoxy rebar's AR meta_title says «سابك» (SABIC) while its `name` says «من
+# حديد» (Hadeed) and its image is epoxy_sabic.png. That contradiction is the
+# SITE's, and under "source truth is never edited" we record it rather than
+# quietly pick a winner.
 _QUERY_ENRICHED = _QUERY_TEMPLATE.format(
+    quantity=_QUANTITY_FACTS,
     extra="description{html} short_description{html} "
+          "meta_title meta_description meta_keyword "
           "image{url label} media_gallery{url label position} "
           "custom_attributesV2(filters:{is_visible_on_front:true}){items{"
           "code ... on AttributeValue{value} "
@@ -131,15 +165,39 @@ _ATTRIBUTE_CODE_SAFE = re.compile(r"^[A-Za-z0-9_]+$")
 # The en_SA store view returns English names for the same uids (verified
 # live: "اسمنت الرياض" -> "Riyadh Cement"). uid + name ONLY — the bilingual
 # table costs pages, never payloads.
+#
+# THE GROUPED FRAGMENT IS NOT OPTIONAL. Both English queries carried a
+# ConfigurableProduct fragment and no GroupedProduct one, so `names_en` never
+# learned a single member uid — and a grouped member's name IS its variant
+# label, the thing that tells one member from another. The site publishes
+# 161/161 English member names and 150 of them differ from the Arabic
+# ("Hadeed Epoxy Rebar| Ø10mm × 12m | ASTM A775 Grade 60"); all 162 stored
+# variants carried variant=''. Under the standing bilingual rule that is a
+# defect, and it needed BOTH this fragment and the row() call to be fixed —
+# either one alone leaves the column empty.
 _ENGLISH_STORE = "en_SA"
+# The language the PRIMARY pass collects in. Not a new assumption: this
+# connector already asserts it every time it writes the default store's name
+# into product_name_ar and reads the other half from _ENGLISH_STORE above. The
+# two are one setting and a store whose default view is not Arabic would have
+# to change both together.
+_PRIMARY_LANG = "ar"
+# Facts about the PAGE, which is why they file under Site metadata and not
+# beside the product's own properties. Requested by name because
+# custom_attributesV2 is filtered to is_visible_on_front:true and these are
+# not visible on the front, so the "take every visible attribute" reader could
+# never see them. Their human label per store comes from the same
+# customAttributeMetadataV2 call every other code uses.
+_META_FIELDS = ("meta_title", "meta_description", "meta_keyword")
+_EN_GROUPED_FRAGMENT = "... on GroupedProduct{items{product{uid name}}}"
 _EN_QUERY = """query($pageSize:Int!,$currentPage:Int!){
   products(filter:{price:{from:"0"}},pageSize:$pageSize,currentPage:$currentPage){
     page_info{current_page total_pages}
-    items{uid name ... on ConfigurableProduct{
+    items{uid name %(grouped)s ... on ConfigurableProduct{
       configurable_options{attribute_code label}
       variants{product{uid name} attributes{code label}}}}
   }
-}"""
+}""" % {"grouped": _EN_GROUPED_FRAGMENT}
 
 # The SAME en pass when enrichment is on: descriptions and attribute values
 # ride pages the names already cost, so the English half of every detail is
@@ -149,14 +207,16 @@ _EN_QUERY_ENRICHED = """query($pageSize:Int!,$currentPage:Int!){
   products(filter:{price:{from:"0"}},pageSize:$pageSize,currentPage:$currentPage){
     page_info{current_page total_pages}
     items{uid name description{html} short_description{html}
+      meta_title meta_description meta_keyword
       custom_attributesV2(filters:{is_visible_on_front:true}){items{
         code ... on AttributeValue{value}
         ... on AttributeSelectedOptions{selected_options{label}}}}
+      %(grouped)s
       ... on ConfigurableProduct{
       configurable_options{attribute_code label}
       variants{product{uid name} attributes{code label}}}}
   }
-}"""
+}""" % {"grouped": _EN_GROUPED_FRAGMENT}
 
 # selling_unit_from (the "50كجم" in a variant's NAME agreeing with its weight)
 # moved to ..normalize on 2026-07-25: sikaegshop states its pack size the same
@@ -271,6 +331,63 @@ def _spans_a_range(product: dict) -> bool:
 def _range_text(product: dict) -> str:
     low, high = _range_ends(product)
     return f"{low}..{high}"
+
+
+def _display_method(product: dict) -> str:
+    """HOW THIS PAGE PRESENTS ITS PRODUCT — one of vocab.DisplayMethod, or "".
+
+    Read off `__typename` plus the min/max test, both of which are already in
+    the census response: this costs NO extra request. Measured on madar
+    2026-07-29 — 400 single, 36 options_one_price, 292 options_priced, 33
+    member_list over 161 leaves.
+
+    The min/max test is what separates the two configurable cases, and it is
+    the difference between a page that shows one price and a page that shows
+    "from X". Note it is only trustworthy for CONFIGURABLE: Magento answers
+    max == min on all 33 grouped products even though 20 of them really span,
+    which is exactly why a grouped product's own price_range is refused
+    elsewhere in this file — so the grouped answer is taken from the typename
+    alone and never from the range.
+
+    An unstudied shape (a BundleProduct, a VirtualProduct — neither exists on
+    this store today) returns "". A shape we have not studied is not a shape we
+    may guess at, and the column's whole value is that it never bluffs.
+    """
+    shape = str(product.get("__typename") or "")
+    if shape == "GroupedProduct":
+        return DisplayMethod.MEMBER_LIST.value
+    if shape == "ConfigurableProduct":
+        return (DisplayMethod.OPTIONS_PRICED.value if _spans_a_range(product)
+                else DisplayMethod.OPTIONS_ONE_PRICE.value)
+    if shape == "SimpleProduct":
+        return DisplayMethod.SINGLE.value
+    return ""
+
+
+def _quantity_facts(child: dict) -> tuple[str, str, str]:
+    """(minimum_quantity, quantity_increment, quantity_is_decimal) as the site
+    states them — and "" wherever it states nothing.
+
+    NOTHING IS DERIVED HERE. madar's rebar publishes weight 1000 with a 0.25
+    minimum in 0.05 steps and never writes «طن» anywhere a crawl can reach
+    (verified exhaustively 2026-07-29: member and parent attributes,
+    description, short_description, every meta field, both category
+    descriptions, both store views, and the full rendered page). The owner
+    ruled «الحقائق الخام فقط» — raw facts only — so this returns the numbers
+    and lets the display layer say "per 1,000 kg". Turning them into a unit
+    would put a word on the row that the shop has never printed.
+
+    Magento's default for a product nobody configured is min_sale_qty 1 /
+    qty_increments 1, which says nothing; it is stored anyway rather than
+    filtered, because "the site says 1" and "the site says nothing" are
+    different facts and only the site gets to tell them apart.
+    """
+    minimum = child.get("min_sale_qty")
+    increment = child.get("qty_increments")
+    decimal = child.get("is_qty_decimal")
+    return ("" if minimum is None else str(minimum),
+            "" if increment is None else str(increment),
+            "" if decimal is None else ("1" if decimal else "0"))
 
 
 class MagentoGraphqlConnector:
@@ -404,10 +521,14 @@ class MagentoGraphqlConnector:
             # The human label for EVERY attribute, in each store's own
             # words — «المصنع» beside "Manufacturer" — where the facet list
             # only ever labelled what the shop filters by.
-            codes = {str(a.get("code") or "")
-                     for product in fetched
-                     for a in ((product.get("custom_attributesV2") or {})
-                               .get("items")) or []} - {""}
+            codes = ({str(a.get("code") or "")
+                      for product in fetched
+                      for a in ((product.get("custom_attributesV2") or {})
+                                .get("items")) or []}
+                     # The meta codes are asked for by name rather than taken
+                     # from the visible-attribute bag, so they would otherwise
+                     # never reach the label query and would print as raw codes.
+                     | set(_META_FIELDS)) - {""}
             labels_ar = self._attribute_labels(endpoint, None, notes, codes)
             labels_en = self._attribute_labels(endpoint, _ENGLISH_STORE, notes, codes)
             unknown_codes: set[str] = set()
@@ -579,6 +700,11 @@ class MagentoGraphqlConnector:
                                 ((item.get("short_description") or {})
                                  .get("html")) or ""),
                             "attributes": attributes,
+                            # About the PAGE, not the product — see
+                            # _META_FIELDS. Bilingual like everything else: the
+                            # two stores write their own.
+                            "meta": {code: str(item.get(code) or "")
+                                     for code in _META_FIELDS},
                         }
                     # The axis NAME is per attribute and shared by every product
                     # that varies by it, so one map serves the whole crawl.
@@ -586,6 +712,17 @@ class MagentoGraphqlConnector:
                         code = str(option.get("attribute_code") or "")
                         if code and option.get("label"):
                             axis_labels[code] = str(option["label"])
+                    # A GROUPED member's English name. It is not decoration:
+                    # the member name is what the page prints beside each
+                    # member's price, so it IS this row's variant label, and
+                    # the English half of it was being dropped for all 161
+                    # members on the source. `items` is the grouped selection;
+                    # `variants` below is the configurable one.
+                    for member in item.get("items") or []:
+                        child = member.get("product") or {}
+                        cuid = str(child.get("uid") or "")
+                        if cuid and child.get("name"):
+                            names[cuid] = str(child["name"])
                     for v in item.get("variants") or []:
                         child = v.get("product") or {}
                         cuid = str(child.get("uid") or "")
@@ -673,6 +810,20 @@ class MagentoGraphqlConnector:
                     walk(child, here)
                 if children:
                     return              # only LEAVES list products; parents repeat them
+                # WHY PARENTS STILL DO NOT LIST, measured rather than assumed
+                # (live A/B, 2026-07-29). 90 of madar's 761 products carry no
+                # classification, and the obvious theory — "they are filed on a
+                # branch node, and only leaves are listed here" — is wrong.
+                # Listing all 17 branch nodes as well as the 56 leaves reaches
+                # 671 products instead of 669: it finds TWO, for a 30% larger
+                # category walk on a source that crawls daily.
+                #
+                # The other 88 are the shop's own silence. Asked directly, they
+                # answer `categories: []` (71231005, 70402032, 70601014 all
+                # verified), and no listing anywhere in the tree returns them.
+                # They are not mis-filed by this walk; they are unfiled by
+                # madar. That is a fact to record, not a bug to fix here, and
+                # no amount of extra listing will reach them.
                 if wanted and uid not in wanted and not (set(here) & wanted):
                     return
                 path = " > ".join(here)
@@ -748,11 +899,19 @@ class MagentoGraphqlConnector:
         # recorded which product they belonged to.
         parent_sku = str(product.get("sku") or "")
 
+        # HOW THE PAGE PRESENTS THIS PRODUCT — read once, because it is a
+        # property of the PRODUCT and identical on every row it emits. What one
+        # unit of the price BUYS is the other question, and it is answered per
+        # row below, because it genuinely differs per member.
+        display = _display_method(product)
+
         def row(pid, vid, sku, name, reg, fin, stock, label="", fp="",
-                basis="", unit="", vat=None, axes=None, axes_en=None):
+                basis="", unit="", vat=None, axes=None, axes_en=None,
+                variant_en="", quantity=("", "", ""), stock_qty=None):
             effective = fin if fin is not None else reg
             if effective is None:
                 return  # a product with no price — skip, don't emit an empty required field
+            minimum, increment, is_decimal = quantity
             out.append(builder.row(
                 external_product_id=pid, external_variant_id=vid, external_sku=sku or "",
                 # The PRODUCT's English name, never the child's — madar names
@@ -783,9 +942,30 @@ class MagentoGraphqlConnector:
                 # it. Composed with the SAME rule as the Arabic label so the two
                 # read alike — «العرض (ملم): 610» / "Width (mm): 610" — instead
                 # of one being a sentence and the other a list.
-                variant=", ".join(f"{axis}: {value}" for axis, value in (axes_en or {}).items()),
+                #
+                # `variant_en` overrides it for a GROUPED member, whose label is
+                # not built from axes at all: the member has no axes, its NAME
+                # is its label, and building this column only from axes_en is
+                # why all 162 grouped variants stored variant='' while the site
+                # published 161 English member names.
+                variant=variant_en or ", ".join(
+                    f"{axis}: {value}" for axis, value in (axes_en or {}).items()),
                 variant_axes=option_axes_json(axes_en or {}),
                 basis_quantity=basis, unit=unit,
+                # WHAT THE SITE SAYS ABOUT THE QUANTITY, and only what it says.
+                minimum_quantity=minimum, quantity_increment=increment,
+                quantity_is_decimal=is_decimal,
+                # HOW THE PAGE PRESENTS THE PRODUCT — constant across its rows.
+                display_method=display,
+                # The shop's own count when it publishes one. rowspec and ingest
+                # have both handled this column since before this connector
+                # existed; the query simply never asked for it.
+                stock_quantity="" if stock_qty is None else str(stock_qty),
+                # The language of THIS pass. The connector already asserts it by
+                # writing the default store's name into product_name_ar and
+                # reading English from _ENGLISH_STORE; naming it here just stops
+                # the claim being implicit.
+                lang=_PRIMARY_LANG,
                 product_link=url, country_code_alpha2=ctx["country_code_alpha2"], currency=ctx["currency"],
                 # PER ROW, never per source: on this platform one crawl carries
                 # both answers at once, and a source-level flag stamped on
@@ -833,9 +1013,18 @@ class MagentoGraphqlConnector:
                     # The member's own name is what the page prints beside its
                     # price — it IS the label that tells the two apart.
                     label=str(child.get("name") or ""),
+                    # ...and the en_SA store publishes that same label in
+                    # English for 161 of 161 members, 150 of them genuinely
+                    # different from the Arabic. Keyed by the member's uid,
+                    # which `names_en` only learns now that _EN_QUERY carries a
+                    # GroupedProduct fragment — both halves of this fix are
+                    # needed, either alone leaves the column empty.
+                    variant_en=names_en.get(str(child.get("uid") or "")) or "",
                     fp=option_fingerprint({"member": str(child.get("sku") or "")})
                     if child.get("sku") else "",
-                    basis=basis, unit=unit)
+                    basis=basis, unit=unit,
+                    quantity=_quantity_facts(child),
+                    stock_qty=child.get("only_x_left_in_stock"))
             if not out:
                 # Never fall back to the group figure: it is the cheapest
                 # member's price under the group's name, and saying nothing is
@@ -920,7 +1109,9 @@ class MagentoGraphqlConnector:
                              for a in attrs
                              for code in [str(a.get("code") or "")]
                              if code in axis_labels_en},
-                    basis=basis, unit=unit, vat=variant_vat)
+                    basis=basis, unit=unit, vat=variant_vat,
+                    quantity=_quantity_facts(child),
+                    stock_qty=child.get("only_x_left_in_stock"))
         else:
             # A product standing alone must have ONE price, not a span. Every
             # SimpleProduct in the live census (399 of 399) answers
@@ -937,8 +1128,12 @@ class MagentoGraphqlConnector:
                     "than stored at the range's low end")
                 return out
             reg, fin = _prices(product)
+            # A simple product IS its own leaf, so its quantity facts and its
+            # stock count sit on the product node itself.
             row(product.get("uid"), product.get("uid"), product.get("sku"),
-                product.get("name"), reg, fin, product.get("stock_status"))
+                product.get("name"), reg, fin, product.get("stock_status"),
+                quantity=_quantity_facts(product),
+                stock_qty=product.get("only_x_left_in_stock"))
         return out
 
 
@@ -1070,6 +1265,18 @@ def _enrichment_rows(builder: RowBuilder, product: dict, filterable: dict,
         lang="ar")
     add("short_description", "Summary", mine.get("short_description", ""),
         lang="en")
+
+    # WHAT THE PAGE SAYS ABOUT ITSELF. Recorded, not reconciled: madar's epoxy
+    # rebar reads «سابك» (SABIC) in the AR meta_title while its `name` says «من
+    # حديد» (Hadeed) and its image is epoxy_sabic.png. Under "source truth is
+    # never edited" the disagreement IS the fact, and the Site metadata group
+    # exists so it can be kept without crowding out a product fact.
+    meta_en = dict(mine.get("meta", {}))
+    for code in _META_FIELDS:
+        add(f"{code}_ar", labels_ar.get(code) or facets.get(code) or code,
+            str(product.get(code) or ""), lang="ar")
+        add(code, labels_en.get(code) or facets.get(code) or code,
+            meta_en.get(code, ""), lang="en")
 
     # The "More information" panel, one row per stated fact — manufacturer,
     # origin, grade, coating... — in the site's own values, labelled in the

--- a/scrapex/databases/domain.py
+++ b/scrapex/databases/domain.py
@@ -125,7 +125,7 @@ def _general_plan() -> tuple[Migration, ...]:
 # Listed rather than ranged: the unified chain and this one have diverged, so a
 # new price migration lands at the END of the legacy chain but in the middle of
 # this plan. A range would silently swallow whatever General adds next.
-_MARKETLENS_LEGACY_NUMBERS = (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 15, 16, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55)
+_MARKETLENS_LEGACY_NUMBERS = (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 15, 16, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56)
 
 # Where the identity migration sits in this stream. Everything before it is the
 # price history the unified warehouse already had; everything after is a price

--- a/scrapex/ingest.py
+++ b/scrapex/ingest.py
@@ -212,7 +212,7 @@ def _get_product(conn, source_id: int, r: dict, run_id: int | None = None,
     row = conn.execute(
         "SELECT source_product_id, curation, product_name_ar, product_link, brand, brand_ar, "
         "       external_sku, status, category_path_ar, category_external_id, "
-        "       product_name, product_name_lang, category_path "
+        "       product_name, product_name_lang, category_path, display_method "
         "FROM source_product WHERE source_id = ? AND external_product_id = ?",
         (source_id, r["external_product_id"]),
     ).fetchone()
@@ -255,7 +255,24 @@ def _get_product(conn, source_id: int, r: dict, run_id: int | None = None,
         "category_external_id": r.get("category_external_id") or "",
         "product_name": r["product_name"] or "",
         "product_name_lang": r.get("lang") or "",
-        "has_variants": 1 if r["external_variant_id"] or r["option_fingerprint"] else 0,
+        # HOW THE SITE PRESENTS IT (0056) — one of vocab.DisplayMethod, or ""
+        # from a connector that has not been taught to say. Kept beside
+        # parent_sku because it is the same kind of fact: product identity the
+        # source states, not an open-ended attribute.
+        "display_method": r.get("display_method") or "",
+        # "MORE THAN ONE OF IT", which is not the same question as "does this
+        # row carry a variant id". The old test was `external_variant_id or
+        # option_fingerprint`, and a simple product is emitted as row(uid, uid)
+        # by every shop connector here, so external_variant_id was NEVER empty
+        # and this column read 1 for 763/763 MADAR products and for every
+        # product of sources 1,2,3,4,7,8,9 — one column, one answer, no
+        # information. Comparing the two ids is the honest test: a product that
+        # IS its own variant has no variations. display_method now answers the
+        # richer question; this one goes back to answering its own correctly.
+        "has_variants": 1 if (
+            (r["external_variant_id"]
+             and r["external_variant_id"] != r["external_product_id"])
+            or r["option_fingerprint"]) else 0,
         "curation": CurationStatus.INVENTORIED.value,
     })
     record_change(conn, ChangeType.NEW, "source_product", source_product_id=pid,
@@ -481,10 +498,73 @@ def _basis_quantity(raw: str) -> float:
     return value if value > 0 else 1.0
 
 
+def _optional_quantity(raw: str) -> float | None:
+    """A quantity the SITE stated, or None when it stated nothing.
+
+    Deliberately not _basis_quantity: that one falls back to 1.0, which is the
+    right answer for "how many units does this price buy" (the schema's own
+    default) and the WRONG one here. "The shop requires a minimum of 1" and
+    "the shop states no minimum" are different facts, and a default of 1 would
+    erase the difference on all 3,417 offers that currently say nothing.
+    """
+    text = str(raw or "").strip()
+    if not text:
+        return None
+    try:
+        value = float(text)
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None
+
+
+def _quantity_facts(r: dict) -> dict:
+    """WHAT ONE UNIT OF THE PRICE BUYS, as the site states it (0056).
+
+    ONLY the facts this row actually REPORTED. A connector that has not been
+    taught these columns sends "" for all three, and this returns {} — so the
+    absent column can never overwrite a value an earlier crawl learned. Same
+    rule product_field_diffs already applies to names and brands: an empty
+    incoming value is "the connector did not say", never "the source cleared
+    it".
+
+    None of these is in ux_source_offer_identity, so learning them never splits
+    an offer or mints a second one — an existing offer simply fills in the
+    columns it was always missing.
+    """
+    facts: dict = {}
+    for column in ("minimum_quantity", "quantity_increment"):
+        value = _optional_quantity(r.get(column, ""))
+        if value is not None:
+            facts[column] = value
+    # This one is a flag, so the site saying "false" is itself an answer — but
+    # an ABSENT column is still silence, and "" is what absence looks like.
+    stated = str(r.get("quantity_is_decimal", "") or "").strip()
+    if stated:
+        facts["quantity_is_decimal"] = 1 if stated == "1" else 0
+    return facts
+
+
+def _apply_quantity_facts(conn, offer_id: int, facts: dict) -> None:
+    """Let an existing offer learn what the site says about its quantity.
+
+    Written on every crawl, not only at INSERT: all 3,417 MADAR offers already
+    exist, so an INSERT-only path would have left every one of them blank
+    forever — the same trap 0052 fell into with the trade price, where the
+    values it promised "on the next crawl" could never arrive because nothing
+    asked the warehouse to write them.
+    """
+    if not facts:
+        return
+    sets = ", ".join(f"{column} = ?" for column in facts)   # fixed column names
+    conn.execute(f"UPDATE source_offer SET {sets} WHERE offer_id = ?",
+                 (*facts.values(), offer_id))
+
+
 def _get_offer_id(conn, variant_id: int, r: dict) -> int:
     vat = 1 if r["tax_included"] == "1" else 0
     unit_id = _get_unit_id(conn, canonical_unit(r.get("unit", ""), r.get("currency", "")))
     basis = _basis_quantity(r.get("basis_quantity", ""))
+    quantity = _quantity_facts(r)
     # The unit is part of what an offer IS: 15 per litre and 15 per gallon are
     # different offers, not one offer that changed price. The lookup used to pin
     # selling_unit_id IS NULL, which made every offer unit-less by construction
@@ -497,6 +577,7 @@ def _get_offer_id(conn, variant_id: int, r: dict) -> int:
         (variant_id, r["country_code_alpha2"], unit_id or 0, basis),
     )
     if found is not None:
+        _apply_quantity_facts(conn, found, quantity)
         return found
     # AN OFFER LEARNING ITS UNIT IS NOT A SECOND OFFER. The rule above is right
     # about two KNOWN units, and wrong about the step from unknown to known: the
@@ -518,6 +599,7 @@ def _get_offer_id(conn, variant_id: int, r: dict) -> int:
             conn.execute(
                 "UPDATE source_offer SET selling_unit_id = ?, basis_quantity = ? "
                 "WHERE offer_id = ?", (unit_id, basis, unstated))
+            _apply_quantity_facts(conn, unstated, quantity)
             return unstated
     return _insert(conn, "source_offer", {
         "source_variant_id": variant_id,
@@ -526,6 +608,7 @@ def _get_offer_id(conn, variant_id: int, r: dict) -> int:
         "tax_included": vat,
         "selling_unit_id": unit_id,
         "basis_quantity": basis,
+        **quantity,
     })
 
 

--- a/scrapex/payload.py
+++ b/scrapex/payload.py
@@ -43,7 +43,15 @@ from .vocab import ExtractKind, PayloadClient
 # tax_statement_url and official_source_url. None of the five is additive, so a
 # v4 header fails the column check on its own; the number moves anyway, because
 # the contract changed and the sheet has to be told once.
-PAYLOAD_VERSION = 5
+# 6: PRODUCT_PRICES gains four columns — display_method, minimum_quantity,
+# quantity_increment, quantity_is_decimal (migration 0056). ALL FOUR ARE
+# ADDITIVE, which is exactly the case that flag exists for: they are new slots
+# nothing used to fill, so a payload captured before them is COMPLETE rather
+# than broken and replays unchanged. Nothing is renamed and nothing changes
+# meaning, so unlike versions 2..5 no old header fails a column check on its
+# own — and that is precisely why the number has to move. The header check
+# refuses a mismatch, and the sheet has to be told once.
+PAYLOAD_VERSION = 6
 
 # 40k keeps a comfortable margin under the Google Sheets 50k-char cell limit
 # even after the funnel adds its envelope columns (S1).
@@ -79,7 +87,7 @@ class FunnelPayload(BaseModel):
     # Pinned as a const so the GENERATED json-schema carries it too: a
     # consumer validating against the schema rather than the Python model
     # would otherwise still accept v1.
-    payload_version: Literal[5]
+    payload_version: Literal[6]
     source_key: str = Field(min_length=1, max_length=64)
     kind: ExtractKind
     client: PayloadClient

--- a/scrapex/rowspec.py
+++ b/scrapex/rowspec.py
@@ -125,6 +125,34 @@ PRODUCT_PRICES = RowSpec(
         # product's sku column held whichever variation was ingested last.
         "variant_url",
         "parent_sku",
+        # --- added 2026-07-29 -------------------------------------------------
+        # TWO FACTS THAT WERE BEING CONFLATED, and separating them is the whole
+        # point of this widening.
+        #
+        # HOW THE SITE PRESENTS THE PRODUCT — one of vocab.DisplayMethod, and
+        # constant across every row this product emits. The one column that
+        # looked like it answered this (`has_variants`) answers 1 for every
+        # product of every shop source, so it could not be reused.
+        "display_method",
+        # WHAT ONE UNIT OF THE PRICE BUYS — properties of the OFFER, differing
+        # per member. `unit`/`basis_quantity` above already carried the part the
+        # site states in words ("50كجم" in the name agreeing with weight=50);
+        # these three carry the part it states as NUMBERS, and only as numbers.
+        #
+        # madar's rebar is why. Every member declares is_qty_decimal, weight
+        # 1000, a 0.25 minimum in 0.05 steps — and the Ø8 member costs 4,830
+        # while the Ø32 costs 4,045, which is impossible per piece and exactly
+        # right per tonne. But the shop never writes «طن»: verified 2026-07-29
+        # across member and parent attributes, description, short_description,
+        # every meta field, both category descriptions, both store views and the
+        # full 932KB rendered page — 0 occurrences, and the quantity box is
+        # labelled «الكمية» and nothing else. So the OWNER's ruling is recorded
+        # here as it was given: «الحقائق الخام فقط» — store what the site
+        # publishes, let the display layer render "per 1,000 kg", and never let
+        # a connector write a unit the shop did not say.
+        "minimum_quantity",      # min_sale_qty: the smallest orderable amount
+        "quantity_increment",    # qty_increments: the step it moves in
+        "quantity_is_decimal",   # "0" | "1" — is_qty_decimal, as a FACT
     ),
     required=frozenset({"external_product_id", "country_code_alpha2", "currency", "tax_included", "price"}),
     # The four _ar columns are deliberately NOT additive. RowView returns ""
@@ -135,9 +163,17 @@ PRODUCT_PRICES = RowSpec(
     # no error. Non-additive constrains the HEADER, not the value, and every
     # connector builds its header from this spec, so it costs nothing today
     # and buys a second refusal independent of the version number.
+    # THIS IS THE CASE THE FLAG EXISTS FOR. All four 2026-07-29 columns are new
+    # slots that nothing used to fill, so a payload captured before them is
+    # COMPLETE, not broken: it simply predates the questions. They read as ""
+    # (never said) / "0" (not a decimal quantity), which is the truthful state
+    # of every row already in the warehouse — and no backfill is possible,
+    # because raw_snapshot holds 0 rows.
     additive=frozenset({"unit", "basis_quantity", "lang", "price_trade",
                         "category_external_id",
-                        "variant", "variant_axes", "variant_url", "parent_sku"}),
+                        "variant", "variant_axes", "variant_url", "parent_sku",
+                        "display_method", "minimum_quantity",
+                        "quantity_increment", "quantity_is_decimal"}),
 )
 
 # ---- enrichment: the open-ended attribute bag, one ROW per attribute ---------

--- a/scrapex/vocab.py
+++ b/scrapex/vocab.py
@@ -141,6 +141,15 @@ _DETAIL_GROUP_BY_CODE: dict[str, DetailGroup] = {
     "no_follow": DetailGroup.SITE_METADATA,
     "no_archive": DetailGroup.SITE_METADATA,
     "keywords": DetailGroup.SITE_METADATA,
+    # The page's own <title>, which is not the product's name and sometimes
+    # disagrees with it: madar's epoxy rebar is «من حديد» (Hadeed) in `name`
+    # while meta_title says «سابك» (SABIC), and the image is epoxy_sabic.png.
+    # That is the SITE's inconsistency and we record it rather than resolve
+    # it — source truth is never edited. Filed here because it describes the
+    # PAGE, so it cannot crowd out a product fact.
+    "meta_title": DetailGroup.SITE_METADATA,
+    "meta_description": DetailGroup.SITE_METADATA,
+    "meta_keyword": DetailGroup.SITE_METADATA,
     # Information ABOUT the product — the owner's own three examples.
     "manufacturer": DetailGroup.MORE_INFORMATION,
     "origin": DetailGroup.MORE_INFORMATION,
@@ -263,6 +272,38 @@ def group_for_code(code: str) -> "tuple[DetailGroup, bool]":
         if base.endswith(suffix):
             return group, True
     return DetailGroup.MORE_INFORMATION, False
+
+
+class DisplayMethod(StrEnum):
+    """HOW THE SITE PRESENTS A PRODUCT — a property of the product, constant
+    across every row it produces.
+
+    Not to be confused with what one unit of the price BUYS, which is a
+    property of the OFFER and differs per member (source_offer carries that:
+    selling_unit_id, basis_quantity, minimum_quantity, quantity_increment,
+    quantity_is_decimal). Conflating the two is what made a MADAR row
+    unreadable: a grouped rebar member and a simple bag of cement arrived
+    looking identical, and neither said which it was.
+
+    THE STRUCTURAL POINT, measured on madar's live census 2026-07-29: "sold by
+    a bulk unit" is NOT a fourth shape. It appears INSIDE GroupedProduct (96
+    leaves) and INSIDE ConfigurableProduct (13 leaves, the steel mesh). So it
+    cannot be a fifth value here — a single enum over `__typename` would miss
+    it — and it lives on the offer instead. Two columns, two questions.
+
+    `has_variants` is NOT this column and must never be reused as it: it reads
+    1 for 763 of 763 madar products and for every product of sources 1,2,3,4,7,
+    8,9, because a simple product is emitted as row(uid, uid) and the flag only
+    ever asked whether external_variant_id was non-empty.
+
+    '' is a shape nobody has studied yet, and it is NEVER guessed. A future
+    BundleProduct arrives blank rather than filed as the nearest thing.
+    """
+
+    SINGLE = "single"                       # one product, one price
+    OPTIONS_ONE_PRICE = "options_one_price"  # options, all at the same price
+    OPTIONS_PRICED = "options_priced"       # options priced apart ("from X")
+    MEMBER_LIST = "member_list"             # the page prices the MEMBERS
 
 
 class ExtractKind(StrEnum):

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -57,7 +57,7 @@ def test_migration_creates_the_catalogue_and_integrity_triggers(conn):
     assert objects["relationship_field_pair"] == "table"
     assert objects["trg_dataset_relationship_same_site_insert"] == "trigger"
     assert objects["trg_relationship_field_pair_matches_insert"] == "trigger"
-    assert conn.execute("PRAGMA user_version").fetchone()[0] == 55
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 56
 
 
 def test_one_site_can_hold_multiple_tables_with_different_dynamic_columns(conn):

--- a/tests/test_database_isolation.py
+++ b/tests/test_database_isolation.py
@@ -67,7 +67,7 @@ def test_fresh_registry_creates_two_typed_databases_without_domain_tables_crossi
     assert applied["general"] == list(
         range(1, registry.general.latest_schema_version + 1)
     )
-    assert applied["marketlens"] == list(range(1, 54))   # ... +52 a rate says whether a provider or a shop published it
+    assert applied["marketlens"] == list(range(1, 55))   # ... +54 how the site shows it, and what one unit buys
     assert registry.health()["general"]["status"] == "Healthy"
     assert registry.health()["marketlens"]["status"] == "Healthy"
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -27,12 +27,12 @@ def test_migrate_is_idempotent(tmp_path: Path):
         second = dbmod.migrate(conn)
     finally:
         conn.close()
-    assert first == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55]
+    assert first == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56]
     assert second == []  # T4: running again applies nothing
 
 
 def test_latest_schema_version_matches_the_migration_chain():
-    assert dbmod.latest_schema_version() == 55   # +0055 the tax table speaks the tax vocabulary
+    assert dbmod.latest_schema_version() == 56   # +0056 how the site shows it, and what one unit buys
 
 
 def test_foreign_keys_actually_enforced(tmp_path: Path):

--- a/tests/test_display_method_and_quantity_facts.py
+++ b/tests/test_display_method_and_quantity_facts.py
@@ -1,0 +1,470 @@
+"""0056: HOW THE SITE SHOWS IT, and WHAT ONE UNIT OF THE PRICE BUYS.
+
+Two facts that were being conflated, and every value below was read off the
+LIVE madar store on 2026-07-29 rather than invented — the rebar prices, the
+weights, the 0.25/0.05 quantity rules, the cement 450-bag minimum, the English
+member names and the shape census counts.
+
+The centrepiece is the arithmetic that proves the defect without needing the
+site's word for it: the Ø8mm member costs MORE than the Ø32mm one. Per piece
+that is impossible; per tonne it is exactly right.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scrapex import db as dbmod
+from scrapex.config import ExtractSpec, SourceEntry
+from scrapex.connectors.magento import MagentoGraphqlConnector
+from scrapex.ingest import ingest_payloads
+from scrapex.payload import PAYLOAD_VERSION, FunnelPayload
+from scrapex.rowspec import PRODUCT_PRICES, RowView
+from scrapex.vocab import DisplayMethod, ExtractKind, ExtractScope
+
+# --- the four shapes, as the live store publishes them ------------------------
+#
+# GroupedProduct 10115-HSS — «حديد تسليح ابوكسي من حديد». Every member declares
+# weight 1000, is_qty_decimal true, a 0.25 minimum in 0.05 steps. The two
+# members kept here are the ones whose prices carry the whole argument.
+_REBAR = {
+    "__typename": "GroupedProduct",
+    "uid": "SFNT", "sku": "10115-HSS", "url_key": "hadeed-epoxy-coated-steel-rebar",
+    "name": " حديد تسليح ابوكسي من حديد", "stock_status": "IN_STOCK",
+    "categories": [],
+    # Magento answers max == min on every one of the 33 grouped products even
+    # when the members really span 55% — which is why the grouped branch never
+    # reads this and _display_method takes the typename alone.
+    "price_range": {"minimum_price": {"regular_price": {"value": 4045.13},
+                                      "final_price": {"value": 4045.13}},
+                    "maximum_price": {"final_price": {"value": 4045.13}}},
+    "items": [
+        {"qty": 0, "position": 1, "product": {
+            "uid": "TjY1", "sku": "101150812",
+            "name": "حديد أبوكسي من حديد | 8مم × 12متر | ASTM A775 جريد 60",
+            "stock_status": "IN_STOCK", "weight": 1000,
+            "is_qty_decimal": True, "min_sale_qty": 0.25, "qty_increments": 0.05,
+            "only_x_left_in_stock": None,
+            "price_range": {"minimum_price": {"regular_price": {"value": 4830.0},
+                                              "final_price": {"value": 4830.0}}}}},
+        {"qty": 0, "position": 2, "product": {
+            "uid": "Tjcy", "sku": "101153212",
+            "name": "حديد أبوكسي من حديد | 32مم × 12متر | ASTM A775 جريد 60",
+            "stock_status": "IN_STOCK", "weight": 1000,
+            "is_qty_decimal": True, "min_sale_qty": 0.25, "qty_increments": 0.05,
+            "only_x_left_in_stock": 8,
+            "price_range": {"minimum_price": {"regular_price": {"value": 4045.13},
+                                              "final_price": {"value": 4045.13}}}}},
+    ],
+}
+
+# ConfigurableProduct 70501-RCF — «اسمنت الرياض». The children are priced apart
+# (15.23 .. 27.83), so the page shows "from X". min_sale_qty 450 in steps of
+# 450 at 50 kg a bag: the price is only obtainable at 22.5 tonnes per order.
+_CEMENT = {
+    "__typename": "ConfigurableProduct",
+    "uid": "UkNG", "sku": "70501-RCF", "url_key": "riyadh-cement",
+    "name": "اسمنت الرياض", "stock_status": "IN_STOCK", "categories": [],
+    "price_range": {"minimum_price": {"regular_price": {"value": 15.23},
+                                      "final_price": {"value": 15.23}},
+                    "maximum_price": {"final_price": {"value": 27.83}}},
+    "configurable_options": [{"attribute_code": "cement_type", "label": "نوع الاسمنت"}],
+    "variants": [
+        {"attributes": [{"code": "cement_type", "label": "اسمنت ابيض"}],
+         "product": {
+            "uid": "QzE1OTI=", "sku": "70502001",
+            "name": "اسمنت ابيض - 50كجم - اسمنت الرياض",
+            "stock_status": "IN_STOCK", "weight": 50,
+            "is_qty_decimal": False, "min_sale_qty": 450, "qty_increments": 450,
+            "only_x_left_in_stock": None,
+            "price_range": {"minimum_price": {"regular_price": {"value": 27.83},
+                                              "final_price": {"value": 27.83}}}}},
+    ],
+}
+
+# A configurable whose options are all one price — the page shows a single
+# figure, not a "from".
+_SOCKETS = {
+    "__typename": "ConfigurableProduct",
+    "uid": "TEVH", "sku": "60402-LPF", "url_key": "legrand-sockets",
+    "name": "علب أرضية منبثقة من ليجراند", "stock_status": "IN_STOCK", "categories": [],
+    "price_range": {"minimum_price": {"regular_price": {"value": 194.9},
+                                      "final_price": {"value": 194.9}},
+                    "maximum_price": {"final_price": {"value": 194.9}}},
+    "configurable_options": [{"attribute_code": "gangs", "label": "عدد الوحدات"}],
+    "variants": [
+        {"attributes": [{"code": "gangs", "label": "3"}],
+         "product": {
+            "uid": "TEVHMw==", "sku": "054010",
+            "name": "054010 FLOOR BACK BOX POPUP ALU 3MOD LEGRAND",
+            "stock_status": "IN_STOCK", "weight": 1.4,
+            "is_qty_decimal": False, "min_sale_qty": 1, "qty_increments": 1,
+            "only_x_left_in_stock": None,
+            "price_range": {"minimum_price": {"regular_price": {"value": 194.9},
+                                              "final_price": {"value": 194.9}}}}},
+    ],
+}
+
+# A plain SimpleProduct: one product, one price, and the shop's own count.
+_PUTTY = {
+    "__typename": "SimpleProduct",
+    "uid": "UFVUVFk=", "sku": "71205003", "url_key": "putty-1-kg-sab",
+    "name": " معجون سابك 1 كجم", "stock_status": "IN_STOCK", "categories": [],
+    "weight": 1, "is_qty_decimal": False, "min_sale_qty": 1, "qty_increments": 1,
+    "only_x_left_in_stock": 8,
+    "price_range": {"minimum_price": {"regular_price": {"value": 65.21},
+                                      "final_price": {"value": 65.21}},
+                    "maximum_price": {"final_price": {"value": 65.21}}},
+}
+
+_CENSUS = {"data": {"products": {
+    "page_info": {"current_page": 1, "total_pages": 1},
+    "items": [_REBAR, _CEMENT, _SOCKETS, _PUTTY]}}}
+
+# The en_SA store view. It publishes an English name for every grouped MEMBER —
+# 161 of 161 live, 150 of them genuinely different from the Arabic — and this
+# is the half that never arrived, because both English queries carried a
+# ConfigurableProduct fragment and no GroupedProduct one.
+_ENGLISH = {"data": {"products": {
+    "page_info": {"current_page": 1, "total_pages": 1},
+    "items": [
+        {"uid": "SFNT", "name": "Hadeed Epoxy Coated Steel Rebar", "items": [
+            {"product": {"uid": "TjY1",
+                         "name": "Hadeed Epoxy Rebar| Ø8mm × 12m | ASTM A775 Grade 60"}},
+            {"product": {"uid": "Tjcy",
+                         "name": "Hadeed Epoxy Rebar| Ø32mm × 12m | ASTM A775 Grade 60"}},
+        ]},
+        {"uid": "UkNG", "name": "Riyadh Cement",
+         "configurable_options": [{"attribute_code": "cement_type", "label": "Cement Type"}],
+         "variants": [{"attributes": [{"code": "cement_type", "label": "White Cement"}],
+                       "product": {"uid": "QzE1OTI=", "name": "White Cement - 50kg"}}]},
+        {"uid": "TEVH", "name": "Legrand Pop-up Floor Box Kit"},
+        {"uid": "UFVUVFk=", "name": "SABIC Putty 1 kg"},
+    ]}}}
+
+
+class _Response:
+    def __init__(self, payload): self._payload = payload
+    def json(self): return self._payload
+
+
+class _Fetcher:
+    def __init__(self): self.requests_count = 0
+
+    def post(self, url, json=None, **kwargs):
+        self.requests_count += 1
+        query = (json or {}).get("query", "")
+        page = (json or {}).get("variables", {}).get("currentPage", 1)
+        if (kwargs.get("headers") or {}).get("Store"):
+            if "categoryList" in query:
+                return _Response({"data": {"categoryList": [{"children": []}]}})
+            return _Response(_ENGLISH if page == 1 else
+                             {"data": {"products": {"items": []}}})
+        if "categoryList" in query:
+            return _Response({"data": {"categoryList": [{"children": []}]}})
+        if "category_uid" in query:
+            return _Response({"data": {"products": {
+                "items": [], "page_info": {"current_page": 1, "total_pages": 1}}}})
+        return _Response(_CENSUS if page == 1 else
+                         {"data": {"products": {"items": []}}})
+
+    def close(self): pass
+
+
+def _entry() -> SourceEntry:
+    return SourceEntry.model_validate(dict(
+        source_key="MADAR", source_name="المدار", base_url="https://www.madar.com",
+        family="magento-graphql", currency="SAR", default_region="SA", vat_mode="incl",
+        extract=[ExtractSpec(kind=ExtractKind.PRODUCT_PRICES, scope=ExtractScope.CENSUS)],
+    ))
+
+
+def _rows() -> list[dict]:
+    tables = list(MagentoGraphqlConnector(_Fetcher()).fetch(_entry()))
+    prices = [t for t in tables if t.kind == ExtractKind.PRODUCT_PRICES]
+    view = RowView(PRODUCT_PRICES, prices[0].header)
+    return [view.as_dict(row) for table in prices for row in table.rows]
+
+
+def _by_sku(sku: str) -> dict:
+    found = [r for r in _rows() if r["external_sku"] == sku]
+    assert len(found) == 1, f"expected exactly one row for {sku}, got {len(found)}"
+    return found[0]
+
+
+# ---- P1: the arithmetic that proves per-tonne is per-tonne -------------------
+
+def test_the_thin_bar_costs_more_than_the_thick_one_which_is_only_possible_per_tonne():
+    """THE READY-MADE ASSERTION. A 12 m Ø32 bar carries ~16x the steel of a Ø8
+    bar, so per PIECE the Ø8 cannot cost more. It does — 4,830 against 4,045 —
+    and per TONNE that is exactly right, because thin bars cost more per tonne
+    to roll. The row must therefore carry enough for a reader to know the
+    figure is not the price of one bar."""
+    thin, thick = _by_sku("101150812"), _by_sku("101153212")
+    assert float(thin["price"]) > float(thick["price"]), (
+        "the Ø8 member must cost more than the Ø32 one — this is the live data")
+    # ...and the facts that make that legible now ride the row.
+    assert thin["quantity_is_decimal"] == "1"
+    assert thin["minimum_quantity"] == "0.25"
+    assert thin["quantity_increment"] == "0.05"
+
+
+def test_no_unit_is_invented_where_the_site_states_none():
+    """The owner's ruling, «الحقائق الخام فقط». The shop publishes weight 1000
+    and never the word «طن» — verified 2026-07-29 across member and parent
+    attributes, description, meta, both category descriptions, both store
+    views and the full rendered page. So the unit column stays EMPTY and the
+    numbers carry the meaning. A connector that starts writing 'tonne' here is
+    asserting something the shop has never printed."""
+    thin = _by_sku("101150812")
+    assert thin["unit"] == "", (
+        "madar states no unit for rebar; writing one would invent the shop's word")
+    assert thin["basis_quantity"] == ""
+
+
+def test_a_stated_unit_is_still_read_where_the_site_does_state_it():
+    """The refusal above is about SILENCE, not about units. Cement states its
+    basis twice — weight 50 and «50كجم» in the child's name — and that
+    agreement is exactly what selling_unit_from has always required."""
+    bag = _by_sku("70502001")
+    assert (bag["unit"], bag["basis_quantity"]) == ("kg", "50")
+
+
+# ---- P3: the minimum that makes the price obtainable -------------------------
+
+def test_the_cement_minimum_is_captured():
+    """450 bags in steps of 450, at 50 kg a bag: the price is only obtainable at
+    22.5 tonnes per order. minimum_quantity existed in schema.sql and nothing
+    ever read or wrote it."""
+    bag = _by_sku("70502001")
+    assert bag["minimum_quantity"] == "450"
+    assert bag["quantity_increment"] == "450"
+    assert bag["quantity_is_decimal"] == "0"
+
+
+# ---- P4: the stock counts the site publishes --------------------------------
+
+def test_site_published_stock_counts_ride_the_row():
+    assert _by_sku("101153212")["stock_quantity"] == "8"
+    assert _by_sku("71205003")["stock_quantity"] == "8"
+    # ...and a product the site says nothing about stays blank, never 0.
+    assert _by_sku("101150812")["stock_quantity"] == ""
+
+
+# ---- P2: the English variant names the site publishes -----------------------
+
+def test_a_grouped_member_gets_its_english_name():
+    """Needed BOTH fixes: the GroupedProduct fragment in _EN_QUERY (so names_en
+    learns a member uid at all) and the row() call passing it (so `variant` is
+    not built only from axes a member does not have). Either alone leaves the
+    column empty, which is how all 162 stored variants came to carry ''."""
+    thin = _by_sku("101150812")
+    assert thin["variant"] == "Hadeed Epoxy Rebar| Ø8mm × 12m | ASTM A775 Grade 60"
+    # The Arabic half is unchanged and still the member's own name.
+    assert thin["variant_ar"] == (
+        "حديد أبوكسي من حديد | 8مم × 12متر | ASTM A775 جريد 60")
+
+
+def test_a_configurable_variant_label_is_still_built_from_its_axes():
+    """variant_en overrides the axis composition only where there are no axes.
+    A configurable child must keep composing «Cement Type: White Cement»."""
+    assert _by_sku("70502001")["variant"] == "Cement Type: White Cement"
+
+
+# ---- the display method, one product of each shape --------------------------
+
+def test_display_method_is_right_for_each_of_the_four_shapes():
+    assert _by_sku("101150812")["display_method"] == DisplayMethod.MEMBER_LIST.value
+    assert _by_sku("70502001")["display_method"] == DisplayMethod.OPTIONS_PRICED.value
+    assert _by_sku("054010")["display_method"] == DisplayMethod.OPTIONS_ONE_PRICE.value
+    assert _by_sku("71205003")["display_method"] == DisplayMethod.SINGLE.value
+
+
+def test_an_unstudied_shape_is_left_blank_rather_than_guessed():
+    """A BundleProduct exists nowhere on this store today. When one arrives it
+    must file blank — '' means "nobody has studied this", and the column's
+    whole value is that it never bluffs."""
+    from scrapex.connectors.magento import _display_method
+    assert _display_method({"__typename": "BundleProduct"}) == ""
+    assert _display_method({}) == ""
+
+
+def test_display_method_is_constant_across_every_row_a_product_emits():
+    """It is a property of the PRODUCT, not of the offer — that is the whole
+    reason it sits on source_product and the quantity facts sit on
+    source_offer."""
+    members = [r for r in _rows() if r["external_product_id"] == "SFNT"]
+    assert len(members) == 2
+    assert {r["display_method"] for r in members} == {DisplayMethod.MEMBER_LIST.value}
+
+
+# ---- the simple product is unchanged ----------------------------------------
+
+def test_a_simple_product_is_otherwise_untouched():
+    """The regression guard. Everything this commit adds is additive; a simple
+    row's existing columns must read exactly as they did before."""
+    putty = _by_sku("71205003")
+    assert putty["price"] == "65.21"
+    assert putty["tax_included"] == "1"          # the storefront figure
+    assert putty["external_product_id"] == putty["external_variant_id"]
+    assert putty["product_name_ar"] == " معجون سابك 1 كجم"   # the site's own space
+    assert putty["product_name"] == "SABIC Putty 1 kg"
+    assert putty["variant_ar"] == "" and putty["variant"] == ""
+    assert putty["unit"] == "" and putty["basis_quantity"] == ""
+    assert putty["parent_sku"] == ""
+
+
+# ---- P7: the connector states which language it read ------------------------
+
+def test_every_row_states_the_language_it_was_collected_in():
+    assert {r["lang"] for r in _rows()} == {"ar"}
+
+
+# ---- what the warehouse ends up holding -------------------------------------
+
+def _ingest(tmp_path: Path):
+    conn = dbmod.connect(tmp_path / "harvest.db")
+    dbmod.migrate(conn)
+    tables = [t for t in MagentoGraphqlConnector(_Fetcher()).fetch(_entry())
+              if t.kind == ExtractKind.PRODUCT_PRICES]
+    payloads = [FunnelPayload(
+        payload_version=PAYLOAD_VERSION, source_key="MADAR",
+        kind=ExtractKind.PRODUCT_PRICES, client="cli",
+        scraped_at="2026-07-29T10:00:00Z", source_url=t.source_url,
+        header=t.header, rows=t.rows) for t in tables]
+    ingest_payloads(conn, _entry(), payloads)
+    return conn
+
+
+def test_the_warehouse_stores_both_facts_in_their_own_places(tmp_path):
+    conn = _ingest(tmp_path)
+    try:
+        shapes = dict(conn.execute(
+            "SELECT external_product_id, display_method FROM source_product"))
+        assert shapes["SFNT"] == DisplayMethod.MEMBER_LIST.value
+        assert shapes["UkNG"] == DisplayMethod.OPTIONS_PRICED.value
+        assert shapes["TEVH"] == DisplayMethod.OPTIONS_ONE_PRICE.value
+        assert shapes["UFVUVFk="] == DisplayMethod.SINGLE.value
+
+        offer = conn.execute(
+            "SELECT o.minimum_quantity, o.quantity_increment, o.quantity_is_decimal "
+            "FROM source_offer o JOIN source_variant v USING (source_variant_id) "
+            "WHERE v.external_variant_id = 'TjY1'").fetchone()
+        assert (offer[0], offer[1], offer[2]) == (0.25, 0.05, 1)
+
+        bag = conn.execute(
+            "SELECT o.minimum_quantity, o.quantity_increment, o.quantity_is_decimal "
+            "FROM source_offer o JOIN source_variant v USING (source_variant_id) "
+            "WHERE v.external_variant_id = 'QzE1OTI='").fetchone()
+        assert (bag[0], bag[1], bag[2]) == (450.0, 450.0, 0)
+
+        stock = conn.execute(
+            "SELECT p.stock_quantity FROM price_observation p "
+            "JOIN source_offer o USING (offer_id) "
+            "JOIN source_variant v USING (source_variant_id) "
+            "WHERE v.external_variant_id = 'Tjcy'").fetchone()
+        assert stock[0] == 8
+    finally:
+        conn.close()
+
+
+def test_has_variants_stops_saying_one_for_everything(tmp_path):
+    """P6. A simple product is emitted as row(uid, uid), so the old test
+    (`external_variant_id or option_fingerprint`) read 1 for 763 of 763 MADAR
+    products. A product that IS its own variant has no variations."""
+    conn = _ingest(tmp_path)
+    try:
+        flags = dict(conn.execute(
+            "SELECT external_product_id, has_variants FROM source_product"))
+        assert flags["UFVUVFk="] == 0, "a simple product has no variations"
+        assert flags["SFNT"] == 1
+        assert flags["UkNG"] == 1
+        assert set(flags.values()) != {1}, "the column must stop answering 1 for everything"
+    finally:
+        conn.close()
+
+
+def test_an_offer_learns_the_quantity_facts_without_being_split(tmp_path):
+    """The 0052 trap, avoided: all 3,417 MADAR offers already exist, so an
+    INSERT-only path would leave every one of them blank forever. And none of
+    these columns is in ux_source_offer_identity, so learning them must not
+    mint a second offer beside the first."""
+    conn = _ingest(tmp_path)
+    try:
+        before = conn.execute("SELECT COUNT(*) FROM source_offer").fetchone()[0]
+        conn.execute("UPDATE source_offer SET minimum_quantity = NULL, "
+                     "quantity_increment = NULL, quantity_is_decimal = 0")
+        conn.commit()
+        tables = [t for t in MagentoGraphqlConnector(_Fetcher()).fetch(_entry())
+                  if t.kind == ExtractKind.PRODUCT_PRICES]
+        ingest_payloads(conn, _entry(), [FunnelPayload(
+            payload_version=PAYLOAD_VERSION, source_key="MADAR",
+            kind=ExtractKind.PRODUCT_PRICES, client="cli",
+            scraped_at="2026-07-30T10:00:00Z", source_url=t.source_url,
+            header=t.header, rows=t.rows) for t in tables])
+        assert conn.execute("SELECT COUNT(*) FROM source_offer").fetchone()[0] == before
+        relearned = conn.execute(
+            "SELECT o.minimum_quantity, o.quantity_is_decimal "
+            "FROM source_offer o JOIN source_variant v USING (source_variant_id) "
+            "WHERE v.external_variant_id = 'TjY1'").fetchone()
+        assert (relearned[0], relearned[1]) == (0.25, 1)
+    finally:
+        conn.close()
+
+
+def test_migration_0056_corrects_has_variants_on_rows_that_already_exist():
+    """The backfill, on a warehouse that predates it.
+
+    ingest only ever wrote has_variants at INSERT, so fixing the rule there
+    corrects products discovered from now on and leaves every EXISTING one
+    reading 1 — all 763 MADAR products and every product of sources
+    1,2,3,4,7,8,9. A column that is right for new rows and wrong for old ones
+    is worse than one that is uniformly wrong, because nothing on screen says
+    which kind of row you are looking at. Unlike the other three columns this
+    one is derivable from rows the warehouse already holds, so it is the one
+    thing in 0056 that can be — and is — repaired in place.
+    """
+    conn = dbmod.connect(":memory:")
+    try:
+        for number, file in dbmod._migration_files():      # the pre-0056 warehouse
+            if number >= 56:
+                continue
+            conn.executescript(file.read_text(encoding="utf-8"))
+            conn.execute(f"PRAGMA user_version = {number}")
+        conn.execute("INSERT INTO source_site (source_id, source_key, source_name_ar)"
+                     " VALUES (1, 'MADAR', 'المدار')")
+        # Both stored the way ingest really stored them: has_variants = 1,
+        # because external_variant_id was never empty for either.
+        for pid, ext in ((1, "SIMPLE"), (2, "GROUPED")):
+            conn.execute("INSERT INTO source_product"
+                         " (source_product_id, source_id, external_product_id, has_variants)"
+                         " VALUES (?, 1, ?, 1)", (pid, ext))
+        # A simple product is one variant wearing the PRODUCT's own id...
+        conn.execute("INSERT INTO source_variant (source_product_id, external_variant_id)"
+                     " VALUES (1, 'SIMPLE')")
+        # ...while a grouped product's members carry ids of their own.
+        for member in ("MEMBER-8", "MEMBER-32"):
+            conn.execute("INSERT INTO source_variant (source_product_id, external_variant_id)"
+                         " VALUES (2, ?)", (member,))
+        conn.commit()
+
+        assert dbmod.migrate(conn) == [56]
+
+        flags = dict(conn.execute(
+            "SELECT external_product_id, has_variants FROM source_product"))
+        assert flags["SIMPLE"] == 0, (
+            "a product whose only variant IS itself has no variations")
+        assert flags["GROUPED"] == 1
+    finally:
+        conn.close()
+
+
+def test_a_connector_that_says_nothing_never_blanks_what_was_learned(tmp_path):
+    """The empty-value rule. A payload from a connector that has not been
+    taught these columns must not wipe values an earlier crawl stored."""
+    from scrapex.ingest import _quantity_facts
+    assert _quantity_facts({}) == {}
+    assert _quantity_facts({"minimum_quantity": "", "quantity_increment": "",
+                            "quantity_is_decimal": ""}) == {}
+    # ...while a site that really says "not a decimal quantity" is recorded.
+    assert _quantity_facts({"quantity_is_decimal": "0"}) == {"quantity_is_decimal": 0}

--- a/tests/test_extract_storage.py
+++ b/tests/test_extract_storage.py
@@ -113,7 +113,7 @@ def test_legacy_0014_remains_available_for_explicit_unified_sessions(tmp_path: P
     legacy = dbmod.connect(tmp_path / "legacy.db")
     try:
         dbmod.migrate(legacy)
-        assert dbmod.schema_version(legacy) == 55   # +0055 the tax table speaks the tax vocabulary
+        assert dbmod.schema_version(legacy) == 56   # +0056 how the site shows it, and what one unit buys
         for table in ("price_observation", "generic_record"):
             assert legacy.execute(
                 "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1",

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -62,7 +62,7 @@ def _insert_observation(conn, ids, price: float = 168.78, hash_: str = "h1") -> 
 
 
 def test_migration_reaches_latest_version(conn):
-    assert dbmod.schema_version(conn) == 55   # +0055 the tax table speaks the tax vocabulary
+    assert dbmod.schema_version(conn) == 56   # +0056 how the site shows it, and what one unit buys
 
 
 def test_all_owner_tables_exist(conn):
@@ -168,7 +168,7 @@ def test_migration_0020_preserves_existing_jobs_and_their_log_references():
         upgrading.commit()
 
         assert dbmod.migrate(upgrading) == [20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
-                                            30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55]
+                                            30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56]
 
         joined = upgrading.execute(
             "SELECT j.job_ref, j.status, l.message FROM job_log_entry l"


### PR DESCRIPTION
## The defect

The prices were never wrong — all 3,410 live MADAR prices match the warehouse exactly. Every fact **surrounding** the number was missing, and without them the number is unreadable:

> the Ø8mm rebar member costs **4,830** and the Ø32mm costs **4,045**

Per piece that is impossible (a 12 m Ø32 bar carries ~16× the steel). Per **tonne** it is exactly right — thin bars cost more per tonne to roll. The site says so in numbers: `weight: 1000`, `is_qty_decimal: true`, `min_sale_qty: 0.25`, `qty_increments: 0.05`. ScrapeX stored `basis_quantity 1.0`, no unit, no minimum: *"the price of one thing"*.

## Two questions, two columns

**"Sold by a bulk unit" is not a fourth Magento shape.** It appears inside `GroupedProduct` (96 leaves) *and* inside `ConfigurableProduct` (13 — the steel mesh, whose children carry per-child weights of 6.74–66.02 kg, not a uniform 1000). A single enum over `__typename` would miss it. So:

| question | where it lives |
|---|---|
| how the site **presents** the product | `source_product.display_method` |
| what one unit of the price **buys** | `source_offer.minimum_quantity` / `quantity_increment` / `quantity_is_decimal` |

`has_variants` could not be reused: it read `1` for 3,788 of 3,799 products across the whole warehouse.

## No unit is invented — the owner's ruling

I asked before choosing, and the answer was **«الحقائق الخام فقط»** — raw facts only.

The shop never prints «طن». Verified 2026-07-29 across member *and* parent attributes, `description`, `short_description`, every meta field, both category descriptions, **both store views**, and the full 932 KB rendered page: **0 occurrences**; the quantity box is labelled «الكمية» and nothing else. So the numbers are stored and the display layer renders "per 1,000 kg". Where the site *does* state a unit (cement: `weight 50` + «50كجم» in the name) the existing agreement test still reads it — the refusal is about silence, not about units.

## Verified by a live re-crawl (into a throwaway DB — the live warehouse was not touched)

3,410 rows in 98 requests. Warehouse baseline for every line below was **0**:

| | before | after |
|---|---|---|
| offers flagged decimal-quantity | 0 | **109** |
| offers with a minimum / increment | 0 | **3,410** |
| observations with a stock count | 0 | **297** |
| grouped members with an English label | 0 | **161** |
| products with a display method | 0 | **761** |
| products stating their name language | 0 | **761** |

`display_method` census — **exactly** the predicted split: `single` 400 · `options_priced` 292 · `options_one_price` 36 · `member_list` 33.

The pair, as stored: `101150812` → 4830.0, `101153212` → 4045.13, both `min=0.25 step=0.05 decimal=1`.

> Note on `minimum_quantity`: it lands on all 3,410 because Magento's default is `1` and "the site says 1" is a different fact from "the site says nothing". The meaningful ones are the 96 rebar leaves at 0.25 and the 12 cement leaves at 450.

## Migration 0056

Three `ALTER TABLE ADD COLUMN` with defaults, plus one backfill. Applied to a **read-only snapshot of the real 75 MB warehouse**: `integrity_check ok`, **0** foreign-key violations, no rebuild, no index touched, no offer identity changed.

`has_variants` is the one thing that *can* be backfilled — it is derivable from variants already stored. On real data it corrected **2,477** products (3,788 → 1,311 ones). MADAR lands at 402/361, matching the shape census. The other three columns describe facts the site publishes and we never asked for; `raw_snapshot` holds 0 rows, so they arrive on the next crawl and the defaults read as "the site did not say".

⚠️ **`MarketLensDatabase` needed `56` adding to `_MARKETLENS_LEGACY_NUMBERS` by hand.** That list is enumerated rather than ranged (as its own comment warns), and without this the live warehouse would never have seen the migration at all.

## Two corrections to the brief

1. **`user_version` has not drifted.** The live DB reporting `53` is *fully* migrated. MarketLens has its own compressed numbering — legacy 13, 14, 17 belong to General — so legacy `0055` **is** marketlens `53`. After this it reads `54`.
2. **P8's diagnosis was wrong, so P8 is not changed.** The theory was that the ~92 unclassified products are filed on branch nodes while only leaves are listed. Measured live: listing all 17 branches as well as the 56 leaves reaches 671 products instead of 669 — it finds **two**, for a 30% larger category walk on a daily source. The other 88 answer `categories: []` when asked directly and appear in no listing anywhere. They are unfiled *by madar*. The measurement is recorded in the walk so nobody re-derives it.

## Contract

`PAYLOAD_VERSION` 5 → 6. All four new columns are **additive** — the case that flag exists for. Schema and fixtures regenerated; the Apps Script mirror moved with it.

**➜ The owner must paste the new `apps_script/StagingAppScript.txt` before the next sync**, or the funnel will refuse the payload version.

## Also included

- **P2** needed *two* fixes: the `GroupedProduct` fragment in both English queries (so `names_en` learns a member uid at all) **and** the grouped `row()` call passing it. Either alone leaves the column empty — which is how all 162 grouped variants came to store `variant=''`.
- **P3** `minimum_quantity` existed in `schema.sql` and nothing read or wrote it. Cement: 450 bags in steps of 450 = 22.5 t per order.
- **P10** meta fields under `Site metadata`. The AR `meta_title` says «سابك» where `name` says «من حديد» — the site's own contradiction, recorded rather than resolved.

## Raised, deliberately not changed

- **A real unit source we still drop:** the site publishes a `size` attribute on **107 products** with 59 distinct values (`'50 Kg'`, `'20 Litre'`, `'24 لتر'`, `'13mm'`). Wiring it would fill the unit column honestly — but `unit` feeds the price key, so it changes `price_hash` for those offers. That is your call to take deliberately, not a side effect of this PR.
- **P11** `price_tiers` is **quantity**-gated (700 → 125); `price_trade` (0052) is **customer-group**-gated. Different facts — where the first lands is a new-kind-of-fact decision, which is yours by the standing rule.
- **P9** one of the two "vanished" products is live in `en_SA` only, so marking it absent from an `ar_SA` crawl would be wrong. It waits on the unresolved 761-vs-763 question.
- **The `basePrice`/`finalPrice` tension** (2,853 offers stored at 50.4 `tax_included=0` while the visitor sees 57.96) is untouched, as instructed — but `display_method` now exists precisely so you can rule on it per type instead of per source.

## Tests

Full suite green. `node contract/parity/parity.test.mjs` 3/3. 17 new tests, including the Ø8-vs-Ø32 arithmetic as a standing assertion, the four-shape `display_method` check, the migration backfill against a synthesised pre-0056 warehouse, and a regression guard that a simple product is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
