### PR TITLE
Spark eShop comes back, whole this time

### DIFF
--- a/scrapex/storage.py
+++ b/scrapex/storage.py
@@ -504,6 +504,35 @@ def space_warning(db_path: Path | str) -> str:
     return ""
 
 
+def undeclared_sources(conn) -> list[str]:
+    """Sources this warehouse holds data for that the manifest no longer names.
+
+    SPARK_ESHOP was crawled on 2026-08-03 — 1,789 products, 3,149 offers, 3,149
+    observations, a successful run — and its manifest entry was deleted
+    afterwards while the rows stayed, marked active. That was 22% of every offer
+    here belonging to a source no code could crawl, update or explain, and it
+    was found by hand-censusing the database two days later.
+
+    The manifest is the definition; the warehouse is the consequence. A
+    consequence with no definition is not a small untidiness: every count
+    includes it, every table shows it, and nothing can ever refresh it.
+
+    Reads the CURRENT manifest each call rather than a cached one, because the
+    failure mode is precisely that the manifest changed.
+    """
+    from .config import MANIFEST_FILE, load_manifest
+    try:
+        declared = {entry.source_key for entry in load_manifest(MANIFEST_FILE).sources}
+    except Exception:  # noqa: BLE001 — a broken manifest is validate-manifest's job
+        return []
+    try:
+        stored = {row[0] for row in conn.execute(
+            "SELECT source_key FROM source_site WHERE active = 1")}
+    except sqlite3.DatabaseError:
+        return []                      # not a warehouse; health says so already
+    return sorted(stored - declared)
+
+
 def health(db_path: Path | str) -> dict:
     """SQLite's own verdict, reported as a word plus the raw findings.
 
@@ -533,6 +562,7 @@ def health(db_path: Path | str) -> dict:
         freelist = conn.execute("PRAGMA freelist_count").fetchone()[0]
         page_size = conn.execute("PRAGMA page_size").fetchone()[0]
         identity_problem = _warehouse_identity(conn)
+        forgotten = undeclared_sources(conn)
     except sqlite3.DatabaseError as exc:
         return {"status": "unreadable", "ok": False,
                 "detail": f"SQLite could not read this file: {exc}",
@@ -550,12 +580,20 @@ def health(db_path: Path | str) -> dict:
         return {"status": status, "ok": False, "problems": [detail],
                 "foreign_key_problems": 0, "reclaimable_bytes": reclaimable,
                 "detail": detail}
+    # A forgotten source is not corruption — the file is sound and `ok` stays
+    # true — but it is the one thing quick_check can never see, so it rides the
+    # verdict the Storage page already reads on every visit rather than waiting
+    # for someone to think of censusing the database again.
     return {
         "status": "healthy", "ok": True, "problems": [], "foreign_key_problems": 0,
         "reclaimable_bytes": reclaimable,
+        "undeclared_sources": forgotten,
         "detail": ("No problems found." + (
             f" Compacting would return about {reclaimable:,} bytes of free pages."
-            if reclaimable else "")),
+            if reclaimable else "") + (
+            f" {len(forgotten)} source(s) hold data here but are not in the "
+            f"manifest and can never be refreshed: {', '.join(forgotten)}."
+            if forgotten else "")),
     }
 
 

--- a/sources.yaml
+++ b/sources.yaml
@@ -835,6 +835,14 @@ sources:
     active: false
     currency: EGP
     default_region: EG
+    # THE SHOP SERVES ENGLISH AT ITS ROOT. <html lang="en">, and every title is
+    # English — "Himel Variable Speed Drive VFD, 380V 3-Phase Motor Control".
+    # It has no /en locale at all; that URL answers 404, verified live
+    # 2026-08-03. Without this line the connector files the root title as
+    # Arabic and then asks a shop that has no /en for its /en, which is exactly
+    # how 1,789 English names ended up under the Arabic heading with the
+    # English column — which config.py calls required — empty on every one.
+    default_language: en
     # UNVERIFIED, and the one field here nobody has checked. Egypt charges 14%
     # VAT and the shop prints "LE {{amount}}" with no statement either way; the
     # cart would settle it in one look, and until someone looks this is the

--- a/sources.yaml
+++ b/sources.yaml
@@ -817,6 +817,15 @@ sources:
     # the warehouse marked active with nothing in the code able to crawl or
     # update them. That is 22% of every offer this warehouse holds. Restored
     # here so the data has a definition again.
+    # Everything below is READ OFF THE SHOP, not inferred. /meta.json,
+    # 2026-08-03: {"name":"Spark","city":"El Weili","province":"Cairo",
+    # "country":"EG","currency":"EGP","ships_to_countries":["EG"],
+    # "money_format":"LE {{amount}}","published_products_count":1789}. The
+    # storefront's <html lang> is "en" and every product title is English —
+    # "Himel Variable Speed Drive VFD, 380V 3-Phase Motor Control".
+    #
+    # The first draft asserted EGP and EG without asking. They happened to be
+    # right, and a guess that turns out right is still a guess.
     source_name_ar: سبارك إي شوب
     source_name: Spark eShop
     base_url: https://www.spark-eshop.com/
@@ -826,6 +835,10 @@ sources:
     active: false
     currency: EGP
     default_region: EG
+    # UNVERIFIED, and the one field here nobody has checked. Egypt charges 14%
+    # VAT and the shop prints "LE {{amount}}" with no statement either way; the
+    # cart would settle it in one look, and until someone looks this is the
+    # cautious reading rather than a finding. Do not cite it as evidence.
     vat_mode: incl
     extract:
       - kind: product_prices
@@ -839,8 +852,21 @@ sources:
     min_expected_rows: 50
     max_drop_pct: 50
     notes: >-
-      Shopify storefront. Declared after the fact: the source already held
+      Shopify storefront, declared after the fact: the source already held
       1,789 products and 3,149 offers from the 2026-08-03 run when its
       manifest entry was found to be missing. Left inactive until the owner
-      schedules it, so nothing crawls on a definition nobody has reviewed
-      against the live site.
+      schedules it.
+
+
+      THE ROWS ALREADY IN THE WAREHOUSE ARE NOT TRUSTWORTHY, and the counts
+      say so. Audited 2026-08-03 against the live shop: currency is UNKNOWN on
+      all 3,149 observations where the shop states EGP; country is '*' on all
+      3,149 where the shop ships only to EG; product_name is EMPTY on all
+      1,789 while the ENGLISH titles sit in product_name_ar, which inverts the
+      bilingual rule — 'ABB 1SDA100487R1 | XT5H 630 TMA 630-6300' is not
+      Arabic; and there are zero attribute rows, so not one of the images the
+      shop publishes was stored. The last is explained by the missing
+      enrichment kind and is fixed above. The first three are not explained,
+      and a re-crawl is what would replace them — not a repair of these rows,
+      because rewriting a stored observation is the one thing this project
+      does not do.

--- a/sources.yaml
+++ b/sources.yaml
@@ -810,3 +810,37 @@ sources:
       rides source_date. robots.txt allows the path. Parsed from reading-order
       text, not selectors: the React class names churn, the words do not.
 
+  - source_key: SPARK_ESHOP
+    # It was crawled before it was declared, and then the declaration was
+    # deleted while the data stayed: 1,789 products, 3,149 offers and 3,149
+    # observations from a successful run on 2026-08-03T05:19:45Z, sitting in
+    # the warehouse marked active with nothing in the code able to crawl or
+    # update them. That is 22% of every offer this warehouse holds. Restored
+    # here so the data has a definition again.
+    source_name_ar: سبارك إي شوب
+    source_name: Spark eShop
+    base_url: https://www.spark-eshop.com/
+    family: shopify-json
+    cadence: daily
+    authority: shop
+    active: false
+    currency: EGP
+    default_region: EG
+    vat_mode: incl
+    extract:
+      - kind: product_prices
+        scope: census
+      # THE LINE THE FIRST DRAFT WAS MISSING. Without it the connector never
+      # asks for enrichment, so a shopify source that publishes images stores
+      # none — and tests/test_images_every_connector.py said so by name the
+      # moment the draft was added.
+      - kind: enrichment
+        scope: census
+    min_expected_rows: 50
+    max_drop_pct: 50
+    notes: >-
+      Shopify storefront. Declared after the fact: the source already held
+      1,789 products and 3,149 offers from the 2026-08-03 run when its
+      manifest entry was found to be missing. Left inactive until the owner
+      schedules it, so nothing crawls on a definition nobody has reviewed
+      against the live site.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -195,6 +195,34 @@ def test_no_source_holds_data_the_manifest_has_forgotten(tmp_path):
         f"test invented, and it saw {orphans}")
 
 
+def test_the_english_shop_declares_that_it_is_an_english_shop():
+    """One line stands between this source and 1,789 mislabelled names again.
+
+    spark-eshop serves English at its root — <html lang="en">, and every title
+    reads like "Himel Variable Speed Drive VFD, 380V 3-Phase Motor Control" —
+    and it has no /en locale at all; that URL answers 404, verified live. The
+    connector defaults to assuming Arabic at the root, which is right for the
+    eleven sources that were crawled under that assumption and wrong here.
+
+    Without this declaration the crawl files English titles under the Arabic
+    heading and leaves product_name — which this module calls required — empty
+    on every row, and REPORTS SUCCESS. That is how the 3,149 rows already in
+    the warehouse were written. Deleting this line would not fail anything; it
+    would quietly recreate the defect on the next crawl."""
+    spark = load_manifest(MANIFEST_FILE).get("SPARK_ESHOP")
+
+    assert spark.default_language == "en"
+
+
+def test_the_shop_with_no_definition_is_not_crawled_before_someone_says_so():
+    """Restoring the entry gives 3,149 orphaned rows a definition. It does not
+    endorse them: the manifest's own notes record that currency is UNKNOWN on
+    all 3,149, country is '*' on all 3,149, and there are zero images. Active
+    would mean the scheduler replaces them tonight without the owner deciding
+    to."""
+    assert load_manifest(MANIFEST_FILE).get("SPARK_ESHOP").active is False
+
+
 def test_no_manifest_entry_declares_a_family_nothing_can_build():
     """An entry whose family has no connector is a promise the engine cannot
     keep. SIKA_EGYPT_DATASHEETS declared `datasheet-enrichment` for months with

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -163,36 +163,70 @@ def test_a_probe_placeholder_cannot_be_shipped_active():
     assert "scrapex probe" in str(caught.value)
 
 
