### PR TITLE
fix(gallery): the picture the shop leads with, not the one the alphabet does

### DIFF
--- a/scrapex/reports.py
+++ b/scrapex/reports.py
@@ -1417,10 +1417,31 @@ def stated_order(alias: str = "spa") -> str:
 
     NOT a heuristic and NOT a re-ranking: nothing here reads the URL, the file
     name, the image size or the word "main". It reproduces the number the
-    connector wrote down, which is the position the site published. A code that
-    carries no number (`sku`, `brand`, `color_ar`) yields a rank of 0 for every
-    row, so within one attribute the order is unchanged — `raw_value` stays as
-    the last term and keeps deciding those, exactly as before.
+    connector wrote down, which is the position the site published.
+
+    WHAT IT DOES BESIDES THE GALLERY, because the first draft of this docstring
+    said "nothing outside the gallery moves" and that is not true. The FAMILY is
+    a sort term too, and it sits ahead of `raw_value`, so wherever two different
+    codes share one label the code now decides where `raw_value` used to.
+    Measured on the live warehouse: 208 products in Site metadata, 88 in
+    Specifications and 48 in Attachments reorder, and not one of them is a
+    picture.
+
+    Every one of those is a bilingual pair or a numbered series, and both come
+    out better for it:
+
+        no_archive_ar, no_archive   ->  no_archive, no_archive_ar
+        conduit_type_ar, conduit_type -> conduit_type, conduit_type_ar
+        attachment_3410, _3411, _3409 -> attachment_3409, _3410, _3411
+
+    An `_ar` code always sorts after its unmarked twin, so the English member
+    leads — which is the project's standing rule («English leads», a1c75dd)
+    arriving in a place that had been ordering by whichever VALUE happened to
+    sort first. It is stated here rather than discovered later.
+
+    A code that carries no number yields a rank of 0, so within ONE code the
+    order is unchanged and `raw_value` still decides — that much of the first
+    claim holds, and it is the only part that does.
 
     Both readers take it so the export and the card cannot disagree about which
     picture came first; the export had no third key at all and was returning

