### PR TITLE
fix(engine): eliminate idle UI CPU burn

### DIFF
--- a/scrapex/jobs.py
+++ b/scrapex/jobs.py
@@ -1202,12 +1202,34 @@ class JobRunner:
     def _refresh_rates(self, conn) -> None:
         """Keep the USD column's exchange rates current, quietly.
 
-        Rate-limited inside rates.refresh_if_due (six hours), so calling it every
-        poll costs one SELECT almost always. Isolated from the job loop: a
+        Rate-limited to six hours, so a poll costs the two SELECTs in
+        rates.refresh_is_due and stops there. Isolated from the job loop: a
         Google Finance outage must never stop a crawl from running — the USD
         column is an aid to ranking, and the prices are the product.
+
+        THE DECLINE HAS TO BE CHEAP, and for a long time it was not. The
+        six-hour throttle lives inside refresh_if_due, so this read as free —
+        but `HttpFetcher()` was built to be passed IN, before that function
+        could decline, and its httpx.Client reloads the OS certificate store:
+        1.3s of CPU, twice a second, for a client no request was ever made
+        with. An idle `scrapex ui` sat at ~44% of a core and quietly stretched
+        everything else on the machine, including this suite's own timings
+        (a migrate() measured 5.9s under two idle engines against 1.9s beside
+        none). Asking first is the whole fix.
         """
         from . import rates
+
+        # Before the lock and before the fetcher: a decline must touch nothing
+        # but two SELECTs. Taking the write lock 172,800 times a day to be told
+        # no was the cheaper half of the same mistake.
+        try:
+            if not rates.refresh_is_due(conn):
+                return
+        except Exception as exc:  # noqa: BLE001 — never fatal to the loop
+            traceback.print_exc(file=sys.stderr)
+            self._record_failure(conn, exc)
+            return
+
         from .connectors.base import HttpFetcher
 
         try:

--- a/scrapex/rates.py
+++ b/scrapex/rates.py
@@ -360,6 +360,34 @@ def currencies_in_use(conn: sqlite3.Connection) -> list[str]:
         "ORDER BY currency")]
 
 
+def refresh_is_due(conn: sqlite3.Connection, *, now: str | None = None) -> bool:
+    """Whether refresh_if_due would actually fetch — two SELECTs, nothing else.
+
+    Exists so a caller can find out CHEAPLY. The worker asks this twice a second
+    and the answer is no for six hours at a time, so everything a refresh needs
+    but a decline does not — the write lock, and above all the HTTPS client —
+    must stay on the far side of it. Building that client cost 1.3s of CPU
+    (`load_verify_locations` reloads the whole OS certificate store) and the
+    worker was paying it every poll to hand a fetcher to a function whose first
+    act was to return None: an engine serving nothing burned half a core.
+
+    It is THE predicate refresh_if_due uses, not a copy of it. A second spelling
+    of "is it due" is how the pre-check and the real check drift apart until the
+    cheap answer is no while the expensive one still fetches.
+    """
+    if not currencies_in_use(conn):
+        return False                 # nothing priced yet — nothing to convert
+    previous = last_checked(conn)
+    if not previous:
+        return True                  # never asked
+    try:
+        age = (datetime.strptime(now or utc_now_iso(), "%Y-%m-%dT%H:%M:%SZ")
+               - datetime.strptime(previous, "%Y-%m-%dT%H:%M:%SZ")).total_seconds()
+    except ValueError:
+        return True                  # an unparseable stamp is not a fresh one
+    return not (0 <= age < REFRESH_AFTER_S)
+
+
 def refresh_if_due(conn: sqlite3.Connection, fetcher, *,
                    now: str | None = None) -> RateBatch | None:
     """Fetch and store rates when we last asked longer ago than the interval.
@@ -367,30 +395,35 @@ def refresh_if_due(conn: sqlite3.Connection, fetcher, *,
     Returns the batch when it fetched, or None when nothing was due — so a
     caller can report what happened without inspecting the clock itself.
 
-    The attempt is stamped BEFORE the fetch, so a quote page that is failing
-    does not turn into a request on every single poll. A failure costs one
-    attempt per interval, exactly like a success.
+    The attempt is stamped BEFORE the fetch, and COMMITTED before it, so a quote
+    page that is failing does not turn into a request on every single poll. A
+    failure costs one attempt per interval, exactly like a success.
 
     Never raises for a fetch failure: the batch carries per-currency warnings
     (the Turkey rule) and the caller reports them. CrawlBlocked still
     propagates, because the brakes are not decorative.
+
+    Still safe to call unconditionally: the decision lives in refresh_is_due and
+    is re-made here, so a caller that pre-checks (the worker does, to avoid
+    building a fetcher it will not use) is an optimisation and not the guard.
     """
     stamp = now or utc_now_iso()
