### PR TITLE
fix(db): the default database path stops guessing

### DIFF
--- a/scrapex/db.py
+++ b/scrapex/db.py
@@ -24,9 +24,29 @@ DB_DIR = Path(__file__).resolve().parent.parent / "db"
 SCHEMA_FILE = DB_DIR / "schema.sql"
 MIGRATIONS_DIR = DB_DIR / "migrations"
 
-DEFAULT_DB_PATH = Path(
-    os.environ.get("SCRAPEX_DB_PATH", str(Path.home() / ".scrapex" / "harvest.db"))
-)
+# WHY SILENCE IS NOT A PATH (2026-07-30)
+#
+# This used to fall back to ~/.scrapex/harvest.db, which is NOT the warehouse —
+# the real one is ~/.scrapex/marketlens/marketlens.db, and harvest.db has been
+# sitting there empty since 21 July. So a caller that forgot its path opened a
+# blank database, found no tables, and in the worst case would have WRITTEN a
+# whole crawl into a file nothing else in the product reads. It happened: one
+# settings write went there today before being caught.
+#
+# The env var stays, because naming a path is a deliberate act. Omitting one is
+# not, and now says so. Every legitimate caller already passes a path or is a
+# method on a database object that carries its own; nothing was relying on the
+# guess (verified across scrapex/, tests/ and tools/).
+_ENV_DB_PATH = os.environ.get("SCRAPEX_DB_PATH")
+DEFAULT_DB_PATH = Path(_ENV_DB_PATH) if _ENV_DB_PATH else None
+
+
+class NoDatabasePathError(RuntimeError):
+    """connect() was called with no path and SCRAPEX_DB_PATH is unset.
+
+    Deliberately louder than a default: the default was a DIFFERENT database
+    from the one the product uses, so guessing wrote to the wrong file quietly.
+    """
 
 _MIGRATION_NAME = re.compile(r"^(\d{4})_.+\.sql$")
 
@@ -39,12 +59,18 @@ class WrongDatabaseKindError(RuntimeError):
     """The legacy MarketLens facade was pointed at the General database."""
 
 
-def connect(db_path: Path | str = DEFAULT_DB_PATH) -> sqlite3.Connection:
+def connect(db_path: Path | str | None = DEFAULT_DB_PATH) -> sqlite3.Connection:
     """Open the legacy/MarketLens price database with the mandated pragmas.
 
     This compatibility facade remains for price-domain modules while they move
     behind repositories. It explicitly refuses the General database.
     """
+    if db_path is None:
+        raise NoDatabasePathError(
+            "db.connect() needs a database path: pass one, or set SCRAPEX_DB_PATH. "
+            "There is no default, because the old default (~/.scrapex/harvest.db) "
+            "was not the warehouse (~/.scrapex/marketlens/marketlens.db) and a "
+            "forgotten path silently opened the wrong, empty file.")
     path = Path(db_path)
     if str(path) != ":memory:":
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -262,3 +262,42 @@ def test_a_brand_the_promotion_fills_is_not_reported_as_lost(monkeypatch):
         ).fetchone()[0] == "Riyadh Cement"
     finally:
         conn.close()
+
+
+# ---- the default path stopped guessing, 2026-07-30 ------------------------
+
+def test_connect_with_no_path_refuses_instead_of_opening_the_wrong_file(monkeypatch):
+    """The old default was ~/.scrapex/harvest.db — NOT the warehouse, which is
+    ~/.scrapex/marketlens/marketlens.db. So a caller that forgot its path got a
+    blank database, and a WRITE would have gone into a file nothing else in the
+    product reads. It happened: one settings write landed there before it was
+    caught. A guess that is wrong in silence is worse than a refusal."""
+    import importlib
+    monkeypatch.delenv("SCRAPEX_DB_PATH", raising=False)
+    fresh = importlib.reload(dbmod)
+    try:
+        assert fresh.DEFAULT_DB_PATH is None
+        with pytest.raises(fresh.NoDatabasePathError) as caught:
+            fresh.connect()
+        # The message must name both files, or the reader repeats the mistake.
+        assert "harvest.db" in str(caught.value)
+        assert "marketlens.db" in str(caught.value)
+    finally:
+        importlib.reload(dbmod)
+
+
+def test_naming_a_path_by_env_var_is_still_honoured(monkeypatch, tmp_path):
+    """Omitting a path is an accident; naming one is a decision. Only the
+    accident is refused."""
+    import importlib
+    chosen = tmp_path / "named.db"
+    monkeypatch.setenv("SCRAPEX_DB_PATH", str(chosen))
+    fresh = importlib.reload(dbmod)
+    try:
+        assert fresh.DEFAULT_DB_PATH == chosen
+        conn = fresh.connect()
+        conn.close()
+        assert chosen.exists()
+    finally:
+        monkeypatch.delenv("SCRAPEX_DB_PATH", raising=False)
+        importlib.reload(dbmod)


### PR DESCRIPTION
`connect()` fell back to `~/.scrapex/harvest.db` when given no path. **That is not the warehouse** — the warehouse is `~/.scrapex/marketlens/marketlens.db` — and `harvest.db` had been sitting there empty since 21 July.

So a caller that forgot its path opened a blank database, found no tables, and in the worst case would have **written a whole crawl into a file nothing else in the product reads**.

This is not hypothetical: **one settings write went there today** before it was caught, and only because the empty file raised `no such table` rather than accepting the write.

It is the same family of fault this project has already paid for twice — a crawl writing into a superseded file, and a sealed archive read by a name that had moved. **A guess that is wrong in silence is worse than a refusal.**

## The rule

Omitting a path is an accident; naming one is a decision. **Only the accident is refused.**

`SCRAPEX_DB_PATH` still works, because setting it is deliberate. With neither, `connect()` raises `NoDatabasePathError` and the message names **both** files, so the reader cannot repeat the mistake.

Nothing was relying on the guess — verified across `scrapex/`, `tests/` and `tools/`. Every remaining no-argument call is a **method** on a database object that carries its own path, and the four tests that call `db.connect()` bare set the env var.

The empty file itself is deleted, with a copy kept beside it: a delete that can be undone costs nothing, and this one is 4 KB of nothing.

## Tests

- no path and no env var **refuses**, and the message names `harvest.db` *and* `marketlens.db` — a refusal that does not explain itself would just move the confusion
- naming a path by env var is **still honoured**

**1618 passed, 1 xfailed.** Contract parity **3/3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)