### PR TITLE
The panel does what it says it did

### DIFF
--- a/db/migrations/0059_a_column_order_that_says_who_arranged_it.sql
+++ b/db/migrations/0059_a_column_order_that_says_who_arranged_it.sql
@@ -1,0 +1,67 @@
+-- =====================================================================
+-- 0059 — A COLUMN ORDER THAT SAYS WHO ARRANGED IT
+--
+-- The owner drags a column in Choose Columns. The panel says it saved. The
+-- page reloads. The table is byte-for-byte what it was.
+--
+-- That is not a rendering bug. The grid takes its order from the literal
+-- BROWSE_COLUMNS list in reports.py and has never read dataset_field at
+-- all — `display_order` occurs zero times in reports.py and zero times in
+-- grid.js. Meanwhile the Choose-Columns panel and the Current-View export
+-- both order BY display_order. So the same warehouse answers "what order
+-- are my columns in" three ways, and they disagree at position 0: on MADAR
+-- the grid opens product_name and the panel opens product_name_ar, with
+-- price at grid index 18 against panel index 13.
+--
+-- The fix is for the grid to read the same order. But a stored order can
+-- only be trusted if we can tell whether a PERSON put it there, and today
+-- nothing records that:
+--
+--   dataset_field_id | source_key | field_key | original_name |
+--   display_name | data_type | is_hidden | display_order | first_seen_at
+--
+-- Nothing temporal but first_seen_at, and reorder() stamps nothing. That
+-- gap is not new — migration 0051 hit the same wall and had to INFER
+-- authorship from proxies, writing that nothing owner-authored was lost
+-- because every row carried display_name NULL and is_hidden 0.
+--
+-- SO THIS MIGRATION ADDS PROVENANCE AND NOTHING ELSE. It does not write a
+-- single display_order. An order the owner arranged is his, and a
+-- migration that "corrected" it would be the very defect being fixed,
+-- committed by the fix.
+--
+-- THE BACKFILL, AND WHY IT IS AN INVERSION RATHER THAN A GUESS. A source
+-- whose display_order is exactly its insertion order was never touched by
+-- a person — that is what ensure_fields writes and what reset_view
+-- restores. Any source whose order DEVIATES from dataset_field_id has been
+-- through reorder(), and reorder() is only reachable from the drag handles
+-- in Choose Columns. So deviation is the signature of a hand, and it is
+-- the only signature available. Measured read-only on the live warehouse
+-- 2026-08-03: 11 of 12 sources sit in exact insertion order, 0 rows carry
+-- a display_name, 2 rows are hidden, and saved_view is empty — so exactly
+-- one source is stamped here, and it is stamped because its owner moved
+-- two fields into the details zone.
+--
+-- The stamp is the migration's own timestamp, not a fabricated past: we
+-- know THAT it was arranged, never when. Recording a date we do not have
+-- would be inventing source truth about the owner himself.
+-- =====================================================================
+
+ALTER TABLE dataset_field ADD COLUMN arranged_at TEXT;
+
+UPDATE dataset_field
+   SET arranged_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+ WHERE source_key IN (
+       SELECT source_key
+         FROM (SELECT source_key,
+                      dataset_field_id,
+                      display_order,
+                      ROW_NUMBER() OVER (PARTITION BY source_key
+                                         ORDER BY dataset_field_id) AS by_insertion,
+                      ROW_NUMBER() OVER (PARTITION BY source_key
+                                         ORDER BY display_order, dataset_field_id) AS by_order
+                 FROM dataset_field)
+        WHERE by_insertion <> by_order
+        GROUP BY source_key);
+
+PRAGMA user_version = 59;

--- a/scrapex/databases/domain.py
+++ b/scrapex/databases/domain.py
@@ -165,7 +165,7 @@ def _general_plan() -> tuple[Migration, ...]:
 # Listed rather than ranged: the unified chain and this one have diverged, so a
 # new price migration lands at the END of the legacy chain but in the middle of
 # this plan. A range would silently swallow whatever General adds next.
