### PR TITLE
perf: the test suite runs in minutes, not hours

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,15 @@ jobs:
           echo "panel tests collected: ${count:-0}"
           test "${count:-0}" -ge 40
       - name: Tests (Python engine + Python-vs-frozen contract)
+        # tests/conftest.py restores a prebuilt schema template instead of
+        # replaying 57 migrations per test, which is what turns a ~30-minute
+        # local suite into ~6 minutes. It is a developer-loop convenience, and
+        # this is the line that keeps it one: CI runs the REAL stream 805 times,
+        # so the authority on green tests exactly what it tested before that file
+        # existed. Same reasoning as the panel gate above — a guard that can
+        # vanish quietly is the defect.
+        env:
+          SCRAPEX_FULL_MIGRATIONS: "1"
         run: python -m pytest -q
 
   contract-parity:

--- a/scrapex/config.py
+++ b/scrapex/config.py
@@ -14,6 +14,32 @@ from typing import Literal
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+# WHY THE C LOADER (2026-07-31)
+#
+# The parser was 97% of load_manifest and pydantic was 0.5% of it — all the
+# validators in this file together cost 0.85 ms, while reading 34 KB of YAML cost
+# 180 ms. PyYAML ships a libyaml-backed loader that parses the SAME grammar:
+#
+#   yaml.safe_load(text)                     180.11 ms
+#   yaml.load(text, CSafeLoader)              11.89 ms      15x
+#   load_manifest() end to end          185 ms -> 16 ms     11.6x
+#
+# That is 308 parses per test-suite run, and it is a live cost too: five routes
+# re-parse the manifest on every source edit (webui/app.py add/update/remove/
+# set-active/rename), so every "Add Site" click paid 185 ms of pure-Python parsing.
+#
+# SafeLoader stays the fallback because libyaml is an optional C extension and a
+# pure-Python wheel must still work. That path is byte-identical to the old code:
+# yaml.safe_load(s) IS yaml.load(s, SafeLoader). Both loaders were checked against
+# each other on 28 inputs (duplicate keys, timestamps, Arabic literals, anchors,
+# merge keys, !!python/object, tabs, BOM, multi-document, 200-deep nesting) and on
+# all 7 defect classes this function must reject — same values, same exception
+# types, same yaml.error hierarchy. No behaviour rides on which one loads.
+try:
+    from yaml import CSafeLoader as _ManifestLoader
+except ImportError:                          # PyYAML built without libyaml
+    from yaml import SafeLoader as _ManifestLoader
+
 from .vocab import Authority, Cadence, ConnectorFamily, ExtractKind, ExtractScope, Fetcher, VatMode
 
 MANIFEST_FILE = Path(__file__).resolve().parent.parent / "sources.yaml"
@@ -334,7 +360,7 @@ def _host_of(url: str) -> str:
 
 def load_manifest(path: Path | str = MANIFEST_FILE) -> Manifest:
     """Parse + validate sources.yaml. Raises with a precise message on any defect."""
-    raw = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    raw = yaml.load(Path(path).read_text(encoding="utf-8"), Loader=_ManifestLoader)
     if raw is None:
         raise ValueError(f"{path}: manifest is empty")
     return Manifest.model_validate(raw)

--- a/scrapex/connectors/base.py
+++ b/scrapex/connectors/base.py
@@ -7,6 +7,8 @@ is uniform: ScrapedTable -> funnel payload -> ingest.
 from __future__ import annotations
 
 import random
+import ssl
+import threading
 import time
 from dataclasses import dataclass, field
 from typing import Iterable, Protocol, runtime_checkable
@@ -21,6 +23,42 @@ from ..vocab import ExtractKind, Fetcher, PayloadClient
 # 403 generic clients get a browser UA via SourceEntry notes + per-family
 # override — explicitly, per connector, never silently global.
 DEFAULT_USER_AGENT = "ScrapeX/0.1 (+contact: owner)"
