### PR TITLE
fix(ingest): a product that already exists learns how the site shows it

### DIFF
--- a/scrapex/databases/domain.py
+++ b/scrapex/databases/domain.py
@@ -66,7 +66,47 @@ class Migration:
 
     @property
     def sha256(self) -> str:
+        """The migration's identity: its SQL, NOT its platform's newlines.
+
+        Hashing raw bytes made this checksum platform-dependent, which turned
+        the tamper guard into a false alarm. `.gitattributes` says `* text=auto`
+        and core.autocrlf is on, so the repo stores LF and Windows checks out
+        CRLF: the same committed migration hashes one way on the machine that
+        stamped the ledger and another on the machine that reads it.
+
+        It really fired. `general` migration 0003_field_paging_index.sql was
+        stamped f57f56a4 (1,042 bytes, 23 LF) and read back ba24e532 (1,065
+        bytes, 23 CRLF) — identical SQL — and refused every `scrapex ingest`
+        and `backup-databases` on Windows. Measured across both live databases,
+        57 of 57 migrations matched one form or the other and NOT ONE was
+        genuinely edited: 41 had been stamped from LF content and 16 from CRLF.
+        Re-stamping to CRLF would only have moved the failure to Linux and CI.
+
+        Normalising costs no detection. A real edit changes the SQL, so both
+        forms move and the guard still fails loudly; the only difference now
+        accepted is a line ending, which never changes what the SQL does.
+        """
+        return hashlib.sha256(self._normalised_bytes()).hexdigest()
+
+    @property
+    def legacy_sha256(self) -> str:
+        """The raw-bytes hash a pre-normalisation checkout stamped.
+
+        Accepted on READ so an existing ledger keeps validating, and upgraded
+        to `sha256` in place the next time the stream is stamped. Never used to
+        accept an UNKNOWN digest: it matches only when this very file's raw
+        bytes hash to the stored value, which proves the content is the same
+        modulo newlines rather than assuming it.
+        """
         return hashlib.sha256(self.path.read_bytes()).hexdigest()
+
+    def _normalised_bytes(self) -> bytes:
+        # CRLF and lone CR both fold to LF: the two conventions a Windows
+        # checkout and an old Mac-style file can introduce.
+        return self.path.read_bytes().replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+
+    def matches(self, stored: str) -> bool:
+        return stored in (self.sha256, self.legacy_sha256)
 
 
 @dataclass(frozen=True)
@@ -450,10 +490,19 @@ class DomainDatabase(Generic[T]):
                 "SELECT sha256 FROM database_migration WHERE migration_number = ? LIMIT 1",
                 (migration.number,),
             ).fetchone()
-            if stored is not None and stored[0] != migration.sha256:
+            if stored is not None and not migration.matches(stored[0]):
                 raise DatabaseMigrationError(
                     f"{self.kind} migration {migration.name} checksum changed; restore "
                     "the original migration file and retry"
+                )
+            if stored is not None and stored[0] != migration.sha256:
+                # A digest stamped from raw bytes, proven to be THIS file (see
+                # Migration.legacy_sha256). Upgraded once, here in the path that
+                # already owns the ledger, so the mixed state converges instead
+                # of every reader having to know about both forms forever.
+                conn.execute(
+                    "UPDATE database_migration SET sha256 = ? WHERE migration_number = ?",
+                    (migration.sha256, migration.number),
                 )
             if stored is None:
                 conn.execute(
@@ -488,7 +537,7 @@ class DomainDatabase(Generic[T]):
                     f"{self.kind} migration ledger is incomplete at {migration.name}; "
                     "run database initialization and retry"
                 )
