### PR TITLE
A source declares the language it serves, and a run says it had warnings

### DIFF
--- a/db/migrations/0061_a_run_says_whether_it_had_warnings.sql
+++ b/db/migrations/0061_a_run_says_whether_it_had_warnings.sql
@@ -1,0 +1,53 @@
+-- =====================================================================
+-- 0061 — A RUN SAYS WHETHER IT HAD WARNINGS
+--
+-- SPARK_ESHOP was crawled on 2026-08-03. The run row says: success,
+-- 1,789 products, 3,149 rows. Nothing about it looked wrong, and 1,789
+-- English product names had just been filed under the Arabic column
+-- because the shop has no /en locale and the connector asked for one
+-- anyway.
+--
+-- The explanation was NOT lost. It is in job_log_entry right now:
+--
+--   en locale unavailable — names stay single-language this run:
+--   Client error '404 Not Found' for url
+--   'https://www.spark-eshop.com/en/products.json?limit=250&page=1'
+--
+-- But a run row could not say it had one. Finding that sentence needs a
+-- reader who already suspects something, knows the log exists, and knows
+-- which job id to join on — and for two days nobody did. A count on the
+-- run is what turns "look for trouble" into "trouble is here".
+--
+-- Two columns and no more. The count, because a clean run must be
+-- VISIBLY clean rather than merely quiet; and the first line, because
+-- one sentence is usually enough to decide whether the log is worth
+-- opening. The log stays the full record — this is its index, not a
+-- second copy of it.
+-- =====================================================================
+
+ALTER TABLE crawl_run ADD COLUMN warning_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE crawl_run ADD COLUMN first_warning TEXT NOT NULL DEFAULT '';
+
+-- Backfilled from the log the warnings have always been written to, so a
+-- run that already happened can answer for itself. Only WARNING rows,
+-- and the earliest one per run — the same thing a future run records.
+UPDATE crawl_run
+   SET warning_count = (
+         SELECT COUNT(*) FROM job_log_entry j
+          WHERE j.job_id = crawl_run.job_id
+            AND j.source_key = (SELECT source_key FROM source_site s
+                                 WHERE s.source_id = crawl_run.source_id)
+            AND j.level = 'warning')
+ WHERE job_id IS NOT NULL;
+
+UPDATE crawl_run
+   SET first_warning = COALESCE((
+         SELECT SUBSTR(j.message, 1, 500) FROM job_log_entry j
+          WHERE j.job_id = crawl_run.job_id
+            AND j.source_key = (SELECT source_key FROM source_site s
+                                 WHERE s.source_id = crawl_run.source_id)
+            AND j.level = 'warning'
+          ORDER BY j.job_log_id LIMIT 1), '')
+ WHERE warning_count > 0;
+
+PRAGMA user_version = 61;

--- a/scrapex/config.py
+++ b/scrapex/config.py
@@ -303,6 +303,19 @@ class SourceEntry(BaseModel):
     # rather than an omission: a source with no charter resolves no
     # units at all, which is honest. Ten of eleven are in it today.
     unit_charter: UnitCharter | None = None
+    # WHICH LANGUAGE THE SITE SERVES AT ITS ROOT. Not a preference and not a
+    # guess: shopify's connector files the default locale's title and then
+    # fetches the OTHER locale for the second column, and it had "ar" written
+    # into it as an assumption. SPARK_ESHOP serves English at its root and has
+    # no /en locale at all — that URL 404s — so 1,789 English titles were filed
+    # as Arabic and the English column, which config calls required, stayed
+    # empty on every one.
+    #
+    # Declared per source because the alternative is detecting it, and
+    # detecting it is guessing: "ABB 1SDA100487R1 | XT5H 630 TMA 630-6300"
+    # carries no letters to detect. The shop states it — <html lang> — and a
+    # person checks it once.
+    default_language: Literal["ar", "en"] = "ar"
     # English is the primary display language, so the unmarked name is English
     # and it is REQUIRED. Requiredness inverts here deliberately: these twelve
     # labels are owner-authored rather than scraped, all twelve already carry

