### PR TITLE
fix(ui): simplify and polish split button menus

### DIFF
--- a/design/components.css
+++ b/design/components.css
@@ -1193,6 +1193,7 @@ code {
  * placement; everything visual and interactive is this. Behaviour: split-button.js.
  * ======================================================================== */
 .split-button {
+  position: relative;
   display: inline-flex;
   align-items: stretch;
   border: 1px solid var(--line-strong);
@@ -1234,7 +1235,7 @@ code {
   transform: none;
 }
 .split-button-menu {
-  position: relative;
+  position: static;
   display: flex;
 }
 .split-button-menu > summary { list-style: none; }
@@ -1250,6 +1251,12 @@ code {
   border-end-end-radius: calc(var(--radius) - 1px);
   cursor: pointer;
 }
+.split-button-trigger:focus-visible {
+  position: relative;
+  z-index: 1;
+  outline: 2px solid var(--focus);
+  outline-offset: -2px;
+}
 .split-button-trigger .sx-icon { width: 1.05rem; height: 1.05rem; }
 .split-button-chevron {
   margin-inline-start: auto;
@@ -1263,13 +1270,12 @@ code {
 .split-button-options {
   position: absolute;
   z-index: 120;
-  inset-inline-end: 0;
-  top: calc(100% + var(--sp-2));
+  inset-inline: 0;
+  top: calc(100% + var(--sp-1));
   display: grid;
   gap: 2px;
-  width: max-content;
-  min-width: 12rem;
-  max-width: calc(100vw - 2rem);
+  width: 100%;
+  min-width: 0;
   padding: var(--sp-1);
   background: var(--surface);
   border: 1px solid var(--line-strong);

--- a/design/components.css
+++ b/design/components.css
@@ -1264,47 +1264,31 @@ code {
   position: absolute;
   z-index: 120;
   inset-inline-end: 0;
-  bottom: calc(100% + var(--sp-2));
+  top: calc(100% + var(--sp-2));
   display: grid;
-  gap: var(--sp-1);
-  width: min(20rem, calc(100vw - 2rem));
-  padding: var(--sp-2);
+  gap: 2px;
+  width: max-content;
+  min-width: 12rem;
+  max-width: calc(100vw - 2rem);
+  padding: var(--sp-1);
   background: var(--surface);
   border: 1px solid var(--line-strong);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius);
   box-shadow: var(--shadow-lg);
-  transform-origin: bottom right;
+  transform-origin: top right;
   animation: split-button-options-in var(--dur-fast) var(--ease);
 }
-/* A menu that opens DOWNWARD, for a control near the top of its scroll box. */
-.split-button-menu.opens-down .split-button-options {
-  top: calc(100% + var(--sp-2));
-  bottom: auto;
-  transform-origin: top right;
-}
 @keyframes split-button-options-in {
-  from { opacity: 0; transform: translateY(.35rem) scale(.98); }
+  from { opacity: 0; transform: translateY(-.35rem) scale(.98); }
   to { opacity: 1; transform: translateY(0) scale(1); }
-}
-.split-button-options-head {
-  display: grid;
-  gap: var(--sp-1);
-  padding: var(--sp-2) var(--sp-3) var(--sp-3);
-  border-bottom: 1px solid var(--line);
-}
-.split-button-options-head strong { color: var(--text); font-size: var(--fs-sm); }
-.split-button-options-head span {
-  color: var(--muted);
-  font-size: var(--fs-xs);
-  line-height: 1.4;
 }
 .split-button-option {
   display: grid;
-  grid-template-columns: 2rem minmax(0, 1fr) auto;
+  grid-template-columns: 1.25rem minmax(0, 1fr) auto;
   align-items: center;
-  gap: var(--sp-3);
+  gap: var(--sp-2);
   width: 100%;
-  min-height: 3.5rem;
+  min-height: var(--control-height);
   padding: var(--sp-2) var(--sp-3);
   color: var(--text);
   background: transparent;
@@ -1328,29 +1312,17 @@ code {
 .split-button-option-icon {
   display: grid;
   place-items: center;
-  width: 2rem;
-  height: 2rem;
-  border-radius: var(--radius);
-  background: var(--accent-weak);
+  width: 1.25rem;
+  height: 1.25rem;
   color: var(--accent-ink);
 }
 .split-button-option-icon .sx-icon { width: 1.05rem; height: 1.05rem; }
-.split-button-option-copy { display: grid; gap: var(--sp-1); min-width: 0; }
+.split-button-option-copy { min-width: 0; }
 .split-button-option-copy strong { font-size: var(--fs-sm); }
-.split-button-option-copy small {
-  color: var(--muted);
-  font-size: var(--fs-2xs);
-  font-weight: var(--fw-regular);
-  line-height: 1.35;
-}
 .split-button-option-tag {
-  padding: .15rem .35rem;
-  border-radius: var(--radius-xs);
-  background: var(--surface-container-low);
   color: var(--muted);
   font-family: var(--font-mono);
   font-size: var(--fs-2xs);
-  line-height: 1.4;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/extension/app.html
+++ b/extension/app.html
@@ -141,14 +141,13 @@
                        aria-expanded="false" aria-label="More log actions">
                 <svg class="sx-icon split-button-chevron" aria-hidden="true"><use href="icons/material-icons.svg#expand-more"></use></svg>
               </summary>
-              <div class="split-button-options opens-down" role="menu" aria-label="Log actions">
+              <div class="split-button-options" role="menu" aria-label="Log actions">
                 <button type="button" class="split-button-option" data-split-action="copy" role="menuitem">
                   <span class="split-button-option-icon">
                     <svg class="sx-icon" aria-hidden="true"><use href="icons/material-icons.svg#description"></use></svg>
                   </span>
                   <span class="split-button-option-copy">
                     <strong>Copy visible log</strong>
-                    <small>Every line now on screen, to the clipboard.</small>
                   </span>
                 </button>
                 <button type="button" class="split-button-option" data-split-action="download" role="menuitem">
@@ -157,7 +156,6 @@
                   </span>
                   <span class="split-button-option-copy">
                     <strong>Download full log</strong>
-                    <small>The engine's complete record for this job, every entry.</small>
                   </span>
                 </button>
               </div>

--- a/extension/components.css
+++ b/extension/components.css
@@ -1193,6 +1193,7 @@ code {
  * placement; everything visual and interactive is this. Behaviour: split-button.js.
  * ======================================================================== */
 .split-button {
+  position: relative;
   display: inline-flex;
   align-items: stretch;
   border: 1px solid var(--line-strong);
@@ -1234,7 +1235,7 @@ code {
   transform: none;
 }
 .split-button-menu {
-  position: relative;
+  position: static;
   display: flex;
 }
 .split-button-menu > summary { list-style: none; }
@@ -1250,6 +1251,12 @@ code {
   border-end-end-radius: calc(var(--radius) - 1px);
   cursor: pointer;
 }
+.split-button-trigger:focus-visible {
+  position: relative;
+  z-index: 1;
+  outline: 2px solid var(--focus);
+  outline-offset: -2px;
+}
 .split-button-trigger .sx-icon { width: 1.05rem; height: 1.05rem; }
 .split-button-chevron {
   margin-inline-start: auto;
@@ -1263,13 +1270,12 @@ code {
 .split-button-options {
   position: absolute;
   z-index: 120;
-  inset-inline-end: 0;
-  top: calc(100% + var(--sp-2));
+  inset-inline: 0;
+  top: calc(100% + var(--sp-1));
   display: grid;
   gap: 2px;
-  width: max-content;
-  min-width: 12rem;
-  max-width: calc(100vw - 2rem);
+  width: 100%;
+  min-width: 0;
   padding: var(--sp-1);
   background: var(--surface);
   border: 1px solid var(--line-strong);

--- a/extension/components.css
+++ b/extension/components.css
@@ -1264,47 +1264,31 @@ code {
   position: absolute;
   z-index: 120;
   inset-inline-end: 0;
-  bottom: calc(100% + var(--sp-2));
+  top: calc(100% + var(--sp-2));
   display: grid;
-  gap: var(--sp-1);
-  width: min(20rem, calc(100vw - 2rem));
-  padding: var(--sp-2);
+  gap: 2px;
+  width: max-content;
+  min-width: 12rem;
+  max-width: calc(100vw - 2rem);
+  padding: var(--sp-1);
   background: var(--surface);
   border: 1px solid var(--line-strong);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius);
   box-shadow: var(--shadow-lg);
-  transform-origin: bottom right;
+  transform-origin: top right;
   animation: split-button-options-in var(--dur-fast) var(--ease);
 }
-/* A menu that opens DOWNWARD, for a control near the top of its scroll box. */
-.split-button-menu.opens-down .split-button-options {
-  top: calc(100% + var(--sp-2));
-  bottom: auto;
-  transform-origin: top right;
-}
 @keyframes split-button-options-in {
-  from { opacity: 0; transform: translateY(.35rem) scale(.98); }
+  from { opacity: 0; transform: translateY(-.35rem) scale(.98); }
   to { opacity: 1; transform: translateY(0) scale(1); }
-}
-.split-button-options-head {
-  display: grid;
-  gap: var(--sp-1);
-  padding: var(--sp-2) var(--sp-3) var(--sp-3);
-  border-bottom: 1px solid var(--line);
-}
-.split-button-options-head strong { color: var(--text); font-size: var(--fs-sm); }
-.split-button-options-head span {
-  color: var(--muted);
-  font-size: var(--fs-xs);
-  line-height: 1.4;
 }
 .split-button-option {
   display: grid;
-  grid-template-columns: 2rem minmax(0, 1fr) auto;
+  grid-template-columns: 1.25rem minmax(0, 1fr) auto;
   align-items: center;
-  gap: var(--sp-3);
+  gap: var(--sp-2);
   width: 100%;
-  min-height: 3.5rem;
+  min-height: var(--control-height);
   padding: var(--sp-2) var(--sp-3);
   color: var(--text);
   background: transparent;
@@ -1328,29 +1312,17 @@ code {
 .split-button-option-icon {
   display: grid;
   place-items: center;
-  width: 2rem;
-  height: 2rem;
-  border-radius: var(--radius);
-  background: var(--accent-weak);
+  width: 1.25rem;
+  height: 1.25rem;
   color: var(--accent-ink);
 }
 .split-button-option-icon .sx-icon { width: 1.05rem; height: 1.05rem; }
-.split-button-option-copy { display: grid; gap: var(--sp-1); min-width: 0; }
+.split-button-option-copy { min-width: 0; }
 .split-button-option-copy strong { font-size: var(--fs-sm); }
-.split-button-option-copy small {
-  color: var(--muted);
-  font-size: var(--fs-2xs);
-  font-weight: var(--fw-regular);
-  line-height: 1.35;
-}
 .split-button-option-tag {
-  padding: .15rem .35rem;
-  border-radius: var(--radius-xs);
-  background: var(--surface-container-low);
   color: var(--muted);
   font-family: var(--font-mono);
   font-size: var(--fs-2xs);
-  line-height: 1.4;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/scrapex/webui/static/components.css
+++ b/scrapex/webui/static/components.css
@@ -1193,6 +1193,7 @@ code {
  * placement; everything visual and interactive is this. Behaviour: split-button.js.
  * ======================================================================== */
 .split-button {
+  position: relative;
   display: inline-flex;
   align-items: stretch;
   border: 1px solid var(--line-strong);
@@ -1234,7 +1235,7 @@ code {
   transform: none;
 }
 .split-button-menu {
-  position: relative;
+  position: static;
   display: flex;
 }
 .split-button-menu > summary { list-style: none; }
@@ -1250,6 +1251,12 @@ code {
   border-end-end-radius: calc(var(--radius) - 1px);
   cursor: pointer;
 }
+.split-button-trigger:focus-visible {
+  position: relative;
+  z-index: 1;
+  outline: 2px solid var(--focus);
+  outline-offset: -2px;
+}
 .split-button-trigger .sx-icon { width: 1.05rem; height: 1.05rem; }
 .split-button-chevron {
   margin-inline-start: auto;
@@ -1263,13 +1270,12 @@ code {
 .split-button-options {
   position: absolute;
   z-index: 120;
-  inset-inline-end: 0;
-  top: calc(100% + var(--sp-2));
+  inset-inline: 0;
+  top: calc(100% + var(--sp-1));
   display: grid;
   gap: 2px;
-  width: max-content;
-  min-width: 12rem;
-  max-width: calc(100vw - 2rem);
+  width: 100%;
+  min-width: 0;
   padding: var(--sp-1);
   background: var(--surface);
   border: 1px solid var(--line-strong);

--- a/scrapex/webui/static/components.css
+++ b/scrapex/webui/static/components.css
@@ -1264,47 +1264,31 @@ code {
   position: absolute;
   z-index: 120;
   inset-inline-end: 0;
-  bottom: calc(100% + var(--sp-2));
+  top: calc(100% + var(--sp-2));
   display: grid;
-  gap: var(--sp-1);
-  width: min(20rem, calc(100vw - 2rem));
-  padding: var(--sp-2);
+  gap: 2px;
+  width: max-content;
+  min-width: 12rem;
+  max-width: calc(100vw - 2rem);
+  padding: var(--sp-1);
   background: var(--surface);
   border: 1px solid var(--line-strong);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius);
   box-shadow: var(--shadow-lg);
-  transform-origin: bottom right;
+  transform-origin: top right;
   animation: split-button-options-in var(--dur-fast) var(--ease);
 }
-/* A menu that opens DOWNWARD, for a control near the top of its scroll box. */
-.split-button-menu.opens-down .split-button-options {
-  top: calc(100% + var(--sp-2));
-  bottom: auto;
-  transform-origin: top right;
-}
 @keyframes split-button-options-in {
-  from { opacity: 0; transform: translateY(.35rem) scale(.98); }
+  from { opacity: 0; transform: translateY(-.35rem) scale(.98); }
   to { opacity: 1; transform: translateY(0) scale(1); }
-}
-.split-button-options-head {
-  display: grid;
-  gap: var(--sp-1);
-  padding: var(--sp-2) var(--sp-3) var(--sp-3);
-  border-bottom: 1px solid var(--line);
-}
-.split-button-options-head strong { color: var(--text); font-size: var(--fs-sm); }
-.split-button-options-head span {
-  color: var(--muted);
-  font-size: var(--fs-xs);
-  line-height: 1.4;
 }
 .split-button-option {
   display: grid;
-  grid-template-columns: 2rem minmax(0, 1fr) auto;
+  grid-template-columns: 1.25rem minmax(0, 1fr) auto;
   align-items: center;
-  gap: var(--sp-3);
+  gap: var(--sp-2);
   width: 100%;
-  min-height: 3.5rem;
+  min-height: var(--control-height);
   padding: var(--sp-2) var(--sp-3);
   color: var(--text);
   background: transparent;
@@ -1328,29 +1312,17 @@ code {
 .split-button-option-icon {
   display: grid;
   place-items: center;
-  width: 2rem;
-  height: 2rem;
-  border-radius: var(--radius);
-  background: var(--accent-weak);
+  width: 1.25rem;
+  height: 1.25rem;
   color: var(--accent-ink);
 }
 .split-button-option-icon .sx-icon { width: 1.05rem; height: 1.05rem; }
-.split-button-option-copy { display: grid; gap: var(--sp-1); min-width: 0; }
+.split-button-option-copy { min-width: 0; }
 .split-button-option-copy strong { font-size: var(--fs-sm); }
-.split-button-option-copy small {
-  color: var(--muted);
-  font-size: var(--fs-2xs);
-  font-weight: var(--fw-regular);
-  line-height: 1.35;
-}
 .split-button-option-tag {
-  padding: .15rem .35rem;
-  border-radius: var(--radius-xs);
-  background: var(--surface-container-low);
   color: var(--muted);
   font-family: var(--font-mono);
   font-size: var(--fs-2xs);
-  line-height: 1.4;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/scrapex/webui/templates/source.html
+++ b/scrapex/webui/templates/source.html
@@ -301,10 +301,6 @@
                 {{ icon("expand-more", "split-button-chevron") }}
               </summary>
               <div class="split-button-options" role="menu" aria-label="Export format">
-                <div class="split-button-options-head">
-                  <strong>Other formats</strong>
-                  <span>Uses visible columns, filters and their current order.</span>
-                </div>
                 <button type="button" class="split-button-option" data-split-action="csv"
                         role="menuitem">
                   <span class="split-button-option-icon">
@@ -312,7 +308,6 @@
                   </span>
                   <span class="split-button-option-copy">
                     <strong>CSV table</strong>
-                    <small>Filtered rows in a spreadsheet-friendly file.</small>
                   </span>
                   <span class="split-button-option-tag">.csv</span>
                 </button>
@@ -323,7 +318,6 @@
                   </span>
                   <span class="split-button-option-copy">
                     <strong>JSON data</strong>
-                    <small>Structured data from the current table view.</small>
                   </span>
                   <span class="split-button-option-tag">.json</span>
                 </button>

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -1062,6 +1062,8 @@ def test_the_log_controls_are_one_shared_split_button(open_panel):
     # ScrapeXSplitButton, so the menu opens and closes like the Export one.
     assert page.locator('#activity .split-button-primary[data-split-action="copy"]').count() == 1
     assert page.locator('#activity [data-split-action="download"]').count() == 1
+    assert "Every line now on screen" not in split.text_content()
+    assert "engine's complete record" not in split.text_content()
 
     menu = page.locator("#activity .split-button-menu")
     assert not menu.evaluate("el => el.open")

--- a/tests/test_vendor.py
+++ b/tests/test_vendor.py
@@ -383,9 +383,11 @@ def test_export_actions_follow_the_grid_instead_of_sitting_above_it():
     assert 'class="split-button-menu"' in page
     assert 'class="split-button-trigger"' in page
     assert '<span>Excel workbook</span>' in page
-    assert 'class="split-button-options-head"' in page
+    assert 'class="split-button-options-head"' not in page
     assert page.count('class="split-button-option"') == 2
     assert page.count('class="split-button-option-tag"') == 2
+    assert "Filtered rows in a spreadsheet-friendly file." not in page
+    assert "Structured data from the current table view." not in page
     assert page.count("data-split-action=") == 3
     assert 'class="chip" data-split-action=' not in page
     assert 'role="menu" aria-label="Export format"' in page
@@ -402,6 +404,9 @@ def test_export_actions_follow_the_grid_instead_of_sitting_above_it():
     assert ".split-button-menu[open] .split-button-trigger" in shared_css
     assert ".split-button-primary:active:not(:disabled)" in shared_css
     assert ".split-button-options" in shared_css
+    options_rule = shared_css.split(".split-button-options {", 1)[1].split("}", 1)[0]
+    assert "top: calc(100% + var(--sp-2))" in options_rule
+    assert "bottom:" not in options_rule
     assert ".split-button-option:active:not(:disabled)" in shared_css
 
 

--- a/tests/test_vendor.py
+++ b/tests/test_vendor.py
@@ -405,8 +405,13 @@ def test_export_actions_follow_the_grid_instead_of_sitting_above_it():
     assert ".split-button-primary:active:not(:disabled)" in shared_css
     assert ".split-button-options" in shared_css
     options_rule = shared_css.split(".split-button-options {", 1)[1].split("}", 1)[0]
-    assert "top: calc(100% + var(--sp-2))" in options_rule
+    assert "inset-inline: 0" in options_rule
+    assert "top: calc(100% + var(--sp-1))" in options_rule
+    assert "width: 100%" in options_rule
     assert "bottom:" not in options_rule
+    assert ".split-button-trigger:focus-visible" in shared_css
+    focus_rule = shared_css.split(".split-button-trigger:focus-visible {", 1)[1].split("}", 1)[0]
+    assert "outline-offset: -2px" in focus_rule
     assert ".split-button-option:active:not(:disabled)" in shared_css
 
 


### PR DESCRIPTION
## Summary
- open split-button menus downward on Source and Activity
- replace oversized cards with compact action menus
- align each menu exactly with its split button
- refine keyboard focus without changing behavior

## Verification
- 55 focused UI tests passed
- no export, copy, or download behavior changed