+
+# WHY ONE SHARED SSL CONTEXT (2026-07-31)
+#
+# Every httpx.Client() builds its own, and building one here costs 1.6 SECONDS —
+# not on the network, before a single byte is sent. cProfile puts 5.921s of 5.929s
+# for three constructions inside one C call: _ssl._SSLContext.load_verify_locations.
+# certifi's cacert.pem is 240 KB and this box has resident on-access AV, so OpenSSL
+# re-reads it through the scanner every time. Same certificates from memory
+# (cadata) cost 139 ms, so it is the file read, not the parse. Measured here:
+#
+#   httpx.Client()                          1633.1 ms
+#   httpx.Client(verify=<shared context>)       0.6 ms      2700x
+#
+# It does NOT amortise: six consecutive builds ran 4083, 1744, 2121, 2503, 1675,
+# 1601 ms. Nothing about that is ScrapeX's doing. What WAS ours is how often we
+# paid it. The job worker built a fetcher on every poll while holding the
+# warehouse write lock (jobs.py), so an idle engine burned ~42% of a core and
+# stalled the owner's job inserts; the test suite paid it 37 times per run
+# (10% of total wall clock).
+#
+# The context is built once, lazily, and shared. ssl.SSLContext is documented as
+# safe for concurrent use once configured and nothing here mutates it afterwards.
+# Verification is UNCHANGED — this is httpx's own default context, built via
+# httpx.create_ssl_context(), just not rebuilt per client.
+_SSL_CONTEXT: ssl.SSLContext | None = None
+_SSL_CONTEXT_LOCK = threading.Lock()
+
+
+def shared_ssl_context() -> ssl.SSLContext:
+    """httpx's default CA-verifying context, built once per process."""
+    global _SSL_CONTEXT
+    if _SSL_CONTEXT is None:
+        with _SSL_CONTEXT_LOCK:
+            if _SSL_CONTEXT is None:      # another thread may have won the race
+                _SSL_CONTEXT = httpx.create_ssl_context()
+    return _SSL_CONTEXT
 
 
 @dataclass
@@ -213,6 +251,7 @@ class HttpFetcher:
             headers={"User-Agent": user_agent},
             timeout=timeout_s,
             follow_redirects=True,
+            verify=shared_ssl_context(),   # see the note above: 1633ms -> 0.6ms
         )
         self._min_interval_s = min_interval_s
         self._last_request_at = 0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,294 @@
