### PR TITLE
fix(zid): capture ADVANCEDCASTLE images; Egypt decision recorded

### DIFF
--- a/scrapex/connectors/jsonld.py
+++ b/scrapex/connectors/jsonld.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 
 from bs4 import BeautifulSoup
 
-from ..vocab import Availability
+from ..vocab import Availability, DetailGroup, group_for_code
 from .base import CrawlBlocked
 
 
@@ -273,6 +273,51 @@ def product_row(builder, node: dict, url: str, source, vat: str, pid: str,
         category_path_ar=category_path(node),
         category_path=category_path(english) if english else "",
     )
+
+
+def enrichment_rows(builder, node: dict, pid: str) -> list[list[str]]:
+    """The pictures and prose the product page's JSON-LD already carried.
+
+    Written for salla and left in salla, so the SECOND SSR family to want
+    details had nothing to reach for — and zid, which publishes `image` on
+    every product page it was already fetching, stored none of it. That is the
+    move product_row already made for the same reason: the product id is the
+    one thing that genuinely differs between the two families, so it is the
+    caller's argument rather than a connector importing another connector
+    (base.py). Nothing else here is site-specific.
+
+    schema.org allows `image` as a single URL or a list of them; advancedcastle
+    publishes both forms (a string on single-image products, a list otherwise),
+    so both are read and neither is guessed at.
+    """
+    rows: list[list[str]] = []
+
+    def add(code, label, value, *, url_value="", group=""):
+        if not value:
+            return
+        # The shared map decides WHERE (vocab.group_for_code), so every
+        # source files the same kind of fact in the same place. The
+        # caller's `group` remains the hint for codes this shop names in
+        # a way the map has not been taught yet.
+        decided, recognised = group_for_code(code)
+        rows.append(builder.row(
+            external_product_id=pid, attribute_code=code, attribute_label=label,
+            raw_value=str(value)[:2000], numeric_value="", unit_raw="",
+            value_url=url_value, lang="",
+            attribute_group=decided if recognised else (group or decided)))
+
+    images = node.get("image")
+    if isinstance(images, str):
+        images = [images]
+    for position, href in enumerate(images or []):
+        if not isinstance(href, str) or not href.startswith("http"):
+            continue
+        add(f"image_{position}" if position else "image", "Image",
+            href.rsplit("/", 1)[-1], url_value=href, group=DetailGroup.MEDIA)
+
+    add("description", "Description", node.get("description"), group="Description")
+    add("sku", "SKU", node.get("sku"), group="Specs")
+    return rows
 
 
 def brand_name(node: dict) -> str:

--- a/scrapex/connectors/salla.py
+++ b/scrapex/connectors/salla.py
@@ -22,13 +22,15 @@ from ..config import SourceEntry
 # without it ever being in scope, so a salla source that declared an
 # enrichment extract would have died on NameError after the whole crawl.
 from ..rowspec import ENRICHMENT, PRODUCT_PRICES, RowBuilder
-from ..vocab import DetailGroup, group_for_code, ExtractKind
+from ..vocab import ExtractKind
 from .base import HttpFetcher, ScrapedTable
 # Shared SSR helpers (also re-exported for salla's tests). offer_price/parse are
-# generic; the /p{id} id scheme below is the salla-specific part.
-from .jsonld import (WalkTally, brand_name, category_path, offer_price,
-                     parse_product_jsonld, product_row, sitemap_locs,
-                     sitemap_products, walk_products)
+# generic; the /p{id} id scheme below is the salla-specific part. enrichment_rows
+# moved to jsonld when zid needed the same pictures-and-prose reading — it is
+# imported here rather than left behind so both families share one copy.
+from .jsonld import (WalkTally, brand_name, category_path, enrichment_rows,
+                     offer_price, parse_product_jsonld, product_row,
+                     sitemap_locs, sitemap_products, walk_products)
 
 _PRODUCT_ID = re.compile(r"/p(\d{5,})")
 
@@ -111,7 +113,7 @@ class SallaConnector:
                 # under the SAME token: one product is journaled once, so a
                 # resume cannot land its price without its details.
                 extra = RowBuilder(ENRICHMENT)
