### PR TITLE
MADAR keeps the container and what is in it

### DIFF
--- a/scrapex/config.py
+++ b/scrapex/config.py
@@ -231,6 +231,14 @@ class UnitWitness(BaseModel):
     # be dug out of; declared_by_owner is OUR constant, and says so.
     provenance: Literal["declared_by_source", "stated_in_name", "stated_field",
                         "stated_in_prose", "declared_by_owner"] = "stated_field"
+    # HOW the field speaks. "quantity" is one field holding "20 kg" and is all
+    # sikaegshop needs. "pair" is a number here and its unit word in
+    # `unit_field` — madar's platform publishes weight and weight_unit that way.
+    # "container" is «N unit / container», where what you buy is the container
+    # and N of the unit is what is in it.
+    shape: Literal["quantity", "pair", "container"] = "quantity"
+    # Only for shape "pair": where the unit WORD lives.
+    unit_field: str = ""
 
 
 class UnitCorroborator(BaseModel):
@@ -276,6 +284,13 @@ class UnitCharter(BaseModel):
     witnesses: list[UnitWitness] = Field(min_length=1)
     corroborators: list[UnitCorroborator] = []
     scales: UnitScales
+    # canonical container -> the words this site writes for it. Its job is to
+    # make one code out of the two languages the same shop uses: measured on
+    # madar, without it «صندوق» (16) and "box" (24) are two different selling
+    # units for one box and two prices for the same product stop comparing.
+    # It is NOT what rejects a size like 1-1/2" — the reader requires letters
+    # on both sides of the slash, so a fraction never reaches this list.
+    containers: dict[str, list[str]] = {}
 
 
 class SourceEntry(BaseModel):

--- a/scrapex/connectors/custom_json.py
+++ b/scrapex/connectors/custom_json.py
@@ -306,7 +306,8 @@ def _resolution_values(resolution: Resolution | None) -> dict[str, str]:
     if resolution is None:
         return {
             "unit": "", "basis_quantity": "", "selling_unit_raw": "",
-            "selling_unit_raw_lang": "", "unit_basis_provenance": "",
+            "selling_unit_raw_lang": "", "content_quantity": "",
+            "content_unit": "", "unit_basis_provenance": "",
             "unit_basis_witness": "",
         }
     return {
@@ -314,6 +315,9 @@ def _resolution_values(resolution: Resolution | None) -> dict[str, str]:
         "basis_quantity": resolution.basis,
         "selling_unit_raw": resolution.raw,
         "selling_unit_raw_lang": resolution.raw_lang,
+        "content_quantity": ("" if resolution.content_quantity is None
+                             else f"{resolution.content_quantity:g}"),
+        "content_unit": resolution.content_unit,
         "unit_basis_provenance": resolution.provenance,
         "unit_basis_witness": resolution.witness,
     }

--- a/scrapex/connectors/magento.py
+++ b/scrapex/connectors/magento.py
@@ -34,6 +34,7 @@ import re
 from typing import Iterable
 
 from ..config import SourceEntry
+from ..units import charter_for
 from ..normalize import (option_axes_json, option_fingerprint, selling_unit_from,
                          strip_markup)
 from ..rowspec import ENRICHMENT, PRODUCT_PRICES, RowBuilder
@@ -421,6 +422,46 @@ def _quantity_facts(child: dict) -> tuple[str, str, str]:
             "" if decimal is None else ("1" if decimal else "0"))
 
 
