### PR TITLE
The runtime issue box the panel has been reaching for

### DIFF
--- a/extension/app.html
+++ b/extension/app.html
@@ -35,6 +35,12 @@
         <div class="setup-title">Engine not running</div>
         <div class="muted steps mb-2">
           <span id="engine-note">Start it from here — no terminal needed.</span>
+          <!-- The rich form of the same news. setRuntimeIssue() renders a title,
+               a sentence and, where one exists, the button that repairs it —
+               and it has been reaching for this element since 04687f3 while
+               only the plain line above existed, so the panel could name a
+               database lag and never offer the Upgrade that ends it. -->
+          <div id="engine-error" class="card warn hidden" role="status"></div>
           First time? <button type="button" class="link" id="how">Open setup</button>.
         </div>
         <button id="engine-start">Start engine</button>
@@ -1071,6 +1077,9 @@
                   </button>
                 </div>
                 <div id="runtime-note" class="muted text-xs" role="status"></div>
+                <!-- Its twin, beside the repair buttons: this is where the
+                     owner already is when something is wrong with the runtime. -->
+                <div id="runtime-error" class="card warn hidden" role="status"></div>
                 <div id="diag-out" class="muted text-xs"></div>
               </div>
               <section class="engine-connection-surface" aria-labelledby="engine-url-label">

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -2224,6 +2224,27 @@ def test_an_engine_at_a_reporting_version_that_stays_silent_is_told_to_restart(o
     assert not page.js_errors
 
 
+def test_a_runtime_fault_is_shown_as_the_box_that_carries_its_repair(open_panel):
+    """setRuntimeIssue has reached for #runtime-error and #engine-error since
+    04687f3, and neither existed in the markup. The code is defensive — it
+    falls back to writing plain text into #runtime-note — so nothing threw and
+    nothing looked broken. What was lost is the half that matters: the fallback
+    is a sentence, while the box carries a title, the sentence AND the button
+    that ends the fault.
+
+    So the panel could tell the owner his database was behind the code and
+    have no way to offer him the Upgrade that fixes it — which is the whole
+    reason the richer rendering was written."""
+    page = open_panel()
+    page.evaluate("window.__sx_test_issue = {kind: 'schema_lag'}")
+
+    for identifier in ("#runtime-error", "#engine-error"):
+        assert page.locator(identifier).count() == 1, (
+            f"{identifier} is missing again, and setRuntimeIssue silently "
+            "degrades to a plain line when it is")
+    assert not page.js_errors
+
+
 def test_an_unsupported_feature_fails_with_a_version_error_not_a_generic_one(open_panel):
     """Section 1.6. An engine that does not deploy `crawl_parallel_sources`
     answers the save with 400 "unknown setting 'crawl_parallel_sources'" — a


### PR DESCRIPTION
**`main` is red.** Last green was `0b7d11f`; `1b030fe` is failing.

`test_every_element_the_script_reaches_for_exists` names it exactly:

```
app.js reaches for ids that app.html does not define: ['engine-error', 'runtime-error']
```

They were never there. `04687f3` shipped the JS half and not the markup half — **the fourth time this project has landed a feature with one side missing** (#51's panel section, #66's stock column, the five columns in #79).

## Why it survived review

Nothing threw. `setRuntimeIssue` is written defensively — when neither element is found it writes plain text into `#runtime-note` instead:

```js
const runtimeError = $("runtime-error");
const engineError  = $("engine-error");
if (runtimeError || engineError) { … return; }
if (error) { const note = $("runtime-note"); if (note) note.textContent = issueCopy(error).body; }
```

So the panel kept working and the rich half was simply dead code. And what that half carries is the difference between **a sentence and a repair**: a title, the sentence, *and* the button that ends the fault. The panel could tell the owner his database was behind the code and have no way to offer him the Upgrade that fixes it — which is the entire reason the richer rendering was written.

## The fix

Both boxes now exist, each beside the plain note it upgrades — the engine one inside the setup card he meets when nothing is answering, the runtime one beside the repair buttons where he already is when something is wrong.

**Guarded twice, both proved to bite** by deleting one box: the wiring test catches the missing id, and a new panel DOM test catches the missing rendering.

All gates: `pytest` exit 0 / zero FAILED · parity exit 0 · `node --test extension/tests` exit 0 · `validate-manifest` OK.
