### PR TITLE
Resume for partly crawled sources: show the kept pages, and offer to continue them

### DIFF
--- a/extension/app.css
+++ b/extension/app.css
@@ -152,6 +152,16 @@
   .checklist label .source-identity { min-width: 0; }
   .source-row-actions { display: flex; flex: none; flex-direction: column;
                         align-items: flex-end; gap: var(--sp-1); }
+  /* Kept pages are a fact ABOUT the row, not another chip inside it: full
+     width under the site, so the count and the moment the crawl stopped are
+     read as a sentence rather than squeezed against the buttons — and so the
+     domain keeps the width it needs to say WHICH site is being offered.
+     Full-strength text (not muted) because this is the one thing on the row
+     that decides whether the next click continues the work or destroys it. */
+  .checklist .srow { flex-wrap: wrap; }
+  .source-row-kept { flex-basis: 100%; display: flex; flex-direction: column;
+                     align-items: flex-start; gap: var(--sp-2);
+                     font-size: var(--fs-xs); color: var(--text); }
   .dataset-identity-line { min-width: 0; }
   .dataset-card .source-identity { margin-bottom: var(--sp-2); }
   .sched-summary .source-identity { flex: 1; }

--- a/extension/app.js
+++ b/extension/app.js
@@ -345,6 +345,49 @@ function visibleSources() {
     (s.base_url || "").toLowerCase().includes(term));
 }
 
