### PR TITLE
Activity panel: true progress with a stated denominator, and two crawls at once

### DIFF
--- a/design/components.css
+++ b/design/components.css
@@ -1184,3 +1184,175 @@ code {
   .appearance-switch span,
   .appearance-switch span::after { transition: none; }
 }
+
+/* ==========================================================================
+ * Split button — a primary action beside a menu of secondary ones.
+ *
+ * Canonical here so the dataset Export control and the Activity panel's log
+ * control are the SAME control, not two that drift. A screen adds only its own
+ * placement; everything visual and interactive is this. Behaviour: split-button.js.
+ * ======================================================================== */
+.split-button {
+  display: inline-flex;
+  align-items: stretch;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: var(--shadow-xs);
+}
+.split-button-primary,
+.split-button-trigger {
+  min-height: var(--control-height);
+  border: 0;
+  background: transparent;
+  color: var(--text);
+}
+.split-button-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  padding-inline: var(--sp-4);
+  border-start-start-radius: calc(var(--radius) - 1px);
+  border-end-start-radius: calc(var(--radius) - 1px);
+  font-weight: var(--fw-heavy);
+  cursor: pointer;
+}
+.split-button-primary .sx-icon {
+  width: 1.05rem;
+  height: 1.05rem;
+  color: var(--accent-ink);
+}
+.split-button-primary:hover:not(:disabled),
+.split-button-trigger:hover {
+  background: var(--control-hover);
+  color: var(--text);
+}
+.split-button-primary:active:not(:disabled),
+.split-button-trigger:active {
+  background: var(--accent-weak);
+  color: var(--accent-ink);
+  transform: none;
+}
+.split-button-menu {
+  position: relative;
+  display: flex;
+}
+.split-button-menu > summary { list-style: none; }
+.split-button-menu > summary::-webkit-details-marker { display: none; }
+.split-button-trigger {
+  display: grid;
+  width: var(--control-height);
+  min-width: var(--control-height);
+  padding: 0;
+  place-items: center;
+  border-inline-start: 1px solid var(--line);
+  border-start-end-radius: calc(var(--radius) - 1px);
+  border-end-end-radius: calc(var(--radius) - 1px);
+  cursor: pointer;
+}
+.split-button-trigger .sx-icon { width: 1.05rem; height: 1.05rem; }
+.split-button-chevron {
+  margin-inline-start: auto;
+  transition: transform var(--dur-fast) var(--ease);
+}
+.split-button-menu[open] .split-button-chevron { transform: rotate(180deg); }
+.split-button-menu[open] .split-button-trigger {
+  background: var(--accent-weak);
+  color: var(--accent-ink);
+}
+.split-button-options {
+  position: absolute;
+  z-index: 120;
+  inset-inline-end: 0;
+  bottom: calc(100% + var(--sp-2));
+  display: grid;
+  gap: var(--sp-1);
+  width: min(20rem, calc(100vw - 2rem));
+  padding: var(--sp-2);
+  background: var(--surface);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  transform-origin: bottom right;
+  animation: split-button-options-in var(--dur-fast) var(--ease);
+}
+/* A menu that opens DOWNWARD, for a control near the top of its scroll box. */
+.split-button-menu.opens-down .split-button-options {
+  top: calc(100% + var(--sp-2));
+  bottom: auto;
+  transform-origin: top right;
+}
+@keyframes split-button-options-in {
+  from { opacity: 0; transform: translateY(.35rem) scale(.98); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+.split-button-options-head {
+  display: grid;
+  gap: var(--sp-1);
+  padding: var(--sp-2) var(--sp-3) var(--sp-3);
+  border-bottom: 1px solid var(--line);
+}
+.split-button-options-head strong { color: var(--text); font-size: var(--fs-sm); }
+.split-button-options-head span {
+  color: var(--muted);
+  font-size: var(--fs-xs);
+  line-height: 1.4;
+}
+.split-button-option {
+  display: grid;
+  grid-template-columns: 2rem minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--sp-3);
+  width: 100%;
+  min-height: 3.5rem;
+  padding: var(--sp-2) var(--sp-3);
+  color: var(--text);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius);
+  text-align: start;
+  white-space: normal;
+  cursor: pointer;
+}
+.split-button-option:hover:not(:disabled) {
+  color: var(--text);
+  background: var(--control-hover);
+  border-color: var(--line);
+}
+.split-button-option:active:not(:disabled) {
+  color: var(--text);
+  background: var(--control-active);
+  border-color: var(--line-strong);
+  transform: none;
+}
+.split-button-option-icon {
+  display: grid;
+  place-items: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: var(--radius);
+  background: var(--accent-weak);
+  color: var(--accent-ink);
+}
+.split-button-option-icon .sx-icon { width: 1.05rem; height: 1.05rem; }
+.split-button-option-copy { display: grid; gap: var(--sp-1); min-width: 0; }
+.split-button-option-copy strong { font-size: var(--fs-sm); }
+.split-button-option-copy small {
+  color: var(--muted);
+  font-size: var(--fs-2xs);
+  font-weight: var(--fw-regular);
+  line-height: 1.35;
+}
+.split-button-option-tag {
+  padding: .15rem .35rem;
+  border-radius: var(--radius-xs);
+  background: var(--surface-container-low);
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-2xs);
+  line-height: 1.4;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .split-button-options { animation: none; }
+}

--- a/design/split-button.js
+++ b/design/split-button.js
@@ -1,0 +1,70 @@
+/* One split button, for every surface that needs one.
+ *
+ * The dataset Export control invented this pattern — a primary action beside a
+ * <details> menu of secondary ones — and the Activity panel's log control is the
+ * same shape. Rather than write it twice (the DRY the owner asked for by name),
+ * the behaviour lives here and both the web grid and the extension panel call
+ * it. It is a CLASSIC script, not a module, so it sets one global the way
+ * appearance.js does — the two surfaces cannot import from each other at runtime,
+ * so a shared file copied into both is the only reuse they can share.
+ *
+ * The markup contract (styled by .split-button in components.css):
+ *   <div class="split-button">
+ *     <button class="split-button-primary" data-split-action="PRIMARY">…</button>
+ *     <details class="split-button-menu">
+ *       <summary class="split-button-trigger" aria-haspopup="menu"
+ *                aria-expanded="false">▾</summary>
+ *       <div class="split-button-options" role="menu">
+ *         <button class="split-button-option" data-split-action="X" role="menuitem">…</button>
+ *       </div>
+ *     </details>
+ *   </div>
+ *
+ * wire(root, onAction) hands every clicked [data-split-action] to onAction and
+ * then closes the menu. The caller owns what each action DOES — download a file,
+ * copy to the clipboard — because that is the part that genuinely differs; the
+ * open/close/aria/escape/outside-click dance is the part that does not, and the
+ * part a second copy would get subtly wrong.
+ */
+(function () {
+  "use strict";
+
+  function wire(root, onAction) {
+    if (!root || root.dataset.splitWired) return;
+    root.dataset.splitWired = "1";
+    const menu = root.querySelector(".split-button-menu");
+    const trigger = menu && menu.querySelector(".split-button-trigger");
+
+    const close = () => {
+      if (!menu) return;
+      menu.open = false;
+      if (trigger) trigger.setAttribute("aria-expanded", "false");
+    };
+
+    if (menu && trigger) {
+      // The <details> is the source of truth for open/closed; aria only ever
+      // mirrors it, so a click on the summary and a programmatic close agree.
+      menu.addEventListener("toggle", () =>
+        trigger.setAttribute("aria-expanded", String(menu.open)));
+      menu.addEventListener("keydown", (event) => {
+        if (event.key !== "Escape" || !menu.open) return;
+        event.preventDefault();
+        close();
+        trigger.focus();
+      });
+      // An outside click closes it. Registered on the document, guarded to this
+      // menu, so several split buttons on one page never fight over the event.
+      document.addEventListener("click", (event) => {
+        if (menu.open && !menu.contains(event.target)) close();
+      });
+    }
+
+    root.querySelectorAll("[data-split-action]").forEach((button) =>
+      button.addEventListener("click", (event) => {
+        close();
+        if (typeof onAction === "function") onAction(button.dataset.splitAction, button, event);
+      }));
+  }
+
+  window.ScrapeXSplitButton = { wire };
+})();

--- a/extension/app.css
+++ b/extension/app.css
@@ -639,9 +639,27 @@
 
   .bar { height: .375rem; border-radius: var(--radius-pill); background: var(--chip); overflow: hidden; }
   .bar-fill { height: 100%; width: 0; background: currentColor; transition: width var(--dur-slow) ease; }
+  /* An unknown total: the count is real but the fraction is not, so the fill
+     paces across rather than sitting at a number nobody has. Honest motion, not
+     a stuck 0%. */
+  .bar-fill.indeterminate {
+    width: 40% !important;
+    background: linear-gradient(90deg, transparent, currentColor, transparent);
+    animation: bar-indeterminate 1.4s ease-in-out infinite;
+  }
+  @keyframes bar-indeterminate {
+    0% { transform: translateX(-120%); }
+    100% { transform: translateX(320%); }
+  }
+  .act-progress { margin: var(--sp-2) 0; }
+  #act-queue.note { margin: var(--sp-2) 0; padding: var(--sp-2) var(--sp-3);
+                    border-inline-start: 3px solid var(--accent); background: var(--chip);
+                    border-radius: var(--radius); line-height: 1.5; }
 
