### PR TITLE
fix(ingest): the stock count the price gate would not let through

### DIFF
--- a/scrapex/ingest.py
+++ b/scrapex/ingest.py
@@ -1143,6 +1143,39 @@ def _still_the_same_price(conn: sqlite3.Connection, offer_id: int, v: dict) -> b
             (offer_id,)).fetchone()
         if latest is None or latest["price_trade"] != v["price_trade"]:
             return False
+
+    # THE SAME DEFECT, THE SAME SHAPE, one column over — and this one had a
+    # second witness that should have settled it: record_hash ALREADY counts a
+    # stock move as a new observation (_observation_values hashes "stock"), and
+    # ux_price_obs_dedupe would have admitted the row. This gate disagreed with
+    # the hash and won, because it runs first and returns before the INSERT is
+    # ever reached.
+    #
+    # So madar asked the site for only_x_left_in_stock from 55ae064 on, was
+    # answered for 297 leaves, and appended none of them. Measured on the live
+    # warehouse 2026-07-30: 0 of 6,146 MADAR observations carry a stock figure
+    # while offer_state carries all 297 — and offer_state is DERIVED from the
+    # latest observation by pricehistory.rebuild_offer, so those 297 do not
+    # survive a rebuild. This table is the durable home; that one is a cache of
+    # it.
+    #
+    # The period stays keyed on the PRICE. A stock movement opens no period and
+    # is not a price change — the owner asked for the latest stock state, never a
+    # priced history of it — so it lands as an observation INSIDE the open
+    # period, exactly as the trade tier above does.
+    #
+    # `is not None` IS the no-invented-zero rule, not a null-safety habit: a leaf
+    # the site says nothing about arrives as None, never enters this branch,
+    # appends nothing and stays NULL. A published 0 means "none left", which is
+    # something the shop said, so it compares and it appends.
+    if v.get("stock_quantity") is not None:
+        latest = conn.execute(
+            "SELECT stock_quantity FROM price_observation "
+            "WHERE offer_id = ? AND provenance = 'observed' "
+            "ORDER BY observed_at DESC, price_observation_id DESC LIMIT 1",
+            (offer_id,)).fetchone()
+        if latest is None or latest["stock_quantity"] != v["stock_quantity"]:
+            return False
     return True
 
 

