### PR TITLE
docs(sources): the source register and the candidate queue

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -261,7 +261,9 @@ lose).
   (`plan-closing-the-gaps` §5.2). Measured in `2253308`: 3,874 products at `Crawl-delay: 10`
   ≈ **eleven hours**.
 - **SIKA datasheets** want their own connector (§5.3).
-- **TABLER** has never been probed (§5.4).
+- **TABLER** has never been probed (§5.4). Now tracked with the rest of the unprobed
+  queue in `docs/CANDIDATE-SOURCES.md`, whose row also records that its URL was never
+  written down anywhere.
 
 ### DEC-6 · Authenticated capture for prices an anonymous crawl can never reach
 Decided in principle, unbuilt: ALSWEED's variant prices (`offers.price=0` in JSON-LD),
@@ -458,6 +460,8 @@ owner to-do — **inferred**; the check is which run wrote them.)*
 | file | status |
 |---|---|
 | `BACKLOG.md` (this file) | **live** — the tracking document |
+| `CANDIDATE-SOURCES.md` (07-31) | **live** — the queue of sites the owner has sent and nobody has probed yet. Deliberately outside `sources.yaml` (SR-13). A row leaves it when the site becomes a manifest entry |
+| `SOURCES-REGISTER.md` (07-31) | **live, derived** — the developer's per-source scoreboard, split MarketLens / General. Reads out of the manifest, the connector directory and this file; when it disagrees with `sources.yaml`, the manifest wins. Delete a reference in it when the matching `OP-`/`DEC-`/`BV-` closes |
 | `plan-closing-the-gaps.md` (07-25) | **superseded by this file.** Phases 0–2 delivered; its still-live items are DEC-4, DEC-5, DEC-6, DEBT-2, Q-10. Keep for its measured 07-25 snapshot |
 | `MASTER-PLAN.md` (07-18/23) | **stale and misleading** — see DEC-1. Its §8 asks the owner to confirm a topology its own header says he already rejected, and it cites a `spikes/` directory that has never existed in this repo. Keep as a design study; correct the header once Q-6 is answered |
 | `REVIEW-2026-07-28.md` | **live as evidence, superseded as a queue.** Its open items are OP-4, OP-5, OP-6, OP-7, OP-12, OP-13, OP-14 |

