### PR TITLE
fix(data): opening a card no longer rearranges the other cards

### DIFF
--- a/scrapex/webui/static/grid-theme.css
+++ b/scrapex/webui/static/grid-theme.css
@@ -1226,20 +1226,16 @@
 .selected-product-grid.is-pair {
   grid-template-columns: repeat(2, minmax(0, 24rem));
 }
-/* One focused card and its inspector share the first row; every other selected
-   card flows below. The card keeps the SAME 24rem it has in every other state
-   — a card that changed width when you opened it would read as a different
-   card — and the inspector takes whatever is left. */
-.selected-product-grid.has-focused-record {
-  grid-template-columns: minmax(0, 24rem) minmax(0, 1fr);
-}
-.selected-product-grid.has-focused-record > .selected-product-card {
-  grid-column: 1;
-}
-.selected-product-grid.has-focused-record > .selected-product-card.is-focused {
-  grid-column: 1;
-  grid-row: 1;
-}
+/* Opening a card must not REARRANGE the others. The first attempt cut the grid
+   to two tracks and pinned every card to column 1, so the card you opened rose
+   to the top and the rest fell into a single stack — the owner's report, and
+   exactly the churn that makes a selection hard to read. It is invisible with
+   one card selected, which is why it shipped.
+   The column count therefore does NOT change when a card is focused. The card
+   keeps the cell it already had; the inspector is simply the next item in the
+   flow and spans the rest of that row, so cards after it continue three-up as
+   before. Nothing is pinned to a row or a column: the grid places everything,
+   which is the only way this stays true for 2, 3 or 9 selected cards. */
 .selected-product-card.is-focused {
   outline: 2px solid var(--accent, currentColor);
   outline-offset: 2px;
@@ -1776,8 +1772,10 @@
 }
 
 .selected-product-detail-host {
-  grid-column: 2;
-  grid-row: 1;
+  /* The rest of the focused card's row. Where the card sits in the last column
+     there is no room, and the grid wraps the inspector to the next row — still
+     directly after its card, which is the promise that matters. */
+  grid-column: span 2;
   min-width: 0;      /* or a long value stretches the track and breaks the row */
 }
 .selected-product-detail-host[hidden] { display: none; }
@@ -1981,12 +1979,10 @@
   /* No room for two tracks: the inspector goes UNDER its card rather than
      beside it, and still directly after it, so it never separates from the
      record it describes. */
-  .selected-product-grid.has-focused-record {
-    grid-template-columns: minmax(0, 24rem);
-  }
+  /* One track at this width, so "beside" is impossible: the inspector takes
+     the full width under its own card. */
   .selected-product-grid.has-focused-record > .selected-product-detail-host {
-    grid-column: 1;
-    grid-row: auto;
+    grid-column: 1 / -1;
   }
 }
 