-def test_no_source_holds_data_the_manifest_has_forgotten(tmp_path):
-    """A source can be crawled and then lose its definition, and nothing said so.
-
-    It happened: SPARK_ESHOP was crawled on 2026-08-03 — 1,789 products, 3,149
-    offers, 3,149 observations, a successful run — and its manifest entry was
-    deleted afterwards while the rows stayed, marked active. That is 22% of the
-    warehouse belonging to a source no code could crawl, update or explain, and
-    it was found by censusing the database rather than by anything failing.
-
-    The manifest is the definition; the warehouse is the consequence. A
-    consequence with no definition is not a small untidiness — every count
-    includes it, every table shows it, and nothing can ever refresh it."""
+def _warehouse(tmp_path, *source_keys):
+    """A warehouse holding one active source_site row per key."""
     from scrapex import db as dbmod
-    declared = {entry.source_key for entry in load_manifest(MANIFEST_FILE).sources}
-
     conn = dbmod.connect(tmp_path / "w.db")
     dbmod.migrate(conn)
-    conn.execute("INSERT INTO source_site (source_id, source_key, source_name_ar, "
-                 " source_name, base_url, platform, currency, timezone, authority, "
-                 " active) VALUES (1,'GHOST','ش','G','http://g','shopify-json',"
-                 "'EGP','UTC','shop',1)")
+    for i, key in enumerate(source_keys, start=1):
+        conn.execute("INSERT INTO source_site (source_id, source_key, source_name_ar, "
+                     " source_name, base_url, platform, currency, timezone, authority, "
+                     " active) VALUES (?,?,'ش','G','http://g','shopify-json',"
+                     "'EGP','UTC','shop',1)", (i, key))
     conn.commit()
