### PR TITLE
fix(jobs): the brakes use the lane's own connection, not the orchestrator's

### DIFF
--- a/scrapex/jobs.py
+++ b/scrapex/jobs.py
@@ -203,6 +203,13 @@ class _SourceRun:
     lock guarding all of it.
     """
 
+    # The ORCHESTRATOR's connection, and usable ONLY from its thread. sqlite3
+    # refuses a connection across threads, so a lane must use the one its own
+    # _run_lane opened — never this. Reaching for it inside a lane is what
+    # killed a 3,490-request crawl the moment a pause was asked for: the brake
+    # path wrote the job row through this handle and the worker died with
+    # "SQLite objects created in a thread can only be used in that same thread".
+    # Kept because the sequential path (width 1) legitimately passes it down.
     conn: sqlite3.Connection
     job: dict
     job_id: int
@@ -301,14 +308,14 @@ def _run_source(run: _SourceRun, conn: sqlite3.Connection, source_key: str) -> b
                 return False
             run.stopped = control
         if control == JobControl.CANCEL.value:
-            append_log(run.conn, run.job_id, "cancelled by owner")
-            _finish(run.conn, run.job_id, JobStatus.CANCELLED, None)
+            append_log(conn, run.job_id, "cancelled by owner")
+            _finish(conn, run.job_id, JobStatus.CANCELLED, None)
         else:
-            append_log(run.conn, run.job_id, "paused by owner")
-            _update(run.conn, run.job_id, status=JobStatus.PAUSED.value,
+            append_log(conn, run.job_id, "paused by owner")
+            _update(conn, run.job_id, status=JobStatus.PAUSED.value,
                     control=JobControl.NONE.value, stage=None,
                     last_heartbeat_at=utc_now_iso())
-        run.conn.commit()
+        conn.commit()
         return False
 
     _update(conn, run.job_id, status=JobStatus.RUNNING.value, stage=JobStage.FETCHING.value,
@@ -405,7 +412,7 @@ def _run_source(run: _SourceRun, conn: sqlite3.Connection, source_key: str) -> b
                        "cancel honoured mid-fetch — nothing from this source "
                        "was ingested and the partial fetch was discarded",
                        source_key=source_key)
-            _finish(run.conn, run.job_id, JobStatus.CANCELLED, None)
+            _finish(conn, run.job_id, JobStatus.CANCELLED, None)
         else:
             if kept:
                 append_log(conn, run.job_id,
@@ -431,7 +438,7 @@ def _run_source(run: _SourceRun, conn: sqlite3.Connection, source_key: str) -> b
                          # one that stopped FIRST; the others had not started.
                          "partial_source": source_key}),
                     last_heartbeat_at=utc_now_iso())
-        run.conn.commit()
+        conn.commit()
         return False
     except Exception as exc:  # noqa: BLE001 — one bad source never kills the job (Q3)
         run.errors.append(f"{source_key}: {exc}")

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -13,6 +13,7 @@ import pytest
 
 from scrapex import db as dbmod
 from scrapex.capture import CaptureResult
+from scrapex.connectors.base import CrawlInterrupted
 from scrapex.ingest import IngestResult
 from scrapex.jobs import (
     JobRunner, append_log, create_job, get_job, job_logs, list_jobs, run_job_once, set_control,
@@ -828,3 +829,94 @@ def test_without_a_connection_factory_the_job_stays_sequential(conn, tmp_path):
     assert _parallel_width(conn, None, 5) == 1, "concurrency without a factory"
     assert _parallel_width(conn, lambda: conn, 1) == 1, "one lane is not a race"
     assert _parallel_width(conn, lambda: conn, 5) == 5
+
+
+def test_pausing_a_parallel_crawl_does_not_kill_it(conn, tmp_path):
+    """THE BUG, and it destroyed real work.
+
+    The brake path wrote the job row through `run.conn` — the ORCHESTRATOR's
+    connection — from inside a lane thread. sqlite3 refuses a connection across
+    threads, so asking a running parallel crawl to pause killed the worker with
+    "SQLite objects created in a thread can only be used in that same thread",
+    and a crawl that had made 3,490 requests over ten sources ended `failed`
+    instead of `paused`. The pause is the mechanism that protects a long crawl;
+    it must not be the thing that ends it.
+    """
+    import threading
+    from scrapex import db as dbmod, settings
+    from scrapex.jobs import run_job_once
+
+    db_path = tmp_path / "brakes.db"
+    setup = dbmod.connect(db_path)
+    dbmod.migrate(setup)
+    settings.save(setup, {"crawl_parallel_sources": "3"})
+    setup.commit()
+    ref = create_job(setup, ["A", "B", "C"], RunMode.UPDATE)
+    setup.commit()
+
+    inside = threading.Barrier(3, timeout=10)
+    asked = threading.Event()
+
+    def capture(c, entry, _job_id=None, **_kw):
+        inside.wait()                  # all three lanes are in flight
+        if not asked.is_set():
+            asked.set()
+            # The owner presses pause while every lane is mid-fetch. Written
+            # through the LANE's connection, which is the only legal one here.
+            c.execute("UPDATE crawl_job SET control = 'pause' WHERE job_ref = ?",
+                      (ref,))
+            c.commit()
+        raise CrawlInterrupted("pause")
+
+    run_job_once(setup, ref, _FakeManifest(["A", "B", "C"]), capture=capture,
+                 connect=lambda: dbmod.connect(db_path))
+
+    job = get_job(setup, ref)
+    assert job["status"] == JobStatus.PAUSED.value, (
+        f"a pause ended the job as {job['status']}: {job.get('error_summary')}")
+    assert not job.get("error_summary"), "a clean pause must record no error"
+    setup.close()
+
+
+def test_a_pause_seen_at_the_boundary_uses_the_lanes_connection(conn, tmp_path):
+    """The OTHER brake path, and the one that actually broke in production.
+
+    There are two: a pause noticed mid-fetch (CrawlInterrupted, above) and a
+    pause noticed at the boundary BEFORE a lane starts its next source — which
+    is what happens when the owner presses the button while several lanes are
+    running. That second path wrote the job row through the orchestrator's
+    connection from inside a lane thread, and sqlite3 killed the worker.
+
+    The first version of the test above exercised only the mid-fetch path, so
+    re-breaking the boundary path did not fail it. This one closes that hole.
+    """
+    from scrapex import db as dbmod, settings
+    from scrapex.jobs import run_job_once
+
+    db_path = tmp_path / "boundary.db"
+    setup = dbmod.connect(db_path)
+    dbmod.migrate(setup)
+    settings.save(setup, {"crawl_parallel_sources": "3"})
+    setup.commit()
+    ref = create_job(setup, ["A", "B", "C"], RunMode.UPDATE)
+    # Already asked to pause before a single lane opens a source, so every lane
+    # takes the boundary branch rather than the mid-fetch one.
+    setup.execute("UPDATE crawl_job SET control = 'pause' WHERE job_ref = ?", (ref,))
+    setup.commit()
+
+    reached: list[str] = []
+
+    def capture(_c, entry, _job_id=None, **_kw):
+        reached.append(entry.source_key)     # must never run
+        return _result(entry.source_key)
+
+    run_job_once(setup, ref, _FakeManifest(["A", "B", "C"]), capture=capture,
+                 connect=lambda: dbmod.connect(db_path))
+
+    job = get_job(setup, ref)
+    assert job["status"] == JobStatus.PAUSED.value, (
+        f"the boundary pause ended the job as {job['status']}: "
+        f"{job.get('error_summary')}")
+    assert not job.get("error_summary")
+    assert not reached, "a job asked to pause fetched anyway"
+    setup.close()


### PR DESCRIPTION
**Asking a parallel crawl to pause killed it.** Measured on the owner's machine: ten sources, four lanes, **3,490 requests and 19,609 attributes already ingested**, and the moment a pause was requested the worker died with

```
SQLite objects created in a thread can only be used in that same thread.
The object was created in thread id 20700 and this is thread id 68872.
```

The job ended `failed` instead of `paused`. The pause is the mechanism that protects a long crawl; in my own concurrency work it became the thing that ended one.

## The fault

`_run_source` runs inside a **lane** thread. Its brake paths wrote the job row through `run.conn` — the **orchestrator's** connection — seven times. I reached for it deliberately, to serialise the terminal write; but sqlite3 refuses a connection across threads, so the serialisation I wanted was a crash.

Each lane already opens its own connection in `_run_lane`, `run.lock` already guarantees exactly one lane claims the stop, and the write lock already serialises the write. **The correct handle was in scope the whole time.**

`_SourceRun.conn` stays, because the sequential path (width 1) legitimately passes it down — and now carries the comment explaining why a lane must never touch it, at the exact spot where the next reader would reach for it.

## My first test did not bite, and I almost shipped on it

There are **two** brake paths: a pause noticed **mid-fetch** (`CrawlInterrupted`) and a pause noticed **at the boundary** before a lane starts its next source. The second is what happens when the owner presses the button, and it is what failed.

My first test exercised only the first. I re-broke the line, **the test passed**, and that is the only reason I looked again. A test that cannot fail is worse than no test, because it is mistaken for cover.

## Tests

Both paths, and both proved able to fail by re-breaking the line:

- three lanes in flight, a pause written mid-fetch → job ends **PAUSED** with no error recorded
- a pause already set at the boundary → every lane takes that branch, the job ends **PAUSED**, and `capture` is never called at all

**1653 passed, 1 xfailed.** Contract parity **3/3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)