### PR TITLE
The panel can do everything the page can

### DIFF
--- a/extension/app.html
+++ b/extension/app.html
@@ -833,6 +833,17 @@
                   <button id="recheck" class="ghost">Recheck status</button>
                   <button id="diagnostics" class="ghost">Run diagnostics</button>
                 </div>
+                <!-- The two repair actions, beside the status they repair. They
+                     used to live only on the web Settings page, so the panel —
+                     the application — had to send the owner somewhere else to
+                     perform the most important thing they can do to a stuck
+                     engine. The panel is the control room: nothing the page can
+                     do may be missing here. -->
+                <div class="links mt-2" id="runtime-actions">
+                  <button id="runtime-restart" class="ghost">Restart engine</button>
+                  <button id="runtime-upgrade" class="ghost">Upgrade database</button>
+                </div>
+                <div id="runtime-note" class="muted text-xs" role="status"></div>
                 <div id="diag-out" class="muted text-xs"></div>
               </div>
               <label class="muted text-xs" for="backend">Engine URL</label>

--- a/extension/app.js
+++ b/extension/app.js
@@ -2371,6 +2371,82 @@ async function render() {
   refreshRunButton();
 }
 
+// ---- runtime repair, in the panel ------------------------------------------
+//
+// Restart and Upgrade lived only on the web Settings page. The panel is the
+// application, so it was sending the owner to another surface to perform the
+// most important thing they can do to a stuck engine — and the version notice
+// had to name that surface in words, which is how the gap surfaced.
+//
+// Deliberately plain fetch and no `api()`: these two must work on the day the
+// engine is otherwise unhappy, which is the only day they are wanted. api()
+// throws on a non-2xx, and a 404 here is not a failure to report but a fact to
+// explain — an engine that started before these endpoints existed.
+const ENGINE_TOO_OLD =
+  "This engine started before these actions existed, so it does not have them " +
+  "yet. Start it from the Windows Startup folder (Win+R, shell:startup, " +
+  "double-click ScrapeX Engine.vbs), or sign out and in.";
+
+function wireRuntimeRepair() {
+  const note = $("runtime-note");
+  const restart = $("runtime-restart");
+  const upgrade = $("runtime-upgrade");
+  if (!note || !restart || !upgrade) return;
+
+  upgrade.addEventListener("click", async () => {
+    upgrade.disabled = true;
+    note.textContent = "Upgrading the database…";
+    try {
+      const res = await fetch((await getBackend()) + "/api/databases/upgrade",
+                              {method: "POST"});
+      if (res.status === 404) { note.textContent = ENGINE_TOO_OLD; return; }
+      const body = await res.json();
+      note.textContent = res.ok ? body.message
+        : (body.detail || "The upgrade did not run.");
+    } catch (err) {
+      note.textContent = "Could not reach the engine: " + err.message;
+    } finally { upgrade.disabled = false; }
+  });
+
+  restart.addEventListener("click", async () => {
+    restart.disabled = true;
+    note.textContent = "Restarting — the engine goes quiet for a few seconds.";
+    let missing = false;
+    try {
+      const asked = await fetch((await getBackend()) + "/api/engine/restart",
+                                {method: "POST"});
+      missing = asked.status === 404;
+    } catch (_) {
+      // It exits mid-answer. A dead socket here IS the success path, so a
+      // catch that reported an error would call the working case a failure.
+    }
+    if (missing) { note.textContent = ENGINE_TOO_OLD; restart.disabled = false; return; }
+    // Poll until it answers again, then re-render so every version and status
+    // on this screen comes from the engine that is now running.
+    let attempts = 0;
+    const timer = setInterval(async () => {
+      attempts += 1;
+      try {
+        const probe = await fetch((await getBackend()) + "/api/marketlens/health",
+                                  {cache: "no-store"});
+        if (probe.ok) {
+          clearInterval(timer);
+          restart.disabled = false;
+          note.textContent = "The engine is back.";
+          await render();
+          return;
+        }
+      } catch (_) { /* still down, which is expected */ }
+      if (attempts >= 30) {
+        clearInterval(timer);
+        restart.disabled = false;
+        note.textContent = "The engine has not answered in 30 seconds. " +
+          "Start it from the Windows Startup folder, or sign out and in.";
+      }
+    }, 1000);
+  });
+}
+
 async function init() {
   const backend = await getBackend();
   $("backend").value = backend;
@@ -2419,6 +2495,7 @@ async function init() {
       b.setAttribute("aria-expanded", String(!open));
     }));
 
+  wireRuntimeRepair();
   $("recheck").addEventListener("click", render);
   $("setup-recheck").addEventListener("click", render);
   $("engine-start").addEventListener("click", startEngineFromPanel);