+    return conn
 
-    stored = {row[0] for row in conn.execute(
-        "SELECT source_key FROM source_site WHERE active = 1")}
-    orphans = sorted(stored - declared)
 
-    assert orphans == ["GHOST"], (
-        "the check itself is broken — it should see exactly the source this "
-        f"test invented, and it saw {orphans}")
+def test_a_source_the_manifest_has_forgotten_is_reported(tmp_path):
+    """SPARK_ESHOP was crawled on 2026-08-03 — 1,789 products, 3,149 offers,
+    3,149 observations, a successful run — and its manifest entry was deleted
+    afterwards while the rows stayed, marked active. 22% of every offer in the
+    warehouse belonged to a source no code could crawl, update or explain, and
+    it was found by hand-censusing the database two days later.
+
+    THIS TEST REPLACES ONE THAT COULD NOT FAIL. The first version inserted a
+    row called GHOST into an empty temp database and asserted that GHOST came
+    back — true for any manifest, including one with every source deleted. An
+    adversarial review proved it by removing SPARK_ESHOP from the manifest and
+    watching the two tests beside it go red while this one stayed green: the
+    test named after the incident was the only one that could not see it.
+
+    Worse, it checked nothing that shipped. No production code read
+    source_site.active at all, so the "guard" was a query living in a test."""
+    from scrapex import storage
+    declared = load_manifest(MANIFEST_FILE).sources[0].source_key
+    conn = _warehouse(tmp_path, declared, "SPARK_ESHOP_GONE")
+
+    forgotten = storage.undeclared_sources(conn)
+
+    assert forgotten == ["SPARK_ESHOP_GONE"]
+    assert declared not in forgotten, (
+        "a source the manifest DOES declare was reported as forgotten; the "
+        "check is comparing against nothing")
+
+
+def test_a_warehouse_whose_sources_are_all_declared_is_quiet(tmp_path):
+    """The negative half, and the half the vacuous version never had: with
+    every stored source declared, the answer is empty. Without this, a check
+    that always returned its whole input would pass the test above."""
+    from scrapex import storage
+    keys = [entry.source_key for entry in load_manifest(MANIFEST_FILE).sources[:3]]
+
+    assert storage.undeclared_sources(_warehouse(tmp_path, *keys)) == []
+
+
+def test_the_warehouse_says_it_on_the_page_the_owner_already_opens(tmp_path):
+    """A function nobody calls is the same defect one layer down. It rides
+    storage.health(), which the Storage page runs on every visit — and `ok`
+    stays true, because a forgotten source is not corruption."""
+    from scrapex import storage
+    _warehouse(tmp_path, "SPARK_ESHOP_GONE").close()
+
+    verdict = storage.health(tmp_path / "w.db")
+
+    assert verdict["ok"] is True
+    assert verdict["undeclared_sources"] == ["SPARK_ESHOP_GONE"]
+    assert "SPARK_ESHOP_GONE" in verdict["detail"]
 
 
 def test_the_english_shop_declares_that_it_is_an_english_shop():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -163,6 +163,38 @@ def test_a_probe_placeholder_cannot_be_shipped_active():
     assert "scrapex probe" in str(caught.value)
 
 
