### PR TITLE
fix(jobs): remove inert wake API

### DIFF
--- a/scrapex/jobs.py
+++ b/scrapex/jobs.py
@@ -1134,9 +1134,6 @@ class JobRunner:
             self._thread.join(timeout=timeout_s)
             self._thread = None
 
-    def wake(self) -> None:
-        """Called after enqueueing so a new job starts without waiting a full poll."""
-
     def _locked_capture(self, conn: sqlite3.Connection, entry,
                         job_id: int | None = None, **extras) -> CaptureResult:
         # Whatever run_job_once decided the capture needs — history, resume,

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -364,6 +364,43 @@ def test_healthy_volume_passes_the_canary(conn):
 
 # ---- the worker thread (spec 4: the runtime executes, not the panel) --------
 
+def test_runner_never_advertises_an_inert_early_wake_api(tmp_path):
+    """If an early-wake API exists, it must actually bypass the poll delay.
+
+    Deleting the API is also honest: the shipped interval is only 0.5 seconds
+    and no enqueue path currently asks for an earlier wake. What must not exist
+    is a public method whose docstring promises signalling while its body does
+    nothing.
+    """
+    wake = getattr(JobRunner, "wake", None)
+    if wake is None:
+        return
+
+    import threading
+
+    db = tmp_path / "wake.db"
+    setup = dbmod.connect(db)
+    dbmod.migrate(setup)
+    create_job(setup, ["A"], RunMode.UPDATE)
+    setup.close()
+
+    captured = threading.Event()
+
+    def capture(_conn, entry, _job_id=None):
+        captured.set()
+        return _result(entry.source_key)
+
+    runner = JobRunner(str(db), lambda: _FakeManifest(["A"]),
+                       poll_interval_s=5.0, capture=capture)
+    runner.start()
+    try:
+        wake(runner)
+        assert captured.wait(0.25), (
+            "JobRunner.wake() exists but did not bypass the five-second poll delay")
+    finally:
+        runner.stop()
+
+
 def test_runner_thread_drains_the_queue(tmp_path):
     """The job outlives whoever queued it: nothing but the worker touches it."""
     import time


### PR DESCRIPTION
## Confirmed issue
JobRunner.wake() exposed an early-wake contract but had an empty body and no callers anywhere in the repository.

## Resolution
- remove the unused no-op method
- keep the existing 0.5-second polling model unchanged
- add a behavioral regression that accepts either no wake API or a genuinely effective implementation, but rejects an inert method

Implementing a second event and wiring every enqueue path was not justified solely to remove at most 500 ms of pickup latency that no current requirement depends on.

## Verification
- regression test failed before the fix and passed afterward
- JobRunner module: 48 passed, 1 pre-existing Windows clock-granularity failure also reproduced on main
- Python compileall passed
- git diff --check passed