### PR TITLE
fix(sources): restore ARAMCO's header, move Sika's note to DEC-5

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -260,7 +260,17 @@ lose).
 - **ELBUROJ** needs a second pass for English names, on a 10s-delay crawl
   (`plan-closing-the-gaps` §5.2). Measured in `2253308`: 3,874 products at `Crawl-delay: 10`
   ≈ **eleven hours**.
-- **SIKA datasheets** want their own connector (§5.3).
+- **SIKA datasheets** want their own connector (§5.3). The site is Sika Egypt's *corporate*
+  AEM instance (`egy.sika.com`), not the shop: ~310 products and ~1,050 TDS PDFs behind
+  stable DMS GUIDs, with sitemap `lastmod` driving an incremental re-scrape. It publishes
+  **no prices** — it would feed `material_attribute_value` only, never `price_observation`.
+  `datasheet-enrichment` is in `vocab.ConnectorFamily` with **no builder** in
+  `connectors/factory.py`, so the connector is the whole of the work and a manifest entry
+  cannot come first: `test_no_manifest_entry_declares_a_family_nothing_can_build` refuses a
+  family nothing can build. That is why `SIKA_EGYPT_DATASHEETS` was removed in `256cd27`,
+  which also records the two things that make this bigger than it looks — SIKAEGSHOP already
+  stores 154 datasheet PDFs as `Attachment` rows, so the only new gain is reading *inside*
+  the PDFs, and `pyproject.toml` declares no PDF library at all.
 - **TABLER** has never been probed (§5.4). Now tracked with the rest of the unprobed
   queue in `docs/CANDIDATE-SOURCES.md`, whose row also records that its URL was never
   written down anywhere.

--- a/sources.yaml
+++ b/sources.yaml
@@ -806,7 +806,7 @@ sources:
       parsing MUST assert len(labels)==len(values) (Q4). History accumulates
       from OUR weekly observations, never from their paid feed.
 
-  # ---- probed: Sika Egypt corporate (AEM) — enrichment only, no prices ----
+  # ---- probed live 2026-07-23: official monthly prices as heading + pairs ----
   - source_key: ARAMCO_FUEL_SA
     source_name_ar: أرامكو السعودية
     source_name: Saudi Aramco

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -257,6 +257,57 @@ def test_the_shop_with_no_definition_is_not_crawled_before_someone_says_so():
     assert load_manifest(MANIFEST_FILE).get("SPARK_ESHOP").active is False
 
 
+def test_no_provenance_header_contradicts_the_source_beneath_it():
+    """A header outlived the source it described, and sat above another one.
+
+    `256cd27` removed SIKA_EGYPT_DATASHEETS and took ARAMCO_FUEL_SA's own header
+    line with it, leaving Sika's — "probed: Sika Egypt corporate (AEM) —
+    enrichment only, no prices" — directly above ARAMCO, a source whose whole
+    purpose is the official monthly fuel PRICE. The register even asserted the
+    stale header was gone while it was still in the file.
+
+    NOTHING CAUGHT IT, and nothing would: measured 2026-08-05, deleting a
+    provenance header outright leaves `validate-manifest` at exit 0 and
+    `tests/test_config.py` fully green. A comment is invisible to every gate
+    this project has.
+
+    So the rule is deliberately narrow rather than "every source must have a
+    header" — ten of the twelve do and two do not, and inventing a convention
+    here would be a separate decision. This asserts only what cannot be true: a
+    header that says the source below it has no prices, above a source that
+    declares a price kind."""
+    import re
+
+    from scrapex.vocab import ExtractKind
+
+    text = MANIFEST_FILE.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    priced = {ExtractKind.PRODUCT_PRICES.value, ExtractKind.COMMODITY_PRICE.value}
+    manifest = load_manifest(MANIFEST_FILE)
+
+    contradictions = []
+    for index, line in enumerate(lines):
+        key = re.match(r"\s*- source_key:\s*(\S+)", line)
+        if not key:
+            continue
+        above = index - 1
+        while above >= 0 and not lines[above].strip():
+            above -= 1
+        if above < 0:
+            continue
+        header = lines[above].strip()
+        if not header.startswith("# ----"):
+            continue
+        says_no_prices = "no prices" in header.lower() or "enrichment only" in header.lower()
+        kinds = {spec.kind.value if hasattr(spec.kind, "value") else str(spec.kind)
+                 for spec in manifest.get(key.group(1)).extract}
+        if says_no_prices and kinds & priced:
+            contradictions.append(f"{key.group(1)}: {header}")
+
+    assert contradictions == [], (
+        "a provenance header says its source has no prices while that source "
+        f"declares a price kind: {contradictions}")
+
 def test_no_manifest_entry_declares_a_family_nothing_can_build():
     """An entry whose family has no connector is a promise the engine cannot
     keep. SIKA_EGYPT_DATASHEETS declared `datasheet-enrichment` for months with


### PR DESCRIPTION
## Summary
- `sources.yaml:664` carried a header comment describing Sika Egypt's corporate AEM site (enrichment-only, no prices) directly above `source_key: ARAMCO_FUEL_SA`, a Saudi official fuel-price page. Root cause: commit `256cd27`'s deletion of the `SIKA_EGYPT_DATASHEETS` entry clipped ARAMCO's own header instead of Sika's, so the two headers effectively swapped which one survived.
- Restores ARAMCO's original header verbatim (confirmed still correct against the live connector).
- Moves Sika's substance (corporate AEM host, ~310 products / ~1,050 TDS PDFs, DMS GUIDs, no PDF library in `pyproject.toml`) into `docs/BACKLOG.md` DEC-5, where the unbuilt `datasheet-enrichment` connector is already tracked, and corrects `docs/SOURCES-REGISTER.md`'s DEC-5 bullet, which had asserted the stale comment was still at `:664`.
- Also includes `docs/SOURCES-REGISTER.md` and `docs/CANDIDATE-SOURCES.md` — the developer scoreboard and candidate-source queue the owner asked for on 2026-07-31 (separate commit, unrelated to this bug).
- Confirmed `datasheet-enrichment` still has no builder in `connectors/factory.py` before writing anything that implied otherwise.

Fixes #57

## Test plan
- [x] `py -m scrapex.cli validate-manifest` → `OK: 11 sources`
- [x] `pytest tests/test_config.py` → 15 passed, including `test_no_manifest_entry_declares_a_family_nothing_can_build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)