### PR TITLE
feat(madar): the weight a price is quoted against, and the unit nobody invents

### DIFF
--- a/apps_script/StagingAppScript.txt
+++ b/apps_script/StagingAppScript.txt
@@ -292,7 +292,7 @@ const SYNC_MAX_ROWS = 40000;
  * Both numbers, and the ledger below, are mirrored from scrapex/payload.py and
  * pinned to it by tests/test_payload_compat.py — they cannot drift silently.
  * ========================================================================== */
-const SYNC_PAYLOAD_VERSION = 7;
+const SYNC_PAYLOAD_VERSION = 8;
 const SYNC_PAYLOAD_COMPAT_VERSION = 5;
 const SYNC_PAYLOAD_COMPAT_MIN_VERSION = 5;
 
@@ -305,7 +305,7 @@ const SYNC_PAYLOAD_COMPAT_MIN_VERSION = 5;
  * existed — this table is how they are still understood as generation 5 and
  * keep publishing, instead of every tab going stale the day this file is
  * pasted. */
-const SYNC_GENERATION_OF_VERSION = { "1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 5, "7": 5 };
+const SYNC_GENERATION_OF_VERSION = { "1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 5, "7": 5, "8": 5 };
 
 /* The GAS mirror of payload.compat_generation(). null when unknowable: a
  * version this script has never heard of, from a build newer than this file,

--- a/contracts/fixtures/payload_valid.json
+++ b/contracts/fixtures/payload_valid.json
@@ -1,5 +1,5 @@
 {
-  "payload_version": 7,
+  "payload_version": 8,
   "payload_compat_version": 5,
   "source_key": "MADAR",
   "kind": "product_prices",

--- a/contracts/funnel-payload.schema.json
+++ b/contracts/funnel-payload.schema.json
@@ -43,7 +43,7 @@
     }
   },
   "additionalProperties": false,
-  "description": "Content version 7, meaning generation 5. One contract for CLI + extension producers and the Apps Script consumer. A consumer gates on payload_compat_version and NEVER on payload_version: a newer content version is a payload with an extra column in it, which anything reading by column name can already read. See scraper/ENGINEERING.md T8.",
+  "description": "Content version 8, meaning generation 5. One contract for CLI + extension producers and the Apps Script consumer. A consumer gates on payload_compat_version and NEVER on payload_version: a newer content version is a payload with an extra column in it, which anything reading by column name can already read. See scraper/ENGINEERING.md T8.",
   "properties": {
     "payload_version": {
       "minimum": 1,
@@ -162,7 +162,8 @@
             "enum": [
               5,
               6,
-              7
+              7,
+              8
             ]
           }
         }

--- a/db/migrations/0057_the_weight_the_price_is_quoted_against.sql
+++ b/db/migrations/0057_the_weight_the_price_is_quoted_against.sql
@@ -1,0 +1,115 @@
+-- =====================================================================
+-- 0057 — THE WEIGHT THE PRICE IS QUOTED AGAINST
+--
+-- 0056 finished half the sentence. It asked madar for is_qty_decimal,
+-- min_sale_qty and qty_increments and stored all three, so the warehouse
+-- now knows the Ø8mm rebar member is sold in fractions of 0.05 from a
+-- minimum of 0.25 — and still cannot say fractions OF WHAT. The number
+-- on the row is 4,830 and the row remains unreadable:
+--
+--   Ø8mm  4,830        Ø32mm  4,045
+--
+-- THE ARITHMETIC THAT SETTLES IT, computed 2026-07-30 from the site's own
+-- published dimensions and the density of steel:
+--
+--   a 12 m Ø8  bar weighs   4.735 kg -> 4,830.00 / 4.735 = 1,020 SAR/kg
+--   a 12 m Ø32 bar weighs  75.760 kg -> 4,045.13 / 75.76 =    53 SAR/kg
+--
+-- Two prices on the same shelf, 19x apart per kilogram, one of them at a
+-- thousand riyals a kilo. Per piece the pair is nonsense. The site states
+-- weight = 1000 for BOTH members — for every one of the 96, whatever the
+-- diameter — and against that:
+--
+--   4,830.00 / 1000 = 4.83 SAR/kg     4,045.13 / 1000 = 4.05 SAR/kg
+--
+-- which is two grades of rebar priced four riyals a kilo apart, thin
+-- costing more than thick, exactly as rolling mills price them. The 1000
+-- is not any bar's mass. It is the BASIS the price is quoted against, and
+-- the site publishes it in a field this warehouse has been throwing away.
+--
+-- IT WAS ALREADY BEING FETCHED. magento's query has asked for `weight`
+-- since 0056 (SimpleProduct, PhysicalProductInterface inside a grouped
+-- member, and the configurable child). It reached exactly one reader —
+-- normalize.selling_unit_from — which returns ("","") unless the product
+-- NAME also states a matching kg quantity, because that agreement is what
+-- makes riyadh cement's «50كجم» trustworthy. The rebar member's name
+-- states «8مم × 12متر», a diameter and a length. So weight 1000 arrived
+-- on every crawl and was dropped on every crawl. This migration gives it
+-- somewhere to land.
+--
+-- STILL NO UNIT IS INVENTED, and this is the whole reason the change is
+-- shaped this way. Re-verified read-only on 2026-07-30 against the live
+-- schema, with no cart, no session and no state change on their server:
+-- ProductInterface's only quantity-shaped fields are is_qty_decimal,
+-- min_sale_qty, max_sale_qty, qty_increments, quantity and weight — there
+-- is no `unit`, `uom` or `measure` field in madar's schema AT ALL — and
+-- not one of the rebar member's 22 custom_attributesV2 names the unit the
+-- price is quoted in.
+--
+-- ONE CORRECTION TO THE RECORD, found by this change's own crawl and kept
+-- here rather than quietly dropped. The earlier finding was that «طن»
+-- appears 0 times on the product PAGE, and that holds. It is not 0 times
+-- in the DATA: seven of the nineteen products behind these 109 offers
+-- print it in a meta field, and the epoxy rebar's own meta_title reads
+-- «أفضل سعر طن حديد في السعودية». 0056 started capturing those fields, so
+-- the crawl can now see it. It CORROBORATES the reading — and it is still
+-- not a declaration: SEO copy on a parent product, naming no SKU and no
+-- figure, absent from the other twelve. Writing `tonne` on the strength of
+-- it would make the same 109 offers disagree about a fact none of them
+-- states, so the prose is kept exactly where the shop put it and the unit
+-- column is not filled from it.
+--
+-- The selling unit therefore stays EMPTY, which is the honest answer to
+-- "what unit did the shop state?", and the display layer renders the price
+-- against the weight instead. What the reader sees is the shop's own
+-- number.
+--
+-- WHY NOT basis_quantity, the column that already exists. Three reasons,
+-- any one of them sufficient:
+--   1. It is one half of a pair whose other half is `unit`. Writing 1000
+--      into it asserts "the price is per 1000 <unit>" — the assertion the
+--      owner declined. price_unit() and ingest._unit_with_basis() both
+--      return "" without a unit, so the value would not even render.
+--   2. It is INSIDE ux_source_offer_identity (schema.sql:183). Moving an
+--      offer's basis from 1 to 1000 changes what that offer IS, minting a
+--      second one beside the first — the exact duplicate-row defect
+--      ingest._get_offer_id's "unstated unit adopts a stated one" branch
+--      was written to undo after sika grew 56 of them.
+--   3. It means "what the site states IN WORDS", proven by agreement
+--      between a name and a weight. This is what the site states as a
+--      NUMBER, with nothing corroborating it. Different claims, different
+--      confidence; one column cannot hold both and stay readable.
+--
+-- WHY THE UNIT GETS ITS OWN COLUMN. A weight with no unit is not a fact,
+-- and "kg" was the last link in this chain still coming out of OUR mouth:
+-- normalize.py hardcodes it and so does the enrichment weight row. Magento
+-- publishes StoreConfig.weight_unit, and madar answers "kgs" on both store
+-- views (ar_SA and en_SA, read live 2026-07-30). So the unit is the SHOP's
+-- word now as well, a store quoting "lbs" renders lbs with no code change,
+-- and a crawl that cannot reach storeConfig stores no unit and therefore
+-- shows no basis — a number whose unit we failed to read is not published
+-- as a bare number. Stored per offer rather than per source for the same
+-- reason `currency` is: the qualifier travels with the number it qualifies.
+--
+-- NO BACKFILL IS POSSIBLE and none is attempted — raw_snapshot holds 0
+-- rows, so there is nothing to re-read. NULL reads as "the site did not
+-- say", which is the truthful state of all 3,417 existing MADAR offers.
+--
+-- Two ALTER TABLE ADD COLUMN, both nullable, no default: no table rebuild,
+-- no index touched, no view rewritten, no data loss. NEITHER column is in
+-- ux_source_offer_identity, so no existing offer changes identity and no
+-- offer is split — an offer simply fills in a column it was always
+-- missing, on the next crawl, exactly as 0056's three do.
+-- =====================================================================
+
+-- THE NUMBER. NULL means the source published no weight for this leaf —
+-- never 0, which would be a source claiming weightlessness.
+ALTER TABLE source_offer ADD COLUMN weight REAL;
+
+-- THE UNIT THAT NUMBER IS IN, in the source's own word, folded through
+-- ingest.canonical_unit exactly as the selling unit already is ("kgs" ->
+-- "kg" via _UNIT_ALIASES). NULL means the source did not say, and a weight
+-- whose unit is unknown is never rendered.
+ALTER TABLE source_offer ADD COLUMN weight_unit TEXT;
+
+PRAGMA user_version = 57;

--- a/scrapex/changes.py
+++ b/scrapex/changes.py
@@ -151,6 +151,31 @@ def change_summary(conn: sqlite3.Connection, source_key: str, run_id: int | None
     return {row[0]: row[1] for row in conn.execute(sql, params)}
 
 
+def _display_unit(item: dict) -> str:
+    """What one price BUYS, for a change entry — and it POPS what it reads.
+
+    The stated selling unit when the source stated one; otherwise the weight
+    the price is quoted against, where the source prices by a weight it
+    publishes and names no unit (0057). ONE display string either way: the feed
+    has no Unit column for the two to sit apart in, and a change entry is a
+    sentence, not a record.
+
+    Without this a madar rebar move reads "4,830 -> 4,910" and leaves the
+    reader to assume the missing words — which is the same defect the
+    selling_unit JOIN above was added to fix, arriving by the other door. The
+    raw columns are popped because they are query plumbing, not fields of a
+    change event, and the feed's shape is part of its contract.
+    """
+    from .reports import price_basis, price_unit      # display-only resolution
+    unit_code = item.pop("unit_code", None)
+    basis = item.pop("basis_quantity", 1)
+    weight = item.pop("weight", None)
+    weight_unit = item.pop("weight_unit", None)
+    is_decimal = item.pop("quantity_is_decimal", 0)
+    return (price_unit(unit_code, basis)
+            or price_basis(unit_code, weight, weight_unit, is_decimal))
+
+
 def recent_changes(conn: sqlite3.Connection, source_key: str | None = None,
                    limit: int = 50) -> list[dict]:
     """Newest-first change feed, always bounded (A8).
@@ -160,7 +185,13 @@ def recent_changes(conn: sqlite3.Connection, source_key: str | None = None,
     diesel would otherwise both read as just "DIESEL".
     """
     sql = ("SELECT c.*, sp.product_name_ar, sp.product_name, so.country_code_alpha2, "
-           "       su.unit_code AS unit_code, so.basis_quantity AS basis_quantity "
+           "       su.unit_code AS unit_code, so.basis_quantity AS basis_quantity, "
+           # ...and, for a source that states no unit but prices by a weight it
+           # publishes, that weight. Same reason as the JOIN below: "4,830 ->
+           # 4,910" says nothing without it, and on this source the missing
+           # words are the difference between a bar and a tonne (0057).
+           "       so.quantity_is_decimal AS quantity_is_decimal, "
+           "       so.weight AS weight, so.weight_unit AS weight_unit "
            "FROM change_event c "
            "LEFT JOIN source_product sp ON sp.source_product_id = c.source_product_id "
            "LEFT JOIN source_offer so ON so.offer_id = c.offer_id "
@@ -175,14 +206,13 @@ def recent_changes(conn: sqlite3.Connection, source_key: str | None = None,
     sql += "ORDER BY c.change_event_id DESC LIMIT ?"
     params.append(max(1, min(limit, 500)))
 
-    from .reports import price_unit, region_name   # display-only resolution
+    from .reports import region_name          # display-only resolution
     out = []
     for row in conn.execute(sql, params):
         item = dict(row)
         item["country_code_alpha2"] = item.get("country_code_alpha2") or ""
         item["country"] = region_name(item["country_code_alpha2"])
-        item["unit"] = price_unit(item.pop("unit_code", None),
-                                  item.pop("basis_quantity", 1))
+        item["unit"] = _display_unit(item)
         _describe(item)
         out.append(item)
     return _collapse_new_pairs(out)
@@ -264,11 +294,13 @@ def changes_for_offer(conn: sqlite3.Connection, offer_id: int,
     this offer's story even though those rows carry no offer_id — they were
     recorded before the offer existed.
     """
-    from .reports import price_unit, region_name
+    from .reports import region_name
 
     rows = conn.execute(
         "SELECT c.*, sp.product_name_ar, sp.product_name, so2.country_code_alpha2, "
-        "       su.unit_code AS unit_code, so2.basis_quantity AS basis_quantity "
+        "       su.unit_code AS unit_code, so2.basis_quantity AS basis_quantity, "
+        "       so2.quantity_is_decimal AS quantity_is_decimal, "
+        "       so2.weight AS weight, so2.weight_unit AS weight_unit "
         "FROM change_event c "
         "LEFT JOIN source_product sp ON sp.source_product_id = c.source_product_id "
         "LEFT JOIN source_offer so2 ON so2.offer_id = c.offer_id "
@@ -283,8 +315,7 @@ def changes_for_offer(conn: sqlite3.Connection, offer_id: int,
         item = dict(row)
         item["country_code_alpha2"] = item.get("country_code_alpha2") or ""
         item["country"] = region_name(item["country_code_alpha2"])
-        item["unit"] = price_unit(item.pop("unit_code", None),
-                                  item.pop("basis_quantity", 1))
+        item["unit"] = _display_unit(item)
         _describe(item)
         out.append(item)
     # Same collapse as the feed: the panel and the Changes page must agree.

--- a/scrapex/connectors/magento.py
+++ b/scrapex/connectors/magento.py
@@ -146,6 +146,25 @@ _QUERY_ENRICHED = _QUERY_TEMPLATE.format(
 _AGGREGATIONS_QUERY = """query{products(filter:{price:{from:"0"}},pageSize:1,currentPage:1){
   aggregations{attribute_code label}}}"""
 
+# THE UNIT THE SHOP'S OWN WEIGHTS ARE IN. Magento carries it on StoreConfig,
+# and madar answers "kgs" on both store views — read live 2026-07-30, ar_SA and
+# en_SA alike, one request, no session and no state change.
+#
+# It matters because `weight` is a bare float in the schema and the rebar's
+# 1000 is about to be shown to a reader as the basis its price is quoted
+# against. "kg" was, until this query existed, the one word in that sentence
+# that came out of OUR mouth: normalize.selling_unit_from hardcodes it and so
+# does the enrichment weight row. Now the shop says it. A store configured in
+# "lbs" renders lbs with nothing here changing, and a crawl that cannot reach
+# this answer publishes no basis at all rather than a number with a unit we
+# assumed — the same rule selling_unit_from already applies when a name and a
+# weight disagree.
+#
+# One request per crawl, and unlike aggregations it runs on EVERY crawl: this
+# one qualifies a price, so a prices-only run needs it as much as an enriched
+# one does.
+_STORE_CONFIG_QUERY = "query{storeConfig{weight_unit}}"
+
 # EVERY attribute's human label, in the store's own language — the owner's
 # screenshot of madar's «المزيد من المعلومات» tab shows «المصنع», «بلد
 # المنشأ», «الطول (متر)» where the panel showed manufacturer, origin,
@@ -459,6 +478,10 @@ class MagentoGraphqlConnector:
                 "when the store answers restores it")
         ctx["axis_labels_en"] = english["axis_labels"]
         ctx["axis_values_en"] = english["axis_values"]
+        # The unit the shop states its weights in, read once and stamped on
+        # every row that carries a weight — the qualifier travels with the
+        # number it qualifies, same rule as `currency`.
+        ctx["weight_unit"] = self._weight_unit(endpoint, notes)
         query = _QUERY_ENRICHED if wants_enrichment else _QUERY
         fetched: list[dict] = []      # kept so enrichment needs no second fetch
         page = 1
@@ -639,6 +662,33 @@ class MagentoGraphqlConnector:
                 continue
             found[code] = str(aggregation.get("label") or "") or code
         return found
+
+    def _weight_unit(self, endpoint: str, notes: list) -> str:
+        """The unit this store states its `weight` values in — or "" if it won't say.
+
+        One request per crawl, on every crawl. The answer qualifies a NUMBER
+        that ends up beside a price, so silence here has to cost the whole
+        basis rather than be papered over: without a unit from the shop, the
+        display layer shows no basis at all, and the price cell reads exactly
+        as it does today. That is the same refusal selling_unit_from makes when
+        a name and a weight disagree — publishing 1000 with a unit nobody
+        stated is the one outcome this whole change exists to avoid.
+        """
+        try:
+            answer = (self._fetcher.post(endpoint, json={"query": _STORE_CONFIG_QUERY})
+                      .json() or {})
+        except CrawlBlocked:
+            raise
+        except Exception as exc:  # noqa: BLE001 — the crawl does not hang on this
+            notes.append(f"the store did not state the unit of its weights ({exc}) "
+                         "— prices quoted against a weight show no basis this run")
+            return ""
+        stated = str((((answer.get("data") or {}).get("storeConfig")) or {})
+                     .get("weight_unit") or "")
+        if not stated:
+            notes.append("storeConfig published no weight_unit — prices quoted "
+                         "against a weight show no basis this run")
+        return stated
 
     def _english_names(self, endpoint: str, notes: list,
                        enriched: bool = False) -> dict:
@@ -907,7 +957,8 @@ class MagentoGraphqlConnector:
 
         def row(pid, vid, sku, name, reg, fin, stock, label="", fp="",
                 basis="", unit="", vat=None, axes=None, axes_en=None,
-                variant_en="", quantity=("", "", ""), stock_qty=None):
+                variant_en="", quantity=("", "", ""), stock_qty=None,
+                weight=None):
             effective = fin if fin is not None else reg
             if effective is None:
                 return  # a product with no price — skip, don't emit an empty required field
@@ -955,6 +1006,21 @@ class MagentoGraphqlConnector:
                 # WHAT THE SITE SAYS ABOUT THE QUANTITY, and only what it says.
                 minimum_quantity=minimum, quantity_increment=increment,
                 quantity_is_decimal=is_decimal,
+                # THE WEIGHT THE SITE PUBLISHES FOR THIS LEAF, beside the unit
+                # the STORE says its weights are in. Asked for since 0056 and
+                # until now delivered only to selling_unit_from, which throws
+                # it away unless the product's NAME corroborates it — so the
+                # rebar's 1000 was fetched and dropped on every crawl.
+                #
+                # NOT interpreted here. This connector does not decide whether
+                # 1000 is a basis or a mass; it records that the shop said
+                # 1000 kgs, next to the shop saying the quantity is decimal,
+                # and the display layer reads the two together. The unit is
+                # dropped when there is no weight to qualify — a store-wide
+                # constant on a row that carries no number is noise.
+                weight="" if weight in (None, "") else str(weight),
+                weight_unit=("" if weight in (None, "")
+                             else (ctx.get("weight_unit") or "")),
                 # HOW THE PAGE PRESENTS THE PRODUCT — constant across its rows.
                 display_method=display,
                 # The shop's own count when it publishes one. rowspec and ingest
@@ -1024,6 +1090,13 @@ class MagentoGraphqlConnector:
                     if child.get("sku") else "",
                     basis=basis, unit=unit,
                     quantity=_quantity_facts(child),
+                    # The member's OWN weight — the group publishes none. This
+                    # is the 1000 the rebar has been stating all along, and the
+                    # `... on PhysicalProductInterface` fragment in the query
+                    # is what reaches it: `weight` is not on ProductInterface,
+                    # so a member selection without that fragment is refused by
+                    # the schema outright.
+                    weight=child.get("weight"),
                     stock_qty=child.get("only_x_left_in_stock"))
             if not out:
                 # Never fall back to the group figure: it is the cheapest
@@ -1111,6 +1184,10 @@ class MagentoGraphqlConnector:
                              if code in axis_labels_en},
                     basis=basis, unit=unit, vat=variant_vat,
                     quantity=_quantity_facts(child),
+                    # Per CHILD, never the parent's: madar's steel mesh states
+                    # 6.74 .. 66.02 kg across its thirteen children, so one
+                    # figure for the family would be wrong twelve times.
+                    weight=child.get("weight"),
                     stock_qty=child.get("only_x_left_in_stock"))
         else:
             # A product standing alone must have ONE price, not a span. Every
@@ -1133,6 +1210,7 @@ class MagentoGraphqlConnector:
             row(product.get("uid"), product.get("uid"), product.get("sku"),
                 product.get("name"), reg, fin, product.get("stock_status"),
                 quantity=_quantity_facts(product),
+                weight=product.get("weight"),
                 stock_qty=product.get("only_x_left_in_stock"))
         return out
 

--- a/scrapex/databases/domain.py
+++ b/scrapex/databases/domain.py
@@ -165,7 +165,7 @@ def _general_plan() -> tuple[Migration, ...]:
 # Listed rather than ranged: the unified chain and this one have diverged, so a
 # new price migration lands at the END of the legacy chain but in the middle of
 # this plan. A range would silently swallow whatever General adds next.
-_MARKETLENS_LEGACY_NUMBERS = (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 15, 16, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56)
+_MARKETLENS_LEGACY_NUMBERS = (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 15, 16, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57)
 
 # Where the identity migration sits in this stream. Everything before it is the
 # price history the unified warehouse already had; everything after is a price

--- a/scrapex/ingest.py
+++ b/scrapex/ingest.py
@@ -559,6 +559,25 @@ def _quantity_facts(r: dict) -> dict:
     stated = str(r.get("quantity_is_decimal", "") or "").strip()
     if stated:
         facts["quantity_is_decimal"] = 1 if stated == "1" else 0
+    # THE WEIGHT, AND ONLY WITH ITS UNIT (0057). The two are stored together or
+    # not at all: a bare 1000 in a column is not a fact, and the display layer
+    # would then be free to supply the missing word itself — which is the one
+    # thing this whole change exists to prevent. So a source that publishes a
+    # weight and will not say what unit it is in stores neither, exactly as
+    # normalize.selling_unit_from says nothing when a name and a weight
+    # disagree.
+    #
+    # canonical_unit folds the spelling the same way the SELLING unit is
+    # already folded ("kgs" -> "kg" via _UNIT_ALIASES). That is not editing
+    # source truth — it is the shared spelling table this warehouse has always
+    # run every unit through, and without it "kgs" and "kg" would be two units
+    # for one kilogram.
+    weight = _optional_quantity(r.get("weight", ""))
+    weight_unit = canonical_unit(str(r.get("weight_unit", "") or ""),
+                                 r.get("currency", ""))
+    if weight is not None and weight_unit:
+        facts["weight"] = weight
+        facts["weight_unit"] = weight_unit
     return facts
 
 

--- a/scrapex/payload.py
+++ b/scrapex/payload.py
@@ -80,13 +80,23 @@ from .vocab import ExtractKind, PayloadClient
 # It is the field that lets an OLD reader read a NEW payload, which is the whole
 # point: a reader cannot infer from "7" alone whether 7 is additive over what it
 # knows, so the payload says so itself.
-PAYLOAD_VERSION = 7
+# 8: PRODUCT_PRICES gains the pair `weight` / `weight_unit` (migration 0057) —
+# the weight the source publishes for the thing it is pricing, and the unit the
+# source says its weights are in. 6 stored the site's quantity NUMBERS and left
+# the weight they are quantities OF unmeasured, so a madar rebar row still could
+# not say what 4,830 was for. ADDITIVE, and therefore GENERATION 5: two new
+# slots nothing used to fill, no column renamed, no value's units changed, no
+# required field flipped. A payload written yesterday is complete rather than
+# broken and replays unchanged, the sheet grows two columns on its own, and the
+# owner pastes nothing — which is the case 7 built the ledger for, arriving one
+# commit later.
+PAYLOAD_VERSION = 8
 
 # WHICH GENERATION EACH CONTENT VERSION BELONGS TO — the prose above, encoded.
 #
 # Read it as the ledger it is: 2, 3, 4 and 5 each open their own generation
-# because each renamed a column or inverted a meaning; 6 and 7 stay in 5's
-# because both only added. Adding a version WITHOUT adding its entry here is an
+# because each renamed a column or inverted a meaning; 6, 7 and 8 stay in 5's
+# because all three only added. Adding a version WITHOUT adding its entry here is an
 # import-time KeyError two lines down, which is deliberate: a bump has to say
 # which kind it is, and the loudest possible place to ask is the build.
 #
@@ -94,7 +104,7 @@ PAYLOAD_VERSION = 7
 # stamped 6 and carrying no generation at all, because they were written before
 # the field existed; this table is how a reader knows a 6 is a 5, so an inbox
 # that predates the split keeps publishing instead of going stale.
-GENERATION_OF_VERSION = {1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 5, 7: 5}
+GENERATION_OF_VERSION = {1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 5, 7: 5, 8: 5}
 
 # The generation THIS build speaks, derived rather than typed: it cannot drift
 # from the ledger, and a bump that forgets to declare its kind cannot start.

--- a/scrapex/reports.py
+++ b/scrapex/reports.py
@@ -164,6 +164,75 @@ def price_unit(unit_code: str | None, basis_quantity: float | None = 1) -> str:
     return f"{quantity} {unit_code}"
 
 
+def price_basis(unit_code: str | None, weight, weight_unit: str | None,
+                quantity_is_decimal) -> str:
+    """'1,000 kg' — the WEIGHT a price is quoted against, when the source
+    quotes it that way and names no unit. "" in every other case.
+
+    THE PROBLEM THIS SOLVES, in the source's own numbers. madar's Ø8mm rebar
+    member costs 4,830 and its Ø32mm member costs 4,045. Per piece that is
+    impossible: a 12 m Ø8 bar is 4.7 kg of steel and a 12 m Ø32 bar is 75.8 kg,
+    so those two figures would be 1,020 and 53 riyals a kilogram, on the same
+    shelf. The shop states weight = 1000 on both — on all 96 members, whatever
+    the diameter — and against that they are 4.83 and 4.05 a kilogram, thin
+    dearer than thick, exactly as rolling mills price rebar. The number is only
+    readable beside the weight, and until now nothing on the page carried it.
+
+    WHAT THIS FUNCTION WILL NOT DO IS NAME THE UNIT. madar DECLARES none: its
+    GraphQL schema has no `unit`, `uom` or `measure` field at all, and not one
+    of the rebar member's 22 published attributes says what its price is quoted
+    in. Its MARKETING PROSE is a different matter and must be recorded as such
+    — measured on the crawl of 2026-07-30, seven of the nineteen products
+    behind these offers print «سعر طن الحديد» in a meta field. That corroborates
+    the reading and is still not a declaration: it is a search keyword on a
+    parent product, it names no SKU and no figure, the other twelve say nothing,
+    and promoting it would make the same 109 offers disagree with each other
+    about a fact none of them states.
+
+    So the Unit column beside this one stays EMPTY, because empty is the honest
+    answer to "what unit did the shop state?", and what a reader sees here is
+    two facts the shop did publish, side by side: its weight and its own word
+    for the unit that weight is in. Nobody's inference is on screen.
+
+    THREE CONDITIONS, and all three are the SOURCE's:
+
+    1. The source states no selling unit. If it does, that IS the answer and
+       price_unit() already gives it — riyadh cement says «50كجم» in the name
+       AND weight 50, so it reads "50 kg" through the ordinary path and never
+       reaches here. A stated unit always wins over an inferred basis.
+    2. The source says the quantity is decimal. This is the load-bearing gate.
+       All 3,418 madar leaves publish a weight (measured live 2026-07-30) and
+       for 3,309 of them it is the mass of one piece — a steel angle's 4.986 kg
+       — so weight alone would print "per 4.986 kg" across the whole shop,
+       which is precisely the guess normalize.selling_unit_from was written to
+       refuse. is_qty_decimal narrows it to 109.
+    3. The source publishes a weight AND the unit of its weights. Both or
+       neither: a number whose unit we failed to read is not shown as a bare
+       number (ingest._quantity_facts stores the pair or nothing).
+
+    Kept apart from price_unit() rather than folded into it because the two
+    answer different questions and one of them has to be allowed to answer
+    "nothing". Merging them would fill the Unit column with a word the shop
+    never said, which is the whole defect.
+    """
+    if unit_code:
+        return ""
+    if not quantity_is_decimal:
+        return ""
+    if not weight_unit:
+        return ""
+    try:
+        heavy = float(weight)
+    except (TypeError, ValueError):
+        return ""
+    if heavy <= 0:
+        return ""
+    # Grouped so 1000 reads as a thousand at a glance — the whole point is that
+    # this number is large, and "1000" beside a price is easy to read past.
+    shown = f"{int(heavy):,}" if float(heavy).is_integer() else f"{heavy:,}"
+    return f"{shown} {weight_unit}"
+
+
 def _discounted(regular, effective) -> bool:
     try:
         return regular is not None and effective is not None and             float(regular) > float(effective)
@@ -427,7 +496,12 @@ def browse_observations(conn: sqlite3.Connection, source_key: str, *, search: st
         # keyed on the name the SOURCE publishes, whichever language that is.
         "       COALESCE(NULLIF(sp.product_name,''), sp.product_name_ar), "
         # Appended LAST again (0052), for the same reason.
-        "       po.price_trade "
+        "       po.price_trade, "
+        # Appended LAST again (0057). The weight a price is quoted against and
+        # the shop's own word for its unit, plus the flag that says the shop
+        # sells this by a divisible quantity — three facts that only mean
+        # something together, so they travel together.
+        "       so.quantity_is_decimal, so.weight, so.weight_unit "
         f"{_LATEST_PER_OFFER}{filt} {_order_by(sort, direction)} LIMIT ? OFFSET ?",
         [*base_params, limit, offset],
     ).fetchall()
@@ -443,6 +517,10 @@ def browse_observations(conn: sqlite3.Connection, source_key: str, *, search: st
          # A price without its unit is not a comparable number: 325 per tonne and
          # 325 per bag are different facts that look identical on screen.
          "unit": price_unit(r[14], r[15]),
+         # ...and where the source states NO unit but does state a weight it
+         # prices by, what that weight is. The two never both fill: a stated
+         # unit is the answer, and this is what stands in when there is none.
+         "price_basis": price_basis(r[14], r[20], r[21], r[19]),
          # Resolved per ROW because one source can hold a different tax position
          # per country. Rules are loaded once above, never queried per row.
          # for_row() then reads that evidence for THIS figure: the rule owns the
@@ -824,6 +902,12 @@ _EXPORT_SELECT: dict[str, str] = {
     "last_confirmed_at": "ost.last_confirmed_at",
     "unit_code": "su.unit_code",
     "basis_quantity": "so.basis_quantity",
+    # The weight a price is quoted against, the shop's own word for its unit,
+    # and the flag that says the shop sells this by a divisible quantity. Read
+    # together by price_basis() and meaningless apart (0057).
+    "quantity_is_decimal": "so.quantity_is_decimal",
+    "weight": "so.weight",
+    "weight_unit": "so.weight_unit",
     "brand": "sp.brand",
     "brand_ar": "sp.brand_ar",
     "category_path": "sp.category_path_ar",
@@ -907,6 +991,20 @@ EXPORT_COLUMNS: list[tuple[str, "Callable[[dict, object], object]"]] = [
     # where some are per tonne and some per bag is not a price list, it is a
     # trap.
     ("unit", lambda r, s: price_unit(r["unit_code"], r["basis_quantity"])),
+    # ...and the column that fills in where the source states no unit but does
+    # price by a weight. The pair is deliberately TWO columns that never both
+    # fill: "what unit did the shop state?" and "what weight is this price
+    # quoted against?" are different questions, and the first one is allowed to
+    # answer nothing. Folding them into one cell would put the word "kg" under
+    # a heading that means "the shop said this", for a shop that did not.
+    #
+    # It has to be in the FILE and not only on screen for the reason the Unit
+    # column exists at all: a spreadsheet of bare numbers where 4,830 is per
+    # 1,000 kg and 30.19 is per sheet is not a price list, it is a trap — and
+    # the export is the record leaving the building.
+    ("price_basis", lambda r, s: price_basis(r["unit_code"], r["weight"],
+                                             r["weight_unit"],
+                                             r["quantity_is_decimal"])),
     ("price_before", lambda r, s: _or_blank(r["price_before"])),
     ("price_sale", lambda r, s: _or_blank(r["price_sale"])),
     ("price_trade", lambda r, s: _or_blank(r.get("price_trade"))),
@@ -1344,7 +1442,10 @@ def offer_identity(conn: sqlite3.Connection, source_key: str,
     row = conn.execute(
         "SELECT sp.product_name_ar, sv.variant_ar, sv.external_sku, so.country_code_alpha2, "
         "       so.currency, su.unit_code, so.basis_quantity, sp.product_link, "
-        "       ss.source_key, sp.product_name, sv.variant "
+        "       ss.source_key, sp.product_name, sv.variant, "
+        # Appended LAST: the inspector prints the price too, so it needs the
+        # same basis the table cell shows or the panel and the row disagree.
+        "       so.quantity_is_decimal, so.weight, so.weight_unit "
         "FROM source_offer so "
         "JOIN source_variant sv ON sv.source_variant_id = so.source_variant_id "
         "JOIN source_product sp ON sp.source_product_id = sv.source_product_id "
@@ -1359,6 +1460,7 @@ def offer_identity(conn: sqlite3.Connection, source_key: str,
             "sku": row[2] or "",
             "country_code_alpha2": row[3] or "", "country": region_name(row[3]),
             "currency": row[4], "unit": price_unit(row[5], row[6]),
+            "price_basis": price_basis(row[5], row[12], row[13], row[11]),
             "product_link": row[7] or "", "source_key": row[8],
             "offer_id": offer_id}
 
@@ -1729,7 +1831,11 @@ def table_payload(conn: sqlite3.Connection, source_key: str,
         f"       {_RATE_BY_AUTHORITY}) AS usd_rate_as_of, "
         "       (SELECT cr.source_key FROM currency_rate cr "
         "        WHERE cr.currency = po.currency "
-        f"       {_RATE_BY_AUTHORITY}) AS usd_rate_source "
+        f"       {_RATE_BY_AUTHORITY}) AS usd_rate_source, "
+        # Appended LAST, obeying the rule stated twice above: the three facts
+        # that let the price cell say what one unit of the price buys where the
+        # shop quotes by weight and names no unit (0057).
+        "       so.quantity_is_decimal, so.weight, so.weight_unit "
         f"{_LATEST_PER_OFFER} ORDER BY sp.product_name_ar, so.country_code_alpha2 LIMIT ?",
         (source_key, limit)).fetchall()
 
@@ -1764,6 +1870,11 @@ def table_payload(conn: sqlite3.Connection, source_key: str,
                "country": region_name(r[11]),
                "last_confirmed_on": (r[12] or "")[:10],
                "unit": price_unit(r[13], r[14]), "offer_id": r[15],
+               # The price cell renders this when the Unit column is empty. It
+               # is NOT a unit and must never fill that column: it is the
+               # weight the shop publishes for the thing it is pricing, shown
+               # because the shop also says the quantity is divisible.
+               "price_basis": price_basis(r[13], r[39], r[40], r[38]),
                "official_source": r[16] or "",
                "official_source_link": r[17] or "",
                "brand": r[18] or "",
@@ -1981,7 +2092,15 @@ COLUMN_NOTES: dict[str, str] = {
     "price_min": "The lowest price ever recorded for this record.",
     "price_max": "The highest price ever recorded for this record.",
     "observations": "How many times this price has been recorded.",
-    "unit": "What one price BUYS: a litre, a 50 kg bag, a 100 m roll.",
+    "unit": "What one price BUYS: a litre, a 50 kg bag, a 100 m roll. "
+            "Empty when the source states no unit — never guessed.",
+    "price_basis": "The WEIGHT a price is quoted against, where the source "
+                   "prices by weight and names no unit: madar's rebar is "
+                   "4,830 per 1,000 kg, and per bar it would be nonsense. "
+                   "Both numbers are the shop's — its published weight and "
+                   "its own word for the unit of that weight. Empty wherever "
+                   "the Unit column is filled, and wherever the source does "
+                   "not say its quantity is divisible.",
     "availability": "In stock or out, as the source states it.",
     "tax": "Whether THIS figure includes tax, and at what rate.",
     "tax_included": "The same fact as yes/no, for a spreadsheet.",
@@ -2252,6 +2371,8 @@ _COMPUTED_FROM: dict[str, str] = {
     "category_ar": "source_product.category_path_ar",
     "variant": "source_variant.variant",
     "unit": "selling_unit + source_offer.basis_quantity",
+    "price_basis": ("source_offer.weight + weight_unit, shown only where "
+                    "quantity_is_decimal and no selling_unit"),
     "discount": "computed: price_observation.price_before − price",
     "discount_pct": "computed: the same two prices, as a percentage",
     "price_usd": "computed: price_observation × currency_rate",

--- a/scrapex/rowspec.py
+++ b/scrapex/rowspec.py
@@ -153,6 +153,41 @@ PRODUCT_PRICES = RowSpec(
         "minimum_quantity",      # min_sale_qty: the smallest orderable amount
         "quantity_increment",    # qty_increments: the step it moves in
         "quantity_is_decimal",   # "0" | "1" — is_qty_decimal, as a FACT
+        # --- added 2026-07-30 -------------------------------------------------
+        # THE WEIGHT THE SOURCE PUBLISHES, and the unit the source says its
+        # weights are in. The pair that finally makes 4,830 readable without
+        # anyone writing «طن».
+        #
+        # 0056 stored is_qty_decimal / min_sale_qty / qty_increments and left
+        # the weight on the floor, so the row still could not say what 4,830
+        # was FOR. `weight` was already being ASKED for (magento's query has
+        # carried it since 0056) and reached exactly one destination:
+        # normalize.selling_unit_from, which returns ("","") unless the NAME
+        # states a matching kg quantity. The rebar member's name states a
+        # diameter and a length — «8مم × 12متر» — so weight 1000 arrived on
+        # every crawl and was discarded on every crawl.
+        #
+        # WHY THIS IS NOT `basis_quantity`. That column is one half of a pair
+        # whose other half is `unit`, it defaults to 1, and it is inside
+        # ux_source_offer_identity — so writing 1000 into it would both assert
+        # "the price is per 1000 <unit>" (the assertion we are refusing to
+        # make) and change the identity of every affected offer, minting a
+        # second one beside it. basis_quantity is what the site states IN
+        # WORDS; this is what it states as a NUMBER, and the two are different
+        # claims with different confidence.
+        #
+        # WHY THE UNIT RIDES ALONG. A weight with no unit is not a fact, and
+        # "kg" was the last thing in this chain still coming out of our own
+        # mouth (normalize.py hardcodes it, so does the enrichment weight
+        # row). Magento publishes StoreConfig.weight_unit and madar answers
+        # "kgs" on both store views — verified live 2026-07-30 — so the unit
+        # is now the SHOP's word too, and a store reporting "lbs" renders lbs
+        # without anything here changing. Per row rather than per source for
+        # the same reason `currency` is: a fact travels with the number it
+        # qualifies, and a source-level flag stamped on every observation is
+        # how this warehouse came to assert things a shop never said.
+        "weight",
+        "weight_unit",
     ),
     required=frozenset({"external_product_id", "country_code_alpha2", "currency", "tax_included", "price"}),
     # The four _ar columns are deliberately NOT additive. RowView returns ""
@@ -173,7 +208,8 @@ PRODUCT_PRICES = RowSpec(
                         "category_external_id",
                         "variant", "variant_axes", "variant_url", "parent_sku",
                         "display_method", "minimum_quantity",
-                        "quantity_increment", "quantity_is_decimal"}),
+                        "quantity_increment", "quantity_is_decimal",
+                        "weight", "weight_unit"}),
 )
 
 # ---- enrichment: the open-ended attribute bag, one ROW per attribute ---------

--- a/scrapex/webui/static/grid.js
+++ b/scrapex/webui/static/grid.js
@@ -1298,10 +1298,30 @@
         price.textContent = formatMoney(cell.getValue()) + " " + text(row.currency);
         box.append(price);
         // A price may lose its column but never its unit.
-        if (row.unit) {
+        //
+        // ...and where the source states no unit but prices by a WEIGHT it
+        // publishes, the weight stands in its place. madar's Ø8mm rebar reads
+        // 4,830 and its Ø32mm reads 4,045: per bar that is impossible, per the
+        // 1,000 kg the shop states for both it is two grades of steel four
+        // riyals a kilo apart. The Unit column stays empty either way — the
+        // shop names no unit, and this cell does not name one for it. What is
+        // shown is the shop's own weight and the shop's own word for its unit.
+        const basis = row.unit || row.price_basis;
+        if (basis) {
           const per = document.createElement("span");
           per.className = "per";
-          per.textContent = " / " + row.unit;
+          per.textContent = " / " + basis;
+          if (!row.unit) {
+            // A derived figure never appears without saying what it derives
+            // from — the same rule that makes the USD cell carry its rate and
+            // that rate's date. Without this the reader has no way to tell
+            // "the shop said per 1,000 kg" from "ScrapeX decided per 1,000 kg",
+            // and the whole point is that it is the former.
+            per.title = "The source states no selling unit. It publishes a " +
+              "weight of " + basis + " for this item and states that its " +
+              "quantity is divisible, so the price is shown against that " +
+              "weight. The weight and its unit are both the source's.";
+          }
           box.append(per);
         }
         // The price before the discount, struck through beside the current one
@@ -2155,6 +2175,21 @@
     return span;
   }
 
+  // What one price BUYS, for any cell that prints a price: the unit the source
+  // STATED, or — where it stated none but publishes a weight it prices by — that
+  // weight (reports.price_basis decides, this only picks the first answer any of
+  // the given objects has). The inspector prints the same price the table cell
+  // does, so it has to reach the same answer or the panel and the row it opened
+  // from disagree about what 4,830 means.
+  function basisOf(...carriers) {
+    for (const carrier of carriers) {
+      if (!carrier) continue;
+      if (carrier.unit) return carrier.unit;
+      if (carrier.price_basis) return carrier.price_basis;
+    }
+    return "";
+  }
+
   let openOfferRow = null;
   let nextSelectionPanelMode = null;
   // What the panel on screen was drawn FROM, so a language switch can redraw it
@@ -2575,7 +2610,7 @@
     price.appendChild(el("span", "selected-product-price-label", "Current price"));
     const value = el("strong", "");
     value.appendChild(money(currentPrice, row.currency || offer.currency,
-                            offer.unit || row.unit));
+                            basisOf(offer, row)));
     price.appendChild(value);
     body.appendChild(price);
 
@@ -2896,7 +2931,7 @@
         periods.map((p) => [
           (p.first_detected_at || "").slice(0, 10),
           (p.closed_at || "").slice(0, 10) || "current",
-          money(p.price, p.currency, offer.unit),
+          money(p.price, p.currency, basisOf(offer)),
           (p.opened_because || "").replace(/_/g, " "),
         ])));
       historySections.get("price").push(timeline);
@@ -2930,7 +2965,7 @@
         ["Date", "Price", "Where it came from"],
         observations.map((o) => [
           o.business_date || "",
-          money(o.price, o.currency, offer.unit),
+          money(o.price, o.currency, basisOf(offer)),
           o.provenance === "reported" ? "reported by the source" : "observed by a crawl",
         ])));
       historySections.get("observations").push(recorded);

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -57,7 +57,7 @@ def test_migration_creates_the_catalogue_and_integrity_triggers(conn):
     assert objects["relationship_field_pair"] == "table"
     assert objects["trg_dataset_relationship_same_site_insert"] == "trigger"
     assert objects["trg_relationship_field_pair_matches_insert"] == "trigger"
-    assert conn.execute("PRAGMA user_version").fetchone()[0] == 56
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 57
 
 
 def test_one_site_can_hold_multiple_tables_with_different_dynamic_columns(conn):

--- a/tests/test_database_isolation.py
+++ b/tests/test_database_isolation.py
@@ -67,7 +67,7 @@ def test_fresh_registry_creates_two_typed_databases_without_domain_tables_crossi
     assert applied["general"] == list(
         range(1, registry.general.latest_schema_version + 1)
     )
-    assert applied["marketlens"] == list(range(1, 55))   # ... +54 how the site shows it, and what one unit buys
+    assert applied["marketlens"] == list(range(1, 56))   # ... +55 the weight the price is quoted against
     assert registry.health()["general"]["status"] == "Healthy"
     assert registry.health()["marketlens"]["status"] == "Healthy"
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -27,12 +27,12 @@ def test_migrate_is_idempotent(tmp_path: Path):
         second = dbmod.migrate(conn)
     finally:
         conn.close()
-    assert first == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56]
+    assert first == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57]
     assert second == []  # T4: running again applies nothing
 
 
 def test_latest_schema_version_matches_the_migration_chain():
-    assert dbmod.latest_schema_version() == 56   # +0056 how the site shows it, and what one unit buys
+    assert dbmod.latest_schema_version() == 57   # +0057 the weight the price is quoted against
 
 
 def test_foreign_keys_actually_enforced(tmp_path: Path):

--- a/tests/test_display_method_and_quantity_facts.py
+++ b/tests/test_display_method_and_quantity_facts.py
@@ -160,6 +160,10 @@ class _Fetcher:
                 return _Response({"data": {"categoryList": [{"children": []}]}})
             return _Response(_ENGLISH if page == 1 else
                              {"data": {"products": {"items": []}}})
+        if "storeConfig" in query:
+            # The store's own word for the unit of its weights (0057). Read
+            # live 2026-07-30: madar answers "kgs" on both store views.
+            return _Response({"data": {"storeConfig": {"weight_unit": "kgs"}}})
         if "categoryList" in query:
             return _Response({"data": {"categoryList": [{"children": []}]}})
         if "category_uid" in query:
@@ -571,7 +575,7 @@ def test_migration_0056_corrects_has_variants_on_rows_that_already_exist():
                          " VALUES (2, ?)", (member,))
         conn.commit()
 
-        assert dbmod.migrate(conn) == [56]
+        assert dbmod.migrate(conn) == [56, 57]
 
         flags = dict(conn.execute(
             "SELECT external_product_id, has_variants FROM source_product"))

--- a/tests/test_extract_storage.py
+++ b/tests/test_extract_storage.py
@@ -113,7 +113,7 @@ def test_legacy_0014_remains_available_for_explicit_unified_sessions(tmp_path: P
     legacy = dbmod.connect(tmp_path / "legacy.db")
     try:
         dbmod.migrate(legacy)
-        assert dbmod.schema_version(legacy) == 56   # +0056 how the site shows it, and what one unit buys
+        assert dbmod.schema_version(legacy) == 57   # +0057 the weight the price is quoted against
         for table in ("price_observation", "generic_record"):
             assert legacy.execute(
                 "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1",

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -62,7 +62,7 @@ def _insert_observation(conn, ids, price: float = 168.78, hash_: str = "h1") -> 
 
 
 def test_migration_reaches_latest_version(conn):
-    assert dbmod.schema_version(conn) == 56   # +0056 how the site shows it, and what one unit buys
+    assert dbmod.schema_version(conn) == 57   # +0057 the weight the price is quoted against
 
 
 def test_all_owner_tables_exist(conn):
@@ -168,7 +168,7 @@ def test_migration_0020_preserves_existing_jobs_and_their_log_references():
         upgrading.commit()
 
         assert dbmod.migrate(upgrading) == [20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
-                                            30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56]
+                                            30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57]
 
         joined = upgrading.execute(
             "SELECT j.job_ref, j.status, l.message FROM job_log_entry l"

--- a/tests/test_the_weight_the_price_is_quoted_against.py
+++ b/tests/test_the_weight_the_price_is_quoted_against.py
@@ -93,6 +93,29 @@ _MESH = {
             "only_x_left_in_stock": None,
             "price_range": {"minimum_price": {"regular_price": {"value": 30.19},
                                               "final_price": {"value": 30.19}}}}},
+        # TWO SIZES THE SHOP HAPPENS TO PRICE THE SAME, and they are live:
+        # 10408150420 weighs 25.86 kg and 104075154020 weighs 22.73 kg, and on
+        # 2026-07-30 both cost 84.00. They fold together on the Data page,
+        # which is the one way a wrong basis could reach a reader — see the
+        # test at the end of this file.
+        {"attributes": [{"code": "mesh_size", "label": "8.00ملم * 1.5 * 4.0متر"}],
+         "product": {
+            "uid": "U1JNOA==", "sku": "10408150420",
+            "name": "شبك حديد صبة - 8.00ملم * 1.5 * 4.0متر - 20*20سم",
+            "stock_status": "IN_STOCK", "weight": 25.86,
+            "is_qty_decimal": True, "min_sale_qty": 1, "qty_increments": 1,
+            "only_x_left_in_stock": None,
+            "price_range": {"minimum_price": {"regular_price": {"value": 96.6},
+                                              "final_price": {"value": 96.6}}}}},
+        {"attributes": [{"code": "mesh_size", "label": "7.50ملم * 1.5 * 4.0متر"}],
+         "product": {
+            "uid": "U1JNNzU=", "sku": "104075154020",
+            "name": "شبك حديد صبة - 7.50ملم * 1.5 * 4.0متر - 20*20سم",
+            "stock_status": "IN_STOCK", "weight": 22.73,
+            "is_qty_decimal": True, "min_sale_qty": 1, "qty_increments": 1,
+            "only_x_left_in_stock": None,
+            "price_range": {"minimum_price": {"regular_price": {"value": 96.6},
+                                              "final_price": {"value": 96.6}}}}},
     ],
 }
 
@@ -610,3 +633,40 @@ def test_the_word_boundary_is_real_and_not_a_substring_match():
     assert _STANDALONE_TON.search("1 طن، 2 طن، 3 طن")
     assert _STANDALONE_TON.search("priced per tonne")
     assert not _STANDALONE_TON.search("carton of buttons")
+
+
+def test_folding_two_variants_priced_alike_never_lends_one_its_neighbours_weight(tmp_path):
+    """The one way a WRONG basis could reach a reader, and it is already shut.
+
+    fold_variant_rows groups by (product, price, currency, country) so a shop's
+    six colours at one price read as one row. Two mesh sizes can collide there:
+    live on 2026-07-30, 10408150420 (25.86 kg) and 104075154020 (22.73 kg) both
+    cost 84.00 after tax is taken off. Folded, the row must not show either
+    weight — one member's 25.86 standing for a group that also contains 22.73
+    is a number that is wrong for half the thing it describes.
+
+    Nothing new was written for this. The fold's standing rule — a field the
+    members disagree about goes BLANK rather than taking the first row's answer
+    — already covers any column, which is why the basis was given a column of
+    its own instead of being composed at the last moment in the browser.
+    """
+    conn = _ingest(tmp_path)
+
+    apart = reports.table_payload(conn, "MADAR")["rows"]
+    by_sku = {r["sku"]: r for r in apart}
+    # Told apart, each says its own weight...
+    assert by_sku["10408150420"]["price_basis"] == "25.86 kg"
+    assert by_sku["104075154020"]["price_basis"] == "22.73 kg"
+    assert by_sku["10408150420"]["price"] == by_sku["104075154020"]["price"]
+
+    # ...and folded together, the row says nothing rather than something false.
+    folded = [r for r in reports.table_payload(conn, "MADAR", fold_variants=True)["rows"]
+              if r.get("variants", 1) > 1 and "10408150420" in str(r.get("sku"))]
+    assert len(folded) == 1, folded
+    assert folded[0]["variants"] == 2
+    assert folded[0]["price_basis"] == ""
+
+    # The mesh child that does NOT collide keeps its own basis when folding is on.
+    alone = [r for r in reports.table_payload(conn, "MADAR", fold_variants=True)["rows"]
+             if r.get("sku") == "10404154020"]
+    assert alone and alone[0]["price_basis"] == "6.74 kg"

--- a/tests/test_the_weight_the_price_is_quoted_against.py
+++ b/tests/test_the_weight_the_price_is_quoted_against.py
@@ -1,0 +1,612 @@
+"""0057: the weight a price is quoted against, and the unit nobody may invent.
+
+0056 stored the site's quantity NUMBERS — is_qty_decimal, a 0.25 minimum, a
+0.05 step — and left the weight those are quantities OF on the floor, so the
+row still could not say what 4,830 was FOR. This is the other half.
+
+TWO TESTS CARRY THE WHOLE ARGUMENT and the rest support them:
+
+  * a unit name the source never published must never reach the data, on ANY
+    surface — not the warehouse, not the table, not the file that leaves the
+    building;
+  * and the rebar member must nevertheless read against the weight the shop
+    DID publish, because "say nothing" and "say 4,830 with no referent" are
+    not the same answer.
+
+Every value below was read off the live madar store read-only on 2026-07-30 —
+the prices, the weights, the 0.25/0.05 rules, storeConfig's "kgs", and the
+mesh's thirteen per-child weights. The physical masses are computed from the
+site's own stated dimensions and the density of steel.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from scrapex import db as dbmod
+from scrapex import reports
+from scrapex.config import ExtractSpec, SourceEntry
+from scrapex.connectors.magento import MagentoGraphqlConnector
+from scrapex.ingest import ingest_payloads
+from scrapex.payload import new_payload
+from scrapex.reports import price_basis
+from scrapex.rowspec import PRODUCT_PRICES, RowView
+from scrapex.vocab import ExtractKind, ExtractScope
+
+# --- the store, as it publishes itself ---------------------------------------
+#
+# GroupedProduct 10115-HSS. Both members declare weight 1000 — every one of the
+# live 96 does, whatever the diameter — with is_qty_decimal, a 0.25 minimum and
+# a 0.05 step.
+#
+# THE ARITHMETIC, and it is the reason this file exists. A 12 m Ø8 bar is
+# 4.735 kg of steel and a 12 m Ø32 bar is 75.76 kg. Per PIECE the two prices
+# would be 1,020 and 53 riyals a kilogram, on the same shelf. Against the
+# stated 1000 they are 4.83 and 4.05 — thin dearer than thick, exactly as
+# rolling mills price rebar.
+_REBAR = {
+    "__typename": "GroupedProduct",
+    "uid": "SFNT", "sku": "10115-HSS", "url_key": "hadeed-epoxy-coated-steel-rebar",
+    "name": " حديد تسليح ابوكسي من حديد", "stock_status": "IN_STOCK", "categories": [],
+    "price_range": {"minimum_price": {"regular_price": {"value": 4045.13},
+                                      "final_price": {"value": 4045.13}},
+                    "maximum_price": {"final_price": {"value": 4045.13}}},
+    "items": [
+        {"qty": 0, "position": 1, "product": {
+            "uid": "TjY1", "sku": "101150812",
+            "name": "حديد أبوكسي من حديد | 8مم × 12متر | ASTM A775 جريد 60",
+            "stock_status": "IN_STOCK", "weight": 1000,
+            "is_qty_decimal": True, "min_sale_qty": 0.25, "qty_increments": 0.05,
+            "only_x_left_in_stock": None,
+            "price_range": {"minimum_price": {"regular_price": {"value": 4830.0},
+                                              "final_price": {"value": 4830.0}}}}},
+        {"qty": 0, "position": 2, "product": {
+            "uid": "Tjcy", "sku": "101153212",
+            "name": "حديد أبوكسي من حديد | 32مم × 12متر | ASTM A775 جريد 60",
+            "stock_status": "IN_STOCK", "weight": 1000,
+            "is_qty_decimal": True, "min_sale_qty": 0.25, "qty_increments": 0.05,
+            "only_x_left_in_stock": 8,
+            "price_range": {"minimum_price": {"regular_price": {"value": 4045.13},
+                                              "final_price": {"value": 4045.13}}}}},
+    ],
+}
+
+# "Sold by a bulk unit" is NOT a Magento shape — it appears inside
+# ConfigurableProduct too. The steel mesh's children carry per-child weights
+# (6.74 .. 66.02 kg live), which is why the weight rides the OFFER and one
+# figure per family would be wrong twelve times out of thirteen.
+_MESH = {
+    "__typename": "ConfigurableProduct",
+    "uid": "U1JN", "sku": "10400-SRM", "url_key": "steel-reinforcing-mesh",
+    "name": "شبك حديد صبة", "stock_status": "IN_STOCK", "categories": [],
+    "price_range": {"minimum_price": {"regular_price": {"value": 30.19},
+                                      "final_price": {"value": 30.19}},
+                    "maximum_price": {"final_price": {"value": 229.43}}},
+    "configurable_options": [{"attribute_code": "mesh_size", "label": "المقاس"}],
+    "variants": [
+        {"attributes": [{"code": "mesh_size", "label": "4.00ملم * 1.5 * 4.0متر"}],
+         "product": {
+            "uid": "U1JNNA==", "sku": "10404154020",
+            "name": "شبك حديد صبة - 4.00ملم * 1.5 * 4.0متر - 20*20سم",
+            "stock_status": "IN_STOCK", "weight": 6.74,
+            "is_qty_decimal": True, "min_sale_qty": 1, "qty_increments": 1,
+            "only_x_left_in_stock": None,
+            "price_range": {"minimum_price": {"regular_price": {"value": 30.19},
+                                              "final_price": {"value": 30.19}}}}},
+    ],
+}
+
+# The source stating its basis IN WORDS: weight 50 AND «50كجم» in the name.
+# That agreement is what selling_unit_from trusts, so this row reaches the Unit
+# column through the ordinary path and must never reach price_basis.
+_CEMENT = {
+    "__typename": "ConfigurableProduct",
+    "uid": "UkNG", "sku": "70501-RCF", "url_key": "riyadh-cement",
+    "name": "اسمنت الرياض", "stock_status": "IN_STOCK", "categories": [],
+    "price_range": {"minimum_price": {"regular_price": {"value": 15.23},
+                                      "final_price": {"value": 15.23}},
+                    "maximum_price": {"final_price": {"value": 27.83}}},
+    "configurable_options": [{"attribute_code": "cement_type", "label": "نوع الاسمنت"}],
+    "variants": [
+        {"attributes": [{"code": "cement_type", "label": "اسمنت ابيض"}],
+         "product": {
+            "uid": "QzE1OTI=", "sku": "70502001",
+            "name": "اسمنت ابيض - 50كجم - اسمنت الرياض",
+            "stock_status": "IN_STOCK", "weight": 50,
+            "is_qty_decimal": False, "min_sale_qty": 450, "qty_increments": 450,
+            "only_x_left_in_stock": None,
+            "price_range": {"minimum_price": {"regular_price": {"value": 27.83},
+                                              "final_price": {"value": 27.83}}}}},
+    ],
+}
+
+# THE CONTROL, and the reason the decimal flag is load-bearing. A steel angle
+# publishes a weight like everything else on this store — all 3,418 live leaves
+# do — and 4.986 kg is the mass of one PIECE. Its price is per piece. If a
+# published weight alone were enough to render a basis, this row would read
+# "per 4.986 kg" and the fix would have become the bug.
+_ANGLE = {
+    "__typename": "SimpleProduct",
+    "uid": "QU5HTEU=", "sku": "10201002", "url_key": "steel-angle",
+    "name": "زاوية حديد 20*20*3 ملم", "stock_status": "IN_STOCK", "categories": [],
+    "weight": 4.986, "is_qty_decimal": False, "min_sale_qty": 1, "qty_increments": 1,
+    "only_x_left_in_stock": None,
+    "price_range": {"minimum_price": {"regular_price": {"value": 32.2},
+                                      "final_price": {"value": 32.2}},
+                    "maximum_price": {"final_price": {"value": 32.2}}},
+}
+
+_CENSUS = {"data": {"products": {
+    "page_info": {"current_page": 1, "total_pages": 1},
+    "items": [_REBAR, _MESH, _CEMENT, _ANGLE]}}}
+
+_ENGLISH = {"data": {"products": {
+    "page_info": {"current_page": 1, "total_pages": 1},
+    "items": [
+        {"uid": "SFNT", "name": "Hadeed Epoxy Coated Steel Rebar", "items": [
+            {"product": {"uid": "TjY1",
+                         "name": "Hadeed Epoxy Rebar| Ø8mm × 12m | ASTM A775 Grade 60"}},
+            {"product": {"uid": "Tjcy",
+                         "name": "Hadeed Epoxy Rebar| Ø32mm × 12m | ASTM A775 Grade 60"}},
+        ]},
+        {"uid": "U1JN", "name": "Steel Reinforcing Mesh"},
+        {"uid": "UkNG", "name": "Riyadh Cement"},
+        {"uid": "QU5HTEU=", "name": "Steel Angle 20*20*3 mm"},
+    ]}}}
+
+
+class _Response:
+    def __init__(self, payload): self._payload = payload
+    def json(self): return self._payload
+
+
+class _Fetcher:
+    """The live store's answers. `weight_unit` is what storeConfig really
+    returns — "kgs" on ar_SA and en_SA alike, read 2026-07-30."""
+
+    def __init__(self, weight_unit: str | None = "kgs"):
+        self.weight_unit = weight_unit
+        self.store_config_requests = 0
+
+    def post(self, url, json=None, **kwargs):
+        query = (json or {}).get("query", "")
+        page = (json or {}).get("variables", {}).get("currentPage", 1)
+        if "storeConfig" in query:
+            self.store_config_requests += 1
+            if self.weight_unit is None:      # a store that will not say
+                return _Response({"data": {"storeConfig": {}}})
+            return _Response({"data": {"storeConfig": {"weight_unit": self.weight_unit}}})
+        if (kwargs.get("headers") or {}).get("Store"):
+            if "categoryList" in query:
+                return _Response({"data": {"categoryList": [{"children": []}]}})
+            return _Response(_ENGLISH if page == 1 else
+                             {"data": {"products": {"items": []}}})
+        if "categoryList" in query:
+            return _Response({"data": {"categoryList": [{"children": []}]}})
+        if "category_uid" in query:
+            return _Response({"data": {"products": {
+                "items": [], "page_info": {"current_page": 1, "total_pages": 1}}}})
+        return _Response(_CENSUS if page == 1 else
+                         {"data": {"products": {"items": []}}})
+
+    def close(self): pass
+
+
+def _entry() -> SourceEntry:
+    return SourceEntry.model_validate(dict(
+        source_key="MADAR", source_name="المدار", base_url="https://www.madar.com",
+        family="magento-graphql", currency="SAR", default_region="SA", vat_mode="incl",
+        extract=[ExtractSpec(kind=ExtractKind.PRODUCT_PRICES, scope=ExtractScope.CENSUS)],
+    ))
+
+
+def _tables(fetcher: _Fetcher | None = None):
+    return [t for t in MagentoGraphqlConnector(fetcher or _Fetcher()).fetch(_entry())
+            if t.kind == ExtractKind.PRODUCT_PRICES]
+
+
+def _rows(fetcher: _Fetcher | None = None) -> list[dict]:
+    tables = _tables(fetcher)
+    view = RowView(PRODUCT_PRICES, tables[0].header)
+    return [view.as_dict(row) for table in tables for row in table.rows]
+
+
+def _by_sku(sku: str, fetcher: _Fetcher | None = None) -> dict:
+    found = [r for r in _rows(fetcher) if r["external_sku"] == sku]
+    assert len(found) == 1, f"expected exactly one row for {sku}, got {len(found)}"
+    return found[0]
+
+
+def _ingest(tmp_path: Path, fetcher: _Fetcher | None = None):
+    conn = dbmod.connect(tmp_path / "harvest.db")
+    dbmod.migrate(conn)
+    tables = _tables(fetcher)
+    # new_payload, not FunnelPayload directly: it is the only blessed producer
+    # and it stamps BOTH numbers, so these rows travel exactly as a real crawl's
+    # do — content 8 declaring generation 5. That declaration is the entire
+    # reason the Apps Script already pasted in the owner's sheet can read them.
+    ingest_payloads(conn, _entry(), [new_payload(
+        source_key="MADAR", kind=ExtractKind.PRODUCT_PRICES, client="cli",
+        scraped_at="2026-07-30T10:00:00Z", source_url=t.source_url,
+        header=t.header, rows=t.rows) for t in tables])
+    return conn
+
+
+def _row_for(conn, sku: str) -> dict:
+    rows = [r for r in reports.table_payload(conn, "MADAR")["rows"]
+            if r.get("sku") == sku]
+    assert len(rows) == 1, f"expected one table row for {sku}, got {len(rows)}"
+    return rows[0]
+
+
+# =============================================================================
+# THE FIRST OF THE TWO. A unit the source never published must not reach the
+# data — on any surface, by any route.
+# =============================================================================
+
+# The words madar has never DECLARED as a unit. Re-verified read-only
+# 2026-07-30: its GraphQL schema has no `unit`, `uom` or `measure` field at
+# all, and not one of the rebar member's 22 custom_attributesV2 names the unit
+# its price is quoted in. So "the unit is a tonne" is OUR inference, and an
+# inference has no business in a column that means "the source said this".
+#
+# It says «طن» in its MARKETING PROSE, which is a different thing and is
+# asserted separately below — see the pair of tests at the end of this file.
+_NEVER_PUBLISHED = ("tonne", "tonnes", "ton", "tons", "metric ton", "t", "طن")
+
+# «طن» as a WORD, not as the tail of «قطن» (cotton) or «بطن». A substring test
+# would fail on real Arabic product names and teach everyone to ignore it.
+_STANDALONE_TON = re.compile(
+    r"(?<![؀-ۿ])طن(?![؀-ۿ])|\btonnes?\b|\bmetric\s+tons?\b",
+    re.IGNORECASE)
+
+
+# EVERY COLUMN IN THE WAREHOUSE THAT MEANS "A UNIT". These are the only places
+# an invented unit could land, and between them they are exhaustive: a unit
+# reaches a reader either as a selling_unit row, as an offer's weight unit, or
+# as text a display layer composed from one of those two.
+#
+# The sweep is deliberately NOT "the word appears nowhere in the database".
+# That invariant is FALSE and a test asserting it would be a trap: madar's own
+# marketing prose says «أفضل سعر طن حديد في السعودية» in the meta_title of 7 of
+# the 19 products behind these offers, and «قطنية» (cotton) contains the letters
+# outright. Source prose is the source's, and deleting it to make a test pass
+# would be the very edit this file exists to forbid. What must stay clean is
+# the set of columns where WE do the writing.
+_UNIT_BEARING_COLUMNS = (
+    ("selling_unit", "unit_code"),
+    ("source_offer", "weight_unit"),
+)
+
+
+def _stored_units(conn):
+    """(table.column, value) for every cell in the warehouse that means a unit."""
+    for table, column in _UNIT_BEARING_COLUMNS:
+        for (value,) in conn.execute(
+                f'SELECT DISTINCT "{column}" FROM "{table}" '
+                f'WHERE COALESCE("{column}", \'\') <> \'\''):
+            yield f"{table}.{column}", value
+
+
+def test_no_unit_the_source_never_published_reaches_the_data(tmp_path):
+    """THE GUARD. Fail if anything, anywhere, calls this a tonne.
+
+    Three routes, because a word can arrive by any of them: as a UNIT the
+    warehouse minted, as TEXT written into some other column, or rendered onto
+    a screen or into a file by a display layer that decided to be helpful.
+    """
+    conn = _ingest(tmp_path)
+
+    # 1. THE UNIT VOCABULARY. selling_unit is resolve-or-create — units arrive
+    #    from sites, so nothing seeds it and nothing constrains it. A connector
+    #    that inferred a bulk unit would mint the row here.
+    minted = {code for (code,) in conn.execute("SELECT unit_code FROM selling_unit")}
+    assert not (minted & set(_NEVER_PUBLISHED)), (
+        f"a unit the shop never printed was minted: {minted & set(_NEVER_PUBLISHED)}")
+
+    # 2. THE OFFER ITSELF. The rebar's two offers must hold no selling unit at
+    #    all — empty is the honest answer to "what unit did the shop state?".
+    units = conn.execute(
+        "SELECT sv.external_sku, so.selling_unit_id, so.basis_quantity "
+        "FROM source_offer so "
+        "JOIN source_variant sv ON sv.source_variant_id = so.source_variant_id "
+        "WHERE sv.external_sku IN ('101150812','101153212')").fetchall()
+    assert len(units) == 2
+    for sku, unit_id, basis in units:
+        assert unit_id is None, f"{sku} was given a selling unit nobody published"
+        # ...and basis_quantity is untouched at its schema default. Writing
+        # 1000 here would both assert "per 1000 <unit>" and change the offer's
+        # identity, minting a second offer beside the first.
+        assert basis == 1, f"{sku} had its basis_quantity rewritten to {basis}"
+
+    # 3. EVERY UNIT-BEARING COLUMN IN THE WAREHOUSE, whatever the source. Not
+    #    only this crawl's offers: a unit is a shared vocabulary, and one
+    #    connector inventing a bulk unit poisons it for every source that
+    #    joins the same table.
+    offenders = [(where, value) for where, value in _stored_units(conn)
+                 if _STANDALONE_TON.search(value) or value in _NEVER_PUBLISHED]
+    assert not offenders, f"a unit nobody published was stored: {offenders}"
+
+    # 4. WHAT THE READER SEES. The Unit column, the price cell's basis, and the
+    #    exported file — a display layer is just as capable of inventing a word
+    #    as a connector is, and it is the surface the owner actually reads.
+    for row in reports.table_payload(conn, "MADAR")["rows"]:
+        for key in ("unit", "price_basis"):
+            assert not _STANDALONE_TON.search(str(row.get(key) or "")), (
+                f"the table rendered {row.get(key)!r} in {key}")
+    header, table = reports.export_source_table(conn, "MADAR")[:2]
+    for line in table:
+        for cell in line:
+            assert not _STANDALONE_TON.search(str(cell or "")), (
+                f"the export rendered {cell!r}")
+
+
+def test_the_connector_emits_no_unit_for_a_product_whose_unit_the_shop_never_states():
+    """Upstream of the warehouse, at the only place that could invent one.
+
+    The connector HAS the weight and HAS the decimal flag, so it is exactly
+    where "obviously that means tonnes" would get written down. It records the
+    numbers and stops.
+    """
+    thin = _by_sku("101150812")
+    assert thin["unit"] == "" and thin["basis_quantity"] == ""
+    assert thin["weight"] == "1000" and thin["weight_unit"] == "kgs"
+    assert thin["quantity_is_decimal"] == "1"
+    assert thin["minimum_quantity"] == "0.25" and thin["quantity_increment"] == "0.05"
+
+
+# =============================================================================
+# THE SECOND OF THE TWO. The member renders against the weight the shop DID
+# publish — and the price itself is not touched.
+# =============================================================================
+
+def test_the_rebar_member_renders_against_its_published_weight(tmp_path):
+    """4,830 stays 4,830. Only what surrounds it changes.
+
+    Ø8 at 4,830 and Ø32 at 4,045 is impossible per bar — 1,020 against 53
+    riyals a kilogram of the same steel — and against the 1000 the shop states
+    for both it is 4.83 against 4.05, thin dearer than thick. That second
+    reading is the one the page now shows, in the shop's own number and the
+    shop's own word for its unit.
+    """
+    conn = _ingest(tmp_path)
+
+    thin = _row_for(conn, "101150812")
+    thick = _row_for(conn, "101153212")
+
+    # THE PRICE IS UNTOUCHED. Nothing here divides, multiplies or rounds.
+    assert thin["price"] == 4830.0
+    assert thick["price"] == 4045.13
+
+    # THE UNIT COLUMN STAYS EMPTY, because the shop stated no unit.
+    assert thin["unit"] == "" and thick["unit"] == ""
+
+    # ...and the price cell says what one unit of that price buys.
+    assert thin["price_basis"] == "1,000 kg"
+    assert thick["price_basis"] == "1,000 kg"
+
+    # The warehouse holds the two facts it was told, and only those.
+    stored = conn.execute(
+        "SELECT so.weight, so.weight_unit, so.quantity_is_decimal "
+        "FROM source_offer so "
+        "JOIN source_variant sv ON sv.source_variant_id = so.source_variant_id "
+        "WHERE sv.external_sku = '101150812'").fetchone()
+    assert tuple(stored) == (1000.0, "kg", 1)
+
+
+def test_the_exported_file_carries_the_basis_beside_the_empty_unit(tmp_path):
+    """The screen and the spreadsheet have to agree. A file of bare numbers
+    where 4,830 is per 1,000 kg and 32.20 is per piece is the trap the Unit
+    column exists to prevent, and the export is the record leaving the
+    building."""
+    conn = _ingest(tmp_path)
+    header, table = reports.export_source_table(conn, "MADAR")[:2]
+    unit_at = header.index("unit")
+    basis_at = header.index("price_basis")
+    sku_at = header.index("sku")
+    by_sku = {line[sku_at]: line for line in table}
+
+    assert by_sku["101150812"][unit_at] == ""
+    assert by_sku["101150812"][basis_at] == "1,000 kg"
+    # The cement states its unit in words, so it answers in the Unit column and
+    # leaves this one empty. The two never both fill.
+    assert by_sku["70502001"][unit_at] == "50 kg"
+    assert by_sku["70502001"][basis_at] == ""
+
+
+def test_a_published_weight_alone_is_not_a_basis(tmp_path):
+    """THE CONTROL, and the reason the decimal flag is load-bearing.
+
+    All 3,418 live madar leaves publish a weight (measured 2026-07-30), and for
+    3,309 of them it is the mass of one PIECE. Rendering on weight alone would
+    print "per 4.986 kg" against a steel angle sold by the piece — precisely
+    the guess normalize.selling_unit_from was written to refuse, applied to the
+    whole shop.
+    """
+    conn = _ingest(tmp_path)
+    angle = _row_for(conn, "10201002")
+    assert angle["price"] == 32.2
+    assert angle["unit"] == "" and angle["price_basis"] == ""
+    # The weight is still STORED — it is a fact the shop published, and the
+    # rule decides where it is shown, not whether it is kept.
+    assert tuple(conn.execute(
+        "SELECT so.weight, so.weight_unit FROM source_offer so "
+        "JOIN source_variant sv ON sv.source_variant_id = so.source_variant_id "
+        "WHERE sv.external_sku = '10201002'").fetchone()) == (4.986, "kg")
+
+
+def test_a_stated_unit_always_wins_over_a_published_weight(tmp_path):
+    """Riyadh cement says «50كجم» in the name AND weight 50, and that agreement
+    is what makes the basis trustworthy. It reaches the Unit column through the
+    path that already existed and must never be re-answered from the weight."""
+    conn = _ingest(tmp_path)
+    cement = _row_for(conn, "70502001")
+    assert cement["unit"] == "50 kg"
+    assert cement["price_basis"] == ""
+
+
+def test_the_mechanism_is_not_a_madar_special_case(tmp_path):
+    """The rule is "a source publishing a decimal quantity against a weight",
+    not "the rebar". It fires inside a ConfigurableProduct too — the steel mesh
+    — which is why the weight rides the OFFER and not the product: its live
+    children span 6.74 .. 66.02 kg, so one figure for the family would be wrong
+    twelve times out of thirteen."""
+    conn = _ingest(tmp_path)
+    mesh = _row_for(conn, "10404154020")
+    assert mesh["price"] == 30.19
+    assert mesh["unit"] == ""
+    assert mesh["price_basis"] == "6.74 kg"
+
+
+# ---- price_basis itself, condition by condition ------------------------------
+
+def test_price_basis_needs_all_three_of_the_sources_own_statements():
+    # Everything present: the shop's weight, the shop's unit, the shop's flag.
+    assert price_basis("", 1000, "kg", 1) == "1,000 kg"
+    # A stated selling unit is the answer; the weight is then a piece's mass.
+    assert price_basis("kg", 1000, "kg", 1) == ""
+    # The shop does not say the quantity is divisible.
+    assert price_basis("", 1000, "kg", 0) == ""
+    # The shop publishes no weight.
+    assert price_basis("", None, "kg", 1) == ""
+    # The shop publishes a weight and will not say what unit it is in. This is
+    # the storeConfig-failed case, and a number with a unit we assumed is worse
+    # than no number at all.
+    assert price_basis("", 1000, "", 1) == ""
+    # Weightlessness is not a fact any shop states.
+    assert price_basis("", 0, "kg", 1) == ""
+
+
+def test_the_basis_is_grouped_and_keeps_the_sources_own_precision():
+    """1,000 not 1000 — the whole point is that the number is large. And the
+    reader's own units: the shop said 1000 kg, so it says 1,000 kg, never 1 t.
+    A tonne is a word this shop has not used."""
+    assert price_basis("", 1000, "kg", 1) == "1,000 kg"
+    assert price_basis("", 66.02, "kg", 1) == "66.02 kg"
+    assert price_basis("", 6.74, "kg", 1) == "6.74 kg"
+    # A store weighing in pounds renders pounds, with nothing here changing.
+    assert price_basis("", 2204.62, "lb", 1) == "2,204.62 lb"
+
+
+def test_a_store_that_will_not_state_its_weight_unit_shows_no_basis(tmp_path):
+    """The refusal, end to end. storeConfig is one request per crawl and it can
+    fail; when it does, the basis disappears and the price cell reads exactly
+    as it did before this change. The run SAYS SO rather than falling back on
+    "everyone means kilograms"."""
+    silent = _Fetcher(weight_unit=None)
+    conn = _ingest(tmp_path, silent)
+    assert silent.store_config_requests == 1     # once per crawl, not per row
+
+    thin = _row_for(conn, "101150812")
+    assert thin["price"] == 4830.0               # the price is never affected
+    assert thin["unit"] == "" and thin["price_basis"] == ""
+    # Neither half is stored, because half of this fact is not a fact.
+    assert tuple(conn.execute(
+        "SELECT so.weight, so.weight_unit FROM source_offer so "
+        "JOIN source_variant sv ON sv.source_variant_id = so.source_variant_id "
+        "WHERE sv.external_sku = '101150812'").fetchone()) == (None, None)
+    # And the crawl reports it, so a silently basis-less table has a reason
+    # a reader can find.
+    warnings = [w for t in _tables(_Fetcher(weight_unit=None)) for w in t.warnings]
+    assert any("weight_unit" in w for w in warnings), warnings
+
+
+# ---- migration 0057 ----------------------------------------------------------
+
+def test_migration_0057_adds_the_two_columns_without_touching_offer_identity():
+    """Both columns are outside ux_source_offer_identity, so an existing offer
+    LEARNS them instead of a second offer being minted beside it — the
+    duplicate-row defect that appeared the day the sika connector learned to
+    read "5 KG" off a name and 56 products grew a twin."""
+    conn = dbmod.connect(":memory:")
+    try:
+        for number, file in dbmod._migration_files():        # the pre-0057 warehouse
+            if number >= 57:
+                continue
+            conn.executescript(file.read_text(encoding="utf-8"))
+            conn.execute(f"PRAGMA user_version = {number}")
+        columns = {r[1] for r in conn.execute("PRAGMA table_info(source_offer)")}
+        assert "weight" not in columns and "weight_unit" not in columns
+
+        assert dbmod.migrate(conn) == [57]
+
+        columns = {r[1]: r for r in conn.execute("PRAGMA table_info(source_offer)")}
+        assert "weight" in columns and "weight_unit" in columns
+        # Nullable and undefaulted: NULL reads as "the site did not say", which
+        # is the truthful state of every row that predates the next crawl. A 0
+        # would be a source claiming weightlessness.
+        assert columns["weight"][3] == 0 and columns["weight"][4] is None
+        assert columns["weight_unit"][3] == 0 and columns["weight_unit"][4] is None
+
+        indexed = {r[2] for r in conn.execute(
+            "PRAGMA index_info(ux_source_offer_identity)")}
+        assert "weight" not in indexed and "weight_unit" not in indexed
+    finally:
+        conn.close()
+
+
+# ---- the other side of the same rule ----------------------------------------
+
+def test_the_shops_own_word_for_a_tonne_survives_verbatim(tmp_path):
+    """SOURCE TRUTH IS NEVER EDITED — including when the source says the very
+    thing we refused to say for it.
+
+    Measured on the live crawl of 2026-07-30: madar's own marketing prose DOES
+    print «طن». Seven of the nineteen products behind these 109 offers carry it
+    in a meta field — the epoxy rebar's meta_title reads «أفضل سعر طن حديد في
+    السعودية» ("the best price per tonne of steel in Saudi Arabia") — and the
+    Rajhi rebar's says «سعر طن حديد التسليح اليوم».
+
+    Two things follow, and they pull in opposite directions, which is exactly
+    why this test sits beside the guard above:
+
+      * That prose is the SHOP's and is kept exactly as written. A sweep that
+        banned the word from the whole warehouse would have to delete it, which
+        is the edit this file exists to forbid — and would also trip over
+        «قطنية» (cotton), where the letters are a substring of another word.
+      * It is still NOT a unit declaration. It is an SEO keyword on a category
+        page, it says nothing about which figure on which SKU it qualifies, and
+        twelve of the same nineteen products say nothing at all. Promoting it
+        into `unit` would make the same 109 offers disagree with each other
+        about a fact none of them states.
+
+    So the word lives in the attribute the shop wrote it in, and the unit
+    columns stay empty. Both halves are asserted here.
+    """
+    conn = _ingest(tmp_path)
+    product_id = conn.execute(
+        "SELECT sv.source_product_id FROM source_variant sv "
+        "WHERE sv.external_sku = '101150812'").fetchone()[0]
+    # The shop's real wording, copied from the live store 2026-07-30.
+    published = "حديد تسليح (حديد) - سابك سابقاً | أفضل سعر طن حديد في السعودية"
+    conn.execute(
+        "INSERT INTO source_product_attribute "
+        "(source_product_id, attribute_code, attribute_label, raw_value, lang) "
+        "VALUES (?, 'meta_title_ar', 'Meta title', ?, 'ar')",
+        (product_id, published))
+    conn.commit()
+
+    kept = conn.execute(
+        "SELECT raw_value FROM source_product_attribute "
+        "WHERE source_product_id = ? AND attribute_code = 'meta_title_ar'",
+        (product_id,)).fetchone()[0]
+    assert kept == published, "the shop's own sentence was altered"
+    assert _STANDALONE_TON.search(kept), "the fixture no longer exercises the case"
+
+    # ...and not one unit column learned the word from it.
+    assert not [v for _where, v in _stored_units(conn) if _STANDALONE_TON.search(v)]
+    thin = _row_for(conn, "101150812")
+    assert thin["unit"] == ""
+    assert thin["price_basis"] == "1,000 kg"
+
+
+def test_the_word_boundary_is_real_and_not_a_substring_match():
+    """«قطنية» (cotton) contains the letters of «طن» and is a real madar
+    product — "قفازات عمل قطنية" (cotton work gloves), live 2026-07-30. A
+    substring test would fire on it, get muted, and stop guarding anything."""
+    assert not _STANDALONE_TON.search("قفازات عمل قطنية مطلية باللاتكس")
+    assert not _STANDALONE_TON.search("بطن")
+    assert _STANDALONE_TON.search("أفضل سعر طن حديد في السعودية")
+    assert _STANDALONE_TON.search("1 طن، 2 طن، 3 طن")
+    assert _STANDALONE_TON.search("priced per tonne")
+    assert not _STANDALONE_TON.search("carton of buttons")


### PR DESCRIPTION
**DRAFT — for the main session's review gate. Please do not merge.**

> **Rebased onto `176621b`.** Main moved five commits while this was being built, including `c5bf4b2`'s content/generation ledger. See **[The contract ledger](#the-contract-ledger)** at the bottom for how this change lands on it — short version: **content 7 → 8, generation 5, and the owner pastes nothing.**

## The problem, in the source's own numbers

The Ø8mm rebar member costs **4,830** and the Ø32mm member costs **4,045**.

Computed from madar's own published dimensions and the density of steel: a 12 m Ø8 bar is **4.735 kg** and a 12 m Ø32 bar is **75.76 kg**. Per piece those prices are **1,020** and **53** riyals a kilogram — of the same steel, on the same shelf. The shop states `weight = 1000` on both, on all 96 members whatever the diameter, and against that they are **4.83** and **4.05** a kilogram: thin dearer than thick, exactly as rolling mills price rebar.

0056 stored the quantity *numbers* (`is_qty_decimal`, min 0.25, step 0.05) and left the weight those are quantities **of** unmeasured. This is the other half.

## One premise in the brief was stale, and it matters

The brief said the connector "does not currently request" the weight. It already does — [`magento.py:82`](scrapex/connectors/magento.py:82), [`:86`](scrapex/connectors/magento.py:86), [`:93`](scrapex/connectors/magento.py:93), added by 0056. The defect is downstream: the weight reached exactly one reader, [`normalize.selling_unit_from`](scrapex/normalize.py:99), which returns `("","")` unless the product **name** states a matching kg quantity. The rebar member's name states «8مم × 12متر» — a diameter and a length. So `weight: 1000` arrived on every crawl and was discarded on every crawl. Nothing else stored it: [`_enrichment_rows`](scrapex/connectors/magento.py:1300) records a weight only for *configurable* children, never grouped members, and only under an enrichment manifest.

## What was built

**Show the basis, do not name it.** `unit` stays empty; the price cell renders the shop's weight.

| | |
|---|---|
| **Capture** | New row columns `weight` / `weight_unit` ([`rowspec.py:156`](scrapex/rowspec.py:156)); stored on `source_offer` by [migration 0057](db/migrations/0057_the_weight_the_price_is_quoted_against.sql) |
| **Render** | [`reports.price_basis()`](scrapex/reports.py:167) → the price cell in [`grid.js:1300`](scrapex/webui/static/grid.js:1300), the row inspector, the change feed, and a new `price_basis` export column |
| **Price** | Untouched. 4,830 stays 4,830 — nothing divides, multiplies or rounds |

**No `tonne` unit was added.** The declined option stayed declined.

### The unit is now the shop's word too

This is the one thing I added beyond the brief, and I think it earns its place. `weight` is a bare float, so `"kg"` was the last word in the sentence still coming out of *our* mouth ([`normalize.py:131`](scrapex/normalize.py:131) and [`magento.py:1310`](scrapex/connectors/magento.py:1310) both hardcode it). Magento publishes `StoreConfig.weight_unit`, and **madar answers `"kgs"`** on both store views — read live, read-only, 2026-07-30. One request per crawl. A store quoting `lbs` now renders lbs with no code change, and a crawl that cannot reach `storeConfig` stores nothing and shows no basis: a number whose unit we failed to read is not published as a bare number.

### Why not `basis_quantity`

Checked first, as asked. Three reasons, any one sufficient:

1. It is half of a pair whose other half is `unit`; `price_unit()` returns `""` without one, so 1000 would not even render — and writing it asserts "per 1000 *unit*", the assertion being refused.
2. It is inside `ux_source_offer_identity` ([`schema.sql:183`](db/schema.sql:183)). Moving an offer's basis 1 → 1000 changes what the offer **is**, minting a second one beside it — the duplicate-row defect that appeared when sika learned to read "5 KG" off a name and 56 products grew a twin.
3. It means "what the site states **in words**", proven by name/weight agreement. This is what it states as a **number**, uncorroborated. Different claims, different confidence.

### The gate is `is_qty_decimal`, and it is load-bearing

**All 3,418 live leaves publish a weight**, and for 3,309 of them it is one piece's mass — a steel angle's 4.986 kg. Rendering on weight alone would print "per 4.986 kg" across the whole shop: the guess `selling_unit_from` exists to refuse, generalised. The flag narrows it to 109.

## One correction to the record — found by this change's own crawl

The brief states madar "publishes no unit of measure anywhere" and that «طن» appears 0 times. **True of the page; not true of the data.**

**Seven of the nineteen products behind these 109 offers print «طن» in a meta field.** The epoxy rebar's own `meta_title` reads «حديد تسليح (حديد) - سابك سابقاً | **أفضل سعر طن حديد** في السعودية», and the Rajhi rebar's says «**سعر طن حديد التسليح** اليوم». 0056 started capturing meta fields, so a crawl can now see it.

It **corroborates** the per-tonne reading independently of the arithmetic — and it is still not a declaration: SEO copy on a parent product, naming no SKU and no figure, absent from the other twelve. Writing `tonne` on the strength of it would make the same 109 offers disagree about a fact none of them states. So the prose is kept exactly where the shop put it and the unit column is not filled from it. **This is the owner's call to revisit, not mine** — flagging it rather than acting on it.

It also killed a bad test of my own: my first guard swept the whole database for the word and would have failed against real data. It now sweeps only the columns where *we* do the writing, and a companion test asserts the shop's prose survives verbatim — including that «قطنية» (cotton, a real madar product) must not trip the word boundary.

## Definition of done

- **`test_no_unit_the_source_never_published_reaches_the_data`** — the unit vocabulary, the offers, and every rendered/exported cell.
- **`test_the_rebar_member_renders_against_its_published_weight`** — 4,830 unchanged, `unit` empty, basis `1,000 kg`.
- Both **mutation-tested**: inventing a `tonne` in the connector fails the first; blanking `price_basis` fails the second.
- Plus **`test_folding_two_variants_priced_alike_never_lends_one_its_neighbours_weight`** — the last surface where a *wrong* basis could reach a reader. `fold_variant_rows` groups by (product, price, currency, country), and two live mesh sizes collide there: the 8.00 mm sheet (25.86 kg) and the 7.50 mm sheet (22.73 kg) both cost 84.00 stored. No code was written for it — the fold's standing rule already blanks a field the members disagree about, and it covers the new column *because* the basis got a column of its own instead of being composed at the last moment in the browser. Verified on the live crawl before the test was written.
- `python -m pytest -q` green · `node contract/parity/parity.test.mjs` **3/3** · `node --test extension/tests/*.test.mjs` **13/13** · `node --test apps_script/tests/*.test.mjs` **13/13** (this one runs the real `StagingAppScript.txt` under a fake spreadsheet) · `validate-manifest` OK

## Measured, live crawl + ingest 2026-07-30

Run into an **isolated warehouse** — the owner's is read-only and another session's engine was actively writing to it (`ELBUROJ` journal live at 08:03). Nothing here touched it, and **migration 0057 has not been applied to the live warehouse.** Re-measured after the rebase onto `176621b`; every figure below is identical on both bases.

| | |
|---|---:|
| offers | 3,418 |
| carrying a published weight | **3,418** |
| …with the shop's own unit for it | 3,418 |
| `quantity_is_decimal = 1` | 109 |
| **rendering a basis** | **109** (96 rebar + 13 mesh) |
| still carrying a stated selling unit | 92 |
| unit vocabulary minted | `['kg']` |
| rows showing both a unit and a basis | **0** |

```
Ø8mm    4,830.00 SAR / 1,000 kg      (Unit column: "")
Ø32mm   4,045.13 SAR / 1,000 kg      (Unit column: "")
```

## Two things for the reviewer to weigh

1. **The 13 mesh children.** They pass the gate (`is_qty_decimal` true) but their `min_sale_qty` and `qty_increments` are both **1**, and their weights are the sheets' *true* masses (computed Ø10 2.0×5.0 m = 65.97 kg vs the stated 66.02). So "30.19 / 6.74 kg" is true — one sheet is 6.74 kg — but you buy whole sheets, and the rebar's uniform 1000 is a declared basis of a different kind. Tightening the gate to *fractional* min/step would give 96 instead of 109. I implemented the rule as specified; this is a judgement call I did not make unilaterally.
2. **`meta_title` vs `name`** — recorded, not fixed, as instructed: the AR `meta_title` says «سابك» (SABIC) where `name` says «من حديد» (Hadeed) and the image is `epoxy_sabic.png`. `meta_title` **is** already captured (0056, `Site metadata`) and this crawl stored it — the contradiction is now visible in the data rather than merely known. A separate change if the owner wants a view for it.

## The contract ledger

This is the first change to land on `c5bf4b2`'s ledger, and it is the case that ledger was built for.

| | |
|---|---|
| `PAYLOAD_VERSION` | 7 → **8** |
| `GENERATION_OF_VERSION` | gains `{8: 5}` |
| `PAYLOAD_COMPAT_VERSION` | **stays 5** — derived, never typed |
| `contracts/header-baseline.json` | **untouched** |
| Owner re-paste | **not required** |

Two additive columns: no rename, no removal, no units change, no required/optional flip. So the generation stands still.

**`header-baseline.json` is untouched, and `export-contract` says so out loud:**

```
kept …/header-baseline.json (generation 5 baseline stands; a baseline is
never rewritten for the generation it describes)
```

It is a floor recording what generation 5 guarantees; additions are not recorded in it, and rewriting it for its own generation would move the floor down with the next rename it exists to catch.

**`StagingAppScript.txt` does move — two mirrored constants and its copy of the ledger — and that is not a re-paste.** `test_the_apps_script_mirror_cannot_drift_from_python` requires the checked-in file to stay truthful for whenever it *is* next pasted. Whether a paste is *needed* is a different question, and I proved the answer rather than asserting it — by loading the script **as the owner's sheet actually holds it** (`c5bf4b2`'s version, which has never heard of content 8) and asking it:

```
the sheet holds the v7 script (generation 5)
  it has never heard of content version 8: true
  a v8 batch DECLARING generation 5  -> ACCEPTED (no re-paste)
  a v8 batch declaring nothing       -> refused: payload_version 8 is unknown …
```

The refusal on the second line is why `new_payload` — which stamps *both* numbers and is the only blessed producer — matters, and the tests here now go through it instead of constructing `FunnelPayload` directly.

**The bump is also safe for a paused crawl,** the other thing that reads a version. `localinbox.read_payloads` re-validates every journal page through the model, so an over-strict gate is how a resume dies at read-back. Under the range check every page from content 5 through 8 resolves to generation 5:

```
v5 unstamped -> accepted     v7 compat=5 -> accepted     v4 unstamped -> REFUSED (older generation)
v6 unstamped -> accepted     v8 compat=5 -> accepted     v9 compat=6  -> REFUSED (newer generation)
```

Checked on real data too, by accident of timing: the nine inbox payloads this change was measured from were written by the pre-rebase build and are stamped **content 7 with no generation at all** — and the content-8 build ingests all 3,418 rows from them with 0 errors, reproducing every number in the table above exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
