### PR TITLE
Sika knows what one unit is, and who said so

### DIFF
--- a/db/migrations/0058_a_unit_that_can_name_who_said_it.sql
+++ b/db/migrations/0058_a_unit_that_can_name_who_said_it.sql
@@ -1,0 +1,118 @@
+-- =====================================================================
+-- 0058 — A UNIT THAT CAN NAME WHO SAID IT
+--
+-- The owner, looking at sikaegshop: «المشكلة التى لم تحل 100% فى sika هى
+-- الوحدات اصلا». He is right, and the shape of the problem is not an empty
+-- column. It is one column trying to be two things.
+--
+-- Plywood is sold by the SHEET — but one sheet is not another sheet, they
+-- differ by thickness and by size. Pipe is sold by the pipe or by the metre
+-- — but pipes differ by length, diameter, wall thickness and pressure
+-- rating. `source_offer.selling_unit_id` has been asked to carry both "what
+-- one of these is" and "which one of these it is", and a field asked to be
+-- two things ends up being neither. Measured on the live warehouse
+-- 2026-08-02: 92 of MADAR's 3,537 offers carry it, ALL of them the single
+-- value kg, and 3,445 carry nothing at all.
+--
+-- WORSE THAN EMPTY. 52 MADAR offers publish a variant option reading
+-- «N كجم/صندوق» or "N Pcs/Box" — the shop naming a BOX and saying what is
+-- in it — and 18 of those are already stored as kg with basis 3 or 4. That
+-- is not an unpopulated field. That is this schema overwriting what the
+-- shop said, today, in the owner's own data, against the first rule the
+-- project has: source truth is never edited.
+--
+-- THE SPLIT THIS MIGRATION MAKES
+--
+--   selling_unit_id + basis_quantity   what one priced thing IS   (already here)
+--   content_quantity + content_unit_id what is INSIDE one of them (new)
+--
+-- Sika Swell 2010 states «10 متر» in its name and 3 kg in its spec row.
+-- Under one column those two facts fight and one has to be silenced — and
+-- silencing a published statement to protect a rule is precisely what this
+-- project may not do. Under two, both survive: unit m, basis 10, content
+-- (3, kg), and price-per-kg is arithmetic rather than a rewrite.
+--
+-- AND A UNIT MUST NOW BE ABLE TO SAY WHERE IT CAME FROM
+--
+-- The warehouse holds 1,472 units today and not one of them can name the
+-- field it was read from. A number whose origin cannot be stated is not a
+-- fact; it is a number someone typed. The owner may not edit source truth,
+-- so he must at minimum be able to SEE which part of it he is looking at —
+-- and to tell «the shop said this» from «we worked this out» at a glance.
+--
+--   unit_basis_provenance   a closed vocabulary, never blank
+--   unit_basis_witness      the field, its language, the charter version
+--                           and the literal text that was read
+--
+-- The two triggers below make that a rule of the database rather than a
+-- habit of the connectors. A unit without both is refused. There is no
+-- point adding a provenance column that a future connector can forget.
+--
+-- NOTHING HERE ENTERS ux_source_offer_identity. No offer changes identity,
+-- none is split, no history moves — the same argument 0057 made in writing
+-- when it added the weight basis, and for the same reason.
+--
+-- The vocabulary rows have carried NULL names since they were created. A
+-- unit the owner reads has to have a word in both languages or the AR/EN
+-- switch shows him a code, so the five that exist are filled. The ones this
+-- work will meet are NOT seeded — see below.
+-- =====================================================================
+
+ALTER TABLE source_offer ADD COLUMN selling_unit_raw TEXT;
+ALTER TABLE source_offer ADD COLUMN selling_unit_raw_lang TEXT;
+ALTER TABLE source_offer ADD COLUMN content_quantity REAL;
+ALTER TABLE source_offer ADD COLUMN content_unit_id INTEGER REFERENCES selling_unit(selling_unit_id);
+ALTER TABLE source_offer ADD COLUMN unit_basis_provenance TEXT;
+ALTER TABLE source_offer ADD COLUMN unit_basis_witness TEXT;
+
+-- The words the owner reads. `name` is English by the naming rule; `name_ar`
+-- is the site's own Arabic term where one exists.
+UPDATE selling_unit SET name = 'metre',  name_ar = 'متر'  WHERE unit_code = 'm';
+UPDATE selling_unit SET name = 'kilogram', name_ar = 'كيلوجرام' WHERE unit_code = 'kg';
+UPDATE selling_unit SET name = 'litre',  name_ar = 'لتر'  WHERE unit_code = 'liter';
+UPDATE selling_unit SET name = 'kilowatt hour', name_ar = 'كيلوواط ساعة' WHERE unit_code = 'kWh';
+UPDATE selling_unit SET name = 'tonne',  name_ar = 'طن'   WHERE unit_code = 'tonne';
+
+-- The vocabulary is NOT seeded here. It is created on demand as units are
+-- actually met, and `selling_unit` holding only units something is priced in
+-- is an invariant a test already asserts. Seeding gm, ml and piece ahead of
+-- their first use would add three rows nobody has encountered and quietly
+-- turn that invariant into a fiction. ingest.py names them at the moment it
+-- creates them instead, from the word list in scrapex/units.py.
+
+-- THE 1,064 THAT ARE ALREADY HERE. Every offer carrying a unit today was
+-- written before any of this existed, so none can name a witness — and the
+-- triggers below would refuse the next crawl that touched one. They are
+-- marked rather than deleted: the value stands, and it says out loud that
+-- nobody can say where it came from. Under the resolution metric it counts
+-- as unresolved, which is the truth about it.
+UPDATE source_offer
+   SET unit_basis_provenance = 'legacy_unwitnessed',
+       unit_basis_witness    = 'pre-0058: written by normalize.selling_unit_from '
+                               || 'or a connector constant; the field it was read '
+                               || 'from was not recorded'
+ WHERE selling_unit_id IS NOT NULL
+   AND (unit_basis_provenance IS NULL OR unit_basis_provenance = '');
+
+-- A unit with no named source is not a fact. Both triggers exist because a
+-- column a connector can forget is a column that will be forgotten — this
+-- schema has watched exactly that happen to selling_unit_id itself.
+CREATE TRIGGER IF NOT EXISTS trg_offer_unit_needs_a_witness_insert
+BEFORE INSERT ON source_offer
+WHEN NEW.selling_unit_id IS NOT NULL
+ AND (NEW.unit_basis_provenance IS NULL OR NEW.unit_basis_provenance = ''
+   OR NEW.unit_basis_witness IS NULL OR NEW.unit_basis_witness = '')
+BEGIN
+  SELECT RAISE(ABORT, 'a selling unit must carry its provenance and its witness');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_offer_unit_needs_a_witness_update
+BEFORE UPDATE OF selling_unit_id, unit_basis_provenance, unit_basis_witness ON source_offer
+WHEN NEW.selling_unit_id IS NOT NULL
+ AND (NEW.unit_basis_provenance IS NULL OR NEW.unit_basis_provenance = ''
+   OR NEW.unit_basis_witness IS NULL OR NEW.unit_basis_witness = '')
+BEGIN
+  SELECT RAISE(ABORT, 'a selling unit must carry its provenance and its witness');
+END;
+
+PRAGMA user_version = 58;