-_MARKETLENS_LEGACY_NUMBERS = (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 15, 16, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58)
+_MARKETLENS_LEGACY_NUMBERS = (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 15, 16, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59)
 
 # Where the identity migration sits in this stream. Everything before it is the
 # price history the unified warehouse already had; everything after is a price

--- a/scrapex/fields.py
+++ b/scrapex/fields.py
@@ -83,6 +83,53 @@ def hidden_columns(conn: sqlite3.Connection, source_key: str) -> set[str]:
         (source_key,))}
 
 
+def arranged(conn: sqlite3.Connection, source_key: str) -> bool:
+    """Has a person arranged this source's columns, or is it still the default?
+
+    The distinction decides which order every surface shows. A default is ours
+    to improve; an arrangement is his, and the day we "correct" one is the day
+    the product overwrote its owner.
+    """
+    row = conn.execute(
+        "SELECT 1 FROM dataset_field WHERE source_key = ? AND arranged_at IS NOT NULL "
+        "LIMIT 1", (source_key,)).fetchone()
+    return row is not None
+
+
+def column_order(conn: sqlite3.Connection, source_key: str,
+                 keys: list[str]) -> list[str]:
+    """The order to show `keys` in — the ONE answer all three surfaces use.
+
+    Until now there were three. The grid read a literal list in reports.py, the
+    Choose-Columns panel and the export read dataset_field.display_order, and
+    they disagreed at position 0: MADAR opened product_name on the grid and
+    product_name_ar in the panel, with price 18th against 13th. So the only
+    reorder control the product has — the drag handles in Choose Columns —
+    saved, reloaded the page, and changed nothing the owner could see.
+
+    Not arranged: the agreed reading order, identity then the offer then the
+    filing, computed from reports.COLUMN_RANK. Anything with no rank keeps its
+    given position, after the ranked ones, so a column this file has never
+    heard of is never dropped.
+
+    Arranged: his display_order, exactly. No blending, no "improving" — a
+    default we may replace and an arrangement we may not are different things.
+    """
+    from . import reports
+
+    if arranged(conn, source_key):
+        stored = {row["field_key"]: row["display_order"]
+                  for row in conn.execute(
+                      "SELECT field_key, display_order FROM dataset_field "
+                      "WHERE source_key = ?", (source_key,))}
+        ceiling = len(stored) + len(keys)
+        return sorted(keys, key=lambda key: (stored.get(key, ceiling), key))
+    ceiling = len(reports.COLUMN_RANK)
+    return [key for _, key in sorted(
+        enumerate(keys),
+        key=lambda pair: reports.COLUMN_RANK.get(pair[1], ceiling + pair[0]))]
+
+
 def set_display_name(conn: sqlite3.Connection, source_key: str, field_key: str,
                      display_name: str | None) -> bool:
     """Rename the LABEL. field_key and original_name are untouched, so a rename
@@ -119,13 +166,21 @@ def reorder(conn: sqlite3.Connection, source_key: str, ordered_keys: list[str]) 
         conn.execute(
             "UPDATE dataset_field SET display_order = ? WHERE source_key = ? AND field_key = ?",
             (position, source_key, field_key))
+    # This is the only path a PERSON can reach — the drag handles and the
+    # Arrow Up/Down keys in Choose Columns both land here. Stamping it is what
+    # lets every surface tell an arrangement from a default, which is the whole
+    # reason a stored order can be trusted at all (0059).
+    conn.execute(
+        "UPDATE dataset_field SET arranged_at = strftime('%Y-%m-%dT%H:%M:%SZ','now') "
+        "WHERE source_key = ?", (source_key,))
 
 
 def reset_view(conn: sqlite3.Connection, source_key: str) -> None:
     """Restore the default: original names, everything visible, discovery order."""
     conn.execute(
         "UPDATE dataset_field SET display_name = NULL, is_hidden = 0, "
-        "display_order = dataset_field_id WHERE source_key = ?", (source_key,))
+        "display_order = dataset_field_id, arranged_at = NULL "
+        "WHERE source_key = ?", (source_key,))
 
 
 # ---- saved views -------------------------------------------------------------

--- a/scrapex/reports.py
+++ b/scrapex/reports.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, field
 
 from . import fields, rates, tax
 from .normalize import option_axes_from
-from .vocab import DETAIL_GROUP_ORDER
+from .vocab import BLOCK_ORDER, Block, DETAIL_GROUP_ORDER
 
 
 @dataclass
@@ -741,6 +741,46 @@ BROWSE_COLUMNS: list[tuple[str, str]] = [
     # list where it is written out in full.
     ("product_link", ""),
 ]
+
+
+# WHICH PART OF THE SENTENCE EACH COLUMN IS. The list above keeps the order its
+# authors gave it and every comment they wrote; this says where each block of it
+# belongs when the table is read. Two facts stay separate on purpose: what a
+# column IS (above) and where it SITS (here), so adding a column means naming
+# its block rather than finding a line number.
+#
+# The owner's agreed order is identity, then the offer, then the filing. Before
+# it, MADAR opened with eighteen columns before the price and ten of them were
+# classification.
+COLUMN_BLOCK: dict[str, Block] = {}
+for _key, _label in BROWSE_COLUMNS:
+    if _key.startswith("category") or _key in ("brand", "brand_ar"):
+        COLUMN_BLOCK[_key] = Block.FILING
+    elif _key in ("product_name", "product_name_ar", "sku", "variant", "variant_ar",
+                  "country_code_alpha2"):
+        COLUMN_BLOCK[_key] = Block.IDENTITY
+    elif _key in ("price_changed_on", "last_confirmed_on", "official_source",
+                  "curation", "product_link", "observations"):
+        COLUMN_BLOCK[_key] = Block.PROVENANCE
+    else:
+        COLUMN_BLOCK[_key] = Block.OFFER
+del _key, _label
+
+
+def browse_columns() -> list[tuple[str, str]]:
+    """BROWSE_COLUMNS in the order the owner agreed to read them.
+
+    A stable sort by block and nothing else, so every column keeps the place
+    its author chose INSIDE its block and the category levels keep coming from
+    _level_columns() — raising CATEGORY_LEVELS stays the one-line change this
+    file promises.
+    """
+    return sorted(BROWSE_COLUMNS, key=lambda pair: BLOCK_ORDER.index(COLUMN_BLOCK[pair[0]]))
+
+
+# Where a key sits when nobody has arranged this source by hand. Built from the
+# agreed order, so the three surfaces cannot disagree by construction.
+COLUMN_RANK: dict[str, int] = {key: rank for rank, (key, _) in enumerate(browse_columns())}
 
 # The bilingual pairs, declared ONCE (owner's standing rule: a site that
 # publishes both languages is captured in both). Everything downstream reads
@@ -2043,8 +2083,18 @@ def table_payload(conn: sqlite3.Connection, source_key: str,
 
     return {
         "source_key": source_key,
-        "columns": [{"key": key, "label": labels[key]} for key, label in BROWSE_COLUMNS
-                    if key in present and key not in hidden]
+        # MEMBERSHIP is unchanged — present, and not hidden. Only the ORDER
+        # moved, and it moved to the one answer every surface now shares.
+        # Before this, the grid read the literal list above and the
+        # Choose-Columns panel and the export read dataset_field.display_order,
+        # so dragging a column saved, reloaded the page, and changed nothing on
+        # screen. The site-named extras keep following the agreed ones, as they
+        # always have.
+        "columns": [{"key": key, "label": labels[key]}
+                    for key in fields.column_order(
+                        conn, source_key,
+                        [key for key, _ in BROWSE_COLUMNS
+                         if key in present and key not in hidden])]
                    # Named the way the SITE names them, like the export.
                    + [{"key": label, "label": label} for label in extra
                       if label not in hidden],

--- a/scrapex/vocab.py
+++ b/scrapex/vocab.py
@@ -52,6 +52,38 @@ class Cadence(StrEnum):
     MONTHLY = "monthly"
 
 
+class Block(StrEnum):
+    """Which part of the sentence a MAIN-TABLE column belongs to.
+
+    DetailGroup below files a fact into the record panel. This files a column
+    into the table itself, and they are different questions: a column can be
+    in the table and still belong to a block, and a fact can be in a group and
+    never be a column at all.
+
+    The owner's agreed reading order, «الهوية ثم العرض ثم التصنيف»:
+
+      IDENTITY    which thing this row is — the name, the sku, the variant
+      OFFER       what it costs and on what terms — the reason the table exists
+      FILING      where the shop files it — brand, category, every level
+      PROVENANCE  where the row came from and when it was last true
+
+    It exists because the table opened with twenty-seven filing columns before
+    the price. Measured on the owner's MADAR: price at grid index 18, and ten
+    of the eighteen before it were classification.
+    """
+
+    IDENTITY = "identity"
+    OFFER = "offer"
+    FILING = "filing"
+    PROVENANCE = "provenance"
+
+
+# The reading order itself. A column's block decides where it sits; its
+# position inside the block stays exactly where its author put it.
+BLOCK_ORDER: tuple[Block, ...] = (
+    Block.IDENTITY, Block.OFFER, Block.FILING, Block.PROVENANCE)
+
+
 class DetailGroup(StrEnum):
     """Where a detail is filed in the record panel. Owner ruling
     2026-07-26: FIVE groups, and anything a future site publishes goes

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -57,7 +57,7 @@ def test_migration_creates_the_catalogue_and_integrity_triggers(conn):
     assert objects["relationship_field_pair"] == "table"
     assert objects["trg_dataset_relationship_same_site_insert"] == "trigger"
     assert objects["trg_relationship_field_pair_matches_insert"] == "trigger"
