### PR TITLE
feat(data): identity, then the offer, then the filing

### DIFF
--- a/scrapex/reports.py
+++ b/scrapex/reports.py
@@ -605,84 +605,80 @@ def _level_columns() -> list[tuple[str, str]]:
 
 
 BROWSE_COLUMNS: list[tuple[str, str]] = [
-    # The two languages of one field sit TOGETHER, English first. They used to
-    # be filed in separate blocks — every English column, then Country, then
-    # every Arabic one — so a bilingual shop showed Record (AR), Record,
-    # Category, Country, Category (AR): the same fact twice with an unrelated
-    # column wedged between. The label for each pair is written once, by
-    # BILINGUAL_COLUMNS below. The "(AR)" is AUTHORED into the label, not
-    # appended at runtime: the mark is a property of the column, not of the
-    # pair, so an Arabic-only source is still told which language it is
-    # reading. (It also makes /api/fields and the grid agree by construction
-    # rather than by both remembering to run the same loop.)
-    ("product_name", "Product name"),
-    ("product_name_ar", "Product name (AR)"),
-    ("country_code_alpha2", "Country code"),
-    ("brand", "Brand"),
-    ("brand_ar", "Brand (AR)"),
-    # Classification (owner ruling 2026-07-22): part of the MAIN table, with
-    # every level the source publishes. "category" carries the source's full
-    # path ("Cables > Low voltage") or, for a source that only files products
-    # under flat labels, the labels themselves. The per-level columns split
-    # the path so the table can sort and group by any layer; presence gating
-    # keeps each level to the sources that actually reach that depth.
-    ("category", "Category"),
-    ("category_ar", "Category (AR)"),
-    # The DEEPEST level this row actually reaches, in one column. The owner's
-    # ask (2026-07-28): «عاوز عمود يكون مجمع اخر تصنيف لكل صف» — sources like
-    # MADAR and ADVANCEDCASTLE classify to different depths row by row, so no
-    # single Category L-column holds "the most specific thing this is". Reading
-    # it off the row means never asking which level to look in.
-    ("category_leaf", "Category leaf"),
-    ("category_leaf_ar", "Category leaf (AR)"),
-    *_level_columns(),
-    ("variant", "Variant"),
-    ("variant_ar", "Variant (AR)"),
-    ("sku", "SKU"),
-    ("price", "Price"),
-    # Derived from currency_rate (the publisher's own implied rates) so 128
-    # currencies can be RANKED in one column. Approximate by nature and
-    # labelled so.
-    ("price_trade", "Trade price"),
-    ("price_usd", "Price (USD est.)"),
-    # The price that held immediately before the current one, and the move
-    # between them. Different questions from the DISCOUNT (which is within
-    # one listing, was -> sale) — this is across TIME.
-    ("price_previous", "Previous price"),
-    ("price_change", "Price change"),
-    ("price_min", "Lowest price"),
-    ("price_max", "Highest price"),
-    ("observations", "Observations"),
-    # The pre-discount price rides INSIDE the price cell, struck through beside
-    # the current one (the owner's asked-for shape) — a separate Was column
-    # would state the same number twice. The discount itself is TWO columns,
-    # matching the export: one cell reading "-84.67 (-7.0%)" can be neither
-    # sorted by size nor by severity, and the owner asked for the split in both
-    # places rather than in one.
-    ("discount", "Discount"),
-    ("discount_pct", "Discount %"),
-    ("unit", "Unit"),
-    ("availability", "Availability"),
-    ("tax", "Tax"),
-    ("price_changed_on", "Price changed on"),
-    ("last_confirmed_on", "Last confirmed on"),
-    # The official body the source names for its figure. Only sources that
-    # actually attribute (GPP country pages) populate it; the presence sweep
-    # hides it everywhere else.
-    ("official_source", "Official source"),
-    ("curation", "Curation"),
-    # Last, and narrow: the arrow that opens the record on the site itself.
-    # It replaced a Details column — the details now open UNDER the table
-    # when a row is selected, so a column for them was a second door to a
-    # room the row already opens (owner's ruling).
+    # WHY IDENTITY, THEN THE OFFER, THEN THE FILING (2026-07-31)
     #
-    # Named `product_link` since 0051, the same key the export uses: the arrow
-    # and the export's URL column were one fact (the link to the record on the
-    # site) arriving down two seeding paths that never reconciled, and
-    # dataset_field allows one row per (source, key). The label stays blank —
-    # the cell is an icon, and the schema page reads the label from the export
-    # list where it is written out in full.
-    ("product_link", ""),
+    # The relative order was always consistent across sources — measured, zero
+    # out-of-order pairs anywhere, so there was nothing to "unify". What was NOT
+    # consistent was where Price LANDED: position 19 in madar, 10 in sika, 8 in
+    # alsweed, 6 in gpp. Price sat at index 33 of this list, behind twenty-four
+    # classification columns, and each source is shown only the columns it
+    # actually fills — so the more levels a source publishes the further right
+    # its price drifts, and the owner hunted for the one number the product
+    # exists to track in a different place in every table.
+    #
+    # Nothing is pinned and no column is forced to appear: the per-source gates
+    # still decide PRESENCE, which is the ruling that keeps a fuel site's USD
+    # estimate off a shop's table. Only the ORDER changed, so that what precedes
+    # Price is the handful of columns nearly every source fills rather than a
+    # variable-length taxonomy.
+    #
+    # The two languages of one field still sit TOGETHER, English first, and the
+    # "(AR)" is authored into the label rather than appended at runtime — see
+    # BILINGUAL_COLUMNS below.
+
+    # ---- identity ----
+    ('product_name', 'Product name'),
+    ('product_name_ar', 'Product name (AR)'),
+    ('sku', 'SKU'),
+    ('variant', 'Variant'),
+    ('variant_ar', 'Variant (AR)'),
+    # ---- the offer: what this record costs ----
+    ('price', 'Price'),
+    ('price_trade', 'Trade price'),
+    ('price_usd', 'Price (USD est.)'),
+    ('discount', 'Discount'),
+    ('discount_pct', 'Discount %'),
+    ('unit', 'Unit'),
+    ('availability', 'Availability'),
+    ('tax', 'Tax'),
+    # ---- the filing, and everything that describes the record ----
+    ('country_code_alpha2', 'Country code'),
+    ('brand', 'Brand'),
+    ('brand_ar', 'Brand (AR)'),
+    ('category', 'Category'),
+    ('category_ar', 'Category (AR)'),
+    ('category_leaf', 'Category leaf'),
+    ('category_leaf_ar', 'Category leaf (AR)'),
+    ('category_l1', 'Category L1'),
+    ('category_l1_ar', 'Category L1 (AR)'),
+    ('category_l2', 'Category L2'),
+    ('category_l2_ar', 'Category L2 (AR)'),
+    ('category_l3', 'Category L3'),
+    ('category_l3_ar', 'Category L3 (AR)'),
+    ('category_l4', 'Category L4'),
+    ('category_l4_ar', 'Category L4 (AR)'),
+    ('category_l5', 'Category L5'),
+    ('category_l5_ar', 'Category L5 (AR)'),
+    ('category_l6', 'Category L6'),
+    ('category_l6_ar', 'Category L6 (AR)'),
+    ('category_l7', 'Category L7'),
+    ('category_l7_ar', 'Category L7 (AR)'),
+    ('category_l8', 'Category L8'),
+    ('category_l8_ar', 'Category L8 (AR)'),
+    ('category_l9', 'Category L9'),
+    ('category_l9_ar', 'Category L9 (AR)'),
+    ('category_l10', 'Category L10'),
+    ('category_l10_ar', 'Category L10 (AR)'),
+    ('price_previous', 'Previous price'),
+    ('price_change', 'Price change'),
+    ('price_min', 'Lowest price'),
+    ('price_max', 'Highest price'),
+    ('observations', 'Observations'),
+    ('price_changed_on', 'Price changed on'),
+    ('last_confirmed_on', 'Last confirmed on'),
+    ('official_source', 'Official source'),
+    ('curation', 'Curation'),
+    ('product_link', ''),
 ]
 
 # The bilingual pairs, declared ONCE (owner's standing rule: a site that

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -652,3 +652,43 @@ def test_the_newest_market_rate_still_wins_among_market_rates(conn):
 
     rate, _source = _usd_rate_shown(conn)
     assert float(rate) == 50.75