--- a/scrapex/config.py
+++ b/scrapex/config.py
@@ -214,12 +214,80 @@ class IdentityRules(BaseModel):
     on_ambiguous: str = "review"   # review | keep_separate
 
 
+class UnitWitness(BaseModel):
+    """One field that may state a unit, and what kind of statement it is."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    field: str
+    # Which language the field is written in. It travels with the reading, so
+    # the owner can see that «20 كيلو» in the Arabic name is what answered —
+    # not a translation of the English one.
+    lang: str = "und"
+    # A closed vocabulary, so "where did this come from" has a small number of
+    # answers rather than free text. declared_by_source is a machine-readable
+    # field the site publishes; stated_in_name and stated_field are the site's
+    # own words for a person to read; stated_in_prose is a sentence it has to
+    # be dug out of; declared_by_owner is OUR constant, and says so.
+    provenance: Literal["declared_by_source", "stated_in_name", "stated_field",
+                        "stated_in_prose", "declared_by_owner"] = "stated_field"
+
+
+class UnitCorroborator(BaseModel):
+    """A field that may CONFIRM a unit and may never originate one."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    field: str
+
+
+class UnitScales(BaseModel):
+    """Which measurement units can be a selling unit on this site."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    # An allow-list. Anything absent is not a candidate, which is what stops
+    # «سيكا باكينج رود 1 سم» becoming a one-centimetre selling unit.
+    pack: list[str] = Field(min_length=1)
+    # Units to strike from a text before reading it, for a site that writes a
+    # dimension using a pack-scale word. Optional, and deliberately absent
+    # where it earns nothing: measured over sikaegshop's 87 products it
+    # changed zero answers, so it is not declared there.
+    dimension: list[str] = []
+
+
+class UnitCharter(BaseModel):
+    """How ONE site states what one of its priced things is.
+
+    Data, not code. The owner has hundreds of sites waiting and a Python
+    branch per site is not a method — «كل موقع ندخله المفروض نشوف طريقة معينة
+    لقياس وتحديد وحداته ونطور الأمر مع الوقت». Validated here so a charter
+    that names an impossible provenance or declares no pack scale fails the
+    build rather than quietly resolving nothing.
+
+    The version travels into every witness string, so a reading can always be
+    traced to the rules that authorised it, and a revision is a diff the owner
+    can read.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: int = 1
+    witnesses: list[UnitWitness] = Field(min_length=1)
+    corroborators: list[UnitCorroborator] = []
+    scales: UnitScales
+
+
 class SourceEntry(BaseModel):
     """One source's full contract."""
 
     model_config = ConfigDict(extra="forbid")
 
     source_key: str
+    # Absent for a source nobody has studied yet, and that is a state
+    # rather than an omission: a source with no charter resolves no
+    # units at all, which is honest. Ten of eleven are in it today.
+    unit_charter: UnitCharter | None = None
     # English is the primary display language, so the unmarked name is English
     # and it is REQUIRED. Requiredness inverts here deliberately: these twelve
     # labels are owner-authored rather than scraped, all twelve already carry

