### PR TITLE
feat(rates): add Google Finance controls and dataset

### DIFF
--- a/extension/app.html
+++ b/extension/app.html
@@ -873,6 +873,48 @@
               </div>
             </div>
           </article>
+          <article class="settings-item">
+            <button class="link sect settings-toggle" data-sect="s-finance" aria-expanded="false">
+              <span class="settings-index" aria-hidden="true">03</span>
+              <span class="settings-toggle-copy">
+                <span class="settings-title">Google Finance</span>
+                <span class="settings-description">Exchange-rate cadence and manual update</span>
+              </span>
+              <svg class="settings-chevron sx-icon" aria-hidden="true">
+                <use href="icons/material-icons.svg#chevron-right"></use>
+              </svg>
+            </button>
+            <div id="s-finance" class="settings-panel hidden">
+              <p class="muted hint">Google Finance supplies the exchange rates used
+                for estimated USD values. Stored prices are never rewritten; each
+                conversion keeps its rate, provider and market time.</p>
+
+              <label class="row" for="google_finance_auto_refresh">
+                <input id="google_finance_auto_refresh" type="checkbox">
+                <span>Update exchange rates automatically</span>
+              </label>
+
+              <label for="google_finance_refresh_hours">Hours between automatic updates</label>
+              <input id="google_finance_refresh_hours" type="number" step="0.25"
+                     min="0.25" max="168" dir="ltr">
+              <p class="muted text-xs">Allowed range: 15 minutes to 7 days.
+                The shipped default is 6 hours.</p>
+
+              <div class="finance-status" aria-label="Google Finance status">
+                <div class="out"><span>Currencies in use</span><strong id="finance-currencies" class="tech">-</strong></div>
+                <div class="out"><span>Last update attempt</span><strong id="finance-last-check" class="tech">-</strong></div>
+                <div class="out"><span>Latest market time</span><strong id="finance-latest-market" class="tech">-</strong></div>
+                <div class="out"><span>Stored history</span><strong id="finance-rows">-</strong></div>
+              </div>
+
+              <div class="row mt-2 finance-actions">
+                <button id="finance-save" type="button" class="primary">Save</button>
+                <button id="finance-refresh" type="button" class="ghost">Update now</button>
+                <button id="finance-dataset" type="button" class="link">Open dataset</button>
+              </div>
+              <div id="finance-msg" class="muted text-sm" role="status" aria-live="polite"></div>
+            </div>
+          </article>
         </div>
       </section>
 
@@ -884,7 +926,7 @@
         <div class="settings-list">
           <article class="settings-item">
             <button class="link sect settings-toggle" data-sect="s-sched" aria-expanded="false">
-              <span class="settings-index" aria-hidden="true">03</span>
+              <span class="settings-index" aria-hidden="true">04</span>
               <span class="settings-toggle-copy">
                 <span class="settings-title">Jobs and scheduling</span>
                 <span class="settings-description">Run cadence and worker availability</span>
@@ -900,7 +942,7 @@
           </article>
           <article class="settings-item">
             <button class="link sect settings-toggle" data-sect="s-output" aria-expanded="false">
-              <span class="settings-index" aria-hidden="true">04</span>
+              <span class="settings-index" aria-hidden="true">05</span>
               <span class="settings-toggle-copy">
                 <span class="settings-title">Data output settings</span>
                 <span class="settings-description">Local exports and external sync</span>
@@ -920,7 +962,7 @@
                the owner actually works, they did not exist at all. -->
           <article class="settings-item">
             <button class="link sect settings-toggle" data-sect="s-crawl" aria-expanded="false">
-              <span class="settings-index" aria-hidden="true">05</span>
+              <span class="settings-index" aria-hidden="true">06</span>
               <span class="settings-toggle-copy">
                 <span class="settings-title">Crawl pace and engine</span>
                 <span class="settings-description">Pace, log retention and engine restart</span>
@@ -975,7 +1017,7 @@
         <div class="settings-list">
           <article class="settings-item">
             <button class="link sect settings-toggle" data-sect="s-about" aria-expanded="false">
-              <span class="settings-index" aria-hidden="true">06</span>
+              <span class="settings-index" aria-hidden="true">07</span>
               <span class="settings-toggle-copy">
                 <span class="settings-title">About</span>
                 <span class="settings-description">Version and product details</span>

--- a/extension/app.js
+++ b/extension/app.js
@@ -348,6 +348,68 @@ async function restartEngineFromPanel() {
   out("crawl-msg", "restart requested — the status dot turns green when it is back", "ok");
 }
 
+// ---- Google Finance rate control -----------------------------------------
+function renderGoogleFinanceStatus(status) {
+  const tracked = status.tracked_currencies || [];
+  $("finance-currencies").textContent = tracked.length ? tracked.join(", ") : "None yet";
+  $("finance-last-check").textContent = status.last_checked || "Never";
+  $("finance-latest-market").textContent = status.latest_market_at || "No rates yet";
+  $("finance-rows").textContent = `${Number(status.rows || 0).toLocaleString()} rate rows`;
+}
+
+async function loadGoogleFinance() {
+  try {
+    const status = await api("/api/rates/google-finance");
+    $("google_finance_auto_refresh").checked = Boolean(status.automatic);
+    $("google_finance_refresh_hours").value = String(status.refresh_hours ?? 6);
+    renderGoogleFinanceStatus(status);
+    out("finance-msg", "");
+  } catch (err) {
+    out("finance-msg", "could not read Google Finance status: " + esc(err.message), "err");
+  }
+}
+
+async function saveGoogleFinance() {
+  const hours = Number($("google_finance_refresh_hours").value);
+  if (!Number.isFinite(hours) || hours < 0.25 || hours > 168) {
+    out("finance-msg", "hours must be between 0.25 and 168", "err");
+    return;
+  }
+  out("finance-msg", "saving...");
+  try {
+    await post("/api/settings", {
+      google_finance_auto_refresh: $("google_finance_auto_refresh").checked,
+      google_finance_refresh_hours: hours,
+    });
+    await loadGoogleFinance();
+  } catch (err) {
+    out("finance-msg", "not saved: " + esc(err.message), "err");
+    return;
+  }
+  out("finance-msg", "saved - the new cadence applies immediately", "ok");
+}
+
+async function refreshGoogleFinance() {
+  const button = $("finance-refresh");
+  button.disabled = true;
+  const oldLabel = button.textContent;
+  button.textContent = "Updating...";
+  out("finance-msg", "requesting the latest rates...");
+  try {
+    const result = await post("/api/rates/google-finance/refresh", {});
+    renderGoogleFinanceStatus(result);
+    const warning = (result.warnings || []).length
+      ? ` ${result.warnings.length} warning(s): ${esc(result.warnings.join("; "))}` : "";
+    out("finance-msg", esc(result.detail || "Update complete.") + warning,
+        warning ? "" : "ok");
+  } catch (err) {
+    out("finance-msg", "update failed: " + esc(err.message), "err");
+  } finally {
+    button.disabled = false;
+    button.textContent = oldLabel;
+  }
+}
+
 // ---- sites -----------------------------------------------------------------
 function hostOf(url) { try { return new URL(url).host; } catch (_) { return url || ""; } }
 
