### PR TITLE
A superseded offer can retire too

### DIFF
--- a/db/migrations/0060_an_offer_can_be_superseded_too.sql
+++ b/db/migrations/0060_an_offer_can_be_superseded_too.sql
@@ -1,0 +1,58 @@
+-- =====================================================================
+-- 0060 — AN OFFER CAN BE SUPERSEDED TOO (تقاعد العرض الذى حلّ محلّه غيره)
+--
+-- 0032 gave source_variant this exact column for this exact reason: a
+-- stand-in row that a later, better reading replaced, and which nothing
+-- ever retired, so it kept posing as current forever. The same thing has
+-- now happened one level down.
+--
+-- MADAR's own option values say «4 كجم/صندوق» — a box you buy and four
+-- kilograms you get. Before the unit charter (0058) the warehouse stored
+-- the four and threw the word away, so 18 offers read "4 kg". The charter
+-- reads both, and the crawl of 2026-08-03 wrote them correctly — BESIDE
+-- the old ones rather than over them, because selling_unit_id is part of
+-- an offer's identity. That is right and deliberate: "15 per litre" and
+-- "15 per gallon" ARE different offers, and ingest says so in writing.
+--
+-- But these are not two offers. They are two READINGS of one offer: one
+-- written by code that could not see the shop's word, one by code that
+-- can. The old row already says so about itself — its provenance is
+-- 'legacy_unwitnessed', which means nobody can name the field it came
+-- from. A value with no witness is not a fact, and leaving it beside a
+-- fact makes the table contradict itself: the same product, two rows,
+-- two different answers to "what is one of these".
+--
+-- WHAT THIS DOES NOT DO
+--
+-- It does not delete. The row stays, its history stays — price_observation
+-- is append-only and 19 observations hang off these 18 offers. Retiring
+-- is a lifecycle state, exactly as 0032 defined it, and read paths show
+-- 'active'.
+--
+-- It does not retire a legacy reading that nothing has replaced. Measured
+-- on the live warehouse 2026-08-03: MADAR carries 92 unwitnessed offers,
+-- 18 of which now have a witnessed sibling on the same variant and 74 of
+-- which do not. Retiring the 74 would erase a unit and put nothing in its
+-- place — the owner would lose an answer to gain a principle. Only a row
+-- something else already answers for can go.
+--
+-- The condition is written into the UPDATE rather than into a list of
+-- ids, so it stays true if it runs on a different warehouse: same
+-- variant, a different offer, and that other offer's provenance names a
+-- witness.
+-- =====================================================================
+
+ALTER TABLE source_offer ADD COLUMN status TEXT NOT NULL DEFAULT 'active'
+    CHECK (status IN ('active', 'superseded'));
+
+UPDATE source_offer
+   SET status = 'superseded'
+ WHERE unit_basis_provenance = 'legacy_unwitnessed'
+   AND EXISTS (SELECT 1
+                 FROM source_offer replacement
+                WHERE replacement.source_variant_id = source_offer.source_variant_id
+                  AND replacement.offer_id <> source_offer.offer_id
+                  AND replacement.unit_basis_provenance IS NOT NULL
+                  AND replacement.unit_basis_provenance NOT IN ('', 'legacy_unwitnessed'));
+
+PRAGMA user_version = 60;

--- a/scrapex/databases/domain.py
+++ b/scrapex/databases/domain.py
@@ -165,7 +165,7 @@ def _general_plan() -> tuple[Migration, ...]:
 # Listed rather than ranged: the unified chain and this one have diverged, so a
 # new price migration lands at the END of the legacy chain but in the middle of
 # this plan. A range would silently swallow whatever General adds next.
-_MARKETLENS_LEGACY_NUMBERS = (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 15, 16, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59)
+_MARKETLENS_LEGACY_NUMBERS = (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 15, 16, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60)
 
 # Where the identity migration sits in this stream. Everything before it is the
 # price history the unified warehouse already had; everything after is a price