+"""One migrated template database, restored per test instead of rebuilt.
+
+WHY THIS FILE EXISTS (2026-07-31)
+---------------------------------
+The suite took ~90 minutes because 114 call sites across 57 files each ran
+`dbmod.migrate()` inside a FUNCTION-scoped fixture. Nothing was wrong with any of
+them individually; the cost is that `migrate()` replays 57 files / 616 statements
+every time, and 74 of those statements are `ALTER TABLE` (36 `RENAME COLUMN`).
+SQLite re-parses the whole schema DDL per rename, so that is 93-97% of the SQL
+time and it is SQLite working as designed — not a pathology to fix.
+
+Measured on the owner's box:
+
+    dbmod.migrate()                          ~1900 ms
+    shutil.copyfile of the migrated file       17.8 ms
+    template_conn.backup(target)               25.4 ms
+    full suite, before                     ~90 min (estimated, never cleanly timed)
+    full suite, with this file               6m18s (measured)
+
+`backup()` is the primitive rather than `copyfile` because every one of those 114
+sites already holds an OPEN connection when it calls `migrate()`. Restoring into
+that connection is what lets this file speed the suite up without editing a single
+test. Fidelity was verified rather than assumed: user_version, application_id, all
+50 tables, 86 indexes, 18 triggers (including the A7 append-only pair), 2 views,
+integrity_check, foreign_key_check and both seed rows are identical to a freshly
+migrated database.
+
+Options that were measured and rejected: storage pragmas (`synchronous=OFF`,
+`journal_mode=MEMORY`) bought 0% and were marginally SLOWER; one transaction for
+all 57 bought 5%; squashing to a v57 baseline bought a lot but deletes the upgrade
+path T5 exists to check.
+
+THREE THINGS HERE ARE LOAD-BEARING. Each was found by breaking a version without
+it, and two of them fail SILENTLY, which is why they are commented at length.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scrapex import db as dbmod
+
+# Captured at import — before any test module can rebind them. `tests/conftest.py`
+# is imported before every test module, so these are the shipped originals.
+_REAL_MIGRATE = dbmod.migrate
+
+
+def _stream_fingerprint() -> tuple[tuple[int, str], ...]:
+    """What the migration stream IS right now — by content, never by identity.
+
+    The obvious guard, `dbmod._migration_files is not _THE_ORIGINAL`, is WRONG
+    here and fails in the silent direction. `tests/test_db.py:346` calls
+    `importlib.reload(scrapex.db)`, which installs a NEW function object that
+    behaves identically — so an identity check turns into a permanent veto for
+    the rest of the session and every later test quietly pays full price again.
+    That is the same failure as an unpatched reload wearing a different mask.
+
+    Comparing the resolved list catches what actually matters (a truncated,
+    reordered or repointed stream) and is blind to which object produced it.
+    """
+    return tuple((number, str(path)) for number, path in dbmod._migration_files())
+
+
+_REAL_STREAM: tuple[tuple[int, str], ...] = ()
+
+# LOAD-BEARING #3: the one file whose SUBJECT is migrate() itself.
+#
+# This is NOT a rot-prone blocklist standing in for a predicate — every other file
+# in the suite is protected by `_may_restore` below. test_db.py is here because two
+# of its tests assert on migrate()'s RETURN VALUE on a pristine connection, which no
+# predicate can distinguish from an ordinary caller. Proven by injecting a real
+# defect into migrate() (correct schema, under-reports the last applied number):
+#
+#                                                  defect, no restore | with restore
+#   test_migrate_is_idempotent                            FAILED      |   passed
+#   test_pending_migrations_agrees_with_migrate            FAILED      |   passed
+#
+# A synthetic [1..57] equals `pending_migrations()` on a fresh database by
+# construction, so the assertion becomes a tautology and the test stops testing.
+# Anything added to this set needs the same standard of evidence.
+NEVER_RESTORE = frozenset({"test_db"})
+
+_TEMPLATE_DIR: Path | None = None
+_TEMPLATE_CONN: sqlite3.Connection | None = None
+_TEMPLATE_UV = 0
+_TEMPLATE_APPLIED: list[int] = []
+
+# CI is the authority on green, and it runs on Linux where neither of this box's
+# pathologies exists (an AV-scanned CA file load, a resident process eating a
+# core). Setting this makes the suite byte-for-byte what it was before this file
+# existed, so "the fast suite might hide something" has a definitive answer rather
+# than an argument: .github/workflows/ci.yml runs the real 57-file stream 805
+# times on every push, and the developer's inner loop does not.
+_FULL_MIGRATIONS = bool(os.environ.get("SCRAPEX_FULL_MIGRATIONS"))
+
+# A broken re-arm or a mis-firing predicate does not turn anything red — it just
+# makes the suite slow again, which is exactly the failure nobody notices until
+# an afternoon is gone. A full run restores ~759 times; anything near zero after a
+# whole-suite run means this file has quietly stopped working.
+_EXPECT_RESTORES_OVER = 500
+
+# Exposed so tests/test_fast_migrations.py can pin this file's behaviour (Q8: a
+# workaround ships with a test pinning it). Not read by anything in scrapex/.
+STATS: dict[str, float] = {"restored": 0, "real": 0, "rearmed": 0, "restore_s": 0.0}
+
+_bypass = {"on": False}
+
+
+def _build_template() -> None:
+    """Run the REAL migrate once, then hold the result open for restoring."""
+    global _TEMPLATE_DIR, _TEMPLATE_CONN, _TEMPLATE_UV, _REAL_STREAM
+    _TEMPLATE_DIR = Path(tempfile.mkdtemp(prefix="scrapex-schema-template-"))
+    path = _TEMPLATE_DIR / "template.db"
+
+    _REAL_STREAM = _stream_fingerprint()
+    conn = dbmod.connect(path)
+    # Keep what the real migrate ACTUALLY returned rather than synthesising it
+    # later. The numbers happen to be contiguous today, so `range(1, uv + 1)`
+    # would agree — but nothing enforces that, and an observed value cannot
+    # drift from the thing it describes.
+    _TEMPLATE_APPLIED[:] = _REAL_MIGRATE(conn)
+    _TEMPLATE_UV = dbmod.schema_version(conn)
+    # LOAD-BEARING #1: CLOSE IT. `dbmod.connect` sets `PRAGMA journal_mode = WAL`,
+    # so until the last connection closes the migrations live in template.db-wal
+    # and template.db itself is ONE PAGE. Reading the file while this connection
+    # was open produced a database with 0 tables reporting `user_version = 0` —
+    # which every caller here would read as "pristine" and happily hand to a test.
+    # Closing checkpoints the WAL into the file. (`PRAGMA wal_checkpoint(TRUNCATE)`
+    # also works; closing is simpler and we want a read-only handle anyway.)
+    conn.close()
+
+    _TEMPLATE_CONN = sqlite3.connect(str(path), check_same_thread=False)
+
+
+def _is_pristine(conn: sqlite3.Connection) -> bool:
+    if int(conn.execute("PRAGMA user_version").fetchone()[0]) != 0:
+        return False
+    return conn.execute("SELECT COUNT(*) FROM sqlite_master").fetchone()[0] == 0
+
+
+def _may_restore(conn: sqlite3.Connection) -> bool:
+    if _bypass["on"] or _TEMPLATE_CONN is None:
+        return False
+
+    # The stream must be the STOCK one. tests/test_db.py:204 `_at_version_46`
+    # monkeypatches `_migration_files` to truncate history and replay it; a
+    # restore would hand it v57 instead of v46. Three of the four tests it guards
+    # fail loudly only by luck — they happen to name a column a later migration
+    # renamed. One that didn't would pass against the wrong schema.
+    if _stream_fingerprint() != _REAL_STREAM:
+        return False
+
+    # The target must be EMPTY. `migrate()` on a partly-migrated or populated
+    # database is an UPGRADE and `backup()` would discard its rows. This guard is
+    # the only thing catching the three helpers that hand-replay a migration
+    # prefix on the stock stream and then upgrade over it:
+    #   tests/test_schema.py:158            "the pre-0020 warehouse"
+    #   tests/test_display_method_and_quantity_facts.py:556  "the pre-0056 warehouse"
+    #   tests/test_the_weight_the_price_is_quoted_against.py:546 "the pre-0057 one"
+    # It is load-bearing, not belt-and-braces: with it removed those three fail.
+    if not _is_pristine(conn):
+        return False
+
+    # No open transaction. A destination inside a write txn raises
+    # "destination database is in use"; a SOURCE inside one HANGS FOREVER with no
+    # exception (killed at 75s in testing). Measured: 0 of the 114 sites hit this,
+    # so this is a guard against a future caller, not a current one.
+    return not conn.in_transaction
+
+
+def _fast_migrate(conn: sqlite3.Connection) -> list[int]:
+    """`dbmod.migrate` with the 57-file replay swapped for a template restore."""
+    if not _may_restore(conn):
+        STATS["real"] += 1
+        # Whatever is installed now — an importlib.reload may have replaced the
+        # original object, and the reloaded one is the one the test wants.
+        return getattr(dbmod, "_conftest_real_migrate", _REAL_MIGRATE)(conn)
+
+    import time
+
+    started = time.perf_counter()
+    _TEMPLATE_CONN.backup(conn)
+    # migrate() ends by stamping the contract version. The template carries the
+    # stamp already, but re-stamping costs nothing and keeps this faithful even if
+    # a test has monkeypatched the contract constants.
+    from scrapex.contract import stamp_contract
+
+    with conn:
+        stamp_contract(conn)
+    STATS["restored"] += 1
+    STATS["restore_s"] += time.perf_counter() - started
+    return list(_TEMPLATE_APPLIED)
+
+
+def _arm() -> None:
+    if dbmod.migrate is not _fast_migrate:
+        # LOAD-BEARING #2: tests/test_db.py:346,355,364,372 call
+        # `importlib.reload(scrapex.db)`, which re-execs the module in place and
+        # rebinds EVERY attribute — including `migrate`, back to the real one. A
+        # patch installed once at pytest_configure dies there, silently, for the
+        # rest of the session. test_db.py is file 21 of 87 in collection order and
+        # 41 of the 57 migrate-calling files sort after it, so ~72% of the suite
+        # quietly reverted to full cost. Proven with the same 25 tests reversed:
+        #   test_archive.py then test_db.py  -> restored=4
+        #   test_db.py then test_archive.py  -> restored=0
+        # Re-arming per test is what makes this file's saving real.
+        dbmod._conftest_real_migrate = dbmod.migrate
+        dbmod.migrate = _fast_migrate
+        STATS["rearmed"] += 1
+
+
+@pytest.fixture(scope="session")
+def schema_template():
+    """This file's own state, for tests/test_fast_migrations.py to pin.
+
+    A fixture and not an import: pytest owns this module's identity, and
+    `from tests import conftest` would build a SECOND module object with its own
+    globals — the tests would then be asserting about a template that never
+    served anybody, and would pass while the real one was broken.
+    """
+    return SimpleNamespace(
+        dir=_TEMPLATE_DIR,
+        conn=_TEMPLATE_CONN,
+        applied=list(_TEMPLATE_APPLIED),
+        user_version=_TEMPLATE_UV,
+        stream=_REAL_STREAM,
+        stats=STATS,
+        disabled=_FULL_MIGRATIONS,
+        real_migrate=_REAL_MIGRATE,
+        fast_migrate=_fast_migrate,
+        may_restore=_may_restore,
+        fingerprint=_stream_fingerprint,
+        never_restore=NEVER_RESTORE,
+        arm=_arm,
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    if _FULL_MIGRATIONS:
+        return
+    _build_template()
+    _arm()
+
+
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    if _FULL_MIGRATIONS:
+        return
+    _arm()
+    # Helper modules are imported under two names in this suite (`test_ingest` and
+    # `tests.test_ingest`, because 28 files do `from tests.test_ingest import ...`),
+    # so compare on the bare module name.
+    module = getattr(item, "module", None)
+    name = module.__name__.rsplit(".", 1)[-1] if module else ""
+    _bypass["on"] = name in NEVER_RESTORE
+
+
+def pytest_terminal_summary(terminalreporter) -> None:
+    if _FULL_MIGRATIONS:
+        terminalreporter.write_line(
+            "schema template: DISABLED (SCRAPEX_FULL_MIGRATIONS) — every "
+            "migrate() ran for real")
+        return
+    if not (STATS["restored"] or STATS["real"]):
+        return
+    each = STATS["restore_s"] / max(1, STATS["restored"])
+    terminalreporter.write_line(
+        f"schema template: {STATS['restored']:.0f} restored "
+        f"({each*1000:.1f}ms each), {STATS['real']:.0f} real migrations, "
+        f"re-armed {STATS['rearmed']:.0f}x")
+    # Whole-suite run that barely restored anything = this file has silently
+    # stopped working. Say so; do not let it pass for a slow afternoon.
+    ran = terminalreporter._session.testscollected
+    if ran > 1000 and STATS["restored"] < _EXPECT_RESTORES_OVER:
+        terminalreporter.write_line(
+            f"  WARNING: only {STATS['restored']:.0f} restores across {ran} tests "
+            f"(expected >{_EXPECT_RESTORES_OVER}). The template is being bypassed "
+            f"— check the re-arm hook and _may_restore().", red=True)
+
+
+def pytest_unconfigure(config: pytest.Config) -> None:
+    # Windows will not remove the directory while the handle is open.
+    global _TEMPLATE_CONN
+    if _TEMPLATE_CONN is not None:
+        _TEMPLATE_CONN.close()
+        _TEMPLATE_CONN = None
+    if _TEMPLATE_DIR is not None:
+        import shutil
+
+        shutil.rmtree(_TEMPLATE_DIR, ignore_errors=True)

--- a/tests/test_fast_migrations.py
+++ b/tests/test_fast_migrations.py
@@ -1,0 +1,180 @@
+"""What tests/conftest.py must keep being true (ENGINEERING.md Q8, P2).
+
+That file swaps a real `migrate()` for a template restore roughly 760 times per
+run. Q8 says a workaround ships with a test pinning current behaviour; these are
+those tests, and they exist because every way this can break is SILENT:
+
+  - a template that is not a real migration hands every test a wrong schema
+  - a guard that vetoes forever makes the suite slow again, never red
+  - a guard that under-fires lets an upgrade test assert against v57
+
+The one that matters most is the first. If the template IS one honest run of the
+real 57-file stream, then every restore that copies it is honest too, and the
+whole mechanism reduces to that single claim.
+"""
+from __future__ import annotations
+
+import importlib
+import sqlite3
+
+import pytest
+
+from scrapex import db as dbmod
+
+# `retention_policy.updated_at` defaults to strftime('%Y-%m-%dT%H:%M:%SZ','now')
+# (db/migrations/0011_retention.sql), so two HONEST migrations a second apart
+# differ there. Comparing it would make this test fail at random, which is worse
+# than not having it — a gate people learn to ignore is not a gate.
+_CLOCK_COLUMNS = {("retention_policy", "updated_at")}
+
+
+def _shape(conn: sqlite3.Connection) -> dict:
+    """Everything about a database that a real migration decides."""
+    shape: dict = {
+        "user_version": conn.execute("PRAGMA user_version").fetchone()[0],
+        "application_id": conn.execute("PRAGMA application_id").fetchone()[0],
+        "integrity": conn.execute("PRAGMA integrity_check").fetchone()[0],
+        "foreign_keys": conn.execute("PRAGMA foreign_key_check").fetchall(),
+        "schema": sorted(
+            (row[0], row[1], row[2] or "")
+            for row in conn.execute(
+                "SELECT type, name, sql FROM sqlite_master WHERE name NOT LIKE 'sqlite_%'")
+        ),
+    }
+    for kind, name, _sql in shape["schema"]:
+        if kind != "table":
+            continue
+        columns = [r[1] for r in conn.execute(f"PRAGMA table_info({name})")
+                   if (name, r[1]) not in _CLOCK_COLUMNS]
+        if not columns:
+            continue
+        picked = ", ".join(f'"{c}"' for c in columns)
+        # tuple() because dbmod.connect sets row_factory = sqlite3.Row while a
+        # plain connection yields tuples; comparing the raw objects compares
+        # their addresses and every row looks different.
+        shape[f"rows:{name}"] = sorted(
+            repr(tuple(row))
+            for row in conn.execute(f"SELECT {picked} FROM {name}"))
+    return shape
+
+
+def test_the_template_is_one_honest_run_of_the_real_migrations(schema_template, tmp_path):
+    """THE gate. Every restored database is a copy of this one, so if this holds,
+    all ~760 of them are as good as a real migration — and if it ever stops
+    holding, the whole suite has been testing a schema nobody ships."""
+    if schema_template.disabled:
+        pytest.skip("SCRAPEX_FULL_MIGRATIONS: there is no template to check")
+
+    honest = dbmod.connect(tmp_path / "honest.db")
+    schema_template.real_migrate(honest)
+
+    served = sqlite3.connect(str(schema_template.dir / "template.db"))
+    try:
+        assert _shape(served) == _shape(honest)
+    finally:
+        served.close()
+        honest.close()
+
+
+def test_the_template_carries_the_whole_stream(schema_template):
+    if schema_template.disabled:
+        pytest.skip("SCRAPEX_FULL_MIGRATIONS: there is no template to check")
+    assert schema_template.user_version == dbmod.latest_schema_version()
+    # Not a rebuilt range(): the list the real migrate actually returned.
+    assert schema_template.applied[-1] == schema_template.user_version
+    assert schema_template.applied == sorted(set(schema_template.applied))
+
+
+def test_a_reloaded_db_module_does_not_disable_the_template(schema_template):
+    """tests/test_db.py calls importlib.reload(scrapex.db) four times.
+
+    The guard that shipped first compared `dbmod._migration_files` by IDENTITY.
+    Reload installs a NEW function object that behaves identically, so that guard
+    became a permanent veto and every file collected after test_db.py silently
+    paid full price again — 41 of the 57 migrate-calling files. Nothing turned
+    red; the suite just got slow. This pins the content comparison that replaced it.
+    """
+    if schema_template.disabled:
+        pytest.skip("SCRAPEX_FULL_MIGRATIONS: nothing is armed")
+
+    before_obj = dbmod._migration_files
+    assert schema_template.fingerprint() == schema_template.stream
+
+    importlib.reload(dbmod)
+    try:
+        assert dbmod._migration_files is not before_obj, (
+            "reload did not replace the object; this test would prove nothing")
+        # Same stream by content, which is the only thing that matters.
+        assert schema_template.fingerprint() == schema_template.stream
+    finally:
+        schema_template.arm()   # leave the session as we found it
+
+
+def test_a_truncated_stream_is_never_served_the_template(schema_template, monkeypatch, tmp_path):
+    """tests/test_db.py:204 replays history by cutting the stream short. Handing
+    it v57 would not fail — it would quietly assert against the wrong schema."""
+    if schema_template.disabled:
+        pytest.skip("SCRAPEX_FULL_MIGRATIONS: nothing is armed")
+
+    conn = dbmod.connect(tmp_path / "truncated.db")
+    try:
+        assert schema_template.may_restore(conn) is True     # pristine: eligible
+        every = dbmod._migration_files()
+        monkeypatch.setattr(dbmod, "_migration_files",
+                            lambda: [f for f in every if f[0] <= 46])
+        assert schema_template.may_restore(conn) is False    # ...but not this stream
+    finally:
+        conn.close()
+
+
+def test_a_database_that_already_has_a_schema_is_upgraded_not_replaced(schema_template, tmp_path):
+    """Three files hand-replay a migration prefix and then upgrade over it. A
+    restore would discard their rows, and `backup()` would not complain."""
+    if schema_template.disabled:
+        pytest.skip("SCRAPEX_FULL_MIGRATIONS: nothing is armed")
+
+    conn = dbmod.connect(tmp_path / "populated.db")
+    try:
+        conn.execute("CREATE TABLE something (id INTEGER PRIMARY KEY)")
+        conn.execute("PRAGMA user_version = 20")
+        conn.commit()
+        assert schema_template.may_restore(conn) is False
+    finally:
+        conn.close()
+
+
+def test_an_open_transaction_is_never_restored_into(schema_template, tmp_path):
+    """A destination inside a write transaction raises; a SOURCE inside one hangs
+    forever with no exception. No call site does this today — this is what keeps
+    that true."""
+    if schema_template.disabled:
+        pytest.skip("SCRAPEX_FULL_MIGRATIONS: nothing is armed")
+
+    conn = dbmod.connect(tmp_path / "busy.db")
+    try:
+        assert schema_template.may_restore(conn) is True    # pristine: eligible
+        # Explicit BEGIN, because the database has to stay PRISTINE for this to
+        # test the transaction guard rather than the emptiness guard — and with
+        # no tables there is no DML to open one implicitly.
+        conn.execute("BEGIN")
+        assert conn.in_transaction
+        assert schema_template.may_restore(conn) is False
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_the_file_that_tests_migrate_itself_is_declared(schema_template):
+    """test_db.py asserts on migrate()'s RETURN VALUE on a pristine connection,
+    which no predicate can tell apart from an ordinary caller. Defect injection
+    proved two of its tests pass while migrate() is broken, so it is excluded by
+    name. If that name ever changes, this fails and the exclusion gets revisited
+    instead of silently lapsing."""
+    if schema_template.disabled:
+        pytest.skip("SCRAPEX_FULL_MIGRATIONS: nothing is excluded")
+    from pathlib import Path
+
+    for name in schema_template.never_restore:
+        assert (Path(__file__).parent / f"{name}.py").is_file(), (
+            f"{name} is excluded from the schema template but no such test file "
+            f"exists — the exclusion is now protecting nothing")


### PR DESCRIPTION
Closes the measurement work in #52.

**The full suite goes from ~30 minutes to 5m25s, with no test file edited.**

Three independent commits, each revertible on its own.

## What each commit does

| commit | change | measured |
|---|---|---|
| `perf(config)` | `yaml.safe_load` → guarded `CSafeLoader` | `load_manifest` 185 ms → 13.75 ms |
| `perf(fetch)` | one shared `ssl.SSLContext` instead of one per client | `HttpFetcher()` 1633 ms → 0.46 ms |
| `perf(tests)` | one migrated template, restored per test | full suite 378 s → and with the two above, **325.5 s** |

The first two are production changes and win in the product too: five routes re-parse the manifest
on every source edit (−169 ms per "Add Site" click), and the SSL fix removes a 1.6–2.7 s stall the
job worker was paying **while holding the warehouse write lock** on every poll.

## Why the suite was slow

114 `dbmod.migrate()` call sites across 57 files, all inside function-scoped fixtures. Each call
replays 57 files / 616 statements, and 74 of those are `ALTER TABLE` (36 `RENAME COLUMN`) — 93–97%
of the SQL time. SQLite re-parses the whole schema DDL per rename; that is SQLite working as
designed, not something to fix.

Measured and rejected before landing on the template: storage pragmas bought **0%** (and
`synchronous=OFF` was *slower*); one transaction for all 57 bought 5%; squashing to a v57 baseline
bought a lot but deletes the upgrade path T5 exists to check.

## What to look at in review

Three things in `tests/conftest.py` are load-bearing, and **two of them fail silently** — each was
found by breaking a version without it:

1. **The template connection is closed before it is read.** `connect()` sets `journal_mode=WAL`, so
   with it open the file is one page and reports `user_version = 0` — which reads as "pristine", and
   every test would silently receive a blank schema.
2. **The patch is re-armed per test.** `tests/test_db.py` calls `importlib.reload(scrapex.db)` four
   times, rebinding `migrate` back to the real one. It is file 21 of 87 and 41 of the 57
   migrate-calling files sort after it, so a one-shot patch loses ~72% of the saving with nothing
   turning red.
3. **The stream guard compares content, not identity.** `_migration_files is not _original` looks
   right and is wrong — reload installs a new function object with identical behaviour, so that
   guard becomes a permanent veto. Same silent failure as (2), wearing a different mask.

`tests/test_db.py` is excluded **by name**, and that deserves the most scrutiny. Two of its tests
assert on `migrate()`'s *return value* on a pristine connection, which no predicate can distinguish
from an ordinary caller. Defect injection (a `migrate()` with a correct schema that under-reports the
last applied number) proved both pass while it is broken:

| | defect, no template | defect, with template |
|---|---|---|
| `test_migrate_is_idempotent` | **FAILED** | passed |
| `test_pending_migrations_agrees_with_migrate` | **FAILED** | passed |

Every other hazard is caught by the predicate rather than a name — including the four helpers that
truncate or hand-replay the migration stream, which route to the real `migrate()` via the content
fingerprint and the pristine check. With both guards disabled, exactly 7 tests fail, and they are
exactly those.

## What keeps it honest

`tests/test_fast_migrations.py` (7 tests) pins the behaviour, per Q8. The central one asserts the
template is identical to one honest `migrate()` on `user_version`, `application_id`,
`integrity_check`, `foreign_key_check`, all 50 tables, 86 indexes, 18 triggers, 2 views and every
seed row — excluding `retention_policy.updated_at`, which defaults to `strftime('now')` and would
make the gate flaky. **If the template is one honest migration, every restore that copies it is
honest too**, and the whole mechanism reduces to that single claim.

`.github/workflows/ci.yml` sets `SCRAPEX_FULL_MIGRATIONS=1`, so CI runs the real stream 805 times on
every push. The fast path is a local developer convenience; the authority on green tests exactly what
it tested before this PR. Same reasoning as the panel-suite gate directly above it in that file.

## Known-failing tests on this branch — both pre-existing

Reproduced with the template fully disabled, so neither is caused by this PR:

- `tests/test_jobs.py::test_two_jobs_on_different_hosts_do_crawl_at_the_same_time` — Windows
  `monotonic` resolution is 0.015625 s and the test asserts a strict `<` on timestamps microseconds
  apart (`assert 5254556.89 < 5254556.89`). Fails 3/3 on `main`.
- `tests/test_rates.py::test_rates_refresh_only_when_the_stored_ones_have_gone_stale` — stamps the
  real clock at line 316, then asserts staleness against a hardcoded `2026-08-01T00:00:00Z`. With
  `REFRESH_AFTER_S = 6h` it fails only in the six-hour UTC window before that date, and heals itself
  after. Both tracked separately.

## Not in this PR

The 8 domain-database files (64 tests) migrate through `DomainDatabase._migrate` and get no benefit
here. A second template would take `MarketLensDatabase.initialize` from 1151.6 ms to 4.9 ms — 144 of
147 domain migrations are on a pristine database, so the same predicate applies — but MarketLens's
v55 stream produces a different schema (40 tables vs the legacy 50) and it needs its own
`application_id`. Separate work, and #52 records a product defect that should be settled first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
