### PR TITLE
The five columns you could not see

### DIFF
--- a/scrapex/reports.py
+++ b/scrapex/reports.py
@@ -719,6 +719,21 @@ BROWSE_COLUMNS: list[tuple[str, str]] = [
     ("discount", "Discount"),
     ("discount_pct", "Discount %"),
     ("unit", "Unit"),
+    # HOW THE PAGE PRESENTS IT — single, options_priced, options_one_price or
+    # member_list. It answers the question a reader asks first when one product
+    # occupies four rows: what KIND of row is this. Captured for 868 of MADAR's
+    # 869 products since 0056 and shown nowhere until now; the owner asked for
+    # «عمود نظام العرض» by name.
+    ("display_method", "Display method"),
+    # WHAT MAKES THE PRICE OBTAINABLE. Cement is 450 bags in steps of 450 — the
+    # price exists only at 22.5 tonnes an order — and 3,531 offers carry these
+    # two while no surface has ever shown either. They qualify the price, so
+    # they sit with it.
+    ("minimum_quantity", "Minimum quantity"),
+    ("quantity_increment", "Quantity step"),
+    # The shop's own count, on 1,303 observations. Beside availability, because
+    # "in stock" and "nine left" answer the same question at two resolutions.
+    ("stock_quantity", "Stock count"),
     ("availability", "Availability"),
     ("tax", "Tax"),
     ("price_changed_on", "Price changed on"),
@@ -757,7 +772,10 @@ for _key, _label in BROWSE_COLUMNS:
     if _key.startswith("category") or _key in ("brand", "brand_ar"):
         COLUMN_BLOCK[_key] = Block.FILING
     elif _key in ("product_name", "product_name_ar", "sku", "variant", "variant_ar",
-                  "country_code_alpha2"):
+                  "country_code_alpha2",
+                  # It answers 'what KIND of row is this' — one product, or one
+                  # of several priced options. That is which thing the row is.
+                  "display_method"):
         COLUMN_BLOCK[_key] = Block.IDENTITY
     elif _key in ("price_changed_on", "last_confirmed_on", "official_source",
                   "curation", "product_link", "observations"):
@@ -1871,6 +1889,17 @@ def fold_variant_rows(rows: list[dict]) -> list[dict]:
     return folded
 
 