+// ---- kept pages: an interrupted crawl the owner can continue ---------------
+//
+// The engine has journaled every fetched page and resumed from it for a while,
+// but nothing here ever SAID so — a source holding 871 pages looked exactly
+// like one holding none, and the only button on offer was the one that throws
+// them away. That is how elburoj reached nine runs and zero completions.
+
+const keptPages = (source) => Number(source?.kept_pages || 0);
+
+/** The interrupted run's own stopping point, in local time.
+ *
+ * A date and not "3 hours ago": a journal can sit for days, and the question
+ * this answers is WHICH run stopped here, not how long ago it was. */
+function fmtStopped(iso) {
+  const at = Date.parse(iso || "");
+  if (!Number.isFinite(at)) return "";
+  return new Date(at).toLocaleString([], {
+    day: "numeric", month: "short", hour: "2-digit", minute: "2-digit" });
+}
+
+const pageCount = (n) => `${n.toLocaleString()} page${n === 1 ? "" : "s"}`;
+
+/** Start a run that CONTINUES the journal instead of clearing it. */
+async function resumeSource(key, button) {
+  const source = state.sources.find((s) => s.source_key === key);
+  if (!source) return;
+  button.disabled = true;
+  try {
+    // The mode is chosen the same way the run-mode select chooses it for a
+    // fresh run. The engine treats update and initial_crawl identically, but
+    // the job history should still say which of the two this was.
+    const r = await post("/api/jobs", {
+      source_keys: [key], resume: true,
+      run_mode: source.observations > 0 ? "update" : "initial_crawl",
+    });
+    state.jobRef = r.job_ref;
+    await pollJob();
+  } catch (e) {
+    button.disabled = false;
+    $("run-blocked").textContent = "Couldn't resume: " + e.message;
+  }
+}
+
 function renderSites() {
   const box = $("sites");
   const shown = visibleSources();
@@ -365,6 +408,27 @@ function renderSites() {
             data-auto="${esc(s.source_key)}" aria-pressed="${s.active ? "true" : "false"}"
             title="Scheduled runs fire only while this is on. Running manually from this panel always works.">Auto: ${
               s.active ? "on" : "off"}</button>` : "";
+      // What an interrupted crawl left behind, with its count and the moment
+      // it stopped: "partly crawled" carrying no number is not something the
+      // owner can decide anything from.
+      //
+      // It takes a full-width line UNDER the site rather than joining the chip
+      // column beside it — "Resume 871 pages" is wide and never wraps, and in
+      // a 360px panel it squeezed the domain down to "elburoj....", hiding
+      // which site the offer was even about. Control first and the sentence
+      // that explains it second, the same shape as the run button and its
+      // hint: the list is a short scrollport, and the half of this block that
+      // has to survive being scrolled past is the half he came here to press.
+      const kept = keptPages(s);
+      const stopped = kept ? fmtStopped(s.kept_at) : "";
+      const keptBlock = kept ? `<span class="source-row-kept">
+          <button type="button" class="chip accent" data-resume="${esc(s.source_key)}"
+            title="Continue this crawl from the ${esc(pageCount(kept))} already kept. None of them is fetched again.">Resume ${
+              esc(pageCount(kept))}</button>
+          <span><strong>${esc(pageCount(kept))} kept</strong> from a run that
+          stopped${stopped ? " " + esc(stopped) : ""}. Resume continues from
+          there and re-fetches none of them; starting a run discards them.</span>
+        </span>` : "";
       return `<div class="srow ${ready ? "" : "off"}">
         <label>
           <input type="checkbox" data-key="${esc(s.source_key)}" ${checked} ${ready ? "" : "disabled"}>
@@ -373,6 +437,7 @@ function renderSites() {
         <span class="source-row-actions">
           ${auto}${reason}
         </span>
+        ${keptBlock}
       </div>`;
     }).join("");
     box.querySelectorAll("input[data-key]").forEach((cb) =>
@@ -381,6 +446,9 @@ function renderSites() {
         renderSelected();
         refreshRunButton();
       }));
+    box.querySelectorAll("button[data-resume]").forEach((button) =>
+      button.addEventListener("click", () =>
+        resumeSource(button.dataset.resume, button)));
     box.querySelectorAll("button[data-auto]").forEach((button) =>
       button.addEventListener("click", async () => {
         const key = button.dataset.auto;
@@ -912,6 +980,17 @@ async function startRun() {
   if (mode === "full_rebuild" &&
       !confirm(`Full rebuild will archive the current catalogue for ${keys.length} site(s) ` +
                `and take a backup first. Continue?`)) return;
+  // A run starts from the top, and capture clears the journal of every source
+  // it touches before it fetches anything. So the pages an interrupted crawl
+  // kept are gone the moment this is queued — silently, and for elburoj that
+  // is 871 pages and most of a day. Say it before it happens.
+  const discarding = state.sources.filter(
+    (s) => state.selected.has(s.source_key) && keptPages(s) > 0);
+  if (discarding.length && !confirm(
+      "Starting a run throws away pages that an interrupted crawl kept:\n\n" +
+      discarding.map((s) => `  ${s.source_key} — ${pageCount(keptPages(s))}`).join("\n") +
+      "\n\nResume, on the site's own row, continues from them instead and " +
+      "re-fetches none of them.\n\nDiscard them and start from the top?")) return;
   $("run").disabled = true;
   try {
     const r = await post("/api/jobs", { source_keys: keys, run_mode: mode });

--- a/scrapex/jobs.py
+++ b/scrapex/jobs.py
@@ -42,16 +42,27 @@ _COUNTER_FIELDS = ("observations", "duplicates", "products", "variants",
 
 def create_job(conn: sqlite3.Connection, source_keys: Iterable[str],
                run_mode: RunMode | str = RunMode.UPDATE,
-               status: JobStatus | str = JobStatus.QUEUED) -> str:
-    """Persist a new job and return its public job_ref."""
+               status: JobStatus | str = JobStatus.QUEUED,
+               checkpoint: dict | None = None) -> str:
+    """Persist a new job and return its public job_ref.
+
+    `checkpoint` seeds the job with a resume point it did not earn by being
+    paused. That is the ONE way a journal outlives the job that filled it: a
+    pause writes `partial_source` here, but cancelling the paused job — or a
+    runtime that dies — leaves the kept pages on disk with no non-terminal job
+    left to carry them. Without this, resume was reachable only for as long as
+    the original job stayed alive, which is exactly how 871 elburoj pages ended
+    up stranded.
+    """
     keys = [str(k) for k in source_keys]
     if not keys:
         raise ValueError("a job needs at least one source_key")
     job_ref = f"job_{uuid.uuid4().hex[:12]}"
     conn.execute(
-        "INSERT INTO crawl_job (job_ref, run_mode, status, source_keys, progress_total) "
-        "VALUES (?,?,?,?,?)",
-        (job_ref, str(run_mode), str(status), json.dumps(keys), len(keys)),
+        "INSERT INTO crawl_job (job_ref, run_mode, status, source_keys, progress_total, "
+        "checkpoint_json) VALUES (?,?,?,?,?,?)",
+        (job_ref, str(run_mode), str(status), json.dumps(keys), len(keys),
+         json.dumps(checkpoint) if checkpoint else None),
     )
     conn.commit()
     return job_ref

--- a/scrapex/localinbox.py
+++ b/scrapex/localinbox.py
@@ -18,6 +18,7 @@ import os
 import hashlib
 import re
 import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 
 from .payload import FunnelPayload
@@ -78,6 +79,49 @@ def list_tokens(base: Path | str, source_key: str) -> set[str]:
         return set()
     return {p.name.split(_TOKEN_SEP, 1)[0]
             for p in target.glob(f"*{_TOKEN_SEP}*.json")}
+
+
+def journal_state(base: Path | str, source_key: str) -> dict:
+    """What this source has KEPT: pages a resume would skip, and when it stopped.
+
+    The journal was already the resume checkpoint; nothing could REPORT it, so a
+    source with 871 pages on disk looked exactly like one with none and the only
+    button on offer was the one that throws them away.
+
+    `pages` counts TOKENS, not files: the token set is precisely what resume
+    hands the connector as its skip set (see `list_tokens`), and a count that
+    could disagree with it would be a number the owner cannot act on.
+
+    `stopped_at` is the newest page's mtime, not the scraped_at buried in its
+    filename. Capture writes each page the moment it arrives, so the two mark
+    the same instant, and mtime does not tie this readout to the filename
+    layout — which exists to carry the token, not to be parsed back.
+
+    A filename scan and a stat per page: no JSON is parsed, because the panel
+    asks this for every source on every refresh.
+    """
+    target = _source_dir(base, source_key)
+    if not target.is_dir():
+        return {"pages": 0, "stopped_at": None}
+    newest: dict[str, float] = {}
+    for p in target.glob(f"*{_TOKEN_SEP}*.json"):
+        try:
+            mtime = p.stat().st_mtime
+        except OSError:
+            # The worker clears this directory the moment an ingest succeeds,
+            # and the panel asks for this on a refresh — so the scan CAN race a
+            # job finishing. A page that vanished between the listing and the
+            # stat costs one page off a count, never the whole answer: raising
+            # here would fail /api/sources, and the panel would report the
+            # engine as unreachable because a crawl had gone WELL.
+            continue
+        token = p.name.split(_TOKEN_SEP, 1)[0]
+        newest[token] = max(newest.get(token, 0.0), mtime)
+    if not newest:
+        return {"pages": 0, "stopped_at": None}
+    stopped = datetime.fromtimestamp(max(newest.values()), timezone.utc)
+    return {"pages": len(newest),
+            "stopped_at": stopped.strftime("%Y-%m-%dT%H:%M:%SZ")}
 
 
 def clear_untokenized(base: Path | str, source_key: str) -> int:

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -27,6 +27,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from .. import db as dbmod
+from .. import localinbox
 from .. import nativehost
 from ..capture import capture_source
 from ..changes import change_summary, changes_for_offer, recent_changes
@@ -1108,6 +1109,12 @@ def create_app(
         out = []
         for entry in app.state.manifest.sources:
             s = summaries.get(entry.source_key)
+            # Widened rather than given a route of its own: the panel already
+            # redraws every source row from THIS answer, and a second request
+            # per source would arrive after the rows were painted — the kept
+            # pages would appear a beat late, next to a Start button that was
+            # already live. One answer, one paint.
+            kept = localinbox.journal_state(localinbox.JOURNAL_DIR, entry.source_key)
             out.append({
                 "source_key": entry.source_key, "source_name": entry.source_name,
                 "source_name_ar": entry.source_name_ar,
@@ -1127,6 +1134,10 @@ def create_app(
                 "fold_variants": entry.fold_variants,
                 "observations": s.observations if s else 0,
                 "products": s.products if s else 0,
+                # An interrupted crawl's pages, still on disk. A resume skips
+                # exactly these; a fresh run deletes them (capture.py).
+                "kept_pages": kept["pages"],
+                "kept_at": kept["stopped_at"],
             })
         return {"sources": out}
 
@@ -2271,14 +2282,40 @@ def create_app(
         except ValueError:
             raise HTTPException(status_code=400, detail="run_mode must be "
                                 f"{[m.value for m in RunMode]}")
+        # RESUME: continue an interrupted crawl from the pages it already kept,
+        # instead of from the top. The worker reads `partial_source` out of the
+        # checkpoint (jobs.run_job_once) and hands capture `resume=True`, which
+        # is what turns the journal into a skip set instead of rubbish to clear.
+        # Seeding it here — rather than reviving the paused job — is deliberate:
+        # the job that filled the journal is usually gone (cancelled, or lost
+        # with the runtime) while its pages are still on disk.
+        resume = bool(body.get("resume"))
+        checkpoint = None
+        if resume:
+            if len(source_keys) != 1:
+                # One checkpoint holds one partial_source, so a two-source
+                # resume could only be honoured for one of them. Refusing beats
+                # silently starting the other from the top.
+                raise HTTPException(status_code=400,
+                                    detail="resume takes exactly one source_key")
+            kept = localinbox.journal_state(localinbox.JOURNAL_DIR, source_keys[0])
+            if not kept["pages"]:
+                # Nothing to continue. Queueing a full crawl under the word
+                # 'resume' would be the opposite of what was asked for.
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"{source_keys[0]} has no kept pages to resume — "
+                           "start a run instead")
+            checkpoint = {"completed_source_keys": [], "errors": [], "succeeded": 0,
+                          "partial_source": source_keys[0]}
         conn = read_conn()
         try:
             ensure_schema(conn)
-            job_ref = create_job(conn, source_keys, run_mode)
+            job_ref = create_job(conn, source_keys, run_mode, checkpoint=checkpoint)
         finally:
             conn.close()
         return {"job_ref": job_ref, "status": "queued", "source_keys": source_keys,
-                "run_mode": run_mode.value}
+                "run_mode": run_mode.value, "resume": resume}
 
     @app.get("/api/jobs")
     def api_list_jobs(limit: int = 20, active_only: bool = False):

--- a/tests/test_api_jobs.py
+++ b/tests/test_api_jobs.py
@@ -72,6 +72,106 @@ def test_create_job_accepts_multiple_sources(client):
     assert r.status_code == 200 and r.json()["source_keys"] == [REAL_SOURCE, "MADAR"]
 
 
+# ---- resume: the kept pages the panel could not see or reach -----------------
+#
+# The journal has been the resume checkpoint for a while, but only a job that
+# was still PAUSED could carry it. Cancel that job — or lose the runtime — and
+# 871 fetched elburoj pages sat on disk with nothing in the product able to
+# report them, let alone continue them.
+
+
+@pytest.fixture()
+def journal(tmp_path, monkeypatch):
+    """Point the API at a throwaway journal dir, as capture and jobs use."""
+    from scrapex import localinbox
+
+    jdir = tmp_path / "job-journal"
+    monkeypatch.setattr(localinbox, "JOURNAL_DIR", jdir)
+    return jdir
+
+
+def _keep_pages(journal: Path, source_key: str, count: int) -> None:
+    """Journal `count` tokenized pages, as an interrupted crawl leaves behind."""
+    from scrapex import localinbox
+    from tests.test_ingest import make_payload, one_row
+
+    for i in range(count):
+        payload = make_payload([one_row(external_product_id=str(3000 + i))])
+        payload.source_key = source_key
+        localinbox.write_payload(journal, payload, token=f"t-{i:04d}")
+
+
+def test_sources_report_the_pages_an_interrupted_crawl_kept(client, journal):
+    """The whole complaint: nothing told the owner a source had kept anything."""
+    before = {s["source_key"]: s for s in client.get("/api/sources").json()["sources"]}
+    assert before[REAL_SOURCE]["kept_pages"] == 0
+    assert before[REAL_SOURCE]["kept_at"] is None
+
+    _keep_pages(journal, REAL_SOURCE, 3)
+
+    after = {s["source_key"]: s for s in client.get("/api/sources").json()["sources"]}
+    assert after[REAL_SOURCE]["kept_pages"] == 3
+    assert after[REAL_SOURCE]["kept_at"].endswith("Z")
+    assert after["MADAR"]["kept_pages"] == 0, "one source's journal leaked onto another"
+
+
+def test_a_resume_job_carries_the_journal_into_its_checkpoint(client, journal, db_path):
+    """`partial_source` is the only thing that makes the worker pass resume=True
+    to capture — without it the run clears the journal and starts from the top."""
+    _keep_pages(journal, REAL_SOURCE, 2)
+
+    body = client.post("/api/jobs",
+                       json={"source_keys": [REAL_SOURCE], "resume": True}).json()
+
+    assert body["resume"] is True
+    conn = dbmod.connect(db_path)
+    try:
+        from scrapex.jobs import get_job
+        job = get_job(conn, body["job_ref"])
+    finally:
+        conn.close()
+    assert job["checkpoint"]["partial_source"] == REAL_SOURCE
+    assert job["status"] == "queued", "resume must queue, never execute in the request"
+
+
+def test_a_plain_run_is_not_secretly_a_resume(client, journal, db_path):
+    """A run without the flag must keep starting from the top — the checkpoint
+    stays empty, so capture clears the journal as it always has."""
+    _keep_pages(journal, REAL_SOURCE, 2)
+
+    ref = client.post("/api/jobs", json={"source_keys": [REAL_SOURCE]}).json()["job_ref"]
+
+    conn = dbmod.connect(db_path)
+    try:
+        from scrapex.jobs import get_job
+        assert get_job(conn, ref)["checkpoint"] == {}
+    finally:
+        conn.close()
+
+
+def test_resume_with_nothing_kept_is_refused_rather_than_silently_restarting(
+        client, journal):
+    """Queueing a full crawl under the word 'resume' is the opposite of what was
+    asked for — and for elburoj it is eight hours of it."""
+    r = client.post("/api/jobs", json={"source_keys": [REAL_SOURCE], "resume": True})
+
+    assert r.status_code == 409
+    assert "no kept pages" in r.json()["detail"]
+    assert client.get("/api/jobs").json()["jobs"] == []   # nothing was queued
+
+
+def test_resume_refuses_more_than_one_source(client, journal):
+    """One checkpoint holds one partial_source, so a two-source resume could be
+    honoured for one of them at most."""
+    _keep_pages(journal, REAL_SOURCE, 2)
+
+    r = client.post("/api/jobs",
+                    json={"source_keys": [REAL_SOURCE, "MADAR"], "resume": True})
+
+    assert r.status_code == 400
+    assert client.get("/api/jobs").json()["jobs"] == []
+
+
 # ---- poll --------------------------------------------------------------------
 
 def test_get_unknown_job_is_404(client):

--- a/tests/test_job_journal.py
+++ b/tests/test_job_journal.py
@@ -122,6 +122,50 @@ def test_a_hostile_token_is_sanitised_not_rejected(tmp_path):
     assert localinbox.list_tokens(tmp_path, "GPP_ENERGY") == {"a-b-c"}
 
 
+def test_journal_state_reports_exactly_what_a_resume_would_skip(tmp_path):
+    """The count the panel shows and the skip set the connector gets are the
+    same number, or it is a number the owner cannot act on. Untokenized pages
+    are re-emitted by the re-run, so they are not kept work and must not be
+    counted as any."""
+    localinbox.write_payload(tmp_path, _page("t", "EG", "1").to_payload(), token="T1")
+    localinbox.write_payload(tmp_path, _page("t", "SA", "1").to_payload(), token="T2")
+    localinbox.write_payload(tmp_path, _page("", "US", "1").to_payload())
+
+    state = localinbox.journal_state(tmp_path, "GPP_ENERGY")
+
+    assert state["pages"] == len(localinbox.list_tokens(tmp_path, "GPP_ENERGY")) == 2
+    assert state["stopped_at"].endswith("Z"), state["stopped_at"]
+
+
+def test_a_page_cleared_mid_scan_costs_one_page_not_the_whole_answer(
+        tmp_path, monkeypatch):
+    """capture clears the journal the moment an ingest succeeds, and the panel
+    asks for this state on every refresh — so the scan can race a job
+    finishing. Raising there would fail /api/sources, and the panel would
+    report the engine unreachable because a crawl had gone WELL."""
+    localinbox.write_payload(tmp_path, _page("t", "EG", "1").to_payload(), token="T1")
+    real = localinbox._source_dir(tmp_path, "GPP_ENERGY")
+
+    class _RacingDir:
+        def is_dir(self):
+            return True
+
+        def glob(self, pattern):
+            yield real / "T2__cleared_00000000.json"   # gone before we stat it
+            yield from real.glob(pattern)
+
+    monkeypatch.setattr(localinbox, "_source_dir", lambda base, key: _RacingDir())
+
+    assert localinbox.journal_state(tmp_path, "GPP_ENERGY")["pages"] == 1
+
+
+def test_a_source_that_kept_nothing_says_so_rather_than_failing(tmp_path):
+    """Every source is asked this on every panel refresh, including the ones
+    that have never been interrupted and have no directory at all."""
+    assert localinbox.journal_state(tmp_path, "NEVER_RAN") == \
+        {"pages": 0, "stopped_at": None}
+
+
 def test_clear_untokenized_keeps_the_checkpoint_pages(tmp_path):
     localinbox.write_payload(tmp_path, _page("t", "EG", "1").to_payload(), token="T1")
     localinbox.write_payload(tmp_path, _page("", "SA", "1").to_payload())
@@ -239,6 +283,32 @@ def test_pause_mid_fetch_keeps_pages_and_resume_completes_the_job(conn, journal,
     assert second.served == ["DIESEL--US"]
     assert "partial_source" not in job["checkpoint"]
     assert localinbox.list_tokens(journal, "GPP_ENERGY") == set()
+    observations = conn.execute("SELECT COUNT(*) FROM price_observation").fetchone()[0]
+    assert observations == 3, "the resumed job must land the WHOLE crawl"
+
+
+def test_a_seeded_checkpoint_resumes_a_journal_whose_own_job_is_gone(
+        conn, journal, monkeypatch):
+    """The failure this feature exists for: elburoj's paused job was cancelled,
+    so the only non-terminal job that could have carried its 871 kept pages
+    became terminal and the pages were unreachable. A NEW job seeded with the
+    same partial_source picks them up — the journal, not the job row, is the
+    asset."""
+    localinbox.write_payload(journal, _page("DIESEL--EG", "EG", "20.50").to_payload(),
+                             token="DIESEL--EG")
+    localinbox.write_payload(journal, _page("DIESEL--SA", "SA", "1.77").to_payload(),
+                             token="DIESEL--SA")
+    connector = _PagedConnector()
+    _with_connector(monkeypatch, connector)
+
+    ref = create_job(conn, ["GPP_ENERGY"],
+                     checkpoint={"completed_source_keys": [], "errors": [],
+                                 "succeeded": 0, "partial_source": "GPP_ENERGY"})
+    job = run_job_once(conn, ref, {"GPP_ENERGY": make_entry()})
+
+    assert job["status"] == JobStatus.COMPLETED.value
+    assert connector.skip_tokens == {"DIESEL--EG", "DIESEL--SA"}
+    assert connector.served == ["DIESEL--US"], "a kept page was fetched again"
     observations = conn.execute("SELECT COUNT(*) FROM price_observation").fetchone()[0]
     assert observations == 3, "the resumed job must land the WHOLE crawl"
 

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -1095,3 +1095,124 @@ def test_a_pace_of_zero_is_refused_before_it_reaches_the_engine(open_panel):
     assert "greater than zero" in page.inner_text("#crawl-msg")
     posted = page.evaluate("window.__calls.filter(c => c.includes('/api/settings'))")
     assert not [c for c in posted if "POST" in c], "the flood reached the engine"
+
+
+# ---- kept pages: a partly crawled site can be continued, 2026-07-29 ---------
+#
+# «ازرار الخاصة بـresume للمواقع التى تم زحف جزء منها غير موجودة» — the engine
+# had journaled 871 elburoj pages and could resume from them, but the panel
+# never said they existed and offered no way to continue. The only button on
+# the row was the one that throws them away.
+
+KEPT_SITE = {"source_key": "ELBUROJ", "base_url": "https://elburoj.com",
+             "source_name": "Elburoj", "source_name_ar": "البروج",
+             "family": "salla-html", "active": False, "implemented": True,
+             "observations": 0, "products": 0,
+             "kept_pages": 871, "kept_at": "2026-07-29T09:14:30Z"}
+CLEAN_SITE = {"source_key": "MADAR", "base_url": "https://madar.example.com",
+              "source_name": "Madar", "family": "salla-html",
+              "active": True, "implemented": True,
+              "observations": 120, "products": 40,
+              "kept_pages": 0, "kept_at": None}
+
+
+def _run_tab(page):
+    page.click(RUN_TAB)
+    page.wait_for_timeout(400)
+
+
+def _writes(page, path="/api/jobs"):
+    return [w for w in page.evaluate("() => window.__writes.slice()")
+            if w["path"].startswith(path)]
+
+
+def test_a_partly_crawled_site_says_how_much_it_kept_and_offers_to_continue(open_panel):
+    """The count is the whole point: "partly crawled" with no number is not
+    something the owner can decide anything from."""
+    page = open_panel(sources=[KEPT_SITE, CLEAN_SITE])
+    _run_tab(page)
+
+    resume = page.locator('button[data-resume="ELBUROJ"]')
+    assert resume.is_visible()
+    assert "871" in resume.inner_text()
+
+    note = page.inner_text("#sites")
+    assert "871 pages kept" in note
+    assert "stopped" in note and "Jul" in note and "Invalid" not in note
+    # The difference between the two buttons is stated, not left to be guessed.
+    assert "re-fetches none of them" in note and "discards them" in note
+
+
+def test_a_site_with_nothing_kept_is_offered_no_resume(open_panel):
+    """A Resume that starts from the top would be a lie, and the row would carry
+    a control that does nothing it says."""
+    page = open_panel(sources=[KEPT_SITE, CLEAN_SITE])
+    _run_tab(page)
+
+    assert page.locator('button[data-resume="MADAR"]').count() == 0
+    assert "kept" not in text_of(page, '.srow:has(input[data-key="MADAR"])')
+
+
+def test_resume_queues_a_run_that_continues_instead_of_starting_over(open_panel):
+    page = open_panel(sources=[KEPT_SITE, CLEAN_SITE])
+    _run_tab(page)
+    page.evaluate("() => { window.__writes.length = 0; }")
+
+    page.click('button[data-resume="ELBUROJ"]')
+    page.wait_for_timeout(300)
+
+    queued = _writes(page)
+    assert queued, page.evaluate("() => window.__writes.slice()")
+    assert queued[0]["body"] == {
+        "source_keys": ["ELBUROJ"], "resume": True, "run_mode": "initial_crawl"}
+    assert not page.js_errors
+
+
+def test_a_fresh_run_warns_before_it_throws_the_kept_pages_away(open_panel):
+    """Losing 871 pages and most of a day to a mis-click is exactly the failure
+    this feature exists to prevent."""
+    page = open_panel(sources=[KEPT_SITE, CLEAN_SITE])
+    _run_tab(page)
+    page.check('input[data-key="ELBUROJ"]')
+    asked: list[str] = []
+    page.on("dialog", lambda d: (asked.append(d.message), d.dismiss()))
+    page.evaluate("() => { window.__writes.length = 0; }")
+
+    page.click("#run")
+    page.wait_for_timeout(300)
+
+    assert asked, "the run started with no warning at all"
+    assert "871 pages" in asked[0] and "ELBUROJ" in asked[0]
+    assert not _writes(page), "the kept pages were discarded without a word"
+
+
+def test_the_warned_run_still_runs_when_the_owner_says_yes(open_panel):
+    """The warning is a warning, not a block — and what it starts is a plain
+    run, never a resume wearing the wrong name."""
+    page = open_panel(sources=[KEPT_SITE, CLEAN_SITE])
+    _run_tab(page)
+    page.check('input[data-key="ELBUROJ"]')
+    page.on("dialog", lambda d: d.accept())
+    page.evaluate("() => { window.__writes.length = 0; }")
+
+    page.click("#run")
+    page.wait_for_timeout(300)
+
+    queued = _writes(page)
+    assert queued and queued[0]["body"] == {
+        "source_keys": ["ELBUROJ"], "run_mode": "initial_crawl"}
+
+
+def test_a_selection_that_keeps_nothing_is_not_nagged(open_panel):
+    """The warning must fire on the fact, not on every run."""
+    page = open_panel(sources=[KEPT_SITE, CLEAN_SITE])
+    _run_tab(page)
+    page.check('input[data-key="MADAR"]')
+    asked: list[str] = []
+    page.on("dialog", lambda d: (asked.append(d.message), d.accept()))
+
+    page.click("#run")
+    page.wait_for_timeout(300)
+
+    assert asked == []
+    assert _writes(page), "the run did not start"

--- a/tools/panel_harness.py
+++ b/tools/panel_harness.py
@@ -103,6 +103,11 @@ def stub(backend: str = DEFAULT_BACKEND, *, engine_up=True, sources=None, jobs=N
             "crawl_user_agent": {"value": ""},
             "log_retention_days": {"value": "30"}}},
     }
+    # A write answers differently from a read on the same path: POST /api/jobs
+    # returns the new job's ref, and the panel stores it to start polling. The
+    # read table would hand back the job LIST, so anything that checked what a
+    # click actually queued was testing against a shape the engine never sends.
+    write_routes = {"/api/jobs": {"job_ref": "job_stub", "status": "queued"}}
     return f"""
 window.chrome = {{
   runtime: {{ getURL: p => p, lastError: null }},
@@ -111,23 +116,36 @@ window.chrome = {{
   storage: {{ local: {{ get: async () => ({{backend: {backend!r}}}), set: async () => {{}} }} }},
 }};
 const ROUTES = {json.dumps(routes)};
+const WRITE_ROUTES = {json.dumps(write_routes)};
 const ENGINE_UP = {str(engine_up).lower()};
 const SLOW = {str(slow).lower()};
 const FAIL = {json.dumps(list(fail_routes))};
 window.__calls = [];
-window.fetch = async (url) => {{
+// The BODY of every write, which __calls (a path list) cannot carry — and the
+// body is where "resume" lives, so a test that only saw the path could not
+// tell a resume from a run that discards the journal.
+window.__writes = [];
+window.fetch = async (url, options) => {{
   const path = String(url).replace({backend!r}, "");
+  const method = (options && options.method) || "GET";
   window.__calls.push(path);
+  if (method !== "GET") {{
+    let body = null;
+    try {{ body = JSON.parse((options && options.body) || "null"); }} catch (_) {{}}
+    window.__writes.push({{path, method, body}});
+  }}
   if (!ENGINE_UP) throw new Error("engine down");
   if (SLOW) await new Promise(r => setTimeout(r, 60000));   // freeze on loading state
   if (FAIL.some(f => path.startsWith(f))) {{
     return {{ ok: false, status: 500, statusText: "engine error",
               json: async () => ({{detail: "the engine could not do that"}}) }};
   }}
-  const key = Object.keys(ROUTES).find(k => path.startsWith(k));
+  const table = method === "GET" ? ROUTES
+                                 : {{...ROUTES, ...WRITE_ROUTES}};
+  const key = Object.keys(table).find(k => path.startsWith(k));
   if (!key) return {{ ok: false, status: 404, statusText: "not found",
                       json: async () => ({{detail: "not found"}}) }};
-  return {{ ok: true, status: 200, json: async () => ROUTES[key] }};
+  return {{ ok: true, status: 200, json: async () => table[key] }};
 }};
 """
 


### PR DESCRIPTION
The owner's report: «ازرار الخاصة بـresume للمواقع التى تم زحف جزء منها غير موجودة» — no Resume buttons for sources that were partly crawled.

**Draft — do not merge.** Opened for the main session's review.

## What was already there

Per-page resume is implemented and works. [`capture.py:220-224`](scrapex/capture.py:220) journals each fetched page as it arrives; [`jobs.py:341-347`](scrapex/jobs.py:341) records `partial_source` on a pause; [`capture.py:193-204`](scrapex/capture.py:193) turns that journal into the connector's `skip_tokens` on the next run. None of that is rebuilt here.

## The gap, measured

`C:\Users\User01\.scrapex\job-journal\ELBUROJ\` — **871 tokenized pages**, newest scraped_at `2026-07-29T09:14:30Z`. Every other source's journal directory is empty.

The last ELBUROJ job, `job_dce0858bb44f`, paused mid-fetch and wrote `{"partial_source": "ELBUROJ"}` into its checkpoint — then was **cancelled from paused**. [`set_control`](scrapex/jobs.py:100) settles a job the worker is not holding in place, so the cancel never reached the mid-fetch branch that discards the journal ([`jobs.py:321-327`](scrapex/jobs.py:321)). The 871 pages survived; the only non-terminal job that could carry them did not. Nine ELBUROJ jobs, zero completions.

So the fix could not be "surface the paused job's Resume" — by the time the owner looked, there was no job left to resume. **The journal, not the job row, is the asset.**

## Which endpoint — widened, not minted

Checked both, as asked. `/api/jobs` cannot answer it: the question is per-*source* and outlives every job. `/api/sources` fits exactly — it is already per-source and the panel already redraws every row from that single answer. A separate route would paint the kept pages one round-trip *after* the Start button went live, which is the window this feature exists to close.

Added: `kept_pages`, `kept_at` ([`app.py:1112-1140`](scrapex/webui/app.py:1112)). Measured cost over the real 871-page journal: **21.7 ms for all ten sources**, no JSON parsed — a filename scan and a stat per page.

## The three deliverables

| | |
|---|---|
| **Show the fact** | The row reads `871 pages kept from a run that stopped Jul 29, 12:14 PM.` ([`app.js:411-431`](extension/app.js:411)) |
| **Offer the action** | `Resume 871 pages`, with the difference stated inline: *"Resume continues from there and re-fetches none of them; starting a run discards them."* |
| **Don't hide the discard** | Start over a source with kept pages confirms first, naming the source and the count ([`app.js:983-993`](extension/app.js:983)) |

`POST /api/jobs` gains `resume: true`, seeding the checkpoint with `partial_source` ([`app.py:2285-2312`](scrapex/webui/app.py:2285)). **409** when nothing is kept — queueing a full crawl under the word "resume" is the opposite of the request, and for ELBUROJ it is eight hours of it. **400** for more than one source, since one checkpoint holds one `partial_source`.

Resume sends `update` or `initial_crawl` by the same rule the run-mode select already uses. The engine treats the two identically; the job history should still say which it was.

## Verified by hand against the real journal — read, not consumed

```
/api/sources → ELBUROJ: kept_pages=871  kept_at=2026-07-29T09:14:30Z
panel row    → "Resume 871 pages" + "871 pages kept from a run that stopped Jul 29, 12:14 PM…"
Start        → warned, naming ELBUROJ and 871 pages; queued nothing when dismissed
journal      → 871 files before, 871 after.  UNCHANGED: True
```

`kept_at` agrees with the newest `scraped_at` in the filenames (`091430Z`), which is the check that mtime is the right source for it. Run against a throwaway database and the real `sources.yaml`, so the owner's engine and warehouse were untouched. **The resume run itself was not started** — 8 hours, and he has said he does not want one now.

## Two things the first version got wrong

The Resume chip is wide and never wraps, so in the 360px panel it squeezed the domain to `elburoj....` — hiding *which* site the offer was about. Moved to its own full-width line. Then the button sat below the sentence and fell past the checklist's 190px scroll fold: the control this change exists for was the first thing cut. Control first, explanation second — the same shape as `#run` and `#run-blocked`.

## A race found while reviewing the diff

`capture` clears the journal the instant an ingest succeeds, and the panel asks for this state on every refresh. A page vanishing between the listing and the `stat` would have thrown, failing `/api/sources` — and the panel reports that as *"Couldn't reach the engine"*. So a crawl going **well** would have looked like a dead engine. Now it costs one page off a count ([`localinbox.py:105-116`](scrapex/localinbox.py:105)), with a test.

## Worth a reviewer's eye

- **`skip_tokens` is not universal, but the gate is self-correcting.** Only connectors that emit `page_token` fill the journal, and every one that does (gpp, hybris, magento, salla, woocommerce, zid) also implements `skip_tokens`. A connector without it produces no tokenized pages, so `kept_pages` is 0 and no Resume appears. ELBUROJ is `salla-html`. The promise on the button holds today; it is an invariant nothing currently enforces.
- **Resume is not blocked while a job is running on that source.** It queues behind, as any run does. If the running job completes first, the journal is empty by then and the resume crawls whole — wasteful, not destructive. Left out deliberately to keep the diff tight; say the word if it should be gated.
- **`full_rebuild` + resume is accepted.** `archive_first` would fire again on the resumed source. That is the existing behaviour of resuming a paused rebuild, not something introduced here, so it is untouched. The panel never sends that combination.

## Tests

14 new. Six panel tests driven in a real browser through `tools/panel_harness.py` — the harness now records **write bodies** (`window.__writes`), because `__calls` is a path list and `resume` lives in the body, so a test that only saw the path could not tell a resume from a run that discards the journal.

The load-bearing one is [`test_a_seeded_checkpoint_resumes_a_journal_whose_own_job_is_gone`](tests/test_job_journal.py:268) — a new job seeded with `partial_source` picks up a journal whose job is terminal, skips both kept pages, fetches only the tail, and ingests all three. That is ELBUROJ's exact situation.

```
python -m pytest      1506 passed, 1 xfailed
node contract/parity/parity.test.mjs   3/3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