--- a/scrapex/connectors/shopify.py
+++ b/scrapex/connectors/shopify.py
@@ -24,6 +24,17 @@ PAGE_SIZE = 250  # Shopify hard max per page
 ENGLISH_LOCALE = "en"
 
 
+def _root_title(title: str, language: str) -> dict[str, str]:
+    """The root locale's title, in the column that names its language.
+
+    Two columns, and which one is not a detail: an unmarked column is English
+    by the project's root rule and the _ar one is the site's own Arabic. Put
+    the wrong one in and the AR|EN switch shows a reader English under a
+    heading that says Arabic, which is worse than a blank.
+    """
+    return {"product_name": title} if language == "en" else {"product_name_ar": title}
+
+
 class ShopifyConnector:
     connector_id = "shopify-json"
 
@@ -55,7 +66,9 @@ class ShopifyConnector:
                 break
             for product in products:
                 titles[str(product.get("id") or "")] = str(product.get("title") or "")
-                rows.extend(self._product_rows(builder, product, base, currency, vat_flag, source.default_region))
+                rows.extend(self._product_rows(builder, product, base, currency, vat_flag,
+                                               source.default_region,
+                                               source.default_language))
                 if wants_enrichment:
                     detail_rows.extend(enrichment_rows(detail, product))
             if len(products) < PAGE_SIZE:
@@ -65,12 +78,18 @@ class ShopifyConnector:
         # The owner's standing rule: a site that publishes both languages is
         # captured in both. Applied to the rows already built, so a failed
         # English pass costs a note and never a price.
-        english = self._english_titles(base, titles, notes)
-        if english:
+        # The second language is whatever the root is NOT. A shop serving
+        # English at its root has no /en to fetch — that URL 404s on
+        # spark-eshop — and asking for it was how an English shop ended up
+        # with an empty English column.
+        other_locale = "ar" if source.default_language == "en" else ENGLISH_LOCALE
+        other = self._other_locale_titles(base, other_locale, titles, notes)
+        if other:
             product_at = builder.header.index("external_product_id")
-            english_at = builder.header.index("product_name")
+            other_at = builder.header.index(
+                "product_name_ar" if source.default_language == "en" else "product_name")
             for row in rows:
-                row[english_at] = english.get(row[product_at], "")
+                row[other_at] = other.get(row[product_at], "")
 
         yield ScrapedTable(
             source_key=source.source_key,
@@ -90,9 +109,9 @@ class ShopifyConnector:
                 rows=detail_rows,
             )
 
-    def _english_titles(self, base: str, titles: dict[str, str],
-                        notes: list[str]) -> dict[str, str]:
-        """product id -> English title, or {} when the shop has only one language.
+    def _other_locale_titles(self, base: str, locale: str, titles: dict[str, str],
+                             notes: list[str]) -> dict[str, str]:
+        """product id -> the title in the shop's OTHER locale, or {}.
 
         Joined by id, and kept only where it DIFFERS from the title already
         collected: a shop whose locale prefix simply re-serves its single
@@ -103,15 +122,17 @@ class ShopifyConnector:
         found: dict[str, str] = {}
         page = 1
         while True:
-            url = f"{base}/{ENGLISH_LOCALE}/products.json?limit={PAGE_SIZE}&page={page}"
+            url = f"{base}/{locale}/products.json?limit={PAGE_SIZE}&page={page}"
             try:
                 products = self._fetcher.get(url).json().get("products", [])
             except CrawlBlocked:
                 raise
             except Exception as exc:  # noqa: BLE001 — bilingual is additive
                 if page == 1:
-                    notes.append(f"{ENGLISH_LOCALE} locale unavailable — names "
-                                 f"stay single-language this run: {exc}")
+                    notes.append(
+                        f"{locale} locale unavailable — every name stays in the "
+                        f"{'product_name' if locale == 'ar' else 'product_name_ar'} "
+                        f"column this run: {exc}")
                 break
             if not products:
                 break
@@ -130,7 +151,8 @@ class ShopifyConnector:
         return found
 
     @staticmethod