-    assert conn.execute("PRAGMA user_version").fetchone()[0] == 58
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 59
 
 
 def test_one_site_can_hold_multiple_tables_with_different_dynamic_columns(conn):

--- a/tests/test_database_isolation.py
+++ b/tests/test_database_isolation.py
@@ -67,7 +67,7 @@ def test_fresh_registry_creates_two_typed_databases_without_domain_tables_crossi
     assert applied["general"] == list(
         range(1, registry.general.latest_schema_version + 1)
     )
-    assert applied["marketlens"] == list(range(1, 57))   # ... +56 a unit that can name who said it
+    assert applied["marketlens"] == list(range(1, 58))   # ... +56 a unit that can name who said it
     assert registry.health()["general"]["status"] == "Healthy"
     assert registry.health()["marketlens"]["status"] == "Healthy"
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -27,12 +27,12 @@ def test_migrate_is_idempotent(tmp_path: Path):
         second = dbmod.migrate(conn)
     finally:
         conn.close()
-    assert first == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58]
+    assert first == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59]
     assert second == []  # T4: running again applies nothing
 
 
 def test_latest_schema_version_matches_the_migration_chain():
-    assert dbmod.latest_schema_version() == 58   # +0057 the weight the price is quoted against
+    assert dbmod.latest_schema_version() == 59   # +0057 the weight the price is quoted against
 
 
 def test_foreign_keys_actually_enforced(tmp_path: Path):