-    if not (wanted := currencies_in_use(conn)):
-        return None                  # nothing priced yet — nothing to convert
-    previous = last_checked(conn)
-    if previous:
-        try:
-            age = (datetime.strptime(stamp, "%Y-%m-%dT%H:%M:%SZ")
-                   - datetime.strptime(previous, "%Y-%m-%dT%H:%M:%SZ")).total_seconds()
-        except ValueError:
-            age = None               # an unparseable stamp is not a fresh one
-        if age is not None and 0 <= age < REFRESH_AFTER_S:
-            return None
+    if not refresh_is_due(conn, now=stamp):
+        return None
+    wanted = currencies_in_use(conn)
     conn.execute(
         "INSERT INTO scrapex_meta (key, value) VALUES (?,?) "
         "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
         (LAST_CHECK_KEY, stamp))
+    # Committed here, on its own, or the throttle only holds for exceptions this
+    # function chooses to swallow. An escaping one — CrawlBlocked, which is
+    # deliberately allowed through — reaches the worker's recorder, and that
+    # rolls back before writing, taking an uncommitted stamp with it. The next
+    # poll was then due again: a blocked quote page turned into a request every
+    # half-second against the one site this module most needs to stay welcome
+    # at, each one preceded by rebuilding the 1.3s HTTPS client. "One attempt
+    # per interval" is the promise above; this is what makes it true.
+    conn.commit()
     batch = fetch_rates(fetcher, wanted)
     store_rates(conn, batch.rates)
     return batch

