### PR TITLE
Restart could never work, and said it had

### DIFF
--- a/extension/app.js
+++ b/extension/app.js
@@ -2473,16 +2473,26 @@ function wireRuntimeRepair() {
   restart.addEventListener("click", async () => {
     restart.disabled = true;
     note.textContent = "Restarting — the engine goes quiet for a few seconds.";
-    let missing = false;
+    // A thrown fetch is the SUCCESS path — the engine exits mid-answer and the
+    // socket dies. An answered fetch that is not ok is the opposite, and the
+    // first version of this treated both the same: it looked only for 404 and
+    // let every other status fall through to the health poll, which of course
+    // succeeded, because the engine had never gone anywhere. The owner pressed
+    // the button, read "The engine is back.", and nothing had happened. The
+    // engine had in fact answered 500 with a precise reason, and the panel
+    // threw it away.
+    let refused = null;
     try {
       const asked = await fetch((await getBackend()) + "/api/engine/restart",
                                 {method: "POST"});
-      missing = asked.status === 404;
-    } catch (_) {
-      // It exits mid-answer. A dead socket here IS the success path, so a
-      // catch that reported an error would call the working case a failure.
-    }
-    if (missing) { note.textContent = ENGINE_TOO_OLD; restart.disabled = false; return; }
+      if (asked.status === 404) refused = ENGINE_TOO_OLD;
+      else if (!asked.ok) {
+        let detail = `The engine refused (HTTP ${asked.status}).`;
+        try { detail = (await asked.json()).detail || detail; } catch (_) {}
+        refused = detail;
+      }
+    } catch (_) { /* the socket died: it is going down, which is the point */ }
+    if (refused) { note.textContent = refused; restart.disabled = false; return; }
     // Poll until it answers again, then re-render so every version and status
     // on this screen comes from the engine that is now running.
     let attempts = 0;

--- a/scrapex/relaunch.py
+++ b/scrapex/relaunch.py
@@ -88,9 +88,37 @@ def open_engine_log(path: Path | None = None):
     return open(target, "ab")
 
 
+def _restart_log(log: Path) -> Path:
+    """Where a helper writes when the engine still owns the main log.
+
+    Deliberately a sibling and not a temp file: it is read by the same person,
+    from the same folder, on the same bad day.
+    """
+    return log.with_suffix(log.suffix + ".restart")
+
+
 def _spawn_detached(command: list[str], cwd: Path, log: Path) -> int:
-    """Start a process that survives this one. Its output goes to the engine log."""
-    handle = open_engine_log(log)
+    """Start a process that survives this one. Its output goes to the engine log.
+
+    Unless it cannot. On Windows the LIVE engine holds engine.log through the
+    stdout handle it was launched with, and that handle carries no write
+    sharing — so a second opener gets EACCES even though the file is plainly
+    writable (mode 0o666, os.access says yes). That is exactly the state a
+    restart runs in, by definition: the engine being replaced is still running.
+    So the one action that can repair a stuck engine could never start, on any
+    Windows machine, and the button reported "could not start the helper
+    ([Errno 13] Permission denied)".
+
+    Housekeeping does not outrank the point — the same rule rotate_engine_log
+    already states. If the main log is held, the helper writes beside it and
+    the launch proceeds.
+    """
+    try:
+        handle = open_engine_log(log)
+    except OSError:
+        fallback = _restart_log(log)
+        fallback.parent.mkdir(parents=True, exist_ok=True)
+        handle = open(fallback, "ab")
     flags = 0
     if sys.platform == "win32":
         flags = subprocess.CREATE_NO_WINDOW | subprocess.DETACHED_PROCESS

--- a/tests/test_relaunch_log.py
+++ b/tests/test_relaunch_log.py
@@ -79,3 +79,51 @@ def test_a_rotation_that_cannot_happen_never_stops_a_start(tmp_path: Path, monke
     finally:
         handle.close()
     assert log.read_bytes().endswith(b"the engine started anyway\n")
+
+
+def test_a_log_the_live_engine_is_holding_does_not_block_the_restart(tmp_path, monkeypatch):
+    """Reproduced on the owner's machine: the button answered 500 with
+    "could not start the helper ([Errno 13] Permission denied:
+    ...\.scrapex\engine.log)".
+
+    On Windows the running engine holds engine.log through the stdout handle it
+    was launched with, and that handle carries no write sharing — so a second
+    opener gets EACCES while the file is plainly writable (mode 0o666,
+    os.access says yes; measured). And that is the ONLY state a restart ever
+    runs in: the engine being replaced is still running. So the one action that
+    repairs a stuck engine could never start, on any Windows machine.
+
+    Housekeeping does not outrank the point."""
+    from scrapex import relaunch
+
+    log = tmp_path / "engine.log"
+    log.write_bytes(b"held by the live engine\n")
+
+    def held(path=None):
+        raise PermissionError(13, "Permission denied", str(log))
+
+    monkeypatch.setattr(relaunch, "open_engine_log", held)
+    recorded = {}
+
+    class _Popen:
+        def __init__(self, command, **kwargs):
+            recorded["stdout"] = kwargs.get("stdout")
+            self.pid = 4242
+
+    monkeypatch.setattr(relaunch.subprocess, "Popen", _Popen)
+
+    pid = relaunch._spawn_detached(["python", "-c", "pass"], tmp_path, log)
+
+    assert pid == 4242, "the helper did not launch when the main log was held"
+    assert recorded["stdout"] is not None, "it launched with nowhere to write"
+    assert relaunch._restart_log(log).exists(), (
+        "the helper's output has no file beside the one it could not open")
+
+
+def test_the_fallback_log_sits_beside_the_one_it_replaces(tmp_path):
+    """Read by the same person, from the same folder, on the same bad day."""
+    from scrapex import relaunch
+
+    log = tmp_path / "engine.log"
+    assert relaunch._restart_log(log).parent == log.parent
+    assert relaunch._restart_log(log).name.startswith(log.name)

--- a/tests/test_settings_live_in_the_extension.py
+++ b/tests/test_settings_live_in_the_extension.py
@@ -84,6 +84,27 @@ def test_the_panel_repair_buttons_reach_the_same_endpoints():
         "the buttons are in the markup and nothing listens to them")
 
 
+def test_a_refused_restart_is_shown_and_not_covered_with_good_news():
+    """The owner pressed Restart, read "The engine is back.", and nothing had
+    happened. The engine had answered 500 with a precise reason — the helper
+    could not open the log the live engine was holding — and the panel threw it
+    away, because only 404 was treated as an answer worth reading and every
+    other status fell through to the health poll. The poll of course succeeded:
+    the engine had never gone anywhere.
+
+    A thrown fetch is the success path here, since the process exits mid-answer.
+    An ANSWERED fetch that is not ok is its opposite, and the two must not share
+    a branch."""
+    script = (ROOT / "extension" / "app.js").read_text(encoding="utf-8")
+    block = script.split('"/api/engine/restart"', 1)[1].split("setInterval", 1)[0]
+
+    assert "asked.ok" in block or "!asked.ok" in block, (
+        "the panel reads only the 404 and treats every other refusal as success")
+    assert "detail" in block, (
+        "the engine's reason is discarded, so the owner sees a generic outcome "
+        "for a specific fault")
+
+
 def test_the_crawl_pace_is_reachable_from_the_panel():
     """The specific controls that were unreachable, now where they belong."""
     panel = PANEL.read_text(encoding="utf-8")


### PR DESCRIPTION
**Reported:** «انا جربت الاربع ازرار اشعر ان استخدامهم لا يعنى شى لا يحدث شى حرفيا».

I asked the running engine directly rather than reading the code.

```
POST /api/engine/restart     -> HTTP 500
POST /api/databases/upgrade  -> HTTP 200
GET  /api/version            -> HTTP 404
```

Not 404. **500**, with a precise reason:

> could not start the helper that brings the engine back (`[Errno 13] Permission denied: 'C:\Users\User01\.scrapex\engine.log'`).

## It could never have worked

Reproduced outside the engine, on the owner's machine:

```
exists: True | is_dir: False
size: 53244 | mode: 0o666 | writable: True
open('ab') -> FAILED: PermissionError [Errno 13] Permission denied
```

The file is plainly writable and a second opener still gets `EACCES`. That is the Windows signature of a handle held **without write sharing** — the live engine holds `engine.log` through the stdout handle it was launched with, in `_spawn_detached`.

And the only state a restart ever runs in is the one where the engine being replaced is **still running** — which is exactly the state that locks the log. So the one action that repairs a stuck engine was blocked by its own housekeeping, on any Windows machine.

`rotate_engine_log` already writes the rule down: *housekeeping does not outrank the point.* The helper now falls back to `engine.log.restart` — a sibling, not a temp file, because it is read by the same person from the same folder on the same bad day — and the launch proceeds.

## The second half is mine

From yesterday's panel work in #77. The button looked only for 404 and let **every other status** fall through to the health poll — which of course succeeded, because the engine had never gone anywhere. So the panel printed **"The engine is back."** over a refusal it had been handed in writing.

A thrown `fetch` **is** the success path here: the process exits mid-answer and the socket dies. An *answered* fetch that is not ok is its opposite. They no longer share a branch, and the engine's own sentence is what the owner sees.

## Guards

| test | what it pins |
|---|---|
| `test_a_log_the_live_engine_is_holding_does_not_block_the_restart` | a locked main log must not stop the helper launching |
| `test_the_fallback_log_sits_beside_the_one_it_replaces` | it lands where the reader will look |
| `test_a_refused_restart_is_shown_and_not_covered_with_good_news` | a non-ok answer is read, and its `detail` shown |

**Both proved to bite:** removing the fallback fails the relaunch test; restoring the 404-only branch fails the panel one.

`node --test extension/tests` exit 0 · `app.js` parses as a module · relaunch, settings-rule, panel-wiring and API suites exit 0, zero FAILED.

## Note on the other three buttons

**Upgrade database works** — it answered 200 and the panel showed *"Both databases are already up to date."* **Recheck status** and **Run diagnostics** also work; they re-read and rewrite the status text, which on a healthy engine looks like nothing changed. Only Restart was genuinely broken.
