### PR TITLE
fix(db): the lag guard names only this database's own migrations

### DIFF
--- a/scrapex/db.py
+++ b/scrapex/db.py
@@ -165,9 +165,31 @@ def pending_migrations(conn: sqlite3.Connection) -> list[tuple[int, str]]:
     Same definition of "not applied" that migrate() uses, so the two can never
     disagree: a number above the recorded user_version.
     """
-    current = schema_version(conn)
+    # WHICH MIGRATIONS BELONG TO THIS DATABASE, and this took two wrong
+    # answers to get right — both of which cried wolf, which is worse than
+    # silence.
+    #
+    # First attempt compared filename numbers against user_version: the ledger
+    # numbers a migration by its POSITION in this database's stream (0057 is
+    # recorded as 55), so it announced two applied migrations as pending.
+    #
+    # Second attempt compared filenames against the ledger, and announced 0013,
+    # 0014 and 0017 as pending — they are GENERAL-database migrations. One
+    # directory holds both streams, and the legacy facade cannot tell them
+    # apart. The domain layer already declares the split, so it is asked rather
+    # than re-derived here; one list, and it is the one the migrator obeys.
+    from .databases.domain import _MARKETLENS_LEGACY_NUMBERS as _MINE
+    try:
+        applied = {row[0] for row in conn.execute(
+            "SELECT migration_name FROM database_migration")}
+    except sqlite3.DatabaseError:
+        # Older than the ledger: user_version is all there is, and on such a
+        # database no renumbering has happened yet, so it is still true.
+        current = schema_version(conn)
+        return [(number, file.name) for number, file in _migration_files()
+                if number > current and number in _MINE]
     return [(number, file.name) for number, file in _migration_files()
-            if number > current]
+            if number in _MINE and file.name not in applied]
 
 
 def migrate(conn: sqlite3.Connection) -> list[int]:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -398,13 +398,60 @@ def test_pending_migrations_names_what_has_not_been_applied(tmp_path):
 
 
 def test_pending_migrations_agrees_with_migrate(tmp_path):
-    """The two must never disagree: what migrate() would apply is exactly what
-    pending_migrations() reports, or the banner lies in one direction or the
-    other."""
+    """What the guard reports must be a SUBSET of what migrate() applies, never
+    a superset — the banner may under-report in an edge case, but it must never
+    name a migration that will not run.
+
+    Not equality, and the difference is the point: the legacy migrate() applies
+    every file in the directory, which holds BOTH database streams, while the
+    guard reports only this database's own. Asserting equality was asserting
+    that the two streams are one, which is how 0013, 0014 and 0017 — General
+    migrations — were announced as pending on a current MarketLens database."""
     conn = dbmod.connect(tmp_path / "agree.db")
     try:
-        expected = [n for n, _name in dbmod.pending_migrations(conn)]
-        applied = dbmod.migrate(conn)
-        assert applied == expected
+        reported = {n for n, _name in dbmod.pending_migrations(conn)}
+        applied = set(dbmod.migrate(conn))
+        assert reported <= applied, (
+            f"the guard named migrations migrate() never ran: "
+            f"{sorted(reported - applied)}")
+        assert dbmod.pending_migrations(conn) == []
+    finally:
+        conn.close()
+
+
+def test_the_lag_guard_does_not_cry_wolf_on_a_current_database(tmp_path):
+    """TWO WRONG ANSWERS, both of which announced work that was already done —
+    and a guard that cries wolf is worse than no guard.
+
+    1. Comparing filename numbers against user_version: the ledger numbers a
+       migration by its POSITION in this database's stream (0057 is recorded as
+       55), so a fully current database was told 0056 and 0057 were pending.
+    2. Comparing filenames against the ledger: 0013, 0014 and 0017 are GENERAL
+       database migrations. One directory holds both streams and the legacy
+       facade cannot tell them apart, so a current database was told three
+       migrations were waiting that will never apply to it.
+
+    A fully migrated database must report NOTHING. That is the whole promise.
+    """
+    conn = dbmod.connect(tmp_path / "current.db")
+    try:
+        dbmod.migrate(conn)
+        assert dbmod.pending_migrations(conn) == [], (
+            "a fully migrated database was told it is behind")
+    finally:
+        conn.close()
+
+
+def test_the_lag_guard_ignores_the_other_databases_migrations(tmp_path):
+    """The migrations directory holds BOTH streams. Only this database's own
+    may ever be reported, or the banner names files that will never apply."""
+    from scrapex.databases.domain import _MARKETLENS_LEGACY_NUMBERS
+
+    conn = dbmod.connect(tmp_path / "streams.db")
+    try:
+        reported = {n for n, _name in dbmod.pending_migrations(conn)}
+        assert reported, "a fresh database must be behind something"
+        stray = reported - set(_MARKETLENS_LEGACY_NUMBERS)
+        assert not stray, f"migrations from the other stream reported: {sorted(stray)}"
     finally:
         conn.close()


### PR DESCRIPTION
The guard shipped an hour ago and **cried wolf on the owner's own database within minutes of being merged**. Twice, for two different reasons, and both times it announced work that was already done — worse than saying nothing, and exactly what its own commit message warned against.

## First wrong answer

It compared **filename numbers** against `user_version`. The ledger numbers a migration by its **position** in this database's stream — `0057` is recorded as **55** — so a fully current database was told 0056 and 0057 were waiting.

## Second wrong answer

Comparing **filenames** against the ledger instead named `0013`, `0014` and `0017`. **Those are General-database migrations.** One directory holds both streams and the legacy facade cannot tell them apart, so a current MarketLens database was told three migrations were pending that will never apply to it.

The domain layer already declares the split — `_MARKETLENS_LEGACY_NUMBERS` — so it is **asked rather than re-derived**. One list, and it is the one the migrator obeys.

## An assumption the old test was encoding

`test_pending_migrations_agrees_with_migrate` asserted the guard and the legacy `migrate()` report the **same** set. They cannot: `migrate()` applies every file in the directory, both streams; the guard reports one.

**Asserting equality was asserting the two streams are one — the second bug, written down as a test.** It now asserts the relationship actually required: the guard's list is a **subset**, so it may never name a migration that will not run.

## Tests

- a fully migrated database reports **nothing** (the first false alarm)
- **nothing outside this database's own stream** is ever reported (the second)
- the subset relationship, replacing the equality that was wrong

Verified against the live warehouse: it now reports **none**, which is the truth — 0056 and 0057 were applied at 04:36 and 11:38 today.

**1692 passed, 1 xfailed.** Contract parity **3/3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)