### PR TITLE
feat(panel): the number of sites crawled at once is reachable

### DIFF
--- a/extension/app.html
+++ b/extension/app.html
@@ -888,6 +888,10 @@
               <label for="crawl_min_interval_s">Minimum seconds between requests</label>
               <input id="crawl_min_interval_s" type="number" step="0.1" min="0.1" dir="ltr">
 
+              <label for="crawl_parallel_sources">Sites crawled at the same time</label>
+              <input id="crawl_parallel_sources" type="number" step="1" min="1" max="8" dir="ltr">
+              <p class="muted text-xs" id="crawl-parallel-effect">&nbsp;</p>
+
               <label for="crawl_timeout_s">Request timeout in seconds</label>
               <input id="crawl_timeout_s" type="number" min="1" dir="ltr">
 

--- a/extension/app.js
+++ b/extension/app.js
@@ -237,7 +237,14 @@ function setStatus(engine) {
 // for a feature that had been shipped weeks earlier. Settings belong here.
 
 const CRAWL_KEYS = ["crawl_honour_delay", "crawl_min_interval_s",
-                    "crawl_timeout_s", "crawl_user_agent"];
+                    "crawl_parallel_sources", "crawl_timeout_s",
+                    "crawl_user_agent"];
+
+// The engine's own ceiling (jobs.py MAX_PARALLEL_SOURCES). Past a handful the
+// wall-clock stops improving while the open handles and the contended write
+// lock keep growing, so the field refuses what the engine would clamp anyway
+// rather than accepting a number and silently ignoring it.
+const MAX_PARALLEL_SOURCES = 8;
 
 function crawlPaceEffect() {
   // What the choice MEANS, in the units the owner thinks in. A checkbox that
@@ -247,6 +254,18 @@ function crawlPaceEffect() {
   $("crawl-pace-effect").textContent = honour
     ? "Each site's own delay wins when it asks for more than " + every + "s."
     : "Our pace only: " + every + "s between requests, whatever a site asks for.";
+}
+
+function crawlParallelEffect() {
+  // What the number MEANS, in the terms the owner asked in. elburoj starved
+  // nine other sources for days because one slow site held the whole run; the
+  // field that fixes that should say so, and should say the part people get
+  // wrong — this is sites at once, never two pages of one site at once.
+  const at = parseInt($("crawl_parallel_sources").value, 10) || 1;
+  $("crawl-parallel-effect").textContent = at <= 1
+    ? "One site at a time: a slow site holds up every source behind it."
+    : at + " different sites at once. Two sources on the SAME site still take "
+      + "turns, so no site is asked for more than it was before.";
 }
 
 async function loadCrawlSettings() {
@@ -259,10 +278,12 @@ async function loadCrawlSettings() {
   };
   $("crawl_honour_delay").checked = !["0", "false", false].includes(value("crawl_honour_delay"));
   $("crawl_min_interval_s").value = value("crawl_min_interval_s") || "1.0";
+  $("crawl_parallel_sources").value = value("crawl_parallel_sources") || "1";
   $("crawl_timeout_s").value = value("crawl_timeout_s") || "30";
   $("crawl_user_agent").value = value("crawl_user_agent") || "";
   $("log_retention_days").value = value("log_retention_days") || "30";
   crawlPaceEffect();
+  crawlParallelEffect();
 }
 
 async function saveCrawlSettings() {
@@ -278,6 +299,9 @@ async function saveCrawlSettings() {
     await post("/api/settings", {
       crawl_honour_delay: $("crawl_honour_delay").checked ? "1" : "0",
       crawl_min_interval_s: String(interval),
+      crawl_parallel_sources: String(Math.min(
+        Math.max(parseInt($("crawl_parallel_sources").value, 10) || 1, 1),
+        MAX_PARALLEL_SOURCES)),
       crawl_timeout_s: String(parseInt($("crawl_timeout_s").value, 10) || 30),
       crawl_user_agent: $("crawl_user_agent").value.trim(),
       log_retention_days: String(parseInt($("log_retention_days").value, 10) || 30),
@@ -285,6 +309,7 @@ async function saveCrawlSettings() {
   } catch (err) { out("crawl-msg", "not saved: " + err.message, "err"); return; }
   out("crawl-msg", "saved — it applies to the next crawl, not one already running", "ok");
   crawlPaceEffect();
+  crawlParallelEffect();
 }
 
 async function restartEngineFromPanel() {
@@ -2076,6 +2101,7 @@ async function init() {
   $("engine-restart").addEventListener("click", restartEngineFromPanel);
   $("crawl_honour_delay").addEventListener("change", crawlPaceEffect);
   $("crawl_min_interval_s").addEventListener("input", crawlPaceEffect);
+  $("crawl_parallel_sources").addEventListener("input", crawlParallelEffect);
   document.querySelector('[data-sect="s-crawl"]')
     .addEventListener("click", () => {
       if (!$("s-crawl").classList.contains("hidden")) loadCrawlSettings();

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -1216,3 +1216,45 @@ def test_a_selection_that_keeps_nothing_is_not_nagged(open_panel):
 
     assert asked == []
     assert _writes(page), "the run did not start"
+
+
+def test_the_number_of_sites_crawled_at_once_is_reachable(open_panel):
+    """The engine gained per-host concurrency and the panel had no field for it,
+    so the feature shipped switched off with no way to switch it on — the same
+    shape of miss as the crawl pace itself."""
+    page = open_panel()
+    page.click(SETTINGS_TAB)
+    page.click('[data-sect="s-crawl"]')
+    page.wait_for_timeout(300)
+
+    assert page.input_value("#crawl_parallel_sources") == "1"
+    # One at a time is the default, and the panel says what that COSTS.
+    assert "holds up every source" in page.inner_text("#crawl-parallel-effect")
+
+    page.fill("#crawl_parallel_sources", "4")
+    page.wait_for_timeout(100)
+    effect = page.inner_text("#crawl-parallel-effect")
+    assert "4 different sites" in effect
+    # The part people get wrong, said out loud: no site is asked for more.
+    assert "SAME site" in effect
+    assert not page.js_errors
+
+
+def test_a_width_above_the_engines_ceiling_is_clamped_not_ignored(open_panel):
+    """The engine clamps to MAX_PARALLEL_SOURCES anyway. Accepting 40 and
+    silently running 8 would teach the owner a number that is not true."""
+    page = open_panel()
+    page.click(SETTINGS_TAB)
+    page.click('[data-sect="s-crawl"]')
+    page.wait_for_timeout(300)
+    page.fill("#crawl_parallel_sources", "40")
+    page.click("#crawl-save")
+    page.wait_for_timeout(300)
+
+    writes = page.evaluate(
+        "window.__writes.filter(w => w.path.startsWith('/api/settings'))")
+    assert writes, "nothing was sent to the engine"
+    assert writes[-1]["body"]["crawl_parallel_sources"] == "8", (
+        "40 reached the engine, which clamps to 8 — so the panel taught a "
+        "number that is not what runs")
+    assert "saved" in page.inner_text("#crawl-msg")

--- a/tools/panel_harness.py
+++ b/tools/panel_harness.py
@@ -99,6 +99,7 @@ def stub(backend: str = DEFAULT_BACKEND, *, engine_up=True, sources=None, jobs=N
         "/api/settings": {"settings": {
             "crawl_honour_delay": {"value": "1"},
             "crawl_min_interval_s": {"value": "1.0"},
+            "crawl_parallel_sources": {"value": "1"},
             "crawl_timeout_s": {"value": "30"},
             "crawl_user_agent": {"value": ""},
             "log_retention_days": {"value": "30"}}},


### PR DESCRIPTION
The engine gained per-host concurrency in `63dc24b` and **the panel had no field for it**, so the feature shipped switched off with no way to switch it on.

The owner asked why two things he started were queued. The answer: `crawl_parallel_sources` was still **1** and nothing in the interface could change it. That is the same miss as the crawl pace itself, one commit later.

## What it says

The field states what the number *means*, in the terms he asked in:

- **1** — "One site at a time: a slow site holds up every source behind it."
- **4** — "4 different sites at once. Two sources on the SAME site still take turns, so no site is asked for more than it was before."

That second half is the part that is easy to get wrong, so it is on screen rather than only in a commit message.

## Clamped, not silently ignored

`jobs.py` clamps to `MAX_PARALLEL_SOURCES` (8). A panel that accepted 40 and ran 8 would teach a number that is not what runs, so the panel clamps before sending.

## Tests

- the field is reachable, defaults to 1, and the consequence line tracks it as you type
- **40 reaches the engine as 8** — asserted against the request body the harness records, not against the message on screen

**1554 passed, 1 xfailed.** Contract parity **3/3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)