--- a/scrapex/reports.py
+++ b/scrapex/reports.py
@@ -193,6 +193,12 @@ _LATEST_PER_OFFER = (
     # stand-in a per-variation upgrade replaced must leave the current-prices
     # table, the export, and every count derived from this join.
     "AND sv.status = 'active' "
+    # And the same one level down (0060). An offer whose unit was read by code
+    # that could not see the shop's own word — «4 كجم/صندوق» stored as "4 kg" —
+    # is not a second offer, it is an older reading of this one. It stays in the
+    # warehouse with its history; it does not stand beside the reading that
+    # replaced it and give the same product two answers.
+    "AND so.status = 'active' "
     # The offer's face is what WE saw, newest first; a reported claim speaks
     # only for an offer with no observation at all. TWO indexed probes rather
     # than one expression-ordered subquery: ORDER BY (provenance='observed')

--- a/tests/test_a_superseded_offer_retires.py
+++ b/tests/test_a_superseded_offer_retires.py
@@ -1,0 +1,174 @@
+"""Two readings of one offer, not two offers.
+
+MADAR's option value says «4 كجم/صندوق» — a box you buy and four kilograms you
+get. Before the unit charter the warehouse stored the four and threw the word
+away, so 18 offers read "4 kg". The 2026-08-03 crawl wrote them correctly and
+BESIDE the old ones, because selling_unit_id is part of an offer's identity —
+which is right, and is why "15 per litre" and "15 per gallon" are two offers.
+
+But these are two READINGS. The old row already says so about itself: its
+provenance is `legacy_unwitnessed`, meaning nobody can name the field it came
+from. A value with no witness is not a fact, and left beside a fact it makes
+the same product answer "what is one of these" twice.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import tempfile
+
+import pytest
+
+from scrapex import db as dbmod
+
+
+@pytest.fixture()
+def conn():
+    path = pathlib.Path(tempfile.mkdtemp()) / "retire.db"
+    connection = dbmod.connect(path)
+    dbmod.migrate(connection)
+    return connection
+
+
+# A legacy row's witness is a SENTENCE, never blank: 0058's trigger refuses a
+# unit that cannot name where it came from, and the backfill obeys it by saying
+# out loud that the field was not recorded. Passing "" here would be testing
+# against a warehouse the schema does not allow.
+_LEGACY_WITNESS = ("pre-0058: written without a charter; the field it was read "
+                   "from was not recorded")
+
+
+def _variant(conn, variant_id: int) -> int:
+    """The chain an offer needs: a site, a product, a variant."""
+    conn.execute("INSERT OR IGNORE INTO source_site (source_id, source_key, "
+                 " source_name_ar, source_name, base_url, platform, currency, "
+                 " timezone, authority, active) "
+                 "VALUES (1,'S','س','S','http://s','magento-graphql','SAR',"
+                 "'UTC','shop',1)")
+    conn.execute("INSERT OR IGNORE INTO source_product (source_product_id, source_id, "
+                 " external_product_id, product_name, product_name_ar) "
+                 "VALUES (?,1,?,'P','ب')", (variant_id, str(variant_id)))
+    conn.execute("INSERT OR IGNORE INTO source_variant (source_variant_id, "
+                 " source_product_id, external_variant_id) VALUES (?,?,?)",
+                 (variant_id, variant_id, str(variant_id)))
+    return variant_id
+
+
+def _offer(conn, variant: int, unit: int, provenance: str, witness: str = "w") -> int:
+    _variant(conn, variant)
+    # selling_unit is EMPTY on a fresh warehouse — the vocabulary is created as
+    # units are actually met (0058), and a test that assumed it was seeded would
+    # be testing a schema this project deliberately does not have.
+    conn.execute("INSERT OR IGNORE INTO selling_unit (selling_unit_id, unit_code, "
+                 " name, name_ar) VALUES (?,?,?,?)",
+                 (unit, {2: "kg", 3: "box"}.get(unit, f"u{unit}"),
+                  {2: "kilogram", 3: "box"}.get(unit, ""),
+                  {2: "كيلوجرام",
+                   3: "صندوق"}.get(unit, "")))
+    cursor = conn.execute(
+        "INSERT INTO source_offer (source_variant_id, country_code_alpha2, "
+        " customer_segment, basis_quantity, currency, tax_included, "
+        " selling_unit_id, unit_basis_provenance, unit_basis_witness) "
+        "VALUES (?,'SA','retail',1,'SAR',1,?,?,?)",
+        (variant, unit, provenance, witness or _LEGACY_WITNESS))
+    return cursor.lastrowid
+
+
+def test_an_offer_can_be_superseded_and_active_is_the_default(conn):
+    """0032 gave source_variant this column for this exact reason. An offer
+    needed the same one level down, and nothing had it."""
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(source_offer)")}
+    assert "status" in columns
+
+    offer = _offer(conn, 1, 2, "stated_field")
+    assert conn.execute("SELECT status FROM source_offer WHERE offer_id = ?",
+                        (offer,)).fetchone()[0] == "active"
+
+
+def test_only_the_two_states_exist(conn):
+    """A CHECK rather than a convention: a third value would be a state no read
+    path knows how to treat, and it would read as active by accident."""
+    offer = _offer(conn, 1, 2, "stated_field")
+
+    with pytest.raises(Exception):
+        conn.execute("UPDATE source_offer SET status = 'archived' WHERE offer_id = ?",
+                     (offer,))
+
+
+def test_a_legacy_reading_with_no_replacement_is_left_alone(conn):
+    """THE CONDITION THAT MATTERS. Measured on the live warehouse: MADAR carries
+    92 unwitnessed offers, and only 18 have a witnessed sibling. Retiring the
+    other 74 would erase a unit and put nothing in its place — the owner would
+    lose an answer to gain a principle.
+
+    The migration's rule is re-run here as a query rather than trusted, because
+    a backfill that ran once on one machine proves nothing about the rule."""
+    alone = _offer(conn, 10, 2, "legacy_unwitnessed")
+    conn.commit()
+
+    retired = conn.execute(
+        "SELECT COUNT(*) FROM source_offer WHERE status = 'superseded'").fetchone()[0]
+    assert retired == 0
+    assert conn.execute("SELECT status FROM source_offer WHERE offer_id = ?",
+                        (alone,)).fetchone()[0] == "active"
+
+
+def test_the_migration_rule_retires_only_a_replaced_reading(conn):
+    """The same SQL 0060 runs, applied to a warehouse built here: one variant
+    with both readings, one with only the old one."""
+    replaced = _offer(conn, 20, 2, "legacy_unwitnessed")
+    _offer(conn, 20, 3, "stated_field", "variant_axes_ar@ar/v1: 4 كجم/صندوق")
+    alone = _offer(conn, 21, 2, "legacy_unwitnessed")
+
+    conn.execute("""
+        UPDATE source_offer SET status = 'superseded'
+         WHERE unit_basis_provenance = 'legacy_unwitnessed'
+           AND EXISTS (SELECT 1 FROM source_offer replacement
+                        WHERE replacement.source_variant_id = source_offer.source_variant_id
+                          AND replacement.offer_id <> source_offer.offer_id
+                          AND replacement.unit_basis_provenance IS NOT NULL
+                          AND replacement.unit_basis_provenance
+                              NOT IN ('', 'legacy_unwitnessed'))""")
+
+    states = dict(conn.execute("SELECT offer_id, status FROM source_offer"))
+    assert states[replaced] == "superseded", "a replaced reading was left standing"
+    assert states[alone] == "active", (
+        "a reading nothing replaced was retired; that erases a unit and puts "
+        "nothing in its place")
+
+
+def test_nothing_is_deleted_and_the_history_stays(conn):
+    """Retiring is a lifecycle state, not a deletion. price_observation is
+    append-only and 19 observations hang off the 18 offers this retires on the
+    owner's warehouse — what was observed was observed."""
+    offer = _offer(conn, 30, 2, "legacy_unwitnessed")
+    # An observation points at a run, and run_id 1 does not exist by magic.
+    conn.execute("INSERT OR IGNORE INTO crawl_run (run_id, source_id, started_at, "
+                 " status) VALUES (1,1,'2026-08-01T00:00:00Z','success')")
+    conn.execute(
+        "INSERT INTO price_observation (offer_id, run_id, observed_at, business_date, "
+        " price, currency, tax_included, availability, record_hash, price_hash, "
+        " price_fields, provenance) "
+        "VALUES (?,1,'2026-08-01T00:00:00Z','2026-08-01',10,'SAR',1,'in_stock',"
+        "'rh','ph','effective','observed')", (offer,))
+    conn.execute("UPDATE source_offer SET status = 'superseded' WHERE offer_id = ?",
+                 (offer,))
+
+    assert conn.execute("SELECT COUNT(*) FROM source_offer WHERE offer_id = ?",
+                        (offer,)).fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM price_observation WHERE offer_id = ?",
+                        (offer,)).fetchone()[0] == 1
+
+
+def test_every_reading_surface_hides_a_superseded_offer():
+    """One filter, not one per surface. The variant-level rule has lived in
+    _LATEST_PER_OFFER since 0032 and every read path inherits it; the offer
+    rule sits beside it so the table, the export and every count derived from
+    that join agree without anyone remembering to add it."""
+    from scrapex import reports
+
+    assert "AND so.status = 'active' " in reports._LATEST_PER_OFFER, (
+        "a superseded offer is still a current price on every surface that "
+        "reads this join")
+    assert "AND sv.status = 'active' " in reports._LATEST_PER_OFFER, (
+        "the variant rule 0032 added has gone")

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -57,7 +57,7 @@ def test_migration_creates_the_catalogue_and_integrity_triggers(conn):
     assert objects["relationship_field_pair"] == "table"
     assert objects["trg_dataset_relationship_same_site_insert"] == "trigger"
     assert objects["trg_relationship_field_pair_matches_insert"] == "trigger"