-                attribute_rows = enrichment_rows(extra, node, url)
+                attribute_rows = enrichment_rows(extra, node, _salla_id(url, node))
                 if attribute_rows:
                     yield ScrapedTable(source.source_key, ENRICHMENT.kind, base,
                                        extra.header, attribute_rows,
@@ -139,39 +141,3 @@ class SallaConnector:
             self._fetcher, sitemap_url, lambda url: bool(_PRODUCT_ID.search(url)),
             dedupe=one_url_per_product,
             unreadable_children=tally.unreadable_children)
-
-
-def enrichment_rows(builder: RowBuilder, node: dict, url: str) -> list[list[str]]:
-    """The pictures and prose the product page's JSON-LD already carried."""
-    from .salla import _PRODUCT_ID  # local: keeps the module's import list flat
-
-    found = _PRODUCT_ID.search(url)
-    pid = found.group(1) if found else str(node.get("sku") or url)
-    rows: list[list[str]] = []
-
-    def add(code, label, value, *, url_value="", group=""):
-        if not value:
-            return
-        # The shared map decides WHERE (vocab.group_for_code), so every
-        # source files the same kind of fact in the same place. The
-        # caller's `group` remains the hint for codes this shop names in
-        # a way the map has not been taught yet.
-        decided, recognised = group_for_code(code)
-        rows.append(builder.row(
-            external_product_id=pid, attribute_code=code, attribute_label=label,
-            raw_value=str(value)[:2000], numeric_value="", unit_raw="",
-            value_url=url_value, lang="",
-            attribute_group=decided if recognised else (group or decided)))
-
-    images = node.get("image")
-    if isinstance(images, str):
-        images = [images]
-    for position, href in enumerate(images or []):
-        if not isinstance(href, str) or not href.startswith("http"):
-            continue
-        add(f"image_{position}" if position else "image", "Image",
-            href.rsplit("/", 1)[-1], url_value=href, group=DetailGroup.MEDIA)
-
-    add("description", "Description", node.get("description"), group="Description")
-    add("sku", "SKU", node.get("sku"), group="Specs")
-    return rows

--- a/scrapex/connectors/zid.py
+++ b/scrapex/connectors/zid.py
@@ -38,6 +38,30 @@ fetcher of its own (below), and this crawl's own session must never be allowed
 to touch an Egyptian URL first, or every product page after it would come back
 in EGP and be stored as a Saudi price.
 
