### PR TITLE
The ruling is generated from the code it rules on

### DIFF
--- a/docs/data-page-schema.md
+++ b/docs/data-page-schema.md
@@ -1,35 +1,113 @@
 # What the Data page shows, and where
 
+The column tables below are GENERATED from `scrapex/reports.py` by
+`python -m scrapex.cli export-docs`. Do not hand-edit them: the code is the
+truth and this is its readable form. The prose is hand-written, because those
+are the owner's rulings and nothing derives them.
+
 The owner asked to review the schema of the Data page: what belongs in the
 table at the top, what belongs in the container that opens underneath when a
 row is selected, and what a language switch governs. This file is the ruling,
 so the answer stops being re-decided per screen.
 
-## The split
+## The table, in reading order
 
-**The table answers "how do these compare?"** It holds what you scan across
-many rows at once and sort, filter or group by:
+**The table answers "how do these compare?"** — what you scan across many
+rows at once and sort, filter or group by. Identity, then the offer, then the
+filing: the price is the reason the table exists, so nothing files in front
+of it.
 
-| | |
+**Identity** — which thing this row is
+
+| column | what it means |
 |---|---|
-| identity | Record (name), Record (AR), SKU, product id, Brand, Brand (AR), Country |
-| classification | Category and every level the source publishes (L1–L4) |
-| the offer | Price, Unit, Discount, Status, Tax |
-| the variation | Variant, and one column per AXIS the source varies by |
-| the site's own facets | one column per attribute the source FILTERS by |
-| provenance | Price changed, Last confirmed, Curation |
+| Product name | The product's name in English, where the source publishes one. |
+| Product name (AR) | The same name in Arabic, where the source publishes one. |
+| Country code | The country the price applies to, as an ISO 3166-1 alpha-2 code. |
+| Variant | Which variation this row is, in English. |
+| Variant (AR) | The same variation in the site's own Arabic words. |
+| SKU | The source's own code for this item. |
+| Display method | How the site itself presents this product, in its own terms: `single` for one product with one price, `options_priced` where each option carries it… |
 
-**The container answers "what is this one thing?"** It holds what describes a
-single record and would be noise repeated eighty-seven times:
+**The offer** — what it costs and on what terms
 
-| | |
+| column | what it means |
 |---|---|
-| pictures | every image the source publishes, the gallery leading |
-| description | the short one and the long one, as the source's own paragraphs |
-| specifications | the site's own "technical specifications" card |
-| attachments | datasheets and other files, with their real size |
-| measurements | weight, stock, thresholds |
-| the price story | the change timeline, the change feed, every observation |
+| Price | What a visitor actually pays today. |
+| Trade price | The price for trade or wholesale buyers, where the source publishes a second one beside the retail price. |
+| Price (USD est.) | An approximate US-dollar figure, so many currencies can be ranked in one column. UNDER REVIEW — the owner has flagged this column for a decision: t… |
+| Previous price | The price that held immediately before the current one. |
+| Price change | The move from that previous price to this one. |
+| Lowest price | The lowest price ever recorded for this record. |
+| Highest price | The highest price ever recorded for this record. |
+| Discount | How much the listing takes off, as an amount. |
+| Discount % | The same discount as a percentage. |
+| Unit | What one price BUYS: a litre, a 50 kg bag, a 100 m roll. Empty when the source states no unit — never guessed. |
+| Minimum quantity | The smallest amount the shop will sell at this price. Cement is 450 bags: below that the price on the row is not obtainable at all. Blank means the… |
+| Quantity step | The step the shop sells in. Rebar moves in 0.05 of its basis and cement in whole pallets of 450, so a quantity between two steps cannot be ordered.… |
+| Stock count | The shop's own count of what is left, where it publishes one. A published 0 is a fact and is shown as 0; a blank means the shop said nothing, and t… |
+| Availability | In stock or out, as the source states it. |
+| Tax | Whether THIS figure includes tax, and at what rate. |
+
+**The filing** — where the shop files it
+
+| column | what it means |
+|---|---|
+| Brand | The brand, as the source publishes it — never inferred from the name. |
+| Brand (AR) | The same brand in Arabic, where the source publishes one. |
+| Category | The full classification path the source files this product under, in English where it publishes one. |
+| Category (AR) | The same path in Arabic, where the source publishes one. |
+| Category leaf | — |
+| Category leaf (AR) | — |
+| Category L1 | — |
+| Category L1 (AR) | — |
+| Category L2 | — |
+| Category L2 (AR) | — |
+| Category L3 | — |
+| Category L3 (AR) | — |
+| Category L4 | — |
+| Category L4 (AR) | — |
+| Category L5 | — |
+| Category L5 (AR) | — |
+| Category L6 | — |
+| Category L6 (AR) | — |
+| Category L7 | — |
+| Category L7 (AR) | — |
+| Category L8 | — |
+| Category L8 (AR) | — |
+| Category L9 | — |
+| Category L9 (AR) | — |
+| Category L10 | — |
+| Category L10 (AR) | — |
+
+**Provenance** — where the row came from, and when it was last true
+
+| column | what it means |
+|---|---|
+| Observations | How many times this price has been recorded. |
+| Price changed on | When the price last MOVED. |
+| Last confirmed on | When a completed run last saw it still true. |
+| Official source | The body the source attributes its figure to. |
+| Curation | Your own review state for this product. |
+| product_link | The product's page on the site — the arrow opens it, and the export carries the full address. |
+
+Category levels are generated: `CATEGORY_LEVELS = 10`,
+so raising the ceiling is one line and this table follows it.
+
+## The container, and what is filed where
+
+**The container answers "what is this one thing?"** — what describes a single
+record and would be noise repeated eighty-seven times.
+
+| group | |
+|---|---|
+| Description | |
+| Specifications | |
+| More information | |
+| Store | |
+| Site metadata | |
+| Attachments | |
+| Media | |
 
 Selecting two or more rows turns the same container into a **comparison** of
 them, marking the fields that differ.