-            if stored[0] != migration.sha256:
+            if not migration.matches(stored[0]):
                 raise DatabaseMigrationError(
                     f"{self.kind} migration {migration.name} checksum changed; restore "
                     "the original migration file and retry"

--- a/scrapex/ingest.py
+++ b/scrapex/ingest.py
@@ -14,8 +14,8 @@ from dataclasses import dataclass, field
 from decimal import Decimal
 
 from .changes import (
-    ALIAS_FIELDS, classify_availability, classify_price, product_field_diffs,
-    record_alias, record_change,
+    ALIAS_FIELDS, TRACKED_PRODUCT_FIELDS, classify_availability, classify_price,
+    product_field_diffs, record_alias, record_change,
 )
 from .config import SourceEntry
 from . import db as _dbmod, pricekey, tax
@@ -161,12 +161,30 @@ def _product_sku(r) -> str:
     return str(r.get("parent_sku") or r.get("external_sku") or "")
 
 
+# The one tracked field whose value is DERIVED here rather than carried by a
+# row: `product_sku` is the parent's sku or the row's own (_product_sku above).
+_DERIVED_DIFF_KEYS = frozenset({"product_sku"})
+
+# Every OTHER row key product_field_diffs reads, taken FROM the tracked list
+# instead of hand-listed beside it.
+#
+# This narrowed dict is the diff's only input, so a key absent here is a field
+# that is tracked and can never change — silently, because nothing raises and
+# the column simply stays as it was. That is exactly how 0056 shipped:
+# display_method was added to TRACKED_PRODUCT_FIELDS *specifically* so the 763
+# MADAR products that already existed could learn it (only the INSERT path
+# writes it, and they were inserted days earlier), and the hand-written tuple
+# here was not extended with it — so three successful `update` crawls diffed a
+# dict that had no display_method key, produced no diff, and wrote nothing.
+# Deriving the keys means the two lists cannot drift apart again: adding a pair
+# to TRACKED_PRODUCT_FIELDS is now the whole change.
+_DIFF_ROW_KEYS = tuple(row_key for _, row_key in TRACKED_PRODUCT_FIELDS
+                       if row_key not in _DERIVED_DIFF_KEYS)
+
+
 def _with_product_sku(r) -> dict:
     """The row plus the derived product sku, for the field-diff comparison."""
-    incoming = {key: r.get(key) for key in
-                ("product_name", "product_link", "brand", "brand_ar", "external_sku",
-                 "category_path", "category_path_ar", "category_external_id",
-                 "product_name_ar", "lang", "parent_sku")}
+    incoming = {key: r.get(key) for key in _DIFF_ROW_KEYS}
     incoming["product_sku"] = _product_sku(r)
     return incoming
 

--- a/tests/test_database_integrity_report.py
+++ b/tests/test_database_integrity_report.py
@@ -24,9 +24,16 @@ def test_an_edited_applied_migration_is_reported_as_what_it_is(tmp_path, monkeyp
     db = _db_at_head(tmp_path)
     assert db.health().ok, "the fresh database was not healthy to begin with"
 
-    # Edit an applied migration the only way that matters: its bytes.
+    # Edit an applied migration the only way that matters: its bytes. Both the
+    # canonical (newline-normalised) digest and the legacy raw-bytes digest are
+    # derived from those bytes, so a real edit moves BOTH — patching only one
+    # leaves the health check a matching digest to accept, and on an LF checkout
+    # (CI) the raw and normalised hashes are equal, so the unpatched one is the
+    # stored value itself. Simulate the byte change at both derivations.
     target = db._migrations[-1]
     monkeypatch.setattr(type(target), "sha256",
+                        property(lambda self: "0" * 64))
+    monkeypatch.setattr(type(target), "legacy_sha256",
                         property(lambda self: "0" * 64))
 
     report = db.health()

--- a/tests/test_display_method_and_quantity_facts.py
+++ b/tests/test_display_method_and_quantity_facts.py
@@ -412,6 +412,103 @@ def test_an_offer_learns_the_quantity_facts_without_being_split(tmp_path):
         conn.close()
 
 
+def _payloads_through_a_file(tmp_path: Path, scraped_at: str) -> list[FunnelPayload]:
+    """The payloads a crawl really ingests: SERIALIZED to disk and read back.
+
+    The in-memory path is what the 0056 tests exercised, and it is the reason
+    this defect shipped green — so the round trip is the shape asserted here.
+    """
+    payloads = []
+    for i, t in enumerate(MagentoGraphqlConnector(_Fetcher()).fetch(_entry())):
+        if t.kind != ExtractKind.PRODUCT_PRICES:
+            continue
+        written = FunnelPayload(
+            payload_version=PAYLOAD_VERSION, source_key="MADAR",
+            kind=ExtractKind.PRODUCT_PRICES, client="cli",
+            scraped_at=scraped_at, source_url=t.source_url,
+            header=t.header, rows=t.rows)
+        path = tmp_path / f"madar-prices-{i}.json"
+        path.write_text(written.model_dump_json(), encoding="utf-8")
+        payloads.append(FunnelPayload.model_validate_json(
+            path.read_text(encoding="utf-8")))
+    return payloads
+
+
+def test_the_payload_written_to_disk_still_carries_display_method(tmp_path):
+    """The header the crawl WRITES, not the one the current spec would build."""
+    payload = _payloads_through_a_file(tmp_path, "2026-07-30T10:00:00Z")[0]
+    assert "display_method" in payload.header
+    assert len(payload.header) == len(PRODUCT_PRICES.columns)
+    view = RowView(PRODUCT_PRICES, payload.header)
+    assert {view.get(row, "display_method") for row in payload.rows} == {
+        DisplayMethod.MEMBER_LIST.value, DisplayMethod.OPTIONS_PRICED.value,
+        DisplayMethod.OPTIONS_ONE_PRICE.value, DisplayMethod.SINGLE.value}
+
+
+def test_a_product_that_already_exists_learns_display_method(tmp_path):
+    """THE DEFECT THIS FILE SHIPPED. All 763 MADAR products were first seen
+    2026-07-25..27, days before display_method existed, so every one of them
+    takes the UPDATE path and NOT the INSERT that writes the column. Three
+    successful `update` crawls later the column was empty on all 763 and
+    change_event held 0 display_method rows.
+
+    The cause was not the connector, the payload or the diff — each of those
+    was verified working. It was ingest._with_product_sku narrowing the row to
+    a HAND-LISTED tuple of keys that was never extended with display_method, so
+    product_field_diffs was handed a dict in which the field could not differ.
+    The sibling test above passes on a FRESH database, where every product is
+    inserted; only a second ingest can see this.
+    """
+    conn = dbmod.connect(tmp_path / "harvest.db")
+    try:
+        dbmod.migrate(conn)
+        ingest_payloads(conn, _entry(),
+                        _payloads_through_a_file(tmp_path, "2026-07-29T10:00:00Z"))
+        # The live warehouse's state: the products exist, the column does not.
+        conn.execute("UPDATE source_product SET display_method = ''")
+        conn.commit()
+        before = conn.execute("SELECT COUNT(*) FROM source_product").fetchone()[0]
+
+        ingest_payloads(conn, _entry(),
+                        _payloads_through_a_file(tmp_path, "2026-07-30T10:00:00Z"))
+
+        shapes = dict(conn.execute(
+            "SELECT external_product_id, display_method FROM source_product"))
+        assert shapes == {"SFNT": DisplayMethod.MEMBER_LIST.value,
+                          "UkNG": DisplayMethod.OPTIONS_PRICED.value,
+                          "TEVH": DisplayMethod.OPTIONS_ONE_PRICE.value,
+                          "UFVUVFk=": DisplayMethod.SINGLE.value}
+        # Learning a column must not mint a second product beside the first.
+        assert conn.execute(
+            "SELECT COUNT(*) FROM source_product").fetchone()[0] == before
+        # And the learning is an EVENT, like every other tracked field's.
+        assert conn.execute(
+            "SELECT COUNT(*) FROM change_event "
+            "WHERE field_key = 'display_method'").fetchone()[0] == len(shapes)
+    finally:
+        conn.close()
+
+
+def test_every_tracked_product_field_can_actually_be_updated():
+    """The guard on the class of defect, not just this instance.
+
+    _with_product_sku builds the ONLY dict product_field_diffs ever reads, so a
+    tracked field missing from it is tracked-but-frozen — and nothing raises:
+    the column just silently keeps its old value forever. Adding a pair to
+    TRACKED_PRODUCT_FIELDS must be the whole change.
+    """
+    from scrapex.changes import TRACKED_PRODUCT_FIELDS
+    from scrapex.ingest import _with_product_sku
+
+    # Asserted against the PUBLIC behaviour of _with_product_sku, not against
+    # the constant that implements it: this test has to be able to fail on the
+    # hand-listed version too, and an ImportError is not this defect's shape.
+    reachable = set(_with_product_sku({}))
+    tracked = {row_key for _, row_key in TRACKED_PRODUCT_FIELDS}
+    assert tracked - reachable == set(), (
+        f"tracked but unreachable by the diff: {sorted(tracked - reachable)}")
+
+
 def test_migration_0056_corrects_has_variants_on_rows_that_already_exist():
     """The backfill, on a warehouse that predates it.
 

--- a/tests/test_display_method_and_quantity_facts.py
+++ b/tests/test_display_method_and_quantity_facts.py
@@ -464,10 +464,23 @@ def test_a_product_that_already_exists_learns_display_method(tmp_path):
         dbmod.migrate(conn)
         ingest_payloads(conn, _entry(),
                         _payloads_through_a_file(tmp_path, "2026-07-29T10:00:00Z"))
-        # The live warehouse's state: the products exist, the column does not.
-        conn.execute("UPDATE source_product SET display_method = ''")
+
+        # Seed the warehouse to look like the live one: every product already
+        # exists, was first seen BEFORE display_method was a column (the real
+        # min first_seen is 2026-07-25T06:57:29Z), and the column is empty. The
+        # first_seen date is cosmetic to path selection — INSERT vs UPDATE turns
+        # on the row already existing — but it is the shape the owner describes,
+        # and empty-on-existing-rows is precisely what broke.
+        conn.execute("UPDATE source_product SET display_method = '', "
+                     "first_seen_at = '2026-07-25T06:57:29Z'")
         conn.commit()
         before = conn.execute("SELECT COUNT(*) FROM source_product").fetchone()[0]
+        assert conn.execute(
+            "SELECT MAX(first_seen_at) FROM source_product").fetchone()[0] \
+            < "2026-07-29", "the seed must predate the column to exercise UPDATE"
+        assert not any(v for _, v in conn.execute(
+            "SELECT external_product_id, display_method FROM source_product")), \
+            "the seed must start with the column empty on every row"
 
         ingest_payloads(conn, _entry(),
                         _payloads_through_a_file(tmp_path, "2026-07-30T10:00:00Z"))
@@ -478,6 +491,19 @@ def test_a_product_that_already_exists_learns_display_method(tmp_path):
                           "UkNG": DisplayMethod.OPTIONS_PRICED.value,
                           "TEVH": DisplayMethod.OPTIONS_ONE_PRICE.value,
                           "UFVUVFk=": DisplayMethod.SINGLE.value}
+        # The owner's report format: the count per value. Each of the four live
+        # shapes is present exactly once in the fixture, so the breakdown the
+        # owner will read off the 763 (single 400 / options_one_price 36 /
+        # options_priced 292 / member_list 33) is exercised here as 1 / 1 / 1 / 1
+        # with zero left empty — the same UPDATE path, at fixture scale.
+        breakdown = dict(conn.execute(
+            "SELECT display_method, COUNT(*) FROM source_product "
+            "GROUP BY display_method ORDER BY display_method"))
+        assert breakdown == {DisplayMethod.MEMBER_LIST.value: 1,
+                             DisplayMethod.OPTIONS_ONE_PRICE.value: 1,
+                             DisplayMethod.OPTIONS_PRICED.value: 1,
+                             DisplayMethod.SINGLE.value: 1}
+        assert "" not in breakdown, "no pre-existing product may be left empty"
         # Learning a column must not mint a second product beside the first.
         assert conn.execute(
             "SELECT COUNT(*) FROM source_product").fetchone()[0] == before

--- a/tests/test_migration_checksum_line_endings.py
+++ b/tests/test_migration_checksum_line_endings.py
@@ -1,0 +1,179 @@
+r"""A migration's identity is its SQL, not its platform's newlines.
+
+Hashing raw bytes made the tamper guard platform-dependent. `.gitattributes`
+says `* text=auto` and core.autocrlf is on, so the repo stores LF and a Windows
+checkout gets CRLF — the same committed migration hashes one way on the machine
+that stamped the ledger and another on the machine that reads it.
+
+It fired for real. `general` migration 0003_field_paging_index.sql was stamped
+f57f56a4 (1,042 bytes, 23 LF) and read back ba24e532 (1,065 bytes, 23 CRLF),
+identical SQL, and refused every `scrapex ingest` and `scrapex backup-databases`
+on Windows with "checksum changed; restore the original migration file". The
+file was never edited: it is byte-identical to its only commit, `d9dab1b`.
+
+Measured across both live databases before the fix: 57 of 57 migrations matched
+one form or the other and NOT ONE was genuinely edited — 41 stamped from LF
+content, 16 from CRLF. So re-stamping to CRLF would only have moved the failure
+to Linux and CI, and 40 MarketLens rows were already latently broken behind a
+connect() path that does not verify checksums.
+"""
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from scrapex.databases.domain import (
+    DatabaseMigrationError, GeneralDatabase, Migration,
+)
+
+_SQL_LF = (
+    b"PRAGMA application_id = 1398294350;\n"
+    b"CREATE TABLE thing (id INTEGER PRIMARY KEY);\n"
+    b"CREATE TABLE scrapex_meta (key TEXT PRIMARY KEY, value TEXT);\n"
+    b"INSERT INTO scrapex_meta VALUES ('database_kind', 'general');\n"
+    b"CREATE TABLE database_migration (\n"
+    b"  migration_number INTEGER PRIMARY KEY, migration_name TEXT NOT NULL,\n"
+    b"  sha256 TEXT NOT NULL,\n"
+    b"  applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')));\n"
+    b"PRAGMA user_version = 1;\n"
+)
+
+
+def _rig(path, migration_path):
+    class _Rig(GeneralDatabase):
+        def __init__(self, p):
+            super().__init__(p)
+            self._migrations = (Migration(1, migration_path),)
+    return _Rig(path)
+
+
+def _stored(db_path) -> str:
+    conn = sqlite3.connect(db_path)
+    try:
+        return conn.execute(
+            "SELECT sha256 FROM database_migration WHERE migration_number = 1"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+
+def test_the_same_sql_hashes_the_same_through_lf_and_crlf(tmp_path):
+    """The defect, at its root. Two checkouts of ONE commit must agree."""
+    lf, crlf = tmp_path / "lf.sql", tmp_path / "crlf.sql"
+    lf.write_bytes(_SQL_LF)
+    crlf.write_bytes(_SQL_LF.replace(b"\n", b"\r\n"))
+    assert lf.read_bytes() != crlf.read_bytes(), "the fixture must differ in bytes"
+    assert Migration(1, lf).sha256 == Migration(1, crlf).sha256
+    # And the raw hashes really do disagree — that is what broke.
+    assert Migration(1, lf).legacy_sha256 != Migration(1, crlf).legacy_sha256
+
+
+def test_a_lone_cr_folds_too(tmp_path):
+    """Old Mac-style endings are the third convention, folded for the same reason."""
+    cr = tmp_path / "cr.sql"
+    cr.write_bytes(_SQL_LF.replace(b"\n", b"\r"))
+    lf = tmp_path / "lf.sql"
+    lf.write_bytes(_SQL_LF)
+    assert Migration(1, cr).sha256 == Migration(1, lf).sha256
+
+
+def test_a_ledger_stamped_from_raw_bytes_still_verifies(tmp_path):
+    """THE LIVE CONDITION. An existing warehouse must keep opening.
+
+    Both live databases carried a MIXTURE of raw and normalised digests, so a
+    reader that accepted only the new form would have locked the owner out of
+    the very databases the fix is meant to unblock.
+    """
+    sql = tmp_path / "0001_base.sql"
+    sql.write_bytes(_SQL_LF.replace(b"\n", b"\r\n"))   # a Windows checkout
+    db = tmp_path / "rig.db"
+    _rig(db, sql).initialize()
+
+    # Rewind the ledger to the digest a pre-normalisation build stamped.
+    legacy = Migration(1, sql).legacy_sha256
+    conn = sqlite3.connect(db)
+    conn.execute("UPDATE database_migration SET sha256 = ?", (legacy,))
+    conn.commit()
+    conn.close()
+    assert _stored(db) == legacy
+
+    # It must open, and not raise the false alarm.
+    _rig(db, sql).connect().close()
+
+
+def test_stamping_upgrades_a_legacy_digest_in_place(tmp_path):
+    """The mixed state converges instead of every reader knowing both forms."""
+    sql = tmp_path / "0001_base.sql"
+    sql.write_bytes(_SQL_LF.replace(b"\n", b"\r\n"))
+    db = tmp_path / "rig.db"
+    _rig(db, sql).initialize()
+
+    legacy = Migration(1, sql).legacy_sha256
+    canonical = Migration(1, sql).sha256
+    assert legacy != canonical
+    conn = sqlite3.connect(db)
+    conn.execute("UPDATE database_migration SET sha256 = ?", (legacy,))
+    conn.commit()
+    conn.close()
+
+    rig = _rig(db, sql)
+    conn = sqlite3.connect(db)
+    try:
+        rig._stamp_and_verify_checksums(conn)   # noqa: SLF001 — the unit under test
+    finally:
+        conn.close()
+    assert _stored(db) == canonical, "the legacy digest was not upgraded"
+
+
+def test_a_real_edit_still_fails_loudly(tmp_path):
+    """Normalising must cost NO detection. Only a newline is forgiven."""
+    sql = tmp_path / "0001_base.sql"
+    sql.write_bytes(_SQL_LF)
+    db = tmp_path / "rig.db"
+    _rig(db, sql).initialize()
+
+    # Same line count, one identifier changed.
+    sql.write_bytes(_SQL_LF.replace(b"CREATE TABLE thing", b"CREATE TABLE other"))
+    with pytest.raises(DatabaseMigrationError, match="checksum changed"):
+        _rig(db, sql).connect()
+
+
+def test_whitespace_inside_a_line_is_not_a_line_ending(tmp_path):
+    """The narrowest possible edit still fails: folding newlines must not turn
+    into folding whitespace generally."""
+    sql = tmp_path / "0001_base.sql"
+    sql.write_bytes(_SQL_LF)
+    db = tmp_path / "rig.db"
+    _rig(db, sql).initialize()
+
+    sql.write_bytes(_SQL_LF.replace(b"CREATE TABLE thing", b"CREATE  TABLE thing"))
+    with pytest.raises(DatabaseMigrationError, match="checksum changed"):
+        _rig(db, sql).connect()
+
+
+def test_every_shipped_migration_hashes_the_same_on_either_platform(tmp_path):
+    """The regression guard over the REAL 57 migrations.
+
+    Each shipped file is rewritten into both conventions and re-hashed: the
+    digest may not depend on which one a checkout produced. This is the property
+    the live databases needed and did not have — CI runs on Linux (LF) and the
+    owner develops on Windows (CRLF), and before the fix those two disagreed
+    about every multi-line migration in the repo.
+    """
+    from scrapex.databases import domain
+
+    plans = (domain._general_plan(), domain._marketlens_plan())  # noqa: SLF001
+    seen = 0
+    for plan in plans:
+        for migration in plan:
+            body = migration.path.read_bytes().replace(b"\r\n", b"\n")
+            as_lf, as_crlf = tmp_path / "lf.sql", tmp_path / "crlf.sql"
+            as_lf.write_bytes(body)
+            as_crlf.write_bytes(body.replace(b"\n", b"\r\n"))
+            assert Migration(1, as_lf).sha256 == Migration(1, as_crlf).sha256, (
+                f"{migration.name} hashes differently per line ending")
+            # And the shipped file agrees with its own normalised form.
+            assert migration.sha256 == Migration(1, as_lf).sha256, migration.name
+            seen += 1
+    assert seen >= 50, f"expected the full stream, walked only {seen}"


### PR DESCRIPTION
## Scope — two defects, and why both are here

This branch fixes **two** things. They are separate claims and reviewable apart; here is why the second rides along rather than being split out.

1. **The brief** — `display_method` was empty on all 763 MADAR products. One broken link in `ingest`.
2. **A defect I tripped over proving #1 on the live warehouse** — the owner asked me to run the live MADAR ingest. `scrapex ingest` and `scrapex backup-databases` both refused to run:

   ```
   general migration 0003_field_paging_index.sql checksum changed;
   restore the original migration file and retry
   ```

   The migration was not edited — it is byte-identical to its only commit, `d9dab1b`, and `git status` is clean. The guard was firing on a **line ending**. Without fixing it I could not run the ingest the task required, so it is a real defect met in the line of the work, not unrelated hardening. It lives in commits `d93d61e` (fix) + `43f283e` (a pre-existing test that followed the widened contract), so a reviewer can read it as one unit. **If you'd rather it be its own PR, say so and I'll split those two commits out** — they touch no file that #1 touches.

Commits:
- `baecaa0` `fix(ingest)` — #1, the `display_method` link
- `d93d61e` `fix(db)` — #2, newline-independent migration checksums
- `43f283e` `test(db)` — #2, the integrity test follows the widened `Migration` contract

---

## #1 — The broken link

`scrapex/ingest.py:164` — `_with_product_sku`.

It narrows the incoming row to a **hand-listed tuple of keys** before handing it to `product_field_diffs`. That tuple was never extended with `display_method`, so the diff was given a dict in which the field could not differ. No diff, no `UPDATE`, and nothing raised — the column just kept its old value.

Everything the brief ruled out really was fine. The connector computes it, emits it on every row, the 34-column header survives serialization to disk and back, and the diff fires correctly *when it is given the value*. It never was.

### Why only the product-level column

`display_method` is written in exactly two places: the INSERT at `ingest.py:262`, and the tracked-field UPDATE at `ingest.py:235`. All 763 MADAR products were first seen **2026-07-25 → 07-27**, days before the column existed, so every one of them takes the **UPDATE** path. The INSERT never runs for them.

`changes.py:47-55` added `display_method` to `TRACKED_PRODUCT_FIELDS` *specifically* so those existing products could learn it. The narrowing three functions away is what silently defeated that. The offer-level columns filled because they are written by their own upsert, which reads the full row.

Measured on the live warehouse before the fix:

| fact | value |
|---|---|
| MADAR products | 763 |
| …with a non-empty `display_method` | 0 |
| `change_event` rows for `display_method`, ever | **0** |
| MADAR crawls on the new code | jobs 55, 59, 64 — all `run_mode='update'`, all completed |

Zero change events across three successful crawls is the tell: the diff was never even a no-op on a *changed* value, it was blind.

### The fix

The diff's keys are now **derived from `TRACKED_PRODUCT_FIELDS`**, so the two lists cannot drift apart again — adding a tracked pair is the whole change. `product_sku` is the one exemption, being derived here rather than carried by a row. `external_sku` leaves the dict: it was never a tracked row key and the diff never read it.

### Proven without re-crawling

Per the owner's instruction, the regression is proven against a **database seeded to look like the live one** rather than a fresh crawl — products that already exist, first-seen before the column existed (so the UPDATE path is the one exercised), column empty. `test_a_product_that_already_exists_learns_display_method` ingests, seeds that state, ingests **again**, and asserts every product learns its value, broken down by value the way the owner reads it. Pre-fix it fails `{'SFNT': ''} != {'SFNT': 'member_list'}`.

Two more:
- `test_every_tracked_product_field_can_actually_be_updated` — the guard on the *class* of defect. Pre-fix: `assert {'display_method'} == set()`.
- `test_the_payload_written_to_disk_still_carries_display_method` — pins the round trip.

Both ingest tests go through a payload **serialized to a file and read back**, not the in-memory path — the in-memory-only test is what let this ship green.

### The number the owner asked for

A live MADAR ingest was run through the sanctioned CLI path (run 54, status success, 3,418 confirmed, 16,092 details, 0 errors). Measured on the live warehouse, WAL-aware:

| value | products |
|---|---|
| `single` | 400 |
| `options_priced` | 292 |
| `options_one_price` | 36 |
| `member_list` | 33 |
| *(empty)* | 2 |
| **carrying a value** | **761 / 763** |

**0 → 761**, matching the expected 400 / 36 / 292 / 33. `change_event` gained 761 rows. The two empties are the products the site no longer publishes — `NjE1NQ==` "SANDWICH PANEL 4 MTR * 3 CM" and `NzAxNA==` "SANDWICH PANEL 5 MTR * 3 CM", both `last_seen_at 2026-07-26`, absent from the crawl. Counting what the site still publishes: **761 / 761**.

Unchanged and verified: 763 products (no duplicate minted), 3,425 offers, 109 `quantity_is_decimal`, 3,418 `minimum_quantity`, **92 `selling_unit_id`** — deliberately untouched.

---

## #2 — A migration's identity is its SQL, not its platform's newlines

`.gitattributes` sets `* text=auto` and `core.autocrlf` is on, so the repo stores LF and Windows checks out CRLF:

| | bytes | CRLF | LF | sha256 |
|---|---|---|---|---|
| on disk (Windows checkout) | 1,065 | 23 | 0 | `ba24e532…` |
| git blob (repo storage) | 1,042 | 0 | 23 | `f57f56a4…` ← the ledger's value |

`Migration.sha256` hashed **raw bytes**, so the same committed migration hashed one way on the machine that stamped the ledger and another on the machine that read it. Measured across both live databases: **57 of 57 migrations matched one form or the other and not one was genuinely edited** — 41 stamped from LF content, 16 from CRLF. Re-stamping `0003` to CRLF would only have moved the failure to Linux and CI, and 40 MarketLens rows were already latently broken behind `db.connect()` (which doesn't verify checksums the way `DomainDatabase` does).

The fix normalises newlines before hashing, so identity depends on the SQL and nothing else. The pre-existing raw digest is still accepted on read and upgraded in place on the next stamp, so the mixed ledger converges. **Detection is unchanged** — a real edit moves both digests and still fails loudly; two of the seven new tests prove that, including a single-space change *inside* a line, and they pass before and after the fix. `Migration.sha256` was the only place hashing repo file bytes.

That CI split was itself a proof: the first push went **red on Linux, green on Windows** on a pre-existing test that patched only `sha256`. On an LF checkout raw == normalised == stored, so the unpatched `legacy_sha256` *was* the stored digest and health wrongly read OK; on CRLF it differed and the test passed. A real byte edit moves both — `43f283e` patches both (see its own note in the diff).

---

## Not touched

`selling_unit_id` (92 of 3,425) — naming MADAR's per-tonne unit is an open owner decision; the shop never writes «طن» and the facts to render it are already stored. No migration — 0056 is already applied.

## One issue found in passing, not touched

A live `initial_crawl` of **ELBUROJ** failed independently while this work ran: `payload_version` 5 vs the required 6 (bumped in `55ae064`). A different code path (payload validation, not the migration ledger), it began before any change here, and the MADAR ingest — a different source — succeeded. Flagged for its own session; out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
