### PR TITLE
The panel can choose its own columns

### DIFF
--- a/extension/app.html
+++ b/extension/app.html
@@ -698,6 +698,31 @@
         </div>
       </form>
 
+      <!-- WHICH COLUMNS THIS SOURCE SHOWS, AND IN WHAT ORDER.
+           Owner ruling: no capability may exist on the web page that is absent
+           from this panel. Choosing columns lived only on the web page —
+           /api/fields was called from grid.js and from nowhere else — so the
+           control room could not do the one thing the owner most often wants
+           to do to a table. His words are quoted in app.js, where the logic is:
+           this file is interface, and Arabic here is data, never chrome.
+           Reordering here is Up/Down rather than drag: the panel is a narrow
+           column and a drag target that thin is a control you fight. -->
+      <section class="card" aria-labelledby="source-edit-columns-heading">
+        <div class="section-head">
+          <div>
+            <h2 id="source-edit-columns-heading">Columns</h2>
+            <p>What this source shows, and in what order.</p>
+          </div>
+          <button type="button" id="source-columns-reset" class="ghost compact">Reset to agreed order</button>
+        </div>
+        <!-- Says WHOSE order is on screen. An owner who has arranged his
+             columns should not have to wonder whether an update replaced them,
+             and one who has not should know the order is ours to improve. -->
+        <p id="source-columns-origin" class="hint" role="status" aria-live="polite"></p>
+        <ul id="source-columns-list" class="stack" aria-live="polite"></ul>
+        <span id="source-columns-result" class="hint" role="status" aria-live="polite"></span>
+      </section>
+
       <!-- TWO actions, never one. The owner's ruling: stopping a source and
            erasing its data are different things with different outcomes, so
            neither can be mistaken for the other. Each says what it keeps. -->

--- a/extension/app.js
+++ b/extension/app.js
@@ -1271,6 +1271,95 @@ function renderSourceManager() {
     button.addEventListener("click", () => openSourceEditor(button.dataset.editSource)));
 }
 