@@ -52,9 +130,19 @@ them, marking the fields that differ.
    rows fill it — no global gate. A shop with no geography shows no Country
    column; a source with no variations gains no axis columns.
 5. **The owner moves fields between the two places.** Choose Columns has two
-   zones; hiding a field moves it into the container rather than losing it.
-6. **Nothing is computed into a price.** Every figure is what the source
+   zones; hiding a field moves it into the container rather than losing it. It
+   is reachable from the side panel and from the web page, and both write the
+   same order — the panel is the control room, and nothing it cannot do may
+   live on the page.
+6. **An order you arranged is yours.** Until you move a column, the table shows
+   the agreed order above and we may improve it. The moment you do, that
+   arrangement wins on every surface and no update replaces it. Each screen
+   says which of the two you are looking at.
+7. **Nothing is computed into a price.** Every figure is what the source
    published; the Tax column states, per row, whether that figure includes tax.
+   Where a shop names a container and what is in it — «4 كجم/صندوق» — both are
+   stored, and a price per kilogram is arithmetic over two stated facts rather
+   than a rewrite of one.
 
 ## What an export carries
 
@@ -62,3 +150,4 @@ The Excel download is not the view — it is the whole record: a `prices` sheet,
 a `details` sheet, a `history` sheet and an `about` sheet naming the source,
 the export time, the counts and what each sheet is. CSV and JSON stay the view
 you are looking at, filters and column order included.
+

--- a/scrapex/cli.py
+++ b/scrapex/cli.py
@@ -4,7 +4,8 @@ Commands land phase by phase; Phase 0 ships exactly what Phase 0 built:
   init-db            create/upgrade harvest.db (A10 lock + S6 migrations)
   validate-manifest  parse + validate sources.yaml (S5; same check runs in CI)
   export-contract    write contracts/funnel-payload.schema.json from the model (T8)
-  export-version     write the capability baseline, version vectors and CHANGELOG
+  export-version     write the capability baseline, version vectors, CHANGELOG
+                     and the Data page ruling's generated column tables
   funnel-test        send a tiny self-test payload through the staging funnel
   status             per-source last-run age (S8 watchdog; stub until ingest lands)
 
@@ -223,7 +224,141 @@ def _cmd_export_version(args: argparse.Namespace) -> int:
     changelog = ROOT_DIR / "CHANGELOG.md"
     changelog.write_text(_render_changelog(), encoding="utf-8")
     print(f"wrote {changelog} (generated from scrapex/version.py — do not hand-edit)")