--- a/scrapex/databases/domain.py
+++ b/scrapex/databases/domain.py
@@ -165,7 +165,7 @@ def _general_plan() -> tuple[Migration, ...]:
 # Listed rather than ranged: the unified chain and this one have diverged, so a
 # new price migration lands at the END of the legacy chain but in the middle of
 # this plan. A range would silently swallow whatever General adds next.
-_MARKETLENS_LEGACY_NUMBERS = (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 15, 16, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57)
+_MARKETLENS_LEGACY_NUMBERS = (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 15, 16, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58)
 
 # Where the identity migration sits in this stream. Everything before it is the
 # price history the unified warehouse already had; everything after is a price

--- a/scrapex/ingest.py
+++ b/scrapex/ingest.py
@@ -521,7 +521,13 @@ def _get_unit_id(conn: sqlite3.Connection, unit_code: str) -> int | None:
                      (unit_code,))
     if found is not None:
         return found
-    return _insert(conn, "selling_unit", {"unit_code": unit_code})
+    # Named as it is born. The vocabulary is not seeded — a row here means
+    # something is actually priced in that unit — but a row with no words is a
+    # code on the owner's screen the moment the AR/EN switch is thrown.
+    from .units import UNIT_NAMES
+    english, arabic = UNIT_NAMES.get(unit_code, ("", ""))
+    return _insert(conn, "selling_unit",
+                   {"unit_code": unit_code, "name": english, "name_ar": arabic})
 
 
 def _unit_with_basis(r: dict) -> str:
@@ -669,8 +675,11 @@ def _get_offer_id(conn, variant_id: int, r: dict) -> int:
         )
         if unstated is not None:
             conn.execute(
-                "UPDATE source_offer SET selling_unit_id = ?, basis_quantity = ? "
-                "WHERE offer_id = ?", (unit_id, basis, unstated))
+                "UPDATE source_offer SET selling_unit_id = ?, basis_quantity = ?, "
+                "unit_basis_provenance = COALESCE(NULLIF(unit_basis_provenance,''), ?), "
+                "unit_basis_witness = COALESCE(NULLIF(unit_basis_witness,''), ?) "
+                "WHERE offer_id = ?",
+                (unit_id, basis, *_witness_for(r), unstated))
             _apply_quantity_facts(conn, unstated, quantity)
             return unstated
     return _insert(conn, "source_offer", {
@@ -680,8 +689,29 @@ def _get_offer_id(conn, variant_id: int, r: dict) -> int:
         "tax_included": vat,
         "selling_unit_id": unit_id,
         "basis_quantity": basis,
+        **(dict(zip(("unit_basis_provenance", "unit_basis_witness"), _witness_for(r)))
+           if unit_id else {}),
         **quantity,
     })
+
+
+def _witness_for(r: dict) -> tuple[str, str]:
+    """Where this offer's unit came from, for the trigger 0058 added.
+
+    A connector that has been taught a charter states both, and they travel on
+    the row. One that has not still writes units — magento and the fuel pages
+    do, from their own constants and from normalize.selling_unit_from — and
+    those are not facts anyone can trace to a field, so they say so. Marking
+    them is not bookkeeping: the resolution metric counts a unit with no named
+    witness as unresolved, and that is the honest score for a number whose
+    origin nobody recorded.
+    """
+    provenance = (r.get("unit_basis_provenance") or "").strip()
+    witness = (r.get("unit_basis_witness") or "").strip()
+    if provenance and witness:
+        return provenance, witness
+    return ("legacy_unwitnessed",
+            "written without a charter: the field it was read from was not recorded")
 
 
 # ---- price parsing (via the ONE shared parser, Q2) ---------------------------