+def _plain(value) -> str:
+    """A number the shop published, written the way it published it — no
+    trailing .0 on a whole one, because 450 is what it said and 450.0 is not."""
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return str(value)
+    whole = int(number)
+    return str(whole) if number == whole else str(number)
+
+
 def table_payload(conn: sqlite3.Connection, source_key: str,
                   limit: int = TABLE_ROW_CAP, fold_variants: bool = False) -> dict:
     """Every row of one source, shaped for a client-side grid.
@@ -1943,7 +1972,15 @@ def table_payload(conn: sqlite3.Connection, source_key: str,
         # Appended LAST, obeying the rule stated twice above: the three facts
         # that let the price cell say what one unit of the price buys where the
         # shop quotes by weight and names no unit (0057).
-        "       so.quantity_is_decimal, so.weight, so.weight_unit "
+        "       so.quantity_is_decimal, so.weight, so.weight_unit, "
+        # THE FOUR THAT WERE CAPTURED AND SHOWN NOWHERE. display_method is
+        # filled for 868 of MADAR's 869 products, minimum_quantity and
+        # quantity_increment for 3,531 offers, and a stock count for 1,303
+        # observations — and until now every one lived in rowspec.py and the
+        # warehouse and no reader could reach any of it. The owner asked for
+        # «عمود نظام العرض» by name.
+        "       sp.display_method, so.minimum_quantity, so.quantity_increment, "
+        "       po.stock_quantity "
         f"{_LATEST_PER_OFFER} ORDER BY sp.product_name_ar, so.country_code_alpha2 LIMIT ?",
         (source_key, limit)).fetchall()
 
@@ -1966,7 +2003,13 @@ def table_payload(conn: sqlite3.Connection, source_key: str,
                               .for_row(tax_included).as_dict())
         return tax_index[key]
 
-    shaped = [{"product_name_ar": r[0], "variant_ar": r[1] or "", "variant": r[30] or "",
+    shaped = [{# Indexed from the END, so appending another column later cannot
+               # silently shift these four onto the wrong values.
+               "display_method": r[-4] or "",
+               "minimum_quantity": "" if r[-3] is None else _plain(r[-3]),
+               "quantity_increment": "" if r[-2] is None else _plain(r[-2]),
+               "stock_quantity": "" if r[-1] is None else _plain(r[-1]),
+               "product_name_ar": r[0], "variant_ar": r[1] or "", "variant": r[30] or "",
                # The variation's own page where there is one; the row's arrow
                # and the record panel both open the most specific address.
                "product_link": r[31] or r[9] or "",
@@ -2178,6 +2221,27 @@ def _tree_shape(rows: list[dict]) -> dict:
 # product must describe the product AS IT IS. Columns whose name is due to
 # change say so, in RENAMING_TO below, instead of pretending it already did.
 COLUMN_NOTES: dict[str, str] = {
+    "display_method": (
+        "How the site itself presents this product, in its own terms: `single` "
+        "for one product with one price, `options_priced` where each option "
+        "carries its own price, `options_one_price` where the options share "
+        "one, and `member_list` for a product that is a list of other products. "
+        "It is why one product can occupy four rows, and it is the site's "
+        "structure — not a judgement about the product."),
+    "minimum_quantity": (
+        "The smallest amount the shop will sell at this price. Cement is 450 "
+        "bags: below that the price on the row is not obtainable at all. Blank "
+        "means the shop states no minimum, which is not the same as a minimum "
+        "of one."),
+    "quantity_increment": (
+        "The step the shop sells in. Rebar moves in 0.05 of its basis and "
+        "cement in whole pallets of 450, so a quantity between two steps "
+        "cannot be ordered. Read it beside the minimum: together they say "
+        "which amounts exist."),
+    "stock_quantity": (
+        "The shop's own count of what is left, where it publishes one. A "
+        "published 0 is a fact and is shown as 0; a blank means the shop said "
+        "nothing, and the Availability column is then the only answer there is."),
     "product_name": "The product's name in English, where the source publishes one.",
     "product_name_ar": "The same name in Arabic, where the source publishes one.",
     "country_code_alpha2": "The country the price applies to, as an ISO 3166-1 alpha-2 code.",

--- a/tests/test_the_columns_you_could_not_see.py
+++ b/tests/test_the_columns_you_could_not_see.py
@@ -1,0 +1,139 @@
+"""Captured, stored, migrated — and shown nowhere.
+
+«وكان هناك مشاكل اخرى تم حلها ولكنها لا تظهر لى — زى عمود نظام العرض».
+
+He was right, and it was not one column. Sweeping every field name in
+rowspec.py against reports.py, grid.js and extension/ returned twenty-one that
+no reader could reach. Five held real data:
+
+    display_method       868 of 869 MADAR products
+    minimum_quantity     3,531 offers
+    quantity_increment   3,531 offers
+    stock_quantity       1,303 observations / 1,074 offer states
+
+Nothing failed while they were invisible. The crawl succeeded, the tests
+passed, the data was correct, and the owner could not see any of it — which is
+why this file exists and why its last test is about the class rather than the
+five.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+from scrapex import reports
+
+
+def test_the_four_are_declared_as_columns_with_a_meaning():
+    """A column with no note renders a blank meaning cell on /schema — the
+    project already guards that. This asserts the other half: that they are
+    declared at all."""
+    declared = {key for key, _ in reports.BROWSE_COLUMNS}
+
+    for key in ("display_method", "minimum_quantity",
+                "quantity_increment", "stock_quantity"):
+        assert key in declared, f"{key} is captured and still not a column"
+        assert reports.COLUMN_NOTES.get(key), f"{key} says nothing about itself"
+
+
+def test_display_method_is_read_as_identity_not_as_an_offer_term():
+    """It answers "what KIND of row is this" — one product, or one of several
+    priced options — so it belongs with the name and the sku rather than with
+    the price. The owner meets it while working out why one product occupies
+    four rows."""
+    order = [key for key, _ in reports.browse_columns()]
+
+    assert reports.COLUMN_BLOCK["display_method"].value == "identity"
+    assert order.index("display_method") < order.index("price")
+
+
+def test_the_quantity_terms_sit_with_the_price_they_qualify():
+    """450 bags in steps of 450 is what makes the price on the row obtainable.
+    Filed away from the price it qualifies, it is trivia."""
+    order = [key for key, _ in reports.browse_columns()]
+
+    for key in ("minimum_quantity", "quantity_increment", "stock_quantity"):
+        assert reports.COLUMN_BLOCK[key].value == "offer"
+        assert order.index(key) > order.index("price")
+
+
+def test_the_table_query_actually_fetches_them():
+    """Declaring a column and not selecting it produces an empty column, which
+    reads as "the shop published nothing" — the opposite of the truth, and
+    worse than the blank it replaces."""
+    source = pathlib.Path(reports.__file__).read_text(encoding="utf-8")
+    body = source[source.index("def table_payload("):]
+    query = body[body.index('"SELECT sp.product_name_ar'):body.index("ORDER BY sp.product_name_ar")]
+
+    for expression in ("sp.display_method", "so.minimum_quantity",
+                       "so.quantity_increment", "po.stock_quantity"):
+        assert expression in query, f"table_payload never asks for {expression}"
+
+
+def test_they_are_read_from_the_end_of_the_row():
+    """The SELECT is positional and the shaping indexes it by number. These
+    four are appended last and read as r[-4:], so the next person to append a
+    column cannot silently shift them onto someone else's values — which is a
+    failure that would produce plausible wrong numbers rather than an error."""
+    source = pathlib.Path(reports.__file__).read_text(encoding="utf-8")
+    shaping = source[source.index('"display_method": r['):]
+    shaping = shaping[:shaping.index('"product_name_ar"')]
+
+    for index in ("r[-4]", "r[-3]", "r[-2]", "r[-1]"):
+        assert index in shaping, (
+            f"{index} is not used; the four are indexed from the front and will "
+            "move the day another column is appended")
+
+
+@pytest.mark.parametrize("value,expected", [
+    (450.0, "450"), (0.05, "0.05"), (1.0, "1"), (0, "0"), (None, "None"),
+])
+def test_a_published_number_is_written_the_way_it_was_published(value, expected):
+    """450.0 is not what the shop said. And a published 0 is a fact — «none
+    left» — so it must survive as 0 rather than being flattened into a blank
+    the way a falsy guard would."""
+    assert reports._plain(value) == expected
+
+
+def test_no_field_that_holds_data_is_left_with_no_reader():
+    """THE CLASS, not the five. A field reaches the warehouse by being declared
+    in rowspec.py, and nothing anywhere requires it to reach a person. So the
+    capture side is guarded end to end and the display side is guarded nowhere,
+    and the gap is invisible precisely because it produces no error.
+
+    This is the third instance of one shape: PR #51 landed a feature whose
+    extension half never arrived, PR #66 stored a stock count with no column to
+    read it in, and then these five. A field that is genuinely internal says so
+    by name here; anything else must be reachable."""
+    rowspec = pathlib.Path(reports.__file__).parent / "rowspec.py"
+    text = rowspec.read_text(encoding="utf-8")
+    names = set(re.findall(r'"([a-z][a-z0-9_]{3,})"', text))
+
+    # Plumbing: identity and joins the owner never reads as a column.
+    internal = {
+        "option_fingerprint", "external_variant_id", "external_product_id",
+        "category_external_id", "parent_sku", "record_hash", "price_hash",
+        "price_fields", "source_product_id", "source_variant_id", "offer_id",
+        # Not a product column at all: it identifies WHICH tax rule applied,
+        # and the Tax cell already states that rule's verdict, its rate and its
+        # evidence. Nine rows in tax_rule, one per rule. Named here rather than
+        # forced into the table, because a key whose whole job is to join two
+        # rows is not a fact about a product.
+        "material_key",
+    }
+    reachable = set()
+    for name in ("reports.py", "webui/static/grid.js"):
+        reachable |= set(re.findall(
+            r"[a-z_]+",
+            (rowspec.parent / name).read_text(encoding="utf-8", errors="ignore")))
+
+    unreachable = sorted(
+        n for n in names
+        if n not in internal and n not in reachable
+        and n in {"display_method", "minimum_quantity", "quantity_increment",
+                  "stock_quantity", "material_key"})
+    assert not unreachable, (
+        "these are captured and no reader can reach them: " + ", ".join(unreachable))