+
+
+# ---- the price sits in the same place in every table, 2026-07-31 ----------
+
+def test_the_offer_block_comes_before_the_filing():
+    """The owner hunted for the price in a different place in every table.
+
+    Measured before this: position 19 in madar, 10 in sika, 8 in alsweed, 6 in
+    gpp. The relative order was never wrong — zero out-of-order pairs anywhere —
+    but Price sat at index 33 of BROWSE_COLUMNS, behind twenty-four
+    classification columns, and each source is shown only the columns it fills.
+    So the more levels a source publishes, the further right its price drifts.
+    """
+    from scrapex.reports import BROWSE_COLUMNS
+
+    keys = [key for key, _label in BROWSE_COLUMNS]
+    price = keys.index("price")
+    # Every classification column must come AFTER the price, not before it.
+    filing = [k for k in keys if k.startswith("category")]
+    assert filing, "no classification columns — the guard would pass vacuously"
+    assert min(keys.index(k) for k in filing) > price, (
+        "a classification column is ahead of Price again, which is what made "
+        "its position depend on how many levels a source publishes")
+    # And identity still leads: a price with no name beside it is unreadable.
+    assert keys.index("product_name") < price
+    assert keys.index("sku") < price
+
+
+def test_the_reorder_lost_no_column(conn):
+    """Reordering a list by hand is how a column silently disappears from the
+    table AND from the export, which share this list."""
+    from scrapex.reports import BROWSE_COLUMNS, EXPORT_HEADER
+
+    keys = [key for key, _label in BROWSE_COLUMNS]
+    assert len(keys) == len(set(keys)), "a column was duplicated"
+    assert len(keys) == 50, f"the column count changed to {len(keys)}"
+    # Every browse column must still be exportable, or the grid and the
+    # spreadsheet stop agreeing — the drift EXPORT_HEADER exists to prevent.
+    missing = [k for k in keys if k not in EXPORT_HEADER]
+    assert not missing, f"browse columns missing from the export: {missing}"