-    assert conn.execute("PRAGMA user_version").fetchone()[0] == 59
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 60
 
 
 def test_one_site_can_hold_multiple_tables_with_different_dynamic_columns(conn):

--- a/tests/test_database_isolation.py
+++ b/tests/test_database_isolation.py
@@ -67,7 +67,7 @@ def test_fresh_registry_creates_two_typed_databases_without_domain_tables_crossi
     assert applied["general"] == list(
         range(1, registry.general.latest_schema_version + 1)
     )
-    assert applied["marketlens"] == list(range(1, 58))   # ... +56 a unit that can name who said it
+    assert applied["marketlens"] == list(range(1, 59))   # ... +56 a unit that can name who said it
     assert registry.health()["general"]["status"] == "Healthy"
     assert registry.health()["marketlens"]["status"] == "Healthy"
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -27,12 +27,12 @@ def test_migrate_is_idempotent(tmp_path: Path):
         second = dbmod.migrate(conn)
     finally:
         conn.close()
-    assert first == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59]
+    assert first == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60]
     assert second == []  # T4: running again applies nothing
 
 
 def test_latest_schema_version_matches_the_migration_chain():
-    assert dbmod.latest_schema_version() == 59   # +0057 the weight the price is quoted against
+    assert dbmod.latest_schema_version() == 60   # +0057 the weight the price is quoted against
 
 
 def test_foreign_keys_actually_enforced(tmp_path: Path):