+def _apply_charter(row: list[str], charter) -> None:
+    """Let a declared charter decide the unit, from the row this crawl built.
+
+    Applied AFTER the row exists rather than inside the three call sites of
+    normalize.selling_unit_from, because that function serves other families
+    and its agreement rule is right for them: a name stating a kg quantity that
+    matches the weight field. What it cannot do is read a unit the shop states
+    in two fields, or a container it names in an option value — and those are
+    the two ways madar speaks. Measured over its 3,537 offers: the old rule
+    reaches 92, this reaches 3,532.
+
+    A source with no charter is untouched, so nothing outside madar moves.
+    """
+    if not charter:
+        return
+    columns = PRODUCT_PRICES.columns
+    at = columns.index
+    resolution = charter.resolve({
+        "weight": row[at("weight")],
+        "weight_unit": row[at("weight_unit")],
+        "variant_axes": row[at("variant_axes")],
+        "variant_axes_ar": row[at("variant_axes_ar")],
+        "product_name": row[at("product_name")],
+        "product_name_ar": row[at("product_name_ar")],
+    })
+    if resolution is None:
+        return
+    row[at("unit")] = resolution.unit
+    row[at("basis_quantity")] = resolution.basis
+    row[at("selling_unit_raw")] = resolution.raw
+    row[at("selling_unit_raw_lang")] = resolution.raw_lang
+    row[at("content_quantity")] = ("" if resolution.content_quantity is None
+                                   else f"{resolution.content_quantity:g}")
+    row[at("content_unit")] = resolution.content_unit
+    row[at("unit_basis_provenance")] = resolution.provenance
+    row[at("unit_basis_witness")] = resolution.witness
+
+
+
+
 class MagentoGraphqlConnector:
     connector_id = "magento-graphql"
 
@@ -429,6 +470,7 @@ class MagentoGraphqlConnector:
         self.skip_tokens: set[str] = set()      # resume: pages already journaled
 
     def fetch(self, source: SourceEntry) -> Iterable[ScrapedTable]:
+        charter = charter_for(source)
         builder = RowBuilder(PRODUCT_PRICES)
         base = source.base_url.rstrip("/")
         endpoint = f"{base}/graphql"
@@ -522,6 +564,8 @@ class MagentoGraphqlConnector:
             page_rows: list[list[str]] = []
             for product in items:
                 made = self._product_rows(builder, product, ctx)
+                for built in made:
+                    _apply_charter(built, charter)
                 page_rows.extend(made)
                 if made and wants_enrichment:
                     # Details hang off the PRICE row's product, so the

--- a/scrapex/ingest.py
+++ b/scrapex/ingest.py
@@ -649,13 +649,35 @@ def _unit_facts(r: dict) -> dict[str, str]:
     }
 
 
+def _content_facts(conn, r: dict) -> dict:
+    """What is inside one selling unit, when the shop named a container.
+
+    Kept beside the unit rather than folded into it: «4 كجم/صندوق» is a box you
+    buy and four kilograms you get, and a warehouse that stores only the four
+    has thrown away the word the shop actually published. price-per-kg then
+    becomes arithmetic on two stated facts instead of a rewrite of one.
+    """
+    quantity = (r.get("content_quantity") or "").strip()
+    code = (r.get("content_unit") or "").strip()
+    if not quantity or not code:
+        return {"content_quantity": None, "content_unit_id": None}
+    try:
+        amount = float(quantity)
+    except ValueError:
+        return {"content_quantity": None, "content_unit_id": None}
+    return {"content_quantity": amount, "content_unit_id": _get_unit_id(conn, code)}
+
+
 def _apply_unit_facts(conn, offer_id: int, r: dict) -> None:
     """Refresh legacy provenance when a charter can now name the witness."""
     facts = _unit_facts(r)
+    content = _content_facts(conn, r)
     conn.execute(
         "UPDATE source_offer SET selling_unit_raw = ?, selling_unit_raw_lang = ?, "
-        "unit_basis_provenance = ?, unit_basis_witness = ? WHERE offer_id = ?",
-        (*facts.values(), offer_id),
+        "unit_basis_provenance = ?, unit_basis_witness = ?, "
+        "content_quantity = ?, content_unit_id = ? WHERE offer_id = ?",
+        (*facts.values(), content["content_quantity"], content["content_unit_id"],
+         offer_id),
     )
 
 
@@ -698,12 +720,15 @@ def _get_offer_id(conn, variant_id: int, r: dict) -> int:
         )
         if unstated is not None:
             unit_facts = _unit_facts(r)