-    def _product_rows(builder, product, base, currency, vat_flag, region) -> list[list[str]]:
+    def _product_rows(builder, product, base, currency, vat_flag, region,
+                      language: str = "ar") -> list[list[str]]:
         option_names = [opt.get("name", f"option{i}") for i, opt in enumerate(product.get("options", []), start=1)]
         handle = product.get("handle", "")
         rows = []
@@ -146,9 +168,12 @@ class ShopifyConnector:
                 external_product_id=product.get("id"),
                 external_variant_id=variant.get("id"),
                 external_sku=variant.get("sku") or "",
-                # This store answers in Arabic; the English pass above fills
-                # the unmarked column from the same shop's en locale.
-                product_name_ar=product.get("title") or "",
+                # The root locale's title goes in ITS OWN column, not always
+                # the Arabic one. shopify had "ar" written in as an assumption,
+                # and a shop serving English at its root then filed 1,789
+                # English titles as Arabic while the English column — the one
+                # config calls required — stayed empty on every product.
+                **_root_title(product.get("title") or "", language),
                 **brand_pair(product.get("vendor") or ""),
                 variant_ar=variant.get("title") if options else "",
                 # The axes as STRUCTURE beside the sentence built from them

--- a/scrapex/databases/domain.py
+++ b/scrapex/databases/domain.py
@@ -165,7 +165,7 @@ def _general_plan() -> tuple[Migration, ...]:
 # Listed rather than ranged: the unified chain and this one have diverged, so a
 # new price migration lands at the END of the legacy chain but in the middle of
 # this plan. A range would silently swallow whatever General adds next.
-_MARKETLENS_LEGACY_NUMBERS = (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 15, 16, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60)
+_MARKETLENS_LEGACY_NUMBERS = (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 15, 16, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61)
 
 # Where the identity migration sits in this stream. Everything before it is the
 # price history the unified warehouse already had; everything after is a price

--- a/scrapex/jobs.py
+++ b/scrapex/jobs.py
@@ -652,6 +652,18 @@ def _run_source(run: _SourceRun, conn: sqlite3.Connection, source_key: str) -> b
         for warning in shown[:30]:
             append_log(conn, run.job_id, warning, level=LogLevel.WARNING,
                        source_key=source_key)
