### PR TITLE
Every caller of the restart endpoint reads the refusal

### DIFF
--- a/extension/app.js
+++ b/extension/app.js
@@ -506,14 +506,25 @@ async function saveCrawlSettings() {
 
 async function restartEngineFromPanel() {
   out("crawl-msg", "restarting the engine…");
-  try { await post("/api/engine/restart", {}); }
-  catch (err) {
-    // A restart tears down the very connection carrying its own reply, so a
-    // dropped request here is the SUCCESS case as often as the failure case.
-    // Claiming failure would be a lie; the status dot settles it either way.
-    out("crawl-msg", "restart requested — watch the status dot (" + err.message + ")");
-    return;
-  }
+  // A DROPPED request is the success case: the restart tears down the very
+  // connection carrying its own reply. A DELIVERED refusal is the opposite, and
+  // the previous version could not tell them apart because it only read
+  // err.message from a thrown api() call. So a hard 500 — "could not start the
+  // helper ([Errno 13] Permission denied ...)" — was printed INSIDE the words
+  // "restart requested", and the owner was told to watch a status dot that
+  // would never change. Raw fetch, so the status and the body are both readable.
+  let refused = null;
+  try {
+    const asked = await fetch((await getBackend()) + "/api/engine/restart",
+                              {method: "POST"});
+    if (asked.status === 404) refused = ENGINE_TOO_OLD;
+    else if (!asked.ok) {
+      let detail = `The engine refused (HTTP ${asked.status}).`;
+      try { detail = (await asked.json()).detail || detail; } catch (_) {}
+      refused = detail;
+    }
+  } catch (_) { /* the socket died: it is going down, which is the point */ }
+  if (refused) { out("crawl-msg", esc(refused), "err"); return; }
   out("crawl-msg", "restart requested — the status dot turns green when it is back", "ok");
 }
 

--- a/scrapex/webui/templates/database_unavailable.html
+++ b/scrapex/webui/templates/database_unavailable.html
@@ -97,6 +97,15 @@
       try {
         const asked = await fetch("/api/engine/restart", {method: "POST"});
         missing = asked.status === 404;
+        // Same rule as the settings page: a delivered refusal must not fall
+        // through to a poll that the refusing engine answers itself.
+        if (!missing && !asked.ok) {
+          let detail = "The engine refused (HTTP " + asked.status + ").";
+          try { detail = (await asked.json()).detail || detail; } catch (e) {}
+          note.textContent = detail;
+          done(this);
+          return;
+        }
       } catch (err) { /* the engine exits mid-answer, which is the success path */ }
       if (missing) { note.textContent = stale(); done(this); return; }
       // Poll until something answers again, then reload. Never claim it is back

--- a/scrapex/webui/templates/settings.html
+++ b/scrapex/webui/templates/settings.html
@@ -558,6 +558,17 @@ revealSettingsHash();
     try {
       const asked = await fetch("/api/engine/restart", {method: "POST"});
       missing = asked.status === 404;
+      // A delivered refusal is not a restart in progress. Reading only the 404
+      // let a 500 fall through to the poll below, which answers at once —
+      // because the engine that refused is the one still holding the port — and
+      // the page then reloaded as if it had worked.
+      if (!missing && !asked.ok) {
+        let detail = "The engine refused (HTTP " + asked.status + ").";
+        try { detail = (await asked.json()).detail || detail; } catch (e) {}
+        note.textContent = detail;
+        restart.disabled = false;
+        return;
+      }
     } catch (err) { /* it exits mid-answer, which is the success path */ }
     if (missing) { note.textContent = stale; restart.disabled = false; return; }
     let attempts = 0;

--- a/tests/test_settings_live_in_the_extension.py
+++ b/tests/test_settings_live_in_the_extension.py
@@ -105,6 +105,41 @@ def test_a_refused_restart_is_shown_and_not_covered_with_good_news():
         "for a specific fault")
 
 
+def test_every_caller_of_the_restart_endpoint_reads_the_refusal():
+    """Four copies of one handler, and the bug was in all four.
+
+    Each one asked only `status === 404` and let everything else fall through to
+    a poll — a poll the refusing engine answers ITSELF, because the engine that
+    refused is the one still holding the port. So a hard 500 ("could not start
+    the helper ([Errno 13] Permission denied ...)") became "The engine is back."
+    on one surface and was printed inside the words "restart requested" on
+    another. The owner pressed the button and, correctly, said nothing happened.
+
+    A DROPPED request is the success case here: the restart tears down the
+    connection carrying its own reply. A DELIVERED non-2xx is its opposite. Any
+    caller that cannot tell them apart will report the failure as progress, so
+    the rule is on the class and not on the three copies I happened to fix."""
+    callers = {
+        "extension/app.js": (ROOT / "extension" / "app.js"),
+        "settings.html": (ROOT / "scrapex" / "webui" / "templates" / "settings.html"),
+        "database_unavailable.html":
+            (ROOT / "scrapex" / "webui" / "templates" / "database_unavailable.html"),
+    }
+    for name, path in callers.items():
+        text = path.read_text(encoding="utf-8")
+        if "/api/engine/restart" not in text:
+            continue
+        for block in text.split("/api/engine/restart")[1:]:
+            window = block[:1400]
+            assert ".ok" in window, (
+                f"{name} calls the restart endpoint and never inspects whether "
+                "the answer was ok — only a 404 would be noticed, and every "
+                "other refusal reads as a restart in progress")
+            assert "detail" in window, (
+                f"{name} discards the engine's own reason, so a specific fault "
+                "reaches the owner as a generic outcome")
+
+
 def test_the_crawl_pace_is_reachable_from_the_panel():
     """The specific controls that were unreachable, now where they belong."""
     panel = PANEL.read_text(encoding="utf-8")


### PR DESCRIPTION
PR #78 fixed one handler. **There were four.**

A full inventory of the engine lifecycle found the same defect in the other three. Each asked only `status === 404` and let everything else fall through to a poll — and that poll is answered by the refusing engine itself, because the engine that refused is the one still holding the port.

So one 500 produced three different reassuring lies:

| surface | what it did with the 500 |
|---|---|
| `settings.html` | polled, got 200 from the engine that refused, **reloaded the page** |
| `database_unavailable.html` | same, then `location.reload()` |
| panel, Collection tab | printed the refusal **inside** *"restart requested — watch the status dot"* |

The owner pressed the buttons and said nothing happened. He was right, and the product told him three different reassuring things about it — including pointing him at a status dot that would never change.

## The rule

A **dropped** request is the success case here: the restart tears down the connection carrying its own reply. A **delivered** non-2xx is its opposite. Any caller that cannot tell them apart reports the failure as progress.

All three now separate them and show the engine's own sentence — which was always the most useful text in the system and was the one thing never displayed.

## The guard is on the class, not on the copies

`test_every_caller_of_the_restart_endpoint_reads_the_refusal` walks every file that calls `/api/engine/restart` and requires each call site to inspect `.ok` and read `detail`. Four copies of one handler is precisely why the bug could be fixed once and stay broken.

**Proved to bite:** restoring the 404-only branch in `settings.html` fails it.

Settings-rule, panel-wiring, web-UI and settings-page suites exit 0, zero FAILED. `node --test extension/tests` exit 0. `app.js` parses as a module.