--- a/tests/test_display_method_and_quantity_facts.py
+++ b/tests/test_display_method_and_quantity_facts.py
@@ -575,7 +575,7 @@ def test_migration_0056_corrects_has_variants_on_rows_that_already_exist():
                          " VALUES (2, ?)", (member,))
         conn.commit()
 
-        assert dbmod.migrate(conn) == [56, 57, 58]
+        assert dbmod.migrate(conn) == [56, 57, 58, 59]
 
         flags = dict(conn.execute(
             "SELECT external_product_id, has_variants FROM source_product"))

--- a/tests/test_extract_storage.py
+++ b/tests/test_extract_storage.py
@@ -113,7 +113,7 @@ def test_legacy_0014_remains_available_for_explicit_unified_sessions(tmp_path: P
     legacy = dbmod.connect(tmp_path / "legacy.db")
     try:
         dbmod.migrate(legacy)
-        assert dbmod.schema_version(legacy) == 58   # +0058 the weight the price is quoted against
+        assert dbmod.schema_version(legacy) == 59   # +0059 the weight the price is quoted against
         for table in ("price_observation", "generic_record"):
             assert legacy.execute(
                 "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1",

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -62,7 +62,7 @@ def _insert_observation(conn, ids, price: float = 168.78, hash_: str = "h1") -> 
 
 
 def test_migration_reaches_latest_version(conn):
-    assert dbmod.schema_version(conn) == 58   # +0058 the weight the price is quoted against
+    assert dbmod.schema_version(conn) == 59   # +0059 the weight the price is quoted against
 
 
 def test_all_owner_tables_exist(conn):
@@ -168,7 +168,7 @@ def test_migration_0020_preserves_existing_jobs_and_their_log_references():
         upgrading.commit()
 
         assert dbmod.migrate(upgrading) == [20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
-                                            30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58]
+                                            30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59]
 
         joined = upgrading.execute(
             "SELECT j.job_ref, j.status, l.message FROM job_log_entry l"

--- a/tests/test_the_panel_does_what_it_says.py
+++ b/tests/test_the_panel_does_what_it_says.py
@@ -1,0 +1,149 @@
+"""One column order, read by every surface.
+
+The owner drags a column in Choose Columns. The panel says it saved. The page
+reloads. The table is byte-for-byte what it was.
+
+That was not a rendering bug. The grid took its order from the literal
+BROWSE_COLUMNS list and had never read dataset_field at all — `display_order`
+occurred zero times in reports.py and zero times in grid.js — while the
+Choose-Columns panel and the Current-View export both ordered BY display_order.
+So the same warehouse answered "what order are my columns in" three ways, and
+they disagreed at position 0: MADAR opened product_name on the grid and
+product_name_ar in the panel, with price 18th against 13th.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import tempfile
+
+import pytest
+
+from scrapex import db as dbmod, fields, reports
+from scrapex.vocab import BLOCK_ORDER, Block
+
+
+@pytest.fixture()
+def conn():
+    path = pathlib.Path(tempfile.mkdtemp()) / "order.db"
+    connection = dbmod.connect(path)
+    dbmod.migrate(connection)
+    return connection
+
+
+def test_the_agreed_order_puts_the_offer_straight_after_the_identity():
+    """«الهوية ثم العرض ثم التصنيف». Before this, the main table opened with
+    twenty-seven filing columns and reached price at index 32."""
+    order = [key for key, _ in reports.browse_columns()]
+
+    assert order.index("price") < order.index("category"), (
+        "the price is still filed behind the classification")
+    assert order.index("price") <= 8, (
+        f"price sits at index {order.index('price')}; the agreement puts the "
+        "offer directly after the identity")
+    # And identity really is first — the name, not a category.
+    assert order[0] == "product_name"
+
+
+def test_every_column_has_a_block_and_the_blocks_run_in_the_agreed_order():
+    """A column with no block would sort by accident. The membership is
+    asserted rather than assumed, because the mapping is by rule and a rule
+    that misses a key fails silently."""
+    keys = [key for key, _ in reports.BROWSE_COLUMNS]
+
+    assert set(reports.COLUMN_BLOCK) == set(keys), (
+        "some column has no block: "
+        f"{sorted(set(keys) - set(reports.COLUMN_BLOCK))}")
+
+    blocks = [reports.COLUMN_BLOCK[key] for key, _ in reports.browse_columns()]
+    positions = [BLOCK_ORDER.index(block) for block in blocks]
+    assert positions == sorted(positions), (
+        "the blocks are interleaved; browse_columns is not sorting by block")
+
+
+def test_the_category_levels_still_come_from_the_generator():
+    """PR #63 was sent back for re-typing twenty tuples by hand and orphaning
+    _level_columns(). reports.py promises that raising the ceiling is one line,
+    and this asserts the promise is true rather than written."""
+    before = [key for key, _ in reports.browse_columns() if key.startswith("category_l")]
+
+    original = reports.CATEGORY_LEVELS
+    try:
+        reports.CATEGORY_LEVELS = original + 2
+        rebuilt = reports._level_columns()
+    finally:
+        reports.CATEGORY_LEVELS = original
+
+    assert len(rebuilt) == (original + 2) * 2, (
+        "raising CATEGORY_LEVELS did not produce more levels — the generator "
+        "is no longer what builds them")
+    assert len(before) == original * 2 + 2      # +2 for category_leaf and its _ar
+
+
+def test_an_unarranged_source_shows_the_agreed_order(conn):
+    """The default is ours to improve. Nobody has touched this source, so the
+    agreement decides."""
+    keys = ["category_l1", "price", "product_name", "brand", "sku"]
+
+    assert not fields.arranged(conn, "NEW")
+    assert fields.column_order(conn, "NEW", keys) == [
+        "product_name", "sku", "price", "brand", "category_l1"]
+
+
+def test_an_arrangement_the_owner_made_wins_and_is_not_blended(conn):
+    """His arrangement is his. A default we may replace and an arrangement we
+    may not are different things, and the code must be able to tell them
+    apart — which is the entire reason 0059 exists."""
+    keys = ["category_l1", "price", "product_name", "brand", "sku"]
+    fields.ensure_fields(conn, "MINE", keys)
+    fields.reorder(conn, "MINE", ["brand", "price"])
+
+    assert fields.arranged(conn, "MINE"), (
+        "dragging a column did not stamp the source, so no surface can tell "
+        "his order from ours")
+    shown = fields.column_order(conn, "MINE", keys)
+    assert shown[:2] == ["brand", "price"], (
+        "the agreed order overrode what he arranged")
+
+
+def test_resetting_the_view_hands_the_order_back(conn):
+    """Reset means reset. If arranged_at survived it, the source would keep
+    claiming an arrangement that no longer exists and never see an improved
+    default again."""
+    keys = ["category_l1", "price", "product_name"]
+    fields.ensure_fields(conn, "MINE", keys)
+    fields.reorder(conn, "MINE", ["category_l1"])
+    assert fields.arranged(conn, "MINE")
+
+    fields.reset_view(conn, "MINE")
+
+    assert not fields.arranged(conn, "MINE")
+    assert fields.column_order(conn, "MINE", keys)[0] == "product_name"
+
+
+def test_a_column_the_agreement_has_never_heard_of_is_not_dropped(conn):
+    """A source-named extra, or a column added tomorrow. Ranking is not
+    membership: an unranked key keeps its given position and follows the ranked
+    ones, because losing a column to fix an order would be the worse bug."""
+    keys = ["price", "something_new", "product_name", "another_new"]
+
+    shown = fields.column_order(conn, "X", keys)
+
+    assert set(shown) == set(keys), "a column was lost to the ordering"
+    assert shown.index("something_new") < shown.index("another_new"), (
+        "the unranked columns lost their relative order")
+    assert shown.index("price") < shown.index("something_new")
+
+
+def test_the_grid_and_the_chooser_read_the_same_function(conn):
+    """The bug in one sentence: they did not. This asserts the shared reader is
+    what reports.table_payload calls, so the two cannot drift again without
+    someone deleting this line."""
+    source = pathlib.Path(reports.__file__).read_text(encoding="utf-8")
+    body = source[source.index('"columns": ['):source.index('"rows": shaped')]
+
+    assert "fields.column_order(" in body, (
+        "table_payload is ordering columns itself again; the chooser writes an "
+        "order the grid will ignore, which is exactly what the owner reported")
+    assert "for key, label in BROWSE_COLUMNS" not in body, (
+        "the literal list is back in charge of the grid's order")

--- a/tests/test_the_weight_the_price_is_quoted_against.py
+++ b/tests/test_the_weight_the_price_is_quoted_against.py
@@ -551,7 +551,7 @@ def test_migration_0057_adds_the_two_columns_without_touching_offer_identity():
         columns = {r[1] for r in conn.execute("PRAGMA table_info(source_offer)")}
         assert "weight" not in columns and "weight_unit" not in columns
 
-        assert dbmod.migrate(conn) == [57, 58]   # 0058 rides along: it adds the
+        assert dbmod.migrate(conn) == [57, 58, 59]   # 0058 rides along: it adds the
             # witness columns 0057's units will need, and the chain runs forward
 
         columns = {r[1]: r for r in conn.execute("PRAGMA table_info(source_offer)")}


### PR DESCRIPTION
Drag a column in Choose Columns. The panel says it saved. The page reloads. **The table is byte-for-byte what it was.**

Not a rendering bug. The grid took its order from the literal `BROWSE_COLUMNS` list and **had never read `dataset_field` at all** — `display_order` occurs zero times in `reports.py` and zero times in `grid.js` — while the Choose-Columns panel and the Current-View export both ordered *by* `display_order`.

Three surfaces, three answers, disagreeing at position 0:

| | grid | panel / export |
|---|---|---|
| MADAR, first column | `product_name` | `product_name_ar` |
| MADAR, price index | **18** | 13 |
| SIKAEGSHOP, price index | 9 | 5 |

## One order now, and it is generated

`vocab` gains `Block` and `BLOCK_ORDER` — identity, offer, filing, provenance — the reading order the owner agreed to. `reports.COLUMN_BLOCK` files each column into one, `browse_columns()` is a **stable sort by block alone**, and `COLUMN_RANK` falls out of it. The list keeps its authors' order and every comment they wrote; only the blocks decide where each part of it sits.

**The category levels still come from `_level_columns()`**, so this file's promise that raising `CATEGORY_LEVELS` is one line stays true. That promise is what PR #63 broke and was sent back for.

**Price moves from index 32 in the list to 6.** First eight: `product_name, product_name_ar, country_code_alpha2, variant, variant_ar, sku, price, price_trade`.

## An arrangement he made is not ours to improve

`fields.column_order` is the single reader all three surfaces call. **Not arranged** → the agreed order. **Arranged** → his `display_order`, exactly, with no blending. An unranked column keeps its given position rather than being dropped, because losing a column to fix an order is the worse bug.

That distinction needed a fact nothing recorded, so **0059 adds `arranged_at` and nothing else — it writes no `display_order` at all**. Its backfill is an inversion rather than a guess: a source whose order matches its insertion order was never touched by a person, and deviation is the only signature a hand leaves. Measured read-only on the live warehouse: **exactly one source of twelve** is stamped, and it is stamped because two fields were dragged into the details zone. `reorder()` stamps from now on; `reset_view()` clears it.

## Guarded

Eight tests, and all three mutations bite:

| mutation | result |
|---|---|
| the grid orders itself again | fails |
| `reorder()` stops stamping | fails (2 tests) |
| an arrangement is blended with the agreement | fails |

All gates: `pytest` exit 0 / zero FAILED · parity exit 0 · `node --test extension/tests` exit 0 · `validate-manifest` OK.