--- a/tests/test_idle_cost.py
+++ b/tests/test_idle_cost.py
@@ -1,0 +1,174 @@
+"""What an engine serving NOTHING is allowed to cost.
+
+Measured on 2026-07-31: a `scrapex ui` started from the Startup folder had
+accumulated 6036 seconds of CPU over 4.6 hours of complete idleness — no crawl
+queued, no browser attached — and sampling it showed 44-52% of one core. Two
+such engines (ports 8000 and 8010) were between them eating ~42% of the
+machine's total physical CPU.
+
+It was not the poll loop's frequency and not a busy-wait: `_stop.wait(0.5)` is a
+proper blocking Event.wait. It was one line of the poll BODY. `_refresh_rates`
+built its transport eagerly, to pass in:
+
+    batch = rates.refresh_if_due(conn, HttpFetcher())
+
+`HttpFetcher()` constructs an httpx.Client, which builds an SSL context, which
+calls `load_verify_locations` and reloads the whole OS certificate store — 1.3s
+of pure CPU on this machine. Python evaluates the argument first, so the engine
+paid that twice a second in order to hand a fully-armed HTTPS client to a
+function whose first act, for six hours out of every six hours and one poll, was
+`return None`. Bisecting proved where it lived: uvicorn with the worker off idled
+at 0.1% of a core; the worker alone idled at 30%.
+
+The cost of this is not only the waste. It silently stretches everything else on
+the machine, including this suite: `dbmod.migrate()` measured 5.945s with two
+idle engines running against 1.9s beside none, which is the kind of thing that
+gets blamed on the code under test.
+
+These tests are about the shape of the idle path, not about rates. The cheap
+question must be asked before anything expensive is built — so the first test
+is the one that will still fail if someone reintroduces the cost by a different
+route, and it does not depend on a clock at all.
+"""
+from __future__ import annotations
+
+import sqlite3
+import time
+
+import pytest
+
+from scrapex import db as dbmod
+from scrapex import rates
+from scrapex.jobs import JobRunner
+
+
+def _idle_warehouse(path) -> None:
+    """A warehouse in the state a real idle engine is in: priced rows, so the
+    USD column has currencies to convert, and a rate check that already
+    happened — the ordinary case, and the one that was expensive."""
+    conn = dbmod.connect(path)
+    dbmod.migrate(conn)
+    conn.execute("INSERT INTO source_site (source_id, source_key, source_name_ar, "
+                 " source_name, base_url, platform, currency, timezone, authority, active) "
+                 "VALUES (1,'S','س','S','http://s','custom_json','SAR','UTC','shop',1)")
+    conn.execute("INSERT INTO crawl_run (run_id, source_id, started_at, status) "
+                 "VALUES (1,1,'2026-07-01T00:00:00Z','success')")
+    conn.execute("INSERT INTO source_product (source_product_id, source_id, "
+                 " external_product_id, product_name, product_name_ar) "
+                 "VALUES (1,1,'p','P','ب')")
+    conn.execute("INSERT INTO source_variant (source_variant_id, source_product_id, "
+                 " external_variant_id) VALUES (1,1,'v')")
+    conn.execute("INSERT INTO source_offer (offer_id, source_variant_id, "
+                 " country_code_alpha2, customer_segment, basis_quantity, currency, "
+                 " tax_included) VALUES (1,1,'SA','retail',1,'SAR',1)")
+    conn.execute("INSERT INTO price_observation (offer_id, run_id, observed_at, "
+                 " business_date, price, currency, tax_included, availability, "
+                 " record_hash, price_hash, price_fields, provenance) "
+                 "VALUES (1,1,'2026-07-01T00:00:00Z','2026-07-01',100,'SAR',1,"
+                 "'in_stock','rh','ph','effective','observed')")
+    # We asked just now, so no refresh is due — the state an engine spends
+    # virtually all of its life in.
+    conn.execute("INSERT INTO scrapex_meta (key, value) VALUES (?,?) "
+                 "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                 (rates.LAST_CHECK_KEY, rates.utc_now_iso()))
+    conn.commit()
+    conn.close()
+
+
+def test_an_idle_poll_never_builds_an_http_client(tmp_path, monkeypatch):
+    """THE regression test for the 44% core. No clock, no threshold: the idle
+    path must not construct the transport at all.
+
+    A timing assertion alone would let this back in the moment someone finds a
+    cheaper way to build an SSL context — the bug is that a decline pays for
+    machinery it never uses, and that is what is asserted.
+    """
+    from scrapex.connectors import base
+
+    db = tmp_path / "idle.db"
+    _idle_warehouse(db)
+
+    built = []
+
+    class _Tripwire:
+        def __init__(self, *args, **kwargs):
+            built.append(1)
+
+    # _refresh_rates imports HttpFetcher from this module inside the function,
+    # so patching the attribute is what the call will actually resolve.
+    monkeypatch.setattr(base, "HttpFetcher", _Tripwire)
+
+    runner = JobRunner(str(db), lambda: None, path_provider=lambda: str(db))
+    conn = dbmod.connect(db)
+    try:
+        for _ in range(50):
+            runner._refresh_rates(conn)
+    finally:
+        conn.close()
+
+    assert built == [], (
+        f"{len(built)} HTTPS client(s) built across 50 idle polls. Whatever a "
+        "refresh needs but a DECLINE does not — above all the transport, whose "
+        "constructor reloads the OS certificate store — belongs on the far side "
+        "of rates.refresh_is_due.")
+
+
+def test_an_idle_poll_does_not_take_the_write_lock(tmp_path):
+    """The cheaper half of the same mistake: the lock file was created, written,
+    and unlinked twice a second, 172,800 times a day, to be told no. It also put
+    ~/.scrapex/marketlens/marketlens.db.lock under constant churn, which is
+    where the owner first noticed something was moving."""
+    db = tmp_path / "lock.db"
+    _idle_warehouse(db)
+    lock_path = str(db) + ".lock"
+
+    taken = []
+    real = dbmod.write_lock
+
+    def counting(path, *args, **kwargs):
+        taken.append(str(path))
+        return real(path, *args, **kwargs)
+
+    runner = JobRunner(str(db), lambda: None, path_provider=lambda: str(db))
+    conn = dbmod.connect(db)
+    original = dbmod.write_lock
+    dbmod.write_lock = counting
+    try:
+        for _ in range(20):
+            runner._refresh_rates(conn)
+    finally:
+        dbmod.write_lock = original
+        conn.close()
+
+    assert taken == [], f"idle polls took the write lock {len(taken)} times"
+    import os
+    assert not os.path.exists(lock_path)
+
+
+def test_an_idle_engine_uses_almost_no_cpu(tmp_path):
+    """The end-to-end guard, in the units the problem was reported in.
+
+    Measured as CPU TIME, not wall time, so a loaded machine makes this test
+    slower but never flakier — a busy CI box does not inflate how much CPU our
+    own threads burned. The gap it is policing is enormous (about 0.9s of CPU
+    over this window before the fix, against roughly nothing after), so the
+    threshold sits far from both.
+    """
+    db = tmp_path / "cpu.db"
+    _idle_warehouse(db)
+
+    runner = JobRunner(str(db), lambda: None, path_provider=lambda: str(db))
+    runner.start()
+    try:
+        time.sleep(1.0)                      # let the first pass settle
+        started = time.process_time()
+        time.sleep(3.0)
+        burned = time.process_time() - started
+    finally:
+        runner.stop()
+
+    assert burned < 0.5, (
+        f"an idle worker burned {burned:.2f}s of CPU in 3s of doing nothing "
+        f"(~{100 * burned / 3:.0f}% of a core). An engine serving nothing must "
+        "cost nothing; see this module's docstring for how this went unnoticed "
+        "for hours at a time.")

--- a/tests/test_rates.py
+++ b/tests/test_rates.py
@@ -384,3 +384,64 @@ def test_a_failing_quote_page_costs_one_attempt_per_interval_not_one_per_poll():
     for _ in range(10):
         assert rates.refresh_if_due(conn, _Broken(), now="2026-07-28T00:05:00Z") is None
     assert _Broken.calls == 1
+
+
+def test_the_attempt_survives_an_exception_that_escapes_the_fetch(tmp_path):
+    """The throttle has to hold for the errors this module lets THROUGH, too.
+
+    A per-currency failure is swallowed into warnings, so the caller commits and
+    the stamp lands. CrawlBlocked deliberately propagates — and the worker's
+    recorder, which is where it lands, calls conn.rollback() before writing its
+    report. An uncommitted stamp went with it, so the very next poll was due
+    again: a blocked quote page became a request every half-second against the
+    one site this module most needs to stay welcome at. Hence the stamp is
+    committed on its own, before the fetch.
+    """
+    from scrapex import db as dbmod, rates
+
+    db = tmp_path / "blocked.db"
+    conn = dbmod.connect(db)
+    dbmod.migrate(conn)
+    conn.execute("INSERT INTO source_site (source_id, source_key, source_name_ar, "
+                 " source_name, base_url, platform, currency, timezone, authority, active) "
+                 "VALUES (1,'S','س','S','http://s','custom_json','SAR','UTC','shop',1)")
+    conn.execute("INSERT INTO crawl_run (run_id, source_id, started_at, status) "
+                 "VALUES (1,1,'2026-07-01T00:00:00Z','success')")
+    conn.execute("INSERT INTO source_product (source_product_id, source_id, "
+                 " external_product_id, product_name, product_name_ar) "
+                 "VALUES (1,1,'p','P','ب')")
+    conn.execute("INSERT INTO source_variant (source_variant_id, source_product_id, "
+                 " external_variant_id) VALUES (1,1,'v')")
+    conn.execute("INSERT INTO source_offer (offer_id, source_variant_id, "
+                 " country_code_alpha2, customer_segment, basis_quantity, currency, "
+                 " tax_included) VALUES (1,1,'SA','retail',1,'SAR',1)")
+    conn.execute("INSERT INTO price_observation (offer_id, run_id, observed_at, "
+                 " business_date, price, currency, tax_included, availability, "
+                 " record_hash, price_hash, price_fields, provenance) "
+                 "VALUES (1,1,'2026-07-01T00:00:00Z','2026-07-01',100,'SAR',1,"
+                 "'in_stock','rh','ph','effective','observed')")
+    conn.commit()
+
+    class _Blocked:
+        calls = 0
+        def get(self, url):
+            _Blocked.calls += 1
+            raise CrawlBlocked("the site said no")
+
+    with pytest.raises(CrawlBlocked):
+        rates.refresh_if_due(conn, _Blocked(), now="2026-07-28T00:00:00Z")
+    assert _Blocked.calls == 1
+
+    # What the worker does with a propagated failure: roll back, then report.
+    conn.rollback()
+
+    assert rates.last_checked(conn) == "2026-07-28T00:00:00Z", (
+        "the attempt was rolled back with the failure it was reporting")
+    for _ in range(10):
+        assert rates.refresh_if_due(conn, _Blocked(), now="2026-07-28T00:05:00Z") is None
+    assert _Blocked.calls == 1
+
+    # And it is a THROTTLE, not a lockout: due again once the window passes.
+    with pytest.raises(CrawlBlocked):
+        rates.refresh_if_due(conn, _Blocked(), now="2026-07-29T00:00:00Z")
+    assert _Blocked.calls == 2


### PR DESCRIPTION
﻿## Summary
- avoid constructing HttpFetcher on every idle JobRunner poll
- check whether rate refresh is due before taking the write lock or building the HTTPS client
- durably record refresh attempts so propagated failures remain throttled
- add structural, lock-churn, CPU-budget, and failure-throttle regression coverage

## Measured impact
- idle engine: 64.9% to 0.3% of one CPU core in simultaneous A/B measurement
- idle poll: about 1256 ms to 0.8 ms

## Verification
- 23 focused idle/rates tests passed
- JobRunner suite has one pre-existing Windows clock-granularity failure; reproduced unchanged on main
- git diff --check passed


Closes #61
