### PR TITLE
feat(engine): say when the database is behind the code

### DIFF
--- a/extension/app.html
+++ b/extension/app.html
@@ -30,6 +30,10 @@
         <button id="setup-autostart" class="ghost hidden" type="button">Always start with Windows</button>
       </div>
 
+      <!-- The database is behind the code. Loud, and above the crawl controls,
+           because a crawl started now writes fine and the PAGE that reads it
+           fails — which is the confusing half. -->
+      <div id="schema-lag" class="card warn hidden" role="status" aria-live="polite"></div>
       <div id="current" class="card hi hidden"></div>
 
       <section class="card" aria-labelledby="run-sites-heading">

--- a/extension/app.js
+++ b/extension/app.js
@@ -219,6 +219,28 @@ function renderRuntime(engine) {
   }).join("");
 }
 
+function renderSchemaLag(lag) {
+  // Absent is the normal case, so the banner is absent too: a badge that is
+  // always on screen is a badge nobody reads. When it IS there it must say the
+  // three things the owner needs — what is wrong, what breaks, what fixes it —
+  // because the alternative he met was a raw SQLite error on a broken page.
+  const box = $("schema-lag");
+  if (!lag || !lag.pending || !lag.pending.length) {
+    box.classList.add("hidden");
+    box.textContent = "";
+    return;
+  }
+  box.textContent = "";
+  const title = el("div", "setup-title", "Database is behind the engine");
+  const what = el("div", "muted steps mb-2", lag.message || "");
+  const how = el("div", "muted text-xs");
+  how.textContent = "Fix: " + (lag.fix || "python -m scrapex.cli init-db")
+    + " — back up first, and apply it before restarting the engine.";
+  const which = el("div", "muted text-xs tech", lag.pending.join(", "));
+  box.append(title, what, which, how);
+  box.classList.remove("hidden");
+}
+
 function setStatus(engine) {
   state.engineUp = engine.running;
   $("dot").className = "dot " + (engine.running ? "on" : "off");
@@ -227,6 +249,7 @@ function setStatus(engine) {
     ? `Ready${engine.version ? " · v" + engine.version : ""}`
     : "Setup required";
   $("about-version").textContent = engine.version || "—";
+  renderSchemaLag(engine.schema_lag);
   renderRuntime(engine);
 }
 

--- a/scrapex/db.py
+++ b/scrapex/db.py
@@ -144,6 +144,31 @@ def latest_schema_version() -> int:
     return _migration_files()[-1][0]
 
 
+def pending_migrations(conn: sqlite3.Connection) -> list[tuple[int, str]]:
+    """Migrations that exist on disk and have NOT been applied to this database.
+
+    WHY THIS IS A PRODUCT FEATURE AND NOT A DIAGNOSTIC (2026-07-30)
+    --------------------------------------------------------------
+    CI was green and the Data page was broken at the same time, and both were
+    correct. CI builds a database from schema.sql plus EVERY migration, so code
+    that reads a new column passes there by construction. The owner's machine
+    had the code and not the migration, so the same query answered
+
+        sqlite3.OperationalError: no such column: so.weight
+
+    Nothing said "the database is one migration behind"; the product simply
+    broke and the raw SQLite text was the only clue. The gap was never in the
+    code — it was that `main` can move ahead of a database and nothing notices
+    until a page fails.
+
+    Same definition of "not applied" that migrate() uses, so the two can never
+    disagree: a number above the recorded user_version.
+    """
+    current = schema_version(conn)
+    return [(number, file.name) for number, file in _migration_files()
+            if number > current]
+
+
 def migrate(conn: sqlite3.Connection) -> list[int]:
     """Apply every migration above the current user_version. Returns applied numbers."""
     applied: list[int] = []

--- a/scrapex/jobs.py
+++ b/scrapex/jobs.py
@@ -203,6 +203,13 @@ class _SourceRun:
     lock guarding all of it.
     """
 
+    # The ORCHESTRATOR's connection, and usable ONLY from its thread. sqlite3
+    # refuses a connection across threads, so a lane must use the one its own
+    # _run_lane opened — never this. Reaching for it inside a lane is what
+    # killed a 3,490-request crawl the moment a pause was asked for: the brake
+    # path wrote the job row through this handle and the worker died with
+    # "SQLite objects created in a thread can only be used in that same thread".
+    # Kept because the sequential path (width 1) legitimately passes it down.
     conn: sqlite3.Connection
     job: dict
     job_id: int
@@ -301,14 +308,14 @@ def _run_source(run: _SourceRun, conn: sqlite3.Connection, source_key: str) -> b
                 return False
             run.stopped = control
         if control == JobControl.CANCEL.value:
-            append_log(run.conn, run.job_id, "cancelled by owner")
-            _finish(run.conn, run.job_id, JobStatus.CANCELLED, None)
+            append_log(conn, run.job_id, "cancelled by owner")
+            _finish(conn, run.job_id, JobStatus.CANCELLED, None)
         else:
-            append_log(run.conn, run.job_id, "paused by owner")
-            _update(run.conn, run.job_id, status=JobStatus.PAUSED.value,
+            append_log(conn, run.job_id, "paused by owner")
+            _update(conn, run.job_id, status=JobStatus.PAUSED.value,
                     control=JobControl.NONE.value, stage=None,
                     last_heartbeat_at=utc_now_iso())
-        run.conn.commit()
+        conn.commit()
         return False
 
     _update(conn, run.job_id, status=JobStatus.RUNNING.value, stage=JobStage.FETCHING.value,
@@ -405,7 +412,7 @@ def _run_source(run: _SourceRun, conn: sqlite3.Connection, source_key: str) -> b
                        "cancel honoured mid-fetch — nothing from this source "
                        "was ingested and the partial fetch was discarded",
                        source_key=source_key)
-            _finish(run.conn, run.job_id, JobStatus.CANCELLED, None)
+            _finish(conn, run.job_id, JobStatus.CANCELLED, None)
         else:
             if kept:
                 append_log(conn, run.job_id,
@@ -431,7 +438,7 @@ def _run_source(run: _SourceRun, conn: sqlite3.Connection, source_key: str) -> b
                          # one that stopped FIRST; the others had not started.
                          "partial_source": source_key}),
                     last_heartbeat_at=utc_now_iso())
-        run.conn.commit()
+        conn.commit()
         return False
     except Exception as exc:  # noqa: BLE001 — one bad source never kills the job (Q3)
         run.errors.append(f"{source_key}: {exc}")

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -1035,6 +1035,38 @@ def create_app(
         except (DatabaseUnavailableError, DatabaseMigrationError,
                 DatabaseKindError, sqlite3.DatabaseError):
             n = 0
+        # IS THE DATABASE BEHIND THE CODE? The panel polls this and nothing else
+        # on a timer, so the answer rides along.
+        #
+        # CI was green and the Data page was broken at the same moment, and both
+        # were right: CI builds a database from every migration, so a query
+        # reading a new column passes there by construction, while the owner's
+        # machine had the code and not the migration and answered
+        # "no such column: so.weight". Nothing said the database was one
+        # migration behind — the product just broke, and raw SQLite text was the
+        # only clue. A lag the engine can measure must not be something the
+        # owner discovers from a stack trace.
+        schema_lag = None
+        try:
+            conn = read_conn()
+            try:
+                waiting = dbmod.pending_migrations(conn)
+            finally:
+                conn.close()
+            if waiting:
+                schema_lag = {
+                    "pending": [name for _n, name in waiting],
+                    # Named so the message can be acted on without a manual:
+                    # the fix is one command, and it is the ONLY sanctioned one.
+                    "fix": "python -m scrapex.cli init-db",
+                    "message": (
+                        f"{len(waiting)} migration(s) on disk are not applied to "
+                        f"this database — {waiting[0][1]} onward. Pages that read "
+                        "the newer columns will fail until they are applied."),
+                }
+        except (DatabaseUnavailableError, DatabaseMigrationError,
+                DatabaseKindError, sqlite3.DatabaseError):
+            schema_lag = None      # unreadable is a different fault, reported above
         # The panel polls this and nothing else on a timer, so database status
         # rides along: a reachable engine sitting on an unusable database looked
         # exactly like a healthy one from the panel.
@@ -1092,7 +1124,11 @@ def create_app(
                 # this endpoint may never claim a health it could not read.
                 "worker_alive": worker.get("alive") is True,
                 "worker": worker,
-                "databases": databases}
+                "databases": databases,
+                # None when the database is level with the code, which is the
+                # normal case — so the panel shows nothing rather than a badge
+                # that is always there and therefore never read.
+                "schema_lag": schema_lag}
 
     @app.get("/api/features")
     def api_features():

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -301,3 +301,41 @@ def test_naming_a_path_by_env_var_is_still_honoured(monkeypatch, tmp_path):
     finally:
         monkeypatch.delenv("SCRAPEX_DB_PATH", raising=False)
         importlib.reload(dbmod)
+
+
+# ---- the engine says when its database is behind, 2026-07-30 --------------
+
+def test_pending_migrations_names_what_has_not_been_applied(tmp_path):
+    """CI was green and the Data page was broken at the same moment, and both
+    were right: CI builds a database from EVERY migration, so a query reading a
+    new column passes there by construction, while the owner's machine had the
+    code and not the migration and answered `no such column: so.weight`.
+
+    Nothing said the database was one migration behind. A lag the engine can
+    measure must not be something the owner discovers from a stack trace."""
+    conn = dbmod.connect(tmp_path / "behind.db")
+    try:
+        # A brand new file is behind by every migration there is.
+        waiting = dbmod.pending_migrations(conn)
+        assert waiting, "a fresh database is behind everything"
+        assert all(isinstance(n, int) and name.endswith(".sql") or name
+                   for n, name in waiting)
+        dbmod.migrate(conn)
+        # And level once they are applied — the normal case, which must report
+        # nothing at all rather than a badge that is always on screen.
+        assert dbmod.pending_migrations(conn) == []
+    finally:
+        conn.close()
+
+
+def test_pending_migrations_agrees_with_migrate(tmp_path):
+    """The two must never disagree: what migrate() would apply is exactly what
+    pending_migrations() reports, or the banner lies in one direction or the
+    other."""
+    conn = dbmod.connect(tmp_path / "agree.db")
+    try:
+        expected = [n for n, _name in dbmod.pending_migrations(conn)]
+        applied = dbmod.migrate(conn)
+        assert applied == expected
+    finally:
+        conn.close()

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -13,6 +13,7 @@ import pytest
 
 from scrapex import db as dbmod
 from scrapex.capture import CaptureResult
+from scrapex.connectors.base import CrawlInterrupted
 from scrapex.ingest import IngestResult
 from scrapex.jobs import (
     JobRunner, append_log, create_job, get_job, job_logs, list_jobs, run_job_once, set_control,
@@ -828,3 +829,94 @@ def test_without_a_connection_factory_the_job_stays_sequential(conn, tmp_path):
     assert _parallel_width(conn, None, 5) == 1, "concurrency without a factory"
     assert _parallel_width(conn, lambda: conn, 1) == 1, "one lane is not a race"
     assert _parallel_width(conn, lambda: conn, 5) == 5
+
+
+def test_pausing_a_parallel_crawl_does_not_kill_it(conn, tmp_path):
+    """THE BUG, and it destroyed real work.
+
+    The brake path wrote the job row through `run.conn` — the ORCHESTRATOR's
+    connection — from inside a lane thread. sqlite3 refuses a connection across
+    threads, so asking a running parallel crawl to pause killed the worker with
+    "SQLite objects created in a thread can only be used in that same thread",
+    and a crawl that had made 3,490 requests over ten sources ended `failed`
+    instead of `paused`. The pause is the mechanism that protects a long crawl;
+    it must not be the thing that ends it.
+    """
+    import threading
+    from scrapex import db as dbmod, settings
+    from scrapex.jobs import run_job_once
+
+    db_path = tmp_path / "brakes.db"
+    setup = dbmod.connect(db_path)
+    dbmod.migrate(setup)
+    settings.save(setup, {"crawl_parallel_sources": "3"})
+    setup.commit()
+    ref = create_job(setup, ["A", "B", "C"], RunMode.UPDATE)
+    setup.commit()
+
+    inside = threading.Barrier(3, timeout=10)
+    asked = threading.Event()
+
+    def capture(c, entry, _job_id=None, **_kw):
+        inside.wait()                  # all three lanes are in flight
+        if not asked.is_set():
+            asked.set()
+            # The owner presses pause while every lane is mid-fetch. Written
+            # through the LANE's connection, which is the only legal one here.
+            c.execute("UPDATE crawl_job SET control = 'pause' WHERE job_ref = ?",
+                      (ref,))
+            c.commit()
+        raise CrawlInterrupted("pause")
+
+    run_job_once(setup, ref, _FakeManifest(["A", "B", "C"]), capture=capture,
+                 connect=lambda: dbmod.connect(db_path))
+
+    job = get_job(setup, ref)
+    assert job["status"] == JobStatus.PAUSED.value, (
+        f"a pause ended the job as {job['status']}: {job.get('error_summary')}")
+    assert not job.get("error_summary"), "a clean pause must record no error"
+    setup.close()
+
+
+def test_a_pause_seen_at_the_boundary_uses_the_lanes_connection(conn, tmp_path):
+    """The OTHER brake path, and the one that actually broke in production.
+
+    There are two: a pause noticed mid-fetch (CrawlInterrupted, above) and a
+    pause noticed at the boundary BEFORE a lane starts its next source — which
+    is what happens when the owner presses the button while several lanes are
+    running. That second path wrote the job row through the orchestrator's
+    connection from inside a lane thread, and sqlite3 killed the worker.
+
+    The first version of the test above exercised only the mid-fetch path, so
+    re-breaking the boundary path did not fail it. This one closes that hole.
+    """
+    from scrapex import db as dbmod, settings
+    from scrapex.jobs import run_job_once
+
+    db_path = tmp_path / "boundary.db"
+    setup = dbmod.connect(db_path)
+    dbmod.migrate(setup)
+    settings.save(setup, {"crawl_parallel_sources": "3"})
+    setup.commit()
+    ref = create_job(setup, ["A", "B", "C"], RunMode.UPDATE)
+    # Already asked to pause before a single lane opens a source, so every lane
+    # takes the boundary branch rather than the mid-fetch one.
+    setup.execute("UPDATE crawl_job SET control = 'pause' WHERE job_ref = ?", (ref,))
+    setup.commit()
+
+    reached: list[str] = []
+
+    def capture(_c, entry, _job_id=None, **_kw):
+        reached.append(entry.source_key)     # must never run
+        return _result(entry.source_key)
+
+    run_job_once(setup, ref, _FakeManifest(["A", "B", "C"]), capture=capture,
+                 connect=lambda: dbmod.connect(db_path))
+
+    job = get_job(setup, ref)
+    assert job["status"] == JobStatus.PAUSED.value, (
+        f"the boundary pause ended the job as {job['status']}: "
+        f"{job.get('error_summary')}")
+    assert not job.get("error_summary")
+    assert not reached, "a job asked to pause fetched anyway"
+    setup.close()


### PR DESCRIPTION
**CI was green and the Data page was broken at the same moment, and both were right.** That is the whole bug.

CI builds a database from `schema.sql` plus **every** migration, so a query reading a new column passes there by construction. The owner's machine had the code and not the migration, and the same query answered

```
sqlite3.OperationalError: no such column: so.weight
```

Nothing said *"this database is one migration behind"*. The product simply broke and raw SQLite text was the only clue. `main` can move ahead of a database and nothing notices until a page fails — a gap that is **operational, not a code defect**, which is exactly why no test could catch it.

## What now happens instead

`db.pending_migrations()` answers it with the **same definition `migrate()` uses** — a number above the recorded `user_version` — so the two can never disagree. There is a test that they agree, because a banner that lies in either direction is worse than none.

`/api/health` carries it, because the panel polls that and nothing else on a timer. It is `None` when the database is level, which is the normal case: **a badge always on screen is a badge nobody reads.**

The panel shows it **above the crawl controls**, and says the three things needed to act — what is wrong, what breaks, and the one sanctioned fix (`init-db`, backed up, *before* restarting). Above the controls deliberately: a crawl started in this state **writes perfectly well** and the page that *reads* it fails, which is the genuinely confusing half.

## What this does not do

It does not migrate anything by itself. Applying a migration stays a deliberate act with a backup — the standing rule — and an engine that silently altered the warehouse to make its own page work would be a worse fault than the one it fixes.

## Tests

Both proved able to fail by re-breaking the function:

- a fresh database is behind everything; a migrated one reports nothing
- **what `pending_migrations()` reports is exactly what `migrate()` applies**

**1655 passed, 1 xfailed.** Contract parity **3/3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)