--- a/tests/test_settings_live_in_the_extension.py
+++ b/tests/test_settings_live_in_the_extension.py
@@ -21,7 +21,12 @@ PANEL = ROOT / "extension" / "app.html"
 
 # The engine's OWN lifecycle is not a setting: restarting or upgrading the
 # runtime is a repair you may need precisely when the panel cannot reach it.
-# Named here so the exemption is a decision on the record, not a loophole.
+# So these two may appear on the web page.
+#
+# What they may NOT do is appear ONLY there. Owner ruling, 2026-08-01: the
+# extension is the control room, and a capability the page has and the panel
+# lacks is a defect. This set was an exemption list; it is now a parity list,
+# and the test below reads it in the other direction too.
 RUNTIME_REPAIR_IDS = {"runtime-restart", "runtime-upgrade"}
 
 
@@ -39,6 +44,44 @@ def test_the_web_page_offers_no_setting_to_change():
         f"{sorted(stray)}. Settings belong in extension/app.html — a setting "
         "the owner cannot reach from the side panel is a setting he does not "
         "have.")
+
+
+def test_the_panel_can_do_everything_the_web_page_can():
+    """The owner's ruling: «مينفعش يكون فى ميزة على الويب لا توجد فى extension».
+
+    The version notice had to tell him to press "Restart engine" on the web
+    Settings page, because the panel — the application — had no such button.
+    An action that exists on only one of the two surfaces sends the reader
+    somewhere else at the exact moment they most need to act.
+
+    Display may live anywhere. Doing may not live only on the page."""
+    page = WEB_SETTINGS.read_text(encoding="utf-8")
+    panel = PANEL.read_text(encoding="utf-8")
+
+    on_page = {i for i in RUNTIME_REPAIR_IDS if f'id="{i}"' in page}
+    missing = {i for i in on_page if f'id="{i}"' not in panel}
+
+    assert not missing, (
+        f"the web page can do {sorted(missing)} and the side panel cannot. "
+        "Every action on that page must have its equivalent in "
+        "extension/app.html, wired to the same endpoint.")
+
+
+def test_the_panel_repair_buttons_reach_the_same_endpoints():
+    """Present is not the same as wired. A button that renders and does nothing
+    is worse than an absent one: it looks like the feature is broken rather
+    than missing."""
+    script = (ROOT / "extension" / "app.js").read_text(encoding="utf-8")
+
+    # Quoted, so the path must END where it is supposed to. A bare substring
+    # check passed happily on "/api/engine/restart_DISABLED" — it asserted a
+    # prefix, not an endpoint, which is the same shape of mistake as a title
+    # that recovers only the part you could already read.
+    for endpoint in ('"/api/engine/restart"', '"/api/databases/upgrade"'):
+        assert endpoint in script, (
+            f"the panel has no call to {endpoint}, so its button cannot work")
+    assert "runtime-restart" in script and "runtime-upgrade" in script, (
+        "the buttons are in the markup and nothing listens to them")
 
 
 def test_the_crawl_pace_is_reachable_from_the_panel():


### PR DESCRIPTION
**Owner ruling:** «انا عاوز extension غرفة التحكم فى كل شى — يعنى مينفعش يكون فى ميزة على الويب لا توجد فى extension».

## What was wrong

**Restart engine** and **Upgrade database** lived only on the web Settings page. They were a named exemption to "settings live in the extension", justified as *repair* rather than *configuration*. That justification held for where they were **allowed** — but nobody asked whether they were allowed to be there **alone**. They were not.

It surfaced through the version notice, which had to say *"Press Restart engine on the ScrapeX Settings page"*. The owner went looking for it in the panel; it was not there. A control room that redirects you at the moment you most need to act is not a control room.

## What changed

Both buttons are now in the panel, in the **Engine connection** section beside the status they repair, wired to the same endpoints (`POST /api/engine/restart`, `POST /api/databases/upgrade`).

Deliberately plain `fetch` rather than `api()`: these two are wanted precisely on the day the engine is unhappy, `api()` throws on any non-2xx, and a **404 here is not a failure to report but a fact to explain** — an engine that started before these endpoints existed. Restart polls `/api/marketlens/health` and then re-renders, so every version on the screen afterwards comes from the engine that is now running. A dead socket mid-request is the success path, not an error.

## The guard changed direction

`RUNTIME_REPAIR_IDS` was an **exemption** list. It is now a **parity** list, read both ways: what the page can do, the panel must be able to do. A second test covers the other half — *present* is not *wired*, and a button that renders and does nothing looks broken rather than missing.

**Both proved to bite.** The wiring one did **not** at first: it asserted a bare substring, so `"/api/engine/restart_DISABLED"` satisfied it. It asserts the quoted path now — the same shape of mistake as a title that recovers only the part you could already read.

`node --test extension/tests` exit 0 · contract parity exit 0 · panel wiring, the settings rule and the web UI suites exit 0.