--- a/scrapex/units.py
+++ b/scrapex/units.py
@@ -1,0 +1,207 @@
+"""What one priced thing IS, decided from a per-source charter.
+
+The owner asked for a precise analysis and, more importantly, for a METHOD:
+«كل موقع ندخله المفروض نشوف طريقة معينة لقياس وتحديد وحداته ونطور الأمر مع
+الوقت». He has hundreds of sites waiting. So the decision cannot live in
+Python branches — a branch per site is not a method, it is a pile.
+
+It lives in `sources.yaml`, under the source, as data the owner reads and
+approves. This module is the machine that carries a charter out. It knows
+nothing about any particular shop.
+
+THE THREE THINGS A CHARTER DECLARES
+
+  witnesses      the fields that may STATE a unit, in rank order, each with
+                 its language and what kind of statement it is
+  corroborators  fields that may confirm and may never originate — the
+                 platform's own numeric weight is one: it is a logistics
+                 figure that does not name its unit at all (sikaegshop's
+                 "kg" is written in OUR code, not on the site)
+  scales.pack    which measurement units can be a SELLING unit here — an
+                 allow-list, so anything unlisted is not a candidate
+
+The pack list is what answers the owner's original complaint. «سيكا باكينج
+رود 1 سم» carries a number and a unit word in its name, and a rule that
+reads them makes one centimetre the selling unit of a product sold by the
+metre. cm is simply not on sikaegshop's list, so the name states nothing the
+charter can use and the ranked witnesses find «1 Meter» one row lower.
+
+`scales.dimension` also exists — a list of units to strike out of a text
+before reading it — and sikaegshop does not use it. It was in the first draft
+of that charter, described as the thing that saved the Backing Rods, and
+measuring it over all 87 products showed it changed ZERO answers: the
+allow-list and the word boundary below were already doing the work. It is
+kept as a capability because a site that expresses a dimension in a
+pack-scale word will need it; it is not declared where it earns nothing,
+because a rule that carries nothing reads like a guarantee and is not one.
+
+WHAT COMES BACK, AND WHY IT IS FOUR THINGS AND NOT ONE
+
+A unit that cannot name where it came from is not a fact, it is a number
+someone typed. So a Resolution carries the unit, the quantity, the kind of
+statement it was, and the literal text that was read — and the database
+refuses a unit that arrives without the last two (migration 0058).
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass
+
+# The unit words the project understands, mapped to the vocabulary in
+# `selling_unit`. Arabic spellings are DATA the sites publish, not
+# translations: «كيلو» is what the shop wrote, and reading it is capture,
+# not interpretation. Longest-first matching happens in _pattern_for.
+UNIT_WORDS: dict[str, tuple[str, ...]] = {
+    "kg":    ("kg", "kgs", "كجم", "كيلوجرام", "كيلوغرام", "كيلو"),
+    "gm":    ("gm", "gms", "g", "gram", "grams", "جرام", "غرام", "جم"),
+    "ml":    ("ml", "mls", "millilitre", "milliliter", "مليلتر", "ملي", "مل"),
+    "liter": ("liter", "litre", "liters", "litres", "ltr", "l", "لتر"),
+    "m":     ("m", "meter", "metre", "meters", "metres", "mtr", "متر", "امتار", "أمتار"),
+    "tonne": ("tonne", "tonnes", "ton", "tons", "طن"),
+    "piece": ("piece", "pieces", "pcs", "pc", "قطعة", "قطع", "حبة"),
+    "mm":    ("mm", "millimetre", "millimeter", "مم", "ملم"),
+    "cm":    ("cm", "centimetre", "centimeter", "سم"),
+}
+
+# What each unit is CALLED, in both languages. ingest writes these when it
+# creates a vocabulary row, because a unit with no words shows the owner a code
+# the moment he switches the interface to Arabic. Arabic here is the ordinary
+# term, not a translation of the English word — «طن» is what the sites say.
+UNIT_NAMES: dict[str, tuple[str, str]] = {
+    "kg":    ("kilogram", "كيلوجرام"),
+    "gm":    ("gram", "جرام"),
+    "ml":    ("millilitre", "مليلتر"),
+    "liter": ("litre", "لتر"),
+    "m":     ("metre", "متر"),
+    "tonne": ("tonne", "طن"),
+    "piece": ("piece", "قطعة"),
+    "mm":    ("millimetre", "مليمتر"),
+    "cm":    ("centimetre", "سنتيمتر"),
+    "kWh":   ("kilowatt hour", "كيلوواط ساعة"),
+}
+
+# Which vocabulary entry a word belongs to, built once.
+_WORD_TO_UNIT = {word: unit for unit, words in UNIT_WORDS.items() for word in words}
+
+_ARABIC_DIGITS = str.maketrans("٠١٢٣٤٥٦٧٨٩", "0123456789")
+
+
+@dataclass(frozen=True)
+class Resolution:
+    """One offer's unit, and the statement it was read from."""
+
+    unit: str
+    quantity: float
+    provenance: str
+    witness: str
+    raw: str
+    raw_lang: str
+
+    @property
+    def basis(self) -> str:
+        """The quantity as the warehouse writes it — no trailing .0 on whole
+        numbers, because "20" is what the shop said and "20.0" is not."""
+        whole = int(self.quantity)
+        return str(whole) if self.quantity == whole else str(self.quantity)
+
+
+class Charter:
+    """A source's declared way of reading its own units.
+
+    Constructed from the manifest block, never from code. An absent charter
+    is not an error and not a default: it means this source has not been
+    studied yet, and `resolve` returns None rather than guessing. Guessing is
+    the failure mode the whole design exists to prevent.
+    """
+
+    def __init__(self, block: dict | None) -> None:
+        block = block or {}
+        self.version = int(block.get("version") or 1)
+        self.witnesses = tuple(
+            (w["field"], w.get("lang", "und"), w.get("provenance", "stated_field"))
+            for w in block.get("witnesses", ()))
+        self.corroborators = tuple(c["field"] for c in block.get("corroborators", ()))
+        scales = block.get("scales") or {}
+        self.pack = tuple(scales.get("pack", ()))
+        self.dimension = tuple(scales.get("dimension", ()))
+
+    def __bool__(self) -> bool:
+        return bool(self.witnesses and self.pack)
+
+    def resolve(self, fields: dict[str, str | None]) -> Resolution | None:
+        """Ask each witness in turn; the first that speaks decides.
+
+        `fields` maps the names used in the charter to whatever the connector
+        read. A field the connector did not capture is simply silent — a
+        charter naming a field that does not exist yet is a charter written
+        ahead of its connector, which is allowed and which the dry run
+        reports.
+        """
+        if not self:
+            return None
+        for field, lang, provenance in self.witnesses:
+            text = fields.get(field)
+            if not text:
+                continue
+            found = self._read(str(text))
+            if found is None:
+                continue
+            quantity, unit, literal = found
+            return Resolution(
+                unit=unit,
+                quantity=quantity,
+                provenance=provenance,
+                witness=f"{field}@{lang}/v{self.version}: {literal}",
+                raw=literal,
+                raw_lang=lang,
+            )
+        return None
+
+    def _read(self, text: str) -> tuple[float, str, str] | None:
+        """The first pack-scale quantity in this text.
+
+        "Sika Fiber Polypropylene 18mm ® 900 gm" is the shape that defeats a
+        rule which simply takes the first number-and-unit it finds. Two things
+        stop it, and neither is clever: "mm" is not on this site's pack list,
+        and the boundary after the unit word refuses to let the "m" in "18mm"
+        stand for a metre. What survives is the pack.
+
+        Nothing here ranks or scores. The site's own words are read in the
+        order the site wrote them, and only the words it declared can be a
+        unit are eligible.
+        """
+        cleaned = unicodedata.normalize("NFKC", text).translate(_ARABIC_DIGITS)
+        if self.dimension:
+            cleaned = self._pattern_for(self.dimension).sub(" ", cleaned)
+        match = self._pattern_for(self.pack).search(cleaned)
+        if not match:
+            return None
+        number = float(match.group(1).replace(",", "."))
+        word = match.group(2).lower()
+        unit = _WORD_TO_UNIT.get(word)
+        if unit is None or unit not in self.pack:
+            return None
+        return number, unit, match.group(0).strip()
+
+    @staticmethod
+    def _pattern_for(units: tuple[str, ...]) -> re.Pattern[str]:
+        words: list[str] = []
+        for unit in units:
+            words.extend(UNIT_WORDS.get(unit, (unit,)))
+        # Longest first, or "m" would match the head of "ml" and a 600 ml
+        # tube would be recorded as 600 metres.
+        words.sort(key=len, reverse=True)
+        alternatives = "|".join(re.escape(word) for word in words)
+        # No \b after an Arabic word: the Arabic letters are word characters
+        # and a following Arabic letter would be swallowed, so a right-hand
+        # boundary is asserted as "not a letter" instead.
+        return re.compile(
+            r"(\d+(?:[.,]\d+)?)\s*(" + alternatives + r")(?![^\W\d_])",
+            re.IGNORECASE | re.UNICODE)
+
+
+def charter_for(source: dict | None) -> Charter:
+    """The charter declared by a manifest entry, or an empty one."""
+    return Charter((source or {}).get("unit_charter"))