-  /* Activity log: a bounded, scrollable tail — never the whole log. */
-  .logbox { max-height: 160px; overflow-y: auto; border: 1px solid var(--line);
+  /* Activity log: a bounded, scrollable box. Every entry is present; the box
+     scrolls rather than the page, and the tail is followed only while the owner
+     is already at the bottom (no auto-scroll button to manage). */
+  .logbox { max-height: 220px; overflow-y: auto; border: 1px solid var(--line);
             border-radius: var(--radius); padding: var(--sp-2); }
   .logline { display: flex; gap: var(--sp-2); padding: 1px 0; }
   .logline .lvl { flex: none; width: 4.5em; }

--- a/extension/app.html
+++ b/extension/app.html
@@ -6,6 +6,9 @@
 <title>ScrapeX</title>
 <link rel="icon" href="icons/x-mark.svg">
 <script src="appearance.js"></script>
+<!-- The shared split-button behaviour, before app.js (a module) so its global
+     exists when the Activity panel's log control wires itself. -->
+<script src="split-button.js"></script>
 <link rel="stylesheet" href="tokens.css">
 <link rel="stylesheet" href="components.css">
 <link rel="stylesheet" href="app.css">
@@ -102,16 +105,64 @@
         <div class="row"><h2 class="flush">Activity</h2>
           <span id="act-elapsed" class="muted tech"></span></div>
         <div id="act-state" class="kv"></div>
-        <div class="bar my-2"><div id="act-bar" class="bar-fill"></div></div>
+
+        <!-- The bar is a fraction of REQUESTS against a stated denominator, not
+             of sources. act-progress-label says what it is a fraction OF; an
+             unknown total renders the bar indeterminate, never stuck at 0%. -->
+        <div class="act-progress">
+          <div class="bar my-1" role="progressbar" aria-labelledby="act-progress-label">
+            <div id="act-bar" class="bar-fill"></div>
+          </div>
+          <div id="act-progress-label" class="muted text-xs" role="status" aria-live="polite"></div>
+        </div>
+
+        <!-- Why a second run is not moving: which job holds the worker and this
+             one's place in line. Empty for the running job. -->
+        <div id="act-queue" class="note hidden text-xs"></div>
+
         <div id="act-counters"></div>
+
         <div class="row mt-2">
-          <span class="muted text-xs">Last 200 log entries</span>
-          <button id="autoscroll" class="ghost">Pause auto-scroll</button>
+          <span id="log-caption" class="muted text-xs">Live log</span>
         </div>
         <div id="logbox" class="logbox tech"></div>
         <div class="links mt-2">
-          <button id="copy-logs" class="ghost">Copy visible logs</button>
-          <button id="dl-logs" class="ghost">Download full logs</button>
+          <!-- The shared split button (components.css + split-button.js), the
+               SAME control the dataset Export uses — one implementation. The
+               primary copies what is on screen; the menu downloads everything. -->
+          <div class="split-button" role="group" aria-label="Log actions">
+            <button type="button" id="copy-logs" class="split-button-primary"
+                    data-split-action="copy" aria-label="Copy the visible log to the clipboard">
+              <svg class="sx-icon" aria-hidden="true"><use href="icons/material-icons.svg#description"></use></svg>
+              <span>Copy visible</span>
+            </button>
+            <details class="split-button-menu">
+              <summary class="split-button-trigger" aria-haspopup="menu"
+                       aria-expanded="false" aria-label="More log actions">
+                <svg class="sx-icon split-button-chevron" aria-hidden="true"><use href="icons/material-icons.svg#expand-more"></use></svg>
+              </summary>
+              <div class="split-button-options opens-down" role="menu" aria-label="Log actions">
+                <button type="button" class="split-button-option" data-split-action="copy" role="menuitem">
+                  <span class="split-button-option-icon">
+                    <svg class="sx-icon" aria-hidden="true"><use href="icons/material-icons.svg#description"></use></svg>
+                  </span>
+                  <span class="split-button-option-copy">
+                    <strong>Copy visible log</strong>
+                    <small>Every line now on screen, to the clipboard.</small>
+                  </span>
+                </button>
+                <button type="button" class="split-button-option" data-split-action="download" role="menuitem">
+                  <span class="split-button-option-icon">
+                    <svg class="sx-icon" aria-hidden="true"><use href="icons/material-icons.svg#file-download"></use></svg>
+                  </span>
+                  <span class="split-button-option-copy">
+                    <strong>Download full log</strong>
+                    <small>The engine's complete record for this job, every entry.</small>
+                  </span>
+                </button>
+              </div>
+            </details>
+          </div>
         </div>
       </section>
     </section>

--- a/extension/app.js
+++ b/extension/app.js
@@ -42,7 +42,7 @@ async function openTab(path) { chrome.tabs.create({ url: (await getBackend()) + 
 const state = {
   sources: [], selected: new Set(), filter: "", sourceFilter: "",
   editingSourceKey: null,
-  job: null, jobRef: null, autoscroll: true, logs: [], logSignature: null,
+  job: null, jobRef: null, logs: [], logSignature: null, logAtBottom: true,
   engineUp: false,
 };
 
@@ -1053,33 +1053,176 @@ async function startRun() {
 const POLL_MS = 1500;   // throttled: aggregated progress, never per-record events
 let pollTimer = null;
 
+// ---- ONE formatter each (the DRY the owner asked for) ----------------------
+// A count with thousands separators. Every number the panel shows goes through
+// here, so 1030 reads as "1,030" everywhere and never as a bare 1030 in one
+// place and grouped in another.
+function fmtCount(n) {
+  return Number(n || 0).toLocaleString();
+}
+
+// A duration in seconds as human time. Shared by elapsed AND the finish
+// estimate, so the two can never format the same span two different ways.
+function fmtDuration(secs) {
+  secs = Math.max(0, Math.round(secs));
+  if (secs < 60) return `${secs}s`;
+  const m = Math.floor(secs / 60);
+  if (m < 60) return `${m}m ${secs % 60}s`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m`;
+}
+
 function fmtElapsed(startedAt) {
   if (!startedAt) return "";
-  const secs = Math.max(0, Math.round((Date.now() - Date.parse(startedAt)) / 1000));
-  const m = Math.floor(secs / 60);
-  return m ? `${m}m ${secs % 60}s` : `${secs}s`;
+  return fmtDuration((Date.now() - Date.parse(startedAt)) / 1000);
+}
+
+// The date an estimate carries, "29 Jul" from "2026-07-29" — the same rule that
+// makes a converted price carry its rate's date. Bare YYYY-MM-DD if it cannot
+// be parsed, which is still a stated date.
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+function fmtAsOf(iso) {
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(String(iso || ""));
+  return m ? `${Number(m[3])} ${MONTHS[Number(m[2]) - 1]}` : String(iso || "");
+}
+
+// The bar and the sentence beneath it, from job.fetch — requests against a
+// stated denominator. THREE honest shapes, never a bare percentage and never a
+// bar stuck at 0%:
+//   known total   -> a real fraction, the sentence says what OF and (for an
+//                    estimate) its date
+//   unknown total -> an indeterminate bar and "total not known yet", because a
+//                    first-ever crawl genuinely cannot say
+function renderProgress(job) {
+  const f = job.fetch || {};
+  const bar = $("act-bar");
+  const label = $("act-progress-label");
+  if (f.expected) {
+    const pct = Math.min(100, Math.round((f.requests / f.expected) * 100));
+    bar.classList.remove("indeterminate");
+    bar.style.width = pct + "%";
+    // "1,030 of ~2,461 expected (est. 29 Jul)" — a declared total drops the "~"
+    // and the date because it is a count, not a guess.
+    const tilde = f.basis === "estimate" ? "~" : "";
+    const basis = f.basis === "estimate"
+      ? ` · estimate from the last crawl${f.as_of ? " (" + fmtAsOf(f.as_of) + ")" : ""}`
+      : f.basis === "declared" ? " · the site's own page count"
+      : "";
+    label.textContent =
+      `${fmtCount(f.requests)} of ${tilde}${fmtCount(f.expected)} requests (${pct}%)${basis}`;
+  } else {
+    // No denominator anywhere: the count climbs and the bar says so, rather
+    // than drawing 0% of a number nobody has.
+    bar.classList.add("indeterminate");
+    bar.style.width = "100%";
+    const unknown = (f.unknown_sources || []).length;
+    label.textContent = f.requests
+      ? `${fmtCount(f.requests)} requests so far · total not known yet` +
+        (unknown ? ` (${unknown} source${unknown > 1 ? "s" : ""} with no past crawl to estimate from)` : "")
+      : "starting…";
+  }
+}
+
+// An honest finish estimate, ONLY when the denominator that could ground it
+// exists. Derived from the same numbers the bar draws, so it can never claim a
+// precision the bar does not have.
+function finishEstimate(job) {
+  const f = job.fetch || {};
+  if (!f.expected || !job.started_at || f.requests < 2) return "";
+  const elapsed = (Date.now() - Date.parse(job.started_at)) / 1000;
+  const rate = f.requests / elapsed;               // requests per second so far
+  if (rate <= 0) return "";
+  const remaining = Math.max(0, f.expected - f.requests) / rate;
+  const about = f.basis === "estimate" ? "about " : "";
+  return `~${about}${fmtDuration(remaining)} left`;
 }
 
 function renderActivity(job) {
   const box = $("activity");
   if (!job) { box.classList.add("hidden"); return; }
   box.classList.remove("hidden");
-  $("act-elapsed").textContent = fmtElapsed(job.started_at);
+  const elapsed = fmtElapsed(job.started_at);
+  const left = finishEstimate(job);
+  $("act-elapsed").textContent = [elapsed && `elapsed ${elapsed}`, left]
+    .filter(Boolean).join(" · ");
   $("act-state").innerHTML =
     `<span>${esc(job.status.replace(/_/g, " "))}${job.stage ? " · " + esc(job.stage) : ""}</span>` +
     `<span class="content">${esc(job.current_source_key || "—")}</span>`;
-  $("act-bar").style.width = job.progress.percent + "%";
+  renderProgress(job);
+  renderQueue(job);
+  $("act-counters").innerHTML = activityCounters(job).map(([k, v, title]) =>
+    `<div class="kv"${title ? ` title="${esc(title)}"` : ""}>` +
+    `<span>${esc(k)}</span><span class="tech">${esc(v)}</span></div>`).join("");
+}
+
+// Every row states what it measures. The politeness rows (304s, pace) are the
+// owner's own asks: they are the clearest sign a recurring crawl is being cheap
+// and welcome, and they only appear when the crawl actually reported them.
+function activityCounters(job) {
   const c = job.counters || {};
+  const f = job.fetch || {};
+  const source = firstFetchingSource(job) || {};
   const rows = [
     ["Sites done", `${job.progress.done} / ${job.progress.total}`],
-    ["New data rows", c.observations || 0],
-    ["Unchanged", c.duplicates || 0],
-    ["New products", c.products || 0],
-    ["Requests", c.requests || 0],
-    ["Errors", c.errors || 0],
+    ["Requests", fmtCount(f.requests)],
+    ["New data rows", fmtCount(c.observations)],
+    ["Unchanged", fmtCount(c.duplicates)],
+    ["New products", fmtCount(c.products)],
+    ["Errors", fmtCount(c.errors)],
   ];
-  $("act-counters").innerHTML = rows.map(([k, v]) =>
-    `<div class="kv"><span>${esc(k)}</span><span class="tech">${esc(v)}</span></div>`).join("");
+  // 304 Not-Modified against the requests made: the single best sign a recurring
+  // crawl is being polite and cheap. Shown only once the source reports it.
+  if (source.not_modified) {
+    rows.push(["Unchanged pages (304)",
+               `${fmtCount(source.not_modified)} of ${fmtCount(source.requests)}`,
+               "Pages the site said had not changed since our last visit — fetched cheaply, nothing re-downloaded."]);
+  }
+  if (source.retries) {
+    rows.push(["Retries", fmtCount(source.retries),
+               "Requests we had to attempt more than once (a dropped connection, a rate-limit)."]);
+  }
+  // The pace ACTUALLY in force, and whether the site's Crawl-delay is honoured —
+  // a fast crawl and a polite one must not look the same while they happen.
+  if (source.pace_s != null && source.pace_s > 0) {
+    rows.push(["Pace", `${source.pace_s}s between requests`,
+               source.honouring_delay
+                 ? "Honouring the site's requested crawl delay."
+                 : "Crawl delay overridden for this run at your request."]);
+    const perMin = source.pace_s > 0 ? Math.round(60 / source.pace_s) : 0;
+    if (perMin) rows.push(["Rate", `~${perMin} requests/min at this pace`]);
+  }
+  return rows;
+}
+
+// The slot of whichever source is fetching right now — the source-level facts
+// (304s, pace) belong to a source, not the whole job.
+function firstFetchingSource(job) {
+  const slots = (job.fetch && job.fetch.sources) || {};
+  const current = job.current_source_key;
+  if (current && slots[current]) return slots[current];
+  return Object.values(slots).find((s) => s && s.state === "fetching") || null;
+}
+
+// Why a queued job is not moving — a fact, not a placeholder. Nothing invents a
+// finish time for the job in front; "when a slot frees" is the honest wait.
+function renderQueue(job) {
+  const box = $("act-queue");
+  const behind = job.queued_behind;
+  if (!behind || behind.starting_now) { box.classList.add("hidden"); box.textContent = ""; return; }
+  box.classList.remove("hidden");
+  const running = (behind.running || [])
+    .map((r) => r.source_keys.join(", ")).filter(Boolean);
+  const runningText = running.length
+    ? `${running.length === 1 ? "" : running.length + " jobs: "}${running.join("; ")}`
+    : "another job";
+  const ahead = behind.position - 1;
+  box.innerHTML =
+    `<strong>Queued.</strong> The engine crawls ${behind.capacity} ` +
+    `site${behind.capacity > 1 ? "s" : ""} at a time and is busy with ${esc(runningText)}. ` +
+    (ahead > 0 ? `${ahead} job${ahead > 1 ? "s" : ""} ahead of this one; it` : "This") +
+    ` starts when a slot frees. ` +
+    `<span class="muted">Raise “Sites crawled at the same time” in Settings to run more together.</span>`;
 }
 
 // The identity of a log AS DISPLAYED: level and message, in order. The
@@ -1090,7 +1233,8 @@ function logSignatureOf(entries) {
   return entries.map((e) => `${e.level}\u0000${e.message}`).join("\u0001");
 }
 
-function renderLogs(entries) {
+function renderLogs(entries, meta) {
+  const box = $("logbox");
   // Rewriting innerHTML destroys the selection inside it, and this runs on a
   // 1.5s poll — so an owner trying to copy an error message out of the log had
   // the highlight taken away from them every 1.5 seconds, whether or not a
@@ -1100,14 +1244,38 @@ function renderLogs(entries) {
   const signature = logSignatureOf(entries);
   // childElementCount guards the other direction: a view switch can empty this
   // box, and a signature that still matched would then leave it empty forever.
-  if (signature === state.logSignature && $("logbox").childElementCount) return;
+  if (signature === state.logSignature && box.childElementCount) return;
+  // Follow the tail only when the owner is ALREADY at the bottom. Auto-scroll is
+  // no longer a button he has to manage (he asked for that gone): the log simply
+  // keeps up if he is watching the newest line, and stays put the moment he
+  // scrolls up to read something, so a repaint never yanks him away mid-read.
+  const wasAtBottom = box.scrollHeight - box.scrollTop - box.clientHeight < 24;
   state.logSignature = signature;
   state.logs = entries;
-  $("logbox").innerHTML = entries.map((e) =>
+  box.innerHTML = entries.map((e) =>
     `<div class="logline"><span class="lvl muted">${esc(e.level)}</span>` +
     `<span class="content">${esc(e.message)}</span></div>`).join("") ||
     `<span class="muted">No log entries yet.</span>`;
-  if (state.autoscroll) $("logbox").scrollTop = $("logbox").scrollHeight;
+  if (wasAtBottom) box.scrollTop = box.scrollHeight;
+  // Say what is shown out of what exists — the caption that used to read
+  // "Last 200 log entries" is now the truth, whatever the count.
+  const total = meta && meta.total != null ? meta.total : entries.length;
+  $("log-caption").textContent = total
+    ? `Live log · ${fmtCount(total)} entr${total === 1 ? "y" : "ies"}, all shown`
+    : "Live log";
+}
+
+// The mini-player's own progress figure, drawn from the SAME fetch progress the
+// Activity bar uses — never the old sites-percentage that read 0% all run.
+function miniProgress(job) {
+  const f = job.fetch || {};
+  if (f.expected) {
+    const pct = Math.min(100, Math.round((f.requests / f.expected) * 100));
+    return { pct, text: `${pct}% · ${fmtCount(f.requests)}/${fmtCount(f.expected)}`,
+             indeterminate: false };
+  }
+  return { pct: 100, text: f.requests ? `${fmtCount(f.requests)} requests` : "starting…",
+           indeterminate: true };
 }
 
 function renderMiniplayer(job, queued) {
@@ -1116,12 +1284,14 @@ function renderMiniplayer(job, queued) {
   box.classList.remove("hidden");
   const scope = job.source_keys.length > 1 ? `${job.source_keys.length} sites` : job.source_keys[0];
   $("mini-title").textContent = `${scope} — ${job.status.replace(/_/g, " ")}`;
-  $("mini-pct").textContent = `${job.progress.percent}% (${job.progress.done}/${job.progress.total})`;
-  $("mini-bar").style.width = job.progress.percent + "%";
+  const prog = miniProgress(job);
+  $("mini-pct").textContent = prog.text;
+  $("mini-bar").style.width = prog.pct + "%";
+  $("mini-bar").classList.toggle("indeterminate", prog.indeterminate);
   const c = job.counters || {};
   const bits = [];
   if (job.current_source_key) bits.push(`now: ${job.current_source_key}`);
-  if (c.observations != null) bits.push(`${c.observations} new data rows`);
+  if (c.observations != null) bits.push(`${fmtCount(c.observations)} new data rows`);
   if (queued > 0) bits.push(`${queued} queued`);
   $("mini-sub").textContent = bits.join(" · ") || "starting…";
   const paused = job.status === "paused";
@@ -1141,8 +1311,13 @@ async function pollJob() {
     state.jobRef = job.job_ref;
     renderMiniplayer(job, Math.max(0, jobs.length - 1));
     renderActivity(job);
-    try { renderLogs((await api(`/api/jobs/${job.job_ref}/logs?limit=200`)).entries); }
-    catch (_) {}
+    // No ?limit: the log shows EVERY entry now (the 200 cap was the client's,
+    // and it dropped exactly the line that explained a long run's failure). The
+    // answer carries `total` so the caption can state what is shown out of what.
+    try {
+      const log = await api(`/api/jobs/${job.job_ref}/logs`);
+      renderLogs(log.entries, log);
+    } catch (_) {}
     refreshRunButton();
     pollTimer = setTimeout(pollJob, POLL_MS);
     return;
@@ -1153,7 +1328,8 @@ async function pollJob() {
     try {
       const done = await api(`/api/jobs/${state.jobRef}`);
       renderActivity(done);
-      renderLogs((await api(`/api/jobs/${state.jobRef}/logs?limit=200`)).entries);
+      const log = await api(`/api/jobs/${state.jobRef}/logs`);
+      renderLogs(log.entries, log);
     } catch (_) {}
     state.jobRef = null;
     await loadSources();
@@ -1185,9 +1361,9 @@ async function loadDatasets() {
                aria-label="Open ${esc(sourceDomain(s.base_url) || s.source_name || s.source_key)} dataset in workbook">
         <span class="dataset-card-open">${icon("chevron-right", "sm")}</span>
         <div><div class="dataset-identity-line">${sourceIdentity(
-          s, false, Number(s.observations).toLocaleString())}</div>
-          <div class="n">${Number(s.products || 0).toLocaleString()} products</div>
-          <div class="n">${esc(s.changes || "no recorded changes yet")}</div></div>
+          s, false, fmtCount(s.observations))}</div>
+          <div class="n">${fmtCount(s.products)} products</div>
+          <div class="n muted">${esc(freshnessLine(s))}</div></div>
       </article>`).join("");
     box.querySelectorAll("[data-open]").forEach((card) => {
       card.addEventListener("click", () => openDataset(card.dataset.open));
@@ -1200,6 +1376,19 @@ async function loadDatasets() {
   } catch (_) {
     box.innerHTML = `<div class="card"><span class="err">Couldn't reach the engine.</span></div>`;
   }
+}
+
+// The freshness of a dataset — the first thing anyone asks, and the fact the
+// card was missing where it used to read "no recorded changes yet". A read-out
+// from the last SUCCESSFUL crawl; "never" is a real answer, not a blank.
+function freshnessLine(s) {
+  const last = s.last_success;
+  if (!last || !last.started_at) return "no successful crawl yet";
+  const when = String(last.started_at).slice(0, 16).replace("T", " ");
+  const measure = last.rows_seen
+    ? `${fmtCount(last.rows_seen)} rows seen`
+    : last.requests_count ? `${fmtCount(last.requests_count)} requests` : "";
+  return `Last crawled ${when} UTC${measure ? " · " + measure : ""}`;
 }
 
 function openDataset(key) {
@@ -2088,14 +2277,20 @@ async function init() {
   $("run-mode").addEventListener("change", refreshMode);
   $("run").addEventListener("click", startRun);
 
-  $("autoscroll").addEventListener("click", (e) => {
-    state.autoscroll = !state.autoscroll;
-    e.target.textContent = state.autoscroll ? "Pause auto-scroll" : "Resume auto-scroll";
-  });
-  $("copy-logs").addEventListener("click", () =>
-    navigator.clipboard.writeText(state.logs.map((l) => `${l.logged_at} ${l.level} ${l.message}`).join("\n")));
-  $("dl-logs").addEventListener("click", async () =>
-    state.jobRef && openTab(`/api/jobs/${state.jobRef}/logs?limit=200`));
+  // ONE split button (the shared component the dataset Export uses), no more
+  // "Pause auto-scroll" — the primary copies what is on screen, the menu
+  // downloads the engine's complete record. Same actions from either place.
+  window.ScrapeXSplitButton.wire($("activity").querySelector(".split-button"),
+    (action) => {
+      if (action === "copy") {
+        navigator.clipboard.writeText(
+          state.logs.map((l) => `${l.logged_at || ""} ${l.level} ${l.message}`).join("\n"));
+      } else if (action === "download") {
+        // No ?limit: the download is the FULL log, every entry, which is the
+        // whole reason it is a separate action from Copy visible.
+        if (state.jobRef) openTab(`/api/jobs/${state.jobRef}/logs`);
+      }
+    });
 
   $("mini-view").addEventListener("click", () => {
     showView("run"); $("activity").scrollIntoView({ behavior: "smooth", block: "center" });

--- a/extension/components.css
+++ b/extension/components.css
@@ -1184,3 +1184,175 @@ code {
   .appearance-switch span,
   .appearance-switch span::after { transition: none; }
 }
+
+/* ==========================================================================
+ * Split button — a primary action beside a menu of secondary ones.
+ *
+ * Canonical here so the dataset Export control and the Activity panel's log
+ * control are the SAME control, not two that drift. A screen adds only its own
+ * placement; everything visual and interactive is this. Behaviour: split-button.js.
+ * ======================================================================== */
+.split-button {
+  display: inline-flex;
+  align-items: stretch;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: var(--shadow-xs);
+}
+.split-button-primary,
+.split-button-trigger {
+  min-height: var(--control-height);
+  border: 0;
+  background: transparent;
+  color: var(--text);
+}
+.split-button-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  padding-inline: var(--sp-4);
+  border-start-start-radius: calc(var(--radius) - 1px);
+  border-end-start-radius: calc(var(--radius) - 1px);
+  font-weight: var(--fw-heavy);
+  cursor: pointer;
+}
+.split-button-primary .sx-icon {
+  width: 1.05rem;
+  height: 1.05rem;
+  color: var(--accent-ink);
+}
+.split-button-primary:hover:not(:disabled),
+.split-button-trigger:hover {
+  background: var(--control-hover);
+  color: var(--text);
+}
+.split-button-primary:active:not(:disabled),
+.split-button-trigger:active {
+  background: var(--accent-weak);
+  color: var(--accent-ink);
+  transform: none;
+}
+.split-button-menu {
+  position: relative;
+  display: flex;
+}
+.split-button-menu > summary { list-style: none; }
+.split-button-menu > summary::-webkit-details-marker { display: none; }
+.split-button-trigger {
+  display: grid;
+  width: var(--control-height);
+  min-width: var(--control-height);
+  padding: 0;
+  place-items: center;
+  border-inline-start: 1px solid var(--line);
+  border-start-end-radius: calc(var(--radius) - 1px);
+  border-end-end-radius: calc(var(--radius) - 1px);
+  cursor: pointer;
+}
+.split-button-trigger .sx-icon { width: 1.05rem; height: 1.05rem; }
+.split-button-chevron {
+  margin-inline-start: auto;
+  transition: transform var(--dur-fast) var(--ease);
+}
+.split-button-menu[open] .split-button-chevron { transform: rotate(180deg); }
+.split-button-menu[open] .split-button-trigger {
+  background: var(--accent-weak);
+  color: var(--accent-ink);
+}
+.split-button-options {
+  position: absolute;
+  z-index: 120;
+  inset-inline-end: 0;
+  bottom: calc(100% + var(--sp-2));
+  display: grid;
+  gap: var(--sp-1);
+  width: min(20rem, calc(100vw - 2rem));
+  padding: var(--sp-2);
+  background: var(--surface);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  transform-origin: bottom right;
+  animation: split-button-options-in var(--dur-fast) var(--ease);
+}
+/* A menu that opens DOWNWARD, for a control near the top of its scroll box. */
+.split-button-menu.opens-down .split-button-options {
+  top: calc(100% + var(--sp-2));
+  bottom: auto;
+  transform-origin: top right;
+}
+@keyframes split-button-options-in {
+  from { opacity: 0; transform: translateY(.35rem) scale(.98); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+.split-button-options-head {
+  display: grid;
+  gap: var(--sp-1);
+  padding: var(--sp-2) var(--sp-3) var(--sp-3);
+  border-bottom: 1px solid var(--line);
+}
+.split-button-options-head strong { color: var(--text); font-size: var(--fs-sm); }
+.split-button-options-head span {
+  color: var(--muted);
+  font-size: var(--fs-xs);
+  line-height: 1.4;
+}
+.split-button-option {
+  display: grid;
+  grid-template-columns: 2rem minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--sp-3);
+  width: 100%;
+  min-height: 3.5rem;
+  padding: var(--sp-2) var(--sp-3);
+  color: var(--text);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius);
+  text-align: start;
+  white-space: normal;
+  cursor: pointer;
+}
+.split-button-option:hover:not(:disabled) {
+  color: var(--text);
+  background: var(--control-hover);
+  border-color: var(--line);
+}
+.split-button-option:active:not(:disabled) {
+  color: var(--text);
+  background: var(--control-active);
+  border-color: var(--line-strong);
+  transform: none;
+}
+.split-button-option-icon {
+  display: grid;
+  place-items: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: var(--radius);
+  background: var(--accent-weak);
+  color: var(--accent-ink);
+}
+.split-button-option-icon .sx-icon { width: 1.05rem; height: 1.05rem; }
+.split-button-option-copy { display: grid; gap: var(--sp-1); min-width: 0; }
+.split-button-option-copy strong { font-size: var(--fs-sm); }
+.split-button-option-copy small {
+  color: var(--muted);
+  font-size: var(--fs-2xs);
+  font-weight: var(--fw-regular);
+  line-height: 1.35;
+}
+.split-button-option-tag {
+  padding: .15rem .35rem;
+  border-radius: var(--radius-xs);
+  background: var(--surface-container-low);
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-2xs);
+  line-height: 1.4;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .split-button-options { animation: none; }
+}

--- a/extension/split-button.js
+++ b/extension/split-button.js
@@ -1,0 +1,70 @@
+/* One split button, for every surface that needs one.
+ *
+ * The dataset Export control invented this pattern — a primary action beside a
+ * <details> menu of secondary ones — and the Activity panel's log control is the
+ * same shape. Rather than write it twice (the DRY the owner asked for by name),
+ * the behaviour lives here and both the web grid and the extension panel call
+ * it. It is a CLASSIC script, not a module, so it sets one global the way
+ * appearance.js does — the two surfaces cannot import from each other at runtime,
+ * so a shared file copied into both is the only reuse they can share.
+ *
+ * The markup contract (styled by .split-button in components.css):
+ *   <div class="split-button">
+ *     <button class="split-button-primary" data-split-action="PRIMARY">…</button>
+ *     <details class="split-button-menu">
+ *       <summary class="split-button-trigger" aria-haspopup="menu"
+ *                aria-expanded="false">▾</summary>
+ *       <div class="split-button-options" role="menu">
+ *         <button class="split-button-option" data-split-action="X" role="menuitem">…</button>
+ *       </div>
+ *     </details>
+ *   </div>
+ *
+ * wire(root, onAction) hands every clicked [data-split-action] to onAction and
+ * then closes the menu. The caller owns what each action DOES — download a file,
+ * copy to the clipboard — because that is the part that genuinely differs; the
+ * open/close/aria/escape/outside-click dance is the part that does not, and the
+ * part a second copy would get subtly wrong.
+ */
+(function () {
+  "use strict";
+
+  function wire(root, onAction) {
+    if (!root || root.dataset.splitWired) return;
+    root.dataset.splitWired = "1";
+    const menu = root.querySelector(".split-button-menu");
+    const trigger = menu && menu.querySelector(".split-button-trigger");
+
+    const close = () => {
+      if (!menu) return;
+      menu.open = false;
+      if (trigger) trigger.setAttribute("aria-expanded", "false");
+    };
+
+    if (menu && trigger) {
+      // The <details> is the source of truth for open/closed; aria only ever
+      // mirrors it, so a click on the summary and a programmatic close agree.
+      menu.addEventListener("toggle", () =>
+        trigger.setAttribute("aria-expanded", String(menu.open)));
+      menu.addEventListener("keydown", (event) => {
+        if (event.key !== "Escape" || !menu.open) return;
+        event.preventDefault();
+        close();
+        trigger.focus();
+      });
+      // An outside click closes it. Registered on the document, guarded to this
+      // menu, so several split buttons on one page never fight over the event.
+      document.addEventListener("click", (event) => {
+        if (menu.open && !menu.contains(event.target)) close();
+      });
+    }
+
+    root.querySelectorAll("[data-split-action]").forEach((button) =>
+      button.addEventListener("click", (event) => {
+        close();
+        if (typeof onAction === "function") onAction(button.dataset.splitAction, button, event);
+      }));
+  }
+
+  window.ScrapeXSplitButton = { wire };
+})();

--- a/scrapex/capture.py
+++ b/scrapex/capture.py
@@ -97,16 +97,55 @@ def crawl_settings(conn: sqlite3.Connection) -> dict:
     }
 
 
-def _job_progress(conn: sqlite3.Connection, job_id: int,
-                  source_key: str) -> Callable[[int, str], None]:
+def _job_progress(conn: sqlite3.Connection, job_id: int, source_key: str,
+                  fetcher=None) -> Callable[[int, str], None]:
     """A per-request heartbeat for the job row, throttled to stay negligible.
 
-    Every 10 requests the heartbeat and the live request counter move — the
-    panel's Requests figure ticks and a watchdog can tell life from a hang.
-    Every 50, one log line states plainly what is happening. The counter is
-    provisional (this source's count so far); the authoritative total is merged
-    per source by the job loop as before.
+    Every 10 requests the heartbeat and this source's live slot move — the
+    panel's progress figure ticks and a watchdog can tell life from a hang.
+    Every 50, one log line states plainly what is happening.
+
+    `fetcher` is read, never written: it is already counting everything worth
+    showing (304s, retries, the pace actually in force, the frontier a connector
+    declared), and reading it here is what puts those facts on the panel without
+    a second accounting of any of them. Omitted, the tick still records the
+    count — every existing caller and test keeps working.
     """
+    def measurements(count: int) -> dict:
+        live: dict = {"requests": count, "state": "fetching"}
+        if fetcher is None:
+            return live
+        # A connector that enumerated its frontier outranks the estimate seeded
+        # from the last successful run: it counted, the estimate guessed.
+        expected = getattr(fetcher, "expected_requests", None)
+        if expected:
+            live["expected"] = int(expected)
+            live["basis"] = "declared"
+            live["as_of"] = None
+        # 304s are the single best sign a recurring crawl is being cheap and
+        # polite, and retries the best early sign a site is pushing back.
+        live["not_modified"] = int(getattr(fetcher, "not_modified_count", 0) or 0)
+        live["retries"] = int(getattr(fetcher, "retry_count", 0) or 0)
+        # The pace IN FORCE, which is not the setting: robots.txt can raise it
+        # (see HttpFetcher._robots_for), and whether that was honoured is the
+        # owner's own per-run choice. A run that was fast because the site asked
+        # for nothing and one that was fast because we overrode a 10s delay must
+        # not look identical while it happens.
+        live["pace_s"] = float(getattr(fetcher, "_min_interval_s", 0.0) or 0.0)
+        live["honouring_delay"] = bool(getattr(fetcher, "_honour_crawl_delay", True))
+        return live
+
+    def publish(count: int, *, force: bool = False) -> None:
+        from .jobs import record_source_fetch
+
+        record_source_fetch(conn, job_id, source_key, **measurements(count))
+        if not force and count and count % 50 == 0:
+            # Local import: jobs.py imports this module at its top.
+            from .jobs import append_log
+            append_log(conn, job_id, f"fetching — {count} requests so far",
+                       source_key=source_key)
+        conn.commit()
+
     def tick(count: int, url: str) -> None:
         if count % 10:
             return
@@ -119,17 +158,14 @@ def _job_progress(conn: sqlite3.Connection, job_id: int,
         if control and control[0] in ("cancel", "pause"):
             from .connectors.base import CrawlInterrupted
             raise CrawlInterrupted(control[0])
-        conn.execute(
-            "UPDATE crawl_job SET last_heartbeat_at = strftime('%Y-%m-%dT%H:%M:%SZ','now'), "
-            "counters_json = json_set(COALESCE(NULLIF(counters_json,''),'{}'), "
-            "'$.requests', ?) WHERE job_id = ?",
-            (count, job_id))
-        if count % 50 == 0:
-            # Local import: jobs.py imports this module at its top.
-            from .jobs import append_log
-            append_log(conn, job_id, f"fetching — {count} requests so far",
-                       source_key=source_key)
-        conn.commit()
+        publish(count)
+
+    # A declaration arrives once, normally while the count is still in single
+    # figures, so it must not wait for the tenth-request tick — otherwise every
+    # crawl that DOES know its total would show "unknown" for its first ten
+    # pages, which is the complaint this is here to answer.
+    tick.on_expectation = lambda _total: publish(
+        getattr(fetcher, "requests_count", 0) or 0, force=True)
     return tick
 
 
@@ -212,7 +248,12 @@ def capture_source(conn: sqlite3.Connection, entry: SourceEntry,
         # start-time heartbeat for a quarter hour — indistinguishable from a
         # hang. The fetch holds no lock (see above), so these tiny job-row
         # writes are exactly the kind the lock design set out to keep flowing.
-        fetcher.on_request = _job_progress(conn, job_id, entry.source_key)
+        tick = _job_progress(conn, job_id, entry.source_key, fetcher)
+        fetcher.on_request = tick
+        # The other half of the same display: the moment a connector knows how
+        # many pages it will fetch, the panel's bar gains a real denominator.
+        if hasattr(fetcher, "on_expectation"):
+            fetcher.on_expectation = tick.on_expectation
     tables: list = []
     try:
         for t in connector.fetch(entry):            # network only — no DB involved
@@ -279,8 +320,15 @@ def capture_source(conn: sqlite3.Connection, entry: SourceEntry,
         # per page. Read from `tables` and not from the journal, because a defect
         # describes what THIS attempt produced.
         defects = list(dict.fromkeys(d for t in tables for d in t.defects))
+        # What the fetch actually cost, recorded ON THE RUN. crawl_run has had a
+        # requests_count column since the schema was written and nothing ever
+        # wrote it, so every run in the warehouse reads 0 — which is why the
+        # panel had no measured expectation to show a bar against. From here a
+        # successful run leaves the next crawl of this source a real number, and
+        # it sharpens by itself every time.
         result = ingest_payloads(conn, entry, payloads, job_id=job_id,
-                                 fetch_defects=defects)
+                                 fetch_defects=defects,
+                                 requests_count=requests_count)
         # ERRORS, not notices: rows a journaled page was holding did not land,
         # so the run genuinely IS partial (the taxonomy on IngestResult). Any
         # softer channel would let a resume that dropped 871 pages close as a

--- a/scrapex/connectors/base.py
+++ b/scrapex/connectors/base.py
@@ -135,6 +135,29 @@ class CrawlInterrupted(CrawlBlocked):
         self.control = control
 
 
+def declare_frontier(fetcher, pages: int) -> None:
+    """"I now know I will fetch `pages` more pages" — for any fetcher, or none.
+
+    THE ONE GUARD, so no connector grows its own. A connector is handed whatever
+    fetcher its caller built, and the connector tests build minimal fakes with
+    just the methods under test: reaching straight for `expect_requests` turned a
+    progress-display improvement into an AttributeError that failed real crawls
+    of magento and salla. A display fact must never be able to do that.
+
+    The fetcher, when it can hear this, uses it to give the Activity panel a
+    denominator that is a count rather than a guess (HttpFetcher.expect_requests).
+    A fetcher that cannot falls back to the panel's dated estimate, which is a
+    worse number and an honest one.
+    """
+    declare = getattr(fetcher, "expect_requests", None)
+    if declare is None:
+        return
+    try:
+        declare(pages)
+    except Exception:  # noqa: BLE001 — a progress figure may never break a crawl
+        pass
+
+
 class HttpFetcher:
     """Shared polite HTTP transport (F5): rate-limited, retrying, one UA.
 
@@ -215,6 +238,17 @@ class HttpFetcher:
         self.requests_count = 0   # recorded into crawl_run (F5 accounting)
         self.not_modified_count = 0
         self.retry_count = 0
+        # How many requests this crawl expects to make IN TOTAL, once something
+        # actually knows. None until then, and None is the honest answer: a
+        # sitemap-driven connector learns its frontier before it fetches a
+        # single product page, while a connector that discovers pages as it
+        # walks genuinely cannot know, and must not be made to guess.
+        #
+        # It lives here because this object is already the one counting
+        # requests: an expectation in a different unit from the count it is
+        # compared against is how a progress bar starts lying. See
+        # expect_requests below for the one arithmetic rule.
+        self.expected_requests: int | None = None
         # Optional live-progress hook, called after EVERY completed request with
         # (requests_count, url). A 450-page country crawl used to be a quarter
         # hour of total silence — 0/1 sources, zero requests, a start-time
@@ -222,6 +256,51 @@ class HttpFetcher:
         # The display's failure must never become the crawl's: the call site
         # guards the hook.
         self.on_request = None
+        # Called once with the new total whenever expect_requests raises it, so
+        # a denominator reaches the panel the moment it is known instead of at
+        # the next throttled request tick.
+        self.on_expectation = None
+
+    # ---- what this crawl expects to cost ------------------------------------
+
+    def expect_requests(self, pages: int) -> None:      # noqa: D401 — see declare_frontier
+        """A connector declaring "I now know I will fetch `pages` more pages".
+
+        Counted FROM THE REQUESTS ALREADY MADE, because that is the only way the
+        expectation stays in the same unit as the counter it will be compared
+        with: reading a sitemap index costs real requests before the frontier is
+        known, and an expectation that ignored them would be short by exactly
+        those pages and the bar would arrive at 100% early.
+
+        The declaration only ever goes UP. A connector that enumerates a second
+        frontier (a second sitemap, a second category tree) is adding to what it
+        will fetch, not replacing it — and a bar that shrank mid-crawl would be
+        the same lie in the other direction.
+
+        The number remains an EXPECTATION and every screen that shows it says
+        so: a retry, a 404 or a variant page can still make the real count
+        differ. It is not a budget and nothing here enforces it.
+        """
+        try:
+            more = int(pages)
+        except (TypeError, ValueError):
+            return                      # a display input never breaks a crawl
+        if more < 0:
+            return
+        declared = self.requests_count + more
+        if self.expected_requests is None or declared > self.expected_requests:
+            self.expected_requests = declared
+            if self.on_expectation is not None:
+                # Published NOW rather than at the next request tick. That tick
+                # is throttled to every tenth request to keep the writes free,
+                # but a frontier is normally known while the count is still in
+                # single figures — so waiting for it would leave every crawl
+                # that DOES know its total showing "unknown" for its first ten
+                # pages, which is the exact complaint being fixed.
+                try:
+                    self.on_expectation(declared)
+                except Exception:  # noqa: BLE001 — progress display only
+                    pass
 
     # ---- validators, so a repeat crawl can be answered with 304 -------------
 

--- a/scrapex/connectors/gpp.py
+++ b/scrapex/connectors/gpp.py
@@ -209,7 +209,17 @@ class GlobalPetrolPricesConnector:
         A 400-page crawl used to materialise as one giant table at the end —
         correct, but all-or-nothing: a pause at page 399 threw away every
         fetched page. Yielding per page lets capture journal each one as it
-        arrives; the tokens are the checkpoint."""
+        arrives; the tokens are the checkpoint.
+
+        NO expect_requests here either, and for a different reason from zid's.
+        This frontier is discovered IN PIECES: the number of materials is known
+        up front, but each material's country pages only exist once that
+        material's list page has been read (parse_country_links below). A total
+        declared material by material would rise all through the crawl, and a
+        bar whose denominator grows is one that runs backwards — 60% becoming
+        30% because the crawl found more work is less use than no bar at all.
+        The panel's estimate from the last successful run covers this source,
+        which is a recurring crawl of a stable page set and estimates well."""
         builder = RowBuilder(COMMODITY_PRICE)
         base = source.base_url.rstrip("/")
         currency = source.currency or "USD"

--- a/scrapex/connectors/magento.py
+++ b/scrapex/connectors/magento.py
@@ -39,7 +39,7 @@ from ..normalize import (option_axes_json, option_fingerprint, selling_unit_from
 from ..rowspec import ENRICHMENT, PRODUCT_PRICES, RowBuilder
 from ..vocab import (Availability, DetailGroup, DisplayMethod, ExtractKind,
                      group_for_code)
-from .base import CrawlBlocked, HttpFetcher, ScrapedTable
+from .base import CrawlBlocked, HttpFetcher, ScrapedTable, declare_frontier
 
 PAGE_SIZE = 100
 
@@ -543,6 +543,14 @@ class MagentoGraphqlConnector:
                 page_token=token,
             )
             total_pages = ((products.get("page_info") or {}).get("total_pages")) or page
+            # The store has just told us how many listing pages there are, so
+            # from here the crawl's size is known rather than guessed. Declared
+            # every page (expect_requests only ever raises the number) because
+            # total_pages can grow under us on a live catalogue, and minus the
+            # pages a resume already holds, which cost no request.
+            declare_frontier(self._fetcher,
+                             len([p for p in range(page + 1, int(total_pages) + 1)
+                                  if f"page-{p}" not in self.skip_tokens]))
             if page >= total_pages:
                 break
             page += 1

--- a/scrapex/connectors/salla.py
+++ b/scrapex/connectors/salla.py
@@ -23,7 +23,7 @@ from ..config import SourceEntry
 # enrichment extract would have died on NameError after the whole crawl.
 from ..rowspec import ENRICHMENT, PRODUCT_PRICES, RowBuilder
 from ..vocab import ExtractKind
-from .base import HttpFetcher, ScrapedTable
+from .base import HttpFetcher, ScrapedTable, declare_frontier
 # Shared SSR helpers (also re-exported for salla's tests). offer_price/parse are
 # generic; the /p{id} id scheme below is the salla-specific part. enrichment_rows
 # moved to jsonld when zid needed the same pictures-and-prose reading — it is
@@ -136,8 +136,23 @@ class SallaConnector:
 
     def _product_urls(self, sitemap_url: str, tally: WalkTally) -> list[str]:
         """Salla's two rules: /p{id} marks a product, and one URL per product id
-        (the sitemap lists every product once per locale). The walking is shared."""
-        return sitemap_products(
+        (the sitemap lists every product once per locale). The walking is shared.
+
+        THE FRONTIER IS KNOWN HERE, before a single product page is fetched, and
+        this connector spends exactly one request per URL in it — the enrichment
+        rows come off the same page it already fetched for the price. So the
+        total is not an estimate for this family: it is a count, and declaring it
+        is what lets the panel show a fraction of something real instead of a
+        percentage of the number of sources.
+        """
+        urls = sitemap_products(
             self._fetcher, sitemap_url, lambda url: bool(_PRODUCT_ID.search(url)),
             dedupe=one_url_per_product,
             unreadable_children=tally.unreadable_children)
+        # Minus the pages a paused run already journaled: a resume will not
+        # re-fetch those, so counting them would leave the bar permanently short
+        # of its own total by exactly the number of pages the resume saved.
+        declare_frontier(
+            self._fetcher,
+            len([url for url in urls if safe_token(url) not in self.skip_tokens]))
+        return urls

--- a/scrapex/connectors/zid.py
+++ b/scrapex/connectors/zid.py
@@ -308,7 +308,21 @@ class ZidConnector:
         return rates, notes
 
     def _product_urls(self, sitemap_url: str, tally: WalkTally) -> list[str]:
-        """Zid's rule for what a product URL is; the walking is shared."""
+        """Zid's rule for what a product URL is; the walking is shared.
+
+        NO expect_requests HERE, deliberately, and salla's identical-looking
+        method does declare one. The frontier is equally known; the COST of it
+        is not. A zid product page may advertise an English alternate, and
+        _english_node then spends a second request on it — per product, decided
+        by that product's own head. A bilingual store costs up to twice this
+        list and an Arabic-only one costs exactly it, and nothing here can tell
+        which until the pages arrive.
+
+        Declaring the list anyway would put a denominator on screen that the
+        numerator sails past halfway through every bilingual crawl. The panel's
+        estimate — this source's last successful run, which DID pay for those
+        English pages — is the better number, and it says it is an estimate.
+        """
         return sitemap_products(
             self._fetcher, sitemap_url, lambda url: _PRODUCT_PATH in url,
             unreadable_children=tally.unreadable_children)

--- a/scrapex/db.py
+++ b/scrapex/db.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import os
 import re
 import sqlite3
+import threading
 import time
 from contextlib import contextmanager
 from pathlib import Path
@@ -323,6 +324,45 @@ def _reclaim_if_stale(lock_path: Path) -> bool:
         return False
 
 
+# One gate per database file, for the writers INSIDE this process.
+#
+# THE FILE LOCK CANNOT SERIALISE US FROM OURSELVES. It is keyed by pid, and
+# _reclaim_if_stale deliberately refuses to steal a lock whose owner is alive —
+# so when a second THREAD of this same runtime arrives, it finds a live owner
+# that is us, waits out the whole timeout, and is then told "another scrapex
+# process (pid 43572) is writing to the database", naming its own pid.
+#
+# Measured 2026-07-30, two threads of one process on one database: the second
+# raised DbLockedError after its full budget. That is not serialisation, it is
+# refusal — and it is reachable today, because crawl_parallel_sources > 1 runs
+# per-host lanes as threads of this process (jobs.py _drive_lanes) and every
+# lane ingests under this lock. Two lanes whose ingests overlap by more than
+# the timeout lose a source outright, with a message that blames a process
+# that does not exist.
+#
+# A real lock in front of the file lock fixes it: threads of this runtime QUEUE
+# here, and whichever one holds this gate is the only one that ever races the
+# file against other processes. The caller's timeout still bounds the wait, so
+# an HTTP route that must answer keeps answering (409) rather than hanging.
+_GATES: dict[str, threading.Lock] = {}
+_GATES_GUARD = threading.Lock()
+
+
+def _process_gate(lock_path: Path) -> threading.Lock:
+    """The in-process gate for a lock file, created once per path.
+
+    Keyed on the LOCK FILE, normalised the way the filesystem compares it, so
+    two spellings of one database cannot end up with two gates and fall back to
+    racing the file.
+    """
+    key = os.path.normcase(os.path.abspath(str(lock_path)))
+    with _GATES_GUARD:
+        gate = _GATES.get(key)
+        if gate is None:
+            gate = _GATES[key] = threading.Lock()
+    return gate
+
+
 @contextmanager
 def write_lock(db_path: Path | str = DEFAULT_DB_PATH, timeout_s: float = 10.0):
     """CLI-level lock file: two `scrapex` write commands never interleave (A10).
@@ -330,31 +370,45 @@ def write_lock(db_path: Path | str = DEFAULT_DB_PATH, timeout_s: float = 10.0):
     O_CREAT|O_EXCL is atomic on Windows and POSIX. A lock left behind by a
     CRASHED process is reclaimed automatically once its pid is confirmed gone;
     only a genuinely live holder makes us wait.
+
+    Threads of THIS process queue on an in-process gate first (see _GATES): the
+    file lock can only tell processes apart, and asking it to tell our own
+    threads apart made it refuse them instead.
     """
     lock_path = Path(str(db_path) + ".lock")
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     deadline = time.monotonic() + timeout_s
-    while True:
-        try:
-            fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-            break
-        except FileExistsError:
-            if _reclaim_if_stale(lock_path):
-                continue                       # dead owner: retry immediately
-            if time.monotonic() >= deadline:
-                owner, _ = _lock_owner(
-                    lock_path.read_text(encoding="ascii", errors="replace"))
-                raise DbLockedError(
-                    f"another scrapex process (pid {owner}) is writing to the database; "
-                    "wait for its crawl to finish and retry"
-                ) from None
-            time.sleep(0.2)
+    gate = _process_gate(lock_path)
+    if not gate.acquire(timeout=max(0.0, timeout_s)):
+        raise DbLockedError(
+            "another crawl in this runtime is writing to the database; it has "
+            f"held the write lock for more than {timeout_s:g}s. Wait for it to "
+            "finish and retry — nothing was written."
+        )
     try:
-        os.write(fd, f"{os.getpid()}:{_process_started_at(os.getpid())}".encode("ascii"))
-        os.close(fd)
-        yield
-    finally:
+        while True:
+            try:
+                fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+                break
+            except FileExistsError:
+                if _reclaim_if_stale(lock_path):
+                    continue                       # dead owner: retry immediately
+                if time.monotonic() >= deadline:
+                    owner, _ = _lock_owner(
+                        lock_path.read_text(encoding="ascii", errors="replace"))
+                    raise DbLockedError(
+                        f"another scrapex process (pid {owner}) is writing to the database; "
+                        "wait for its crawl to finish and retry"
+                    ) from None
+                time.sleep(0.2)
         try:
-            lock_path.unlink()
-        except FileNotFoundError:  # already cleaned up — not an error path worth failing
-            pass
+            os.write(fd, f"{os.getpid()}:{_process_started_at(os.getpid())}".encode("ascii"))
+            os.close(fd)
+            yield
+        finally:
+            try:
+                lock_path.unlink()
+            except FileNotFoundError:  # already cleaned up — not an error path worth failing
+                pass
+    finally:
+        gate.release()

--- a/scrapex/ingest.py
+++ b/scrapex/ingest.py
@@ -129,6 +129,41 @@ def previous_rows_seen(conn: sqlite3.Connection, source_key: str) -> int | None:
     return int(row[0]) if row is not None else None
 
 
+def last_successful_run(conn: sqlite3.Connection, source_key: str) -> dict | None:
+    """The last run of this source that SUCCEEDED, and what it measured.
+
+    Two very different screens need exactly this row and neither may grow its
+    own copy of the query: the Activity panel takes `requests_count` as the
+    denominator its progress bar states, and the Data page shows when the data
+    on screen was last actually gathered. One reader, so the two can never
+    disagree about which run was the last good one.
+
+    'Succeeded' means status='success' — never 'partial', because a run that
+    lost half a catalogue is not a measurement of the catalogue, and using it
+    as an expectation would quietly halve the bar's denominator.
+
+    None means it has never succeeded (or never ran). That is a real answer and
+    both callers must say so rather than substituting a zero: a bar against 0 is
+    the 0% the owner has been staring at, and "last crawled: never" is the fact
+    the Data page is missing.
+    """
+    row = conn.execute(
+        "SELECT r.started_at, r.finished_at, r.rows_seen, r.requests_count, "
+        "       r.products_discovered, r.errors_count "
+        "FROM crawl_run r JOIN source_site s ON s.source_id = r.source_id "
+        "WHERE s.source_key = ? AND r.status = 'success' "
+        "ORDER BY r.run_id DESC LIMIT 1",
+        (source_key,),
+    ).fetchone()
+    if row is None:
+        return None
+    return {"started_at": row[0], "finished_at": row[1], "rows_seen": int(row[2] or 0),
+            # 0 means "this run predates requests_count ever being written"
+            # (see ingest_payloads) — an absence, not a measurement of zero.
+            "requests_count": int(row[3] or 0),
+            "products_discovered": int(row[4] or 0), "errors_count": int(row[5] or 0)}
+
+
 # ---- tiny DRY upsert helpers -------------------------------------------------
 
 def _find_id(conn: sqlite3.Connection, sql: str, params: tuple) -> int | None:
@@ -768,12 +803,22 @@ def _observation_values(r: dict, observed_at: str) -> dict:
 
 def ingest_payloads(conn: sqlite3.Connection, entry: SourceEntry,
                     payloads: list[FunnelPayload], job_id: int | None = None,
-                    fetch_defects: Sequence[str] = ()) -> IngestResult:
+                    fetch_defects: Sequence[str] = (),
+                    requests_count: int = 0) -> IngestResult:
     """Ingest one source's payloads into harvest.db in a single transaction.
 
     All-or-nothing at the DB level (F1): the crawl_run and every row commit
     together, or nothing does. Per-row *data* problems are isolated into
-    result.errors and do not abort the batch (Q3)."""
+    result.errors and do not abort the batch (Q3).
+
+    `requests_count` is how many HTTP requests the fetch spent. crawl_run has
+    carried a column for it since the schema was written, annotated "F5
+    politeness accounting" (schema.sql:381) — and NOTHING has ever written it,
+    so every run in the warehouse reads 0. A caller that does not know the
+    number (the local-inbox path ingests files, having made no requests) leaves
+    it alone and gets the same 0 as before. The job path does know, and once it
+    records it, the next crawl of that source has a measured expectation to
+    show a progress bar against instead of a percentage of nothing."""
     from .contract import assert_writable
     assert_writable(conn)  # two-engine guardrail: never write across contract versions
     source_id = _get_source_id(conn, entry, _first_currency(payloads))
@@ -865,10 +910,10 @@ def ingest_payloads(conn: sqlite3.Connection, entry: SourceEntry,
     conn.execute(
         "UPDATE crawl_run SET finished_at = strftime('%Y-%m-%dT%H:%M:%SZ','now'), "
         "status = ?, products_discovered = ?, variants_discovered = ?, errors_count = ?, "
-        "rows_seen = ? WHERE run_id = ?",
+        "rows_seen = ?, requests_count = ? WHERE run_id = ?",
         (result.status.value, result.products, result.variants,
          len(result.errors) + len(result.contained),
-         sum(len(p.rows) for p in payloads), run_id),
+         sum(len(p.rows) for p in payloads), int(requests_count), run_id),
     )
     return result
 

--- a/scrapex/jobs.py
+++ b/scrapex/jobs.py
@@ -15,12 +15,14 @@ capture step injected. JobRunner is a thin thread loop on top of it.
 from __future__ import annotations
 
 import json
+import re
 import sqlite3
 import sys
 import threading
 import traceback
 import uuid
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Callable, Iterable
@@ -143,14 +145,167 @@ def append_log(conn: sqlite3.Connection, job_id: int, message: str,
     )
 
 
-def job_logs(conn: sqlite3.Connection, job_ref: str, limit: int = 200) -> list[dict]:
-    """Newest-last tail of the job log (spec 25: the panel only ever tails)."""
-    rows = conn.execute(
-        "SELECT l.* FROM job_log_entry l JOIN crawl_job j ON j.job_id = l.job_id "
-        "WHERE j.job_ref = ? ORDER BY l.job_log_id DESC LIMIT ?",
-        (job_ref, limit),
-    ).fetchall()
-    return [dict(r) for r in reversed(rows)]
+def job_logs(conn: sqlite3.Connection, job_ref: str,
+             limit: int | None = None) -> list[dict]:
+    """The job's log, oldest first. `limit` keeps only the newest that many.
+
+    None means EVERY entry, and that is now the default. A tail was the wrong
+    shape for the one job the log exists for: reading why a run went wrong.
+    Capped at 200 (here and again in the route), the line that explained a
+    failure was thrown away by the display for any run long enough to need it —
+    and the panel's own heading called the 200 it was given "the last 200",
+    which reads as a complete list.
+    """
+    sql = ("SELECT l.* FROM job_log_entry l JOIN crawl_job j ON j.job_id = l.job_id "
+           "WHERE j.job_ref = ? ORDER BY l.job_log_id DESC")
+    params: tuple = (job_ref,)
+    if limit is not None:
+        sql += " LIMIT ?"
+        params += (limit,)
+    return [dict(r) for r in reversed(conn.execute(sql, params).fetchall())]
+
+
+def job_log_count(conn: sqlite3.Connection, job_ref: str) -> int:
+    """How many entries this job's log actually holds.
+
+    So a display can state what it is showing OUT OF what exists. A viewer that
+    cannot say that is a viewer that cannot be trusted not to be hiding
+    something — which is precisely what it was doing.
+    """
+    row = conn.execute(
+        "SELECT COUNT(*) FROM job_log_entry l JOIN crawl_job j ON j.job_id = l.job_id "
+        "WHERE j.job_ref = ?", (job_ref,)).fetchone()
+    return int(row[0]) if row is not None else 0
+
+
+# ---- what each source is fetching, and what it is a fraction OF --------------
+#
+# THE BAR WAS ANSWERING A QUESTION NOBODY ASKED (2026-07-30).
+#
+# progress_total is the number of SOURCES, so a one-source job reads 0/1 — 0% —
+# for its entire duration. Measured: an ELBUROJ run sat at "0% (0/1)" for
+# 18m23s while its Requests counter climbed past 1,030 and everything was fine.
+# Nothing was broken; the fraction was of the wrong thing.
+#
+# So each source gets a slot under counters_json.$.sources, carrying the count
+# and — the whole point — WHAT THE COUNT IS A FRACTION OF, plus where that
+# denominator came from. Three bases, in descending order of what they claim:
+#
+#   declared  a connector enumerated its frontier before fetching it, so this
+#             is a count and not a guess (salla's sitemap, magento's
+#             total_pages). Replaces an estimate the moment it arrives.
+#   estimate  this source's last SUCCESSFUL run spent this many requests. Dated,
+#             and shown as an estimate, because it is one. It improves by itself
+#             every crawl, which is exactly what was asked for.
+#   measured  the source has finished. Its expectation is now its actual count,
+#             because history is not a prediction.
+#
+# A source with none of the three has `expected: null`, and every screen must
+# say the total is not known rather than draw a bar at 0% — that bar is the
+# original complaint, and an honest indeterminate one is better than a precise
+# lie. A first-ever crawl of a site with no sitemap is genuinely this case.
+#
+# It lives in counters_json rather than a new column or table because it is a
+# counter on the job, migration 0056 is the last one applied, and none of this
+# is worth a schema change. _merge_counters never touches this key.
+SOURCES_KEY = "sources"
+
+# What may appear in a json path fragment. Deliberately narrower than anything
+# SQLite would accept: see _slot_path.
+_SOURCE_KEY_SAFE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,63}$")
+
+
+def _slot_path(source_key: str) -> str:
+    """The json path for one source's slot.
+
+    Interpolated, not bound: SQLite takes the json PATH as a literal and a bound
+    parameter cannot be a path fragment. Safe because source_key is validated
+    against ^[A-Z][A-Z0-9_]{2,63}$ before anything reaches the warehouse
+    (config.py:21) — no quote, dot or bracket can occur in one. Asserted rather
+    than assumed, because the day that regex loosens this becomes injection.
+    """
+    if not _SOURCE_KEY_SAFE.match(source_key or ""):
+        raise ValueError(f"unsafe source_key for a json path: {source_key!r}")
+    return f"$.{SOURCES_KEY}.{source_key}"
+
+
+def record_source_fetch(conn: sqlite3.Connection, job_id: int, source_key: str,
+                        **fields) -> None:
+    """Merge `fields` into one source's slot, and beat the job's heartbeat.
+
+    The WRITE is a json_set that touches ONLY this source's subtree
+    ($.sources.<key>), so two per-host lanes updating DIFFERENT sources from
+    their own connections cannot clobber each other however they interleave —
+    SQLite applies each json_set to the column's current value. The Python read
+    just above is only to carry this source's own prior fields forward (keep
+    `expected` when updating `requests`), and it is safe because a source is
+    written by exactly one lane: it lives in one host-lane, whose sources run
+    strictly in order, and the fetch tick and the boundary update for it are
+    sequential on that lane.
+
+    Called from the fetch tick (live, every tenth request) and from the job loop
+    at each source boundary. Both go through here so the slot has exactly one
+    writer's worth of rules.
+    """
+    if not fields:
+        return
+    row = conn.execute("SELECT counters_json FROM crawl_job WHERE job_id = ?",
+                       (job_id,)).fetchone()
+    if row is None:
+        return
+    current = json.loads(row[0] or "{}") if row[0] else {}
+    slot = dict(((current.get(SOURCES_KEY) or {}).get(source_key) or {}))
+    slot.update({k: v for k, v in fields.items()})
+    conn.execute(
+        "UPDATE crawl_job SET last_heartbeat_at = strftime('%Y-%m-%dT%H:%M:%SZ','now'), "
+        f"counters_json = json_set(COALESCE(NULLIF(counters_json,''),'{{}}'), "
+        f"'{_slot_path(source_key)}', json(?)) WHERE job_id = ?",
+        (json.dumps(slot, ensure_ascii=False), job_id))
+
+
+def _merge_counters_column(conn: sqlite3.Connection, job_id: int,
+                           counters: dict) -> None:
+    """Write the aggregate counters WITHOUT erasing the per-source slots.
+
+    The slots live in the same JSON column, written by a different statement
+    (and, with per-host lanes, by a different thread on a different connection).
+    A plain `counters_json = ?` here would take the whole column with an
+    in-memory dict that has never held them — so every source's denominator
+    would vanish at the first source boundary, and the bar would go back to
+    being a fraction of nothing exactly when it started to matter.
+
+    json_patch is RFC-7386 merge semantics: the named keys are replaced, keys it
+    says nothing about (`sources`) are left alone.
+    """
+    conn.execute(
+        "UPDATE crawl_job SET counters_json = "
+        "json_patch(COALESCE(NULLIF(counters_json,''),'{}'), ?) WHERE job_id = ?",
+        (json.dumps(counters, ensure_ascii=False), job_id))
+
+
+def _seed_source_expectations(conn: sqlite3.Connection, job_id: int,
+                             source_keys: Iterable[str]) -> None:
+    """Give every source a denominator BEFORE it starts, where one exists.
+
+    Seeded up front rather than when each source begins, because a job's bar is
+    a fraction of the whole job: with three sources, a denominator that only
+    covered the one currently fetching would read 100% while two sites had not
+    been touched.
+    """
+    from .ingest import last_successful_run
+
+    for source_key in source_keys:
+        previous = last_successful_run(conn, source_key)
+        spent = (previous or {}).get("requests_count") or 0
+        record_source_fetch(
+            conn, job_id, source_key, state="waiting", requests=0,
+            # A previous SUCCESS that spent 0 requests means that run predates
+            # requests_count ever being recorded (ingest.py wrote the column for
+            # the first time on 2026-07-30) — an absence, so it must not become
+            # a denominator of zero.
+            expected=spent or None,
+            basis="estimate" if spent else None,
+            as_of=((previous or {}).get("started_at") or "")[:10] if spent else None)
 
 
 def _as_job(row: sqlite3.Row) -> dict:
@@ -190,6 +345,110 @@ def _merge_counters(counters: dict, result: CaptureResult) -> dict:
 # failure modes (open handles, contended write lock) keep growing. Eight is
 # generous for a manifest of ten sources on ten hosts.
 MAX_PARALLEL_SOURCES = 8
+
+# The same ceiling for whole JOBS. The owner's scheduled crawls are one job per
+# source (scheduler.fire_due), so ten sites firing daily is ten single-source
+# jobs — and within-job lane concurrency does nothing for a job that has one
+# lane. Running the JOBS concurrently is what actually crawls those ten sites at
+# once; this bounds how many at a time, and the per-host reservation below keeps
+# it polite.
+MAX_PARALLEL_JOBS = 8
+
+
+def job_capacity(conn: sqlite3.Connection) -> int:
+    """How many jobs the engine will run at once — the owner's site budget, capped.
+
+    ONE definition, read by the worker that enforces it AND by the API that
+    explains the queue, so the panel can never promise a concurrency the worker
+    will not deliver. At 1 (the shipped default) the engine runs exactly one job
+    at a time and the panel says so.
+    """
+    try:
+        from . import settings
+        width = int(settings.get(conn, "crawl_parallel_sources") or 1)
+    except (ValueError, TypeError, sqlite3.DatabaseError):
+        return 1
+    return max(1, min(width, MAX_PARALLEL_JOBS))
+
+
+# ---- admission: the two rules that make concurrent JOBS safe ----------------
+
+def _host_of(manifest, key: str, fallback: str) -> str:
+    """The politeness identity of a source: its host, www-stripped, lowercased.
+
+    ONE definition, used to bucket lanes AND to reserve a host across jobs — so
+    a source cannot be filed under one host name for grouping and a different
+    one for reservation, which is the crack two jobs would slip through to crawl
+    a site together. A key the manifest cannot resolve gets `fallback`, and the
+    caller passes a value unique to that source so two unknowns never collide.
+    """
+    try:
+        host = urlsplit(manifest.get(key).base_url).netloc.lower()
+    except Exception:  # noqa: BLE001 — resolved, and reported, per source
+        return fallback
+    return host.removeprefix("www.") or fallback
+
+
+class _CrawlAdmission:
+    """The rules that let several JOBS crawl at once without a site feeling it.
+
+    Held by the worker and shared — the SAME object — by every concurrent job.
+    That sharing is the whole point: a rule that lived inside one job could only
+    ever govern that job's own lanes, and the risk here is precisely the one
+    that spans jobs. A lane handed no admission (the sequential default, every
+    test, the CLI) admits itself and the code path is exactly as it was.
+
+    per-host reservation
+        Two lanes on one host serialise, whichever JOB each belongs to. This is
+        the rule `_host_lanes` already enforces inside a job — that two sources
+        of one site never run together — lifted to span jobs, so a scheduled
+        crawl and a hand-started one of the same site cannot double the load it
+        asked to be spared. This is the safety property the task calls the whole
+        risk, and the test `two jobs never crawl one host together` pins it.
+
+    budget
+        At most N sites crawl at once across the ENTIRE engine, N being the
+        owner's existing "Sites crawled at the same time" setting. Without it, J
+        concurrent jobs of W lanes each would open J×W sessions at once and the
+        setting would bound nothing.
+    """
+
+    def __init__(self, budget: int | None) -> None:
+        self._budget = threading.Semaphore(budget) if budget and budget > 0 else None
+        self._hosts: dict[str, threading.Lock] = {}
+        self._guard = threading.Lock()
+
+    def _host_lock(self, host: str) -> threading.Lock:
+        with self._guard:
+            lock = self._hosts.get(host)
+            if lock is None:
+                lock = self._hosts[host] = threading.Lock()
+            return lock
+
+    @contextmanager
+    def lane(self, host: str):
+        """Admit one lane to crawl `host`: reserve the host, then take a slot.
+
+        HOST FIRST, THEN SLOT — one global acquisition order, so the wait graph
+        has no cycle and cannot deadlock. Holding an (almost always uncontended,
+        since the owner's hosts are distinct) host reservation while waiting for
+        a slot is harmless; the reverse would let a lane that cannot run yet sit
+        on a scarce slot and starve one that can.
+
+        The reservation and the slot both span the lane's whole run — a host
+        with several sources is one site being crawled, and holds one of each
+        for the duration of its sequential sources.
+        """
+        host_lock = self._host_lock(host) if host else nullcontext()
+        with host_lock:
+            if self._budget is None:
+                yield
+                return
+            self._budget.acquire()
+            try:
+                yield
+            finally:
+                self._budget.release()
 
 
 # ---- lanes: concurrency that a site can never feel --------------------------
@@ -238,11 +497,7 @@ def _host_lanes(manifest, source_keys: list[str]) -> list[list[str]]:
     """
     lanes: dict[str, list[str]] = {}
     for index, key in enumerate(source_keys):
-        try:
-            host = urlsplit(manifest.get(key).base_url).netloc.lower()
-        except Exception:  # noqa: BLE001 — resolved, and reported, per source
-            host = f"?{index}"
-        lanes.setdefault(host.removeprefix("www.") or f"?{index}", []).append(key)
+        lanes.setdefault(_host_of(manifest, key, f"?{index}"), []).append(key)
     return list(lanes.values())
 
 
@@ -266,32 +521,51 @@ def _parallel_width(conn: sqlite3.Connection, connect, lanes: int) -> int:
     return max(1, min(width, lanes, MAX_PARALLEL_SOURCES))
 
 
-def _drive_lanes(run: _SourceRun, lanes: list[list[str]], width: int, connect) -> None:
-    """Run each lane to completion; lanes concurrently when asked."""
+def _drive_lanes(run: _SourceRun, lanes: list[list[str]], width: int, connect,
+                 admission: "_CrawlAdmission | None" = None) -> None:
+    """Run each lane to completion; lanes concurrently when asked.
+
+    `admission` (when present) is the cross-job gate every lane passes through —
+    it is threaded down here rather than consulted per source, because a lane is
+    already one host's worth of work and the reservation is a fact about the
+    host, not the source. width<=1 is NOT a shortcut past it: a single-lane job
+    still competes with OTHER jobs for the same host and the same budget, so it
+    is admitted the same way, just without an executor of its own.
+    """
     if width <= 1:
         for lane in lanes:
-            _run_lane(run, lane, None)
+            _run_lane(run, lane, None, admission)
         return
     with ThreadPoolExecutor(max_workers=width,
                             thread_name_prefix="scrapex-lane") as pool:
-        futures = [pool.submit(_run_lane, run, lane, connect) for lane in lanes]
+        futures = [pool.submit(_run_lane, run, lane, connect, admission)
+                   for lane in lanes]
         for future in futures:
             future.result()      # a lane that raised must not vanish silently
 
 
-def _run_lane(run: _SourceRun, lane: list[str], connect) -> None:
-    """One host's sources, strictly in order, on a connection of this lane's own."""
-    conn = connect() if connect is not None else run.conn
-    try:
-        for source_key in lane:
-            with run.lock:
-                if run.stopped is not None:
-                    return          # another lane already hit the brakes
-            if not _run_source(run, conn, source_key):
-                return
-    finally:
-        if connect is not None:
-            conn.close()
+def _run_lane(run: _SourceRun, lane: list[str], connect,
+              admission: "_CrawlAdmission | None" = None) -> None:
+    """One host's sources, strictly in order, on a connection of this lane's own.
+
+    The admission is acquired around the WHOLE lane, held across its sequential
+    sources: they are all the same site, and reserving it once is what stops
+    another job's lane touching that site until this one is done with it.
+    """
+    host = _host_of(run.manifest, lane[0], lane[0]) if lane else ""
+    admit = admission.lane(host) if admission is not None else nullcontext()
+    with admit:
+        conn = connect() if connect is not None else run.conn
+        try:
+            for source_key in lane:
+                with run.lock:
+                    if run.stopped is not None:
+                        return          # another lane already hit the brakes
+                if not _run_source(run, conn, source_key):
+                    return
+        finally:
+            if connect is not None:
+                conn.close()
 
 
 def _run_source(run: _SourceRun, conn: sqlite3.Connection, source_key: str) -> bool:
@@ -320,7 +594,9 @@ def _run_source(run: _SourceRun, conn: sqlite3.Connection, source_key: str) -> b
 
     _update(conn, run.job_id, status=JobStatus.RUNNING.value, stage=JobStage.FETCHING.value,
             current_source_key=source_key, last_heartbeat_at=utc_now_iso())
+    record_source_fetch(conn, run.job_id, source_key, state="fetching")
     conn.commit()
+    spent: int | None = None      # requests this source cost, once it is known
     try:
         entry = run.manifest.get(source_key)
         previous = previous_rows_seen(conn, source_key)
@@ -341,6 +617,7 @@ def _run_source(run: _SourceRun, conn: sqlite3.Connection, source_key: str) -> b
             extras["resume"] = True
         result = (run.capture(conn, entry, run.job_id, **extras) if extras
                   else run.capture(conn, entry, run.job_id))
+        spent = int(result.requests_count)
         _merge_counters(run.counters, result)
         append_log(conn, run.job_id,
                    f"{result.ingest.observations} observations, "
@@ -445,10 +722,21 @@ def _run_source(run: _SourceRun, conn: sqlite3.Connection, source_key: str) -> b
         append_log(conn, run.job_id, f"failed: {exc}", level=LogLevel.ERROR, source_key=source_key)
 
     run.done.append(source_key)
+    # This source is history now, so its expectation becomes its actual count:
+    # a finished source contributes a MEASUREMENT to the job's denominator, and
+    # leaving a guess in there would keep the job's total wrong for the rest of
+    # the run. `requests` is left as the final figure for display; the job-wide
+    # numerator stops counting this slot and reads the merged total instead
+    # (see _job_view), so nothing is double-counted.
+    record_source_fetch(conn, run.job_id, source_key, state="done",
+                        **({"requests": int(spent), "expected": int(spent),
+                            "basis": "measured", "as_of": None}
+                           if spent is not None else {}))
     _update(conn, run.job_id, progress_done=len(run.done),
             checkpoint_json=json.dumps({"completed_source_keys": run.done,
                                         "errors": run.errors, "succeeded": run.succeeded}),
-            counters_json=json.dumps(run.counters), last_heartbeat_at=utc_now_iso())
+            last_heartbeat_at=utc_now_iso())
+    _merge_counters_column(conn, run.job_id, run.counters)
     conn.commit()
     return True
 
@@ -458,7 +746,8 @@ def _run_source(run: _SourceRun, conn: sqlite3.Connection, source_key: str) -> b
 def run_job_once(conn: sqlite3.Connection, job_ref: str, manifest,
                  capture: Callable[[sqlite3.Connection, object], CaptureResult] = capture_source,
                  backup: Callable[[], object] | None = None,
-                 connect: Callable[[], sqlite3.Connection] | None = None) -> dict:
+                 connect: Callable[[], sqlite3.Connection] | None = None,
+                 admission: "_CrawlAdmission | None" = None) -> dict:
     """Execute one job to completion, or until a pause/cancel boundary.
 
     `connect` opens a database connection of the caller's choosing. It is the
@@ -467,6 +756,12 @@ def run_job_once(conn: sqlite3.Connection, job_ref: str, manifest,
     across threads, and an in-memory database could not be reopened anyway.
     Omit it (every test does) and the job runs one source at a time exactly as
     it always has, whatever crawl_parallel_sources says.
+
+    `admission` is the CROSS-JOB gate: when the worker runs several jobs at
+    once, it hands every one the SAME admission, and that shared object is what
+    keeps two jobs off one host and bounds the total sites in flight. Omit it
+    and the job answers to no one but itself — which is every caller that runs a
+    job alone.
 
     Still the testable seam, and still synchronous from the caller's side: it
     returns when the job has reached a boundary, threads or no threads.
@@ -483,6 +778,11 @@ def run_job_once(conn: sqlite3.Connection, job_ref: str, manifest,
     checkpoint = job["checkpoint"]
     done: list[str] = list(checkpoint.get("completed_source_keys", []))
     counters: dict = job["counters"]
+    # The per-source slots are NOT aggregate counters and must not ride in this
+    # dict: they are written per source, from per-lane connections, straight into
+    # the column. Carried here they would be re-written stale at every boundary
+    # by whichever lane finished last.
+    counters.pop(SOURCES_KEY, None)
     # Failures must survive a pause the same way counters do — rehydrating them
     # from the checkpoint is what stops a resumed job that already lost a source
     # from reporting a clean COMPLETED.
@@ -530,7 +830,15 @@ def run_job_once(conn: sqlite3.Connection, job_ref: str, manifest,
     # entries share a host, concurrency would double the load we put on it and
     # halve the delay it asked for. Sources are bucketed into per-host LANES;
     # lanes run concurrently, and within a lane strictly in order.
-    lanes = _host_lanes(manifest, [k for k in job["source_keys"] if k not in done])
+    pending = [k for k in job["source_keys"] if k not in done]
+    # Every pending source gets whatever denominator exists BEFORE it starts, so
+    # the bar has something true to be a fraction of from the first second
+    # rather than after the first source finishes. Sources that have never
+    # succeeded get `expected: null`, which the panel reads as "the total is not
+    # known yet" — not as zero.
+    _seed_source_expectations(conn, job_id, pending)
+    conn.commit()
+    lanes = _host_lanes(manifest, pending)
     width = _parallel_width(conn, connect, len(lanes))
     run = _SourceRun(conn=conn, job=job, job_id=job_id, manifest=manifest,
                      capture=capture, rebuilding=rebuilding, checkpoint=checkpoint,
@@ -540,7 +848,7 @@ def run_job_once(conn: sqlite3.Connection, job_ref: str, manifest,
         append_log(conn, job_id,
                    f"crawling {len(lanes)} site(s), up to {width} at a time")
         conn.commit()
-    _drive_lanes(run, lanes, width, connect)
+    _drive_lanes(run, lanes, width, connect, admission)
     done, errors, counters = run.done, run.errors, run.counters
     succeeded = run.succeeded
     if run.stopped is not None:
@@ -768,10 +1076,20 @@ def _finish(conn: sqlite3.Connection, job_id: int, status: JobStatus, error_summ
 # ---- the background worker ---------------------------------------------------
 
 class JobRunner:
-    """One worker thread draining queued jobs. Owns the only long-running writes.
+    """One poll loop that dispatches queued jobs, running several at once.
 
-    Deliberately single-threaded: it keeps the single-writer topology (A10) and
-    makes 'one crawl at a time' the default the OS never has to fight over.
+    The LOOP is single-threaded and owns scheduling, the heartbeat and the rate
+    refresh. Each JOB runs on its own thread with its own connection, up to the
+    owner's "Sites crawled at the same time" setting — so ten single-source
+    schedules firing together crawl ten sites at once instead of nine waiting on
+    one. The single-WRITER invariant (A10) is unchanged: it was never the single
+    thread that guaranteed it — the process-wide write lock did, and it now
+    serialises those job threads' ingests the same way it always serialised the
+    crawl against the HTTP process. Two jobs never touch one site together
+    because every lane passes the shared _CrawlAdmission's per-host reservation.
+
+    At budget 1 (the shipped default) this is exactly one job at a time, byte
+    for byte the old behaviour; raising the setting is what turns it on.
     """
 
     def __init__(self, db_path, manifest_provider: Callable[[], object],
@@ -789,6 +1107,11 @@ class JobRunner:
         self._stop = threading.Event()
         self._reopen = threading.Event()   # a restore needs our file handle gone
         self._thread: threading.Thread | None = None
+        # job_ref -> its running thread. The loop launches into this and reaps
+        # from it; the SAME admission below is shared by every job in it, which
+        # is the only way its per-host rule can span jobs rather than one.
+        self._running: dict[str, threading.Thread] = {}
+        self._admission: _CrawlAdmission | None = None
 
     def start(self) -> None:
         if self._thread is not None:
@@ -926,7 +1249,6 @@ class JobRunner:
         try:
             reclaim_orphaned_jobs(conn)     # a previous runtime may have died mid-run
             while not self._stop.wait(self._poll_interval_s):
-                job_ref = None
                 try:
                     if conn is None:
                         # A previous pass released the handle and could not get
@@ -935,14 +1257,21 @@ class JobRunner:
                         # unplugged drive) is usually over by the next poll.
                         conn = dbmod.connect(self._db_path)
                         reclaim_orphaned_jobs(conn)
-                    try:
-                        conn = self._follow_the_warehouse(conn)
-                    except BaseException:
-                        # The old handle is closed and the new one never opened.
-                        # Holding the dead object is what turned a passing fault
-                        # into a permanently silent worker, so let it go.
-                        conn = None
-                        raise
+                    self._reap_finished()
+                    # A database move or a restore renames the live file, which
+                    # cannot happen under a live crawl handle — so the reopen
+                    # waits until every job thread has let its connection go.
+                    # This is the same boundary the single-job worker used
+                    # ("between jobs"); with several jobs it is "between waves".
+                    if not self._running:
+                        try:
+                            conn = self._follow_the_warehouse(conn)
+                        except BaseException:
+                            # The old handle is closed and the new one never
+                            # opened. Holding the dead object is what turned a
+                            # passing fault into a permanently silent worker.
+                            conn = None
+                            raise
                     touch_runtime_heartbeat(conn)   # proof of life for enqueue-only clients
                     # Reaching here IS the recovery: the loop is running and
                     # the warehouse is writable. Clearing later would leave an
@@ -954,23 +1283,15 @@ class JobRunner:
                     # alarms cannot be relied on to wake anything.
                     fire_due(conn, manifest=self._manifest_provider())
                     self._refresh_rates(conn)
-                    job_ref = self._next_queued(conn)
-                    if job_ref is None:
-                        continue
-                    run_job_once(conn, job_ref, self._manifest_provider(),
-                                 capture=self._capture or self._locked_capture,
-                                 backup=lambda: backup_database(self._db_path),
-                                 # Only the worker knows a real path to reopen,
-                                 # so only the worker can offer concurrency.
-                                 connect=lambda: dbmod.connect(self._db_path))
-                except Exception as exc:  # noqa: BLE001 — survive any one job...
-                    # ...but NEVER silently. Swallowing this used to leave the job
+                    self._dispatch(conn)
+                except Exception as exc:  # noqa: BLE001 — survive any one pass...
+                    # ...but NEVER silently. Swallowing this used to leave a job
                     # 'running' forever (blocking its source's schedules) or spin
                     # the loop on it at poll speed with nothing written anywhere.
+                    # A job that blew up records and parks ITSELF (see _start_job);
+                    # this handler is for the loop's own scheduling work.
                     traceback.print_exc(file=sys.stderr)
                     self._record_failure(conn, exc)
-                    if job_ref is not None and conn is not None:
-                        self._fail_orphan(conn, job_ref, exc)
         except BaseException as exc:  # noqa: BLE001
             # The loop itself is gone — the connect, the orphan reclaim, or
             # anything the inner handler could not hold. This is the case
@@ -985,6 +1306,92 @@ class JobRunner:
         finally:
             if conn is not None:
                 conn.close()
+
+    # ---- concurrent job dispatch --------------------------------------------
+
+    def _reap_finished(self) -> None:
+        """Drop the threads of jobs that have returned. Cheap; every poll.
+
+        A finished job thread has already recorded its own outcome and closed
+        its own connection (see _start_job); reaping is only bookkeeping, so the
+        wave can shrink and let the next queued job in.
+        """
+        for job_ref, thread in list(self._running.items()):
+            if not thread.is_alive():
+                thread.join()
+                del self._running[job_ref]
+
+    def _next_startable(self, conn: sqlite3.Connection) -> str | None:
+        """The lowest-id queued job that is not already in flight.
+
+        Membership in `_running` — not a status flip — is what stops the same
+        job being picked twice in the window before its thread sets 'preparing'.
+        That keeps run_job_once the single place a job's status changes, so its
+        careful "control is not cleared here" invariant is never second-guessed
+        from the loop.
+        """
+        running = set(self._running)
+        for row in conn.execute(
+                "SELECT job_ref FROM crawl_job WHERE status = ? ORDER BY job_id",
+                (JobStatus.QUEUED.value,)):
+            if row[0] not in running:
+                return row[0]
+        return None
+
+    def _dispatch(self, conn: sqlite3.Connection) -> None:
+        """Fill the wave up to the budget with queued jobs.
+
+        A reopen pending means a rename is waiting on our handles, so nothing new
+        starts until the wave drains — see the loop. The admission is created
+        once per wave and reused while any job runs, because a NEW admission per
+        job would give each its own host locks and the cross-job rule would
+        govern nothing. Its budget is re-read only when the wave is empty, so a
+        setting change takes effect between waves rather than mid-crawl.
+        """
+        if str(self._path_provider()) != str(self._db_path) or self._reopen.is_set():
+            return
+        capacity = job_capacity(conn)
+        if not self._running or self._admission is None:
+            self._admission = _CrawlAdmission(capacity)
+        while len(self._running) < capacity:
+            job_ref = self._next_startable(conn)
+            if job_ref is None:
+                return
+            self._start_job(job_ref, self._admission)
+
+    def _start_job(self, job_ref: str, admission: _CrawlAdmission) -> None:
+        """Run one job on its own thread, with its own connection.
+
+        A job thread cannot borrow the loop's connection (sqlite3 forbids one
+        across threads), so it opens and closes its own. It records and parks
+        ITSELF on failure — the loop's handler cannot, because the loop no longer
+        waits on the job. Registered in `_running` BEFORE it starts so the very
+        next poll cannot re-pick it.
+        """
+        def run() -> None:
+            conn = None
+            try:
+                conn = dbmod.connect(str(self._db_path))
+                run_job_once(conn, job_ref, self._manifest_provider(),
+                             capture=self._capture or self._locked_capture,
+                             backup=lambda: backup_database(self._db_path),
+                             # Only the worker knows a real path to reopen, so
+                             # only the worker can offer concurrency.
+                             connect=lambda: dbmod.connect(str(self._db_path)),
+                             admission=admission)
+            except Exception as exc:  # noqa: BLE001 — one job never takes the loop with it
+                traceback.print_exc(file=sys.stderr)
+                self._record_failure(conn, exc)
+                if conn is not None:
+                    self._fail_orphan(conn, job_ref, exc)
+            finally:
+                if conn is not None:
+                    conn.close()
+
+        thread = threading.Thread(target=run, name=f"scrapex-job-{job_ref}",
+                                  daemon=True)
+        self._running[job_ref] = thread
+        thread.start()
 
     def _record_failure(self, conn: sqlite3.Connection | None, exc: BaseException) -> None:
         """Write the failure even when the worker no longer holds a connection.

--- a/scrapex/reports.py
+++ b/scrapex/reports.py
@@ -34,6 +34,12 @@ class SourceSummary:
     curation: dict[str, int] = field(default_factory=dict)
     last_run: str | None = None
     last_status: str | None = None
+    # The last run that actually SUCCEEDED, and what it measured — the freshness
+    # of the data on screen, which is the first thing anyone asks and the one
+    # fact the source cards were missing. None means it has never succeeded, a
+    # real answer the card must state rather than paper over. Shape is
+    # ingest.last_successful_run's dict.
+    last_success: dict | None = None
     # unified layer (post-curation)
     matched_variants: int = 0
     published_rows: int = 0
@@ -71,6 +77,11 @@ def source_summary(conn: sqlite3.Connection, source_key: str) -> SourceSummary |
         "ORDER BY started_at DESC LIMIT 1", (source_id,)).fetchone()
     if run is not None:
         s.last_run, s.last_status = run[0], run[1]
+    # The last SUCCESS, which is a different question from the last run: a source
+    # whose most recent crawl failed still has data, and its freshness is the
+    # date of the last good one. The ONE reader both this page and the panel use.
+    from .ingest import last_successful_run
+    s.last_success = last_successful_run(conn, source_key)
 
     s.matched_variants = _scalar(conn,
         "SELECT COUNT(*) FROM source_variant_match svm "

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -37,8 +37,8 @@ from ..databases import (
     DatabaseKindError, DatabaseMigrationError, DatabaseRegistry,
     DatabaseUnavailableError, GeneralDatabase, MarketLensDatabase,
 )
-from ..jobs import (JobRunner, create_job, get_job, job_logs, list_jobs,
-                    set_control, worker_health)
+from ..jobs import (JobRunner, create_job, get_job, job_log_count, job_logs,
+                    list_jobs, set_control, worker_health)
 from ..fields import (
     delete_view, ensure_fields, list_fields, list_views, promotable_attributes,
     reorder, reset_view, save_view, set_display_name, set_promotion,
@@ -959,9 +959,13 @@ def create_app(
         try:
             jobs = list_jobs(conn, limit=50)
             job_ref = job_ref or (jobs[0]["job_ref"] if jobs else None)
+            # Every entry, same as the panel and the API: this page's whole job
+            # is reading why a run went wrong, and the line that says so is
+            # exactly the one a tail drops.
             return _page(request, "logs.html", "logs", None,
                          jobs=[_job_view(j) for j in jobs], job_ref=job_ref,
-                         entries=job_logs(conn, job_ref) if job_ref else [])
+                         entries=job_logs(conn, job_ref) if job_ref else [],
+                         entry_total=job_log_count(conn, job_ref) if job_ref else 0)
         finally:
             conn.close()
 
@@ -1170,6 +1174,11 @@ def create_app(
                 "fold_variants": entry.fold_variants,
                 "observations": s.observations if s else 0,
                 "products": s.products if s else 0,
+                # When the data on screen was last actually gathered, and by what
+                # measure — the freshness fact the cards were missing. None where
+                # a source has never had a successful crawl, which the card says
+                # in words rather than showing a blank or a zero.
+                "last_success": s.last_success if s else None,
                 # An interrupted crawl's pages, still on disk. A resume skips
                 # exactly these; a fresh run deletes them (capture.py).
                 "kept_pages": kept["pages"],
@@ -2358,20 +2367,25 @@ def create_app(
         conn = read_conn()
         try:
             jobs = list_jobs(conn, limit=limit, active_only=active_only)
+            # A queued job needs to say WHY it is queued, and that answer is not
+            # in its own row: it is in the row of the job holding the worker.
+            # Computed here, where the whole list is in hand.
+            queue = _queue_state(conn)
         finally:
             conn.close()
-        return {"jobs": [_job_view(j) for j in jobs]}
+        return {"jobs": [_job_view(j, queue) for j in jobs], "queue": queue}
 
     @app.get("/api/jobs/{job_ref}")
     def api_get_job(job_ref: str):
         conn = read_conn()
         try:
             job = get_job(conn, job_ref)
+            queue = _queue_state(conn) if job is not None else None
         finally:
             conn.close()
         if job is None:
             raise HTTPException(status_code=404, detail=f"unknown job {job_ref!r}")
-        return _job_view(job)
+        return _job_view(job, queue)
 
     @app.post("/api/jobs/{job_ref}/control")
     def api_control_job(job_ref: str, body: dict):
@@ -2394,15 +2408,31 @@ def create_app(
         return _job_view(job)
 
     @app.get("/api/jobs/{job_ref}/logs")
-    def api_job_logs(job_ref: str, limit: int = 200):
+    def api_job_logs(job_ref: str, limit: int | None = None):
+        """Every entry by default.
+
+        THE CAP WAS IN TWO PLACES and removing either alone changes nothing.
+        The panel asked for `?limit=200` (app.js) and this route then clamped
+        whatever it was given to 200 as well — so a run whose 400th log line
+        explains the failure had that line silently discarded twice over, under
+        a heading that read "Last 200 log entries" as though 200 were all there
+        were.
+
+        `total` travels with the entries so the panel can state what it is
+        showing out of what exists, and an explicit `limit` still works for a
+        caller that genuinely wants a tail.
+        """
         conn = read_conn()
         try:
             if get_job(conn, job_ref) is None:
                 raise HTTPException(status_code=404, detail=f"unknown job {job_ref!r}")
-            entries = job_logs(conn, job_ref, limit=min(max(limit, 1), 200))
+            entries = job_logs(conn, job_ref,
+                               limit=None if limit is None else max(int(limit), 1))
+            total = job_log_count(conn, job_ref)
         finally:
             conn.close()
-        return {"job_ref": job_ref, "entries": entries}
+        return {"job_ref": job_ref, "entries": entries, "total": total,
+                "truncated": len(entries) < total}
 
     @app.post("/api/capture")
     def api_capture(body: dict):
@@ -2443,7 +2473,133 @@ def _is_implemented(entry) -> bool:
     return entry.family in _BUILDERS
 
 
-def _job_view(job: dict) -> dict:
+# Which basis wins when a job's denominator is assembled from several sources.
+# A total that mixes a measurement with an estimate IS an estimate — the weakest
+# contributor names the whole, because claiming otherwise is how an undated guess
+# gets displayed as a fact.
+_BASIS_RANK = {"measured": 0, "declared": 1, "estimate": 2}
+
+
+def _fetch_progress(job: dict) -> dict:
+    """Requests fetched, what that is a fraction OF, and where the total came from.
+
+    THE ONE PLACE this is computed. The panel's bar, its counters and the web
+    Jobs page all read this, so they cannot drift into disagreeing about how far
+    along a crawl is — and there is exactly one definition of the numerator to
+    get wrong.
+
+    `progress_total` (the number of SOURCES) is not this and never was: a
+    one-source job is 0/1 for its whole duration, which is the 0% the owner
+    watched for 18 minutes while 1,030 requests succeeded behind it. Sites done
+    remains reported, separately and honestly, as its own count.
+
+    `expected` is None when nothing knows the total — a source's first ever
+    crawl. Callers MUST render that as unknown; a bar drawn at 0% against it is
+    the original defect.
+    """
+    counters = job.get("counters") or {}
+    slots = counters.get("sources") or {}
+    # Sources already merged at their boundary, plus whatever the ones still
+    # fetching have counted so far. A finished source is in the merged total, so
+    # its slot is deliberately not added again.
+    merged = int(counters.get("requests") or 0)
+    in_flight = sum(int((slot or {}).get("requests") or 0)
+                    for slot in slots.values()
+                    if (slot or {}).get("state") == "fetching")
+    requests = merged + in_flight
+
+    expectations = [slot for slot in slots.values()
+                    if slot and slot.get("expected")]
+    unknown = [key for key, slot in slots.items()
+               if not (slot or {}).get("expected")]
+    expected = sum(int(slot["expected"]) for slot in expectations) or None
+    basis = None
+    as_of = None
+    if expected is not None:
+        basis = max((slot.get("basis") or "estimate" for slot in expectations),
+                    key=lambda name: _BASIS_RANK.get(name, 2))
+        # The OLDEST date among the estimates, because an estimate is only as
+        # fresh as its stalest part.
+        dates = sorted(slot["as_of"] for slot in expectations if slot.get("as_of"))
+        as_of = dates[0] if dates else None
+    return {
+        "requests": requests,
+        "expected": expected,
+        "basis": basis,               # measured | declared | estimate | None
+        "as_of": as_of,               # the estimate's date, when it is one
+        # Sources with no denominator at all. Named so the panel can say which
+        # site it cannot predict rather than quietly leaving it out of the total.
+        "unknown_sources": sorted(unknown),
+        "sources": slots,
+    }
+
+
+def _queue_state(conn) -> dict:
+    """Which jobs hold the worker, and which wait behind them, in firing order.
+
+    The engine runs up to `capacity` jobs at once (jobs.job_capacity — the
+    owner's "Sites crawled at the same time" setting). A second run waits only
+    when that budget is full, and until now the panel said "queued" with no
+    reason at all: the concurrency added in 63dc24b is WITHIN a job across its
+    sources, so a crawl-behind-a-crawl looked like the parallel feature failing.
+
+    Both facts are stated here, from the one place that knows them, so the panel
+    can say "running alongside N others" or "waiting for a slot" and never
+    disagree with what the worker will actually do.
+    """
+    from ..jobs import job_capacity
+
+    capacity = job_capacity(conn)
+    holders = conn.execute(
+        "SELECT job_ref, source_keys FROM crawl_job "
+        "WHERE status IN ('running','preparing','resuming','pausing','cancelling') "
+        "ORDER BY job_id").fetchall()
+    waiting = conn.execute(
+        "SELECT job_ref, source_keys FROM crawl_job WHERE status = 'queued' "
+        "ORDER BY job_id").fetchall()
+    return {
+        "capacity": capacity,
+        "running": [{"job_ref": row[0], "source_keys": json.loads(row[1] or "[]")}
+                    for row in holders],
+        # Position 1 is the next job to start. A slot is free the moment fewer
+        # than `capacity` jobs are running, and the worker fills it on its next
+        # poll (half a second) — so a job whose position is within the free slots
+        # is starting now, not waiting.
+        "waiting": [{"job_ref": row[0], "source_keys": json.loads(row[1] or "[]"),
+                     "position": index + 1}
+                    for index, row in enumerate(waiting)],
+    }
+
+
+def _queued_behind(job: dict, queue: dict | None) -> dict | None:
+    """What this queued job is waiting for, or None if it is not waiting.
+
+    Everything here is a fact from the queue, never a reassurance: which jobs
+    hold the budget, which sites they are crawling, this job's place in line, and
+    whether a slot is already free for it (the worker starts it on the next
+    poll). The panel turns it into a sentence; nothing invents a finish time for
+    a job ahead, because that job's own denominator may be unknown and a
+    made-up wait is worse than an honest "when a slot frees".
+    """
+    if queue is None or job["status"] != JobStatus.QUEUED.value:
+        return None
+    mine = next((item for item in queue["waiting"]
+                 if item["job_ref"] == job["job_ref"]), None)
+    if mine is None:
+        return None
+    free_slots = max(0, queue["capacity"] - len(queue["running"]))
+    return {
+        "position": mine["position"],
+        "capacity": queue["capacity"],
+        "running_count": len(queue["running"]),
+        "running": queue["running"],
+        # True when this job is within the free slots — it is not really waiting,
+        # it starts on the next poll. The panel must not call that "queued".
+        "starting_now": mine["position"] <= free_slots,
+    }
+
+
+def _job_view(job: dict, queue: dict | None = None) -> dict:
     """The shape the side panel polls: aggregated progress only (spec 25) — never
     raw records, and everything needed to redraw the mini-player from scratch
     after the panel was closed."""
@@ -2456,8 +2612,15 @@ def _job_view(job: dict) -> dict:
         "source_keys": job["source_keys"],
         "current_source_key": job["current_source_key"],
         "stage": job["stage"],
-        "progress": {"done": done, "total": total,
-                     "percent": round(done / total * 100) if total else 0},
+        # SITES done, which is all this ever measured. It keeps its name and
+        # loses the percentage: 0/1 is a true statement about a one-source job
+        # and "0%" was not.
+        "progress": {"done": done, "total": total},
+        # PAGES fetched against a stated denominator — what the bar draws.
+        "fetch": _fetch_progress(job),
+        # Why this job is not moving, when it is not. None for the job that holds
+        # the worker and for anything already finished.
+        "queued_behind": _queued_behind(job, queue),
         "counters": job["counters"],
         "created_at": job["created_at"],
         "started_at": job["started_at"],

--- a/scrapex/webui/static/components.css
+++ b/scrapex/webui/static/components.css
@@ -1184,3 +1184,175 @@ code {
   .appearance-switch span,
   .appearance-switch span::after { transition: none; }
 }
+
+/* ==========================================================================
+ * Split button — a primary action beside a menu of secondary ones.
+ *
+ * Canonical here so the dataset Export control and the Activity panel's log
+ * control are the SAME control, not two that drift. A screen adds only its own
+ * placement; everything visual and interactive is this. Behaviour: split-button.js.
+ * ======================================================================== */
+.split-button {
+  display: inline-flex;
+  align-items: stretch;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: var(--shadow-xs);
+}
+.split-button-primary,
+.split-button-trigger {
+  min-height: var(--control-height);
+  border: 0;
+  background: transparent;
+  color: var(--text);
+}
+.split-button-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  padding-inline: var(--sp-4);
+  border-start-start-radius: calc(var(--radius) - 1px);
+  border-end-start-radius: calc(var(--radius) - 1px);
+  font-weight: var(--fw-heavy);
+  cursor: pointer;
+}
+.split-button-primary .sx-icon {
+  width: 1.05rem;
+  height: 1.05rem;
+  color: var(--accent-ink);
+}
+.split-button-primary:hover:not(:disabled),
+.split-button-trigger:hover {
+  background: var(--control-hover);
+  color: var(--text);
+}
+.split-button-primary:active:not(:disabled),
+.split-button-trigger:active {
+  background: var(--accent-weak);
+  color: var(--accent-ink);
+  transform: none;
+}
+.split-button-menu {
+  position: relative;
+  display: flex;
+}
+.split-button-menu > summary { list-style: none; }
+.split-button-menu > summary::-webkit-details-marker { display: none; }
+.split-button-trigger {
+  display: grid;
+  width: var(--control-height);
+  min-width: var(--control-height);
+  padding: 0;
+  place-items: center;
+  border-inline-start: 1px solid var(--line);
+  border-start-end-radius: calc(var(--radius) - 1px);
+  border-end-end-radius: calc(var(--radius) - 1px);
+  cursor: pointer;
+}
+.split-button-trigger .sx-icon { width: 1.05rem; height: 1.05rem; }
+.split-button-chevron {
+  margin-inline-start: auto;
+  transition: transform var(--dur-fast) var(--ease);
+}
+.split-button-menu[open] .split-button-chevron { transform: rotate(180deg); }
+.split-button-menu[open] .split-button-trigger {
+  background: var(--accent-weak);
+  color: var(--accent-ink);
+}
+.split-button-options {
+  position: absolute;
+  z-index: 120;
+  inset-inline-end: 0;
+  bottom: calc(100% + var(--sp-2));
+  display: grid;
+  gap: var(--sp-1);
+  width: min(20rem, calc(100vw - 2rem));
+  padding: var(--sp-2);
+  background: var(--surface);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  transform-origin: bottom right;
+  animation: split-button-options-in var(--dur-fast) var(--ease);
+}
+/* A menu that opens DOWNWARD, for a control near the top of its scroll box. */
+.split-button-menu.opens-down .split-button-options {
+  top: calc(100% + var(--sp-2));
+  bottom: auto;
+  transform-origin: top right;
+}
+@keyframes split-button-options-in {
+  from { opacity: 0; transform: translateY(.35rem) scale(.98); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+.split-button-options-head {
+  display: grid;
+  gap: var(--sp-1);
+  padding: var(--sp-2) var(--sp-3) var(--sp-3);
+  border-bottom: 1px solid var(--line);
+}
+.split-button-options-head strong { color: var(--text); font-size: var(--fs-sm); }
+.split-button-options-head span {
+  color: var(--muted);
+  font-size: var(--fs-xs);
+  line-height: 1.4;
+}
+.split-button-option {
+  display: grid;
+  grid-template-columns: 2rem minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--sp-3);
+  width: 100%;
+  min-height: 3.5rem;
+  padding: var(--sp-2) var(--sp-3);
+  color: var(--text);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius);
+  text-align: start;
+  white-space: normal;
+  cursor: pointer;
+}
+.split-button-option:hover:not(:disabled) {
+  color: var(--text);
+  background: var(--control-hover);
+  border-color: var(--line);
+}
+.split-button-option:active:not(:disabled) {
+  color: var(--text);
+  background: var(--control-active);
+  border-color: var(--line-strong);
+  transform: none;
+}
+.split-button-option-icon {
+  display: grid;
+  place-items: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: var(--radius);
+  background: var(--accent-weak);
+  color: var(--accent-ink);
+}
+.split-button-option-icon .sx-icon { width: 1.05rem; height: 1.05rem; }
+.split-button-option-copy { display: grid; gap: var(--sp-1); min-width: 0; }
+.split-button-option-copy strong { font-size: var(--fs-sm); }
+.split-button-option-copy small {
+  color: var(--muted);
+  font-size: var(--fs-2xs);
+  font-weight: var(--fw-regular);
+  line-height: 1.35;
+}
+.split-button-option-tag {
+  padding: .15rem .35rem;
+  border-radius: var(--radius-xs);
+  background: var(--surface-container-low);
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-2xs);
+  line-height: 1.4;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .split-button-options { animation: none; }
+}

--- a/scrapex/webui/static/grid-theme.css
+++ b/scrapex/webui/static/grid-theme.css
@@ -641,194 +641,21 @@
   line-height: 1.45;
 }
 .data-grid-exportbar #grid-toolbar { flex: none; justify-content: flex-end; margin: 0; }
-.grid-export-split {
-  display: inline-flex;
-  align-items: stretch;
-  border: 1px solid var(--line-strong);
-  border-radius: var(--radius);
-  background: var(--surface);
-  box-shadow: var(--shadow-xs);
-}
-.grid-export-primary,
-.grid-export-trigger {
-  min-height: var(--control-height);
-  border: 0;
-  background: transparent;
-  color: var(--text);
-}
-.grid-export-primary {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--sp-2);
-  padding-inline: var(--sp-4);
-  border-start-start-radius: calc(var(--radius) - 1px);
-  border-end-start-radius: calc(var(--radius) - 1px);
-  font-weight: var(--fw-heavy);
-}
-.grid-export-primary .sx-icon {
-  width: 1.05rem;
-  height: 1.05rem;
-  color: var(--accent-ink);
-}
-#grid-toolbar .grid-export-primary:hover:not(:disabled),
-#grid-toolbar .grid-export-trigger:hover {
-  background: var(--control-hover);
-  color: var(--text);
-}
-#grid-toolbar .grid-export-primary:active:not(:disabled),
-#grid-toolbar .grid-export-trigger:active {
-  background: var(--accent-weak);
-  color: var(--accent-ink);
-  transform: none;
-}
-.grid-export-menu {
-  position: relative;
-  display: flex;
-}
-.grid-export-menu > summary {
-  list-style: none;
-}
-.grid-export-menu > summary::-webkit-details-marker {
-  display: none;
-}
-.grid-export-trigger {
-  display: grid;
-  width: var(--control-height);
-  min-width: var(--control-height);
-  padding: 0;
-  place-items: center;
-  border-inline-start: 1px solid var(--line);
-  border-start-end-radius: calc(var(--radius) - 1px);
-  border-end-end-radius: calc(var(--radius) - 1px);
-  cursor: pointer;
-}
-.grid-export-trigger .sx-icon {
-  width: 1.05rem;
-  height: 1.05rem;
-}
-.grid-export-chevron {
-  margin-inline-start: auto;
-  transition: transform var(--dur-fast) var(--ease);
-}
-.grid-export-menu[open] .grid-export-chevron {
-  transform: rotate(180deg);
-}
-.grid-export-menu[open] .grid-export-trigger {
-  background: var(--accent-weak);
-  color: var(--accent-ink);
-}
-.grid-export-options {
-  position: absolute;
-  z-index: 120;
-  inset-inline-end: 0;
-  bottom: calc(100% + var(--sp-2));
-  display: grid;
-  gap: var(--sp-1);
-  width: min(20rem, calc(100vw - 2rem));
-  padding: var(--sp-2);
-  background: var(--surface);
-  border: 1px solid var(--line-strong);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-lg);
-  transform-origin: bottom right;
-  animation: grid-export-options-in var(--dur-fast) var(--ease);
-}
-@keyframes grid-export-options-in {
-  from { opacity: 0; transform: translateY(.35rem) scale(.98); }
-  to { opacity: 1; transform: translateY(0) scale(1); }
-}
-.grid-export-options-head {
-  display: grid;
-  gap: var(--sp-1);
-  padding: var(--sp-2) var(--sp-3) var(--sp-3);
-  border-bottom: 1px solid var(--line);
-}
-.grid-export-options-head strong {
-  color: var(--text);
-  font-size: var(--fs-sm);
-}
-.grid-export-options-head span {
-  color: var(--muted);
-  font-size: var(--fs-xs);
-  line-height: 1.4;
-}
-.grid-export-option {
-  display: grid;
-  grid-template-columns: 2rem minmax(0, 1fr) auto;
-  align-items: center;
-  gap: var(--sp-3);
-  width: 100%;
-  min-height: 3.5rem;
-  padding: var(--sp-2) var(--sp-3);
-  color: var(--text);
-  background: transparent;
-  border: 1px solid transparent;
-  border-radius: var(--radius);
-  text-align: start;
-  white-space: normal;
-}
-#grid-toolbar .grid-export-option:hover:not(:disabled) {
-  color: var(--text);
-  background: var(--control-hover);
-  border-color: var(--line);
-}
-#grid-toolbar .grid-export-option:active:not(:disabled) {
-  color: var(--text);
-  background: var(--control-active);
-  border-color: var(--line-strong);
-  transform: none;
-}
-.grid-export-option-icon {
-  display: grid;
-  place-items: center;
-  width: 2rem;
-  height: 2rem;
-  border-radius: var(--radius);
-  background: var(--accent-weak);
-  color: var(--accent-ink);
-}
-.grid-export-option-icon .sx-icon {
-  width: 1.05rem;
-  height: 1.05rem;
-}
-.grid-export-option-copy {
-  display: grid;
-  gap: var(--sp-1);
-  min-width: 0;
-}
-.grid-export-option-copy strong {
-  font-size: var(--fs-sm);
-}
-.grid-export-option-copy small {
-  color: var(--muted);
-  font-size: var(--fs-2xs);
-  font-weight: var(--fw-regular);
-  line-height: 1.35;
-}
-.grid-export-extension {
-  padding: .15rem .35rem;
-  border-radius: var(--radius-xs);
-  background: var(--surface-container-low);
-  color: var(--muted);
-  font-family: var(--font-mono);
-  font-size: var(--fs-2xs);
-  line-height: 1.4;
-}
-
+/* The Export control is the SHARED split button (components.css +
+   split-button.js); the grid adds only where it sits and how it stacks on a
+   narrow viewport. Its shell, menu and option styles are NOT redefined here —
+   that is the single implementation the panel reuses. */
+.data-grid-exportbar .split-button { flex: none; }
 @media (max-width: 640px) {
   .data-grid-exportbar { align-items: flex-start; flex-direction: column; }
   .data-grid-exportbar #grid-toolbar,
-  .grid-export-split { width: 100%; }
-  .grid-export-primary { flex: 1; justify-content: center; }
-  .grid-export-options {
+  .data-grid-exportbar .split-button { width: 100%; }
+  .data-grid-exportbar .split-button-primary { flex: 1; justify-content: center; }
+  .data-grid-exportbar .split-button-options {
     inset-inline-start: auto;
     inset-inline-end: 0;
     width: min(20rem, calc(100vw - 3rem));
   }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .grid-export-options { animation: none; }
 }
 
 .grid-feature-popover {

--- a/scrapex/webui/static/grid.js
+++ b/scrapex/webui/static/grid.js
@@ -3089,44 +3089,26 @@
   // ---- export ---------------------------------------------------------------
   function wireExport() {
     if (!toolbar) return;
-    const menu = toolbar.querySelector(".grid-export-menu");
-    const trigger = menu && menu.querySelector(".grid-export-trigger");
-    const closeMenu = () => {
-      if (!menu) return;
-      menu.open = false;
-      if (trigger) trigger.setAttribute("aria-expanded", "false");
-    };
-    if (menu && trigger) {
-      menu.addEventListener("toggle", () =>
-        trigger.setAttribute("aria-expanded", String(menu.open)));
-      menu.addEventListener("keydown", (event) => {
-        if (event.key !== "Escape" || !menu.open) return;
-        event.preventDefault();
-        closeMenu();
-        trigger.focus();
-      });
-      document.addEventListener("click", (event) => {
-        if (menu.open && !menu.contains(event.target)) closeMenu();
-      });
-    }
-    toolbar.querySelectorAll("[data-export]").forEach((button) =>
-      button.addEventListener("click", () => {
-        const kind = button.dataset.export;
-        const name = SOURCE + "-" + new Date().toISOString().slice(0, 10);
-        closeMenu();
-        // CSV and JSON are THIS VIEW: your filters, your column order, your
-        // hidden columns. Exporting something other than what is on screen is
-        // how a spreadsheet and a screen start disagreeing.
-        if (kind === "csv") table.download("csv", name + ".csv");
-        else if (kind === "json") table.download("json", name + ".json");
-        // Excel is the WHOLE RECORD, and it comes from the server. Two reasons.
-        // The browser cannot build it: the details, the price history and the
-        // provenance are not in the grid. And it never could — this called
-        // Tabulator's xlsx writer, which needs a SheetJS library that has never
-        // been vendored here, so the button logged a console error and produced
-        // no file at all, silently, for as long as it has existed.
-        else if (kind === "xlsx") window.location = "/export/" + encodeURIComponent(SOURCE) + ".xlsx";
-      }));
+    const root = toolbar.querySelector(".split-button");
+    if (!root) return;
+    // The SHARED split button — the same open/close/aria/escape/outside-click
+    // behaviour the Activity panel's log control uses. What each action DOES
+    // stays here, because that is the part that genuinely differs.
+    window.ScrapeXSplitButton.wire(root, (kind) => {
+      const name = SOURCE + "-" + new Date().toISOString().slice(0, 10);
+      // CSV and JSON are THIS VIEW: your filters, your column order, your
+      // hidden columns. Exporting something other than what is on screen is
+      // how a spreadsheet and a screen start disagreeing.
+      if (kind === "csv") table.download("csv", name + ".csv");
+      else if (kind === "json") table.download("json", name + ".json");
+      // Excel is the WHOLE RECORD, and it comes from the server. Two reasons.
+      // The browser cannot build it: the details, the price history and the
+      // provenance are not in the grid. And it never could — this called
+      // Tabulator's xlsx writer, which needs a SheetJS library that has never
+      // been vendored here, so the button logged a console error and produced
+      // no file at all, silently, for as long as it has existed.
+      else if (kind === "xlsx") window.location = "/export/" + encodeURIComponent(SOURCE) + ".xlsx";
+    });
   }
 
   // The command bar's way into Choose Columns. It exists because the column

--- a/scrapex/webui/static/split-button.js
+++ b/scrapex/webui/static/split-button.js
@@ -1,0 +1,70 @@
+/* One split button, for every surface that needs one.
+ *
+ * The dataset Export control invented this pattern — a primary action beside a
+ * <details> menu of secondary ones — and the Activity panel's log control is the
+ * same shape. Rather than write it twice (the DRY the owner asked for by name),
+ * the behaviour lives here and both the web grid and the extension panel call
+ * it. It is a CLASSIC script, not a module, so it sets one global the way
+ * appearance.js does — the two surfaces cannot import from each other at runtime,
+ * so a shared file copied into both is the only reuse they can share.
+ *
+ * The markup contract (styled by .split-button in components.css):
+ *   <div class="split-button">
+ *     <button class="split-button-primary" data-split-action="PRIMARY">…</button>
+ *     <details class="split-button-menu">
+ *       <summary class="split-button-trigger" aria-haspopup="menu"
+ *                aria-expanded="false">▾</summary>
+ *       <div class="split-button-options" role="menu">
+ *         <button class="split-button-option" data-split-action="X" role="menuitem">…</button>
+ *       </div>
+ *     </details>
+ *   </div>
+ *
+ * wire(root, onAction) hands every clicked [data-split-action] to onAction and
+ * then closes the menu. The caller owns what each action DOES — download a file,
+ * copy to the clipboard — because that is the part that genuinely differs; the
+ * open/close/aria/escape/outside-click dance is the part that does not, and the
+ * part a second copy would get subtly wrong.
+ */
+(function () {
+  "use strict";
+
+  function wire(root, onAction) {
+    if (!root || root.dataset.splitWired) return;
+    root.dataset.splitWired = "1";
+    const menu = root.querySelector(".split-button-menu");
+    const trigger = menu && menu.querySelector(".split-button-trigger");
+
+    const close = () => {
+      if (!menu) return;
+      menu.open = false;
+      if (trigger) trigger.setAttribute("aria-expanded", "false");
+    };
+
+    if (menu && trigger) {
+      // The <details> is the source of truth for open/closed; aria only ever
+      // mirrors it, so a click on the summary and a programmatic close agree.
+      menu.addEventListener("toggle", () =>
+        trigger.setAttribute("aria-expanded", String(menu.open)));
+      menu.addEventListener("keydown", (event) => {
+        if (event.key !== "Escape" || !menu.open) return;
+        event.preventDefault();
+        close();
+        trigger.focus();
+      });
+      // An outside click closes it. Registered on the document, guarded to this
+      // menu, so several split buttons on one page never fight over the event.
+      document.addEventListener("click", (event) => {
+        if (menu.open && !menu.contains(event.target)) close();
+      });
+    }
+
+    root.querySelectorAll("[data-split-action]").forEach((button) =>
+      button.addEventListener("click", (event) => {
+        close();
+        if (typeof onAction === "function") onAction(button.dataset.splitAction, button, event);
+      }));
+  }
+
+  window.ScrapeXSplitButton = { wire };
+})();

--- a/scrapex/webui/templates/_source_list.html
+++ b/scrapex/webui/templates/_source_list.html
@@ -36,6 +36,22 @@
         {# The English name reads on its own line, the way the table flips
            AR|EN — dir="ltr" because it IS English, whatever the line above is
            written in. Nothing at all when the site has one name only. #}
+        {# The freshness of the data — the first thing anyone asks, and the fact
+           the card was missing. A READ-OUT only (this is the web UI): when it
+           was last gathered, and one honest measure of it. Every number states
+           what it is. #}
+        <span class="dataset-choice-detail" data-dataset-fresh>
+          {% if s.last_success %}
+          <small class="dataset-choice-state">
+            Last crawled {{ (s.last_success.started_at or "")[:16]|replace("T", " ") }} UTC
+            {%- if s.last_success.rows_seen %} · {{ "{:,}".format(s.last_success.rows_seen) }} rows seen
+            {%- elif s.last_success.requests_count %} · {{ "{:,}".format(s.last_success.requests_count) }} requests
+            {%- endif %}
+          </small>
+          {% else %}
+          <small class="dataset-choice-state">Has data, but no crawl has succeeded yet</small>
+          {% endif %}
+        </span>
       </a>
       {% endfor %}
     </section>

--- a/scrapex/webui/templates/logs.html
+++ b/scrapex/webui/templates/logs.html
@@ -5,8 +5,9 @@
   <div class="page-heading">
     <span class="page-eyebrow">System</span>
     <h1 class="page-title">Logs</h1>
-    <p class="page-description">Inspect the most recent 200 technical events for one job.
-      The engine keeps the complete local log.</p>
+    <p class="page-description">Every technical event recorded for one job —
+      {{ "{:,}".format(entry_total) }} for this one. Nothing on this page is
+      truncated.</p>
   </div>
 </header>
 
@@ -69,7 +70,9 @@
     try {
       const job = await (await fetch(`/api/jobs/${encodeURIComponent(jobRef)}`)).json();
       const status = (job.job || job).status;
-      const answer = await (await fetch(`/api/jobs/${encodeURIComponent(jobRef)}/logs?limit=200`)).json();
+      // No limit: the route's default is every entry, and a tail is exactly how
+      // the line that explains a long run's failure went missing.
+      const answer = await (await fetch(`/api/jobs/${encodeURIComponent(jobRef)}/logs`)).json();
       paint(answer.entries || []);
       if (!TERMINAL.has(status)) setTimeout(tick, 4000);
     } catch (err) { setTimeout(tick, 8000); }

--- a/scrapex/webui/templates/source.html
+++ b/scrapex/webui/templates/source.html
@@ -12,6 +12,9 @@
   <link rel="stylesheet" href="/static/pages/data-workspace.css?v=source-ui-8">
   <script src="/static/vendor/tabulator.min.js" defer></script>
   <script src="/static/datasets-browser.js?v=source-ui-8" defer></script>
+{# The shared split-button behaviour, before grid.js which calls it. Deferred,
+   like grid.js, so both run after the DOM is parsed and in source order. #}
+  <script src="/static/split-button.js?v=design-system-44" defer></script>
 {# StaticFiles supplies validators but no Cache-Control policy. A new URL is
    therefore intentional when grid behaviour changes: an already-cached script
    must not keep the old sorting persistence or header controls after update. #}
@@ -280,45 +283,49 @@
                 current table view.</span>
         </div>
         <div id="grid-toolbar" class="toolbar" aria-label="Export">
-          <div class="grid-export-split" role="group" aria-label="Export data">
-            <button type="button" class="grid-export-primary" data-export="xlsx"
+          {# The shared split button (components.css + split-button.js), the
+             SAME control the Activity panel's log uses — one implementation, so
+             the two can never drift. data-split-action carries what each button
+             does; grid.js reads it. #}
+          <div class="split-button" role="group" aria-label="Export data">
+            <button type="button" class="split-button-primary" data-split-action="xlsx"
                     aria-label="Export complete record as an Excel workbook"
                     title="Export complete record as an Excel workbook">
               {{ icon("file-download") }}
               <span>Excel workbook</span>
             </button>
-            <details class="grid-export-menu">
-              <summary class="grid-export-trigger" aria-haspopup="menu"
+            <details class="split-button-menu">
+              <summary class="split-button-trigger" aria-haspopup="menu"
                        aria-expanded="false" aria-label="Other export formats"
                        title="Other export formats">
-                {{ icon("expand-more", "grid-export-chevron") }}
+                {{ icon("expand-more", "split-button-chevron") }}
               </summary>
-              <div class="grid-export-options" role="menu" aria-label="Export format">
-                <div class="grid-export-options-head">
+              <div class="split-button-options" role="menu" aria-label="Export format">
+                <div class="split-button-options-head">
                   <strong>Other formats</strong>
                   <span>Uses visible columns, filters and their current order.</span>
                 </div>
-                <button type="button" class="grid-export-option" data-export="csv"
+                <button type="button" class="split-button-option" data-split-action="csv"
                         role="menuitem">
-                  <span class="grid-export-option-icon">
+                  <span class="split-button-option-icon">
                     {{ icon("description") }}
                   </span>
-                  <span class="grid-export-option-copy">
+                  <span class="split-button-option-copy">
                     <strong>CSV table</strong>
                     <small>Filtered rows in a spreadsheet-friendly file.</small>
                   </span>
-                  <span class="grid-export-extension">.csv</span>
+                  <span class="split-button-option-tag">.csv</span>
                 </button>
-                <button type="button" class="grid-export-option" data-export="json"
+                <button type="button" class="split-button-option" data-split-action="json"
                         role="menuitem">
-                  <span class="grid-export-option-icon">
+                  <span class="split-button-option-icon">
                     {{ icon("insert-drive-file") }}
                   </span>
-                  <span class="grid-export-option-copy">
+                  <span class="split-button-option-copy">
                     <strong>JSON data</strong>
                     <small>Structured data from the current table view.</small>
                   </span>
-                  <span class="grid-export-extension">.json</span>
+                  <span class="split-button-option-tag">.json</span>
                 </button>
               </div>
             </details>

--- a/tests/test_api_jobs.py
+++ b/tests/test_api_jobs.py
@@ -48,7 +48,9 @@ def test_create_job_queues_without_executing(client):
 
     state = client.get(f"/api/jobs/{body['job_ref']}").json()
     assert state["status"] == "queued"          # queued, NOT run by the request
-    assert state["progress"] == {"done": 0, "total": 1, "percent": 0}
+    # Sites done, and no percentage: 0/1 is true about a one-source job, and the
+    # "0%" that used to ride beside it was the complaint, not the measurement.
+    assert state["progress"] == {"done": 0, "total": 1}
     assert state["started_at"] is None
 
 
@@ -70,6 +72,61 @@ def test_create_job_rejects_bad_run_mode(client):
 def test_create_job_accepts_multiple_sources(client):
     r = client.post("/api/jobs", json={"source_keys": [REAL_SOURCE, "MADAR"]})
     assert r.status_code == 200 and r.json()["source_keys"] == [REAL_SOURCE, "MADAR"]
+
+
+# ---- the honest queue: a second run says WHY it waits ------------------------
+
+def test_a_second_queued_job_is_told_what_it_is_waiting_for(client, db_path):
+    """A crawl behind a crawl said "queued" with no reason, and the owner read
+    it as the parallel feature failing. The API now states the fact: how many
+    are running, and this job's place in line."""
+    from scrapex import db as dbmod
+    from scrapex.jobs import _update, get_job
+
+    first = client.post("/api/jobs", json={"source_keys": [REAL_SOURCE]}).json()["job_ref"]
+    second = client.post("/api/jobs", json={"source_keys": ["MADAR"]}).json()["job_ref"]
+
+    # Put the first into a running state, as the worker would, so the second is
+    # genuinely waiting behind it (default budget 1).
+    conn = dbmod.connect(db_path)
+    try:
+        _update(conn, get_job(conn, first)["job_id"], status="running")
+        conn.commit()
+    finally:
+        conn.close()
+
+    listing = client.get("/api/jobs").json()
+    assert listing["queue"]["capacity"] == 1
+    assert [j["job_ref"] for j in listing["queue"]["running"]] == [first]
+
+    state = client.get(f"/api/jobs/{second}").json()
+    behind = state["queued_behind"]
+    assert behind is not None
+    assert behind["position"] == 1 and behind["running_count"] == 1
+    assert behind["starting_now"] is False           # budget full, it truly waits
+    assert behind["running"][0]["source_keys"] == [REAL_SOURCE]
+
+    # The running job itself is not "behind" anything.
+    assert client.get(f"/api/jobs/{first}").json()["queued_behind"] is None
+
+
+def test_a_queued_job_within_the_free_budget_is_starting_not_waiting(client, db_path):
+    """With a free slot, a queued job is not really waiting — the worker starts
+    it on the next poll — and the panel must not dress that as a stall."""
+    from scrapex import db as dbmod, settings
+
+    conn = dbmod.connect(db_path)
+    try:
+        settings.save(conn, {"crawl_parallel_sources": "2"})
+        conn.commit()
+    finally:
+        conn.close()
+
+    only = client.post("/api/jobs", json={"source_keys": [REAL_SOURCE]}).json()["job_ref"]
+    state = client.get(f"/api/jobs/{only}").json()
+    behind = state["queued_behind"]
+    assert behind is not None and behind["starting_now"] is True
+    assert behind["capacity"] == 2 and behind["running_count"] == 0
 
 
 # ---- resume: the kept pages the panel could not see or reach -----------------
@@ -279,8 +336,13 @@ def test_finished_job_reports_progress_and_counters(client, db_path):
         conn.close()
     state = client.get(f"/api/jobs/{ref}").json()
     assert state["status"] == "completed"
-    assert state["progress"] == {"done": 1, "total": 1, "percent": 100}
+    assert state["progress"] == {"done": 1, "total": 1}
     assert state["counters"]["observations"] == 3 and state["finished_at"] is not None
+    # A finished source's expectation IS its actual count: the run is history and
+    # history is not a prediction, so the bar closes on a measurement.
+    assert state["fetch"]["requests"] == state["fetch"]["expected"]
+    assert state["fetch"]["basis"] == "measured"
+    assert state["fetch"]["unknown_sources"] == []
 
 
 # ---- records for the panel's Browse Data screen (spec 20) -------------------

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -55,6 +55,75 @@ def test_write_lock_blocks_second_holder(tmp_path: Path):
                 pass  # pragma: no cover — must not be reached
 
 
+def test_two_threads_of_one_process_serialise_rather_than_refuse(tmp_path: Path):
+    """The bug that made concurrent JOBS unsafe. The file lock is keyed by pid,
+    and _reclaim_if_stale refuses to steal a LIVE owner's lock — so a second
+    THREAD of this same runtime found a live owner (itself), waited out its whole
+    timeout, and was refused, naming its own pid. Two per-host lanes whose
+    ingests overlapped by more than the timeout would lose a source outright.
+
+    An in-process gate in front of the file lock fixes it: threads of one runtime
+    queue and each one holds the lock in turn — nobody is refused."""
+    import threading
+    import time
+
+    db_path = tmp_path / "threads.db"
+    order: list = []
+    guard = threading.Lock()
+    errors: list = []
+
+    def worker(name: str) -> None:
+        try:
+            with dbmod.write_lock(db_path, timeout_s=10.0):
+                with guard:
+                    order.append(("in", name))
+                time.sleep(0.15)
+                with guard:
+                    order.append(("out", name))
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"{name}: {exc}")
+
+    threads = [threading.Thread(target=worker, args=(name,)) for name in "ABC"]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == [], f"a thread was refused its own runtime's lock: {errors}"
+    # Strictly serialised: every 'in' is immediately followed by its own 'out'.
+    assert len(order) == 6
+    for i in range(0, len(order), 2):
+        assert order[i][0] == "in" and order[i + 1][0] == "out" \
+            and order[i][1] == order[i + 1][1], f"held by two at once: {order}"
+
+
+def test_the_in_process_gate_still_bounds_its_wait(tmp_path: Path):
+    """The gate must not hang forever: a thread that cannot get in within its
+    timeout is told so, with nothing written — the same contract the file lock
+    always had, so an HTTP route stays answerable."""
+    import threading
+
+    db_path = tmp_path / "gate.db"
+    holding = threading.Event()
+    release = threading.Event()
+
+    def holder() -> None:
+        with dbmod.write_lock(db_path, timeout_s=5.0):
+            holding.set()
+            release.wait(5.0)
+
+    thread = threading.Thread(target=holder)
+    thread.start()
+    assert holding.wait(5.0)
+    try:
+        with pytest.raises(dbmod.DbLockedError):
+            with dbmod.write_lock(db_path, timeout_s=0.2):
+                pass  # pragma: no cover — must not be reached
+    finally:
+        release.set()
+        thread.join()
+
+
 def test_write_lock_releases_on_exit(tmp_path: Path):
     db_path = tmp_path / "t.db"
     with dbmod.write_lock(db_path, timeout_s=0.1):

--- a/tests/test_ingest_reported.py
+++ b/tests/test_ingest_reported.py
@@ -185,8 +185,10 @@ def test_a_running_jobs_row_gains_a_pulse_during_the_fetch(conn):
 
     row = conn.execute("SELECT counters_json, last_heartbeat_at FROM crawl_job "
                        "WHERE job_id=?", (job_id,)).fetchone()
-    assert json.loads(row["counters_json"])["requests"] == 120, \
-        "the Requests figure the panel shows never moved"
+    slot = json.loads(row["counters_json"])["sources"]["GPP_ENERGY"]
+    assert slot["requests"] == 120, \
+        "the progress figure the panel shows never moved"
+    assert slot["state"] == "fetching"
     assert row["last_heartbeat_at"], "no pulse — a watchdog reads this as a hang"
     lines = [entry["message"] for entry in job_logs(conn, job_ref)]
     assert "fetching — 50 requests so far" in lines

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -394,6 +394,114 @@ def test_runner_thread_drains_the_queue(tmp_path):
     assert status == JobStatus.COMPLETED.value
 
 
+def test_the_worker_runs_two_queued_jobs_at_once_when_the_budget_allows(tmp_path):
+    """The owner's real complaint: ten single-source schedules fire together and
+    nine wait on one. With the budget raised, the WORKER — not just a lane inside
+    one job — runs them side by side. Two jobs, distinct hosts, must be in flight
+    together, which the barrier only lets happen if they truly are."""
+    import threading
+    import time
+
+    from scrapex import settings
+
+    db = tmp_path / "wave.db"
+    setup = dbmod.connect(db)
+    dbmod.migrate(setup)
+    settings.save(setup, {"crawl_parallel_sources": "2"})
+    ref_a = create_job(setup, ["AA"], RunMode.UPDATE)
+    ref_b = create_job(setup, ["BB"], RunMode.UPDATE)
+    setup.commit()
+    setup.close()
+
+    manifest = _HostedManifest({"AA": "https://a.example.com/",
+                                "BB": "https://b.example.net/"})
+    both_inside = threading.Barrier(2, timeout=10)
+
+    def capture(_conn, entry, _job_id=None, **_kw):
+        both_inside.wait()          # passes only if BOTH jobs are crawling at once
+        return _result(entry.source_key)
+
+    runner = JobRunner(str(db), lambda: manifest, poll_interval_s=0.02,
+                       capture=capture)
+    runner.start()
+    try:
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            check = dbmod.connect(db)
+            try:
+                done = {get_job(check, r)["status"] for r in (ref_a, ref_b)}
+            finally:
+                check.close()
+            if done == {JobStatus.COMPLETED.value}:
+                break
+            time.sleep(0.05)
+    finally:
+        runner.stop()
+    assert done == {JobStatus.COMPLETED.value}, (
+        "two queued jobs did not both complete — the worker did not run them "
+        "together")
+
+
+def test_the_worker_holds_a_second_job_when_the_budget_is_one(tmp_path):
+    """The shipped default is unchanged: budget 1 runs strictly one job at a
+    time, and the second stays queued until the first is done."""
+    import threading
+    import time
+
+    from scrapex import settings
+
+    db = tmp_path / "one.db"
+    setup = dbmod.connect(db)
+    dbmod.migrate(setup)
+    settings.save(setup, {"crawl_parallel_sources": "1"})
+    ref_a = create_job(setup, ["AA"], RunMode.UPDATE)
+    ref_b = create_job(setup, ["BB"], RunMode.UPDATE)
+    setup.commit()
+    setup.close()
+
+    manifest = _HostedManifest({"AA": "https://a.example.com/",
+                                "BB": "https://b.example.net/"})
+    release_first = threading.Event()
+    a_running = threading.Event()
+    saw_b_queued_while_a_ran = threading.Event()
+
+    def capture(_conn, entry, _job_id=None, **_kw):
+        if entry.source_key == "AA":
+            a_running.set()
+            release_first.wait(10)
+        return _result(entry.source_key)
+
+    runner = JobRunner(str(db), lambda: manifest, poll_interval_s=0.02,
+                       capture=capture)
+    runner.start()
+    try:
+        assert a_running.wait(10), "the first job never started"
+        # While AA is held mid-crawl, BB must still be queued — one at a time.
+        check = dbmod.connect(db)
+        try:
+            if get_job(check, ref_b)["status"] == JobStatus.QUEUED.value:
+                saw_b_queued_while_a_ran.set()
+        finally:
+            check.close()
+        release_first.set()
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            check = dbmod.connect(db)
+            try:
+                done = {get_job(check, r)["status"] for r in (ref_a, ref_b)}
+            finally:
+                check.close()
+            if done == {JobStatus.COMPLETED.value}:
+                break
+            time.sleep(0.05)
+    finally:
+        release_first.set()
+        runner.stop()
+    assert saw_b_queued_while_a_ran.is_set(), (
+        "budget 1 let a second job start alongside the first")
+    assert done == {JobStatus.COMPLETED.value}
+
+
 def test_list_jobs_active_only_excludes_finished(conn):
     done_ref = create_job(conn, ["A"], RunMode.UPDATE)
     run_job_once(conn, done_ref, _FakeManifest(["A"]), capture=_capture_ok([]))
@@ -920,3 +1028,164 @@ def test_a_pause_seen_at_the_boundary_uses_the_lanes_connection(conn, tmp_path):
     assert not job.get("error_summary")
     assert not reached, "a job asked to pause fetched anyway"
     setup.close()
+
+# ---- crawling several JOBS at once, 2026-07-30 ---------------------------
+
+class _HostedManifest:
+    """A manifest whose sources carry a real base_url, so the per-host rule has
+    a host to reserve. `hosts` maps source_key -> base_url."""
+
+    def __init__(self, hosts: dict[str, str]):
+        self._hosts = hosts
+
+    def get(self, key):
+        if key not in self._hosts:
+            raise KeyError(f"unknown source_key {key!r}")
+        return SimpleNamespace(source_key=key, base_url=self._hosts[key],
+                               min_expected_rows=None, max_drop_pct=None)
+
+
+def _timed_capture(events, gate, hold_s):
+    """A capture that records when it enters and leaves the crawl of a source,
+    so a test can prove two crawls of one host never overlap."""
+    import threading
+    import time
+
+    lock = threading.Lock()
+
+    def capture(_conn, entry, _job_id=None, **_kw):
+        with lock:
+            events.append(("enter", entry.source_key, time.monotonic()))
+        gate.wait(hold_s)          # hold the "crawl" open long enough to overlap
+        with lock:
+            events.append(("exit", entry.source_key, time.monotonic()))
+        return _result(entry.source_key)
+
+    return capture
+
+
+def _run_two_jobs(db_path, refs, manifest, capture, admission):
+    """Run two jobs concurrently, each on its own thread and connection, sharing
+    one admission — exactly as the worker runs them."""
+    import threading
+
+    from scrapex import db as dbmod
+    from scrapex.jobs import run_job_once
+
+    def run(ref):
+        c = dbmod.connect(db_path)
+        try:
+            run_job_once(c, ref, manifest, capture=capture,
+                         connect=lambda: dbmod.connect(db_path), admission=admission)
+        finally:
+            c.close()
+
+    threads = [threading.Thread(target=run, args=(ref,)) for ref in refs]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+
+def _intervals(events):
+    """(source_key, enter_time, exit_time) pairs from a flat event log."""
+    enters = {key: t for kind, key, t in events if kind == "enter"}
+    return [(key, enters[key], t) for kind, key, t in events if kind == "exit"]
+
+
+def test_two_jobs_never_crawl_one_host_at_the_same_time(tmp_path):
+    """THE cross-job safety property. Two separate jobs, each a single source on
+    the SAME site, with the budget wide enough that only the per-host rule can
+    keep them apart. If the rule spans jobs, their crawls do not overlap."""
+    import threading
+
+    from scrapex import db as dbmod
+    from scrapex.jobs import _CrawlAdmission
+
+    db_path = str(tmp_path / "one_host.db")
+    setup = dbmod.connect(db_path)
+    dbmod.migrate(setup)
+    ref_a = create_job(setup, ["AA"], RunMode.UPDATE)
+    ref_b = create_job(setup, ["BB"], RunMode.UPDATE)
+    setup.commit()
+    setup.close()
+
+    manifest = _HostedManifest({"AA": "https://one.example.com/a",
+                                "BB": "https://one.example.com/b"})
+    events: list = []
+    # A gate that never releases early: each crawl holds for the full 0.4s, so if
+    # the two COULD overlap they would. Budget 2 means the semaphore admits both
+    # — only the host reservation can serialise them.
+    gate = threading.Event()
+    admission = _CrawlAdmission(2)
+    _run_two_jobs(db_path, [ref_a, ref_b], manifest,
+                  _timed_capture(events, gate, 0.4), admission)
+
+    intervals = _intervals(events)
+    assert len(intervals) == 2
+    (_, a_in, a_out), (_, b_in, b_out) = sorted(intervals, key=lambda item: item[1])
+    assert a_out <= b_in, (
+        "two jobs crawled one host at the same time — the per-host rule did not "
+        f"span jobs: {events}")
+
+
+def test_two_jobs_on_different_hosts_do_crawl_at_the_same_time(tmp_path):
+    """The other half: the per-host rule must not become a global lock. Two jobs
+    on DIFFERENT sites, budget 2, must genuinely overlap — otherwise the safety
+    test above would pass by making everything sequential."""
+    import threading
+
+    from scrapex import db as dbmod
+    from scrapex.jobs import _CrawlAdmission
+
+    db_path = str(tmp_path / "two_hosts.db")
+    setup = dbmod.connect(db_path)
+    dbmod.migrate(setup)
+    ref_a = create_job(setup, ["AA"], RunMode.UPDATE)
+    ref_b = create_job(setup, ["BB"], RunMode.UPDATE)
+    setup.commit()
+    setup.close()
+
+    manifest = _HostedManifest({"AA": "https://a.example.com/",
+                                "BB": "https://b.example.net/"})
+    events: list = []
+    # A barrier both crawls must reach together: it only releases once BOTH are
+    # inside, so the test deadlocks (and fails on timeout) if they cannot overlap.
+    both_inside = threading.Barrier(2, timeout=10)
+    admission = _CrawlAdmission(2)
+    _run_two_jobs(db_path, [ref_a, ref_b], manifest,
+                  _timed_capture(events, both_inside, 10), admission)
+
+    intervals = _intervals(events)
+    assert len(intervals) == 2
+    (_, a_in, a_out), (_, b_in, b_out) = sorted(intervals, key=lambda item: item[1])
+    assert b_in < a_out, "different hosts should crawl at the same time"
+
+
+def test_the_budget_bounds_how_many_sites_crawl_at_once(tmp_path):
+    """Even on distinct hosts, no more than the budget crawl together — the
+    setting is a real ceiling, not a suggestion. Budget 1 keeps it strictly
+    sequential, which is the shipped default's behaviour unchanged."""
+    import threading
+
+    from scrapex import db as dbmod
+    from scrapex.jobs import _CrawlAdmission
+
+    db_path = str(tmp_path / "budget.db")
+    setup = dbmod.connect(db_path)
+    dbmod.migrate(setup)
+    refs = [create_job(setup, [key], RunMode.UPDATE) for key in ("AA", "BB", "CC")]
+    setup.commit()
+    setup.close()
+
+    manifest = _HostedManifest({"AA": "https://a.example.com/",
+                                "BB": "https://b.example.net/",
+                                "CC": "https://c.example.org/"})
+    events: list = []
+    gate = threading.Event()
+    admission = _CrawlAdmission(1)          # one site at a time
+    _run_two_jobs(db_path, refs, manifest, _timed_capture(events, gate, 0.2), admission)
+
+    intervals = sorted(_intervals(events), key=lambda item: item[1])
+    for (_, _prev_in, prev_out), (_, next_in, _next_out) in zip(intervals, intervals[1:]):
+        assert prev_out <= next_in, f"budget 1 let two sites overlap: {events}"

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -905,6 +905,232 @@ def test_history_backfill_is_offered_only_where_the_source_publishes_history(ope
     assert "Energy Prices" in page.text_content("#mode-help")
 
 
+# ---- the rebuilt Activity panel: progress that states its denominator --------
+
+def _running_job(**over):
+    job = {
+        "job_ref": "job_live", "source_keys": ["SALLA_SHOP"],
+        "status": "running", "stage": "fetching",
+        "started_at": "2026-07-30T10:00:00Z", "current_source_key": "SALLA_SHOP",
+        "progress": {"done": 0, "total": 1},
+        "fetch": {"requests": 0, "expected": None, "basis": None, "as_of": None,
+                  "unknown_sources": [], "sources": {}},
+        "counters": {"observations": 0, "duplicates": 0, "products": 0,
+                     "requests": 0, "errors": 0},
+        "queued_behind": None,
+    }
+    job.update(over)
+    return job
+
+
+def _bar_width_pct(page):
+    return page.evaluate("""() => {
+        const bar = document.getElementById("act-bar");
+        const fill = bar.getBoundingClientRect().width;
+        const track = bar.parentElement.getBoundingClientRect().width;
+        return track ? Math.round(fill / track * 100) : 0;
+    }""")
+
+
+def _open_on_run(open_panel, **kw):
+    """Open the panel and reveal the Run view, where the Activity card lives."""
+    page = open_panel(**kw)
+    page.click(RUN_TAB)
+    page.wait_for_timeout(400)
+    return page
+
+
+def test_the_bar_is_a_fraction_of_requests_against_a_stated_denominator(open_panel):
+    """The whole complaint: 0% for 18 minutes because the bar measured SOURCES.
+    Now it measures requests against a real total, and the sentence beneath it
+    says what that total is and — for an estimate — its date."""
+    job = _running_job(
+        current_source_key="SALLA_SHOP",
+        fetch={"requests": 1030, "expected": 2461, "basis": "estimate",
+               "as_of": "2026-07-29", "unknown_sources": [],
+               "sources": {"SALLA_SHOP": {"state": "fetching", "requests": 1030,
+                                          "expected": 2461, "basis": "estimate",
+                                          "as_of": "2026-07-29", "not_modified": 40,
+                                          "retries": 2, "pace_s": 1.0,
+                                          "honouring_delay": True}}})
+    page = _open_on_run(open_panel, jobs=[job])
+
+    label = text_of(page, "#act-progress-label")
+    assert "1,030" in label and "2,461" in label, label
+    assert "42%" in label, label                 # 1030/2461
+    assert "estimate" in label and "29 Jul" in label, label
+    width = _bar_width_pct(page)
+    assert 38 <= width <= 46, f"the bar did not reflect the fraction: {width}%"
+    # The politeness read-out the owner asked for: 304s against the total.
+    assert "304" in text_of(page, "#act-counters")
+    assert not page.js_errors
+
+
+def test_a_declared_total_reads_as_a_count_not_an_estimate(open_panel):
+    """A sitemap connector KNOWS its frontier — that is a count, so no "~" and no
+    date, and the bar is a true fraction from the first pages."""
+    job = _running_job(
+        fetch={"requests": 50, "expected": 400, "basis": "declared", "as_of": None,
+               "unknown_sources": [],
+               "sources": {"SALLA_SHOP": {"state": "fetching", "requests": 50,
+                                          "expected": 400, "basis": "declared"}}})
+    page = _open_on_run(open_panel, jobs=[job])
+    label = text_of(page, "#act-progress-label")
+    assert "50" in label and "400" in label
+    assert "estimate" not in label
+    assert "page count" in label            # "the site's own page count"
+    assert not page.js_errors
+
+
+def test_an_unknown_denominator_reads_as_unknown_not_zero_percent(open_panel):
+    """A first-ever crawl of a site with no sitemap genuinely cannot know its
+    total. The bar is indeterminate and SAYS the total is not known — the one
+    thing it must never do is sit at 0% of a number nobody has."""
+    job = _running_job(
+        fetch={"requests": 340, "expected": None, "basis": None, "as_of": None,
+               "unknown_sources": ["SALLA_SHOP"],
+               "sources": {"SALLA_SHOP": {"state": "fetching", "requests": 340}}})
+    page = _open_on_run(open_panel, jobs=[job])
+
+    label = text_of(page, "#act-progress-label")
+    assert "340" in label
+    assert "not known yet" in label, label
+    assert "0%" not in label
+    assert page.locator("#act-bar").evaluate("el => el.classList.contains('indeterminate')")
+    assert not page.js_errors
+
+
+def test_a_queued_second_job_says_why_it_waits(open_panel):
+    """"queued" with no reason read as the parallel feature failing. Now it names
+    what holds the worker and this job's place in line."""
+    job = _running_job(
+        status="queued", stage=None, current_source_key=None, started_at=None,
+        fetch={"requests": 0, "expected": None, "basis": None, "as_of": None,
+               "unknown_sources": [], "sources": {}},
+        queued_behind={"position": 1, "capacity": 1, "running_count": 1,
+                       "starting_now": False,
+                       "running": [{"job_ref": "job_first",
+                                    "source_keys": ["ELBUROJ"]}]})
+    page = _open_on_run(open_panel, jobs=[job])
+    queue = text_of(page, "#act-queue")
+    assert "Queued" in queue
+    assert "ELBUROJ" in queue
+    assert "slot frees" in queue
+    assert "Sites crawled at the same time" in queue   # points to the fix
+    assert not page.js_errors
+
+
+# ---- the log: no cap, one split button, no auto-scroll button ----------------
+
+def _log_entries(n):
+    return [{"logged_at": f"2026-07-30T10:{i // 60:02d}:{i % 60:02d}Z",
+             "level": "info", "message": f"fetching — {i} requests so far"}
+            for i in range(n)]
+
+
+def test_no_log_entry_is_dropped_and_the_cap_is_gone(open_panel):
+    """The 200 cap was the client's, and it dropped exactly the line that
+    explained a long run's failure. Every entry is shown, and the request no
+    longer asks for a limited slice."""
+    entries = _log_entries(250)
+    page = _open_on_run(open_panel, jobs=[_running_job()], logs=entries)
+
+    assert page.locator("#logbox .logline").count() == 250, "the log was truncated"
+    assert "250" in text_of(page, "#log-caption") and "all shown" in text_of(page, "#log-caption")
+    # No caller asked for ?limit=200 (or any limit) on the log endpoint.
+    limited = page.evaluate(
+        "() => window.__calls.filter(p => /\\/logs/.test(p) && /limit=/.test(p))")
+    assert limited == [], f"a log fetch still capped itself: {limited}"
+
+
+def test_the_pause_auto_scroll_button_is_gone(open_panel):
+    """He asked for it removed."""
+    page = _open_on_run(open_panel, jobs=[_running_job()], logs=_log_entries(5))
+    assert page.locator("#autoscroll").count() == 0
+    body = page.text_content("#activity")
+    assert "auto-scroll" not in body.lower()
+
+
+def test_the_log_controls_are_one_shared_split_button(open_panel):
+    """Copy and Download become ONE split button — the SAME component the dataset
+    Export uses, not a second implementation."""
+    page = _open_on_run(open_panel, jobs=[_running_job()], logs=_log_entries(5))
+
+    split = page.locator("#activity .split-button")
+    assert split.count() == 1
+    # The primary copies; the menu holds copy + download. Wired by the shared
+    # ScrapeXSplitButton, so the menu opens and closes like the Export one.
+    assert page.locator('#activity .split-button-primary[data-split-action="copy"]').count() == 1
+    assert page.locator('#activity [data-split-action="download"]').count() == 1
+
+    menu = page.locator("#activity .split-button-menu")
+    assert not menu.evaluate("el => el.open")
+    page.click("#activity .split-button-trigger")
+    assert menu.evaluate("el => el.open"), "the shared split-button behaviour did not open the menu"
+    assert not page.js_errors
+
+
+def test_the_split_button_copies_the_visible_log_and_downloads_the_full_one(open_panel):
+    """Both actions do what they say: copy writes the on-screen lines to the
+    clipboard; download opens the FULL log endpoint, uncapped."""
+    page = _open_on_run(open_panel, jobs=[_running_job()], logs=_log_entries(3))
+    page.evaluate("""() => {
+        window.__copied = [];
+        navigator.clipboard.writeText = (t) => { window.__copied.push(t); return Promise.resolve(); };
+        window.__opened = [];
+        window.chrome.tabs.create = (o) => window.__opened.push(o.url);
+    }""")
+
+    page.click('#activity .split-button-primary[data-split-action="copy"]')
+    page.wait_for_timeout(100)
+    copied = page.evaluate("() => window.__copied")
+    assert copied and "fetching — 0 requests so far" in copied[0]
+    assert copied[0].count("\n") == 2, "copy did not carry every visible line"
+
+    page.click("#activity .split-button-trigger")
+    page.click('#activity [data-split-action="download"]')
+    page.wait_for_timeout(100)
+    opened = page.evaluate("() => window.__opened")
+    assert len(opened) == 1 and opened[0].endswith("/api/jobs/job_live/logs"), opened
+    assert "limit=" not in opened[0], "the full-log download capped itself"
+    assert not page.js_errors
+
+
+def test_the_data_tab_states_when_each_source_was_last_crawled(open_panel):
+    """The card read "no recorded changes yet"; the freshness of the data is the
+    fact the owner actually asked for."""
+    sources = [
+        {"source_key": "SALLA_SHOP", "base_url": "https://shop.example.com",
+         "source_name": "Example Shop", "family": "salla-html", "active": True,
+         "implemented": True, "observations": 763, "products": 763,
+         "last_success": {"started_at": "2026-07-29T08:30:00Z", "finished_at": "",
+                          "rows_seen": 763, "requests_count": 812,
+                          "products_discovered": 763, "errors_count": 0}},
+    ]
+    page = open_panel(sources=sources)
+    page.click(DATA_TAB)
+    page.wait_for_timeout(300)
+    card = page.text_content("#datasets")
+    assert "Last crawled 2026-07-29 08:30" in card
+    assert "763 rows seen" in card
+    assert "no recorded changes yet" not in card
+    assert not page.js_errors
+
+
+def test_a_source_that_never_succeeded_says_so_on_the_data_tab(open_panel):
+    """"never" is a real answer the card must state, not paper over with a zero."""
+    sources = [
+        {"source_key": "NEWSHOP", "base_url": "https://new.example.com",
+         "source_name": "New Shop", "family": "salla-html", "active": True,
+         "implemented": True, "observations": 5, "products": 5, "last_success": None},
+    ]
+    page = open_panel(sources=sources)
+    page.click(DATA_TAB)
+    page.wait_for_timeout(300)
+    assert "no successful crawl yet" in page.text_content("#datasets")
+    assert not page.js_errors
+
+
 # ---- active crawl status bar -------------------------------------------------
 
 def test_the_active_crawl_minimizes_to_a_statusbar_and_opens_again(open_panel):

--- a/tests/test_vendor.py
+++ b/tests/test_vendor.py
@@ -369,30 +369,40 @@ def test_status_bar_is_a_real_feature_and_owns_the_row_total():
 def test_export_actions_follow_the_grid_instead_of_sitting_above_it():
     page = (TEMPLATES / "source.html").read_text(encoding="utf-8")
     script = (VENDOR.parent / "grid.js").read_text(encoding="utf-8")
-    css = THEME.read_text(encoding="utf-8")
+    # The split-button SHELL is now the shared component (components.css); the
+    # grid-theme keeps only where the exportbar sits and how it stacks.
+    theme_css = THEME.read_text(encoding="utf-8")
+    shared_css = (VENDOR.parent / "components.css").read_text(encoding="utf-8")
 
     assert 'class="data-grid-exportbar"' in page
     assert page.index('class="data-grid-viewport"') < page.index('class="data-grid-exportbar"')
-    assert 'class="grid-export-split"' in page
-    assert 'class="grid-export-primary" data-export="xlsx"' in page
-    assert 'class="grid-export-menu"' in page
-    assert 'class="grid-export-trigger"' in page
+    # The Export control IS the shared split button — the same classes the panel
+    # log control uses. That reuse is the DRY the owner asked for by name.
+    assert 'class="split-button"' in page
+    assert 'class="split-button-primary" data-split-action="xlsx"' in page
+    assert 'class="split-button-menu"' in page
+    assert 'class="split-button-trigger"' in page
     assert '<span>Excel workbook</span>' in page
-    assert 'class="grid-export-options-head"' in page
-    assert page.count('class="grid-export-option"') == 2
-    assert page.count('class="grid-export-extension"') == 2
-    assert page.count("data-export=") == 3
-    assert 'class="chip" data-export=' not in page
+    assert 'class="split-button-options-head"' in page
+    assert page.count('class="split-button-option"') == 2
+    assert page.count('class="split-button-option-tag"') == 2
+    assert page.count("data-split-action=") == 3
+    assert 'class="chip" data-split-action=' not in page
     assert 'role="menu" aria-label="Export format"' in page
-    assert 'if (event.key !== "Escape" || !menu.open) return;' in script
-    assert 'if (menu.open && !menu.contains(event.target)) closeMenu();' in script
-    assert ".grid-export-split" in css
-    split_rule = css.split(".grid-export-split {", 1)[1].split("}", 1)[0]
+    # The behaviour lives ONCE, in split-button.js, and grid.js calls it rather
+    # than re-implementing the open/close/escape/outside-click dance.
+    assert "ScrapeXSplitButton.wire(" in script
+    assert 'if (event.key !== "Escape" || !menu.open) return;' not in script, \
+        "grid.js must not carry a second copy of the split-button behaviour"
+    # The shell styles live in the SHARED component, not re-declared per grid.
+    assert ".grid-export-split" not in theme_css and ".grid-export-menu" not in theme_css
+    assert ".split-button {" in shared_css
+    split_rule = shared_css.split(".split-button {", 1)[1].split("}", 1)[0]
     assert "overflow: hidden" not in split_rule, "the split must not clip its menu"
-    assert ".grid-export-menu[open] .grid-export-trigger" in css
-    assert "#grid-toolbar .grid-export-primary:active:not(:disabled)" in css
-    assert ".grid-export-options" in css
-    assert "#grid-toolbar .grid-export-option:active:not(:disabled)" in css
+    assert ".split-button-menu[open] .split-button-trigger" in shared_css
+    assert ".split-button-primary:active:not(:disabled)" in shared_css
+    assert ".split-button-options" in shared_css
+    assert ".split-button-option:active:not(:disabled)" in shared_css
 
 
 def test_unimplemented_grid_features_are_visible_but_disabled():

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -148,6 +148,25 @@ def test_dataset_context_survives_tab_switches(client):
 
 # ---- content, not just status codes -----------------------------------------
 
+def test_the_data_page_states_when_each_source_was_last_crawled(client):
+    """The freshness of the data is the first thing anyone asks, and the source
+    cards were missing it. A READ-OUT on the web Data page — never a control."""
+    body = client.get("/data").text
+    assert "Last crawled" in body
+    assert "rows seen" in body or "requests" in body
+    # The date is the run's, stated to the minute, not a bare "recently".
+    assert "2026-" in body
+
+
+def test_the_data_freshness_readout_is_not_a_control(client):
+    """The web UI is display-only (settings live in the extension). The freshness
+    line must be text, never a button or a form that writes anything."""
+    body = client.get("/data").text
+    fresh = body.split("data-dataset-fresh", 1)[1].split("</span>", 1)[0]
+    for control in ("<button", "<input", "<form", "<select"):
+        assert control not in fresh, f"the freshness read-out grew a {control}"
+
+
 def test_changes_tab_shows_the_movement_and_its_percentage(client):
     body = client.get("/changes", params={"source_key": SOURCE}).text
     assert "price increase" in body                 # the change type

--- a/tools/grid_harness.py
+++ b/tools/grid_harness.py
@@ -65,12 +65,16 @@ def _host_dom(source_key: str) -> str:
     <div id="grid" class="tablewrap" data-source="{source_key}"></div>
   </div>
   <div id="grid-toolbar" class="toolbar">
-    <details class="grid-export-menu">
-      <summary class="grid-export-trigger">Export</summary>
-      <button type="button" data-export="csv">CSV</button>
-      <button type="button" data-export="json">JSON</button>
-      <button type="button" data-export="xlsx">Excel</button>
-    </details>
+    <div class="split-button">
+      <button type="button" class="split-button-primary" data-split-action="xlsx">Excel</button>
+      <details class="split-button-menu">
+        <summary class="split-button-trigger">Export</summary>
+        <div class="split-button-options">
+          <button type="button" class="split-button-option" data-split-action="csv">CSV</button>
+          <button type="button" class="split-button-option" data-split-action="json">JSON</button>
+        </div>
+      </details>
+    </div>
   </div>
   <section id="offer-panel" class="record-panel" tabindex="-1" hidden></section>
 </div>
@@ -140,9 +144,14 @@ def build_page(tmp: Path, payload: dict, *, source_key: str = "TESTSRC",
     vendor_css = (STATIC / "vendor" / "tabulator.min.css").read_text(encoding="utf-8")
     vendor_js = (STATIC / "vendor" / "tabulator.min.js").read_text(encoding="utf-8")
     tokens_css = (STATIC / "tokens.css").read_text(encoding="utf-8")
+    components_css = (STATIC / "components.css").read_text(encoding="utf-8")
     table_css = (STATIC / "table-theme.css").read_text(encoding="utf-8")
     grid_css = (STATIC / "grid-theme.css").read_text(encoding="utf-8")
     ui_js = (STATIC / "ui.js").read_text(encoding="utf-8")
+    # The Export control's split button is the SHARED component: its styles live
+    # in components.css and its behaviour in split-button.js, so the harness must
+    # carry both or grid.js's wireExport calls into an undefined global.
+    split_button_js = (STATIC / "split-button.js").read_text(encoding="utf-8")
     grid_js = (STATIC / "grid.js").read_text(encoding="utf-8")
 
     # The icon helper resolves <use href="/static/..."> against the server. On
@@ -169,6 +178,7 @@ def build_page(tmp: Path, payload: dict, *, source_key: str = "TESTSRC",
         "<style>html,body{margin:0;height:100%}"
         ".data-grid-frame{height:100%}.data-grid-viewport{height:80vh}</style>"
         f"<style>{tokens_css}</style>"
+        f"<style>{components_css}</style>"
         f"<style>{vendor_css}</style>"
         f"<style>{table_css}</style>"
         f"<style>{grid_css}</style>\n"
@@ -178,6 +188,7 @@ def build_page(tmp: Path, payload: dict, *, source_key: str = "TESTSRC",
         f"<script>{stub}</script>\n"
         f"<script>{vendor_js}</script>\n"
         f"<script>{ui_js}</script>\n"
+        f"<script>{split_button_js}</script>\n"
         # grid.js last: it runs its fetch immediately, so the stub above and the
         # library it constructs against must both already exist.
         f"<script>{grid_js}</script>",

--- a/tools/panel_harness.py
+++ b/tools/panel_harness.py
@@ -69,7 +69,7 @@ OUTPUTS = [
 
 def stub(backend: str = DEFAULT_BACKEND, *, engine_up=True, sources=None, jobs=None,
          records=None, changes=None, slow=False, tab=None, resolve=None, probe=None,
-         fail_routes=(), storage=None) -> str:
+         fail_routes=(), storage=None, logs=None) -> str:
     """A chrome.* shim plus a fetch() interceptor.
 
     Any state can be rendered deterministically, including ones a live engine
@@ -109,6 +109,12 @@ def stub(backend: str = DEFAULT_BACKEND, *, engine_up=True, sources=None, jobs=N
     # read table would hand back the job LIST, so anything that checked what a
     # click actually queued was testing against a shape the engine never sends.
     write_routes = {"/api/jobs": {"job_ref": "job_stub", "status": "queued"}}
+    # The job log endpoint. A distinct shape from the jobs LIST (both live under
+    # /api/jobs), and matched ahead of it by the interceptor's `/logs` check —
+    # otherwise every log fetch would get the job list and the panel would draw
+    # an empty log. Carries `total` so the "all shown" caption has its number.
+    entries = logs if logs is not None else []
+    log_payload = {"entries": entries, "total": len(entries), "truncated": False}
     return f"""
 window.chrome = {{
   runtime: {{ getURL: p => p, lastError: null }},
@@ -118,6 +124,7 @@ window.chrome = {{
 }};
 const ROUTES = {json.dumps(routes)};
 const WRITE_ROUTES = {json.dumps(write_routes)};
+const LOG_PAYLOAD = {json.dumps(log_payload)};
 const ENGINE_UP = {str(engine_up).lower()};
 const SLOW = {str(slow).lower()};
 const FAIL = {json.dumps(list(fail_routes))};
@@ -140,6 +147,11 @@ window.fetch = async (url, options) => {{
   if (FAIL.some(f => path.startsWith(f))) {{
     return {{ ok: false, status: 500, statusText: "engine error",
               json: async () => ({{detail: "the engine could not do that"}}) }};
+  }}
+  // The log endpoint lives under /api/jobs too, so it must be answered BEFORE
+  // the generic /api/jobs list route swallows it.
+  if (/^\\/api\\/jobs\\/[^/]+\\/logs/.test(path)) {{
+    return {{ ok: true, status: 200, json: async () => LOG_PAYLOAD }};
   }}
   const table = method === "GET" ? ROUTES
                                  : {{...ROUTES, ...WRITE_ROUTES}};
@@ -194,6 +206,11 @@ def build_page(tmp: Path, stub_js: str, name: str = "panel.html") -> Path:
     )
     app_js = (EXT / "app.js").read_text(encoding="utf-8")
     appearance_js = (EXT / "appearance.js").read_text(encoding="utf-8")
+    # The shared split-button behaviour, loaded (in app.html) before app.js so
+    # its global exists when the Activity panel wires the log control. It is a
+    # classic head script, which build_page drops with the rest of <head>, so
+    # the harness must carry it explicitly or app.js's init throws.
+    split_button_js = (EXT / "split-button.js").read_text(encoding="utf-8")
     engine_js = (EXT / "engine.js").read_text(encoding="utf-8")
     transport_js = (EXT / "transport.js").read_text(encoding="utf-8")
 
@@ -216,6 +233,7 @@ def build_page(tmp: Path, stub_js: str, name: str = "panel.html") -> Path:
         f"<style>{tokens_css}</style><style>{components_css}</style>"
         f"<style>{style}</style>\n{body}\n"
         f"<script>{appearance_js}</script>\n"
+        f"<script>{split_button_js}</script>\n"
         f"<script>{stub_js}</script>\n"
         # No manual DOMContentLoaded dispatch: this inline script is parsed
         # BEFORE the browser fires the real event, so dispatching one as well

--- a/tools/sync_design_assets.py
+++ b/tools/sync_design_assets.py
@@ -22,6 +22,12 @@ ASSETS = {
         ROOT / "extension" / "appearance.js",
         ROOT / "scrapex" / "webui" / "static" / "appearance.js",
     ),
+    # The one split-button behaviour, shared so the dataset Export control and
+    # the Activity panel's log control cannot become two implementations.
+    ROOT / "design" / "split-button.js": (
+        ROOT / "extension" / "split-button.js",
+        ROOT / "scrapex" / "webui" / "static" / "split-button.js",
+    ),
     ROOT / "design" / "tokens.css": (
         ROOT / "extension" / "tokens.css",
         ROOT / "scrapex" / "webui" / "static" / "tokens.css",


### PR DESCRIPTION
## What & why

The Activity panel's lower half read as unprofessional and did not express the tool's strength («الجزء السفلى فهو غير احترافى … ولا يعبر عن قوة الادة»). This rebuilds it and fixes the three diagnosed causes. **Draft — please review; do not merge.**

## A · Progress that is TRUE, and says what it is a fraction OF
`crawl_job.progress_total` counts **sources**, so a one-source job read `0/1` (0%) for its whole run while requests climbed past 1,030. The bar now measures **requests against a stated denominator**, in three honest shapes — and *never a bare percentage*:

- **declared** — sitemap/paged connectors enumerate their frontier before fetching, so they declare it once (`HttpFetcher.expect_requests` via `declare_frontier`; wired in `salla.py`, `magento.py`). A count, not a guess.
- **estimate** — where the frontier is genuinely unknowable (`zid` fetches a per-product English page decided by that product's own `<head>`; `gpp` discovers its frontier in pieces), the last **successful** run's `requests_count` seeds a **dated** estimate that sharpens every crawl. Both non-declaring connectors carry a comment saying why.
- **measured** — a finished source's expectation becomes its actual count.

An **unknown** total renders an **indeterminate** bar that says *"total not known yet"* — never a bar stuck at 0%. `crawl_run.requests_count` (a column present since the schema was written and **never once written**) is now recorded, so the estimate exists next crawl. One reader, `ingest.last_successful_run`, serves both the panel estimate and the Data page.

## B · Two JOBS at once (chose concurrency; here's why)
The owner's scheduled crawls are **one job per source** (`scheduler.fire_due`), so the within-job lane concurrency from `63dc24b` did nothing for them — nine jobs waited on one. The worker now runs up to the owner's **"Sites crawled at the same time"** setting jobs concurrently, each on its own connection (`JobRunner._dispatch`/`_start_job`).

The whole risk — the **per-host rule spanning jobs** — is enforced by a shared `_CrawlAdmission` every lane passes through: a process-wide **per-host reservation** (two jobs never crawl one site together) plus a **budget semaphore**. Test: `test_two_jobs_never_crawl_one_host_at_the_same_time` (+ its inverse, so the safety test can't pass by making everything sequential).

Foundational fix: the file write-lock is keyed by **pid**, so a **second thread** of this same runtime was refused (`DbLockedError` after the full timeout — measured). An **in-process gate** now lets threads queue and serialise, which is what makes concurrent ingests safe (`db.py`; `test_two_threads_of_one_process_serialise_rather_than_refuse`).

At **budget 1 (the shipped default) behaviour is unchanged** — one job at a time — but now **explained**: the panel says which job holds the worker and this one's place in line, and points at the setting to run more.

## C · The log
The 200 cap was the **client's** (`?limit=200` in three places) *and* the route clamped to 200 too — the line explaining a long run's failure was discarded twice under a heading reading "Last 200". Now:
- **Every entry shown** (log volume is modest — entries throttle to ~1 per 50 requests — so no virtualisation needed; the box scrolls, the caption states the count).
- **"Pause auto-scroll" removed** — the log follows the tail only while you're already at the bottom.
- **Copy + Download → one split button**, the **shared component extracted from the dataset Export control** into `design/split-button.js` + `.split-button` in `design/components.css`, synced to both surfaces. The grid Export was retrofitted onto it — **one implementation, not two**.

## Data page
Each source card now states the **last successful crawl** (when + rows seen / requests), a read-out shared with the panel's estimate — never a control.

## DRY
One formatter each in the panel (`fmtCount`, `fmtDuration`→`fmtElapsed`, `fmtAsOf`); one denominator/queue computation in the API (`_fetch_progress`, `_queue_state`, `job_capacity`); one last-run reader; one split button.

## Measured against a real short crawl
Local fake salla site, **real** connector / fetcher / capture / jobs path, reading exactly what the panel reads (`_fetch_progress`):

| | START | MIDDLE | END |
|---|---|---|---|
| **First crawl** (no history) | `total not known yet` | `10 of 13 (77%)` declared | `13 of 13 (100%)` measured |
| **Second crawl** (history) | `0 of ~13 (0%)` estimate | `10 of 13 (77%)` declared | `13 of 13 (100%)` measured |

## Tests
Full `pytest` green; `node contract/parity/parity.test.mjs` 3/3. New coverage: panel DoM (`test_panel_dom.py`), cross-job concurrency + write-lock threads (`test_jobs.py`, `test_db.py`), queue API (`test_api_jobs.py`), Data freshness (`test_workspace.py`), split-button reuse (`test_vendor.py`). The settings-live-in-the-extension guardrail still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