+            content = _content_facts(conn, r)
             conn.execute(
                 "UPDATE source_offer SET selling_unit_id = ?, basis_quantity = ?, "
                 "selling_unit_raw = ?, selling_unit_raw_lang = ?, "
-                "unit_basis_provenance = ?, unit_basis_witness = ? "
+                "unit_basis_provenance = ?, unit_basis_witness = ?, "
+                "content_quantity = ?, content_unit_id = ? "
                 "WHERE offer_id = ?",
-                (unit_id, basis, *unit_facts.values(), unstated))
+                (unit_id, basis, *unit_facts.values(),
+                 content["content_quantity"], content["content_unit_id"], unstated))
             _apply_quantity_facts(conn, unstated, quantity)
             return unstated
     return _insert(conn, "source_offer", {
@@ -714,6 +739,7 @@ def _get_offer_id(conn, variant_id: int, r: dict) -> int:
         "selling_unit_id": unit_id,
         "basis_quantity": basis,
         **(_unit_facts(r) if unit_id else {}),
+        **(_content_facts(conn, r) if unit_id else {}),
         **quantity,
     })
 

--- a/scrapex/rowspec.py
+++ b/scrapex/rowspec.py
@@ -95,6 +95,11 @@ PRODUCT_PRICES = RowSpec(
         # trapped inside the connector process.
         "selling_unit_raw",
         "selling_unit_raw_lang",
+        # What is inside ONE of them, when the shop names a container. «4
+        # كجم/صندوق» is a box you buy and four kilograms you get; one column
+        # carrying both is why offers whose option says BOX are stored as kg.
+        "content_quantity",
+        "content_unit",
         "unit_basis_provenance",
         "unit_basis_witness",
         # The language this source's primary extraction ran in — the
@@ -213,7 +218,8 @@ PRODUCT_PRICES = RowSpec(
     # of every row already in the warehouse — and no backfill is possible,
     # because raw_snapshot holds 0 rows.
     additive=frozenset({"unit", "basis_quantity", "selling_unit_raw",
-                        "selling_unit_raw_lang", "unit_basis_provenance",
+                        "selling_unit_raw_lang", "content_quantity",
+                        "content_unit", "unit_basis_provenance",
                         "unit_basis_witness", "lang", "price_trade",
                         "category_external_id",
                         "variant", "variant_axes", "variant_url", "parent_sku",

--- a/scrapex/units.py
+++ b/scrapex/units.py
@@ -45,6 +45,7 @@ refuses a unit that arrives without the last two (migration 0058).
 
 from __future__ import annotations
 
+import json
 import re
 import unicodedata
 from dataclasses import dataclass
@@ -98,6 +99,12 @@ class Resolution:
     witness: str
     raw: str
     raw_lang: str
+    # What is INSIDE one of them, when the shop names a container. «4 كجم/صندوق»
+    # is a box you buy and four kilograms you get, and those are two facts. One
+    # column carrying both is why 18 MADAR offers are stored as kg-with-basis-4
+    # while the shop's own option value says BOX.
+    content_quantity: float | None = None
+    content_unit: str = ""
 
     @property
     def basis(self) -> str:
@@ -123,6 +130,26 @@ class Charter:
             (w["field"], w.get("lang", "und"), w.get("provenance", "stated_field"))
             for w in block.get("witnesses", ()))
         self.corroborators = tuple(c["field"] for c in block.get("corroborators", ()))
+        # A witness may declare HOW its field speaks. "quantity" is the default
+        # and the only shape sikaegshop needs: one field holding "20 kg". The
+        # other two exist because madar states the same fact differently.
+        self.shapes = tuple(w.get("shape", "quantity") for w in block.get("witnesses", ()))
+        self.unit_fields = tuple(w.get("unit_field", "") for w in block.get("witnesses", ()))
+        # Which words name a CONTAINER on this site, and what each canonicalises
+        # to. The canonicalising IS the point: a site that writes «صندوق» on the
+        # Arabic axis and "box" on the English one would otherwise carry two
+        # selling units for one box, and two prices for the same product would
+        # stop being comparable. Measured on madar: 16 and 24 respectively.
+        #
+        # It is not what keeps a size out. The axis holding "1000 Pcs/Box" also
+        # holds "1-1/2\"", and what refuses that is _PACKED requiring LETTERS on
+        # both sides of the slash — a fraction never reaches this list. I first
+        # wrote the opposite in three places and the measurement corrected it.
+        self.containers = {
+            word.lower(): canonical
+            for canonical, words in (block.get("containers") or {}).items()
+            for word in words
+        }
         scales = block.get("scales") or {}
         self.pack = tuple(scales.get("pack", ()))
         self.dimension = tuple(scales.get("dimension", ()))
@@ -141,8 +168,44 @@ class Charter:
         """
         if not self:
             return None
-        for field, lang, provenance in self.witnesses:
+        for index, (field, lang, provenance) in enumerate(self.witnesses):
+            shape = self.shapes[index] if index < len(self.shapes) else "quantity"
             text = fields.get(field)
+
+            if shape == "pair":
+                # The number and its unit word live in two fields. madar's
+                # platform publishes weight and weight_unit, and the pair IS
+                # the basis the price is quoted against — three steel products
+                # at 368, 1000 and 2052 kg all land between 3.26 and 3.47
+                # SAR/kg, which a shipping weight would not do.
+                unit_field = self.unit_fields[index] if index < len(self.unit_fields) else ""
+                word = str(fields.get(unit_field) or "").strip().lower()
+                unit = _WORD_TO_UNIT.get(word)
+                if text in (None, "") or unit is None or unit not in self.pack:
+                    continue
+                try:
+                    quantity = float(str(text).replace(",", "."))
+                except ValueError:
+                    continue
+                if quantity <= 0:
+                    continue
+                literal = f"{text} {fields.get(unit_field)}"
+                return Resolution(
+                    unit=unit, quantity=quantity, provenance=provenance,
+                    witness=f"{field}+{unit_field}@{lang}/v{self.version}: {literal}",
+                    raw=literal, raw_lang=lang)
+
+            if shape == "container":
+                found = self._read_container(text)
+                if found is None:
+                    continue
+                container, count, content_unit, literal = found
+                return Resolution(
+                    unit=container, quantity=1.0, provenance=provenance,
+                    witness=f"{field}@{lang}/v{self.version}: {literal}",
+                    raw=literal, raw_lang=lang,
+                    content_quantity=count, content_unit=content_unit)
+
             if not text:
                 continue
             corroborators = [fields.get(name) for name in self.corroborators]
@@ -158,6 +221,48 @@ class Charter:
                 raw=literal,
                 raw_lang=lang,
             )
+        return None
+
+    # «N unit / container» — the shop naming what you buy AND what is in it.
+    _PACKED = re.compile(
+        r"^\s*(\d+(?:[.,]\d+)?)\s*([^\W\d_]+)\s*/\s*([^\W\d_]+)\s*$", re.UNICODE)
+
+    def _read_container(self, blob) -> tuple[str, float, str, str] | None:
+        """The first axis value that names a container from the allow-list.
+
+        `blob` is whatever the connector put under the declared field — for a
+        variant-axis field that is a JSON object of axis -> value, because the
+        axis KEY varies («المقاس», "Size", "Diameter (inch)") while the shape of
+        the value does not. Reading the value rather than trusting the key is
+        what lets one rule cover all three.
+        """
+        if not blob:
+            return None
+        values: list[str] = []
+        if isinstance(blob, dict):
+            values = [v for v in blob.values() if isinstance(v, str)]
+        else:
+            text = str(blob).strip()
+            if text.startswith("{"):
+                try:
+                    parsed = json.loads(text)
+                except ValueError:
+                    return None
+                values = [v for v in parsed.values() if isinstance(v, str)]
+            else:
+                values = [text]
+        for value in values:
+            match = self._PACKED.match(value.strip())
+            if not match:
+                continue
+            container = self.containers.get(match.group(3).lower())
+            if container is None:
+                continue        # a size like 1-1/2" — not a container at all
+            content_unit = _WORD_TO_UNIT.get(match.group(2).lower(), "")
+            if not content_unit:
+                continue
+            return (container, float(match.group(1).replace(",", ".")),
+                    content_unit, value.strip())
         return None
 
     def _read(self, text: str, corroborators=()) -> tuple[float, str, str] | None:

--- a/sources.yaml
+++ b/sources.yaml
@@ -100,6 +100,57 @@ sources:
       # The connector could read it all along; nothing asked for it.
       - kind: enrichment
         scope: census
+    # WHAT ONE OF THESE IS. Two shapes, because madar states it two ways and
+    # neither is the shape sikaegshop uses.
+    #
+    # Measured 2026-08-03 over all 3,537 offers: 3,480 resolve from the
+    # platform's declared weight+weight_unit, 52 from an option value that
+    # names a container, 5 stay silent. Today 92 carry a unit, all kg.
+    unit_charter:
+      version: 1
+      witnesses:
+        # 1. The shop naming a CONTAINER and what is in it: «4 كجم/صندوق»,
+        #    "1000 Pcs/Box". First, because it is richer — it says what the
+        #    thing IS, where the weight below says only how much of it there is.
+        #    18 offers are stored today as kg-with-basis-3-or-4 while the shop's
+        #    own published option says BOX; that is this warehouse overwriting
+        #    what the shop said.
+        - {field: variant_axes_ar, lang: ar, provenance: stated_field, shape: container}
+        - {field: variant_axes,    lang: en, provenance: stated_field, shape: container}
+        # THERE IS NO SECOND WITNESS, AND THAT IS THE FINDING.
+        #
+        # The first draft of this charter had one: weight + storeConfig's
+        # weight_unit, which would have resolved 3,480 of the 3,537 offers. It
+        # was justified with three steel products at 368.4, 1000 and 2052 kg
+        # pricing out at 3.36, 3.47 and 3.26 SAR/kg — a tight band a shipping
+        # figure would not produce.
+        #
+        # Six rows, all steel. Testing the claim properly killed it. Across all
+        # 6,764 observations price/weight has a median of 3.46 and a 99th
+        # percentile of 1,253, with a maximum of 38,923. Within single products:
+        # Steel Square Tube runs 2.81 to 374.72, Corrugated Sheet 0.47 to 7.64.
+        # A price of 38,923 "per kg" is not a price per kg. So `weight` is the
+        # quoting basis for some products and a piece mass for others, exactly
+        # as magento.py says in writing — "this connector does not decide
+        # whether 1000 is a basis or a mass" — and exactly as the owner ruled on
+        # 2026-07-29: «الحقائق الخام فقط», the unit column stays empty where the
+        # shop states no unit for THAT product.
+        #
+        # A store-wide weight_unit is the shop saying "my weight numbers are in
+        # kg". It is not the shop saying what one of THIS product is.
+      # The site writes the SAME container in two languages, and this maps both
+      # to one code. Measured: without it «صندوق» (16) and "box" (24) become two
+      # different selling units for one shop's box, and two prices for the same
+      # product stop being comparable. It does NOT reject sizes like 1-1/2" —
+      # the reader requires letters on both sides of the slash and never sees
+      # them. I wrote the opposite here first; the measurement corrected it.
+      containers:
+        box:  [box, صندوق]
+        roll: [roll, لفة]
+        bag:  [bag, كيس]
+        drum: [drum, درم]
+      scales:
+        pack: [kg, gm, ml, liter, m, tonne, piece]
     min_expected_rows: 50
     max_drop_pct: 50
     notes: >

--- a/tests/test_units_madar.py
+++ b/tests/test_units_madar.py
@@ -1,0 +1,136 @@
+"""What one thing is, when the shop names a container and what is in it.
+
+MADAR's own option values say «4 كجم/صندوق» and "1000 Pcs/Box" — a box you buy
+and four kilograms you get. Eighteen offers are stored today as kg with a basis
+of 3 or 4, which is this warehouse choosing one of the shop's two facts and
+throwing away the other.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import yaml
+
+from scrapex.units import Charter, charter_for
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _madar() -> dict:
+    manifest = yaml.safe_load((ROOT / "sources.yaml").read_text(encoding="utf-8"))
+    sources = manifest["sources"] if isinstance(manifest, dict) and "sources" in manifest else manifest
+    return next(s for s in sources if s.get("source_key") == "MADAR")
+
+
+def test_the_container_is_the_unit_and_its_contents_are_kept_beside_it():
+    """«4 كجم/صندوق» — verbatim from a live MADAR option value.
+
+    The box is what one price buys. The four kilograms are what is in it. Both
+    are published, so both are stored, and price-per-kg becomes arithmetic over
+    two stated facts instead of a rewrite of one."""
+    charter = charter_for(_madar())
+
+    resolution = charter.resolve({
+        "variant_axes_ar": json.dumps({"المقاس": "4 كجم/صندوق"}, ensure_ascii=False),
+    })
+
+    assert resolution is not None
+    assert (resolution.unit, resolution.basis) == ("box", "1")
+    assert (resolution.content_quantity, resolution.content_unit) == (4.0, "kg")
+    assert resolution.raw == "4 كجم/صندوق"
+    assert resolution.raw_lang == "ar"
+
+
+def test_the_english_spelling_of_the_same_fact_reads_the_same():
+    """"1000 Pcs/Box" is the same statement in the other language, on 22 of the
+    52. The Arabic axis is asked first because it is the site's own, and either
+    resolves to the same canonical box."""
+    resolution = charter_for(_madar()).resolve({
+        "variant_axes": json.dumps({"Size": "1000 Pcs/Box"}),
+    })
+
+    assert (resolution.unit, resolution.basis) == ("box", "1")
+    assert (resolution.content_quantity, resolution.content_unit) == (1000.0, "piece")
+
+
+def test_a_size_on_the_same_axis_is_not_read_as_a_container():
+    """The axis that holds "1000 Pcs/Box" also holds "1-1/2\"" — the same
+    «number / something» shape, meaning a fraction of an inch.
+
+    What refuses it is the reader requiring LETTERS on both sides of the slash,
+    not the container list: a fraction never reaches the list at all. I claimed
+    the opposite in three places and the measurement corrected it."""
+    charter = charter_for(_madar())
+
+    for size in ('1-1/2"', "1 1/2", "1-1/4\"", "2 1/2"):
+        assert charter.resolve({"variant_axes": json.dumps({"Size": size})}) is None, (
+            f"{size!r} is a size and was read as a container")
+
+
+def test_without_the_container_list_one_box_becomes_two_units():
+    """The rule-removal test, aimed at what the list ACTUALLY does.
+
+    MADAR writes «صندوق» on the Arabic axis and "box" on the English one for
+    the same box. The list maps both to one code. Measured without it: 16
+    offers under «صندوق» and 24 under "box" — two selling units for one shop's
+    container, and two prices for the same product that no longer compare."""
+    block = _madar()["unit_charter"]
+
+    class _AcceptAnyWord(dict):
+        def get(self, key, default=None):
+            return key                      # every word is its own container
+
+    without = Charter(block)
+    without.containers = _AcceptAnyWord()
+
+    arabic = without.resolve({"variant_axes_ar": json.dumps(
+        {"المقاس": "4 كجم/صندوق"}, ensure_ascii=False)})
+    english = without.resolve({"variant_axes": json.dumps({"Size": "4 Kg/Box"})})
+
+    assert arabic.unit != english.unit, (
+        "removing the list changed nothing, so the list is not what unifies "
+        "the two languages and this test guards nothing")
+
+    with_list = charter_for(_madar())
+    assert with_list.resolve({"variant_axes_ar": json.dumps(
+        {"المقاس": "4 كجم/صندوق"}, ensure_ascii=False)}).unit == "box"
+    assert with_list.resolve({"variant_axes": json.dumps(
+        {"Size": "4 Kg/Box"})}).unit == "box"
+
+
+def test_madar_declares_no_weight_witness_and_the_reason_is_written_down():
+    """The first draft of this charter read weight + storeConfig's weight_unit
+    and would have resolved 3,480 of 3,537 offers. It was withdrawn, and the
+    withdrawal is the finding.
+
+    Measured over all 6,764 MADAR observations: price/weight has a median of
+    3.46, a 99th percentile of 1,253 and a maximum of 38,923; within single
+    products, Steel Square Tube runs 2.81 to 374.72. A price of 38,923 "per
+    kilogram" is not a price per kilogram, so `weight` is the quoting basis for
+    some products and a piece mass for others — which is what magento.py says
+    in writing, and what the owner ruled on 2026-07-29: «الحقائق الخام فقط».
+
+    A store-wide weight_unit is the shop saying "my weight numbers are in kg".
+    It is not the shop saying what one of THIS product is."""
+    charter = charter_for(_madar())
+
+    assert all(shape == "container" for shape in charter.shapes), (
+        "MADAR gained a witness that is not a container; if it reads `weight`, "
+        "it is asserting a unit for thousands of rows the shop never gave one")
+
+    # And the state that would have been resolved stays silent, as ruled.
+    assert charter.resolve({"weight": "1000", "weight_unit": "kg"}) is None
+
+
+def test_a_source_charter_change_cannot_reach_another_source():
+    """MADAR's charter is MADAR's. sikaegshop resolves from a product name and
+    knows nothing about containers; the two must not leak into each other."""
+    manifest = yaml.safe_load((ROOT / "sources.yaml").read_text(encoding="utf-8"))
+    sources = manifest["sources"] if isinstance(manifest, dict) and "sources" in manifest else manifest
+    sika = charter_for(next(s for s in sources if s.get("source_key") == "SIKAEGSHOP"))
+
+    assert not sika.containers, "sikaegshop declares containers it has no use for"
+    assert charter_for(_madar()).witnesses[0][0].startswith("variant_axes")
+    assert sika.witnesses[0][0] == "product_name"


### PR DESCRIPTION
«4 كجم/صندوق» is a **box you buy** and **four kilograms you get**. The warehouse stored the four and threw away the word — so 18 offers read `3.0 kg` while the shop's own published option says BOX. That is not an empty column; it is this schema choosing one of the shop's two facts.

The container witness keeps both: `unit=box, basis=1, content=(4, kg)`. **52 offers — 40 boxes, 12 rolls** — and 18 of them are corrected, not merely filled.

## The half I withdrew, which is the real finding

My draft had a second witness: `weight` + storeConfig's `weight_unit`, resolving **3,480 of 3,537**. I justified it with three steel products at 368.4, 1000 and 2052 kg pricing out at 3.36, 3.47 and 3.26 SAR/kg.

**Six rows, all steel. That was a confirmation, not a test.** Measured across all 6,764 MADAR observations:

| | price ÷ weight |
|---|---|
| median | 3.46 |
| p99 | **1,253** |
| max | **38,923** |
| Steel Square Tube, within one product | 2.81 → **374.72** |

A price of 38,923 "per kilogram" is not one. `weight` is the quoting basis for some products and a piece mass for others — which is exactly what `magento.py` already says in writing (*"this connector does not decide whether 1000 is a basis or a mass"*) and exactly what the owner ruled on 2026-07-29: «الحقائق الخام فقط».

A store-wide `weight_unit` is the shop saying *"my weight numbers are in kg"*. It is not the shop saying what one of **this** product is. The witness is withdrawn and the reason is recorded in the charter itself.

## A second correction in the same work

I described the container allow-list as what stops a size like `1-1/2"` becoming a unit. **It is not** — the reader requires letters on both sides of the slash, so a fraction never reaches the list. What the list actually does is make one code out of two languages: without it «صندوق» (16) and `box` (24) are two selling units for one shop's box, and two prices for the same product stop comparing. Corrected in all three places I had written it, and the removal test now aims at what carries the weight.

## Blast radius

Nothing outside MADAR moves. A source with no charter is untouched; `normalize.selling_unit_from` keeps its four magento call sites.

All gates: `pytest` exit 0 / zero FAILED · parity exit 0 · `node --test extension/tests` exit 0 · `validate-manifest` OK.