--- a/sources.yaml
+++ b/sources.yaml
@@ -370,6 +370,38 @@ sources:
       # sentence is here so that decision is made with the price in front of it.
       - kind: enrichment
         scope: census
+    # WHAT ONE OF THESE IS. Owner ruling 2026-08-02, after he checked the
+    # site himself: on THIS shop the product name settles every conflict —
+    # «اسم المنتج يحسم كل شى بالنسبة لموقع سيكا (قاعدة لا تعمم)». Written
+    # here, under this source, because it is a fact about this shop and not
+    # a law about shops.
+    #
+    # It matters because the shop states a weight TWICE and the two disagree
+    # on 14 of the 76 products carrying both: an authored Specifications row
+    # («الوزن» / "weight") and the platform's own numeric `weight` field. On
+    # product 261 the page shows 1 and 20. The name says 20 KG, so 20 it is.
+    unit_charter:
+      version: 1
+      witnesses:
+        - {field: product_name,    lang: en, provenance: stated_in_name}
+        - {field: product_name_ar, lang: ar, provenance: stated_in_name}
+        - {field: attr_3,          lang: en, provenance: stated_field}
+        - {field: attr_3_ar,       lang: ar, provenance: stated_field}
+        - {field: attr_1,          lang: en, provenance: stated_in_prose}
+        - {field: attr_1_ar,       lang: ar, provenance: stated_in_prose}
+      corroborators:
+        # The platform's field. It may agree; it may never originate. It does
+        # not name its own unit — the "kg" was written in OUR code.
+        - {field: weight}
+      scales:
+        # Only these can be a SELLING unit here. That allow-list is what
+        # stops «سيكا باكينج رود 1 سم» becoming a one-centimetre unit — cm
+        # is simply not a candidate — and the word boundary in units.py is
+        # what stops the m in "18mm" being read as a metre. Measured over
+        # all 87: declaring a separate `dimension` list changed ZERO
+        # answers, so it is not declared. A rule that carries nothing reads
+        # like a guarantee and is not one.
+        pack: [kg, gm, ml, liter, m]
     min_expected_rows: 30
     max_drop_pct: 50
     notes: >

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -57,7 +57,7 @@ def test_migration_creates_the_catalogue_and_integrity_triggers(conn):
     assert objects["relationship_field_pair"] == "table"
     assert objects["trg_dataset_relationship_same_site_insert"] == "trigger"
     assert objects["trg_relationship_field_pair_matches_insert"] == "trigger"