+    schema = ROOT_DIR / "docs" / "data-page-schema.md"
+    schema.write_text(_render_data_page_schema() + chr(10), encoding="utf-8")
+    print(f"wrote {schema} (column tables generated from scrapex/reports.py)")
     return 0
+
+
+_DATA_PAGE_RULES = """
+## The rules behind it
+
+1. **A column's name states the language of its content — in display and in
+   storage.** English is the primary display language, so an unmarked column is
+   English and Arabic lives in one marked `ar`. A source that publishes only
+   Arabic fills only the marked column, and its single visible column reads
+   `Record (AR)`, because the label describes the content, not the presence of
+   a counterpart.
+2. **One language at a time.** The AR|EN switch governs the table AND the
+   container. Printing both languages side by side in the cards under the table
+   is the same fact twice, not more detail.
+3. **A missing translation shows the fact, never a blank.** Where a source
+   published only one side of a pair, that side is shown under a heading that
+   names its language.
+4. **Presence is per source.** A column appears only where that source's own
+   rows fill it — no global gate. A shop with no geography shows no Country
+   column; a source with no variations gains no axis columns.
+5. **The owner moves fields between the two places.** Choose Columns has two
+   zones; hiding a field moves it into the container rather than losing it. It
+   is reachable from the side panel and from the web page, and both write the
+   same order — the panel is the control room, and nothing it cannot do may
+   live on the page.
+6. **An order you arranged is yours.** Until you move a column, the table shows
+   the agreed order above and we may improve it. The moment you do, that
+   arrangement wins on every surface and no update replaces it. Each screen
+   says which of the two you are looking at.
+7. **Nothing is computed into a price.** Every figure is what the source
+   published; the Tax column states, per row, whether that figure includes tax.
+   Where a shop names a container and what is in it — «4 كجم/صندوق» — both are
+   stored, and a price per kilogram is arithmetic over two stated facts rather
+   than a rewrite of one.
+
+## What an export carries
+
+The Excel download is not the view — it is the whole record: a `prices` sheet,
+a `details` sheet, a `history` sheet and an `about` sheet naming the source,
+the export time, the counts and what each sheet is. CSV and JSON stay the view
+you are looking at, filters and column order included.
+"""
+
+
+def _render_data_page_schema() -> str:
+    """The Data page ruling, with its column tables GENERATED (issue 32).
+
+    The file calls itself the ruling, and it had drifted into stating the
+    opposite of the code: it listed classification levels L1 to L4 while
+    CATEGORY_LEVELS is 10, filed Brand under identity where reports.py files it
+    under the classification, described the reading order as identity then
+    classification then the offer — the order the agreement replaced — and named
+    none of display_method, minimum_quantity, quantity_increment or
+    stock_quantity, nor eight of the price columns.
+
+    A ruling nobody can trust is worse than no ruling, and PR #63 was sent back
+    partly for leaving this file behind. So the PROSE stays hand-written — those
+    are the owner's decisions and no code can derive them — and the tables come
+    from the same lists the table itself is built from. tests/test_docs.py fails
+    when the committed file no longer matches.
+    """
+    from . import reports
+    from .vocab import BLOCK_ORDER, DETAIL_GROUP_ORDER
+
+    heading = {
+        "identity": "**Identity** — which thing this row is",
+        "offer": "**The offer** — what it costs and on what terms",
+        "filing": "**The filing** — where the shop files it",
+        "provenance": "**Provenance** — where the row came from, and when it was last true",
+    }
+    lines = [
+        "# What the Data page shows, and where",
+        "",
+        "The column tables below are GENERATED from `scrapex/reports.py` by",
+        "`python -m scrapex.cli export-docs`. Do not hand-edit them: the code is the",
+        "truth and this is its readable form. The prose is hand-written, because those",
+        "are the owner's rulings and nothing derives them.",
+        "",
+        "The owner asked to review the schema of the Data page: what belongs in the",
+        "table at the top, what belongs in the container that opens underneath when a",
+        "row is selected, and what a language switch governs. This file is the ruling,",
+        "so the answer stops being re-decided per screen.",
+        "",
+        "## The table, in reading order",
+        "",
+        "**The table answers \"how do these compare?\"** — what you scan across many",
+        "rows at once and sort, filter or group by. Identity, then the offer, then the",
+        "filing: the price is the reason the table exists, so nothing files in front",
+        "of it.",
+        "",
+    ]
+    columns = reports.browse_columns()
+    for block in BLOCK_ORDER:
+        members = [(key, label) for key, label in columns
+                   if reports.COLUMN_BLOCK[key] is block]
+        if not members:
+            continue
+        lines += [heading[block.value], "", "| column | what it means |", "|---|---|"]
+        for key, label in members:
+            note = (reports.COLUMN_NOTES.get(key) or "").strip()
+            note = " ".join(note.split())
+            if len(note) > 150:
+                note = note[:147].rstrip() + "…"
+            lines.append(f"| {label or key} | {note or '—'} |")
+        lines.append("")
+    lines += [
+        f"Category levels are generated: `CATEGORY_LEVELS = {reports.CATEGORY_LEVELS}`,",
+        "so raising the ceiling is one line and this table follows it.",
+        "",
+        "## The container, and what is filed where",
+        "",
+        "**The container answers \"what is this one thing?\"** — what describes a single",
+        "record and would be noise repeated eighty-seven times.",
+        "",
+        "| group | |",
+        "|---|---|",
+    ]
+    for group in DETAIL_GROUP_ORDER:
+        lines.append(f"| {group} | |")
+    lines += [
+        "",
+        "Selecting two or more rows turns the same container into a **comparison** of",
+        "them, marking the fields that differ.",
+        "",
+    ]
+    # THE PROSE. Hand-written and kept verbatim: these are the owner's rulings
+    # and no list in the code derives them. Generating them would be inventing
+    # decisions; leaving them out would lose the only part a reader argues with.
+    lines += _DATA_PAGE_RULES.strip().split(chr(10))
+    lines.append("")
+    return chr(10).join(lines)
 
 
 def _write_capability_baseline() -> str:
@@ -296,7 +431,7 @@ def _render_changelog() -> str:
             lines.append(f"- **{capability.key}**{evidence} — {capability.summary} "
                          f"_Runs in: {surfaces}._")
         lines.append("")
-    return "\n".join(lines)
+    return chr(10).join(lines)
 
 
 def _cmd_funnel_test(args: argparse.Namespace) -> int:

--- a/tests/test_the_ruling_matches_the_code.py
+++ b/tests/test_the_ruling_matches_the_code.py
@@ -1,0 +1,104 @@
+"""docs/data-page-schema.md calls itself the ruling. It has to be true.
+
+It had drifted into stating the opposite of the code, in five ways at once:
+
+  * classification levels L1 to L4, while CATEGORY_LEVELS is 10
+  * Brand filed under identity, where reports.py files it under the filing
+  * the reading order given as identity, classification, the offer — the exact
+    order the owner's agreement replaced
+  * display_method, minimum_quantity, quantity_increment and stock_quantity
+    absent, though all four are columns
+  * eight price columns absent
+
+A document nobody can trust is worse than no document, and PR #63 was sent
+back partly for leaving this one behind. The tables are generated now; these
+tests are what stop them going stale again.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+from scrapex import reports
+from scrapex.cli import _render_data_page_schema
+from scrapex.vocab import BLOCK_ORDER
+
+RULING = pathlib.Path(__file__).resolve().parent.parent / "docs" / "data-page-schema.md"
+
+
+def test_the_committed_file_is_what_the_generator_produces():
+    """The golden test. Regenerate with:
+
+        python -m scrapex.cli export-version
+
+    A file that can be hand-edited is a file that will be, and the edit will be
+    the one nobody notices — this document went five facts out of date without
+    a single test failing."""
+    assert RULING.read_text(encoding="utf-8") == _render_data_page_schema() + "\n", (
+        "docs/data-page-schema.md no longer matches the code it claims to "
+        "describe. Run `python -m scrapex.cli export-version` and commit it.")
+
+
+def test_every_column_in_the_table_appears_in_the_ruling():
+    """A column the ruling does not mention is a column whose placement was
+    never ruled on — which is exactly how display_method came to be captured
+    for 868 products and shown nowhere."""
+    text = RULING.read_text(encoding="utf-8")
+
+    missing = [label or key for key, label in reports.browse_columns()
+               if (label or key) not in text]
+
+    assert not missing, f"the ruling does not mention: {missing}"
+
+
+def test_the_ruling_states_the_agreed_reading_order():
+    """Identity, then the offer, then the filing. The old file put the
+    classification second and the price third, which is the arrangement the
+    owner replaced — and it kept saying so for weeks after the code changed."""
+    text = RULING.read_text(encoding="utf-8")
+    positions = [text.index(f"**{block.value.capitalize()}**"
+                            if block.value != "offer" else "**The offer**")
+                 for block in BLOCK_ORDER
+                 if (f"**{block.value.capitalize()}**" in text
+                     or (block.value == "offer" and "**The offer**" in text))]
+
+    assert positions == sorted(positions), (
+        "the ruling's blocks are out of the agreed reading order")
+    assert text.index("**The offer**") < text.index("**The filing**"), (
+        "the ruling still files the classification in front of the price")
+
+
+def test_the_category_ceiling_in_the_ruling_is_the_real_one():
+    """It said L1–L4 while the code generated ten. Anyone reading it to find
+    out how deep a source could be filed got a wrong answer, and a wrong answer
+    from the document that calls itself the ruling is worse than silence."""
+    text = RULING.read_text(encoding="utf-8")
+
+    assert f"CATEGORY_LEVELS = {reports.CATEGORY_LEVELS}" in text
+    assert f"Category L{reports.CATEGORY_LEVELS}" in text, (
+        "the deepest level the code generates is not in the ruling")
+
+
+def test_the_owners_prose_survives_generation():
+    """The rules are HIS and no code derives them. A generator that dropped
+    them would leave a file of tables nobody argues with — and the arguable
+    part is the point."""
+    text = RULING.read_text(encoding="utf-8")
+
+    for ruling in ("A column's name states the language of its content",
+                   "One language at a time",
+                   "A missing translation shows the fact, never a blank",
+                   "Presence is per source",
+                   "An order you arranged is yours",
+                   "Nothing is computed into a price"):
+        assert ruling in text, f"the generator dropped a ruling: {ruling!r}"
+
+
+def test_the_file_says_it_is_generated_and_how_to_regenerate_it():
+    """Otherwise the next person edits it by hand, the golden test fails on
+    their unrelated PR, and they learn the rule from a red build instead of
+    from the file."""
+    text = RULING.read_text(encoding="utf-8")
+
+    assert "GENERATED from `scrapex/reports.py`" in text
+    assert "export-docs" in text or "export-version" in text


### PR DESCRIPTION
`docs/data-page-schema.md` calls itself **the ruling**, and it had drifted into stating the opposite of the code — in five ways at once:

| the ruling said | the code says |
|---|---|
| classification levels **L1–L4** | `CATEGORY_LEVELS = 10` |
| Brand under **identity** | `reports.py` files it under the **filing** |
| order: identity → classification → the offer | identity → **the offer** → the filing |
| no `display_method`, `minimum_quantity`, `quantity_increment`, `stock_quantity` | all four are columns |
| eight price columns absent | present |

**Not one test failed while it said all that.** A document nobody can trust is worse than no document — and PR #63 was sent back partly for leaving this one behind. It was the third of the three requirements.

## Generated

The tables come from `browse_columns()`, `COLUMN_BLOCK` and `COLUMN_NOTES`, written by `python -m scrapex.cli export-version` beside `CHANGELOG.md`, which has worked exactly this way since issue 32. The category ceiling is printed from `CATEGORY_LEVELS`, so the file **follows** the one-line change instead of contradicting it.

## The prose is not generated, and that is the point

Rules 1–7 are the owner's decisions and no list in the code derives them. They are kept verbatim, and **two are added** for work that has since landed:

- Choose Columns is reachable from the side panel as well as the web page, and both write the same order.
- **An order you arranged is yours.** The agreed order is ours to improve until you move a column; after that no update replaces it, and each screen says which of the two you are looking at.

A generator that dropped the prose would leave a file of tables nobody argues with, and the arguable part is the point.

## Guarded

A golden test, plus five that name the specific drifts. Three mutations bite — and the first is how it drifted in the first place:

| mutation | result |
|---|---|
| a hand edit to the file | 3 fail |
| a column added to the code, doc not regenerated | 2 fail |
| the prose dropped by the generator | 1 fails |

All gates: `pytest` exit 0 / zero FAILED · parity exit 0 · `node --test extension/tests` exit 0 · `validate-manifest` OK.