+def test_no_source_holds_data_the_manifest_has_forgotten(tmp_path):
+    """A source can be crawled and then lose its definition, and nothing said so.
+
+    It happened: SPARK_ESHOP was crawled on 2026-08-03 — 1,789 products, 3,149
+    offers, 3,149 observations, a successful run — and its manifest entry was
+    deleted afterwards while the rows stayed, marked active. That is 22% of the
+    warehouse belonging to a source no code could crawl, update or explain, and
+    it was found by censusing the database rather than by anything failing.
+
+    The manifest is the definition; the warehouse is the consequence. A
+    consequence with no definition is not a small untidiness — every count
+    includes it, every table shows it, and nothing can ever refresh it."""
+    from scrapex import db as dbmod
+    declared = {entry.source_key for entry in load_manifest(MANIFEST_FILE).sources}
+
+    conn = dbmod.connect(tmp_path / "w.db")
+    dbmod.migrate(conn)
+    conn.execute("INSERT INTO source_site (source_id, source_key, source_name_ar, "
+                 " source_name, base_url, platform, currency, timezone, authority, "
+                 " active) VALUES (1,'GHOST','ش','G','http://g','shopify-json',"
+                 "'EGP','UTC','shop',1)")
+    conn.commit()
+
+    stored = {row[0] for row in conn.execute(
+        "SELECT source_key FROM source_site WHERE active = 1")}
+    orphans = sorted(stored - declared)
+
+    assert orphans == ["GHOST"], (
+        "the check itself is broken — it should see exactly the source this "
+        f"test invented, and it saw {orphans}")
+
+
 def test_no_manifest_entry_declares_a_family_nothing_can_build():
     """An entry whose family has no connector is a promise the engine cannot
     keep. SIKA_EGYPT_DATASHEETS declared `datasheet-enrichment` for months with


### PR DESCRIPTION
SPARK_ESHOP was **crawled and then had its manifest entry deleted while the data stayed**: 1,789 products, 3,149 offers and 3,149 observations from a successful run on 2026-08-03, sitting in the warehouse marked active with nothing in the code able to crawl, update or explain them. That is **22% of every offer this warehouse holds**. This gives them a definition again.

## The owner asked whether I had inspected the site. I had not

The first draft copied `currency: EGP`, `default_region: EG` and `vat_mode: incl` out of the deleted entry and invented `min_expected_rows` / `max_drop_pct` from ELSEWEDYSHOP. Nothing in it had been checked against anything.

`/meta.json`, read 2026-08-03:

```json
{"name":"Spark","city":"El Weili","province":"Cairo","country":"EG",
 "currency":"EGP","ships_to_countries":["EG"],"money_format":"LE {{amount}}",
 "published_products_count":1789}
```

1,789 — matching the warehouse exactly. EGP and EG were right. **A guess that turns out right is still a guess**, so they are cited now rather than asserted. `vat_mode` remains unchecked and says so in place, instead of passing as a finding.

## The rows already in the warehouse are not trustworthy, and the entry says so

| the first draft asserted | the 3,149 stored rows say |
|---|---|
| currency EGP | **UNKNOWN**, all 3,149 |
| region EG | **`*`**, all 3,149 |
| — | `product_name` **empty on all 1,789** |
| — | **zero** attribute rows — not one published image |

And the **English** titles are in `product_name_ar`. `ABB 1SDA100487R1 | XT5H 630 TMA 630-6300` is not Arabic.

The images are explained by the **missing `enrichment` kind**, which this PR adds — `tests/test_images_every_connector.py` named it the moment the draft appeared. The other three are not explained. All four are recorded beside the source they describe, so nobody reads this entry and believes the data behind it is sound.

## The English shop now says so out loud

`<html lang="en">`, every title like *"Himel Variable Speed Drive VFD, 380V 3-Phase Motor Control"*, and **no `/en` locale at all** — that URL answers 404, verified live.

The connector's default is *"assume Arabic at the root, fetch /en for English"*, which is right for the eleven sources crawled under it and wrong here. Under that default the crawl files English titles into `product_name_ar`, asks a shop with no `/en` for its `/en`, fails, and leaves `product_name` — which `config.py` calls **required** — empty on every row. Then it **reports success**. That is exactly how the 3,149 rows were written.

`default_language: en` could not be added before #91 landed; the manifest would have rejected a key the model did not have. It is inert until someone activates the source, which is the point — **the declaration is in place before the first crawl rather than discovered after it.**

## Two guards, both proved to bite

Deleting `default_language: en` would fail nothing — no test, no validation, no error. It would silently recreate the defect on the next run. So a test asserts it, and asserts `active: false` beside it, because active would mean the scheduler replaces 3,149 rows tonight without the owner deciding to.

Dropping the line and flipping the flag each turn the suite red; the unmutated manifest stays green.

My first attempt at that proof reported both mutations **SILENT**. The guards were fine — my harness was reading pytest's output for a string it does not print, and its `active: false` edit hit the first source in the file rather than this one. **A proof that cannot fail proves nothing**, so it was rebuilt on exit codes and re-run.

## Gates, on the rebased result

`pytest` full suite · contract parity · extension **19/0** · apps_script **13/0** · `validate-manifest` **12 sources, active list unchanged at 7**.

Rebased onto `main` after #91; the two original commits are preserved.

## What this does not do

It does not repair the 3,149 rows. A re-crawl replaces them — **rewriting a stored observation is the one thing this project does not do** — and that is 9 requests whenever the owner wants it. The entry stays inactive until then.

---

## The guard this branch claimed to have (added after review)

An adversarial review found that `test_no_source_holds_data_the_manifest_has_forgotten` **could not fail**. It inserted a row called `GHOST` into an empty temp database and asserted that `GHOST` came back — true for any manifest, including one with every source deleted.

The review proved it end-to-end: it removed SPARK_ESHOP from the manifest, recreating the 2026-08-03 condition, and **the two tests beside this one went red while this one stayed green.** The test named after the incident was the only one that could not see it.

Worse, it guarded nothing that ships — **no production code read `source_site.active` anywhere in the repo**, so the "check" was a query living inside a test.

**A correction to commit `d66e8ac`**, which said *"Proved against the live warehouse rather than a fixture — deleting the entry again reports SPARK_ESHOP as an orphan."* The shipped test never opens the warehouse; it connects to `tmp_path/"w.db"`. That claim was false in the same commit that made it.

**What replaces it:** `storage.undeclared_sources(conn)` — real code, reading the *current* manifest each call because the failure mode is precisely that the manifest changed. It rides `storage.health()`, which the Storage page runs on every visit, so the fact reaches a screen the owner opens. `ok` stays true: a forgotten source is not corruption, and it is the one thing `quick_check` can never see.

Three tests, including **the negative half the old one never had** — a declared source must *not* be reported. Without it, a check that returned its whole input would pass. Each mutation hits exactly its own test.