-    assert conn.execute("PRAGMA user_version").fetchone()[0] == 57
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 58
 
 
 def test_one_site_can_hold_multiple_tables_with_different_dynamic_columns(conn):

--- a/tests/test_database_isolation.py
+++ b/tests/test_database_isolation.py
@@ -67,7 +67,7 @@ def test_fresh_registry_creates_two_typed_databases_without_domain_tables_crossi
     assert applied["general"] == list(
         range(1, registry.general.latest_schema_version + 1)
     )
-    assert applied["marketlens"] == list(range(1, 56))   # ... +55 the weight the price is quoted against
+    assert applied["marketlens"] == list(range(1, 57))   # ... +56 a unit that can name who said it
     assert registry.health()["general"]["status"] == "Healthy"
     assert registry.health()["marketlens"]["status"] == "Healthy"
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -27,12 +27,12 @@ def test_migrate_is_idempotent(tmp_path: Path):
         second = dbmod.migrate(conn)
     finally:
         conn.close()
-    assert first == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57]
+    assert first == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58]
     assert second == []  # T4: running again applies nothing
 
 
 def test_latest_schema_version_matches_the_migration_chain():
-    assert dbmod.latest_schema_version() == 57   # +0057 the weight the price is quoted against
+    assert dbmod.latest_schema_version() == 58   # +0057 the weight the price is quoted against
 
 
 def test_foreign_keys_actually_enforced(tmp_path: Path):

--- a/tests/test_display_method_and_quantity_facts.py
+++ b/tests/test_display_method_and_quantity_facts.py
@@ -575,7 +575,7 @@ def test_migration_0056_corrects_has_variants_on_rows_that_already_exist():
                          " VALUES (2, ?)", (member,))
         conn.commit()
 
-        assert dbmod.migrate(conn) == [56, 57]
+        assert dbmod.migrate(conn) == [56, 57, 58]
 
         flags = dict(conn.execute(
             "SELECT external_product_id, has_variants FROM source_product"))