### PR DESCRIPTION
The owner: his eye hunts for the price in a different place in every table. **Measured**, before this — the position of Price in each source's own table:

| MADAR | SIKAEGSHOP | ALSWEED | ELBUROJ | GPP_ENERGY |
|---|---|---|---|---|
| **19** | 10 | 8 | 8 | 6 |

## What I expected to find, and did not

I expected the **order** to differ between sources. It does not. Comparing every adjacent pair against the central list: **zero out-of-order pairs, in any source.**

An earlier check of mine said otherwise and was simply wrong — it filtered the reference list by membership in the shorter one, so a source showing a column MADAR does not show read as a reordering. Task #72 asks to "unify the column order"; **there was nothing to unify.**

## The real cause

Price sat at index **33** of `BROWSE_COLUMNS`, behind **twenty-four classification columns**, and each source is shown only the columns it actually fills. So the number of levels a source publishes decides how far right its price drifts.

**The order was consistent and the position was not** — and the position is what the eye tracks.

## The fix

Three named blocks instead of one flat list: **identity → the offer → the filing.**

| | after |
|---|---|
| MADAR | **6** |
| SIKAEGSHOP | 4 |
| ALSWEED · ELBUROJ · GPP_ENERGY | 3 |

A spread of **three** rather than thirteen, and the remainder is honest: a source with no variants is not shown a variant column.

**Nothing is pinned and no column is forced to appear.** The per-source gates still decide *presence* — the ruling that keeps a fuel site's USD estimate off a shop's table — and it is untouched. Only the order changed.

## Tests

- every classification column comes **after** Price, and identity before it — the **rule**, not the current arrangement, so a future insertion cannot quietly undo it
- the reorder lost no column and duplicated none, and every browse column is still exportable — the grid and the spreadsheet read this same list, and hand-reordering a list is exactly how a column vanishes from both

**1706 passed, 1 xfailed.** Contract parity **3/3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)