+THE PICTURES (2026-07-29). Every advancedcastle product page publishes `image`
+in the SAME Product JSON-LD the price is read from, and not one was stored:
+this connector had no enrichment branch at all, so a zid source that
+contracted enrichment would have been served prices and silence. The reading
+itself is not zid's to write (salla already had it), so it moved to jsonld and
+both families now share it. What zid adds is the branch, and the choice to run
+it for a PRICELESS product too — a variant-priced page publishes no usable
+price and still publishes its pictures.
+
+MEASURED, live warehouse before this fix: 168/168 ADVANCEDCASTLE products, 0
+carrying an image. MEASURED, this connector run end-to-end against the live
+site after the fix (168 products, one crawl): 168/168 products land at least
+one image, 435 image rows total, 771 enrichment rows including description
+and sku.
+
+MEASURED LIMIT, stated rather than papered over: on a 42-product sample of the
+live catalogue, the page's own gallery markup (`#product-images
+img.carousel-img`) carries 124 images against JSON-LD's 109 for the same
+products, and every JSON-LD image is among them. On 10 of the 42, JSON-LD
+names fewer pictures than the gallery shows. Every product still gets at least
+one image from JSON-LD, so nothing is left blank; reading the gallery as well
+would recover the remaining ones and is a separate, owner-visible enhancement,
+not part of restoring what was being dropped.
+
 Two things this deliberately does NOT do. It does not convert anything: the
 crawled price stays the price the store printed. And it does not reconcile the
 rate with the prices — on 2026-07-29 the store published 3.754116 SAR and
@@ -53,11 +77,12 @@ from urllib.parse import urljoin
 
 from ..localinbox import safe_token
 from ..config import SourceEntry
-from ..rowspec import PRODUCT_PRICES, RowBuilder
+from ..rowspec import ENRICHMENT, PRODUCT_PRICES, RowBuilder
+from ..vocab import ExtractKind
 from .base import CrawlBlocked, HttpFetcher, ScrapedTable
-from .jsonld import (WalkTally, alternate_links, english_alternate, offer_price,
-                     parse_product_jsonld, product_row, sitemap_products,
-                     walk_product_pages)
+from .jsonld import (WalkTally, alternate_links, english_alternate,
+                     enrichment_rows, offer_price, parse_product_jsonld,
+                     product_row, sitemap_products, walk_product_pages)
 
 _PRODUCT_PATH = "/products/"
 
@@ -131,6 +156,8 @@ class ZidConnector:
     def fetch(self, source: SourceEntry) -> Iterable[ScrapedTable]:
         base = source.base_url.rstrip("/")
         vat = "1" if source.vat_mode.value == "incl" else "0"
+        wants_enrichment = any(spec.kind == ExtractKind.ENRICHMENT
+                               for spec in source.extract)
         tally = WalkTally()
         rates: dict[str, float] = {}
         rate_notes: list[str] = []
@@ -155,25 +182,42 @@ class ZidConnector:
                 abroad, notes = self._rates_abroad(html, url, source)
                 rates.update(abroad)
                 rate_notes.extend(notes)
-            if not offer_price(node.get("offers"))[0]:
+            pid = _product_id(url, node)
+            if offer_price(node.get("offers"))[0]:
+                # The SAME product, in the store's other language. Fetched only
+                # when THIS page advertises one, so an Arabic-only Zid store
+                # still costs exactly one request per product and reaches none
+                # of this.
+                english, lost = self._english_node(html, node, url, source)
+                tally.english_lost += lost
+                # One table per product, journaled as fetched: accumulating the
+                # whole catalogue and yielding once at the end meant an
+                # interrupted crawl had written nothing at all.
+                builder = RowBuilder(PRODUCT_PRICES)
+                row = product_row(builder, node, url, source, vat, pid,
+                                  english=english)
+                if row is None:  # unreachable today; the price was checked above
+                    tally.priceless += 1
+                else:
+                    yield ScrapedTable(source.source_key, PRODUCT_PRICES.kind,
+                                       base, builder.header, [row],
+                                       page_token=token)
+            else:
                 tally.priceless += 1
-                continue
-            # The SAME product, in the store's other language. Fetched only when
-            # THIS page advertises one, so an Arabic-only Zid store still costs
-            # exactly one request per product and reaches none of this.
-            english, lost = self._english_node(html, node, url, source)
-            tally.english_lost += lost
-            # One table per product, journaled as fetched: accumulating the
-            # whole catalogue and yielding once at the end meant an interrupted
-            # crawl had written nothing at all.
-            builder = RowBuilder(PRODUCT_PRICES)
-            row = product_row(builder, node, url, source, vat,
-                              _product_id(url, node), english=english)
-            if row is None:  # unreachable today; the price was checked above
-                tally.priceless += 1
-                continue
-            yield ScrapedTable(source.source_key, PRODUCT_PRICES.kind, base,
-                               builder.header, [row], page_token=token)
+            if wants_enrichment:
+                # The pictures and prose the SAME page already carried, under
+                # the SAME token: one product is journaled once, so a resume
+                # cannot land its price without its details. Outside the price
+                # branch on purpose — a variant-priced product publishes no
+                # usable price and still publishes its images, and dropping
+                # those with the price is how this connector came to store no
+                # image at all.
+                extra = RowBuilder(ENRICHMENT)
+                attribute_rows = enrichment_rows(extra, node, pid)
+                if attribute_rows:
+                    yield ScrapedTable(source.source_key, ENRICHMENT.kind, base,
+                                       extra.header, attribute_rows,
+                                       page_token=token)
 
         # Every skip above used to be silent, so a crawl that landed half the
         # catalogue reported plain success — the GPP lesson, and the one salla

--- a/sources.yaml
+++ b/sources.yaml
@@ -169,12 +169,32 @@ sources:
     extract:
       - kind: product_prices
         scope: census
+      # The images the owner reported missing. The product JSON-LD this crawl
+      # already reads for the price carries `image` on every product, but
+      # ingest REFUSES an enrichment payload from a source that does not
+      # contract enrichment — so the connector's new branch alone would have
+      # changed nothing. Both links, or neither.
+      - kind: enrichment
+        scope: census
     min_expected_rows: 20
     max_drop_pct: 50
     notes: >
       403 for non-browser user agents — the source declares a Chrome user_agent
       the fetcher sends. Variant prices are in the page HTML, not JSON-LD (v1
       records the product-level JSON-LD price only).
+
+      NO IMAGES WERE STORED until 2026-07-29, and the cause was not this store:
+      168 of 168 products were crawled and 0 carried an image, because nothing
+      asked for any. The zid connector had no enrichment branch, and this
+      source contracted no enrichment extract. Both are fixed together. The
+      pictures cost no extra request — they are in the same Product JSON-LD as
+      the price. MEASURED before/after, live: 0/168 products with an image,
+      then (this connector, one crawl, after the fix) 168/168 with at least
+      one image, 435 image rows, 771 enrichment rows total. A separate
+      42-product sample found the page's own gallery markup names 124 images
+      against JSON-LD's 109 for the same products, with every JSON-LD image
+      among them — so 15 of 124 stay unread; reading the gallery too is a
+      separate call for the owner, not a silent widening of this fix.
 
       BILINGUAL + TWO COUNTRIES, established live 2026-07-28. Every page's own
       <head> publishes five alternates: ar-sa (unprefixed, x-default), en
@@ -198,6 +218,16 @@ sources:
       migration and therefore an owner decision. Note the warehouse would keep
       the two countries apart correctly if it were captured: source_offer is
       keyed on country_code_alpha2 and the price key carries region+currency.
+
+      OWNER-CONFIRMED 2026-07-30. Asked directly, with the sharper fact that
+      the store's TWO published rates (SAR 3.754116, EGP 50.5485 per USD —
+      captured 2026-07-29 by _rates_abroad) imply a ratio of 13.46 while its
+      Egyptian pages actually price at 11.768: the store does not convert its
+      own prices with its own declared rate, so an Egyptian price would be
+      neither a merchant price nor a faithful conversion of one. Decision:
+      stay Saudi-only and keep publishing the store's Egyptian RATE (already
+      shipped, source_kind='shop') rather than crawl a number that is honest
+      under neither reading. Not revisited unless the owner raises it again.
 
   # ---- probed: Shopify; products.json OPEN ----
   - source_key: ELSEWEDYSHOP

--- a/tests/test_zid.py
+++ b/tests/test_zid.py
@@ -13,7 +13,7 @@ from scrapex.connectors.base import (CrawlBlocked, DEFAULT_USER_AGENT,
 from scrapex.connectors.jsonld import alternate_links, english_alternate
 from scrapex.connectors.zid import ZidConnector
 from scrapex.ingest import ingest_payloads
-from scrapex.rowspec import PRODUCT_PRICES, RowView
+from scrapex.rowspec import ENRICHMENT, PRODUCT_PRICES, RowView
 from scrapex.vocab import ExtractKind, ExtractScope
 
 FX = Path(__file__).parent / "fixtures"
@@ -53,6 +53,14 @@ def make_entry() -> SourceEntry:
         family="zid-html", currency="SAR", default_region="SA", vat_mode="incl", user_agent=CHROME_UA,
         extract=[ExtractSpec(kind=ExtractKind.PRODUCT_PRICES, scope=ExtractScope.CENSUS)],
     ))
+
+
+def make_enriched_entry() -> SourceEntry:
+    """The source as sources.yaml now declares it: prices AND details."""
+    return make_entry().model_copy(update={"extract": [
+        ExtractSpec(kind=ExtractKind.PRODUCT_PRICES, scope=ExtractScope.CENSUS),
+        ExtractSpec(kind=ExtractKind.ENRICHMENT, scope=ExtractScope.CENSUS),
+    ]})
 
 
 def test_resolve_fetcher_uses_source_user_agent():
@@ -167,6 +175,125 @@ def test_a_zid_page_that_cannot_be_read_leaves_a_warning():
 
     assert any("no Product" in w and "1 product page(s)" in w
                for w in warnings)
+
+
+# ---- the pictures, reported missing by the owner 2026-07-29 ----------------
+#
+# Measured before the fix, against the live warehouse: ADVANCEDCASTLE held 168
+# products and 0 images. Not a display fault and not this store's doing — the
+# `image` was in the very JSON-LD the price was read from, and nothing asked
+# for it. Two links were open at once: zid had no enrichment branch, and the
+# source contracted no enrichment extract (ingest refuses an enrichment payload
+# from a source that does not declare one). Each test below holds one of them.
+
+def detail_rows(connector, entry):
+    """(rows as dicts, tokens) across every enrichment table yielded."""
+    rows, tokens = [], []
+    for table in connector.fetch(entry):
+        if str(table.kind) != "enrichment":
+            continue
+        view = RowView(ENRICHMENT, table.header)
+        rows.extend(view.as_dict(r) for r in table.rows)
+        tokens.append(table.page_token)
+    return rows, tokens
+
+
+def test_the_pictures_the_live_page_publishes_reach_the_row():
+    """The 2026-07-20 capture publishes TWO images in its Product JSON-LD and
+    the connector stored neither, because it had no enrichment branch at all."""
+    rows, tokens = detail_rows(ZidConnector(_LiveStubFetcher()),
+                               make_enriched_entry())
+
+    images = [r for r in rows if r["attribute_code"].startswith("image")]
+    assert images, "the page's own pictures must be captured"
+    # Positional, in the order the store published them — the first image is
+    # the store's own primary, so it keeps the unsuffixed code.
+    first = images[0]
+    assert first["attribute_code"] == "image"
+    assert first["value_url"].startswith("https://media.zid.store/")
+    assert first["value_url"].endswith("-thumbnail-1000x1000-70.jpeg")
+    assert any(r["attribute_code"] == "image_1" for r in images)
+    # The link is the fact; nothing was invented to sit beside it.
+    assert all(r["raw_value"] and r["value_url"] for r in images)
+    assert all(r["attribute_group"] == "Media" for r in images)
+    # Details ride the SAME checkpoint as the price off that page, so a resume
+    # can never land a price whose pictures were dropped.
+    assert all(tokens), "details with no checkpoint cannot survive a resume"
+
+
+def test_one_image_url_is_one_row_and_not_one_row_per_character():
+    """schema.org allows `image` as a bare string, and advancedcastle uses that
+    form on single-image products. Iterating it without the isinstance guard
+    yields a row per CHARACTER — 108 of them, each a one-letter 'image'."""
+    rows, _t = detail_rows(ZidConnector(_BilingualStubFetcher()),
+                           make_enriched_entry())
+
+    images = [r for r in rows if r["attribute_code"].startswith("image")]
+    assert len(images) == 1
+    assert images[0]["attribute_code"] == "image"
+    assert images[0]["value_url"].startswith("https://media.zid.store/")
+
+
+def test_a_source_that_contracts_no_enrichment_is_sent_none():
+    """The other half of the same defect, in the other direction: details must
+    not be emitted where the source did not ask for them — ingest refuses such
+    a payload outright, so emitting it would be an error, not a bonus."""
+    rows, _t = detail_rows(ZidConnector(_LiveStubFetcher()), make_entry())
+
+    assert rows == []
+
+
+def test_a_priceless_product_still_publishes_its_pictures():
+    """A variant-priced page has no usable price and still has its images. The
+    price check used to `continue` past everything below it, so the pictures
+    left with the price."""
+    node = ('{"@context":"https://schema.org","@type":"Product",'
+            '"name":"\\u062e\\u0648\\u0630\\u0629","sku":"AC-HELMET-9",'
+            '"image":"https://media.zid.store/store/helmet.jpg",'
+            '"offers":{"@type":"Offer","price":"0","priceCurrency":"SAR"}}')
+
+    class _Priceless(_StubFetcher):
+        def get(self, url, **kwargs):
+            if "/products/" in url:
+                self.requests_count += 1
+                return _Resp('<html><head><script type="application/ld+json">'
+                             + node + "</script></head><body></body></html>")
+            return super().get(url, **kwargs)
+
+    connector = ZidConnector(_Priceless())
+    entry = make_enriched_entry()
+    tables = list(connector.fetch(entry))
+
+    prices = [t for t in tables if str(t.kind) == "product_prices" and t.rows]
+    details = [t for t in tables if str(t.kind) == "enrichment"]
+    assert prices == [], "an unusable price must still never be guessed at"
+    assert details, "a product with no price still published its picture"
+    view = RowView(ENRICHMENT, details[0].header)
+    codes = {view.as_dict(r)["attribute_code"] for t in details for r in t.rows}
+    assert "image" in codes
+    # And the skip is still counted out loud, as it always was.
+    warnings = [w for t in tables for w in t.warnings]
+    assert any("no usable price" in w for w in warnings)
+
+
+def test_zid_pictures_reach_the_warehouse():
+    """End to end, because the connector alone proves nothing: ingest refuses
+    enrichment from a source that does not contract it, which is exactly the
+    second link this fix had to open."""
+    entry = make_enriched_entry()
+    tables = list(ZidConnector(_LiveStubFetcher()).fetch(entry))
+    conn: sqlite3.Connection = dbmod.connect(":memory:")
+    try:
+        dbmod.migrate(conn)
+        result = ingest_payloads(conn, entry, [t.to_payload() for t in tables])
+        stored = conn.execute(
+            "select count(*) from source_product_attribute "
+            "where attribute_code like 'image%' and value_url <> ''").fetchone()[0]
+    finally:
+        conn.close()
+
+    assert not result.errors
+    assert result.attributes and stored, "0 images was the reported defect"
 
 
 # ---- bilingual: advancedcastle serves ar AND en, 2026-07-28 ----------------


### PR DESCRIPTION
## DRAFT — for the main session's review, not for merge

Owner report: «البيانات الموجودة الخاصة بـadvancedcastle تفتقد الصور ودولة مصر» — ADVANCEDCASTLE data has no images and no Egypt. Two separate issues.

## Part 1 — images (bug, fixed)

**Measured before** (`marketlens.db`, read-only): ADVANCEDCASTLE — 168 products, **0 with an image**. Every other zid/salla-family source with an enrichment extract stores images; this one had none.

**Root cause, found by tracing the chain, not guessed:** two independent gaps, either alone sufficient to keep the count at zero.
1. `scrapex/connectors/zid.py` had **no enrichment branch at all** — `product_row` used it, `enrichment_rows` did not exist for zid.
2. `sources.yaml`'s ADVANCEDCASTLE entry declared only `product_prices`, no `enrichment` — and `ingest.py` refuses an enrichment payload from a source that doesn't contract it (`does not declare enrichment; payload refused`).

The picture is in the **same Product JSON-LD** the price is already read from (`image`, verified live), so no extra request is needed.

**Fix:**
- [jsonld.py](scrapex/connectors/jsonld.py) — `enrichment_rows` moved here from `salla.py` (salla and zid share the reading; only the product-id derivation differs, same pattern as `product_row`).
- [zid.py](scrapex/connectors/zid.py) — added the enrichment branch, gated on `wants_enrichment`, and deliberately placed **outside** the price-existence check: a variant-priced (priceless) product still publishes its pictures.
- [salla.py](scrapex/connectors/salla.py) — now imports the shared `enrichment_rows` instead of keeping its own copy.
- [sources.yaml](sources.yaml) — added `kind: enrichment` to ADVANCEDCASTLE's `extract`.

**Measured after** (this connector, one live crawl end-to-end into a scratch in-memory warehouse, same 168-product catalogue): **168/168 products land at least one image** — 435 image rows, 771 enrichment rows total (images + description + sku).

**Known, stated limit:** a 42-product live sample shows the page's own gallery markup (`#product-images img.carousel-img`) carries 124 images against JSON-LD's 109 for the same products — every JSON-LD image is among the gallery's, so nothing is wrong, but 15 images are not yet read. Documented in the connector docstring and `sources.yaml` as a separate, owner-visible enhancement — not silently folded into this fix.