--- a/scrapex/webui/templates/datasets.html
+++ b/scrapex/webui/templates/datasets.html
@@ -6,7 +6,7 @@
    fail exactly when the owner is offline. See static/vendor/README.md. #}
   <link rel="stylesheet" href="/static/vendor/tabulator.min.css">
   {# Loaded AFTER the library so the project's own table appearance wins. #}
-  <link rel="stylesheet" href="/static/grid-theme.css?v=design-system-44">
+  <link rel="stylesheet" href="/static/grid-theme.css?v=design-system-45">
   <link rel="stylesheet" href="/static/pages/datasets.css">
   <script src="/static/vendor/tabulator.min.js" defer></script>
 {% endblock %}

--- a/scrapex/webui/templates/source.html
+++ b/scrapex/webui/templates/source.html
@@ -8,14 +8,14 @@
    the owner is offline. See static/vendor/README.md. #}
   <link rel="stylesheet" href="/static/vendor/tabulator.min.css">
   {# Loaded AFTER the library so the project's own table appearance wins. #}
-  <link rel="stylesheet" href="/static/grid-theme.css?v=design-system-44">
+  <link rel="stylesheet" href="/static/grid-theme.css?v=design-system-45">
   <link rel="stylesheet" href="/static/pages/data-workspace.css?v=source-ui-8">
   <script src="/static/vendor/tabulator.min.js" defer></script>
   <script src="/static/datasets-browser.js?v=source-ui-8" defer></script>
 {# StaticFiles supplies validators but no Cache-Control policy. A new URL is
    therefore intentional when grid behaviour changes: an already-cached script
    must not keep the old sorting persistence or header controls after update. #}
-  <script src="/static/grid.js?v=design-system-44" defer></script>
+  <script src="/static/grid.js?v=design-system-45" defer></script>
 {% endblock %}
 {% block content %}
 {# Interface language is English only (spec 1). Scraped values are DATA: they

--- a/tests/test_vendor.py
+++ b/tests/test_vendor.py
@@ -310,10 +310,12 @@ def test_grid_behaviour_changes_bust_the_browser_cache():
     # and a visible token-based focus state.
     # design-system-44: the export split control gained a quieter hierarchy
     # and a structured, descriptive menu without changing export behaviour.
-    assert '/static/grid.js?v=design-system-44' in page
-    assert '/static/grid-theme.css?v=design-system-44' in page
-    assert '/static/grid-theme.css?v=design-system-44' in (
+    assert '/static/grid.js?v=design-system-45' in page
+    assert '/static/grid-theme.css?v=design-system-45' in page
+    assert '/static/grid-theme.css?v=design-system-45' in (
         TEMPLATES / "datasets.html").read_text(encoding="utf-8")
+    # design-system-45: opening a card no longer rearranges the others — the
+    # column count is unchanged on focus and nothing is pinned to a row.
     # design-system-44: two selected cards keep the established card width and
     # aligned slots; the focused card KEEPS ITS PLACE with the inspector beside
     # it, and the other selected cards move below without clearing the table
@@ -920,10 +922,17 @@ def test_selected_rows_render_as_product_cards_with_a_responsive_inspector():
     assert 'focusedCard.classList.add("is-focused")' in multi
     assert 'productGrid.classList.add("has-focused-record")' in multi
     assert ".selected-product-grid.has-focused-record" in css
-    # Two tracks: the card keeps its established 24rem, the inspector takes
-    # the rest of the row. A card that changed width when opened would read as
-    # a different card.
-    assert "grid-template-columns: minmax(0, 24rem) minmax(0, 1fr);" in css
+    # OPENING A CARD MUST NOT REARRANGE THE OTHERS. The first attempt cut the
+    # grid to two tracks and pinned every card to column 1, so the opened card
+    # rose to the top and the rest fell into a single stack. The column count
+    # must not change on focus, and nothing may be pinned to a row or a column.
+    assert "grid-template-columns: minmax(0, 24rem) minmax(0, 1fr);" not in css
+    focused = css.split(".selected-product-card.is-focused {", 1)[1].split("}", 1)[0]
+    assert "grid-row" not in focused and "grid-column" not in focused, (
+        "the focused card is pinned again, so it jumps out of its place")
+    host = css.split(".selected-product-detail-host {", 1)[1].split("}", 1)[0]
+    assert "grid-column: span 2;" in host, "the inspector must span, not be pinned"
+    assert "grid-row" not in host
     assert ".selected-product-card.is-focused" in css
     # A truncated value must stay readable somewhere, or the card decides what
     # a fact SAYS rather than where it is shown.


### PR DESCRIPTION
My own fix from `420e428`, reported by the owner with screenshots. **Two lines of it were wrong:**

```css
.has-focused-record { grid-template-columns: minmax(0,24rem) minmax(0,1fr) }
.has-focused-record > .selected-product-card { grid-column: 1 }
```

Two tracks, and every card pinned to the first one. So the moment you pressed **Details** or **History**:

- the card you opened **rose to the top** (it also carried `grid-row: 1`)
- every other selected card **fell out of the three-up grid into a single stack**, one per row

The selection you were reading rearranged itself under you.

It is invisible with **one** card selected, where nothing follows to be displaced — which is exactly the case the tests and I both looked at, and why it shipped.

## The rule now

The column count does **not** change on focus, and **nothing is pinned** to a row or a column. The card keeps the cell it already had; the inspector is the next item in the flow and spans the rest of that row, so cards after it continue three-up as before.

The grid places everything — which is the only way this stays true for 2, 3 or 9 selected cards rather than for the number I happened to test.

Where the focused card sits in the last column there is no room to span, so the grid wraps the inspector to the next row — still directly after its own card, which is the promise that matters. Below 760px there is one track, so "beside" is impossible and it takes the full width under its card.

Assets go to **design-system-45**: a cached stylesheet would keep the pinning.

## Tests

The previous test asserted the two-track rule — **it was asserting the bug**. It now fails if the column count changes on focus, if the focused card gains a `grid-row`/`grid-column`, or if the inspector is pinned rather than spanning.

**1554 passed, 1 xfailed.** Contract parity **3/3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)