--- a/tests/fixtures/live/madar_stock_counts_2026-07-30.CAPTURE.md
+++ b/tests/fixtures/live/madar_stock_counts_2026-07-30.CAPTURE.md
@@ -1,0 +1,41 @@
+# Live capture — MADAR (magento-graphql), the REMAINING-STOCK COUNTS
+
+- File: `madar_stock_counts_2026-07-30.json`
+- URL: `https://www.madar.com/graphql` (POST)
+- Captured: 2026-07-30, HTTP 200
+- Query: the connector's own `_QUERY_TEMPLATE` fields, with the census filter
+  swapped from `price:{from:"0"}` to `sku:{in:[...]}` so the capture stays to
+  three products. `only_x_left_in_stock` is asked for exactly where the census
+  asks for it — on `SimpleProduct` at the top level and on the `SimpleProduct`
+  inside a `GroupedProduct` member.
+- Trimmed: nothing. The counts, the `null`s, the names (including the leading
+  whitespace madar puts in `71205003`'s name) and the prices are the bytes the
+  API returned.
+
+## Why these three
+
+They are the two products named in the defect report plus one grouped product,
+and between them they hold both halves of the rule under test.
+
+| sku          | `__typename`      | `only_x_left_in_stock` |
+|--------------|-------------------|------------------------|
+| `530458705`  | `SimpleProduct`   | **1**                  |
+| `71205003`   | `SimpleProduct`   | **8**                  |
+| `10115-HSS`  | `GroupedProduct`  | `null` on all 9 members |
+
+- **`530458705`** "PEGASO P52 STEEL BAR BENDING MACHIN", 27,772.50 — a count of
+  **1**. The smallest non-zero count the site publishes, and the one that is
+  destroyed by a falsy guard rather than a null check. It is the reason
+  `_still_the_same_price` tests `is not None` and not truthiness.
+- **`71205003`** "DADCO POLYESTER-DP200 -4MM", 150.94 — a count of **8**, the
+  second example from the report.
+- **`10115-HSS`** «حديد تسليح ابوكسي من حديد» — the epoxy rebar. All **nine**
+  members answer `null`: the site publishes no remaining count for any of them.
+  This is the half of the contract that has no other witness — these nine must
+  stay NULL and must never be written as 0. "We do not know how many are left"
+  and "none are left" are different facts, and on a price-tracking warehouse the
+  second one is a claim about the shop's ability to sell.
+
+Note this is a `sku:{in:...}` capture, so `categories` answers `[]` for all
+three — madar only fills breadcrumbs on a category listing. The test supplies
+the category context separately; nothing here depends on it.

--- a/tests/fixtures/live/madar_stock_counts_2026-07-30.json
+++ b/tests/fixtures/live/madar_stock_counts_2026-07-30.json
@@ -1,0 +1,336 @@
+{
+ "data": {
+  "products": {
+   "page_info": {
+    "current_page": 1,
+    "total_pages": 1
+   },
+   "items": [
+    {
+     "__typename": "SimpleProduct",
+     "uid": "NzM0MA==",
+     "sku": "530458705",
+     "name": "PEGASO P52 STEEL BAR BENDING MACHIN",
+     "url_key": "530458705",
+     "stock_status": "IN_STOCK",
+     "categories": [],
+     "price_range": {
+      "minimum_price": {
+       "regular_price": {
+        "value": 27772.5
+       },
+       "final_price": {
+        "value": 27772.5
+       }
+      },
+      "maximum_price": {
+       "final_price": {
+        "value": 27772.5
+       }
+      }
+     },
+     "weight": 1,
+     "is_qty_decimal": false,
+     "min_sale_qty": 1,
+     "qty_increments": 1,
+     "only_x_left_in_stock": 1
+    },
+    {
+     "__typename": "SimpleProduct",
+     "uid": "NjEzNg==",
+     "sku": "71205003",
+     "name": "         DADCO POLYESTER-DP200 -4MM",
+     "url_key": "dadco-polyester-dp200-4mm",
+     "stock_status": "IN_STOCK",
+     "categories": [],
+     "price_range": {
+      "minimum_price": {
+       "regular_price": {
+        "value": 150.94
+       },
+       "final_price": {
+        "value": 150.94
+       }
+      },
+      "maximum_price": {
+       "final_price": {
+        "value": 150.94
+       }
+      }
+     },
+     "weight": 1,
+     "is_qty_decimal": false,
+     "min_sale_qty": 1,
+     "qty_increments": 1,
+     "only_x_left_in_stock": 8
+    },
+    {
+     "__typename": "GroupedProduct",
+     "uid": "MjI5OQ==",
+     "sku": "10115-HSS",
+     "name": " حديد تسليح ابوكسي من حديد",
+     "url_key": "hadeed-epoxy-coated-steel-rebar",
+     "stock_status": "IN_STOCK",
+     "categories": [
+      {
+       "uid": "Mw==",
+       "name": "المعادن والحديد الإنشائي",
+       "breadcrumbs": null
+      },
+      {
+       "uid": "NA==",
+       "name": "حديد التسليح والشبك",
+       "breadcrumbs": [
+        {
+         "category_name": "المعادن والحديد الإنشائي"
+        }
+       ]
+      }
+     ],
+     "price_range": {
+      "minimum_price": {
+       "regular_price": {
+        "value": 4045.13
+       },
+       "final_price": {
+        "value": 4045.13
+       }
+      },
+      "maximum_price": {
+       "final_price": {
+        "value": 4045.13
+       }
+      }
+     },
+     "items": [
+      {
+       "qty": 1,
+       "position": 0,
+       "product": {
+        "uid": "NzA=",
+        "sku": "101152012",
+        "name": "حديد أبوكسي من حديد | 20مم × 12متر | ASTM A775 جريد 60",
+        "stock_status": "IN_STOCK",
+        "weight": 1000,
+        "is_qty_decimal": true,
+        "min_sale_qty": 0.25,
+        "qty_increments": 0.05,
+        "only_x_left_in_stock": null,
+        "price_range": {
+         "minimum_price": {
+          "regular_price": {
+           "value": 4045.13
+          },
+          "final_price": {
+           "value": 4045.13
+          }
+         }
+        }
+       }
+      },
+      {
+       "qty": 1,
+       "position": 0,
+       "product": {
+        "uid": "NjY=",
+        "sku": "101151212",
+        "name": "حديد أبوكسي من حديد | 12مم × 12متر | ASTM A775 جريد 60",
+        "stock_status": "IN_STOCK",
+        "weight": 1000,
+        "is_qty_decimal": true,
+        "min_sale_qty": 0.25,
+        "qty_increments": 0.05,
+        "only_x_left_in_stock": null,
+        "price_range": {
+         "minimum_price": {
+          "regular_price": {
+           "value": 4165.88
+          },
+          "final_price": {
+           "value": 4165.88
+          }
+         }
+        }
+       }
+      },
+      {
+       "qty": 1,
+       "position": 0,
+       "product": {
+        "uid": "Njk=",
+        "sku": "101151812",
+        "name": "حديد أبوكسي من حديد | 18مم × 12متر | ASTM A775 جريد 60",
+        "stock_status": "IN_STOCK",
+        "weight": 1000,
+        "is_qty_decimal": true,
+        "min_sale_qty": 0.25,
+        "qty_increments": 0.05,
+        "only_x_left_in_stock": null,
+        "price_range": {
+         "minimum_price": {
+          "regular_price": {
+           "value": 4045.13
+          },
+          "final_price": {
+           "value": 4045.13
+          }
+         }
+        }
+       }
+      },
+      {
+       "qty": 1,
+       "position": 0,
+       "product": {
+        "uid": "NjU=",
+        "sku": "101151012",
+        "name": "حديد أبوكسي من حديد | 10مم × 12متر | ASTM A775 جريد 60",
+        "stock_status": "IN_STOCK",
+        "weight": 1000,
+        "is_qty_decimal": true,
+        "min_sale_qty": 0.25,
+        "qty_increments": 0.05,
+        "only_x_left_in_stock": null,
+        "price_range": {
+         "minimum_price": {
+          "regular_price": {
+           "value": 4588.5
+          },
+          "final_price": {
+           "value": 4588.5
+          }
+         }
+        }
+       }
+      },
+      {
+       "qty": 1,
+       "position": 0,
+       "product": {
+        "uid": "NzI=",
+        "sku": "101153212",
+        "name": "حديد أبوكسي من حديد | 32مم × 12متر | ASTM A775 جريد 60",
+        "stock_status": "IN_STOCK",
+        "weight": 1000,
+        "is_qty_decimal": true,
+        "min_sale_qty": 0.25,
+        "qty_increments": 0.05,
+        "only_x_left_in_stock": null,
+        "price_range": {
+         "minimum_price": {
+          "regular_price": {
+           "value": 4045.13
+          },
+          "final_price": {
+           "value": 4045.13
+          }
+         }
+        }
+       }
+      },
+      {
+       "qty": 1,
+       "position": 0,
+       "product": {
+        "uid": "Njg=",
+        "sku": "101151612",
+        "name": "حديد أبوكسي من حديد | 16مم × 12متر | ASTM A775 جريد 60",
+        "stock_status": "IN_STOCK",
+        "weight": 1000,
+        "is_qty_decimal": true,
+        "min_sale_qty": 0.25,
+        "qty_increments": 0.05,
+        "only_x_left_in_stock": null,
+        "price_range": {
+         "minimum_price": {
+          "regular_price": {
+           "value": 4045.13
+          },
+          "final_price": {
+           "value": 4045.13
+          }
+         }
+        }
+       }
+      },
+      {
+       "qty": 1,
+       "position": 0,
+       "product": {
+        "uid": "NjQ=",
+        "sku": "101150812",
+        "name": "حديد أبوكسي من حديد | 8مم × 12متر | ASTM A775 جريد 60",
+        "stock_status": "IN_STOCK",
+        "weight": 1000,
+        "is_qty_decimal": true,
+        "min_sale_qty": 0.25,
+        "qty_increments": 0.05,
+        "only_x_left_in_stock": null,
+        "price_range": {
+         "minimum_price": {
+          "regular_price": {
+           "value": 4830
+          },
+          "final_price": {
+           "value": 4830
+          }
+         }
+        }
+       }
+      },
+      {
+       "qty": 1,
+       "position": 0,
+       "product": {
+        "uid": "NzE=",
+        "sku": "101152512",
+        "name": "حديد أبوكسي من حديد | 25مم × 12متر | ASTM A775 جريد 60",
+        "stock_status": "IN_STOCK",
+        "weight": 1000,
+        "is_qty_decimal": true,
+        "min_sale_qty": 0.25,
+        "qty_increments": 0.05,
+        "only_x_left_in_stock": null,
+        "price_range": {
+         "minimum_price": {
+          "regular_price": {
+           "value": 4045.13
+          },
+          "final_price": {
+           "value": 4045.13
+          }
+         }
+        }
+       }
+      },
+      {
+       "qty": 1,
+       "position": 0,
+       "product": {
+        "uid": "Njc=",
+        "sku": "101151412",
+        "name": "حديد أبوكسي من حديد | 14مم × 12متر | ASTM A775 جريد 60",
+        "stock_status": "IN_STOCK",
+        "weight": 1000,
+        "is_qty_decimal": true,
+        "min_sale_qty": 0.25,
+        "qty_increments": 0.05,
+        "only_x_left_in_stock": null,
+        "price_range": {
+         "minimum_price": {
+          "regular_price": {
+           "value": 4105.5
+          },
+          "final_price": {
+           "value": 4105.5
+          }
+         }
+        }
+       }
+      }
+     ]
+    }
+   ]
+  }
+ }
+}

--- a/tests/test_stock_counts_reach_the_warehouse.py
+++ b/tests/test_stock_counts_reach_the_warehouse.py
@@ -1,0 +1,294 @@
+"""The shop's remaining-stock count, all the way to the warehouse.
+
+MADAR publishes `only_x_left_in_stock` on 297 priced leaves. 55ae064 added it to
+the census query and carried it to the row, and it still never landed: measured
+on the live warehouse 2026-07-30, 0 of 6,146 MADAR observations held a stock
+figure.
+
+The connector was not the gap. `_still_the_same_price` is BOTH the price-period
+gate and the gate on whether an observation is appended at all, and it decides
+on the price key alone — which deliberately excludes stock, so that a stock
+movement never reads as a price change. An offer whose price had not moved was
+therefore CONFIRMED, nothing was appended, and the column stayed NULL on the row
+that already existed. The identical defect had already been found and fixed one
+column over, for `price_trade`, in the same function.
+
+WHY THE EXISTING ROUND-TRIP TEST DID NOT CATCH IT: it ingests once, into an
+empty database. A first-ever ingest has no open price period, so the gate short-
+circuits before it can drop anything and the value lands. The defect only exists
+on the SECOND crawl of an unmoved price — which is every crawl in production.
+So every test below crawls twice.
+
+All values are the bytes madar returned on 2026-07-30; see
+`fixtures/live/madar_stock_counts_2026-07-30.CAPTURE.md`.
+"""
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from scrapex import db as dbmod
+from scrapex import pricehistory
+from scrapex.config import ExtractSpec, SourceEntry
+from scrapex.connectors.magento import MagentoGraphqlConnector
+from scrapex.ingest import ingest_payloads
+from scrapex.payload import PAYLOAD_VERSION, FunnelPayload
+from scrapex.vocab import ExtractKind, ExtractScope
+
+_FIXTURE = Path(__file__).parent / "fixtures/live/madar_stock_counts_2026-07-30.json"
+
+# The two counts the defect report named, and the nine nulls beside them.
+_PEGASO = "530458705"    # only_x_left_in_stock: 1
+_DADCO = "71205003"      # only_x_left_in_stock: 8
+_REBAR_MEMBERS = ("101150812", "101151012", "101151212", "101151412", "101151612",
+                  "101151812", "101152012", "101152512", "101153212")
+
+
+def _census() -> dict:
+    return json.loads(_FIXTURE.read_text(encoding="utf-8"))
+
+
+def _without_counts(census: dict) -> dict:
+    """The same capture as every MADAR crawl before 55ae064 sent it.
+
+    Not a hypothetical: the query did not ask for the field, so it was absent
+    from the response rather than null. This is what the 6,146 existing
+    observations were built from.
+    """
+    stripped = copy.deepcopy(census)
+
+    def walk(node):
+        if isinstance(node, dict):
+            node.pop("only_x_left_in_stock", None)
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for value in node:
+                walk(value)
+
+    walk(stripped)
+    return stripped
+
+
+class _Response:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class _Fetcher:
+    """Serves one census page from the capture, and nothing it did not capture.
+
+    The en_SA store answers with no items on purpose: this fixture is a
+    `sku:{in:...}` capture of the default store only, so an English name here
+    would be invented. product_name is not a required column, and no assertion
+    below reads it.
+    """
+
+    def __init__(self, census: dict):
+        self._census = census
+        self.requests_count = 0
+
+    def post(self, url, json=None, **kwargs):
+        self.requests_count += 1
+        query = (json or {}).get("query", "")
+        page = (json or {}).get("variables", {}).get("currentPage", 1)
+        empty = _Response({"data": {"products": {
+            "items": [], "page_info": {"current_page": 1, "total_pages": 1}}}})
+        if (kwargs.get("headers") or {}).get("Store"):
+            if "categoryList" in query:
+                return _Response({"data": {"categoryList": [{"children": []}]}})
+            return empty
+        if "storeConfig" in query:
+            # Read live the same day, on both store views.
+            return _Response({"data": {"storeConfig": {"weight_unit": "kgs"}}})
+        if "categoryList" in query:
+            return _Response({"data": {"categoryList": [{"children": []}]}})
+        if "category_uid" in query:
+            return empty
+        return _Response(self._census) if page == 1 else empty
+
+    def close(self):
+        pass
+
+
+def _entry() -> SourceEntry:
+    return SourceEntry.model_validate(dict(
+        source_key="MADAR", source_name="المدار", base_url="https://www.madar.com",
+        family="magento-graphql", currency="SAR", default_region="SA", vat_mode="incl",
+        extract=[ExtractSpec(kind=ExtractKind.PRODUCT_PRICES, scope=ExtractScope.CENSUS)],
+    ))
+
+
+def _crawl(conn, census: dict, scraped_at: str):
+    """One full round trip: connector -> rows -> payload -> ingest -> warehouse."""
+    tables = [t for t in MagentoGraphqlConnector(_Fetcher(census)).fetch(_entry())
+              if t.kind == ExtractKind.PRODUCT_PRICES]
+    payloads = [FunnelPayload(
+        payload_version=PAYLOAD_VERSION, source_key="MADAR",
+        kind=ExtractKind.PRODUCT_PRICES, client="cli", scraped_at=scraped_at,
+        source_url=t.source_url, header=t.header, rows=t.rows) for t in tables]
+    assert payloads, "the capture produced no price payload"
+    return ingest_payloads(conn, _entry(), payloads)
+
+
+@pytest.fixture
+def warehouse(tmp_path):
+    """Two crawls of the same unmoved prices: yesterday without the counts,
+    today with them. This is the production history, in miniature."""
+    conn = dbmod.connect(tmp_path / "harvest.db")
+    dbmod.migrate(conn)
+    first = _crawl(conn, _without_counts(_census()), "2026-07-29T10:00:00Z")
+    second = _crawl(conn, _census(), "2026-07-30T10:15:00Z")
+    try:
+        yield conn, first, second
+    finally:
+        conn.close()
+
+
+def _observations(conn, sku: str) -> list:
+    return conn.execute(
+        "SELECT p.observed_at, p.stock_quantity, p.price FROM price_observation p "
+        "JOIN source_offer o USING (offer_id) "
+        "JOIN source_variant v USING (source_variant_id) "
+        "WHERE v.external_sku = ? ORDER BY p.observed_at, p.price_observation_id",
+        (sku,)).fetchall()
+
+
+def _latest_stock(conn, sku: str):
+    rows = _observations(conn, sku)
+    assert rows, f"no observation at all for {sku}"
+    return rows[-1]["stock_quantity"]
+
+
+# ---- the defect ---------------------------------------------------------------
+
+def test_the_first_crawl_leaves_the_count_null_because_it_never_asked(warehouse):
+    """The starting state, asserted rather than assumed: the 6,146 rows that
+    already exist are NULL truthfully. Nothing here backfills them."""
+    conn, first, _ = warehouse
+    assert first.observations > 0, "the first crawl must have appended something"
+    assert _observations(conn, _PEGASO)[0]["stock_quantity"] is None
+    assert _observations(conn, _DADCO)[0]["stock_quantity"] is None
+
+
+def test_a_published_count_lands_even_though_the_price_did_not_move(warehouse):
+    """THE REGRESSION. Both prices are byte-identical across the two crawls, so
+    the price key is unchanged and the old gate confirmed the row and appended
+    nothing. The count is a new fact about the offer and must be recorded."""
+    conn, _, second = warehouse
+    assert _latest_stock(conn, _PEGASO) == 1.0
+    assert _latest_stock(conn, _DADCO) == 8.0
+    assert second.observations >= 2, (
+        "the second crawl must append the two leaves whose count is new")
+
+
+def test_a_count_of_one_is_not_mistaken_for_nothing(warehouse):
+    """`530458705` publishes exactly 1 — the smallest count madar states, and the
+    value a falsy guard destroys while a null check keeps. The gate tests
+    `is not None` for this reason, and this is the test that says so."""
+    conn, _, _ = warehouse
+    assert _latest_stock(conn, _PEGASO) == 1.0
+
+
+def test_the_price_history_is_untouched_by_a_stock_movement(warehouse):
+    """The other half of the fix: the count lands INSIDE the open period. A
+    stock movement is not a price change and must open no second period, or
+    every one of these offers would report a price move that never happened."""
+    conn, _, _ = warehouse
+    for sku in (_PEGASO, _DADCO):
+        periods = conn.execute(
+            "SELECT COUNT(*), SUM(closed_at IS NULL) FROM price_period p "
+            "JOIN source_offer o USING (offer_id) "
+            "JOIN source_variant v USING (source_variant_id) "
+            "WHERE v.external_sku = ?", (sku,)).fetchone()
+        assert periods[0] == 1, f"{sku}: a stock move opened a second price period"
+        assert periods[1] == 1, f"{sku}: the one period must still be open"
+        prices = {r["price"] for r in _observations(conn, sku)}
+        assert len(prices) == 1, f"{sku}: the price itself must not have moved"
+
+
+def test_the_earlier_null_is_preserved_not_rewritten(warehouse):
+    """price_observation is append-only (trg_price_obs_no_update). The row that
+    was taken before the site was asked keeps its NULL: we genuinely did not
+    know the count then, and inventing one retroactively would be a claim about
+    a day nobody measured."""
+    conn, _, _ = warehouse
+    for sku in (_PEGASO, _DADCO):
+        rows = _observations(conn, sku)
+        assert len(rows) == 2, f"{sku}: expected the old row plus one new one"
+        assert rows[0]["stock_quantity"] is None
+        assert rows[0]["observed_at"] < rows[1]["observed_at"]
+
+
+# ---- the rule that must NOT be broken to achieve the above -------------------
+
+def test_a_product_the_site_says_nothing_about_stays_null(warehouse):
+    """DO NOT INVENT A ZERO. All nine epoxy-rebar members answer null: madar
+    publishes no remaining count for any of them. "We do not know how many are
+    left" and "none are left" are different facts, and on a price warehouse the
+    second is a claim about whether the shop can sell at all.
+
+    Asserted as `is None` per member rather than as an aggregate, so a 0 leaking
+    into one of the nine cannot hide behind the other eight.
+    """
+    conn, _, _ = warehouse
+    for sku in _REBAR_MEMBERS:
+        rows = _observations(conn, sku)
+        assert rows, f"{sku}: the member did not reach the warehouse at all"
+        for row in rows:
+            assert row["stock_quantity"] is None, (
+                f"{sku}: the site published no count; "
+                f"the warehouse invented {row['stock_quantity']!r}")
+
+
+def test_a_silent_product_appends_no_second_observation(warehouse):
+    """The same rule from the other side, and the guard on the fix's cost. The
+    nine silent members have an unmoved price and no count, so the second crawl
+    must confirm them and write nothing — a new observation per crawl per
+    unchanged row would turn an append-only table into a daily copy of itself.
+    """
+    conn, _, _ = warehouse
+    for sku in _REBAR_MEMBERS:
+        assert len(_observations(conn, sku)) == 1, (
+            f"{sku}: a product the site says nothing about gained a second row")
+
+
+# ---- the second-order defect the same gate caused ----------------------------
+
+def test_the_count_survives_a_rebuild(warehouse):
+    """offer_state.stock_quantity is DERIVED: pricehistory.rebuild_offer reads it
+    off the latest observation. So while the append was being skipped, the live
+    warehouse's 297 offer_state counts were only ever the value _confirm_seen
+    stamped on its way out — and _confirm_seen runs for a SUCCESS only. A
+    rebuild, or any run that did not finish, dropped all 297 back to NULL.
+
+    Measured before the fix: offer_state 8.0, then rebuild_offer -> None.
+    """
+    conn, _, _ = warehouse
+    offer_id = conn.execute(
+        "SELECT o.offer_id FROM source_offer o "
+        "JOIN source_variant v USING (source_variant_id) "
+        "WHERE v.external_sku = ?", (_DADCO,)).fetchone()["offer_id"]
+    state = "SELECT stock_quantity FROM offer_state WHERE offer_id = ?"
+    assert conn.execute(state, (offer_id,)).fetchone()["stock_quantity"] == 8.0
+    pricehistory.rebuild_offer(conn, offer_id)
+    assert conn.execute(state, (offer_id,)).fetchone()["stock_quantity"] == 8.0, (
+        "the count did not survive being re-derived from the observations")
+
+
+def test_a_third_crawl_with_an_unchanged_count_appends_nothing(warehouse):
+    """The count is recorded when it MOVES, not on every crawl that sees it.
+    Without this the 297 would grow a row a day each and the append-only table
+    would stop meaning "something changed"."""
+    conn, _, _ = warehouse
+    before = len(_observations(conn, _DADCO))
+    third = _crawl(conn, _census(), "2026-07-31T10:15:00Z")
+    assert len(_observations(conn, _DADCO)) == before
+    assert third.observations == 0
+    assert third.confirmed > 0


### PR DESCRIPTION
**DRAFT — awaiting main-session review. Please do not merge.**

## The broken link

`scrapex/ingest.py:1101` — `_still_the_same_price`.

The connector was **not** the gap, and the diagnosis handed to me no longer held:

| claim in the brief | actual |
|---|---|
| `stock_quantity` in `magento.py` — 0 occurrences | **6 occurrences**, added by `55ae064` at 2026-07-29 19:43, *before* today's 10:15 crawl |
| the connector never sends it | it queries, carries and emits it; `magento.py:1041` |

So the plumbing was not half-built — it was complete. `only_x_left_in_stock` is in `_QUANTITY_FACTS` (`magento.py:72`), rides the census response, reaches `row()` at `magento.py:1112`/`:1203`/`:1226`, is emitted at `magento.py:1041`, survives `RowBuilder.row` and `RowView.as_dict`, and comes out of `_observation_values` in `v["stock_quantity"]` (`ingest.py:685`, `:760`). Every link held.

`_still_the_same_price` is **both** the price-period gate **and** the gate on whether an observation is appended at all. It decides on the price key, which excludes stock deliberately — a stock movement must never read as a price change. So an offer whose price had not moved was `confirmed`, nothing was written, and the column stayed NULL on the row that already existed.

This is the `price_trade` defect, in the same function, ten lines up (`ingest.py:1126-1145`), whose comment already describes this exact failure for its own column.

Two witnesses say the append was always intended:

- `record_hash` already hashes `"stock"` (`ingest.py:722`) — it counts a stock move as a new observation.
- `ux_price_obs_dedupe(offer_id, business_date, record_hash)` would have admitted the row.

The gate disagreed with the hash and won, because it runs first and returns before the `INSERT` is reached.

### It was worse than a missing column

`offer_state` carried all 296, which is why this looked half-working. But `pricehistory.rebuild_offer` **derives** `offer_state.stock_quantity` from the latest observation (`pricehistory.py:48`, `:209`), and `_confirm_seen` — which stamped the live value — runs for a SUCCESS only (`ingest.py:863`). Measured: `offer_state` 8.0, then `rebuild_offer` returns it to `None`. **The 296 in the live warehouse today do not survive a rebuild or an unfinished run.** `price_observation` is the durable home; `offer_state` is a cache of it, and the published view `v_material_price_tracking` reads `po.stock_quantity` (`schema.sql:460`), not `offer_state`.

## No zero is invented

`is not None`, not truthiness. A leaf the site says nothing about never enters the branch, appends nothing, stays NULL. A published `0` means "none left" — the shop's own statement — and lands. The site publishes **no** 0 today and **52** leaves publishing `1`, the value a falsy guard destroys, so the fixture pins both directions.

## Measured — live census, isolated scratch database

A crawl of all ten sources (`job_605209b1efff`) was running when I started and has since **failed** at 9/10 (11:16:14Z, on `ARAMCO_FUEL_SA`). I did not re-crawl MADAR against the live warehouse: the engine imports from the main checkout, so it would run unfixed code, and this branch is a draft. **The live warehouse was opened read-only for measurement and never written.**

```
3,418 leaf rows | 296 with a count | 3,122 with none | 0 published as zero
                                    145 distinct products publish a count

pass 1  count blanked, as production holds it   appended 3,418   stock on 0
pass 2  census verbatim, prices unmoved         appended   296   stock on 296
pass 3  same census again                       appended     0   confirmed 3,418
```

**296 of 296 landed**, and the offers whose *latest* observation carries a count — what the published view reads — is also 296. Pass 3 confirms the count is recorded when it *moves*, not on every crawl, so the append-only table does not become a daily copy of itself.

**On the brief's 297:** today the site publishes **296**. `530458705` → 1 and `71205003` → 8 are both present and both land. One leaf's count went away between 2026-07-29 and today — the shop's stock moved. I did not re-verify the 297 and treat it as correct when taken. Note 296 leaves resolve to 295 distinct variant ids: SKU `502562030` is emitted twice, once standing alone at 138.86 and once as a grouped member at 120.75 — two distinct offers, a pre-existing catalogue quirk, untouched here.

## Other connectors — measured, not widened

Coverage before, from the live warehouse (read-only):

| source | `price_observation` | `offer_state` |
|---|---|---|
| MADAR | 0 / 6,146 | 297 / 3,425 |
| MASDAR | 617 / 617 | 617 / 617 |
| all other 9 | 0 | 0 |

- **MASDAR** (`hybris.py:425`) emits a stock level on the price row and reads 617/617 today only because every one of its offers is on its first observation. Once its prices settle it would have frozen exactly as MADAR did — **this fix covers it too**, and that is a widening of effect I am stating rather than hiding: MASDAR will now append an observation when its stock moves.
- **SIKAEGSHOP** (`custom_json.py:447-468`) — **a second connector drops a published stock figure.** The shop publishes real counts (fixtures hold 198, 83, 8, 1, 99, 100); `custom_json` reads them for `_availability` (`:180`) and for an enrichment attribute row (`:528`), but its **price row never sets `stock_quantity`**. **Not fixed here** — a separate connector-level gap, left disjoint so this diff stays one reviewable change.
- **ELSEWEDYSHOP** (`shopify.py:178`) — `stock_quantity=""` is correct: Shopify publishes only an `available` boolean (`:248`), no count. Nothing dropped.
- salla (ALSWEED, ELBUROJ), zid (ADVANCEDCASTLE), woocommerce (SAMEHGABRIEL), heidelberg — no stock figure in the source data. Nothing dropped.

## Contract and coordination

- **No `PAYLOAD_VERSION` / `PAYLOAD_COMPAT_VERSION` change.** `stock_quantity` is already in `rowspec.py:83`, in the 34-column header and in `price_observation`. Nothing about the payload changed, so the owner's one remaining Apps Script paste is untouched.
- **No migration.** The column and the index already exist.
- **PR #25 merged at 11:12:29Z**, so `weight`/`weight_unit` and migration `0057` are in this branch's base. **No conflict expected** — this diff touches only `ingest.py:1146`, inside `_still_the_same_price`, which #25 did not modify. It does not touch `magento.py` at all.
- Historical NULLs are preserved, not backfilled: `price_observation` is append-only (`trg_price_obs_no_update`), and we genuinely did not know the count on those days.

## The test

`tests/test_stock_counts_reach_the_warehouse.py` — 9 tests, from a live capture (`tests/fixtures/live/madar_stock_counts_2026-07-30.json` plus its `.CAPTURE.md`), full round trip row → payload → ingest → warehouse. **4 fail without the fix**, including the core regression.

It **crawls twice**. The existing round-trip test (`test_display_method_and_quantity_facts.py:342`) already asserts on `price_observation.stock_quantity` and passes — because it ingests **once into an empty database**, where a first-ever ingest has no open price period and the gate short-circuits before it can drop anything. That is precisely why it stayed green while production held zero. The defect only exists on the *second* crawl of an unmoved price, which is every crawl there is. Same lesson as `display_method`, one layer down.

Also pinned: the price history is untouched (one period, still open — a stock move opens no second period), the earlier NULL row is preserved, silent products append nothing at all, and the count now survives `rebuild_offer`.

Full suite green locally (1,541 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