@@ -2323,6 +2385,14 @@ async function init() {
   document.querySelector('[data-sect="s-crawl"]')
     .addEventListener("click", () => {
       if (!$("s-crawl").classList.contains("hidden")) loadCrawlSettings();
+    });
+
+  $("finance-save").addEventListener("click", saveGoogleFinance);
+  $("finance-refresh").addEventListener("click", refreshGoogleFinance);
+  $("finance-dataset").addEventListener("click", () => openTab("/data/google-finance"));
+  document.querySelector('[data-sect="s-finance"]')
+    .addEventListener("click", () => {
+      if (!$("s-finance").classList.contains("hidden")) loadGoogleFinance();
     });
 
   refreshMode();

--- a/scrapex/rates.py
+++ b/scrapex/rates.py
@@ -8,7 +8,8 @@ number must NEVER be shown without the rate used AND the date of that rate.
 `currency_rate` already holds publisher-implied rates (GPP's local/USD pairs,
 migration 0028); this module adds a second, deliberate source — the quote
 pages themselves — under its own source_key, so provenance stays in the row
-by construction. UI wiring comes later; this file only fetches and stores.
+by construction. The UI reads this module's policy; fetching and storage stay
+here so automatic and manual updates cannot drift.
 
 WHAT THE LIVE PAGES LOOK LIKE (observed 2026-07-27, USD-SAR and USD-EGP)
 ------------------------------------------------------------------------
@@ -62,7 +63,7 @@ import sqlite3
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
-from . import db as dbmod
+from . import db as dbmod, settings
 from .connectors.base import CrawlBlocked
 from .payload import utc_now_iso
 
@@ -326,9 +327,11 @@ def store_shop_rates(conn: sqlite3.Connection, source_key: str,
 # How stale a stored rate may be before the worker fetches again. Google Finance
 # moves continuously, but the owner's question is "what was this worth", not
 # "what is it worth this second" — and a scraper that reloads a quote page every
-# poll is a scraper that gets blocked. Six hours keeps the USD column honest
-# within a trading day while costing one request per currency per quarter-day.
-REFRESH_AFTER_S = 6 * 60 * 60
+# poll is a scraper that gets blocked. Six hours remains the shipped default;
+# the owner can now choose the actual cadence in Settings.
+DEFAULT_REFRESH_HOURS = 6.0
+MIN_REFRESH_HOURS = 0.25
+MAX_REFRESH_HOURS = 24.0 * 7
 
 
 # When WE last asked, which is not the same as how old the rate is. Throttling
@@ -337,6 +340,24 @@ REFRESH_AFTER_S = 6 * 60 * 60
 # so every worker poll would decide a refresh was due and hammer the quote page
 # — the exact failure the interval exists to prevent.
 LAST_CHECK_KEY = "rates_last_checked"
+
+
+def automatic_refresh_enabled(conn: sqlite3.Connection) -> bool:
+    """Whether the background worker may refresh rates automatically."""
+    return settings.get(conn, "google_finance_auto_refresh") not in {
+        "0", "false", "False", False,
+    }
+
+
+def refresh_interval_hours(conn: sqlite3.Connection) -> float:
+    """Return the owner-selected interval, bounded to a safe range."""
+    try:
+        value = float(settings.get(conn, "google_finance_refresh_hours"))
+    except (TypeError, ValueError):
+        return DEFAULT_REFRESH_HOURS
+    if not math.isfinite(value) or not MIN_REFRESH_HOURS <= value <= MAX_REFRESH_HOURS:
+        return DEFAULT_REFRESH_HOURS
+    return value
 
 
 def last_checked(conn: sqlite3.Connection) -> str:
@@ -361,10 +382,10 @@ def currencies_in_use(conn: sqlite3.Connection) -> list[str]:
 
 
 def refresh_is_due(conn: sqlite3.Connection, *, now: str | None = None) -> bool:
-    """Whether refresh_if_due would actually fetch — two SELECTs, nothing else.
+    """Whether refresh_if_due would actually fetch — small reads, nothing else.
 
     Exists so a caller can find out CHEAPLY. The worker asks this twice a second
-    and the answer is no for six hours at a time, so everything a refresh needs
+    and the answer is usually no for the selected interval, so refresh-only work
     but a decline does not — the write lock, and above all the HTTPS client —
     must stay on the far side of it. Building that client cost 1.3s of CPU
     (`load_verify_locations` reloads the whole OS certificate store) and the
@@ -375,6 +396,8 @@ def refresh_is_due(conn: sqlite3.Connection, *, now: str | None = None) -> bool:
     of "is it due" is how the pre-check and the real check drift apart until the
     cheap answer is no while the expensive one still fetches.
     """
+    if not automatic_refresh_enabled(conn):
+        return False
     if not currencies_in_use(conn):
         return False                 # nothing priced yet — nothing to convert
     previous = last_checked(conn)
@@ -385,7 +408,26 @@ def refresh_is_due(conn: sqlite3.Connection, *, now: str | None = None) -> bool:
                - datetime.strptime(previous, "%Y-%m-%dT%H:%M:%SZ")).total_seconds()
     except ValueError:
         return True                  # an unparseable stamp is not a fresh one
-    return not (0 <= age < REFRESH_AFTER_S)
+    return not (0 <= age < refresh_interval_hours(conn) * 60 * 60)
+
+
+def refresh_now(conn: sqlite3.Connection, fetcher, *,
+                now: str | None = None) -> RateBatch:
+    """Refresh currencies in use immediately, regardless of auto cadence."""
+    stamp = now or utc_now_iso()
+    wanted = currencies_in_use(conn)
+    if not wanted:
+        return RateBatch()
+    conn.execute(
+        "INSERT INTO scrapex_meta (key, value) VALUES (?,?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (LAST_CHECK_KEY, stamp))
+    # The attempt must survive an escaping CrawlBlocked exception, otherwise a
+    # failed request becomes another request on the next worker poll.
+    conn.commit()
+    batch = fetch_rates(fetcher, wanted)
+    store_rates(conn, batch.rates)
+    return batch
 
 
 def refresh_if_due(conn: sqlite3.Connection, fetcher, *,
@@ -410,20 +452,4 @@ def refresh_if_due(conn: sqlite3.Connection, fetcher, *,
     stamp = now or utc_now_iso()
     if not refresh_is_due(conn, now=stamp):
         return None
-    wanted = currencies_in_use(conn)
-    conn.execute(
-        "INSERT INTO scrapex_meta (key, value) VALUES (?,?) "
-        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-        (LAST_CHECK_KEY, stamp))
-    # Committed here, on its own, or the throttle only holds for exceptions this
-    # function chooses to swallow. An escaping one — CrawlBlocked, which is
-    # deliberately allowed through — reaches the worker's recorder, and that
-    # rolls back before writing, taking an uncommitted stamp with it. The next
-    # poll was then due again: a blocked quote page turned into a request every
-    # half-second against the one site this module most needs to stay welcome
-    # at, each one preceded by rebuilding the 1.3s HTTPS client. "One attempt
-    # per interval" is the promise above; this is what makes it true.
-    conn.commit()
-    batch = fetch_rates(fetcher, wanted)
-    store_rates(conn, batch.rates)
-    return batch
+    return refresh_now(conn, fetcher, now=stamp)

--- a/scrapex/reports.py
+++ b/scrapex/reports.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import sqlite3
 from dataclasses import dataclass, field
 
-from . import fields, tax
+from . import fields, rates, tax
 from .normalize import option_axes_from
 from .vocab import DETAIL_GROUP_ORDER
 
@@ -117,6 +117,49 @@ class BrowsePage:
     @property
     def has_next(self) -> bool:
         return self.offset + self.limit < self.total
+
+
+def google_finance_status(conn: sqlite3.Connection) -> dict:
+    """One bounded read model shared by Settings, Data, and the extension."""
+    row = conn.execute(
+        "SELECT COUNT(*), COUNT(DISTINCT currency), MAX(as_of) "
+        "FROM currency_rate WHERE source_key = ?",
+        (rates.SOURCE_KEY,),
+    ).fetchone()
+    tracked = rates.currencies_in_use(conn)
+    return {
+        "provider": "Google Finance",
+        "source_key": rates.SOURCE_KEY,
+        "provider_url": "https://www.google.com/finance/",
+        "automatic": rates.automatic_refresh_enabled(conn),
+        "refresh_hours": rates.refresh_interval_hours(conn),
+        "minimum_refresh_hours": rates.MIN_REFRESH_HOURS,
+        "maximum_refresh_hours": rates.MAX_REFRESH_HOURS,
+        "last_checked": rates.last_checked(conn),
+        "latest_market_at": row[2] or "",
+        "rows": int(row[0] or 0),
+        "currencies": int(row[1] or 0),
+        "tracked_currencies": tracked,
+        "due": rates.refresh_is_due(conn),
+    }
+
+
+def browse_google_finance_rates(conn: sqlite3.Connection, *,
+                                offset: int = 0, limit: int = 50) -> BrowsePage:
+    """Google Finance rate history, newest first and always bounded."""
+    offset = max(0, int(offset))
+    limit = min(max(1, int(limit)), 200)
+    total = _scalar(
+        conn, "SELECT COUNT(*) FROM currency_rate WHERE source_key = ?",
+        (rates.SOURCE_KEY,),
+    )
+    rows = [dict(row) for row in conn.execute(
+        "SELECT currency, per_usd, as_of, recorded_at, source_key, source_kind "
+        "FROM currency_rate WHERE source_key = ? "
+        "ORDER BY as_of DESC, currency ASC LIMIT ? OFFSET ?",
+        (rates.SOURCE_KEY, limit, offset),
+    )]
+    return BrowsePage(rows=rows, total=total, offset=offset, limit=limit)
 
 
 # One row per offer = its LATEST observation (current price), reused by browse+count.

--- a/scrapex/settings.py
+++ b/scrapex/settings.py
@@ -77,6 +77,13 @@ SETTINGS: dict[str, Setting] = {s.key: s for s in [
     # in the order the job listed them. Raising it crawls that many SITES at
     # once — never two sources of one site, whatever the number says.
     Setting("crawl_parallel_sources", "1", label="Sources crawled at the same time"),
+    # --- Google Finance exchange rates ---
+    # Six hours remains the shipped default, but is no longer hidden policy.
+    # Manual refresh remains available even when automatic refresh is off.
+    Setting("google_finance_auto_refresh", "1",
+            label="Refresh Google Finance rates automatically"),
+    Setting("google_finance_refresh_hours", "6",
+            label="Hours between Google Finance refreshes"),
     # UI-only preference shared by the local Workspace and Chrome side panel.
     # It lives with the engine because browser localStorage is origin-scoped:
     # a chrome-extension:// page and http://127.0.0.1 cannot read each other.

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -10,6 +10,7 @@ Bound to 127.0.0.1 by the CLI — a local, single-machine surface.
 from __future__ import annotations
 
 import json
+import math
 import os
 import re
 import sqlite3
@@ -29,9 +30,10 @@ from fastapi.templating import Jinja2Templates
 from .. import db as dbmod
 from .. import localinbox
 from .. import nativehost
-from ..capture import capture_source
+from ..capture import capture_source, crawl_settings
 from ..changes import change_summary, changes_for_offer, recent_changes
 from ..config import MANIFEST_FILE, SourceEntry, load_manifest
+from ..connectors.base import CrawlBlocked, HttpFetcher
 from ..connectors.factory import _BUILDERS, supports_history
 from ..databases import (
     DatabaseKindError, DatabaseMigrationError, DatabaseRegistry,
@@ -63,7 +65,7 @@ from ..publish import workbook_tables
 from ..settings import UnknownSettingError, get_state, public_settings
 from ..settings import get as settings_get
 from ..settings import save as save_settings
-from .. import compaction, pricehistory, retention
+from .. import compaction, pricehistory, rates, retention
 from ..storage import (
     StorageRefused, backup_folder, backup_now, check_move, export_database,
     wipe_source,
@@ -74,9 +76,11 @@ from ..storage import compact as storage_compact
 from ..probe import probe as probe_url
 from ..ui_manifest import ui_manifest, workspace_navigation_groups
 from ..reports import (
-    BROWSE_COLUMNS, FILTERABLE, SORTABLE, browse_observations, column_presence,
+    BROWSE_COLUMNS, FILTERABLE, SORTABLE, browse_google_finance_rates,
+    browse_observations, column_presence,
     crawl_history, facet_options, parse_filters, watch,
-    data_model_report, export_source_table, history_counts, list_sources, offer_identity,
+    data_model_report, export_source_table, google_finance_status, history_counts,
+    list_sources, offer_identity,
     schema_report,
     offer_observations, price_extremes, product_attributes,
     table_payload,
@@ -121,6 +125,39 @@ def _appearance_value(body: dict | None) -> dict:
         "deviceColors": device_colors,
         "updatedAt": int(updated_at),
     }
+
+
+def _google_finance_setting_values(body: dict) -> dict:
+    """Validate and canonicalise the two public rate-control settings."""
+    values = dict(body or {})
+    if "google_finance_auto_refresh" in values:
+        raw = values["google_finance_auto_refresh"]
+        accepted = isinstance(raw, (bool, int, str)) and raw in {
+            True, False, 0, 1, "0", "1", "true", "false",
+        }
+        if not accepted:
+            raise HTTPException(
+                status_code=400,
+                detail="google_finance_auto_refresh must be true or false",
+            )
+        values["google_finance_auto_refresh"] = (
+            "1" if raw in {True, 1, "1", "true"} else "0"
+        )
+    if "google_finance_refresh_hours" in values:
+        try:
+            hours = float(values["google_finance_refresh_hours"])
+        except (TypeError, ValueError):
+            hours = math.nan
+        if (not math.isfinite(hours)
+                or not rates.MIN_REFRESH_HOURS <= hours <= rates.MAX_REFRESH_HOURS):
+            raise HTTPException(
+                status_code=400,
+                detail=("google_finance_refresh_hours must be between "
+                        f"{rates.MIN_REFRESH_HOURS:g} and "
+                        f"{rates.MAX_REFRESH_HOURS:g}"),
+            )
+        values["google_finance_refresh_hours"] = f"{hours:g}"
+    return values
 
 def database_state(request: Request) -> dict:
     """Runtime status for every page, derived from the request's own app.
@@ -473,12 +510,38 @@ def create_app(
         conn = read_conn()
         try:
             sources, pending, _ = _source_catalog(conn)
+            rate_dataset = google_finance_status(conn)
         finally:
             conn.close()
         return TEMPLATES.TemplateResponse(request=request, name="data.html",
                                           context={"sources": sources, "pending": pending,
+                                                   "rate_dataset": rate_dataset,
                                                    "tab": "data", "source_key": None,
                                                    "wide_page": True})
+
+    @app.get("/data/google-finance", response_class=HTMLResponse)
+    def google_finance_dataset(request: Request, page: int = 1, per_page: int = 50):
+        """The provider's stored rate history as a first-class dataset."""
+        page = max(1, page)
+        per_page = per_page if per_page in {25, 50, 100, 200} else 50
+        conn = read_conn()
+        try:
+            sources, pending, _ = _source_catalog(conn)
+            rate_dataset = google_finance_status(conn)
+            page_data = browse_google_finance_rates(
+                conn, offset=(page - 1) * per_page, limit=per_page,
+            )
+        finally:
+            conn.close()
+        return TEMPLATES.TemplateResponse(
+            request=request, name="google_finance_dataset.html",
+            context={"sources": sources, "pending": pending,
+                     "rate_dataset": rate_dataset, "page_data": page_data,
+                     "page": page, "per_page": per_page,
+                     "tab": "data", "source_key": None,
+                     "rate_dataset_active": True,
+                     "wide_page": True},
+        )
 
     def _view_defaults(source_key: str, view_id: int) -> dict:
         """A saved view as query parameters. Unknown keys never reach SQL.
@@ -581,6 +644,7 @@ def create_app(
         conn = read_conn()
         try:
             sources, pending, source_sites = _source_catalog(conn)
+            rate_dataset = google_finance_status(conn)
             summary = next((source for source in sources
                             if source.source_key == source_key), None)
             page_data, fields, views, columns = None, [], [], []
@@ -630,6 +694,7 @@ def create_app(
             request=request, name="source.html",
             context={"summary": summary, "page_data": page_data, "source_key": source_key,
                      "sources": sources, "pending": pending,
+                     "rate_dataset": rate_dataset,
                      "source_sites": source_sites,
                      "source_site": source_sites.get(source_key, ""),
                      "wide_page": True,
@@ -981,7 +1046,7 @@ def create_app(
 
     @app.get("/settings", response_class=HTMLResponse)
     def page_settings(request: Request):
-        """Spec 33: thirteen sections, every one closed until it is asked for."""
+        """Settings remain collapsed and display the engine's current truth."""
         conn = read_conn()
         try:
             return _page(request, "settings.html", "settings", None,
@@ -990,6 +1055,7 @@ def create_app(
                          retention=_retention_view(conn),
                          excel=excel_status(conn), funnel=apps_script_status(conn),
                          google=google_status(conn),
+                         google_finance=google_finance_status(conn),
                          engines=_engine_rows(),
                          schedule_count=len(list_schedules(conn)),
                          about=_about(conn))
@@ -1744,6 +1810,7 @@ def create_app(
 
     @app.post("/api/settings")
     def api_save_settings(body: dict):
+        body = _google_finance_setting_values(body)
         try:
             with dbmod.write_lock(app.state.db_path):
                 conn = _write_conn()
@@ -1756,6 +1823,46 @@ def create_app(
         except UnknownSettingError as exc:
             raise HTTPException(status_code=400, detail=f"unknown setting {exc}")
         return {"changed": changed, "settings": current}
+
+    @app.get("/api/rates/google-finance")
+    def api_google_finance_status():
+        conn = read_conn()
+        try:
+            return google_finance_status(conn)
+        finally:
+            conn.close()
+
+    @app.post("/api/rates/google-finance/refresh")
+    def api_refresh_google_finance():
+        """Owner-requested refresh, independent of automatic cadence."""
+        try:
+            with dbmod.write_lock(app.state.db_path):
+                conn = _write_conn()
+                fetcher = None
+                try:
+                    wanted = rates.currencies_in_use(conn)
+                    if not wanted:
+                        status = google_finance_status(conn)
+                        return {
+                            "ok": True, "updated": 0, "warnings": [],
+                            "detail": "No non-USD currencies are in use yet.",
+                            **status,
+                        }
+                    fetcher = HttpFetcher(**crawl_settings(conn))
+                    batch = rates.refresh_now(conn, fetcher)
+                    status = google_finance_status(conn)
+                finally:
+                    if fetcher is not None:
+                        fetcher.close()
+                    conn.close()
+        except CrawlBlocked as exc:
+            raise HTTPException(status_code=502, detail=str(exc))
+        updated = len(batch.rates)
+        detail = f"Updated {updated} of {len(wanted)} currencies."
+        return {
+            "ok": True, "updated": updated, "warnings": batch.warnings,
+            "detail": detail, **status,
+        }
 
     @app.get("/api/outputs/excel")
     def api_excel_status():

--- a/scrapex/webui/static/pages/data-workspace.css
+++ b/scrapex/webui/static/pages/data-workspace.css
@@ -53,6 +53,33 @@
 .dataset-choice>.source-identity-meta{grid-column:2;align-self:end;font-size:.58rem;white-space:nowrap}
 .dataset-choice-detail{display:grid;grid-column:2;align-self:end;justify-items:end;gap:.12rem}
 .dataset-choice-state{color:var(--muted);font-size:var(--fs-2xs)}
+
+/* Google Finance is reference data, not a shop-shaped source. Its dedicated
+   page still uses the same workspace frame, spacing, and dataset switcher. */
+.google-finance-overview{margin:.7rem 0}
+.google-finance-facts{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:0}
+.google-finance-facts>span{display:flex;flex-direction:column;gap:.2rem;padding:.85rem 1rem;
+  min-width:0;border-inline-end:1px solid var(--line)}
+.google-finance-facts>span:last-child{border-inline-end:0}
+.google-finance-facts small{color:var(--muted);font-size:var(--fs-2xs)}
+.google-finance-facts strong{font-size:var(--fs-xs);overflow-wrap:anywhere}
+.google-finance-table-wrap{overflow:auto}
+.google-finance-table{width:100%;border-collapse:collapse;font-size:var(--fs-xs)}
+.google-finance-table th,.google-finance-table td{padding:.72rem .85rem;border-bottom:1px solid var(--line);
+  text-align:start;white-space:nowrap}
+.google-finance-table th{color:var(--muted);font-size:var(--fs-2xs);text-transform:uppercase;
+  letter-spacing:.04em;background:var(--bg)}
+.google-finance-table tr:last-child td{border-bottom:0}
+.rate-dataset-pager{display:flex;align-items:center;justify-content:space-between;gap:.75rem;
+  padding:.7rem .9rem;border-top:1px solid var(--line);color:var(--muted);font-size:var(--fs-xs)}
+.rate-dataset-pager .ghost{display:inline-flex;padding:.35rem .65rem;border:1px solid var(--line);
+  border-radius:var(--radius-sm);text-decoration:none;color:var(--text)}
+@media (max-width:760px){.google-finance-facts{grid-template-columns:1fr 1fr}
+  .google-finance-facts>span:nth-child(2){border-inline-end:0}
+  .google-finance-facts>span:nth-child(-n+2){border-bottom:1px solid var(--line)}}
+@media (max-width:440px){.google-finance-facts{grid-template-columns:1fr}
+  .google-finance-facts>span{border-inline-end:0;border-bottom:1px solid var(--line)}
+  .google-finance-facts>span:last-child{border-bottom:0}}
 .dataset-no-results{margin:.5rem;padding:.85rem;text-align:center;border:1px dashed var(--line);
   border-radius:9px;color:var(--muted);font-size:.68rem}
 

--- a/scrapex/webui/templates/_source_list.html
+++ b/scrapex/webui/templates/_source_list.html
@@ -21,6 +21,31 @@
   </header>
 
   <nav class="dataset-list" id="dataset-list" data-dataset-list aria-label="Choose a dataset">
+    {% if rate_dataset %}
+    <section class="dataset-group" data-dataset-group>
+      <span class="dataset-group-label">Reference data</span>
+      <a class="dataset-choice" href="/data/google-finance"
+         data-dataset-choice data-search="google finance exchange rates currencies google_finance"
+         data-domain="google.com/finance"
+         {% if rate_dataset_active or source_key == rate_dataset.source_key %}aria-current="page"{% endif %}>
+        {{ source_identity({"source_key": rate_dataset.source_key,
+                            "source_name": rate_dataset.provider,
+                            "source_name_ar": "",
+                            "base_url": rate_dataset.provider_url},
+                           metric_value="{:,}".format(rate_dataset.rows), metric_label="Rate") }}
+        <span class="dataset-choice-detail" data-dataset-fresh>
+          <small class="dataset-choice-state">
+            {% if rate_dataset.latest_market_at %}
+              Latest quote {{ rate_dataset.latest_market_at[:16]|replace("T", " ") }} UTC
+            {% else %}
+              Ready - refresh after price data is collected
+            {% endif %}
+          </small>
+        </span>
+      </a>
+    </section>
+    {% endif %}
+
     {% if sources %}
     <section class="dataset-group" data-dataset-group>
       <span class="dataset-group-label">Available data</span>
@@ -74,7 +99,7 @@
     </section>
     {% endif %}
 
-    {% if not sources and not pending %}
+    {% if not sources and not pending and not rate_dataset %}
       {# Server-rendered: "Loading…" with nothing left to load was a permanent
          lie on a zero-source install (merge-review finding). #}
       <p class="dataset-no-results" data-dataset-placeholder>No datasets configured yet.</p>

--- a/scrapex/webui/templates/google_finance_dataset.html
+++ b/scrapex/webui/templates/google_finance_dataset.html
@@ -1,0 +1,80 @@
+{% extends "base.html" %}
+{% from "_icons.html" import icon %}
+{% block title %}Google Finance rates - ScrapeX{% endblock %}
+{% block head %}
+  <link rel="stylesheet" href="/static/pages/data-workspace.css?v=google-finance-1">
+  <script src="/static/datasets-browser.js?v=source-ui-8" defer></script>
+{% endblock %}
+{% block content %}
+<div class="data-workspace">
+  <section class="data-view" aria-label="Google Finance exchange-rate dataset">
+    <section class="data-records">
+      <header class="data-records-head">
+        <div class="data-records-title">
+          <span class="data-grid-eyebrow">Reference dataset</span>
+          <h1>Google Finance exchange rates</h1>
+          <p class="muted">Historical provider rates used for estimated USD values.
+            One USD equals the amount shown in each currency.</p>
+        </div>
+        <details class="dataset-menu">
+          <summary class="dataset-menu-trigger" aria-controls="dataset-list" aria-expanded="false">
+            {{ icon("storage") }}<span>Datasets</span>{{ icon("expand-more", "dataset-menu-chevron") }}
+          </summary>
+          {% include "_source_list.html" %}
+        </details>
+      </header>
+
+      <section class="data-source-overview google-finance-overview" aria-label="Provider status">
+        <div class="google-finance-facts">
+          <span><small>Automatic updates</small><strong>{{ "On" if rate_dataset.automatic else "Off" }}</strong></span>
+          <span><small>Interval</small><strong>{{ "%g"|format(rate_dataset.refresh_hours) }} hours</strong></span>
+          <span><small>Last attempt</small><strong class="tech">{{ rate_dataset.last_checked or "Never" }}</strong></span>
+          <span><small>Latest market time</small><strong class="tech">{{ rate_dataset.latest_market_at or "No rates yet" }}</strong></span>
+        </div>
+      </section>
+
+      <section class="data-grid-frame" aria-label="Exchange-rate history">
+        <header class="data-grid-frame-head">
+          <div class="data-grid-heading">
+            <span class="data-grid-eyebrow">Dataset table</span>
+            <h2>Stored rate history</h2>
+            <p>{{ "{:,}".format(page_data.total) }} rows with provider and timestamps preserved.</p>
+          </div>
+        </header>
+        {% if page_data.rows %}
+        <div class="tablewrap google-finance-table-wrap">
+          <table class="google-finance-table">
+            <thead><tr>
+              <th>Currency</th><th>1 USD equals</th><th>Market time (UTC)</th>
+              <th>Recorded at (UTC)</th><th>Provider</th>
+            </tr></thead>
+            <tbody>
+            {% for row in page_data.rows %}
+              <tr>
+                <td><strong class="tech">{{ row.currency }}</strong></td>
+                <td class="num tech">{{ "%.8g"|format(row.per_usd) }}</td>
+                <td class="tech">{{ row.as_of }}</td>
+                <td class="tech">{{ row.recorded_at }}</td>
+                <td><a href="https://www.google.com/finance/quote/USD-{{ row.currency }}"
+                       target="_blank" rel="noopener noreferrer">Google Finance {{ icon("open-in-new", "inline-icon") }}</a></td>
+              </tr>
+            {% endfor %}
+            </tbody>
+          </table>
+        </div>
+        <footer class="rate-dataset-pager" aria-label="Dataset pages">
+          <span>Rows {{ page_data.offset + 1 }}-{{ [page_data.offset + page_data.rows|length, page_data.total]|min }} of {{ page_data.total }}</span>
+          <span class="row">
+            {% if page_data.has_prev %}<a class="ghost" href="?page={{ page - 1 }}&amp;per_page={{ per_page }}">Previous</a>{% endif %}
+            {% if page_data.has_next %}<a class="ghost" href="?page={{ page + 1 }}&amp;per_page={{ per_page }}">Next</a>{% endif %}
+          </span>
+        </footer>
+        {% else %}
+          <div class="empty">No Google Finance rates are stored yet.<br>
+            <span class="muted">Collect non-USD price data, then choose Update now in the extension.</span></div>
+        {% endif %}
+      </section>
+    </section>
+  </section>
+</div>
+{% endblock %}

--- a/scrapex/webui/templates/settings.html
+++ b/scrapex/webui/templates/settings.html
@@ -13,7 +13,7 @@
   </div>
 </header>
 
-{# Spec 33/24: thirteen sections, every one closed by default. Progressive
+{# Fourteen sections, every one closed by default. Progressive
    disclosure here is not decoration — Storage and Data and history hold the
    only controls in the product that can rewrite the warehouse, and they should
    take a deliberate act to reach, not scroll past under a thumb. #}
@@ -251,7 +251,32 @@
   </div>
 </details>
 
-<!-- 7, 8, 9 -------------------------------------------------------------- -->
+<!-- 7 ------------------------------------------------------------------- -->
+<details class="sect" id="s-google-finance">
+  <summary><span class="sect-name">Google Finance</span>
+    <span class="sect-sub">Exchange-rate source, freshness and update policy</span></summary>
+  <div class="sect-body">
+    <p class="hint">Google Finance supplies the exchange rates used for estimated
+      USD values. Stored prices never change: every conversion keeps the rate,
+      provider and market time that produced it.</p>
+    <p class="hint">Controls live in the ScrapeX side panel under
+      <strong>Settings &rarr; Google Finance</strong>. There you can change the
+      automatic interval or run an immediate update.</p>
+    <table>
+      <tr><th>Automatic updates</th><td>{{ "On" if google_finance.automatic else "Off" }}</td></tr>
+      <tr><th>Update interval</th><td class="tech">{{ "%g"|format(google_finance.refresh_hours) }} hours</td></tr>
+      <tr><th>Currencies in use</th><td class="tech">
+        {{ google_finance.tracked_currencies|join(", ") if google_finance.tracked_currencies else "None yet" }}</td></tr>
+      <tr><th>Last update attempt</th><td class="tech">{{ google_finance.last_checked or "Never" }}</td></tr>
+      <tr><th>Latest market time</th><td class="tech">{{ google_finance.latest_market_at or "No rates stored yet" }}</td></tr>
+      <tr><th>Stored history</th><td>{{ google_finance.rows }} rate rows across
+        {{ google_finance.currencies }} currencies</td></tr>
+    </table>
+    <p class="hint"><a class="link" href="/data/google-finance">open the Google Finance dataset</a></p>
+  </div>
+</details>
+
+<!-- 8, 9, 10 ------------------------------------------------------------- -->
   </div>
 </section>
 
@@ -297,7 +322,7 @@
   </div>
 </details>
 
-<!-- 10 ------------------------------------------------------------------ -->
+<!-- 11 ------------------------------------------------------------------ -->
   </div>
 </section>
 
@@ -316,7 +341,7 @@
   </div>
 </details>
 
-<!-- 11 ------------------------------------------------------------------ -->
+<!-- 12 ------------------------------------------------------------------ -->
 <details class="sect" id="s-privacy">
   <summary><span class="sect-name">Privacy and security</span>
     <span class="sect-sub">What is stored, where, and what is never done</span></summary>
@@ -338,7 +363,7 @@
   </div>
 </details>
 
-<!-- 12 ------------------------------------------------------------------ -->
+<!-- 13 ------------------------------------------------------------------ -->
 <details class="sect" id="s-logs">
   <summary><span class="sect-name">Logs and diagnostics</span>
     <span class="sect-sub">Job logs and how long they are kept</span></summary>
@@ -360,7 +385,7 @@
   </div>
 </details>
 
-<!-- 13 ------------------------------------------------------------------ -->
+<!-- 14 ------------------------------------------------------------------ -->
 <details class="sect" id="s-about">
   <summary><span class="sect-name">About</span>
     <span class="sect-sub">Versions and what this build does not do yet</span></summary>

--- a/tests/test_rates.py
+++ b/tests/test_rates.py
@@ -337,6 +337,21 @@ def test_only_currencies_the_warehouse_actually_prices_in_are_fetched(tmp_path):
     assert rates.currencies_in_use(conn) == []
 
 
+def test_manual_refresh_with_no_non_usd_data_is_an_honest_no_op(tmp_path):
+    from scrapex import db as dbmod, rates
+
+    conn = dbmod.connect(tmp_path / "manual-empty.db")
+    dbmod.migrate(conn)
+
+    class _Tripwire:
+        def get(self, _url):
+            raise AssertionError("no currency means no network request")
+
+    batch = rates.refresh_now(conn, _Tripwire(), now="2026-07-31T12:00:00Z")
+    assert batch.rates == [] and batch.warnings == []
+    assert rates.last_checked(conn) == "", "no request was attempted"
+
+
 def test_a_failing_quote_page_costs_one_attempt_per_interval_not_one_per_poll():
     """The attempt is stamped BEFORE the fetch, deliberately.
 

--- a/tests/test_settings_live_in_the_extension.py
+++ b/tests/test_settings_live_in_the_extension.py
@@ -50,6 +50,16 @@ def test_the_crawl_pace_is_reachable_from_the_panel():
         assert f'id="{control}"' in panel, f"{control} is not in the side panel"
 
 
+def test_google_finance_control_is_reachable_from_the_panel():
+    panel = PANEL.read_text(encoding="utf-8")
+    script = (ROOT / "extension" / "app.js").read_text(encoding="utf-8")
+
+    for control in ("google_finance_auto_refresh", "google_finance_refresh_hours",
+                    "finance-save", "finance-refresh", "finance-dataset"):
+        assert f'id="{control}"' in panel
+    assert 'post("/api/rates/google-finance/refresh"' in script
+
+
 def test_the_web_page_still_shows_what_the_engine_holds():
     """Display-only is not the same as blank: moving the controls must not
     take the VALUES away, or the page stops being able to answer the one

--- a/tests/test_settings_page.py
+++ b/tests/test_settings_page.py
@@ -19,10 +19,11 @@ from scrapex.ingest import ingest_payloads  # noqa: E402
 from scrapex.webui.app import create_app  # noqa: E402
 from tests.test_ingest import make_entry, make_payload, one_row  # noqa: E402
 
-# Spec 33 names these thirteen, in this order.
+# Google Finance is a fourteenth display-only section; controls remain in the
+# extension under the owner's one-settings-surface rule.
 SECTIONS = [
     "General", "Local runtime", "Storage", "Crawling", "Engines",
-    "Jobs and scheduling", "Excel", "Apps Script", "Google account",
+    "Jobs and scheduling", "Google Finance", "Excel", "Apps Script", "Google account",
     "Data and history", "Privacy and security", "Logs and diagnostics", "About",
 ]
 
@@ -62,7 +63,7 @@ def prose(client, path: str = "/settings") -> str:
     return re.sub(r"\s+", " ", client.get(path).text)
 
 
-# ---- the thirteen sections (spec 24) ----------------------------------------
+# ---- the fourteen sections --------------------------------------------------
 
 def test_every_named_section_is_present(client):
     body = client.get("/settings").text
@@ -280,6 +281,94 @@ def test_crawl_settings_are_real_knobs_not_decoration(client, db_path):
     conn = dbmod.connect(db_path)
     try:
         assert crawl_settings(conn)["min_interval_s"] == 2.5
+    finally:
+        conn.close()
+
+
+def test_google_finance_settings_control_the_real_worker_predicate(client, db_path):
+    from scrapex import rates, settings
+
+    response = client.post("/api/settings", json={
+        "google_finance_auto_refresh": False,
+        "google_finance_refresh_hours": 2.5,
+    })
+    assert response.status_code == 200
+    conn = dbmod.connect(db_path)
+    try:
+        assert rates.automatic_refresh_enabled(conn) is False
+        assert rates.refresh_interval_hours(conn) == 2.5
+        assert rates.refresh_is_due(conn) is False
+        settings.save(conn, {"google_finance_auto_refresh": "1"})
+        conn.execute(
+            "INSERT INTO scrapex_meta (key, value) VALUES (?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+            (rates.LAST_CHECK_KEY, "2026-07-31T10:00:00Z"),
+        )
+        conn.commit()
+        assert rates.refresh_is_due(conn, now="2026-07-31T12:29:59Z") is False
+        assert rates.refresh_is_due(conn, now="2026-07-31T12:30:00Z") is True
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize("hours", [0, 0.1, 169, "not a number"])
+def test_google_finance_rejects_an_unsafe_refresh_interval(client, hours):
+    response = client.post(
+        "/api/settings", json={"google_finance_refresh_hours": hours},
+    )
+    assert response.status_code == 400
+    assert "between 0.25 and 168" in response.json()["detail"]
+
+
+def test_google_finance_settings_page_reports_provenance_and_freshness(client):
+    body = prose(client)
+    assert "Google Finance supplies the exchange rates" in body
+    assert "Stored prices never change" in body
+    assert "Latest market time" in body
+    assert 'href="/data/google-finance"' in body
+
+
+def test_manual_google_finance_refresh_bypasses_the_automatic_schedule(
+        client, db_path, monkeypatch):
+    import scrapex.webui.app as appmod
+
+    class FakeFetcher:
+        closed = False
+
+        def __init__(self, **_kwargs):
+            pass
+
+        def get(self, _url):
+            class Response:
+                text = ('<div data-source="USD" data-target="EGP" '
+                        'data-last-price="48.25" '
+                        'data-last-normal-market-timestamp="1785167520"></div>')
+            return Response()
+
+        def close(self):
+            FakeFetcher.closed = True
+
+    monkeypatch.setattr(appmod, "HttpFetcher", FakeFetcher)
+    assert client.post("/api/settings", json={
+        "google_finance_auto_refresh": False,
+        "google_finance_refresh_hours": 168,
+    }).status_code == 200
+
+    response = client.post("/api/rates/google-finance/refresh")
+    assert response.status_code == 200
+    result = response.json()
+    assert result["updated"] == 1
+    assert result["warnings"] == []
+    assert result["latest_market_at"] == "2026-07-27T15:52:00Z"
+    assert FakeFetcher.closed is True
+
+    conn = dbmod.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT per_usd, source_kind FROM currency_rate "
+            "WHERE source_key='google_finance'",
+        ).fetchone()
+        assert tuple(row) == (48.25, "provider")
     finally:
         conn.close()
 

--- a/tests/test_webui.py
+++ b/tests/test_webui.py
@@ -9,7 +9,7 @@ import pytest
 pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient  # noqa: E402
 
-from scrapex import db as dbmod  # noqa: E402
+from scrapex import db as dbmod, rates  # noqa: E402
 from scrapex.ingest import ingest_payloads  # noqa: E402
 from scrapex.webui.app import create_app  # noqa: E402
 from tests.test_ingest import make_entry, make_payload, one_row  # noqa: E402
@@ -34,6 +34,35 @@ def test_data_landing_lists_the_source(client):
     r = client.get("/data")
     assert r.status_code == 200
     assert "ELSEWEDYSHOP" in r.text and "السويدي شوب" in r.text
+
+
+def test_google_finance_is_a_first_class_dataset_with_bounded_history(client):
+    conn = dbmod.connect(client.app.state.db_path)
+    try:
+        rates.store_rates(conn, [
+            rates.Rate("EGP", 48.25, "2026-07-27T15:52:00Z",
+                       rates.QUOTE_URL_TEMPLATE.format(code="EGP")),
+            rates.Rate("EGP", 48.10, "2026-07-26T15:52:00Z",
+                       rates.QUOTE_URL_TEMPLATE.format(code="EGP")),
+        ])
+    finally:
+        conn.close()
+
+    landing = client.get("/data")
+    assert landing.status_code == 200
+    assert 'href="/data/google-finance"' in landing.text
+    assert "Reference data" in landing.text
+
+    response = client.get("/data/google-finance?per_page=25")
+    assert response.status_code == 200
+    body = response.text
+    assert "Google Finance exchange rates" in body
+    assert "Stored rate history" in body
+    assert "48.25" in body and "48.1" in body
+    assert "2026-07-27T15:52:00Z" in body
+    assert "1 USD equals" in body
+    assert 'href="/source/google_finance"' not in body
+    assert 'href="/data" title="Data"' in body
 
 
 def test_overview_summarizes_the_workspace_and_data_uses_one_dropdown(client):


### PR DESCRIPTION
Adds owner control over Google Finance automatic refresh (on/off and 0.25-168 hour cadence), an immediate manual update action in the extension, a display-only status section in Workspace Settings, and a first-class paginated Google Finance rate-history dataset. Automatic and manual updates share the same validated fetch/store path; stored prices remain unchanged and rate provenance/timestamps stay visible. Validation: 65 affected rate/settings/extension/idle tests passed; 26 full Web UI tests passed; Python compile and JavaScript syntax checks passed. Stacked on PR #48 because its cheap refresh_is_due predicate is the integration point; after #48 merges this PR can be retargeted to main.