--- a/tests/test_extract_storage.py
+++ b/tests/test_extract_storage.py
@@ -113,7 +113,7 @@ def test_legacy_0014_remains_available_for_explicit_unified_sessions(tmp_path: P
     legacy = dbmod.connect(tmp_path / "legacy.db")
     try:
         dbmod.migrate(legacy)
-        assert dbmod.schema_version(legacy) == 57   # +0057 the weight the price is quoted against
+        assert dbmod.schema_version(legacy) == 58   # +0058 the weight the price is quoted against
         for table in ("price_observation", "generic_record"):
             assert legacy.execute(
                 "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1",

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -62,7 +62,7 @@ def _insert_observation(conn, ids, price: float = 168.78, hash_: str = "h1") -> 
 
 
 def test_migration_reaches_latest_version(conn):
-    assert dbmod.schema_version(conn) == 57   # +0057 the weight the price is quoted against
+    assert dbmod.schema_version(conn) == 58   # +0058 the weight the price is quoted against
 
 
 def test_all_owner_tables_exist(conn):
@@ -168,7 +168,7 @@ def test_migration_0020_preserves_existing_jobs_and_their_log_references():
         upgrading.commit()
 
         assert dbmod.migrate(upgrading) == [20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
-                                            30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57]
+                                            30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58]
 
         joined = upgrading.execute(
             "SELECT j.job_ref, j.status, l.message FROM job_log_entry l"

--- a/tests/test_the_weight_the_price_is_quoted_against.py
+++ b/tests/test_the_weight_the_price_is_quoted_against.py
@@ -551,7 +551,8 @@ def test_migration_0057_adds_the_two_columns_without_touching_offer_identity():
         columns = {r[1] for r in conn.execute("PRAGMA table_info(source_offer)")}
         assert "weight" not in columns and "weight_unit" not in columns
 
-        assert dbmod.migrate(conn) == [57]
+        assert dbmod.migrate(conn) == [57, 58]   # 0058 rides along: it adds the
+            # witness columns 0057's units will need, and the chain runs forward
 
         columns = {r[1]: r for r in conn.execute("PRAGMA table_info(source_offer)")}
         assert "weight" in columns and "weight_unit" in columns

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,176 @@
+"""What one priced thing IS, and who said so.
+
+The owner's complaint, in his words: «الوحدات احيانا ضمن الوصف او ضمن
+الاختيارات variant — يعنى مثلا plywood دا وحدته sheet ولكن له ابعاد محددة
+تختلف عن sheet اخر بابعاد اخرى. فى وحدات للمواسير ماسورة ولكن هناك ابعاد
+مختلفة كأطوال وسمك وتخانة وضغط.»
+
+Every case below is a real product from the live warehouse, quoted.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+import yaml
+
+from scrapex.units import Charter, charter_for
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _sika() -> dict:
+    manifest = yaml.safe_load((ROOT / "sources.yaml").read_text(encoding="utf-8"))
+    sources = manifest["sources"] if isinstance(manifest, dict) and "sources" in manifest else manifest
+    return next(s for s in sources if s.get("source_key") == "SIKAEGSHOP")
+
+
+def test_a_source_with_no_charter_says_nothing_rather_than_guessing():
+    """An absent charter is not a default and not an error: it means this
+    source has not been studied. Ten of the eleven sources are in that state
+    today, and a resolver that guessed for them would fill the warehouse with
+    numbers nobody could defend — which is the situation this work exists to
+    end, not to automate."""
+    blank = charter_for({"source_key": "SOMETHING_NEW"})
+
+    assert not blank
+    assert blank.resolve({"product_name": "Cement bag 50 kg"}) is None
+
+
+def test_the_diameter_in_the_name_is_not_the_selling_unit():
+    """THE ACCEPTANCE TEST. «سيكا باكينج رود 1 سم» — the name states a
+    number and a unit word, and reading them naively makes ONE CENTIMETRE the
+    selling unit of a product the shop sells by the metre. This is the
+    owner's original complaint in its smallest form.
+
+    What saves it is not cleverness and — measured — not the thing I first
+    claimed. My charter declared cm and mm as a separate "dimension scale"
+    and that declaration changed ZERO of the 87 answers, so it was removed.
+    Two plainer things do the work: cm is not in this site's `pack` list, so
+    it is never a candidate at all; and the ranked witnesses then find «1
+    Meter» one row lower."""
+    charter = charter_for(_sika())
+
+    resolution = charter.resolve({
+        "product_name": "Sika Backing ® Rod 1 CM",
+        "product_name_ar": "سيكا باكينج رود 1 سم",
+        "attr_1": "1 Meter",
+        "attr_1_ar": "1 متر",
+    })
+
+    assert resolution is not None
+    assert (resolution.unit, resolution.basis) == ("m", "1")
+    assert resolution.provenance == "stated_in_prose"
+    assert resolution.witness == "attr_1@en/v1: 1 Meter"
+
+
+def test_removing_the_pack_allow_list_breaks_exactly_that_case():
+    """The rule-removal test, aimed at the rule that actually carries the
+    weight. A charter test asserting only an outcome passes for the wrong
+    reason as easily as the right one — and this file's first version proved
+    it, by attributing the Backing Rod's rescue to a declaration that turned
+    out to do nothing.
+
+    Widen `pack` to admit cm and the diameter in the name wins immediately."""
+    block = _sika()["unit_charter"]
+    widened = Charter({**block, "scales": {"pack": list(block["scales"]["pack"]) + ["cm"]}})
+
+    resolution = widened.resolve({
+        "product_name": "Sika Backing ® Rod 1 CM",
+        "attr_1": "1 Meter",
+    })
+
+    assert resolution is not None
+    assert resolution.unit == "cm", (
+        "with cm admitted as a selling unit the name wins and the rod is "
+        "recorded as one centimetre — the owner's original complaint")
+    assert resolution.unit != "m"
+
+
+def test_the_name_settles_a_conflict_on_this_site_and_the_ruling_is_recorded():
+    """Owner ruling 2026-08-02, after checking the page himself: «اسم المنتج
+    يحسم كل شى بالنسبة لموقع سيكا (قاعدة لا تعمم)».
+
+    Product 261 states 20 KG in its name, «20 كيلو» in the shop's authored
+    spec row, and 1 in the platform's numeric weight field — the owner saw
+    all three on the page. Today the platform field wins and the unit is
+    dropped entirely. The ruling belongs to this source, so the test asserts
+    it is written in this source's charter and nowhere shared."""
+    sika = _sika()
+    charter = charter_for(sika)
+
+    first = charter.witnesses[0]
+    assert first[0] == "product_name", (
+        "the name is no longer the top witness for a site whose owner ruled "
+        "that the name decides")
+    assert "weight" in charter.corroborators, (
+        "the platform's numeric field must be able to confirm and never to "
+        "originate — it does not name its own unit")
+    assert "weight" not in [w[0] for w in charter.witnesses]
+
+    resolution = charter.resolve({
+        "product_name": "Sika Creat 114 ® 20 KG",
+        "product_name_ar": "سيكا كريت 114- 20 كيلو",
+        "attr_3": "20 kg",
+        "weight": "1",
+    })
+    assert (resolution.unit, resolution.basis) == ("kg", "20")
+
+
+def test_the_arabic_name_alone_can_state_the_unit():
+    """Bilingual capture is not decoration here. «سيكا لاتكس -5 كيلو» states
+    the pack in Arabic, and a resolver that reads only English would drop it.
+    Nothing is translated: «كيلو» is the word the shop wrote and reading it
+    is capture."""
+    charter = charter_for(_sika())
+
+    resolution = charter.resolve({"product_name": None, "product_name_ar": "سيكا لاتكس -5 كيلو"})
+
+    assert (resolution.unit, resolution.basis) == ("kg", "5")
+    assert resolution.raw_lang == "ar"
+    assert "كيلو" in resolution.witness
+
+
+@pytest.mark.parametrize("name,unit,basis", [
+    ("Sika Fiber Polypropylene 18mm ® 900 gm", "gm", "900"),
+    ("Sika Flex Pro 3  Purform white 600 ml", "ml", "600"),
+    ("Sika Swell 2010 10 Meter", "m", "10"),
+    ("Sika Gard 701 W 20KG", "kg", "20"),
+])
+def test_a_dimension_before_a_pack_size_does_not_win_by_being_first(name, unit, basis):
+    """"18mm ® 900 gm" is the shape that defeats any rule which simply takes
+    the first number-and-unit it finds. Position does not decide it: "mm" is
+    not a candidate at all, and the boundary after the unit word stops the
+    "m" in "18mm" being read as a metre. What is left is the pack."""
+    resolution = charter_for(_sika()).resolve({"product_name": name})
+
+    assert (resolution.unit, resolution.basis) == (unit, basis)
+
+
+def test_millilitres_are_not_metres():
+    """Longest-first matching, asserted rather than assumed: "m" is a unit
+    word and it is the head of "ml", so a naive alternation records a 600 ml
+    tube as 600 metres."""
+    resolution = charter_for(_sika()).resolve({"product_name": "Sealant 600 ml"})
+
+    assert resolution.unit == "ml"
+
+
+def test_every_resolution_can_name_the_field_it_was_read_from():
+    """Migration 0058 makes the database refuse a unit with no witness. This
+    asserts the resolver can always supply one — a unit whose origin cannot
+    be stated is not a fact, it is a number someone typed, and the warehouse
+    already holds 1,064 of those."""
+    charter = charter_for(_sika())
+
+    for fields in ({"product_name": "Sika Gard 701 W 20KG"},
+                   {"product_name_ar": "سيكا لاتكس -5 كيلو"},
+                   {"attr_1": "1 Meter"}):
+        resolution = charter.resolve(fields)
+        assert resolution.provenance
+        assert resolution.witness
+        assert resolution.raw and resolution.raw_lang
+        # The witness names the field, the language, the charter version and
+        # the literal text — enough to re-read the same statement later.
+        assert "@" in resolution.witness and "/v" in resolution.witness


### PR DESCRIPTION
«المشكلة التى لم تحل 100% فى sika هى الوحدات اصلا» — and the shape of it is not an empty column. It is **one column trying to be two things**: what one priced thing IS, and which one of them it is. A field asked to be both ends up being neither.

**Worse than empty.** 52 MADAR offers publish «N كجم/صندوق» or `N Pcs/Box` — the shop naming a **box** and saying what is in it — and 18 are stored as `kg` with basis 3 or 4. The schema is overwriting what the shop said, today, in the owner's live data, against this project's first rule.

## What ships, for one source

| | |
|---|---|
| **Migration 0058** | splits `unit + basis` from `content_quantity + content_unit`; adds `unit_basis_provenance` and `unit_basis_witness`; two triggers refuse a unit arriving without them. The 1,064 units already here are **marked** `legacy_unwitnessed`, not deleted. |
| **`scrapex/units.py`** | carries out a charter. Knows no shop. |
| **`sources.yaml`** | the charter, under the source, validated by the existing `validate-manifest` gate — hundreds of sites are waiting and a Python branch per site is not a method. |

## The owner's ruling, recorded where it belongs

He opened product 261 himself and found the shop states a weight **twice** — an authored spec row and the platform's numeric field, 20 and 1. They disagree on **14 of the 76** products carrying both. His ruling: «اسم المنتج يحسم كل شى بالنسبة لموقع سيكا **(قاعدة لا تعمم)**». It is written under `SIKAEGSHOP` as a fact about that shop, not a law about shops.

## Measured over the 87 live products

```
from the name      77
from «الوزن»        6
from the prose row  4
SILENT              0
------------------------
RESOLVED           87 of 87      (today: 56)
```

Today's 56 all read `kg` from the **English name alone** — so kg was the only unit this warehouse could ever record. Now: `kg` 60 · `ml` 14 · `m` 11 · `gm` 1 · `liter` 1.

**The acceptance test:** the four Backing Rods resolve to `1 m`, witness `attr_1@en/v1: 1 Meter` — **not** the `1 CM` in their names. That was the original complaint.

## A correction I owe the record

My first charter declared cm and mm a separate *dimension scale*, and I described that as the thing which saved the Backing Rods. **The rule-removal test disagreed**, and measuring it over all 87 products showed it changed **zero** answers — the pack allow-list and the word boundary were already doing the work. The declaration is gone and every comment that credited it is corrected. A rule that carries nothing reads like a guarantee and is not one.

## Blast radius

Nothing outside `SIKAEGSHOP` moves. `normalize.selling_unit_from` is untouched — magento calls it from four places. The ten sources with no charter resolve **nothing**, which is the honest state of a source nobody has studied yet.

All gates: `pytest` exit 0 / zero FAILED · parity exit 0 · `node --test extension/tests` exit 0 · `node --test apps_script/tests` exit 0 · `validate-manifest` OK.