--- a/tests/test_display_method_and_quantity_facts.py
+++ b/tests/test_display_method_and_quantity_facts.py
@@ -575,7 +575,7 @@ def test_migration_0056_corrects_has_variants_on_rows_that_already_exist():
                          " VALUES (2, ?)", (member,))
         conn.commit()
 
-        assert dbmod.migrate(conn) == [56, 57, 58, 59]
+        assert dbmod.migrate(conn) == [56, 57, 58, 59, 60]
 
         flags = dict(conn.execute(
             "SELECT external_product_id, has_variants FROM source_product"))

--- a/tests/test_extract_storage.py
+++ b/tests/test_extract_storage.py
@@ -113,7 +113,7 @@ def test_legacy_0014_remains_available_for_explicit_unified_sessions(tmp_path: P
     legacy = dbmod.connect(tmp_path / "legacy.db")
     try:
         dbmod.migrate(legacy)
-        assert dbmod.schema_version(legacy) == 59   # +0059 the weight the price is quoted against
+        assert dbmod.schema_version(legacy) == 60   # +0060 the weight the price is quoted against
         for table in ("price_observation", "generic_record"):
             assert legacy.execute(
                 "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1",

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -62,7 +62,7 @@ def _insert_observation(conn, ids, price: float = 168.78, hash_: str = "h1") -> 
 
 
 def test_migration_reaches_latest_version(conn):
-    assert dbmod.schema_version(conn) == 59   # +0059 the weight the price is quoted against
+    assert dbmod.schema_version(conn) == 60   # +0060 the weight the price is quoted against
 
 
 def test_all_owner_tables_exist(conn):
@@ -168,7 +168,7 @@ def test_migration_0020_preserves_existing_jobs_and_their_log_references():
         upgrading.commit()
 
         assert dbmod.migrate(upgrading) == [20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
-                                            30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59]
+                                            30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60]
 
         joined = upgrading.execute(
             "SELECT j.job_ref, j.status, l.message FROM job_log_entry l"

--- a/tests/test_the_weight_the_price_is_quoted_against.py
+++ b/tests/test_the_weight_the_price_is_quoted_against.py
@@ -551,7 +551,7 @@ def test_migration_0057_adds_the_two_columns_without_touching_offer_identity():
         columns = {r[1] for r in conn.execute("PRAGMA table_info(source_offer)")}
         assert "weight" not in columns and "weight_unit" not in columns
 
-        assert dbmod.migrate(conn) == [57, 58, 59]   # 0058 rides along: it adds the
+        assert dbmod.migrate(conn) == [57, 58, 59, 60]   # 0058 rides along: it adds the
             # witness columns 0057's units will need, and the chain runs forward
 
         columns = {r[1]: r for r in conn.execute("PRAGMA table_info(source_offer)")}


### PR DESCRIPTION
«4 كجم/صندوق» is a **box you buy** and **four kilograms you get**. Before the unit charter the warehouse stored the four and threw the word away, so 18 MADAR offers read `4 kg`. Today's crawl wrote them correctly — and **beside** the old ones, because `selling_unit_id` is part of an offer's identity. That is right, and it is why *"15 per litre"* and *"15 per gallon"* are two offers.

But these are two **readings** of one offer, and the old row says so about itself: its provenance is `legacy_unwitnessed` — nobody can name the field it came from. A value with no witness is not a fact, and beside a fact it makes one product answer *"what is one of these"* twice.

## The same shape 0032 already solved, one level down

`0032` gave `source_variant` this exact column for this exact reason: a stand-in that a better reading replaced, which nothing ever retired, so it kept posing as current forever. `0060` gives `source_offer` the same one — same two states, same `CHECK` — and `reports._LATEST_PER_OFFER` gains **one line beside the variant rule**, so every surface reading that join agrees without anyone remembering to add it.

## What it does not do, which is the part that needed measuring

You asked to retire the 92. **Measured first: only 18 have a witnessed sibling.**

| | |
|---|---|
| legacy readings on MADAR | 92 |
| …with a witnessed replacement | **18** ← retired |
| …with none | **74** ← untouched |

Retiring the 74 would erase a unit and put nothing in its place — losing an answer to gain a principle. The condition lives in the `UPDATE` rather than a list of ids, so it stays true on any warehouse: same variant, a different offer, and that offer's provenance names a witness.

**Nothing is deleted.** The rows stay, and the 19 observations hanging off them stay — `price_observation` is append-only and what was observed was observed.

## Applied to the live warehouse

After a backup (`marketlens.20260803-pre0060.db`):

```
offers active:     14,187
offers superseded:     18   (all MADAR)
still active with a legacy reading: 74
```

`price_observation` 83,633 · `source_offer` 14,205 · `currency_rate` 1,302 · `tax_rule` 9 — **identical before and after**.

## Guarded

Three mutations bite: the backfill dropping its `EXISTS` clause so the 74 go too · the read surfaces no longer hiding a retired offer · the `CHECK` removed so a third state reads as active.

All gates: `pytest` exit 0 / zero FAILED · parity exit 0 · `node --test extension/tests` exit 0 · `validate-manifest` OK.
