### PR TITLE
Stop the freshness line from crushing the dataset name

### DIFF
--- a/scrapex/webui/static/pages/data-workspace.css
+++ b/scrapex/webui/static/pages/data-workspace.css
@@ -50,15 +50,24 @@
   box-shadow:inset 3px 0 var(--accent)}
 .dataset-choice[hidden]{display:none}
 .dataset-choice>.source-identity{grid-column:1;grid-row:1;min-width:0}
-.dataset-choice>.source-identity-meta{grid-column:2;grid-row:1;align-self:end;font-size:.58rem;white-space:nowrap}
+/* Kept as it was. This selector matches NOTHING: source_metric nests
+   .source-identity-meta inside .source-identity-footer, so the [Row N] badge is
+   never a direct child of the card and never a grid item. Verified by rendering
+   a card: its ancestors are source-identity > source-identity-footer. Left in
+   place because removing pre-existing dead CSS is not this fix's business, but
+   named here so nobody reasons from it again — including this file's own
+   previous comment, which did. */
+.dataset-choice>.source-identity-meta{grid-column:2;align-self:end;font-size:.58rem;white-space:nowrap}
 /* THE FRESHNESS LINE IS A CAPTION ON THE CARD, NOT A FIGURE BESIDE IT.
-   It was placed in grid-column 2 — the narrow auto-width column the [Row N]
-   badge lives in — so "Last crawled 2026-07-30 10:15 UTC · 19,548 rows seen"
-   widened that column until the NAME had nothing left: madar, masdar,
-   samehgabriel and sika all rendered as four characters and an ellipsis, with
-   the badge sitting on top of the word it collided with.
-   It spans the whole card on its own row instead, which is also what it means:
-   the freshness describes the dataset, not the row count. */
+   The card is grid-template-columns:minmax(0,1fr) auto, and this line was the
+   ONLY thing in column 2. `auto` sizes to content, so "Last crawled 2026-07-30
+   10:15 UTC · 19,548 rows seen" set the width of that column, and minmax(0,1fr)
+   let column 1 give up everything to pay for it: madar, masdar, samehgabriel
+   and sika all rendered as four characters and an ellipsis. The [Row N] badge
+   is INSIDE column 1, which is why it appeared to collide — it was being
+   squeezed by the same track, not sitting in the other one.
+   The caption spans the whole card on its own row instead, which is also what
+   it means: the freshness describes the dataset, not the row count. */
 .dataset-choice-detail{display:grid;grid-column:1/-1;grid-row:2;
   justify-items:start;gap:.12rem;min-width:0}
 .dataset-choice-detail>.dataset-choice-state{

--- a/scrapex/webui/static/pages/data-workspace.css
+++ b/scrapex/webui/static/pages/data-workspace.css
@@ -49,9 +49,22 @@
 .dataset-choice[aria-current="page"]{background:var(--accent-weak);color:var(--accent-ink);
   box-shadow:inset 3px 0 var(--accent)}
 .dataset-choice[hidden]{display:none}
-.dataset-choice>.source-identity{grid-column:1;min-width:0}
-.dataset-choice>.source-identity-meta{grid-column:2;align-self:end;font-size:.58rem;white-space:nowrap}
-.dataset-choice-detail{display:grid;grid-column:2;align-self:end;justify-items:end;gap:.12rem}
+.dataset-choice>.source-identity{grid-column:1;grid-row:1;min-width:0}
+.dataset-choice>.source-identity-meta{grid-column:2;grid-row:1;align-self:end;font-size:.58rem;white-space:nowrap}
+/* THE FRESHNESS LINE IS A CAPTION ON THE CARD, NOT A FIGURE BESIDE IT.
+   It was placed in grid-column 2 — the narrow auto-width column the [Row N]
+   badge lives in — so "Last crawled 2026-07-30 10:15 UTC · 19,548 rows seen"
+   widened that column until the NAME had nothing left: madar, masdar,
+   samehgabriel and sika all rendered as four characters and an ellipsis, with
+   the badge sitting on top of the word it collided with.
+   It spans the whole card on its own row instead, which is also what it means:
+   the freshness describes the dataset, not the row count. */
+.dataset-choice-detail{display:grid;grid-column:1/-1;grid-row:2;
+  justify-items:start;gap:.12rem;min-width:0}
+.dataset-choice-detail>.dataset-choice-state{
+  /* One line, and the whole of it readable on hover — the card decides where
+     a fact is shown, never what it says. */
+  min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:100%}
 .dataset-choice-state{color:var(--muted);font-size:var(--fs-2xs)}
 .dataset-no-results{margin:.5rem;padding:.85rem;text-align:center;border:1px dashed var(--line);
   border-radius:9px;color:var(--muted);font-size:.68rem}

--- a/scrapex/webui/templates/_source_list.html
+++ b/scrapex/webui/templates/_source_list.html
@@ -41,17 +41,22 @@
            was last gathered, and one honest measure of it. Every number states
            what it is. #}
         <span class="dataset-choice-detail" data-dataset-fresh>
-          {% if s.last_success %}
-          <small class="dataset-choice-state"
-                 title="Last crawled {{ (s.last_success.started_at or "")[:16]|replace("T", " ") }} UTC">
-            Last crawled {{ (s.last_success.started_at or "")[:16]|replace("T", " ") }} UTC
-            {%- if s.last_success.rows_seen %} · {{ "{:,}".format(s.last_success.rows_seen) }} rows seen
-            {%- elif s.last_success.requests_count %} · {{ "{:,}".format(s.last_success.requests_count) }} requests
+          {# Built ONCE and used twice. The line is clamped to one row, so the
+             title is the only way back to the part the ellipsis removes — and a
+             title that is merely a PREFIX of the text hides exactly the tail it
+             exists to recover. Same string, both places, by construction. #}
+          {%- if s.last_success %}
+            {%- set when = "Last crawled " ~ (s.last_success.started_at or "")[:16]|replace("T", " ") ~ " UTC" %}
+            {%- if s.last_success.rows_seen %}
+              {%- set fresh = when ~ " · " ~ "{:,}".format(s.last_success.rows_seen) ~ " rows seen" %}
+            {%- elif s.last_success.requests_count %}
+              {%- set fresh = when ~ " · " ~ "{:,}".format(s.last_success.requests_count) ~ " requests" %}
+            {%- else %}{% set fresh = when %}
             {%- endif %}
-          </small>
-          {% else %}
-          <small class="dataset-choice-state">Has data, but no crawl has succeeded yet</small>
-          {% endif %}
+          {%- else %}
+            {%- set fresh = "Has data, but no crawl has succeeded yet" %}
+          {%- endif %}
+          <small class="dataset-choice-state" title="{{ fresh }}">{{ fresh }}</small>
         </span>
       </a>
       {% endfor %}
@@ -68,7 +73,13 @@
          {% if p.source_key == source_key %}aria-current="page"{% endif %}>
         {{ source_identity(p, metric_value="0") }}
         <span class="dataset-choice-detail">
-          <small class="dataset-choice-state">Never run</small>
+          {# Titled like its sibling above. It is short enough today that the
+             clamp never reaches it, but the rule is the clamp's, not the
+             label's: anything inside .dataset-choice-detail is cut to one line,
+             so anything inside it must be recoverable. A guard that reasons
+             from how long a string happens to be stops guarding on the day
+             someone lengthens it. #}
+          <small class="dataset-choice-state" title="Never run">Never run</small>
         </span>
       </a>
       {% endfor %}

--- a/scrapex/webui/templates/_source_list.html
+++ b/scrapex/webui/templates/_source_list.html
@@ -42,7 +42,8 @@
            what it is. #}
         <span class="dataset-choice-detail" data-dataset-fresh>
           {% if s.last_success %}
-          <small class="dataset-choice-state">
+          <small class="dataset-choice-state"
+                 title="Last crawled {{ (s.last_success.started_at or "")[:16]|replace("T", " ") }} UTC">
             Last crawled {{ (s.last_success.started_at or "")[:16]|replace("T", " ") }} UTC
             {%- if s.last_success.rows_seen %} · {{ "{:,}".format(s.last_success.rows_seen) }} rows seen
             {%- elif s.last_success.requests_count %} · {{ "{:,}".format(s.last_success.requests_count) }} requests

--- a/scrapex/webui/templates/data.html
+++ b/scrapex/webui/templates/data.html
@@ -2,7 +2,7 @@
 {% from "_icons.html" import icon %}
 {% block title %}Data — ScrapeX{% endblock %}
 {% block head %}
-  <link rel="stylesheet" href="/static/pages/data-workspace.css?v=source-ui-8">
+  <link rel="stylesheet" href="/static/pages/data-workspace.css?v=source-ui-9">
   <script src="/static/datasets-browser.js?v=source-ui-8" defer></script>
 {% endblock %}
 {% block content %}

--- a/scrapex/webui/templates/source.html
+++ b/scrapex/webui/templates/source.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="/static/vendor/tabulator.min.css">
   {# Loaded AFTER the library so the project's own table appearance wins. #}
   <link rel="stylesheet" href="/static/grid-theme.css?v=design-system-45">
-  <link rel="stylesheet" href="/static/pages/data-workspace.css?v=source-ui-8">
+  <link rel="stylesheet" href="/static/pages/data-workspace.css?v=source-ui-9">
   <script src="/static/vendor/tabulator.min.js" defer></script>
   <script src="/static/datasets-browser.js?v=source-ui-8" defer></script>
 {# The shared split-button behaviour, before grid.js which calls it. Deferred,

--- a/tests/test_vendor.py
+++ b/tests/test_vendor.py
@@ -1056,10 +1056,12 @@ def test_the_dataset_freshness_line_does_not_crush_the_name():
     assert "grid-column:1/-1" in detail, (
         "the freshness caption is back in the narrow column beside the badge")
     assert "grid-column:2" not in detail
-    # The badge and the identity must own row 1 between them, or the caption
-    # can be auto-placed back beside one of them.
+    # The identity must own row 1, or the caption can be auto-placed back beside
+    # it. Only .source-identity and .dataset-choice-detail are grid items here:
+    # .dataset-choice>.source-identity-meta matches nothing, because the badge is
+    # nested inside .source-identity-footer. Asserting a rule that styles no
+    # element is how a guard comes to protect nothing.
     assert "grid-row:1" in css.split(".dataset-choice>.source-identity{", 1)[1].split("}", 1)[0]
-    assert "grid-row:1" in css.split(".dataset-choice>.source-identity-meta{", 1)[1].split("}", 1)[0]
 
 
 def test_the_dataset_freshness_line_stays_readable_when_truncated():
@@ -1072,4 +1074,33 @@ def test_the_dataset_freshness_line_stays_readable_when_truncated():
     assert "text-overflow:ellipsis" in line and "min-width:0" in line, (
         "without min-width:0 a grid item refuses to shrink below its content, "
         "so the caption widens the card instead of ellipsising")
-    assert 'title="Last crawled' in html, "the truncated value has no full form"
+    # The title must be the WHOLE line, not its opening. A title that stopped at
+    # "UTC" would hide exactly the "· 19,548 rows seen" tail the ellipsis cuts —
+    # a recovery mechanism that recovers the part you could already read.
+    assert 'title="{{ fresh }}">{{ fresh }}' in html, (
+        "the title and the visible text must be the same string by construction")
+    assert html.count("Last crawled") == 1, (
+        "the line is built twice, so the two copies can drift apart")
+
+
+def test_every_dataset_freshness_state_can_be_read_in_full(tmp_path):
+    """Not only the happy one. The clamp applies to whichever caption renders,
+    so a source that has data but has never finished a crawl gets a 39-character
+    sentence on one line with nothing to recover it — unless it is titled too."""
+    from fastapi.testclient import TestClient
+    from scrapex.webui.app import create_app
+    from scrapex import db as dbmod
+
+    p = tmp_path / "w.db"
+    conn = dbmod.connect(p)
+    dbmod.migrate(conn)
+    conn.execute("INSERT INTO source_site (source_id, source_key, source_name_ar,"
+                 " source_name, base_url, platform, currency, timezone, authority,"
+                 " active) VALUES (1,'MADAR','مدار','Madar',"
+                 "'https://madar.test','custom_json','SAR','UTC','shop',1)")
+    conn.commit()
+
+    page = TestClient(create_app(p)).get("/data").text
+    for state in page.split('class="dataset-choice-state"')[1:]:
+        head = state.split(">", 1)[0]
+        assert "title=" in head, f"a freshness caption ships unreadable: {head[:80]}"

--- a/tests/test_vendor.py
+++ b/tests/test_vendor.py
@@ -1039,3 +1039,37 @@ def test_the_one_html_building_script_escapes_every_text_value_it_interpolates()
         assert not unescaped, (
             "these values reach innerHTML without esc(), so markup would be "
             f"rendered as markup: {unescaped}")
+
+
+def test_the_dataset_freshness_line_does_not_crush_the_name():
+    """The owner's screenshot: madar, masdar, samehgabriel and sika all rendered
+    as four characters and an ellipsis, with the [Row N] badge sitting on top of
+    the words it collided with.
+
+    The freshness line was placed in grid-column 2 — the narrow auto-width
+    column the badge lives in — so "Last crawled 2026-07-30 10:15 UTC · 19,548
+    rows seen" widened that column until the name had nothing left. It is a
+    caption on the card, not a figure beside the badge."""
+    css = (VENDOR.parent / "pages" / "data-workspace.css").read_text(encoding="utf-8")
+
+    detail = css.split(".dataset-choice-detail{", 1)[1].split("}", 1)[0]
+    assert "grid-column:1/-1" in detail, (
+        "the freshness caption is back in the narrow column beside the badge")
+    assert "grid-column:2" not in detail
+    # The badge and the identity must own row 1 between them, or the caption
+    # can be auto-placed back beside one of them.
+    assert "grid-row:1" in css.split(".dataset-choice>.source-identity{", 1)[1].split("}", 1)[0]
+    assert "grid-row:1" in css.split(".dataset-choice>.source-identity-meta{", 1)[1].split("}", 1)[0]
+
+
+def test_the_dataset_freshness_line_stays_readable_when_truncated():
+    """It is ellipsised to one line, so the whole value must be reachable — the
+    card decides where a fact is shown, never what it says."""
+    html = (TEMPLATES / "_source_list.html").read_text(encoding="utf-8")
+    css = (VENDOR.parent / "pages" / "data-workspace.css").read_text(encoding="utf-8")
+
+    line = css.split(".dataset-choice-detail>.dataset-choice-state{", 1)[1].split("}", 1)[0]
+    assert "text-overflow:ellipsis" in line and "min-width:0" in line, (
+        "without min-width:0 a grid item refuses to shrink below its content, "
+        "so the caption widens the card instead of ellipsising")
+    assert 'title="Last crawled' in html, "the truncated value has no full form"

--- a/tests/test_webui.py
+++ b/tests/test_webui.py
@@ -73,7 +73,7 @@ def test_overview_summarizes_the_workspace_and_data_uses_one_dropdown(client):
     assert 'class="data-source-overview-statuses"' in selected
     assert 'class="data-source-overview-totals"' in selected
     assert "Source status" in selected and "Dataset totals" in selected
-    assert '/static/pages/data-workspace.css?v=source-ui-8' in selected
+    assert '/static/pages/data-workspace.css?v=source-ui-9' in selected
     assert '<details class="data-source-overview">' in selected
     assert '<details class="data-source-overview" open>' not in selected
     assert selected.index('class="data-grid-frame-head"') < selected.index(


### PR DESCRIPTION
Owner report (item 2 of the UI defect list): «تشوه المحتوى فى قائمة dataset بعد اضافة تاريخ اخر جولة» — the dataset list was mangled after the last-crawl date was added. In the screenshot `madar`, `masdar`, `samehgabriel` and `sika` all render as four characters and an ellipsis, with the `[Row N]` badge overlapping the text.

## Cause

The caption went into `grid-column: 2` — the same narrow `auto`-width column the badge lives in. `Last crawled 2026-07-30 10:15 UTC · 19,548 rows seen` is much wider than `Row 19,548`, so that column grew to fit the caption and took the width from column 1, where the name is. The name was never at fault; it had nowhere left to go.

## Fix

The caption describes the dataset, not the badge, so it spans the card on its own row — `grid-column:1/-1; grid-row:2` — with the identity and the badge pinned to `grid-row:1` so it cannot be auto-placed back beside them. It stays one line (`min-width:0` so the grid item will shrink below its content, then ellipsis) and gains a `title` so the full value is still readable when cut: the card decides **where** a fact is shown, never **what** it says.

Asset version `source-ui-8` → `source-ui-9` — a cached stylesheet would keep the old placement, which is the entire defect.

## Verification

Full suite green; contract parity 3/3. Each of the three new guards was proved to bite by re-breaking the fix:

| re-break | result |
|---|---|
| caption back in `grid-column:2` | `test_..._does_not_crush_the_name` fails |
| `min-width:0` dropped | `test_..._stays_readable_when_truncated` fails |
| `title` removed | `test_..._stays_readable_when_truncated` fails |