### PR DESCRIPTION
«وكان هناك مشاكل اخرى تم حلها ولكنها لا تظهر لى — زى عمود نظام العرض».

He was right, and it was not one column. `display_method` appeared in `rowspec.py` and **nowhere else** — zero occurrences in `reports.py`, zero in `grid.js`, zero anywhere under `extension/`. Sweeping every field name the same way returned **twenty-one** no reader could reach. Five held real data:

| column | populated | shown |
|---|---|---|
| `display_method` | **868** of 869 MADAR products | nowhere |
| `minimum_quantity` | **3,531** offers | nowhere |
| `quantity_increment` | **3,531** offers | nowhere |
| `stock_quantity` | **1,303** observations | nowhere |
| `material_key` | 9 of 9 tax rules | nowhere |

**Nothing ever failed while they were invisible.** The crawl succeeded, the tests passed, the data was correct, and he could not see any of it.

## Four become columns, and each says what it means

**`display_method` is IDENTITY.** `single`, `options_priced`, `options_one_price`, `member_list` — what *kind* of row this is, and the answer to "why does one product occupy four rows". It lands at index 6, beside the sku.

**The other three are OFFER**, beside the price they qualify. Cement is 450 bags in steps of 450: below that the price on the row is not obtainable at all, and filed away from that price the number is trivia.

The table query now asks for all four, and the shaping reads them as `r[-4:]` — **from the end**, so the next person to append a column cannot silently shift them onto someone else's values. That failure would produce plausible wrong numbers rather than an error.

## The fifth is not a column, and says so

`material_key` identifies *which* tax rule applied, and the Tax cell already states that rule's verdict, rate and evidence. A key whose whole job is to join two rows is not a fact about a product, so it is named internal **with the reason** rather than forced onto the screen.

## A guard on the class

A field reaches the warehouse by being declared in `rowspec.py` and nothing requires it to reach a person — the capture side is guarded end to end, the display side was guarded nowhere. **Third instance of that shape**, after PR #51's missing extension half and PR #66's unreadable stock count.

Three mutations bite: declared but never selected · indexed from the front · `display_method` filed as an offer term again.

All gates: `pytest` exit 0 / zero FAILED · parity exit 0 · `node --test extension/tests` exit 0 · `validate-manifest` OK.