+// ---- which columns a source shows, from the panel ---------------------------
+//
+// Owner ruling, 2026-08-01: «انا عاوز extension غرفة التحكم فى كل شى — يعنى
+// مينفعش يكون فى ميزة على الويب لا توجد فى extension».
+//
+// The same endpoint the web page's chooser uses — /api/fields/{source} — because
+// two writers of one order is how the grid and the chooser came to disagree in
+// the first place. The panel is the control room; it does not get its own path
+// to the same fact.
+
+async function loadSourceColumns(sourceKey) {
+  const list = $("source-columns-list");
+  const origin = $("source-columns-origin");
+  if (!list) return;
+  list.innerHTML = "";
+  out("source-columns-result", "");
+  try {
+    const answer = await api("/api/fields/" + encodeURIComponent(sourceKey));
+    const fields = answer.fields || [];
+    // Whose order this is. The owner should never have to wonder whether an
+    // update replaced an arrangement he made.
+    origin.textContent = answer.order_source === "yours"
+      ? "This is the order you arranged."
+      : "This is the agreed order — identity, then the offer, then the filing.";
+    if (!fields.length) {
+      list.innerHTML = `<li class="muted text-xs">This source has no columns yet — it has not been crawled.</li>`;
+      return;
+    }
+    fields.forEach((field, index) => {
+      const item = document.createElement("li");
+      item.className = "row source-column-row";
+      const shown = !field.is_hidden;
+      item.innerHTML =
+        `<label class="row gap-1"><input type="checkbox" data-column-visible="${esc(field.field_key)}"` +
+        `${shown ? " checked" : ""}> <span>${esc(field.display_name || field.original_name || field.field_key)}</span></label>` +
+        `<span class="spacer"></span>` +
+        `<button type="button" class="ghost compact" data-column-up="${esc(field.field_key)}"` +
+        `${index === 0 ? " disabled" : ""} aria-label="Move up">↑</button>` +
+        `<button type="button" class="ghost compact" data-column-down="${esc(field.field_key)}"` +
+        `${index === fields.length - 1 ? " disabled" : ""} aria-label="Move down">↓</button>`;
+      list.append(item);
+    });
+    state.sourceColumns = fields.map((field) => field.field_key);
+  } catch (err) {
+    list.innerHTML = "";
+    out("source-columns-result", "could not read the columns: " + esc(err.message), "err");
+  }
+}
+
+async function saveSourceColumns(sourceKey, body) {
+  out("source-columns-result", "saving…");
+  try {
+    await post("/api/fields/" + encodeURIComponent(sourceKey), body);
+  } catch (err) {
+    out("source-columns-result", "not saved: " + esc(err.message), "err");
+    return;
+  }
+  await loadSourceColumns(sourceKey);
+  out("source-columns-result", "saved — the table and the export both follow this", "ok");
+}
+
+function wireSourceColumns() {
+  const list = $("source-columns-list");
+  if (!list) return;
+  list.addEventListener("change", (event) => {
+    const key = event.target.dataset && event.target.dataset.columnVisible;
+    if (!key) return;
+    saveSourceColumns(state.editingSourceKey,
+                      {field_key: key, hidden: !event.target.checked});
+  });
+  list.addEventListener("click", (event) => {
+    const button = event.target.closest("[data-column-up],[data-column-down]");
+    if (!button) return;
+    const key = button.dataset.columnUp || button.dataset.columnDown;
+    const order = (state.sourceColumns || []).slice();
+    const at = order.indexOf(key);
+    const to = button.dataset.columnUp ? at - 1 : at + 1;
+    if (at < 0 || to < 0 || to >= order.length) return;
+    order[at] = order[to];
+    order[to] = key;
+    saveSourceColumns(state.editingSourceKey, {order});
+  });
+  const reset = $("source-columns-reset");
+  if (reset) {
+    reset.addEventListener("click", () =>
+      saveSourceColumns(state.editingSourceKey, {reset: true}));
+  }
+}
+
 function renderSourceEditor(source) {
   state.editingSourceKey = source.source_key;
   $("source-edit-identity").innerHTML = sourceIdentity(
@@ -1294,6 +1383,7 @@ function renderSourceEditor(source) {
   out("source-edit-rename-result", "");
   out("source-edit-danger-result", "");
   $("source-edit-holds").textContent = "…";
+  loadSourceColumns(source.source_key);
   $("source-edit-wipe-scope").textContent = "";
   // What it HOLDS, fetched rather than guessed: a destructive button that says
   // how much it is about to erase is the difference between a choice and a
@@ -3075,6 +3165,7 @@ async function init() {
     }));
 
   wireRuntimeRepair();
+  wireSourceColumns();
   $("setup-recheck").addEventListener("click", render);
   $("engine-start").addEventListener("click", startEngineFromPanel);
   $("runtime-check-action").addEventListener("click", async () => {

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -42,7 +42,7 @@ from ..databases import (
 from ..jobs import (JobRunner, create_job, get_job, job_log_count, job_logs,
                     list_jobs, set_control, worker_health)
 from ..fields import (
-    delete_view, ensure_fields, list_fields, list_views, promotable_attributes,
+    arranged, delete_view, ensure_fields, list_fields, list_views, promotable_attributes,
     reorder, reset_view, save_view, set_display_name, set_promotion,
     set_visibility, visible_columns,
 )
@@ -76,7 +76,7 @@ from ..storage import compact as storage_compact
 from ..probe import probe as probe_url
 from ..ui_manifest import ui_manifest, workspace_navigation_groups
 from ..reports import (
-    BROWSE_COLUMNS, FILTERABLE, SORTABLE, browse_google_finance_rates,
+    BROWSE_COLUMNS, FILTERABLE, SORTABLE, browse_columns, browse_google_finance_rates,
     browse_observations, column_presence,
     crawl_history, facet_options, parse_filters, watch,
     data_model_report, export_source_table, google_finance_status, history_counts,
@@ -1649,11 +1649,19 @@ def create_app(
             # does not publish — and they then showed up in the manage list
             # forever, because ensure_fields is additive by design.
             present = column_presence(conn, source_key)
+            # Seeded in the AGREED order, not the order the list happens to be
+            # written in: ensure_fields assigns display_order by insertion, so
+            # a source registered here would otherwise carry the unsorted order
+            # the moment its owner arranges anything.
             ensure_fields(conn, source_key,
-                          [key for key, _ in BROWSE_COLUMNS if key in present])
+                          [key for key, _ in browse_columns() if key in present])
             conn.commit()
             return {"source_key": source_key, "fields": list_fields(conn, source_key),
-                    "views": list_views(conn, source_key)}
+                    "views": list_views(conn, source_key),
+                    # Whose order this is. The panel says it out loud, because an
+                    # owner who arranged his columns should never have to wonder
+                    # whether an update replaced them.
+                    "order_source": "yours" if arranged(conn, source_key) else "agreed"}
         finally:
             conn.close()
 

--- a/tests/test_settings_live_in_the_extension.py
+++ b/tests/test_settings_live_in_the_extension.py
@@ -182,6 +182,45 @@ def test_no_surface_teaches_a_windows_ritual():
         + "; ".join(offenders))
 
 
+def test_choosing_columns_is_reachable_from_the_panel():
+    """Owner ruling: «مينفعش يكون فى ميزة على الويب لا توجد فى extension».
+
+    /api/fields is the endpoint behind Choose Columns — hide a column, reorder
+    them, reset the view — and until now grid.js was its only caller. So the
+    control room could not do the thing the owner most often wants to do to a
+    table, and the web page could.
+
+    Present is not wired, so the endpoint is asserted too: a section that
+    renders and calls nothing looks broken rather than missing."""
+    panel = PANEL.read_text(encoding="utf-8")
+    script = (ROOT / "extension" / "app.js").read_text(encoding="utf-8")
+
+    for control in ("source-columns-list", "source-columns-reset",
+                    "source-columns-origin"):
+        assert f'id="{control}"' in panel, f"{control} is not in the side panel"
+
+    assert '"/api/fields/"' in script, (
+        "the panel's Columns section calls nothing; the buttons render and the "
+        "order never changes")
+    for action in ("hidden:", "order}", "reset: true"):
+        assert action in script, (
+            f"the panel cannot {action.strip(':}')} — the web chooser can do all "
+            "three and this one cannot")
+
+
+def test_the_panel_says_whose_column_order_it_is_showing():
+    """An owner who arranged his columns should never have to wonder whether an
+    update replaced them, and one who has not should know the order is ours to
+    improve. The engine answers it; the panel prints it."""
+    script = (ROOT / "extension" / "app.js").read_text(encoding="utf-8")
+    engine = (ROOT / "scrapex" / "webui" / "app.py").read_text(encoding="utf-8")
+
+    assert '"order_source"' in engine, (
+        "/api/fields no longer says whose order it returned")
+    assert "order_source" in script, (
+        "the panel shows an order without saying whose it is")
+
+
 def test_the_crawl_pace_is_reachable_from_the_panel():
     """The specific controls that were unreachable, now where they belong."""
     panel = PANEL.read_text(encoding="utf-8")


### PR DESCRIPTION
Owner ruling: **no capability may exist on the web page that is absent from the panel.** Choosing columns was one.

`/api/fields` is the endpoint behind Choose Columns — hide a column, reorder them, reset the view — and **`grid.js` was its only caller**. So the control room could not do the thing an owner most often wants to do to a table, and the web page could.

## What ships

The source editor gains a **Columns** section: every column this source shows, each with a checkbox to hide it and **↑ ↓** to move it, plus **Reset to agreed order**.

Up/Down rather than drag: the panel is a narrow column and a drag target that thin is a control you fight.

It calls the **same endpoint** the web chooser calls. Two writers of one order is how the grid and the chooser came to disagree in the first place; the panel does not get its own path to the same fact.

## And it says whose order it is showing

`/api/fields` now answers `order_source` — `"yours"` or `"agreed"` — read from the `arranged_at` stamp 0059 added. An owner who arranged his columns should never have to wonder whether an update replaced them, and one who has not should know the order is ours to improve.

## One repair while here

`api_fields` seeded `dataset_field` from `BROWSE_COLUMNS` **in the order that list happens to be written in**, and `ensure_fields` assigns `display_order` by insertion. So a source registered through the panel carried the unsorted order the moment its owner arranged anything. Seeded from `browse_columns()` now.

## A guard caught me, and was right

The owner's words went into the markup first. `test_the_interface_stays_english` failed: the panel's interface is English by spec 1, Arabic in it is **data and never chrome**. The quote now lives in `app.js` where the logic is.

## Guarded

Three mutations bite, and the first is the original state:

| mutation | result |
|---|---|
| the Columns section removed from the panel | fails |
| markup kept, the endpoint call renamed | fails |
| the engine stops naming whose order it returned | fails |

All gates: `pytest` exit 0 / zero FAILED · `app.js` parses as a module · parity exit 0 · `node --test extension/tests` exit 0 · `validate-manifest` OK.