+        # AND ON THE RUN ITSELF. The log has always had them — SPARK_ESHOP's
+        # "en locale unavailable ... 404" is sitting in job_log_entry right now
+        # and it is the one sentence that explains 1,789 mislabelled products.
+        # But a run row could not answer "what went wrong in THIS run" without
+        # someone knowing to go and join a log by job id, and nobody did for
+        # two days. The count is what makes a clean run visibly clean; the
+        # first line is what makes a dirty one worth opening.
+        if shown:
+            conn.execute(
+                "UPDATE crawl_run SET warning_count = ?, first_warning = ? "
+                "WHERE run_id = ?",
+                (len(shown), str(shown[0])[:500], result.ingest.run_id))
         if len(shown) > 30:
             append_log(conn, run.job_id,
                        f"...and {len(shown) - 30} more warnings like these "

--- a/tests/test_a_run_says_whether_it_had_warnings.py
+++ b/tests/test_a_run_says_whether_it_had_warnings.py
@@ -1,0 +1,113 @@
+"""A run that says "success, 3,149 rows" and nothing else.
+
+SPARK_ESHOP was crawled on 2026-08-03. The run row reported success, 1,789
+products, 3,149 rows, and nothing looked wrong. In the same moment 1,789
+English product names were filed under the Arabic column, because the shop
+serves English at its root and has no /en locale for the connector to ask for.
+
+The explanation was never lost — it is in job_log_entry, verbatim:
+
+    en locale unavailable - names stay single-language this run:
+    Client error '404 Not Found' for url
+    'https://www.spark-eshop.com/en/products.json?limit=250&page=1'
+
+But the run could not say it HAD one. Finding that sentence needed a reader
+who already suspected something, knew the log existed, and knew which job id
+to join on. For two days nobody did.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import tempfile
+
+import pytest
+
+from scrapex import db as dbmod
+
+
+@pytest.fixture()
+def conn():
+    path = pathlib.Path(tempfile.mkdtemp()) / "runs.db"
+    connection = dbmod.connect(path)
+    dbmod.migrate(connection)
+    return connection
+
+
+def test_a_run_can_say_it_had_warnings(conn):
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(crawl_run)")}
+
+    assert "warning_count" in columns
+    assert "first_warning" in columns
+
+
+def test_a_clean_run_is_visibly_clean_rather_than_merely_quiet(conn):
+    """Zero is the default, so a run with nothing to report SAYS zero. A NULL
+    would read as "not measured", which is the state this replaces."""
+    conn.execute("INSERT INTO source_site (source_id, source_key, source_name_ar,"
+                 " source_name, base_url, platform, currency, timezone, authority,"
+                 " active) VALUES (1,'S','S','S','http://s','shopify-json','EGP',"
+                 "'UTC','shop',1)")
+    conn.execute("INSERT INTO crawl_run (run_id, source_id, started_at, status)"
+                 " VALUES (1,1,'2026-08-03T00:00:00Z','success')")
+
+    row = conn.execute("SELECT warning_count, first_warning FROM crawl_run"
+                       " WHERE run_id = 1").fetchone()
+    assert row[0] == 0
+    assert row[1] == ""
+
+
+def test_the_backfill_reads_the_log_the_warnings_were_always_written_to(conn):
+    """A run that already happened can answer for itself. The count and the
+    first line come from job_log_entry, which is where append_log has been
+    putting connector warnings all along - so this is an index over a record
+    that exists, not a second copy of it."""
+    conn.execute("INSERT INTO source_site (source_id, source_key, source_name_ar,"
+                 " source_name, base_url, platform, currency, timezone, authority,"
+                 " active) VALUES (12,'SPARK','S','S','http://s','shopify-json',"
+                 "'EGP','UTC','shop',1)")
+    conn.execute("INSERT INTO crawl_job (job_id, job_ref, run_mode, status,"
+                 " source_keys, created_at) VALUES (7,'job_x','update',"
+                 "'completed','[\"SPARK\"]','2026-08-03T00:00:00Z')")
+    conn.execute("INSERT INTO crawl_run (run_id, source_id, job_id, started_at,"
+                 " status) VALUES (5,12,7,'2026-08-03T00:00:00Z','success')")
+    for message in ("en locale unavailable - names stay single-language this run: 404",
+                    "a second warning"):
+        conn.execute("INSERT INTO job_log_entry (job_id, logged_at, level,"
+                     " source_key, message) VALUES (7,'2026-08-03T00:00:01Z',"
+                     "'warning','SPARK',?)", (message,))
+    conn.commit()
+
+    # The same two statements 0061 runs.
+    conn.execute("""
+        UPDATE crawl_run SET warning_count = (
+          SELECT COUNT(*) FROM job_log_entry j
+           WHERE j.job_id = crawl_run.job_id
+             AND j.source_key = (SELECT source_key FROM source_site s
+                                  WHERE s.source_id = crawl_run.source_id)
+             AND j.level = 'warning') WHERE job_id IS NOT NULL""")
+    conn.execute("""
+        UPDATE crawl_run SET first_warning = COALESCE((
+          SELECT SUBSTR(j.message,1,500) FROM job_log_entry j
+           WHERE j.job_id = crawl_run.job_id
+             AND j.source_key = (SELECT source_key FROM source_site s
+                                  WHERE s.source_id = crawl_run.source_id)
+             AND j.level = 'warning'
+           ORDER BY j.job_log_id LIMIT 1), '') WHERE warning_count > 0""")
+
+    count, first = conn.execute("SELECT warning_count, first_warning FROM"
+                                " crawl_run WHERE run_id = 5").fetchone()
+    assert count == 2, "the run still cannot say how many warnings it had"
+    assert first.startswith("en locale unavailable"), (
+        "the EARLIEST warning is the one worth showing; a later one buries the "
+        "sentence that explains the run")
+
+
+def test_the_worker_records_them_on_the_run_and_not_only_in_the_log():
+    """The log keeps everything and this keeps the index. Both, because the log
+    alone is what left SPARK_ESHOP looking clean for two days."""
+    source = (pathlib.Path(dbmod.__file__).parent / "jobs.py").read_text(encoding="utf-8")
+
+    assert "UPDATE crawl_run SET warning_count" in source, (
+        "the worker writes warnings to the log only; a run row is silent again")
+    assert "result.ingest.run_id" in source

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -57,7 +57,7 @@ def test_migration_creates_the_catalogue_and_integrity_triggers(conn):
     assert objects["relationship_field_pair"] == "table"
     assert objects["trg_dataset_relationship_same_site_insert"] == "trigger"
     assert objects["trg_relationship_field_pair_matches_insert"] == "trigger"
-    assert conn.execute("PRAGMA user_version").fetchone()[0] == 60
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 61
 
 
 def test_one_site_can_hold_multiple_tables_with_different_dynamic_columns(conn):

--- a/tests/test_database_isolation.py
+++ b/tests/test_database_isolation.py
@@ -67,7 +67,7 @@ def test_fresh_registry_creates_two_typed_databases_without_domain_tables_crossi
     assert applied["general"] == list(
         range(1, registry.general.latest_schema_version + 1)
     )
-    assert applied["marketlens"] == list(range(1, 59))   # ... +56 a unit that can name who said it
+    assert applied["marketlens"] == list(range(1, 60))   # ... +56 a unit that can name who said it
     assert registry.health()["general"]["status"] == "Healthy"
     assert registry.health()["marketlens"]["status"] == "Healthy"
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -27,12 +27,12 @@ def test_migrate_is_idempotent(tmp_path: Path):
         second = dbmod.migrate(conn)
     finally:
         conn.close()
-    assert first == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60]
+    assert first == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61]
     assert second == []  # T4: running again applies nothing
 
 
 def test_latest_schema_version_matches_the_migration_chain():
-    assert dbmod.latest_schema_version() == 60   # +0057 the weight the price is quoted against
+    assert dbmod.latest_schema_version() == 61   # +0057 the weight the price is quoted against
 
 
 def test_foreign_keys_actually_enforced(tmp_path: Path):

--- a/tests/test_display_method_and_quantity_facts.py
+++ b/tests/test_display_method_and_quantity_facts.py
@@ -575,7 +575,7 @@ def test_migration_0056_corrects_has_variants_on_rows_that_already_exist():
                          " VALUES (2, ?)", (member,))
         conn.commit()
 
-        assert dbmod.migrate(conn) == [56, 57, 58, 59, 60]
+        assert dbmod.migrate(conn) == [56, 57, 58, 59, 60, 61]
 
         flags = dict(conn.execute(
             "SELECT external_product_id, has_variants FROM source_product"))

--- a/tests/test_extract_storage.py
+++ b/tests/test_extract_storage.py
@@ -113,7 +113,7 @@ def test_legacy_0014_remains_available_for_explicit_unified_sessions(tmp_path: P
     legacy = dbmod.connect(tmp_path / "legacy.db")
     try:
         dbmod.migrate(legacy)
-        assert dbmod.schema_version(legacy) == 60   # +0060 the weight the price is quoted against
+        assert dbmod.schema_version(legacy) == 61   # +0061 the weight the price is quoted against
         for table in ("price_observation", "generic_record"):
             assert legacy.execute(
                 "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1",

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -62,7 +62,7 @@ def _insert_observation(conn, ids, price: float = 168.78, hash_: str = "h1") -> 
 
 
 def test_migration_reaches_latest_version(conn):
-    assert dbmod.schema_version(conn) == 60   # +0060 the weight the price is quoted against
+    assert dbmod.schema_version(conn) == 61   # +0061 the weight the price is quoted against
 
 
 def test_all_owner_tables_exist(conn):
@@ -168,7 +168,7 @@ def test_migration_0020_preserves_existing_jobs_and_their_log_references():
         upgrading.commit()
 
         assert dbmod.migrate(upgrading) == [20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
-                                            30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60]
+                                            30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61]
 
         joined = upgrading.execute(
             "SELECT j.job_ref, j.status, l.message FROM job_log_entry l"

--- a/tests/test_the_root_locale_names_its_own_column.py
+++ b/tests/test_the_root_locale_names_its_own_column.py
@@ -1,0 +1,100 @@
+"""An English shop's English titles were filed as Arabic, on 1,789 products.
+
+SPARK_ESHOP serves English at its root and has no /en locale at all — that URL
+answers 404, verified live. The shopify connector had "this store answers in
+Arabic" written into it as an assumption: it filed the root title into
+product_name_ar unconditionally, then fetched /en to fill product_name. The
+fetch failed, the note said "names stay single-language this run", and every
+English title sat under a heading that says Arabic while the English column —
+which config.py calls required — stayed empty on all 1,789.
+
+Nothing failed. The crawl reported success, 3,149 rows.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from scrapex.connectors.shopify import _root_title
+
+
+def test_an_english_shop_fills_the_english_column():
+    """«ABB 1SDA100487R1 | XT5H 630 TMA 630-6300» is not Arabic. Filing it
+    under the _ar heading is not incomplete data, it is a mislabelled fact —
+    and the AR|EN switch then shows a reader English where it promised
+    Arabic, which is worse than a blank."""
+    row = _root_title("ABB 1SDA100487R1 | XT5H 630 TMA 630-6300", "en")
+
+    assert row == {"product_name": "ABB 1SDA100487R1 | XT5H 630 TMA 630-6300"}
+    assert "product_name_ar" not in row
+
+
+def test_an_arabic_shop_still_fills_the_arabic_column():
+    """ELSEWEDYSHOP genuinely serves Arabic at its root and English at /en —
+    measured live: «كشاف واجهات400وات اضاءة ابيض IP 65» against "Luma
+    floodlight 400W IP65 6500K", 0 of 3 titles identical. Nothing about that
+    source may change."""
+    row = _root_title("كشاف واجهات400وات اضاءة ابيض IP 65", "ar")
+
+    assert row == {"product_name_ar": "كشاف واجهات400وات اضاءة ابيض IP 65"}
+    assert "product_name" not in row
+
+
+def test_the_default_is_arabic_because_that_is_what_every_source_assumed():
+    """The field defaults rather than being required, and the default is the
+    assumption that was already baked in — so no existing source changes
+    behaviour by gaining a field it never declared. A default of "en" would
+    silently rewrite eleven sources' columns."""
+    from scrapex.config import SourceEntry
+
+    entry = SourceEntry(source_key="TEST_SHOP", source_name="Test", base_url="http://x",
+                        family="shopify-json", cadence="daily", authority="shop",
+                        currency="EGP", default_region="EG", vat_mode="incl",
+                        extract=[{"kind": "product_prices", "scope": "census"}])
+    assert entry.default_language == "ar"
+
+
+def test_a_language_the_project_does_not_capture_is_refused():
+    """Two columns exist, so two languages are declarable. A third would name a
+    column that is not there, and it would fail at the moment a crawl wrote
+    into nothing rather than at the moment someone typed it."""
+    from pydantic import ValidationError
+    from scrapex.config import SourceEntry
+
+    with pytest.raises(ValidationError):
+        SourceEntry(source_key="TEST_SHOP", source_name="Test", base_url="http://x",
+                    family="shopify-json", cadence="daily", authority="shop",
+                    currency="EGP", default_region="EG", vat_mode="incl",
+                    default_language="fr",
+                    extract=[{"kind": "product_prices", "scope": "census"}])
+
+
+def test_the_connector_asks_for_the_other_locale_not_always_english():
+    """The second pass fetches whatever the root is NOT. Asking an
+    English-rooted shop for /en is asking for a page that does not exist, and
+    the 404 was read as "this shop has one language" rather than "I asked the
+    wrong question"."""
+    source = pathlib.Path(
+        __import__("scrapex.connectors.shopify", fromlist=["x"]).__file__
+    ).read_text(encoding="utf-8")
+
+    assert 'other_locale = "ar" if source.default_language == "en"' in source, (
+        "the connector asks for /en regardless of what the shop serves")
+    assert "{base}/{locale}/products.json" in source, (
+        "the second-locale URL is hardcoded to one language again")
+
+
+def test_the_note_says_which_column_the_names_stayed_in():
+    """The old note — "names stay single-language this run" — was true and
+    useless. It is the one sentence that explained 1,789 mislabelled products,
+    it was written to the job log, and it did not say the thing a reader
+    needed: which column they are in."""
+    source = pathlib.Path(
+        __import__("scrapex.connectors.shopify", fromlist=["x"]).__file__
+    ).read_text(encoding="utf-8")
+
+    assert "column this run" in source
+    assert "product_name" in source.split("locale unavailable")[1][:400], (
+        "the warning still does not name the column the reader must look in")

--- a/tests/test_the_weight_the_price_is_quoted_against.py
+++ b/tests/test_the_weight_the_price_is_quoted_against.py
@@ -551,7 +551,7 @@ def test_migration_0057_adds_the_two_columns_without_touching_offer_identity():
         columns = {r[1] for r in conn.execute("PRAGMA table_info(source_offer)")}
         assert "weight" not in columns and "weight_unit" not in columns
 
-        assert dbmod.migrate(conn) == [57, 58, 59, 60]   # 0058 rides along: it adds the
+        assert dbmod.migrate(conn) == [57, 58, 59, 60, 61]   # 0058 rides along: it adds the
             # witness columns 0057's units will need, and the chain runs forward
 
         columns = {r[1]: r for r in conn.execute("PRAGMA table_info(source_offer)")}


### PR DESCRIPTION
SPARK_ESHOP's **1,789 English product names were filed under the Arabic column**, and its English column — which `config.py` calls required — was empty on every one of them. Nothing failed: the run reported success, 3,149 rows. The owner asked why, and this is the answer plus the reason nobody noticed.

## Why it happened

`shopify.py` had *"this store answers in Arabic"* written into it as an assumption. It filed the root locale's title into `product_name_ar` unconditionally, then fetched `/en` to fill `product_name`. spark-eshop serves **English at its root and has no `/en` locale at all** — that URL 404s, verified live — so the fetch failed, the loop broke, and `product_name` was never touched.

The connector is not wrong about ELSEWEDYSHOP, which is genuinely bilingual. Measured live: its root serves «كشاف واجهات400وات اضاءة ابيض IP 65» and its `/en` serves `Luma floodlight 400W IP65 6500K` — 0 of 3 titles identical. It is wrong about assuming every shop is that shop.

So a source declares `default_language`, the root title goes in the column that **names its language**, and the second pass asks for whatever the root is *not*.

The default is `"ar"` because that is the assumption already baked in — a default of `"en"` would silently rewrite eleven sources' columns. **Detecting it instead was the alternative, and detecting is guessing**: `ABB 1SDA100487R1 | XT5H 630 TMA 630-6300` carries no letters to detect.

## A correction to what I told the owner

I said the connector's warning *"had died with the job"* and that `crawl_run` should keep it. **The first half was wrong** — it is in `job_log_entry` right now, verbatim, and I found it by looking.

What is true is narrower: the run could not say it *had* a warning, so finding that sentence needed a reader who already suspected something and knew which job id to join on. For two days nobody did.

`0061` adds a count and the first line, backfilled from the log the warnings were always written to. **Verified against the live warehouse**: SPARK_ESHOP's run now reports `warning_count=1` and the sentence that explains it. The log stays the full record; this is its index.

The warning itself said *"names stay single-language this run"* — true, and useless. It now names the column they stayed in.

## Proving the tests bite

Three mutations, each re-broken and confirmed red: the root title filed as Arabic again · `/en` asked for regardless · the default flipped to `"en"`.

A fourth defect surfaced while writing them: the backfill first read `level = 'WARNING'`, but the schema's CHECK stores lowercase — **it would have found nothing, silently, and reported every run clean.** Caught by running it against the real warehouse rather than trusting it.

## Gates

`pytest` full suite · contract parity · `validate-manifest` — all green.

## What this does not fix

The 3,149 stored rows. A re-crawl replaces them; rewriting a stored observation is the one thing this project does not do. That decision is the owner's, and it is 9 requests.