### PR TITLE
The version notice compares before it accuses

### DIFF
--- a/contracts/version-vectors.json
+++ b/contracts/version-vectors.json
@@ -1,6 +1,7 @@
 {
   "version": "0.2.0",
   "minimum_extension_version": "0.2.0",
+  "capability_reporting_since": "0.2.0",
   "note": "Both copies of capabilityProblem must reproduce every `problem` string exactly. Python: scrapex/version.py. JavaScript: extension/version.js.",
   "cases": [
     {

--- a/extension/app.js
+++ b/extension/app.js
@@ -9,7 +9,7 @@
 // Arabic renders right-to-left without disturbing the English chrome around it.
 import { checkEngine, getBackend, setBackend } from "./engine.js";
 import { autostartStatus, setAutostart, startEngine } from "./transport.js";
-import { capabilityProblem, deployedFrom, installedVersion } from "./version.js";
+import { capabilityProblem, deployedFrom, installedVersion, CAPABILITY_REPORTING_SINCE, isOlder } from "./version.js";
 
 const $ = (id) => document.getElementById(id);
 const esc = (v) => String(v ?? "").replace(/[&<>"']/g,
@@ -332,15 +332,45 @@ function renderVersionNotice(engine) {
     return;
   }
   if (!report && engine.reachable && engine.version) {
-    // The other direction, and it needs different words: this extension is the
-    // newer of the two and the engine cannot even state what it deploys.
+    // The engine is silent about its features. That is ONE fact, and it has
+    // three different causes, so it cannot have one sentence.
+    //
+    // The first version of this printed "the engine is older than this
+    // extension" without ever comparing the two numbers, and prescribed
+    // "update the engine to <the extension's own version>". With both sides at
+    // 0.1.0 the owner got a card that contradicted itself twice: a claim of
+    // "older" that the two numbers printed directly beneath it denied, and an
+    // instruction to update to the version already installed. A remedy you
+    // have already carried out is not a remedy.
+    const engineIsOlder = installed && isOlder(engine.version, installed);
+    const bothPredateReporting = isOlder(engine.version, CAPABILITY_REPORTING_SINCE);
+    let title;
+    let remedy;
+    if (engineIsOlder) {
+      title = "The ScrapeX engine is older than this extension";
+      remedy = `Update the engine to ${esc(installed)}.`;
+    } else if (bothPredateReporting) {
+      // Same number, or a newer engine, and below the line where reporting
+      // began. Nothing is "behind" anything; both sides are simply early.
+      title = "This ScrapeX engine cannot say what it deploys";
+      remedy = `Version reporting starts at ${esc(CAPABILITY_REPORTING_SINCE)}. ` +
+        `Update the engine and the extension to ${esc(CAPABILITY_REPORTING_SINCE)} ` +
+        `or newer.`;
+    } else {
+      // It claims a version that DOES report, and reported nothing: the files
+      // on disk moved and the process did not. Restarting is the whole fix,
+      // and sending the owner to download something would waste their time.
+      title = "This ScrapeX engine is not reporting what it deploys";
+      remedy = `Version ${esc(engine.version)} publishes a capability report and ` +
+        `this one did not, so the running engine is older than its own files. ` +
+        `Restart the engine.`;
+    }
     notice.innerHTML =
-      `<div class="setup-title">The ScrapeX engine is older than this extension</div>` +
+      `<div class="setup-title">${title}</div>` +
       `<div class="kv"><span>Installed extension</span><span class="tech">${esc(installed || "unknown")}</span></div>` +
       `<div class="kv"><span>Engine</span><span class="tech">${esc(engine.version)}</span></div>` +
-      `<div class="muted text-sm mt-2">This engine does not report which features it ` +
-      `deploys, so nothing here can promise a feature will work. Update the engine ` +
-      `to ${esc(installed || "the extension's version")}.</div>`;
+      `<div class="muted text-sm mt-2">Nothing here can promise a feature will ` +
+      `work until it does. ${remedy}</div>`;
     notice.classList.remove("hidden");
     return;
   }

--- a/extension/app.js
+++ b/extension/app.js
@@ -348,7 +348,13 @@ function renderVersionNotice(engine) {
     let remedy;
     if (engineIsOlder) {
       title = "The ScrapeX engine is older than this extension";
-      remedy = `Update the engine to ${esc(installed)}.`;
+      // The engine runs on this machine, from the same checkout. It reports
+      // the version of the CODE THAT IS RUNNING, which after a pull is older
+      // than the code on disk until the process is restarted — and that is the
+      // common case, not the rare one. "Update" alone sends the owner looking
+      // for a download they already have.
+      remedy = `Update the engine to ${esc(installed)} — and if its files are ` +
+        `already ${esc(installed)}, restart it so it loads them.`;
     } else if (bothPredateReporting) {
       // Same number, or a newer engine, and below the line where reporting
       // began. Nothing is "behind" anything; both sides are simply early.

--- a/extension/app.js
+++ b/extension/app.js
@@ -348,20 +348,26 @@ function renderVersionNotice(engine) {
     let remedy;
     if (engineIsOlder) {
       title = "The ScrapeX engine is older than this extension";
-      // The engine runs on this machine, from the same checkout. It reports
-      // the version of the CODE THAT IS RUNNING, which after a pull is older
-      // than the code on disk until the process is restarted — and that is the
-      // common case, not the rare one. "Update" alone sends the owner looking
-      // for a download they already have.
-      remedy = `Update the engine to ${esc(installed)} — and if its files are ` +
-        `already ${esc(installed)}, restart it so it loads them.`;
+      // Lead with the action, and name where it is. The engine runs on this
+      // machine from the same checkout and reports the version of the code
+      // RUNNING, not the code on disk — so after a pull it is behind until the
+      // process restarts, which is the ordinary case. The reader cannot see
+      // which version is on disk, so do not make the instruction depend on it:
+      // restart first, because it is free and fixes the common case, and let
+      // the number afterwards decide whether anything else is needed.
+      remedy = `Press "Restart engine" on the ScrapeX Settings page. If it ` +
+        `still reports ${esc(engine.version)} afterwards, its files really are ` +
+        `older and need updating to ${esc(installed)}.`;
     } else if (bothPredateReporting) {
       // Same number, or a newer engine, and below the line where reporting
       // began. Nothing is "behind" anything; both sides are simply early.
       title = "This ScrapeX engine cannot say what it deploys";
-      remedy = `Version reporting starts at ${esc(CAPABILITY_REPORTING_SINCE)}. ` +
-        `Update the engine and the extension to ${esc(CAPABILITY_REPORTING_SINCE)} ` +
-        `or newer.`;
+      // Both sides are early, so both have to move — and each moves a different
+      // way, so both ways are named.
+      remedy = `Version reporting starts at ${esc(CAPABILITY_REPORTING_SINCE)}, ` +
+        `and both sides are below it. Update the files, then press "Restart ` +
+        `engine" on the ScrapeX Settings page and reload this extension from ` +
+        `chrome://extensions.`;
     } else {
       // It claims a version that DOES report, and reported nothing: the files
       // on disk moved and the process did not. Restarting is the whole fix,
@@ -369,7 +375,8 @@ function renderVersionNotice(engine) {
       title = "This ScrapeX engine is not reporting what it deploys";
       remedy = `Version ${esc(engine.version)} publishes a capability report and ` +
         `this one did not, so the running engine is older than its own files. ` +
-        `Restart the engine.`;
+        `Press "Restart engine" on the ScrapeX Settings page — there is nothing ` +
+        `to download.`;
     }
     notice.innerHTML =
       `<div class="setup-title">${title}</div>` +

--- a/extension/tests/version-compat.test.mjs
+++ b/extension/tests/version-compat.test.mjs
@@ -13,7 +13,8 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
-import { capabilityProblem, isOlder, parseVersion } from "../version.js";
+import { CAPABILITY_REPORTING_SINCE, capabilityProblem, isOlder,
+         parseVersion } from "../version.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const VECTORS = JSON.parse(
@@ -52,5 +53,33 @@ test("a version that is not a version is refused, never read as very old", () =>
   // missing and send the owner to reload an extension that is current.
   for (const bad of ["", "0.2", "0.2.0.1", "v0.2.0", "0.2.x"]) {
     assert.throws(() => parseVersion(bad), /not a ScrapeX version/);
+  }
+});
+
+
+test("the reporting floor is the contract's, not a second opinion", () => {
+  assert.equal(CAPABILITY_REPORTING_SINCE, VECTORS.capability_reporting_since,
+    "extension/version.js and scrapex/version.py disagree about the first " +
+    "version that reports capabilities; the remedy sentence would then name " +
+    "a version one side does not believe in");
+});
+
+test("no refusal ever prescribes a version you already have", () => {
+  // The owner's card said "Update the engine to 0.1.0" while showing 0.1.0
+  // installed. A remedy that has already been carried out is not a remedy, and
+  // every sentence these functions produce is a remedy.
+  for (const c of VECTORS.cases) {
+    const problem = capabilityProblem(c.key, {
+      extensionVersion: c.extension_version,
+      engineVersion: c.engine_version,
+      deployed: c.deployed,
+      updateInstructions: c.update_instructions || "",
+    });
+    if (!problem) continue;
+    const told = problem.match(/[Uu]pdate the engine to ([0-9]+\.[0-9]+\.[0-9]+)/);
+    if (!told) continue;
+    assert.ok(isOlder(c.engine_version, told[1]),
+      `"${c.name}" tells the owner to update the engine to ${told[1]} ` +
+      `while it is already ${c.engine_version}`);
   }
 });

--- a/extension/version.js
+++ b/extension/version.js
@@ -40,6 +40,13 @@ export function parseVersion(value) {
 }
 
 // True when `left` is strictly behind `right`.
+// The Python twin lives in scrapex/version.py and the shared contract carries
+// it, so the two cannot drift: the first engine that publishes a capability
+// report at all. Below this line, silence means "too old to say", and the
+// remedy is to reach THIS version — not whatever number the extension happens
+// to wear. Both sides can sit at the same version and both be below it.
+export const CAPABILITY_REPORTING_SINCE = "0.2.0";
+
 export function isOlder(left, right) {
   const a = parseVersion(left);
   const b = parseVersion(right);

--- a/scrapex/version.py
+++ b/scrapex/version.py
@@ -211,6 +211,14 @@ def _newest(versions: tuple[str, ...]) -> str:
 # capability costs the extension nothing, which is what keeps an engine-side
 # improvement from telling the owner to go and reload a browser for no reason.
 # (The same logic as the payload contract's additive changes being free.)
+# The first engine that publishes a capability report at all. Before it, an
+# engine's silence about its features means "too old to say", never "does not
+# have them" — and the remedy is to reach THIS version, not to reach whatever
+# number the extension happens to wear. An engine and an extension can sit at
+# the same number and both be below this line; telling the owner to update to
+# the number already installed is not a remedy, it is a loop.
+CAPABILITY_REPORTING_SINCE = "0.2.0"
+
 MINIMUM_EXTENSION_VERSION = _newest(tuple(
     capability.since for capability in CAPABILITIES
     if Surface.PANEL in capability.surfaces
@@ -386,6 +394,7 @@ def export_vectors() -> dict:
     return {
         "version": VERSION,
         "minimum_extension_version": MINIMUM_EXTENSION_VERSION,
+        "capability_reporting_since": CAPABILITY_REPORTING_SINCE,
         "note": "Both copies of capabilityProblem must reproduce every `problem` "
                 "string exactly. Python: scrapex/version.py. JavaScript: "
                 "extension/version.js.",
@@ -418,6 +427,7 @@ def version_report(extension_version: str | None = None) -> dict:
         "latest_extension_version": VERSION,
         "latest_source": LATEST_SOURCE,
         "minimum_extension_version": MINIMUM_EXTENSION_VERSION,
+        "capability_reporting_since": CAPABILITY_REPORTING_SINCE,
         "update_instructions": UPDATE_INSTRUCTIONS,
         "capabilities": [
             {"key": capability.key, "since": capability.since,

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -1583,6 +1583,44 @@ def test_an_engine_older_than_the_extension_says_so_in_different_words(open_pane
     assert not page.js_errors
 
 
+def test_two_sides_at_the_same_version_are_not_told_one_is_older(open_panel):
+    """The owner's screenshot. Installed extension 0.1.0, Engine 0.1.0, and a
+    heading that said the engine was OLDER than the extension — contradicted by
+    the two numbers printed directly beneath it — followed by "Update the engine
+    to 0.1.0", which is the version already installed.
+
+    The branch fired on the engine's silence and never compared the two numbers.
+    Silence has three causes and they do not share a remedy: an engine really
+    behind, both sides below the line where reporting began, or a process that
+    did not restart when its files did."""
+    page = open_panel(extension_version="0.1.0", engine_version="0.1.0",
+                      version_reporting=False)
+
+    text = page.locator("#version-notice").inner_text()
+    assert "older than this extension" not in text.lower(), (
+        "it called the engine older than an extension of the same version")
+    assert "update the engine to 0.1.0" not in text.lower(), (
+        "the remedy is the version already installed")
+    assert "0.2.0" in text, "the sentence must name a version that would help"
+    assert not page.js_errors
+
+
+def test_an_engine_at_a_reporting_version_that_stays_silent_is_told_to_restart(open_panel):
+    """The third cause, and the only one where downloading anything is wasted
+    effort: the files on disk moved to a version that publishes a report, and
+    the running process did not. Nothing to install — restart it."""
+    page = open_panel(extension_version="0.2.0", engine_version="0.2.0",
+                      version_reporting=False)
+
+    text = page.locator("#version-notice").inner_text().lower()
+    assert "restart" in text, "a stale process was sent to download something"
+    # "older than its own files" is the true and useful sentence here. The claim
+    # this guards against is the other one: older than the EXTENSION, which at
+    # equal versions is false.
+    assert "older than this extension" not in text
+    assert not page.js_errors
+
+
 def test_an_unsupported_feature_fails_with_a_version_error_not_a_generic_one(open_panel):
     """Section 1.6. An engine that does not deploy `crawl_parallel_sources`
     answers the save with 400 "unknown setting 'crawl_parallel_sources'" — a

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -1578,6 +1578,13 @@ def test_an_engine_older_than_the_extension_says_so_in_different_words(open_pane
     text = page.locator("#version-notice").inner_text()
     assert "engine is older" in text.lower()
     assert "0.1.0" in text and "0.2.0" in text, "both versions must be named"
+    # The engine is local and started from the same checkout, so it reports the
+    # version of the code RUNNING, not the code on disk. After a pull those
+    # differ until the process restarts, and that is the ordinary case — a
+    # remedy that only says "update" sends the owner hunting for a download
+    # they already have.
+    assert "restart" in text.lower(), (
+        "the usual fix for a locally-run engine is not mentioned")
     assert "chrome://extensions" not in text, (
         "it told the owner to reload the extension for a stale engine")
     assert not page.js_errors

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -1583,8 +1583,13 @@ def test_an_engine_older_than_the_extension_says_so_in_different_words(open_pane
     # differ until the process restarts, and that is the ordinary case — a
     # remedy that only says "update" sends the owner hunting for a download
     # they already have.
-    assert "restart" in text.lower(), (
+    assert "restart engine" in text.lower(), (
         "the usual fix for a locally-run engine is not mentioned")
+    # A reader cannot see which version is on disk, so an instruction that
+    # branches on it is not an instruction. Restart first — it is free and it
+    # fixes the common case — and let the number afterwards decide the rest.
+    assert text.lower().index("restart engine") < text.lower().index("updat"), (
+        "it asks the reader to decide something they cannot see before acting")
     assert "chrome://extensions" not in text, (
         "it told the owner to reload the extension for a stale engine")
     assert not page.js_errors


### PR DESCRIPTION
Reported from the panel: a card headed **"The ScrapeX engine is older than this extension"**, with `Installed extension 0.1.0` and `Engine 0.1.0` printed directly beneath it, ending in **"Update the engine to 0.1.0."**

Two false statements on one card. The heading is contradicted by the two numbers under it, and the remedy is the version already installed.

## Cause

The branch fired on one fact — the engine published no capability report — and asserted a second one it never checked:

```js
if (!report && engine.reachable && engine.version) {
  notice.innerHTML =
    `<div class="setup-title">The ScrapeX engine is older than this extension</div>` + ...
    `Update the engine to ${esc(installed || "the extension's version")}.`
```

No comparison anywhere. And the remedy is built from the *extension's* version, so whenever the two sides match it prescribes what is already installed.

## Fix

Silence has three causes and they do not share a remedy:

| state | sentence | remedy |
|---|---|---|
| engine really is older | "The ScrapeX engine is older than this extension" | update the engine to the extension's version |
| both below the reporting floor | "This ScrapeX engine cannot say what it deploys" | update **both** to `CAPABILITY_REPORTING_SINCE` — the only number that changes anything |
| engine claims a reporting version and reported nothing | "This ScrapeX engine is not reporting what it deploys" | **restart it** — the files moved and the process did not; downloading anything is wasted effort |

`CAPABILITY_REPORTING_SINCE` is named on both sides and carried in the shared `version-vectors.json`, so the remedy cannot name a version one half does not believe in. It also reaches the live `/api/version` report, not just the test vectors.

## Guards

- `test_two_sides_at_the_same_version_are_not_told_one_is_older` — the reported case exactly
- `test_an_engine_at_a_reporting_version_that_stays_silent_is_told_to_restart` — the third cause
- `no refusal ever prescribes a version you already have` — walks every contract vector and fails any "Update the engine to X" where the engine is already at or past X
- `the reporting floor is the contract's, not a second opinion` — binds the two copies of the constant

**Proved to bite:** restoring the unconditional `engineIsOlder = true` fails both DOM tests; restored, all three pass. `node --test extension/tests` 19/19.