--- a/docs/CANDIDATE-SOURCES.md
+++ b/docs/CANDIDATE-SOURCES.md
@@ -1,0 +1,292 @@
+# Candidate sources — the queue, not the contract
+
+Opened **2026-07-31**, on the owner's instruction: «ضيفه فى list واترك امور المعالجة
+للمستقبل لكن اريد الاحتفاظ به حتى لا يضيع … اعمل ملف ضيف فيه كل المصادر الى هبعتهالك
+وهنبقى نشوف الاداة تقدر تشتغلهم ولا محتاجه تعديل مستقبلا» — *put it in a list and leave
+the processing for the future, but I want it kept so it does not get lost; make a file
+holding every source I send you, and we will see later whether the tool can run them or
+needs changes.*
+
+**This file is a holding pen. It is not `sources.yaml`.** Nothing listed here is declared,
+crawled, or promised. SR-13 stands: nothing is collected that is not declared in the
+manifest, so a site sits here until somebody deliberately moves it — and moving it is the
+work this file exists to defer, not to hide.
+
+**Where a site goes when it leaves:** `docs/SOURCES-REGISTER.md` is the developer's
+scoreboard for sources that already exist, split by system (MarketLens = the product and
+price warehouse; General = the generic dataset catalogue, which has no sources yet and
+whose extraction features are off). Every row here is also summarised there under
+*§3 Not yet assigned*.
+
+**Nothing in this file has been probed. No request has been made to any host in it**, by
+ScrapeX or by me. So there is no `platform` column: it is unknown for every row, and the
+day a row is probed its status becomes `probed → <family>` with the evidence beside it.
+
+**Every annotation is the owner's own, quoted and not interpreted.** Where he wrote
+`trusted` / `not rated`, a blank means he said nothing — which is **not** the same as
+`not rated`, a judgement he did make.
+
+**Totals: 37 unprobed hosts · 3 leads with no URL · 2 already known to the project.**
+
+---
+
+## Queue A — individual leads
+
+Sent 2026-07-31 as single URLs with per-site annotations.
+
+| # | site | system | rating | prices? | what is known |
+|---|---|---|---|---|---|
+| 1 | <https://khamato.com/> | — | — | yes | Later annotated by the owner: «منصة بيع تجزئة/جملة لعدة مصانع» — *a retail/wholesale platform for several factories*, listed under **cement · Egypt** in Queue B. |
+| 2 | <https://bulk.khamato.com/> | market | — | — | **Subdomain of #1**, labelled `bulk` — consistent with the wholesale half of that annotation. |
+| 3 | <https://bnaia.com/> | market | not rated | — | Nothing fetched. |
+| 4 | <https://sphinx-store.com/> | market | not rated | — | Nothing fetched. |
+| 5 | <https://www.cmbegypt.com/> | market | **trusted** | **maybe none** | Owner: «market (maybe prices not included)». |
+| 6 | <https://ahrambc.com/> | market | not rated | — | Nothing fetched. |
+| 7 | <https://www.ahmedelsallab.com/> | market | **trusted** | — | Nothing fetched. |
+| 8 | <https://www.sebakashop.com/> | market | not rated | — | Nothing fetched. |
+| 9 | <https://mashreqy.com/> | market | **trusted** | — | Nothing fetched. |
+| 10 | <https://polygroup-eg.com/> | market | — | **maybe none** | Owner: «market (maybe prices not included)». No rating given. |
+| 11 | <https://nile-cement.com/en/products/> | **— not stated** | **trusted** | **maybe none** | Not a homepage: a listing path *and* the `en` locale. The Arabic path is a separate fact to find, never to build from this one (SR-2; precedent at `sources.yaml:422-427`, where the AR and EN aliases of one page share no stem). |
+| 12 | <https://darbuildgroup.com/> | **general** | — | — | Nothing fetched. |
+| 13 | <https://readymixconcreteguide.com/> | **general** | — | — | Named as a *guide*, consistent with the general designation. |
+| 14 | <https://cementegypt.com/> | market | — | — | Nothing fetched. |
+| 15 | <https://yellowpages.com.eg/> | **general** | — | — | A business **directory** by name — records and listings, not product prices, which is what General is for. |
+
+*Append, never reorder — the number is how a site is referred to in a later session.*
+
+### Carried in from `BACKLOG.md` DEC-5
+
+| # | site | received | status |
+|---|---|---|---|
+| 0 | **TABLER** (URL not recorded) | before 2026-07-25 | **not probed.** Named in `plan-closing-the-gaps` §5.4 and DEC-5 as never probed. Its URL is written down nowhere in the repo and needs recovering from the owner. |
+
+---
+
+## Queue B — the coverage matrix
+
+Sent 2026-07-31 in the owner's own structure: **material × country**, with a note on each
+site saying whether it publishes a price at all. That structure is preserved rather than
+flattened, because it is what makes the *gaps* visible — a flat list hides a missing
+country.
+
+Markets: **EG · SA · AE · QA · KW · BH · OM**. Materials so far: **fuel · cement ·
+steel/rebar · bitumen**, plus one official price bulletin covering building materials
+generally.
+
+### B1 · Fuel / retail energy
+
+| country | site | owner's note | status |
+|---|---|---|---|
+| EG | <https://www.petroleum.gov.eg> | — | not probed · **ministry** |
+| SA | <https://www.aramco.com/en/what-we-do/energy-products/retail-fuels> | — | **ALREADY DECLARED AND ACTIVE — `ARAMCO_FUEL_SA`**, monthly, `authority: official` (`sources.yaml:665`). The manifest reads the **`/ar/`** path, not the `/en/` one sent here. Nothing to add but the EN alternate (SR-2). |
+| AE | *لجنة أسعار الوقود الإماراتية* | — | **NO URL GIVEN** |
+| QA | <https://www.qatarenergy.qa> | — | not probed · state-owned |
+| KW | <https://www.kpc.com.kw> | — | not probed · state-owned |
+| BH | *لجنة تسعير ومراقبة الوقود* | — | **NO URL GIVEN** |
+| OM | <https://www.oq.com> | — | not probed · state-owned |
+
+### B2 · Cement
+
+| country | site | owner's note | status |
+|---|---|---|---|
+| EG | <https://www.egyptian-cement.com/products/products-prices> | «أفضل مصدر — منتج مباشر بسعر منشور EGP/طن» — *best source; direct producer with a published EGP/tonne price* | not probed · deep path, straight at the price page |
+| EG | <https://www.khamato.com> | «منصة بيع تجزئة/جملة لعدة مصانع» — *a retail/wholesale platform for several factories* | = **Queue A #1/#2** |
+| SA | <https://www.youmats.com/building-material/cement> | «منصة موردين حقيقية — نطاق سعر الكيس معلن» — *a real supplier platform; the bag price is published as a RANGE* | not probed · **range, not a price — Q-G** |
+| AE | <https://www.fepy.com/building-material/cement-concrete/cement> | «أفضل مصدر — أسعار حية لكل منتج بالدرهم» — *best source; live per-product prices in AED* | not probed |
+| QA | <https://www.qatarcement.com> | «المُنتِج المباشر — بدون سعر منشور، طلب عرض سعر» | **NO PUBLISHED PRICE — Q-F** |
+| KW | <https://www.kuwaitcement.com> | same | **NO PUBLISHED PRICE — Q-F** |
+| BH | <https://www.falcon-cement.com> | same | **NO PUBLISHED PRICE — Q-F** |
+| OM | <https://www.raysutcement.om> · <https://www.occ.om> | «المُنتِجان الرئيسيان — بدون سعر منشور، طلب عرض سعر» | **NO PUBLISHED PRICE — Q-F** · `.om` TLD, see Q-J |
+
+### B3 · Steel / rebar
+
+| country | site | owner's note | status |
+|---|---|---|---|
+| EG | <https://www.ezzsteel.com> | «المُنتِج الأكبر» — *the largest producer* | not probed |
+| EG | <https://elkayansteel.com> | «نطاق سعر الطن معلن يوميًا: 36,200–40,369 جنيه» — *the tonne price is published daily as a range* | not probed · **range, and DAILY — Q-G** |
+| SA | <https://www.youmats.com/steel-iron/reinforcing-iron> | «نفس منصة الأسمنت — أسعار حديد لكل صنف وسمك ظاهرة» | **SAME HOST as B2·SA — Q-H** |
+| AE | <https://www.fepy.com/building-material/steel-rebar-accessories/rebar> | «نفس منصة الأسمنت — سعر الطن ظاهر فعليًا شامل الضريبة» — *tonne price actually shown, VAT included* | **SAME HOST as B2·AE — Q-H** · a stated tax position |
+| QA | <https://www.qatarsteel.com.qa> | «المُنتِج المباشر» | not probed |
+| QA | <https://www.teyseerbm.com/principals/qatar-steel> | «موزّع معتمد لقطر ستيل والأسمنت الوطنية» — *authorised distributor for Qatar Steel and the National Cement Co.* | not probed · a **distributor** standing in for two producers — `authority` question (Q-A) |
+| KW | <https://www.kwtsteel.com> | «المُنتِج المباشر» | not probed |
+| BH | <https://foulath.com> | «مجموعة فولاذ — SULB للحديد الإنشائي» | not probed |
+| OM | <https://jazeerasteel.com> | «الجزيرة للحديد — المُنتِج الرئيسي» | not probed |
+
+### B4 · Bitumen — Qatar, official statistics
+
+| country | site | owner's note | status |
+|---|---|---|---|
+| QA | <https://moci.gov.qa> · <https://psa.gov.qa> | «بيتومين اختراق 60/70» — *penetration bitumen 60/70* | not probed · **ministry + national statistics authority.** A material grade, not a product — see Q-I, which is the good news in this batch. |
+
+### B5 · Egypt — the official building-materials price bulletin
+
+| country | site | what the owner gave | status |
+|---|---|---|---|
+| EG | `img.mhuc.gov.eg` · index: `mhuc.gov.eg/أرشيف_نشرة_أسعار_مواد_البناء` | the **archive** of the housing ministry's building-materials price bulletin | not probed · **a document archive, not a page — Q-K.** Two hosts: an index page and the `img.` host the files sit on. The index path is **non-ASCII Arabic**, so it needs percent-encoding handled end to end. |
+
+### Leads with no URL
+
+| lead | what is needed |
+|---|---|
+| «اسعار مواد البناء **القاول** السعودية» — Saudi building-materials prices | **Q-L** — the URL, and what «القاول» names: a site, a platform, a publication, or *المقاول* (the contractor) as a category. Recorded verbatim because guessing which would be inventing a source. |
+| UAE — *لجنة أسعار الوقود الإماراتية* (fuel pricing committee) | the URL |
+| Bahrain — *لجنة تسعير ومراقبة الوقود* (fuel pricing and monitoring committee) | the URL |
+
+---
+
+## Questions — none of them answerable by guessing
+
+**Q-A · Does «trusted» mean `authority`? This batch makes it urgent.** The manifest's trust
+tier has exactly three legal values — `official`, `aggregator`, `shop` (`vocab.py:38-43`) —
+and it is **not a label: `authority` decides which source wins at publish.** Until now that
+column barely mattered, because nine of eleven sources were shops. Queue B changes that: it
+brings **seven government or state-owned publishers** (`petroleum.gov.eg`, `moci.gov.qa`,
+`psa.gov.qa`, `mhuc.gov.eg`, `qatarenergy.qa`, `kpc.com.kw`, `oq.com`) alongside shops and
+platforms selling **the same materials in the same countries**. So diesel in Egypt, or
+cement in Qatar, will arrive from a ministry *and* a shop, and `authority` is the mechanism
+that decides which figure the sheet publishes — exactly the role SR-4 already settled for
+exchange rates. Also unsettled by the same question: `teyseerbm.com` is a **distributor**
+speaking for two producers, which is neither `official` nor plainly `shop`.
+Held verbatim, unmapped, until the owner rules.
+
+**Q-F · Nine sites publish no price, and the owner already knows.** Five say so outright —
+`qatarcement`, `kuwaitcement`, `falcon-cement`, `raysutcement`, `occ`, all «بدون سعر منشور،
+طلب عرض سعر» (*RFQ only*) — and four more are flagged *maybe*: `cmbegypt`, `polygroup-eg`,
+`nile-cement`, plus whatever B4/B5 turn out to be. **A site with no published price has
+nothing this warehouse can store as a price**, and inventing one from an RFQ is the exact
+thing SR-1 forbids. Each is therefore one of: an **enrichment-only** source (specs,
+datasheets, technical data attached to products priced elsewhere) — the
+`datasheet-enrichment` family, declared at `vocab.py:363` with **no builder** in
+`factory.py` and already wanted by **DEC-5**; a **General** site; or not a source at all.
+**Nine sites now wait on that one unbuilt family, which makes it the most-demanded missing
+piece in the whole queue.** A probe can confirm no price exists; it cannot choose among the
+three.
+
+**Q-G · Two sites publish a price RANGE, and the row has one price column.** `youmats`
+(«نطاق سعر الكيس معلن») and `elkayansteel` («36,200–40,369 جنيه», daily). `COMMODITY_PRICE`
+carries exactly one `price`, with `original_price` meaning the pre-conversion figure and no
+lower/upper pair anywhere (`rowspec.py:249-304`). So a range has three possible homes and
+they are not equivalent: **store the midpoint** — forbidden, that is arithmetic no page ever
+printed, the same error as MADAR's 15% uplift (SR-1, SR-3); **store one bound and record
+which** — honest, loses half the published fact; **add a min/max pair** — a schema migration
+and therefore the owner's decision. This must be settled **before** a connector is written,
+not after it has already chosen.
+
+**Q-H · `youmats` and `fepy` each serve two materials on one host.** Cement and rebar, same
+site, different category path. That is **one source with two targeted extracts**, not two
+sources: `ExtractSpec` already carries `categories: list[str]` — "source category codes,
+when targeting" — beside `materials` and `regions` (`config.py:25-34`). Worth stating now so
+nobody registers `YOUMATS_CEMENT` and `YOUMATS_STEEL` and splits one shop's data in two.
+
+**Q-I · Bitumen 60/70 needs no vocabulary change — verified.** `material_key` is **not** a
+closed enum: it is a free-form column whose only rule is UPPER_SNAKE_CASE
+(`config.py:47-53`), and what a given source may emit is fenced by that source's own
+`materials` list, checked at ingest (`ingest.py:92`). So `BITUMEN_60_70` is a manifest
+declaration — **no migration, no code change** — and the commodity path already generalises
+past fuel. The row model is a better fit than expected: it already carries `unit`,
+`material_label` + `material_label_ar` (the site's own words, both languages),
+`tax_included` with `tax_evidence`, and `official_source_name`/`official_source_link` for
+"Source: Ministry of …" — a field built for exactly this kind of publisher
+(`rowspec.py:249-300`).
+
+**Q-K · The Egyptian bulletin needs a document reader, and that is the only thing it
+needs.** Two halves, and only one is missing:
+- **Missing — reading it.** The bulletin is published as *files* on `img.mhuc.gov.eg`, not
+  as an HTML page or a JSON API. **Nothing in ScrapeX reads a document**: a search of
+  `scrapex/` for PDF handling finds one prose comment about Sika's datasheets
+  (`connectors/custom_json.py:43`) and no code. This is a new family plus a file reader
+  (and text extraction, if the bulletins are scans rather than text). The Arabic index path
+  needs percent-encoding handled too.
+- **Already there — the data model.** Back-issues are **not** the unprecedented problem it
+  looks like. `COMMODITY_PRICE` already distinguishes `provenance` `'observed'` vs
+  `'reported'` with `as_of_date` and `source_date`, written for exactly this: GPP publishes
+  what a price was one month, three months and a year ago, and the row records that those
+  are the source's figures and never our observations (`rowspec.py:284-292`). So an archive
+  backfill has both a precedent and a mechanism. SR-6 and SR-14 are about never letting a
+  source's series pass for our own — `provenance` is the field that keeps them apart, not a
+  prohibition on reading one.
+
+**Q-C · #11's system was never stated.** `nile-cement.com` came with `trusted` and the price
+caveat but neither `market` nor `general`. Left blank.
+
+**Q-D · Khamato: one source or two?** `khamato.com` and `bulk.khamato.com` are one brand on
+two hosts, and the owner's cement note — *a retail/wholesale platform for several
+factories* — makes the question sharper, not softer. The manifest can express it either
+way: two `source_key`s, or one source with a second host declared (`api.base_url` /
+`taxonomy.base_url`, the shape HEIDELBERG_EG uses for three hosts,
+`sources.yaml:403-427`). It turns on whether the two publish **different prices for the same
+product**; if they do, they must be two sources, so a retail and a wholesale price can never
+overwrite each other. If bulk pricing is **quantity-tiered**, the precedent is
+HEIDELBERG_EG — a price that is a row in a matrix, not a number on a product.
+
+**Q-E · The three `general` rows are queued for a system that cannot run.** Queue A #12, #13
+and #15 need generic **row** storage, the catalogue workflow, its UI and a crawl frontier —
+none shipped, all four flags off (`features.py:52-75`). Their blocker is neither a connector
+nor a probe: it is a slice of the product nobody has built.
+
+**Q-J · The probe cannot guess an Omani or Bahraini region.** `_TLD_REGION` maps `sa`, `eg`,
+`ae`, `kw`, `qa` — and not `om` or `bh` (`probe.py:17`). `raysutcement.om` and `occ.om`
+would come back with `default_region: *`. A two-entry dictionary fix when someone gets
+there; recorded so the `*` is not mistaken for a fact about the sites.
+
+**Q-B · A "market" site with no prices is not a MarketLens price source** — folded into Q-F
+above.
+
+**What probing the whole queue would cost.** `probe()` makes at most four requests per site
+— `/products.json`, `/wp-json/wc/store/products`, `/graphql`, then the homepage
+(`probe.py:75-116`). **37 hosts ≤ 148 requests, about two and a half minutes** at the
+fetcher's 1 req/s. Classifying this entire queue is cheap; what it cannot do is answer
+Q-A, Q-C, Q-F, Q-G or Q-L, which are the owner's to settle.
+
+---
+
+## What each row still needs before it can become a manifest entry
+
+Recorded once, here, so a future session does not re-derive it per site. Every field a
+`sources.yaml` entry requires (`sources.yaml:22-45` is the fullest worked example):
+
+| field | who answers it | note |
+|---|---|---|
+| `source_key` | derived from the host | `probe.py:_key_from_host` — uppercase first label |
+| `source_name` (EN) | **required**, English is the primary display language | `sources.yaml:11-18` |
+| `source_name_ar` | the site's own Arabic name for itself | a fact about the source, stated — not scraped |
+| `base_url`, `family` | the probe | `family` is the whole question this file defers |
+| `currency`, `default_region` | the probe, then the owner confirms | probe guesses region from the TLD only — and cannot for `.om`/`.bh` (Q-J). Queue B adds AED, QAR, KWD, BHD, OMR to a warehouse whose manifest has only SAR, EGP and USD today; the five currencies with no rate under **OP-3** are `PEN`, `SLL`, `SYP`, `VEF`, `ZWD`, none of them Gulf, but nobody has checked the Gulf five specifically |
+| `authority` | **the owner — Q-A** | decides which source wins at publish |
+| `vat_mode` + `tax.evidence` | read off the page, with the sentence it was read from | see MADAR/HEIDELBERG_EG for the standard of proof. `fepy` reportedly states VAT inclusion outright |
+| `extract` kinds | the owner decides what is collected | `product_prices` for shops, `commodity_price` for materials by country, `enrichment` for pictures/specs — **both links or neither**: a connector that reads images changes nothing unless the source contracts `enrichment` (`sources.yaml:192-198`) |
+| `materials` / `categories` | the manifest, per extract | how one host serves several materials (Q-H) and how a grade like `BITUMEN_60_70` is fenced (Q-I) |
+| `min_expected_rows`, `max_drop_pct` | after the first real crawl | guard rails, not guesses |
+
+## How a site leaves this file
+
+1. **Probe it** — `POST /api/probe` in the panel, or `scrapex.probe.probe(url)`. It tries
+   each platform's own open API first, then homepage markers, and returns its evidence.
+2. **Register it** with `active: false`. The manifest header is explicit: a source is
+   activated only once its connector has landed with tests (ENGINEERING T1/T2). `active`
+   gates **scheduled** runs only — a manual run from the panel always works.
+3. **Connector, if the family is new.** The ten families below already have one; anything
+   else is a new connector with its own fixture-backed tests.
+4. **Activate** from the panel's Auto switch, which rewrites the manifest surgically.
+
+Then delete the row from this file — a site must not be tracked in two places at once.
+
+## The ten families that already have a connector
+
+So "can the tool run this one?" is answerable without re-reading the code.
+Evidence: `scrapex/connectors/factory.py:33-44`.
+
+`shopify-json` · `magento-graphql` · `woocommerce-storeapi` · `salla-html` ·
+`zid-html` · `hybris-occ` · `custom-json-api` · `heidelberg-price-matrix` ·
+`static-html-table` · `aramco-fuel-page`
+
+Declared in `vocab.ConnectorFamily` but **not** built: `datasheet-enrichment` (Q-F, DEC-5),
+and `TBD-probe`, the placeholder a site carries before it has been classified — the panel
+refuses to activate one.
+
+Two families in that list are worth knowing about before probing Queue B, because they are
+the nearest precedents for material prices by country: **`static-html-table`** (GPP — one
+page, many countries, `commodity_price`, `latest_only`) and **`aramco-fuel-page`** (a
+producer's own price page parsed from reading-order text rather than selectors, because
+"the React class names churn, the words do not"). A ministry or state producer publishing
+a monthly figure looks far more like those two than like a Salla shop.

--- a/docs/SOURCES-REGISTER.md
+++ b/docs/SOURCES-REGISTER.md
@@ -1,0 +1,326 @@
+# Source register — every source, and what is actually finished
+
+For the **developer**. Opened **2026-07-31** on the owner's instruction: «اعمل ملف يضم كل
+المصادر (للمطور) بحيث يقدر يتابع ما تم انجازه … قسم الملف مصادر تبع نظام marketlens واخرى
+general» — *make a file holding every source, for the developer, so he can follow what has
+been accomplished … split the file into sources belonging to the marketlens system and
+others to general.*
+
+**Where this sits among the four files, so none of them is read as the wrong thing:**
+
+| file | what it is | authority |
+|---|---|---|
+| `sources.yaml` | the extraction **contract** — nothing is collected that is not declared there (SR-13) | the only file the code reads |
+| `docs/BACKLOG.md` | project **state** — open problems, decisions, IDs (`OP-`, `DEC-`, `BV-`, `Q-`) | the tracking document |
+| `docs/CANDIDATE-SOURCES.md` | the **queue** of sites the owner has sent that nobody has probed | holding pen |
+| **this file** | the per-source **scoreboard**: what shipped, what is open, which system it belongs to | derived — see below |
+
+**This file is derived, not authoritative.** Every column was read out of the manifest,
+the connector directory or `BACKLOG.md` on 2026-07-31 and carries its `file:line`. When it
+disagrees with `sources.yaml`, the manifest is right and this file is stale.
+
+---
+
+## What "MarketLens" and "General" actually divide
+
+They are two **isolated SQLite databases**, not two labels. Different `application_id`,
+required `database_kind` markers, independent migration ledgers, checksums, locks, backup
+and restore. No `ATTACH`, no cross-database foreign key, no distributed transaction; each
+refuses a file belonging to the other (`docs/db1-domain-database-isolation.md:1-15`,
+`scrapex/databases/domain.py`).
+
+| | **MarketLens** | **General** |
+|---|---|---|
+| file | `~/.scrapex/marketlens/marketlens.db` | `~/.scrapex/general/general.db` |
+| owns | the product and price path — products, offers, price observations, commodity prices | generic **site and dataset definitions**: `site_profile`, `dataset_definition`, `field_definition`, `dataset_relationship` |
+| a source there means | a shop or publisher whose **prices** we record | an arbitrary site whose **structures** are described — tables, lists, detail records, trees |
+| shipped? | yes — `price_tracking` enabled, stage `partial` (`features.py:44-51`) | **definitions and API only.** `generic_dataset_catalog` **disabled**, stage `foundation` (`features.py:52-57`) |
+
+**So the split has a lopsided answer today, and that is the finding, not a gap in this
+file: all 11 declared sources are MarketLens sources. General has none.** It cannot
+usefully have one yet — `generic_extraction` is `not_started` and enabled "only after an
+approved non-product extraction reaches generic storage" (`features.py:58-63`), and
+`generic_dataset_catalog` may be switched on only after generic **row** storage and the
+catalogue UI ship (`docs/GENERIC_CATALOG.md:44-48`). A site registered in General right
+now would hold a description of itself and not one row of data.
+
+---
+
+## 1. MarketLens sources — the eleven
+
+### 1.1 Scoreboard
+
+`A` = `active` in the manifest (scheduled runs only — a manual run from the panel is never
+gated). All eleven have a connector **and** its tests: that part is done, uniformly.
+
+| source | AR | family | connector · tests | A | cur/region | VAT | extracts | min rows / max drop |
+|---|---|---|---|---|---|---|---|---|
+| **MADAR** | المدار | `magento-graphql` | `magento.py` · `test_magento.py` | ✗ | SAR / SA | `incl` | prices + enrichment | 50 / 50% |
+| **ALSWEED** | السويد | `salla-html` | `salla.py` · `test_salla.py` | ✓ | SAR / SA | `incl` | prices + enrichment | 50 / 50% |
+| **ELBUROJ** | البروج | `salla-html` | `salla.py` · `test_salla.py` | ✗ | SAR / SA | `incl` | prices + enrichment | 20 / 50% |
+| **ADVANCEDCASTLE** | القلعة المتقدمة | `zid-html` | `zid.py` · `test_zid.py` | ✓ | SAR / SA | `incl` | prices + enrichment | 20 / 50% |
+| **ELSEWEDYSHOP** | السويدي شوب | `shopify-json` | `shopify.py` · `test_shopify.py` | ✓ | EGP / EG | `incl` | prices + enrichment | 50 / 50% |
+| **MASDAR** | مصدر | `hybris-occ` | `hybris.py` · `test_hybris.py` | ✓ | SAR / SA | `incl` | prices + enrichment | 200 / 50% |
+| **SIKAEGSHOP** | سيكا مصر شوب | `custom-json-api` | `custom_json.py` · `test_customjson.py` | ✗ | EGP / EG | **`excl`** | prices + enrichment | 30 / 50% |
+| **HEIDELBERG_EG** | هايدلبرج ماتيريالز مصر | `heidelberg-price-matrix` | `heidelberg.py` · `test_heidelberg.py` | ✗ | EGP / EG | `incl` | prices + enrichment | 60 / 40% |
+| **SAMEHGABRIEL** | سامح جبرائيل | `woocommerce-storeapi` | `woocommerce.py` · `test_woocommerce.py` | ✓ | EGP / EG | `incl` | prices + enrichment | 10 / **30%** |
+| **GPP_ENERGY** | أسعار الطاقة العالمية | `static-html-table` | `gpp.py` · `test_gpp.py` | ✓ | USD *(fallback)* / `*` | `incl` | **commodity only** | 150 / **20%** |
+| **ARAMCO_FUEL_SA** | أرامكو السعودية | `aramco-fuel-page` | `aramco.py` · `test_aramco.py` | ✓ | SAR / SA | `incl` | **commodity only** | 4 / 50% |
+
+Counts: **7 active, 4 not** · 9 shops, 1 aggregator (GPP), 1 official (ARAMCO) · 6 Saudi,
+5 Egyptian · 9 product sources, 2 commodity sources · **10 connectors** for 11 sources —
+`salla.py` serves ALSWEED and ELBUROJ, which is why a Salla fix is a two-source fix.
+
+> **Read the `A` column with OP-2 in hand.** On 2026-07-29 there were *three* different
+> answers to "which sources are active": `main`, an **uncommitted** `sources.yaml`, and
+> `source_site.active` in the live warehouse, which said all of them. The tree is clean at
+> 2026-07-31, so the column above is now single-valued — it is main's. Whether the live
+> warehouse still disagrees is **not measured here**; OP-2 and **Q-11** stay open.
+
+### 1.2 Per source — what is finished, what is open
+
+**MADAR** · `sources.yaml:22` — Price semantics settled per product **shape**, and settled
+without arithmetic: SimpleProduct (399) and GroupedProduct (33) store `vat_included=1`,
+ConfigurableProduct (328) carries `vat_included=0` because the shop's own API hands back
+the figure it names `finalPriceExclTaxKey`. Two source-wide uplifts were tried and removed;
+the second removal deleted 3,312 prices no madar page had ever printed. GroupedProduct
+stores one row per member, 28/28 matched.
+*Open:* business-segment prices and per-branch availability need a session capture, not a
+connector change — **DEC-6**. Not active.
+
+**ALSWEED** · `:115` — Live since the Salla connector landed. Enrichment contracted
+2026-07-30, closing 1,203 products that had landed with no picture while every page
+published one (15/15 sampled live).
+*Open:* variant prices publish `offers.price=0` in JSON-LD — needs the options XHR or an
+extension capture (**DEC-6**). Canonical slug URLs only; short `/-/p{id}` URLs
+redirect-loop.
+
+**ELBUROJ** · `:143` — Second Salla source. Enrichment contracted from a **captured
+fixture**, with no request made to the live site, because a full crawl was running at the
+time.
+*Open:* the English-name second pass — **DEC-5**, measured at 3,874 products against
+`Crawl-delay: 10` ≈ **eleven hours**. Not active. Its crawl delay is honoured
+automatically (SR-8/F5).
+
+**ADVANCEDCASTLE** · `:175` — Needs a browser `user_agent` (403 otherwise), declared in
+the manifest. Images: **0/168 → 168/168** products in one crawl after 2026-07-29
+(435 image rows, 771 enrichment rows), at zero extra requests — same JSON-LD as the price.
+Bilingual: the English alternate is read for `product_name` and `category_path`.
+*Settled, do not re-litigate:* the Egyptian price is **deliberately not crawled** — it is a
+conversion, not a merchant price (owner-confirmed 2026-07-30, `sources.yaml:242-250`).
+*Open:* the page gallery names 124 images against JSON-LD's 109 on a 42-product sample —
+reading the gallery too is an owner call.
+
+**ELSEWEDYSHOP** · `:253` — `products.json` + `collections.json` open; `updated_at` drives
+change detection. Enrichment costs nothing: 1,442 pictures across all 932 products, every
+product covered (live census 2026-07-30).
+*Open:* **DEC-2** — shopify cannot resume per page as it stands.
+
+**MASDAR** · `:277` — SAP Hybris OCC v2, data host `api.masdaronline.com` ≠ storefront.
+1,354 SKUs from one `fields=FULL` search; real EAN/GTIN. `vat_mode` was **backwards** until
+2026-07-20 and is now derived from the payload rather than trusted from the line. Pictures:
+560 of 640 priced products, three sizes, same response.
+*Open:* **OP-10** — nine English names missing on a bilingual source (SR-2 makes that a
+defect, not a nicety).
+
+**SIKAEGSHOP** · `:325` — The one **`excl`** source: the listing is net and the cart adds
+14%, owner-verified in the shop's own cart. `specail_price` (78/87) is a **trade tier** for
+`customerTypeId 2`, carried as enrichment and never as a discount; `flash_sale_price` is a
+nullable number, null on all 87. Enrichment knowingly costs **87 extra requests** (8 → 95
+per crawl) because the list publishes one attachment of eleven and no SKU at all.
+*Open:* **DEC-3** the interruption rescue cannot survive an interruption · **DEC-6** the
+trade tier an anonymous crawl can never be charged · **BV-4** trade tier reaching the
+warehouse is built, not verified. Not active.
+
+**HEIDELBERG_EG** · `:389` — The heaviest contract and the newest: **three hosts**. The
+storefront is a static Angular app that 404s every API path, so `api.base_url` is declared
+rather than guessed; a **third** host carries the only real taxonomy (5 cement families,
+both languages) because the store API's own `productTypes` has two values and all 9
+products are `Bagged`. Price is not a number on a product but a row in a matrix keyed by
+governorate, plant, quantity tier and segment — which is why `custom-json-api` could not
+serve it. VAT 14% inclusive, proven transitively from the cart's own arithmetic; the
+`statement_url` is the content-hashed **bundle**, deliberately, and will change on redeploy.
+Whole source = **3 requests, ~16 seconds**, one 19 MB body.
+*Open:* recon questions **Q-1…Q-5** (`docs/recon/heidelberg-materials-eg.md`) · raising
+`authority` from `shop` to `official` is the owner's call. Not active.
+
+**SAMEHGABRIEL** · `:540` — WooCommerce Store API; attributes, categories, tags and
+measurements ride the price response.
+*Open:* **split-brain domain** — the homepage serves advancedcastle content and the shop
+may be mid-migration to Zid. `max_drop_pct: 30` is deliberately tight so the migration
+announces itself by failing a run loudly.
+
+**GPP_ENERGY** · `:567` — 5 weekly pages, ~180 countries × 5 energy types.
+`scope: latest_only` is a **licence obligation** (SR-14, tested T6): the latest published
+price only, never their paid historical series — our history accumulates from our own
+weekly observations. One tax rule per **energy type**, each read off that type's own page.
+`ELECTRICITY_BUSINESS` was added after the connector had defined it for a manifest that
+never contracted it — ~125 rows nobody was collecting. `currency: USD` is a **fallback**
+covering only the site's own USD conversions, marked `price_basis=converted`; fuel rows
+carry the currency each country page prints.
+*Open:* **OP-3** — five currencies have no exchange rate after a page-shape change ·
+positional parsing must assert `len(labels)==len(values)` (**Q4**).
+
+**ARAMCO_FUEL_SA** · `:665` — The only `official` source, monthly. Parses the Arabic retail
+fuels page from **reading-order text, not selectors** (React class names churn, the words
+do not); the heading month is the source's own dating and rides `source_date`.
+Publishes 91/95/98, diesel, kerosene — **not LPG**. Writes Saudi fuel rows only.
+
+### 1.3 Cross-source work that is nobody's single source
+
+- **DEC-6 · authenticated capture** — MADAR's business segment, ALSWEED's variants,
+  SIKAEGSHOP's trade tier. All three need an **extension session capture**; none is a
+  connector change. Decided in principle, unbuilt.
+- **DEC-5 · Sika datasheets** want a connector of their own. The family exists in the
+  vocabulary (`datasheet-enrichment`) with **no builder**, so no manifest entry may declare
+  it — `test_no_manifest_entry_declares_a_family_nothing_can_build` enforces that. What the
+  source is and why the old entry was removed live in `BACKLOG.md` DEC-5; the stale header
+  comment it left above ARAMCO_FUEL_SA in `sources.yaml` is gone.
+- **SR-2 bilingual debt** — OP-9 (154 names with no Arabic character in the Arabic column),
+  OP-10 (MASDAR), OP-11 (2,385 attribute rows with no language mark).
+
+---
+
+## 2. General sources — none yet
+
+**Zero sources, and it is the deliberate state, not an omission.** What exists: the
+definition tables, their triggers and a typed local API at `/api/catalog`
+(`docs/GENERIC_CATALOG.md`, `scrapex/catalog.py`). What does not: generic **row** storage,
+the catalogue workflow and its UI, discovery with limits and checkpoint recovery.
+
+Three flags gate it, all off (`scrapex/features.py:52-75`):
+`generic_dataset_catalog` *foundation* · `generic_extraction` *not_started* ·
+`crawl_frontier` *not_started* · `site_data_model` *not_started*.
+
+A site belongs here — not in MarketLens — when what we want from it is **not a product
+price**: a statistics table, a specification list, a registry, a document index. When such
+a site arrives, it waits in `CANDIDATE-SOURCES.md` and its row says General; it cannot be
+made to produce data by declaring it.
+
+Notes for whoever opens this section: definitions are **additive** — a disappeared one is
+retired with `valid_to`, never deleted or reused for a different meaning. Discovery may
+only create relationships with `review_status = suggested`; there is intentionally no
+auto-confirm endpoint. `site_profile` may optionally link to an existing price
+`source_site`, which is how one site can be described in General while its prices live in
+MarketLens.
+
+---
+
+## 3. Not yet assigned to either system
+
+**37 unprobed hosts, 3 leads with no URL, all sent 2026-07-31 except `TABLER`.** No request
+has been made to any of these hosts. The row-by-row detail and the open questions live in
+`docs/CANDIDATE-SOURCES.md`, which is the **authority for this section** — what follows is
+the developer's view of it: how much work each group implies.
+
+They arrived as two differently-shaped batches, and the shape matters more than the count.
+**Queue A** is 15 individual shop-like leads. **Queue B** is a deliberate **coverage
+matrix** — *material × country* across EG · SA · AE · QA · KW · BH · OM, for fuel, cement,
+steel/rebar and bitumen, plus Egypt's official building-materials price bulletin. Two
+entries in it are **already known to the project**: `aramco.com` is the live source
+`ARAMCO_FUEL_SA` (so B1·SA is done, and the only new thing there is that the owner sent the
+`/en/` path while the manifest reads `/ar/`), and `khamato.com` is Queue A #1.
+
+### The five things Queue B changes for the developer
+
+**1 · `authority` stops being a dormant column and becomes the publish mechanism.** Nine of
+the eleven existing sources are shops, so the trust tier has rarely had to decide anything.
+Queue B brings **seven government or state-owned publishers** — `petroleum.gov.eg`,
+`moci.gov.qa`, `psa.gov.qa`, `mhuc.gov.eg`, `qatarenergy.qa`, `kpc.com.kw`, `oq.com` —
+alongside shops and platforms selling **the same material in the same country**. Diesel in
+Egypt and cement in Qatar will arrive from a ministry *and* a shop, and `authority` is the
+field that decides which figure reaches the sheet. That is the role SR-4 already settled for
+exchange rates; it now has to be settled for prices, and it is **Q-A**, an owner decision.
+
+**2 · Nine sites publish no price at all**, five of them stated outright by the owner as
+RFQ-only (`qatarcement`, `kuwaitcement`, `falcon-cement`, `raysutcement`, `occ`) and four
+flagged *maybe* (`cmbegypt`, `polygroup-eg`, `nile-cement`, plus whatever B4/B5 turn out to
+be). Each is an **enrichment-only** source, a General site, or not a source — and the
+enrichment reading needs `datasheet-enrichment`, **declared with no builder** and already
+wanted by **DEC-5**. **That single unbuilt family is now the most-demanded missing piece in
+the queue.**
+
+**3 · Two sites publish a price RANGE and the row has one `price` column** — `youmats`
+(bag-price range) and `elkayansteel` (36,200–40,369 EGP/tonne, daily). `COMMODITY_PRICE`
+has no min/max pair (`rowspec.py:249-304`); storing a midpoint would be arithmetic no page
+ever printed, which is MADAR's uplift mistake again (SR-1, SR-3). **This is a schema
+decision that has to precede the connector, not follow it** — **Q-G**.
+
+**4 · The commodity path already generalises past fuel — verified, and it is the good news.**
+`material_key` is not a closed enum but a free-form UPPER_SNAKE_CASE column
+(`config.py:47-53`) fenced per source by its own `materials` list at ingest
+(`ingest.py:92`), so Qatar's `BITUMEN_60_70` is a **manifest declaration with no migration
+and no code change**. The row already carries `unit`, `material_label`/`material_label_ar`,
+`tax_included` with `tax_evidence`, and `official_source_name`/`official_source_link` — a
+field built for "Source: Ministry of …" publishers exactly like these.
+
+**5 · One thing genuinely does not exist: reading a document.** Egypt's bulletin
+(`img.mhuc.gov.eg`, Arabic-path index) is published as **files**, and a search of `scrapex/`
+for PDF handling finds one prose comment about Sika's datasheets and no code. That is a new
+family plus a file reader. Its *back-issues*, though, are **not** a new problem:
+`COMMODITY_PRICE` already separates `provenance` `'observed'` from `'reported'` with
+`as_of_date` and `source_date`, written for GPP's own published history
+(`rowspec.py:284-292`). SR-6 and SR-14 forbid letting a source's series pass for our
+observations — `provenance` is how they stay apart, not a ban on reading one. **Q-K**.
+
+*Also:* Queue B adds AED, QAR, KWD, BHD and OMR to a manifest that has only SAR, EGP and USD
+today, and the probe's TLD map has no `om` or `bh` (`probe.py:17`) so the two `.om` producers
+would come back `default_region: *` — **Q-J**, a two-entry dictionary fix nobody should
+mistake for a fact about those sites.
+
+### Queue A, by the system the owner designated
+
+**Designated MarketLens — 10.** `bulk.khamato.com` · `bnaia.com` · `sphinx-store.com` ·
+`cmbegypt.com` · `ahrambc.com` · `ahmedelsallab.com` · `sebakashop.com` · `mashreqy.com` ·
+`polygroup-eg.com` · `cementegypt.com`
+→ *Cheapest outcome:* a probe lands on `salla-html`, `zid-html`, `shopify-json` or
+`woocommerce-storeapi` — a manifest entry and a crawl, no new code, because those four are
+platforms rather than sites. *Most expensive:* `TBD-probe`, i.e. a bespoke site, which is
+one new connector with fixture-backed tests each. **Ten connectors were written for eleven
+sources — ELBUROJ is the only source that ever reused one that already existed (§1.1) — so
+historically a new source has arrived needing new code far more often than not.** That is
+history, not a forecast: the four platform families now in the tree did not exist when the
+first source on each arrived, so a queue of shops has a better chance than the record
+suggests. It is still the wrong direction to plan optimistically in.
+Three of these ten (`cmbegypt`, `polygroup-eg`, plus `nile-cement` below) carry the owner's
+*"maybe prices not included"* caveat and join the nine of **Q-F** above.
+
+**Designated General — 3.** `darbuildgroup.com` · `readymixconcreteguide.com` ·
+`yellowpages.com.eg`
+→ **These are blocked on the product, not on a connector.** General holds definitions only:
+generic row storage, the catalogue workflow, its UI and the crawl frontier have not shipped
+and all four flags are off (§2, `features.py:52-75`). Probing them is still free and still
+worth it — it tells us their shape — but nothing can collect from them until that slice is
+built. A directory like `yellowpages.com.eg` is the clearest case of why General exists at
+all: records and listings, no product price anywhere.
+
+**System not stated — 2.** `khamato.com` (sent alone, unannotated) ·
+`nile-cement.com/en/products/` (`trusted`, maybe no prices, no system — **Q-C**).
+→ Left blank on purpose. `khamato.com`'s sibling being a price source suggests MarketLens
+but does not establish it (**Q-D**: the two Khamato hosts may be one source or two, and it
+turns on whether they price the same product differently).
+
+**Legacy — 1.** `TABLER`, named in **DEC-5** as never probed; its URL was never written
+down anywhere in the repo and needs recovering from the owner.
+
+**One annotation is not yet mapped to anything in the code.** The owner rates sites
+`trusted` / `not rated`. The manifest's nearest field is `authority`
+(`official`/`aggregator`/`shop`), which is **not a label** — it decides which source wins at
+publish, so mapping `trusted` onto `official` would silently outrank existing sources. Held
+verbatim, unmapped, until the owner settles **Q-A**.
+
+Sites appear in both this section and the queue only while unassigned; once one becomes a
+manifest entry it leaves the queue and gets a row in §1 or §2.
+
+---
+
+## How to keep this file honest
+
+1. A source moves out of §3 only after a **probe with evidence** — never after a guess
+   about its platform.
+2. A new source lands in §1/§2 as `active: false`. It is activated only when its connector
+   is in `_BUILDERS` **and** has tests (ENGINEERING T1/T2).
+3. When a `BACKLOG.md` item closes, delete the reference here too — a scoreboard that
+   still lists a fixed problem is worse than no scoreboard.
+4. Never restate a number here that this file did not measure. Copy the claim **and** its
+   `file:line`, so the next reader can check it instead of trusting it.


### PR DESCRIPTION
Two new documents the owner asked for, plus the two cross-links that keep them from being lost. **Docs only — no code, no manifest entry, no source declared or activated.**

## What is here

| file | what it is |
|---|---|
| `docs/SOURCES-REGISTER.md` | the developer's per-source scoreboard, split **MarketLens / General** as the owner asked — what shipped per source, what is open, which system it belongs to |
| `docs/CANDIDATE-SOURCES.md` | the holding pen for **37 unprobed hosts and 3 leads with no URL** the owner has sent, deliberately outside `sources.yaml` (SR-13) |
| `docs/BACKLOG.md` | +2 rows in Appendix B, +1 pointer from DEC-5 so `TABLER` is tracked with the rest of the unprobed queue |

## What a reviewer should check

**1. Nothing in the queue has been probed, and the files say so everywhere.** No request was made to any queued host, by ScrapeX or by me. `CANDIDATE-SOURCES.md` therefore has **no `platform` column at all** — it would have been a column of guesses. Every owner annotation is quoted, not interpreted; a blank `rating` means he said nothing, which is not the same as the `not rated` he did say four times.

**2. The register is derived and says so.** Every column was read out of the manifest, the connector directory or `BACKLOG.md` on 2026-07-31 and carries its `file:line`. The header states that when it disagrees with `sources.yaml`, **the manifest wins and the register is stale**. Worth spot-checking a few `file:line` refs — that is the whole basis of the file.

**3. Its finding about the split is real, not an omission.** All 11 declared sources are MarketLens sources; **General has none**, and cannot usefully have one while generic row storage and the catalogue UI are unshipped and all four flags are off (`features.py:52-75`). Three queued sites are designated `general` by the owner, so they are blocked on a product slice, not on a connector.

**4. Five claims are load-bearing and each was verified against the code, not assumed:**

- `authority` becomes the publish mechanism — Queue B brings **seven government / state-owned publishers** alongside shops selling the same material in the same country (**Q-A**, owner's call).
- **Nine sites publish no price**, five stated outright as RFQ-only → `datasheet-enrichment`, declared at `vocab.py:363` with **no builder** in `factory.py`, already wanted by DEC-5.
- **Two sites publish a price RANGE** and `COMMODITY_PRICE` has one `price` column, no min/max (`rowspec.py:249-304`). A midpoint is arithmetic no page ever printed — MADAR's uplift mistake again (SR-1, SR-3). **Schema decision before connector.**
- **`BITUMEN_60_70` needs no migration**: `material_key` is free-form UPPER_SNAKE_CASE (`config.py:47-53`) fenced per source at ingest (`ingest.py:92`).
- **Nothing reads a document.** Egypt's bulletin is published as files; a search of `scrapex/` for PDF handling finds one prose comment and no code. Back-issues are *not* new, though — `provenance` `'observed'`/`'reported'` with `as_of_date` already exists for GPP's published history (`rowspec.py:284-292`).

**5. Twelve questions are left unanswered on purpose** rather than settled by guessing. Q-A (does «trusted» mean `authority`?), Q-C, Q-F, Q-G and Q-L need the owner.

## Notes for the merger

- Branched off `main` (`08098b6`). A local worktree branch `claude/infallible-jennings-905c01` holds an earlier snapshot of the same two files under a commit message that no longer matches its content; **this branch supersedes it** and that one can be deleted.
- The working tree it came from also holds two unrelated, uncommitted efforts — a test-performance change (`ci.yml`, `config.py`, `connectors/base.py`, `tests/conftest.py`, `tests/test_fast_migrations.py`) and a `sources.yaml` comment fix. **Neither is in this branch**, by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