**Test:** [tests/test_zid.py](tests/test_zid.py) — 5 new tests, all confirmed to fail against the pre-fix code (verified by reverting the connector changes and re-running). Covers: live-fixture image capture, the `image` string-vs-list guard (schema.org allows either; without the guard a bare string iterates per-character), the enrichment-not-contracted case, priceless-product images, and end-to-end warehouse ingestion.

## Part 2 — Egypt (owner decision, not built)

`sources.yaml`'s existing notes established the Egyptian price is a *conversion*, not a merchant price (EGP/SAR ratio constant at 11.768 across five products). Since then, the store's own published exchange rate is now captured (`zid.py::_rates_abroad`, shipped separately) — and it does NOT reconcile: SAR 3.754116 / EGP 50.5485 imply a ratio of **13.46**, not the 11.768 the Egyptian pages actually charge. So an Egyptian price would be neither a merchant price nor a faithful conversion of the store's own declared rate.

Put to the owner directly with this evidence. **Decision: stay Saudi-only, keep publishing the store's Egyptian rate** (already shipped under `source_kind='shop'`) rather than crawl a number that's honest under neither reading. No code change needed — matches shipped behavior. Recorded in `sources.yaml` under `OWNER-CONFIRMED 2026-07-30`.

## Verification

- Full suite: **1496 passed, 1 xfailed**
- `node contract/parity/parity.test.mjs`: **3/3**
- `sources.yaml` re-validated through `load_manifest` after every edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)