--- a/scrapex/reports.py
+++ b/scrapex/reports.py
@@ -1388,6 +1388,49 @@ def _with_axis_columns(header: list[str], table: list[list],
     return widened, rows
 
 
+def stated_order(alias: str = "spa") -> str:
+    """ORDER BY terms that give back the sequence the SOURCE published.
+
+    A shop ranks a product's pictures — first is first — and every connector
+    records that rank the only place the row format offers: inside
+    `attribute_code`, as `image`, `image_1`, `image_2` … (magento.py:1364,
+    shopify.py:214, hybris.py:208, jsonld.py for salla and zid,
+    woocommerce.py). Both readers below then sorted by `attribute_group,
+    attribute_label, raw_value` — and all six connectors write the identical
+    label "Image", so group tied, label tied, and the effective sort key was
+    `raw_value`: the filename, alphabetically. The card renders the first row
+    it is handed (grid.js, productSummaryCard), so the picture shown as a
+    product's main image was the one whose file happened to sort first. The
+    rank was never lost from the warehouse; only these two queries threw it
+    away.
+
+    So the code is decoded rather than compared as text. `ORDER BY
+    attribute_code` would not do: it is lexicographic, so `image_10` lands
+    before `image_2` and bare `image` after both. `rtrim` strips the trailing
+    digits, leaving the family (`image_`), and what it stripped is cast to the
+    number it is:
+
+        image      -> ("image",  0)      the shop's first, and it sorts first
+        image_1    -> ("image_", 1)      because "image" < "image_" (shorter)
+        image_2    -> ("image_", 2)
+        image_10   -> ("image_", 10)     after 2, not before it
+
+    NOT a heuristic and NOT a re-ranking: nothing here reads the URL, the file
+    name, the image size or the word "main". It reproduces the number the
+    connector wrote down, which is the position the site published. A code that
+    carries no number (`sku`, `brand`, `color_ar`) yields a rank of 0 for every
+    row, so within one attribute the order is unchanged — `raw_value` stays as
+    the last term and keeps deciding those, exactly as before.
+
+    Both readers take it so the export and the card cannot disagree about which
+    picture came first; the export had no third key at all and was returning
+    whatever order SQLite happened to produce.
+    """
+    code = f"COALESCE({alias}.attribute_code, '')"
+    family = f"rtrim({code}, '0123456789')"
+    return f"{family}, CAST(substr({code}, length({family}) + 1) AS INTEGER)"
+
+
 # Both tabs carry BOTH name columns, like the price tab: they are enumerated
 # on no page, so nothing else would ever tell you they had only one.
 DETAILS_HEADER = ["product_name", "product_name_ar", "country_code_alpha2", "sku", "group",
@@ -1415,7 +1458,8 @@ def export_details_table(conn: sqlite3.Connection, source_key: str,
         "WHERE ss.source_key = ? AND sv.status = 'active' "
         "GROUP BY spa.source_product_attribute_id "
         "ORDER BY sp.product_name, sp.product_name_ar, spa.attribute_group, "
-        "         spa.attribute_label LIMIT ?",
+        f"         spa.attribute_label, {stated_order('spa')}, spa.raw_value "
+        "LIMIT ?",
         (source_key, limit)).fetchall()
     return list(DETAILS_HEADER), [
         [r[0] or "", r[1] or "", (r[2] or "") if r[2] != "*" else "", r[3] or "",
@@ -1631,7 +1675,8 @@ def product_attributes(conn: sqlite3.Connection, offer_id: int,
         "JOIN source_variant sv ON sv.source_product_id = spa.source_product_id "
         "JOIN source_offer so ON so.source_variant_id = sv.source_variant_id "
         "WHERE so.offer_id = ? "
-        "ORDER BY spa.attribute_group, spa.attribute_label, spa.raw_value LIMIT ?",
+        "ORDER BY spa.attribute_group, spa.attribute_label, "
+        f"         {stated_order('spa')}, spa.raw_value LIMIT ?",
         (offer_id, max(1, min(limit, 1000)))).fetchall()
     # `code` and `lang` travel with every row so the panel can PAIR the two
     # languages of one fact (description + description_en) into ONE entry

--- a/scrapex/webui/static/grid.js
+++ b/scrapex/webui/static/grid.js
@@ -2509,6 +2509,12 @@
     const media = el("div", "selected-product-media");
     const imageStage = el("div", "selected-product-image-stage");
     media.appendChild(imageStage);
+    // ORDER IS THE SHOP'S, and this filter must never add a sort of its own.
+    // The rank each connector recorded is decoded by the query that produced
+    // these rows (reports.py stated_order), so images[0] below is the picture
+    // the SOURCE leads with. Sorting here — by filename, by size, by anything
+    // that looks like a main image — would overrule the shop about its own
+    // product, and would fix only this card while the export still disagreed.
     const images = details
       .filter((item) => (item.group || "") === "Media" && safeUrl(item.url))
       .map((item) => ({url: safeUrl(item.url), alt: text(item.value || "")}));

--- a/tests/fixtures/live/elsewedyshop_gallery_order_2026-08-01.CAPTURE.md
+++ b/tests/fixtures/live/elsewedyshop_gallery_order_2026-08-01.CAPTURE.md
@@ -1,0 +1,62 @@
+# Gallery order — live capture 2026-08-01 (issue #35)
+
+`elsewedyshop_gallery_order_2026-08-01.json` — three products, taken verbatim
+out of `https://elsewedyshop.com/products.json?limit=250&page={1,2,3}`.
+User-Agent `ScrapeX/0.1 (+contact: owner)`, requests spaced 1.3 s, HTTP 200 on
+all three, nothing else was asked for. **No image file was downloaded** — the
+URL is the record. No crawl was running (`/api/jobs`: last job finished
+2026-07-30 13:35Z) and the engine was not touched.
+
+## Why a new fixture instead of an existing one
+
+`elsewedyshop_products_images_2026-07-30.json` exists and would nearly do. It
+was captured to prove the pictures were *captured at all*, and it happens to
+contain one gallery whose order disagrees with the alphabet. Issue #35 is about
+the order specifically, and a fixture whose two orders agree passes with the
+defect fully in place — which is how six connectors could each carefully rank
+their pictures and nobody noticed the ranking never arrived. So the
+disagreement here is chosen, stated, and asserted by the test itself
+(`test_the_fixture_actually_disagrees_or_this_whole_file_proves_nothing`)
+rather than left to luck.
+
+## What the three products are for
+
+| id | pictures | why |
+|---|---|---|
+| 8931923394860 | 7 | The shop leads with `FHSDK47-6.jpg`, which sorts **7th of 7** alphabetically — the shop's first is the alphabetically **last**. A filename sort cannot hide in this product. |
+| 9718091219244 | 3 | The two orders **agree** (`212620-1/-2/-3.png`). Guards the opposite mistake: the fix must restore the shop's order, not reverse or shuffle. |
+| 10157311557932 | 1 | The common case. No ordering question exists, and it must come out untouched. |
+
+The demonstrator's gallery, in the order the shop publishes it:
+
+```
+1. FHSDK47-6.jpg     <-- the shop's own first; sorted alphabetically it is 7th
+2. FHSDK47-15.jpg    <-- what the card showed instead
+3. FHSDK47-23.jpg
+4. FHSDK47-24.jpg
+5. FHSDK47-1_2.jpg
+6. FHSDK47-2_2.jpg
+7. FHSDK47-3_2.jpg
+```
+
+## The census the choice was made from
+
+Pages 1–3 of the catalogue, 750 products:
+
+| | count |
+|---|---|
+| products read | 750 |
+| publish more than one picture | 53 (page 1 alone) |
+| of those, first picture **not** the alphabetically first | **31 of 53 on page 1** |
+| publish exactly one picture | 475 |
+| galleries already in alphabetical order | 37 |
+
+So on this shop the read-side defect changed the displayed picture for roughly
+three in five multi-picture products, and could not affect the 475 with one.
+
+## Not captured, deliberately
+
+Shopify's `products.json` states no alt text at all on this shop (1,442 of
+1,442 null, measured 2026-07-30), so there is no caption to pair and nothing
+was translated or invented — the file name stands in as the label, exactly as
+`shopify.py:212` already does.

--- a/tests/fixtures/live/elsewedyshop_gallery_order_2026-08-01.json
+++ b/tests/fixtures/live/elsewedyshop_gallery_order_2026-08-01.json
@@ -1,0 +1,263 @@
+{
+ "products": [
+  {
+   "id": 8931923394860,
+   "title": "طقم لٌقم و رؤوس مُفكات مختلفة المقاسات 47 قطعة\n",
+   "handle": "fixtec-47pcs-ratchet-screwdriver-bit-diff-size-socket-set",
+   "body_html": "\"العلامة التجارية : FixTec\nطقم لُقم 47 قطعة - متعددة المقاسات - لإستخدامات مختلفة \n- مفك فك و ربط بذراع طويل - يد معزولة -  مصنوعة من الصلب الكربونى \"\n",
+   "published_at": "2023-12-14T11:47:22+02:00",
+   "created_at": "2023-12-14T11:47:22+02:00",
+   "updated_at": "2026-08-01T08:28:53+03:00",
+   "vendor": "FixTec",
+   "product_type": "Hand Tools",
+   "tags": [
+    "Tools"
+   ],
+   "variants": [
+    {
+     "id": 47610898940204,
+     "title": "Default Title",
+     "option1": "Default Title",
+     "option2": null,
+     "option3": null,
+     "sku": "110512",
+     "requires_shipping": true,
+     "taxable": false,
+     "featured_image": null,
+     "available": true,
+     "price": "640.00",
+     "grams": 0,
+     "compare_at_price": "850.00",
+     "position": 1,
+     "product_id": 8931923394860,
+     "created_at": "2023-12-14T11:47:22+02:00",
+     "updated_at": "2026-08-01T08:28:53+03:00"
+    }
+   ],
+   "images": [
+    {
+     "id": 43769761726764,
+     "created_at": "2023-12-26T11:58:02+02:00",
+     "position": 1,
+     "updated_at": "2023-12-26T11:58:04+02:00",
+     "product_id": 8931923394860,
+     "variant_ids": [],
+     "src": "https://cdn.shopify.com/s/files/1/0704/4972/5740/files/FHSDK47-6.jpg?v=1703584684",
+     "width": 750,
+     "height": 750
+    },
+    {
+     "id": 43769761628460,
+     "created_at": "2023-12-26T11:58:02+02:00",
+     "position": 2,
+     "updated_at": "2023-12-26T11:58:03+02:00",
+     "product_id": 8931923394860,
+     "variant_ids": [],
+     "src": "https://cdn.shopify.com/s/files/1/0704/4972/5740/files/FHSDK47-15.jpg?v=1703584683",
+     "width": 750,
+     "height": 750
+    },
+    {
+     "id": 43769761661228,
+     "created_at": "2023-12-26T11:58:02+02:00",
+     "position": 3,
+     "updated_at": "2023-12-26T11:58:04+02:00",
+     "product_id": 8931923394860,
+     "variant_ids": [],
+     "src": "https://cdn.shopify.com/s/files/1/0704/4972/5740/files/FHSDK47-23.jpg?v=1703584684",
+     "width": 750,
+     "height": 750
+    },
+    {
+     "id": 43769761595692,
+     "created_at": "2023-12-26T11:58:02+02:00",
+     "position": 4,
+     "updated_at": "2023-12-26T11:58:03+02:00",
+     "product_id": 8931923394860,
+     "variant_ids": [],
+     "src": "https://cdn.shopify.com/s/files/1/0704/4972/5740/files/FHSDK47-24.jpg?v=1703584683",
+     "width": 750,
+     "height": 750
+    },
+    {
+     "id": 43769761759532,
+     "created_at": "2023-12-26T11:58:02+02:00",
+     "position": 5,
+     "updated_at": "2023-12-26T11:58:05+02:00",
+     "product_id": 8931923394860,
+     "variant_ids": [],
+     "src": "https://cdn.shopify.com/s/files/1/0704/4972/5740/files/FHSDK47-1_2.jpg?v=1703584685",
+     "width": 750,
+     "height": 750
+    },
+    {
+     "id": 43769761792300,
+     "created_at": "2023-12-26T11:58:02+02:00",
+     "position": 6,
+     "updated_at": "2023-12-26T11:58:05+02:00",
+     "product_id": 8931923394860,
+     "variant_ids": [],
+     "src": "https://cdn.shopify.com/s/files/1/0704/4972/5740/files/FHSDK47-2_2.jpg?v=1703584685",
+     "width": 750,
+     "height": 750
+    },
+    {
+     "id": 43769761693996,
+     "created_at": "2023-12-26T11:58:02+02:00",
+     "position": 7,
+     "updated_at": "2023-12-26T11:58:04+02:00",
+     "product_id": 8931923394860,
+     "variant_ids": [],
+     "src": "https://cdn.shopify.com/s/files/1/0704/4972/5740/files/FHSDK47-3_2.jpg?v=1703584684",
+     "width": 750,
+     "height": 750
+    }
+   ],
+   "options": [
+    {
+     "name": "Title",
+     "position": 1,
+     "values": [
+      "Default Title"
+     ]
+    }
+   ]
+  },
+  {
+   "id": 9718091219244,
+   "title": "مفتاح اضاءة ثلاثي ذكي واي فاي",
+   "handle": "3-gang-smart-light-switch-wifi-black",
+   "body_html": "تحكم في إضاءتك عن بعد، اضبط مؤقت، وقم بإنشاء سيناريو اضاءة خاص بك. متوافق مع المساعد الصوتي.",
+   "published_at": "2024-11-14T10:30:14+02:00",
+   "created_at": "2024-11-14T10:17:36+02:00",
+   "updated_at": "2026-08-01T08:28:53+03:00",
+   "vendor": "LUMA",
+   "product_type": "الحلول الذكية",
+   "tags": [
+    "Smart solutions"
+   ],
+   "variants": [
+    {
+     "id": 50168586862892,
+     "title": "Default Title",
+     "option1": "Default Title",
+     "option2": null,
+     "option3": null,
+     "sku": "212620",
+     "requires_shipping": true,
+     "taxable": false,
+     "featured_image": null,
+     "available": true,
+     "price": "2430.00",
+     "grams": 0,
+     "compare_at_price": "3035.00",
+     "position": 1,
+     "product_id": 9718091219244,
+     "created_at": "2024-11-14T10:17:36+02:00",
+     "updated_at": "2026-08-01T08:28:53+03:00"
+    }
+   ],
+   "images": [
+    {
+     "id": 47876232020268,
+     "created_at": "2024-11-14T10:25:18+02:00",
+     "position": 1,
+     "updated_at": "2024-11-14T10:25:20+02:00",
+     "product_id": 9718091219244,
+     "variant_ids": [],
+     "src": "https://cdn.shopify.com/s/files/1/0704/4972/5740/files/212620-1.png?v=1731572720",
+     "width": 1000,
+     "height": 1000
+    },
+    {
+     "id": 47876231954732,
+     "created_at": "2024-11-14T10:25:18+02:00",
+     "position": 2,
+     "updated_at": "2024-11-14T10:25:20+02:00",
+     "product_id": 9718091219244,
+     "variant_ids": [],
+     "src": "https://cdn.shopify.com/s/files/1/0704/4972/5740/files/212620-2.png?v=1731572720",
+     "width": 1000,
+     "height": 1000
+    },
+    {
+     "id": 47876231987500,
+     "created_at": "2024-11-14T10:25:18+02:00",
+     "position": 3,
+     "updated_at": "2024-11-14T10:25:20+02:00",
+     "product_id": 9718091219244,
+     "variant_ids": [],
+     "src": "https://cdn.shopify.com/s/files/1/0704/4972/5740/files/212620-3.png?v=1731572720",
+     "width": 1000,
+     "height": 1000
+    }
+   ],
+   "options": [
+    {
+     "name": "Title",
+     "position": 1,
+     "values": [
+      "Default Title"
+     ]
+    }
+   ]
+  },
+  {
+   "id": 10157311557932,
+   "title": "كشاف واجهات400وات اضاءة ابيض IP 65",
+   "handle": "luma-floodlight-400w-ip65-6500k",
+   "body_html": "<p>كشاف واجهات400وات اضاءة ابيض IP 65</p>",
+   "published_at": "2025-12-02T09:45:43+02:00",
+   "created_at": "2025-12-02T07:32:11+02:00",
+   "updated_at": "2026-08-01T08:28:53+03:00",
+   "vendor": "Luma",
+   "product_type": "Floodlight",
+   "tags": [
+    "Floodlight"
+   ],
+   "variants": [
+    {
+     "id": 52388706844972,
+     "title": "Default Title",
+     "option1": "Default Title",
+     "option2": null,
+     "option3": null,
+     "sku": "312890",
+     "requires_shipping": true,
+     "taxable": false,
+     "featured_image": null,
+     "available": true,
+     "price": "7136.40",
+     "grams": 22,
+     "compare_at_price": null,
+     "position": 1,
+     "product_id": 10157311557932,
+     "created_at": "2025-12-02T07:32:11+02:00",
+     "updated_at": "2026-08-01T08:28:53+03:00"
+    }
+   ],
+   "images": [
+    {
+     "id": 52001828274476,
+     "created_at": "2025-12-02T09:23:54+02:00",
+     "position": 1,
+     "updated_at": "2025-12-02T09:23:55+02:00",
+     "product_id": 10157311557932,
+     "variant_ids": [],
+     "src": "https://cdn.shopify.com/s/files/1/0704/4972/5740/files/212549.png?v=1764660235",
+     "width": 1000,
+     "height": 1000
+    }
+   ],
+   "options": [
+    {
+     "name": "Title",
+     "position": 1,
+     "values": [
+      "Default Title"
+     ]
+    }
+   ]
+  }
+ ]
+}

--- a/tests/test_gallery_order.py
+++ b/tests/test_gallery_order.py
@@ -260,11 +260,16 @@ def test_no_two_media_rows_of_one_product_hold_the_same_url(warehouse):
         assert len(set(codes)) == len(codes), f"{product_id} reuses a code"
 
 
-def test_an_attribute_carrying_no_number_is_ordered_exactly_as_before(warehouse):
-    """The new key decodes a rank out of the code. A code that states none —
-    `sku`, `brand`, `color` — must yield the same rank for every row, so
-    `raw_value` goes on deciding those and nothing outside the gallery moves.
-    """
+def test_within_one_code_the_value_still_decides(warehouse):
+    """A code that states no rank yields 0 for every row, so `raw_value` goes on
+    deciding — for rows that share a code.
+
+    THIS TEST USED TO CLAIM MORE THAN IT SHOWED. It was called "…is ordered
+    exactly as before" and its docstring said nothing outside the gallery
+    moves, while inserting the SAME code three times — the one shape where the
+    family term ties and the claim happens to hold. Measured on the live
+    warehouse, 344 products outside the gallery DO move, and the test beneath
+    this one is where that is now stated."""
     conn = sqlite3.connect(":memory:")
     conn.execute("CREATE TABLE spa (attribute_code TEXT, raw_value TEXT)")
     conn.executemany("INSERT INTO spa VALUES (?,?)",
@@ -276,4 +281,51 @@ def test_an_attribute_carrying_no_number_is_ordered_exactly_as_before(warehouse)
         "SELECT raw_value FROM spa ORDER BY raw_value")]
 
     assert ranked == plain == ["amber", "blue", "red"]
+    conn.close()
+
+
+def test_two_codes_under_one_label_are_ordered_by_the_code_english_first(warehouse):
+    """THE EFFECT THIS CHANGE HAS OUTSIDE THE GALLERY, stated rather than left
+    to be found.
+
+    The family is a sort term and it sits ahead of `raw_value`, so wherever two
+    different codes share one label the CODE decides where the VALUE used to.
+    On the live warehouse that is 208 products in Site metadata, 88 in
+    Specifications and 48 in Attachments — not one of them a picture.
+
+    It is an improvement, and that is why it stays: an `_ar` code always sorts
+    after its unmarked twin, so the English member leads. That is the project's
+    standing rule arriving somewhere that had been ordering by whichever value
+    happened to sort first — «مطاطي» before "Rubber" one day and after it the
+    next, depending on the text.
+    """
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE spa (attribute_code TEXT, raw_value TEXT)")
+    conn.executemany("INSERT INTO spa VALUES (?,?)", [
+        ("no_archive_ar", "لا"),   # sorts BEFORE "no" by value
+        ("no_archive", "no"),
+    ])
+
+    ordered = [r[0] for r in conn.execute(
+        f"SELECT attribute_code FROM spa ORDER BY {stated_order('spa')}, raw_value")]
+
+    assert ordered == ["no_archive", "no_archive_ar"], (
+        "the Arabic twin leads its English one; the value is deciding again")
+    conn.close()
+
+
+def test_a_numbered_series_outside_the_gallery_is_ordered_by_its_number(warehouse):
+    """Sika publishes datasheets as `attachment_3409`, `_3410`, `_3411` and the
+    old key sorted them by URL, which put 3410 and 3411 ahead of 3409 on 48 of
+    the owner's 86 products. Same rule, same fix, and it is deliberate."""
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE spa (attribute_code TEXT, raw_value TEXT)")
+    conn.executemany("INSERT INTO spa VALUES (?,?)", [
+        ("attachment_3410", "b.pdf"), ("attachment_3411", "c.pdf"),
+        ("attachment_3409", "a-later-in-the-alphabet.pdf")])
+
+    ordered = [r[0] for r in conn.execute(
+        f"SELECT attribute_code FROM spa ORDER BY {stated_order('spa')}, raw_value")]
+
+    assert ordered == ["attachment_3409", "attachment_3410", "attachment_3411"]
     conn.close()

--- a/tests/test_gallery_order.py
+++ b/tests/test_gallery_order.py
@@ -1,0 +1,279 @@
+"""Issue #35 — the shop chose which picture leads, and the read threw it away.
+
+Every connector ranks a product's pictures and records the rank the only place
+the row format offers: inside `attribute_code` (`image`, `image_1`, `image_2`…).
+Both readers in `reports.py` then sorted by `attribute_group, attribute_label,
+raw_value`, and all six connectors write the identical label "Image" — so group
+tied, label tied, and the effective sort key was the FILE NAME, alphabetically.
+The card renders the first row it is handed (`grid.js` productSummaryCard), so
+the main picture was the one whose file happened to sort first.
+
+WHY A CAPTURED FIXTURE, AND WHY THIS ONE
+----------------------------------------
+`fixtures/live/elsewedyshop_gallery_order_2026-08-01.json`, captured from the
+live shop (see the CAPTURE note beside it). Three products, chosen because a
+fixture whose two orders AGREE proves nothing — it passes with the defect fully
+in place, which is how six connectors could each carefully rank their pictures
+and nobody noticed the ranking never arrived:
+
+  8931923394860   7 pictures. The shop leads with `FHSDK47-6.jpg`, which sorts
+                  SEVENTH OF SEVEN alphabetically. The shop's first is the
+                  alphabetically LAST — the two orders disagree maximally.
+  9718091219244   3 pictures whose two orders agree. Guards the other
+                  direction: the fix must not be "reverse it" or "shuffle".
+  10157311557932  1 picture. The common case, which has no ordering question
+                  and must come out untouched.
+
+Nothing here downloads an image; the URL is the record.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scrapex import db as dbmod
+from scrapex.config import ExtractSpec, SourceEntry
+from scrapex.connectors.shopify import ShopifyConnector
+from scrapex.ingest import ingest_payloads
+from scrapex.reports import export_details_table, product_attributes, stated_order
+from scrapex.vocab import DetailGroup, ExtractKind, ExtractScope
+
+FIXTURE = (Path(__file__).parent / "fixtures" / "live"
+           / "elsewedyshop_gallery_order_2026-08-01.json")
+
+# The product the shop and the alphabet disagree about, and the two guards.
+DISAGREES = "8931923394860"
+AGREES = "9718091219244"
+ONE_PICTURE = "10157311557932"
+
+
+def _payload() -> dict:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def _product(product_id: str) -> dict:
+    for product in _payload()["products"]:
+        if str(product["id"]) == product_id:
+            return product
+    raise AssertionError(f"{product_id} is not in the fixture")
+
+
+def _file_names(product: dict) -> list[str]:
+    return [str(i["src"]).rsplit("/", 1)[-1].split("?")[0]
+            for i in product["images"]]
+
+
+def _entry() -> SourceEntry:
+    return SourceEntry.model_validate(dict(
+        source_key="ELSEWEDYSHOP", source_name="Elsewedy",
+        base_url="https://elsewedyshop.com", family="shopify-json",
+        currency="EGP", default_region="EG", vat_mode="incl",
+        extract=[ExtractSpec(kind=ExtractKind.PRODUCT_PRICES,
+                             scope=ExtractScope.CENSUS),
+                 ExtractSpec(kind=ExtractKind.ENRICHMENT,
+                             scope=ExtractScope.CENSUS)]))
+
+
+def _tables():
+    """The connector run over the captured bytes — no request is made."""
+    body = _payload()
+
+    class _Resp:
+        def __init__(self, payload): self._payload = payload
+        def json(self): return self._payload
+
+    class _Fetcher:
+        def get(self, url, **kwargs):
+            first = "page=1" in url and "/en/" not in url
+            return _Resp(body if first else {"products": []})
+
+    return list(ShopifyConnector(_Fetcher()).fetch(_entry()))
+
+
+@pytest.fixture
+def warehouse():
+    """The SECOND crawl, not the first ingest.
+
+    Production is never a fresh database. Ingesting twice also proves the fix
+    does not quietly depend on rows arriving in insertion order — the upsert on
+    the second pass is free to touch them in any order it likes.
+    """
+    conn = dbmod.connect(":memory:")
+    dbmod.migrate(conn)
+    payloads = [t.to_payload() for t in _tables()]
+    first = ingest_payloads(conn, _entry(), payloads)
+    assert first.errors == [], first.errors[:3]
+    second = ingest_payloads(conn, _entry(), payloads)
+    assert second.errors == [], second.errors[:3]
+    yield conn
+    conn.close()
+
+
+def _offer_of(conn: sqlite3.Connection, product_id: str) -> int:
+    row = conn.execute(
+        "SELECT so.offer_id FROM source_offer so "
+        "JOIN source_variant sv ON sv.source_variant_id = so.source_variant_id "
+        "JOIN source_product sp ON sp.source_product_id = sv.source_product_id "
+        "WHERE sp.external_product_id = ? LIMIT 1", (product_id,)).fetchone()
+    assert row, f"product {product_id} never reached the warehouse"
+    return row[0]
+
+
+def _gallery(conn: sqlite3.Connection, product_id: str) -> list[dict]:
+    """Exactly what the card is handed: the Media rows, in the order given.
+
+    `grid.js` filters `group === "Media"` and renders `images[0]`, adding no
+    sort of its own — so this list IS the gallery, and its head IS the main
+    picture the owner sees.
+    """
+    return [d for d in product_attributes(conn, _offer_of(conn, product_id))
+            if d["group"] == DetailGroup.MEDIA.value and d["url"]]
+
+
+# ---------------------------------------------------------------------------
+# The fixture has to be able to fail. Checked, not assumed.
+# ---------------------------------------------------------------------------
+def test_the_fixture_actually_disagrees_or_this_whole_file_proves_nothing():
+    """A gallery already in alphabetical order passes with the defect intact."""
+    names = _file_names(_product(DISAGREES))
+
+    assert len(names) == 7
+    assert names != sorted(names), "fixture cannot detect an alphabetical sort"
+    assert names[0] == sorted(names)[-1], (
+        "the shop's own first picture must be the alphabetically LAST, so a "
+        f"filename sort is unmistakable: {names}")
+
+
+# ---------------------------------------------------------------------------
+# THE DEFECT — the card
+# ---------------------------------------------------------------------------
+def test_the_card_leads_with_the_picture_the_shop_leads_with(warehouse):
+    """The one the issue is about. Fails on `ORDER BY … raw_value`, which hands
+    the card `FHSDK47-1_2.jpg` — the alphabetically first — as the main."""
+    shop = [i["src"] for i in _product(DISAGREES)["images"]]
+
+    gallery = _gallery(warehouse, DISAGREES)
+
+    assert gallery[0]["url"] == shop[0], (
+        "the card is showing a picture the shop did not choose: "
+        f"{gallery[0]['url']} instead of {shop[0]}")
+
+
+def test_the_whole_gallery_is_the_shops_sequence_not_just_its_head(warehouse):
+    """Fixing only `[0]` would leave the thumbnails and the ‹ › arrows walking
+    the pictures in filename order behind a correct-looking main image."""
+    shop = [i["src"] for i in _product(DISAGREES)["images"]]
+
+    gallery = _gallery(warehouse, DISAGREES)
+
+    assert [g["url"] for g in gallery] == shop
+    assert [g["code"] for g in gallery] == \
+        ["image"] + [f"image_{n}" for n in range(1, len(shop))]
+
+
+def test_the_rank_is_decoded_as_a_number_not_compared_as_text(warehouse):
+    """`ORDER BY attribute_code` is lexicographic: `image_10` would land before
+    `image_2`, and bare `image` after both. Ten pictures is where a text sort
+    and a positional one part company, and no live fixture here has ten."""
+    product_id = _offer_of(warehouse, ONE_PICTURE)
+    row = warehouse.execute(
+        "SELECT sp.source_product_id FROM source_product sp "
+        "JOIN source_variant sv ON sv.source_product_id = sp.source_product_id "
+        "JOIN source_offer so ON so.source_variant_id = sv.source_variant_id "
+        "WHERE so.offer_id = ?", (product_id,)).fetchone()
+    for n in range(1, 12):
+        warehouse.execute(
+            "INSERT INTO source_product_attribute (source_product_id, "
+            " attribute_code, attribute_label, raw_value, value_url, "
+            " attribute_group) VALUES (?,?,?,?,?,?)",
+            (row[0], f"image_{n}", "Image", f"z{n}.jpg",
+             f"https://elsewedyshop.com/x/z{n}.jpg", DetailGroup.MEDIA.value))
+
+    codes = [g["code"] for g in _gallery(warehouse, ONE_PICTURE)]
+
+    assert codes == ["image"] + [f"image_{n}" for n in range(1, 12)], codes
+    assert codes.index("image_2") < codes.index("image_10")
+
+
+# ---------------------------------------------------------------------------
+# THE DEFECT — the export, which had no third sort key at all
+# ---------------------------------------------------------------------------
+def test_the_export_hands_over_the_same_sequence_as_the_card(warehouse):
+    """`export_details_table` ordered by group and label only, so the pictures
+    came out in whatever order SQLite happened to produce. A spreadsheet that
+    disagrees with the screen about which picture is first is the same defect
+    filed twice."""
+    header, rows = export_details_table(warehouse, "ELSEWEDYSHOP")
+    name = _product(DISAGREES)["title"]
+    url_at = header.index("value_url")
+    exported = [r[url_at] for r in rows
+                if r[header.index("group")] == DetailGroup.MEDIA.value
+                and name in (r[0], r[1])]
+
+    assert exported == [i["src"] for i in _product(DISAGREES)["images"]]
+    assert exported == [g["url"] for g in _gallery(warehouse, DISAGREES)]
+
+
+# ---------------------------------------------------------------------------
+# What the fix must not disturb
+# ---------------------------------------------------------------------------
+def test_one_picture_is_one_picture_and_nothing_about_it_moves(warehouse):
+    """475 of the 750 products on the captured pages publish exactly one. There
+    is no ordering question there and the fix must not invent one."""
+    gallery = _gallery(warehouse, ONE_PICTURE)
+
+    assert len(gallery) == 1
+    assert gallery[0]["code"] == "image"
+    assert gallery[0]["url"] == _product(ONE_PICTURE)["images"][0]["src"]
+
+
+def test_a_gallery_the_alphabet_already_agreed_with_comes_out_unchanged():
+    """The fix is "restore the shop's order", not "reverse the old one"."""
+    names = _file_names(_product(AGREES))
+    assert names == sorted(names), "this guard needs an agreeing gallery"
+
+    conn = dbmod.connect(":memory:")
+    dbmod.migrate(conn)
+    payloads = [t.to_payload() for t in _tables()]
+    ingest_payloads(conn, _entry(), payloads)
+    try:
+        gallery = _gallery(conn, AGREES)
+        assert [g["url"] for g in gallery] == \
+            [i["src"] for i in _product(AGREES)["images"]]
+    finally:
+        conn.close()
+
+
+def test_no_two_media_rows_of_one_product_hold_the_same_url(warehouse):
+    """MADAR shipped `image` and `image_1` pointing at one picture on 576
+    products (fixed at capture, commit 105189c). Reading the rank back must not
+    reintroduce it from the other end — this read renumbers nothing, and this
+    is the assertion that says so out loud."""
+    for product_id in (DISAGREES, AGREES, ONE_PICTURE):
+        gallery = _gallery(warehouse, product_id)
+        urls = [g["url"] for g in gallery]
+        codes = [g["code"] for g in gallery]
+        assert len(set(urls)) == len(urls), f"{product_id} stores one URL twice"
+        assert len(set(codes)) == len(codes), f"{product_id} reuses a code"
+
+
+def test_an_attribute_carrying_no_number_is_ordered_exactly_as_before(warehouse):
+    """The new key decodes a rank out of the code. A code that states none —
+    `sku`, `brand`, `color` — must yield the same rank for every row, so
+    `raw_value` goes on deciding those and nothing outside the gallery moves.
+    """
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE spa (attribute_code TEXT, raw_value TEXT)")
+    conn.executemany("INSERT INTO spa VALUES (?,?)",
+                     [("color", "red"), ("color", "amber"), ("color", "blue")])
+
+    ranked = [r[0] for r in conn.execute(
+        f"SELECT raw_value FROM spa ORDER BY {stated_order('spa')}, raw_value")]
+    plain = [r[0] for r in conn.execute(
+        "SELECT raw_value FROM spa ORDER BY raw_value")]
+
+    assert ranked == plain == ["amber", "blue", "red"]
+    conn.close()

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -1346,6 +1346,14 @@ def test_run_mode_uses_the_themed_listbox_instead_of_the_native_blue_popup(open_
     assert themed, "the selected row escaped the active theme"
 
     page.keyboard.press("Escape")
+    # WAITED FOR, not asserted on the next line. Escape hides the list through
+    # a style change the browser applies on its own schedule, and reading
+    # is_visible() in the same breath asks whether it has happened YET. It had
+    # on every local run and on one of CI's two jobs; the other went red on
+    # 2026-08-05 with the list still up, which is a race in the test and not a
+    # defect in the panel. The assertion stays underneath so the intent is
+    # still legible — the wait is what makes it mean something.
+    page.wait_for_selector("#run-mode-list", state="hidden")
     assert not page.locator("#run-mode-list").is_visible()
 
 


### PR DESCRIPTION
Closes #35 (defect **A**). Defect **B** is measured below and deliberately left
for the owner to rule on — it cannot be fixed at read time.

## The defect, proven rather than read

Every connector ranks a product's pictures and records the rank the only place
the row format offers: inside `attribute_code` — `image`, `image_1`, `image_2` …
([magento.py:1364](scrapex/connectors/magento.py:1364),
[shopify.py:214](scrapex/connectors/shopify.py:214),
[hybris.py:208](scrapex/connectors/hybris.py:208), `jsonld.py` for salla and
zid, `woocommerce.py`).

Both readers in `reports.py` then threw it away:

- [reports.py:1492](scrapex/reports.py:1492) — the card:
  `ORDER BY spa.attribute_group, spa.attribute_label, spa.raw_value`
- [reports.py:1275](scrapex/reports.py:1275) — the export: `attribute_group,
  attribute_label` and **no third key at all**

All six connectors write the identical label `"Image"`, so group tied, label
tied, and the effective sort key was `raw_value` — the file name,
alphabetically. [grid.js](scrapex/webui/static/grid.js:2519) renders `images[0]`
with no sort of its own, so the picture shown as a product's main image was the
one whose file happened to sort first.

**Storage never lost the order.** Read-only census of the live warehouse: of the
3,381 offers carrying more than one picture, **0 are unrankable** — every code
still states its position. So the earliest wrong link is the read, the fix is
one place, and no re-crawl is needed.

## Measured effect — live warehouse, shipped ORDER BY vs this one

| source | 1 pic | >1 pic | order changes | **main picture changes** |
|---|---:|---:|---:|---:|
| ADVANCEDCASTLE | 56 | 112 | 88 | **76** |
| SAMEHGABRIEL | 12 | 96 | 96 | **96** |
| SIKAEGSHOP | 6 | 81 | 73 | **68** |
| MADAR | 1 | 3,092 | 13 | **1** |
| ELBUROJ | 368 | 0 | 0 | 0 |
| **TOTAL** | **443** | **3,381** | **270** | **241** |

**241 products change which picture they show.** The 443 with one picture change
nothing — asserted, not assumed.

MADAR is low for a reason worth stating: its `raw_value` is the product *name*,
identical on every picture of a product, so the sort key tied completely and
SQLite happened to return insertion order. It was right **by accident** on 3,092
offers, and only until a query plan changed.

## Three real before/after pairs

**ADVANCEDCASTLE offer 6207** — «مطب طريق مطاطي (ربل) بطول 1 متر», 9 pictures

```
BEFORE  image_1, image_3, image_7, image_4, image_2, image_8, image, image_6, image_5
AFTER   image,   image_1, image_2, image_3, image_4, image_5, image_6, image_7, image_8
main BEFORE  .../79993937-d6a8-45a5-be13-2ffd786cf3d7-thumbnail-1000x1000-70.jpg
main AFTER   .../f2233df4-1c3e-49c3-908b-2b8c280465e9-thumbnail-1000x1000-70.jpg
```

The shop's own first picture was showing **seventh of nine**.

**SAMEHGABRIEL offer 1** — «سلك نحاس مجدول 3 مم», 6 pictures

```
BEFORE  image_4, image, image_3, image_2, image_1, image_5
AFTER   image,   image_1, image_2, image_3, image_4, image_5
main BEFORE  .../2024/07/سلك-نحاس-CU-PVC-مجدول-1-مم-4.jpg
main AFTER   .../2024/08/3.0.png
```

Note the card was leading with a **1 مم** photo on a **3 مم** product.

**SIKAEGSHOP offer 3668** — Sika Grout 200 ® 25 KG, 10 pictures

```
BEFORE  image_3060, 3061, 3062, 3063, 3065, 3066, image_3059, 3067, 3064, 3068
AFTER   image_3059, 3060, 3061, 3062, 3063, 3064, 3065, 3066, 3067, 3068
```

## The fix

One shared, documented sort key, `reports.stated_order()`, taken by **both**
readers so the export and the card cannot disagree about which picture came
first.

`ORDER BY attribute_code` would not do — it is lexicographic, so `image_10`
lands before `image_2` and bare `image` after both. `rtrim` strips the trailing
digits to leave the family, and casts what it stripped to the number it is:

```
image     -> ("image",  0)     the shop's first, and it sorts first
image_1   -> ("image_", 1)     because "image" < "image_" (shorter)
image_2   -> ("image_", 2)
image_10  -> ("image_", 10)    after 2, not before it
```

**Not a heuristic.** Nothing reads the URL, the file name, the image size, or
the word "main". It reproduces the number the connector wrote down, which is the
position the site published. Source truth is not edited: no row is renumbered,
added, or removed — this is `ORDER BY` only.

## What else moved — stated, not discovered later

649 offers reorder rows **outside** the gallery. Every one is a bilingual pair
now leading with the unmarked (English) code instead of with whichever *value*
sorted first — `meta_title` before `meta_title_ar`, not the reverse — plus
SIKAEGSHOP's `Attachments`, which carry a rank the same way and had the same
defect (`attachment_3409` "Video" was sorting behind two PDFs). Rows **gained or
lost** anywhere in that census: **0**.

## The test, and it going red

`tests/test_gallery_order.py`, 9 tests, end to end: connector → ingest → the API
the card reads, and the export beside it. It ingests **twice**, because
production is never a fresh database.

With the two `ORDER BY` changes reverted to what `main` has, **4 fail**:

```
FAILED test_the_card_leads_with_the_picture_the_shop_leads_with
  the card is showing a picture the shop did not choose:
  .../FHSDK47-15.jpg instead of .../FHSDK47-6.jpg
FAILED test_the_whole_gallery_is_the_shops_sequence_not_just_its_head
FAILED test_the_rank_is_decoded_as_a_number_not_compared_as_text
  ['image', 'image_1', 'image_10', 'image_11', 'image_2', ...]
FAILED test_the_export_hands_over_the_same_sequence_as_the_card
```

The fixture — `tests/fixtures/live/elsewedyshop_gallery_order_2026-08-01.json`,
captured live, 3 requests, no image file downloaded — is chosen so the two
orders **disagree**: the shop leads with `FHSDK47-6.jpg`, which sorts **7th of
7** alphabetically. A fixture whose orders agree passes with the defect fully in
place, which is how this survived; a test asserts that property of the fixture
itself so it cannot rot into a tautology. A second product guards the opposite
mistake (a gallery the alphabet already agreed with must come out unchanged) and
a third is the one-picture common case.

## Not fixed here — defect B, SIKAEGSHOP

SIKAEGSHOP keys its codes on the shop's attachment id, **deliberately**
([custom_json.py:583](scrapex/connectors/custom_json.py:583) — an id survives
the shop reordering its list, which a position would not). No read-side sort can
recover a position that was never stored, so its 68 changed products move to
attachment-id order, not to a primacy anyone can defend.

Its payload states both, and the connector reads neither. From
`tests/fixtures/sikaegshop_detail_252.json`:

```
list#  att_id  sort_order  is_primary  file_name
0      3105    1           True        Sika Backing Rod  (1).jpg   <- the shop's own primary
1      3106    2           False       170A3566.jpg                <- what the card shows today
```

`grep -rn "is_primary\|sort_order" scrapex/` returns nothing. That is a
capture-side change plus a re-crawl, and **where the rank should live** — a real
position column on `source_product_attribute`, or a second code scheme — is the
owner's call, not mine. Happy to open it as its own issue with the numbers.

## Coordination

No conflict expected with #43. Zero file overlap: it touches `jsonld.py`,
`salla.py`, `zid.py`, `sources.yaml` and its own fixtures/tests (capture side);
this touches `reports.py`, `grid.js` and its own fixture/test (read side). Its
new `image` / `image_N` rows land in the convention this PR now reads correctly,
so the two compose — #43 stores more pictures, this one shows them in the shop's
order.

## Rules respected

- `PAYLOAD_VERSION` / `PAYLOAD_COMPAT_VERSION` / `GENERATION_OF_VERSION`
  untouched — no row column was needed.
- No migration. Images already have a home.
- No re-crawl, no engine restart. `/api/jobs` checked first: the last job
  finished 2026-07-30 13:35Z, nothing running.
- Live warehouse opened read-only throughout
  (`sqlite3.connect(f"file:{path}?mode=ro", uri=True)`).
- No image file downloaded — the URL is the record.
- No machine translation and no `_ar` pair invented (this shop publishes no alt
  text at all, 1,442 of 1,442 null).

**Draft — do not merge.** Awaiting the main session's review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
