### PR TITLE
MADAR reads the size its own option value states

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -138,6 +138,44 @@ sources:
         #
         # A store-wide weight_unit is the shop saying "my weight numbers are in
         # kg". It is not the shop saying what one of THIS product is.
+        #
+        # 3./4. THE SAME TWO FIELDS, READ AS A PLAIN QUANTITY. «المقاس: 3.25 Kg»
+        #    is the shop stating what one of these is, in the same option value
+        #    the container witness above reads — it simply names a weight
+        #    instead of a box. Ranked BELOW the containers so «4 كجم/صندوق»
+        #    still resolves as a box: measured over all 3,550 active offers,
+        #    these two witnesses alter ZERO container readings.
+        #
+        #    This is what a full rebuild could never fix, and I recorded the
+        #    opposite in 0060. The owner ran one on 2026-08-04; all 74
+        #    unwitnessed readings came back identical, because re-fetching
+        #    cannot teach a charter to look at a field it was never pointed at.
+        #
+        #    Measured on the live warehouse before writing this: 55 legacy rows
+        #    gain a witness WITHOUT ANY NUMBER CHANGING — the axis says 3.25 Kg
+        #    and the row already said 3.25 kg, it just could not say who told
+        #    it. 32 more offers carry no unit at all today (basis 1.0, unit
+        #    NULL) and gain one the shop states, e.g. «Size: 320 g». Zero rows
+        #    with a stored unit are contradicted.
+        #
+        #    TWO SEPARATE DEFENCES STOP THIS BEING A DISASTER, and I first
+        #    wrote that only one did. These option values also carry «amperage:
+        #    20A» (54 of them), «gangs: 1 Gang» (190), «Poles: 1P», «Feature:
+        #    2BB», «Size: 8 In» and «Size: 20 mm», and a rule that read "a
+        #    number then a word" would announce that one of these is twenty
+        #    amperes.
+        #
+        #      - A, Gang, P, BB, In are refused by units.py's UNIT_WORDS: they
+        #        are not measurements at all, and no charter can admit them.
+        #        Adding "a" to the pack below changes nothing — verified.
+        #      - mm and cm ARE real measurements and are refused by the pack
+        #        list, which says which measurements can be a SELLING unit
+        #        here. This is the line that would break if someone widened it.
+        #
+        #    «Size: 1 Ton» does resolve, to one tonne, because tonne is on the
+        #    pack list and a tonne of steel is a thing this shop sells.
+        - {field: variant_axes_ar, lang: ar, provenance: stated_field, shape: quantity}
+        - {field: variant_axes,    lang: en, provenance: stated_field, shape: quantity}
       # The site writes the SAME container in two languages, and this maps both
       # to one code. Measured: without it «صندوق» (16) and "box" (24) become two
       # different selling units for one shop's box, and two prices for the same

--- a/tests/test_madar_reads_the_size_its_own_axis_states.py
+++ b/tests/test_madar_reads_the_size_its_own_axis_states.py
@@ -1,0 +1,122 @@
+"""«المقاس: 3.25 Kg» — the shop saying what one of these is, read at last.
+
+74 MADAR offers carried a unit nobody could source. The owner ran a full
+rebuild on 2026-08-04 expecting it to settle them, because migration 0060 and I
+had both recorded that a re-crawl was the fix. All 74 came back identical:
+re-fetching cannot teach a charter to look at a field it was never pointed at.
+
+The field was there the whole time. The container witnesses already read
+variant_axes for «4 كجم/صندوق»; the same option value on other products says
+«3.25 Kg», and nothing read it as a weight.
+
+Measured on the live warehouse before the charter was touched: 55 legacy rows
+gain a witness with NO NUMBER CHANGING, 32 unit-less offers gain a unit the
+shop states, 0 container readings are altered and 0 stored units contradicted.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scrapex.config import MANIFEST_FILE, load_manifest
+from scrapex.units import Charter
+
+
+@pytest.fixture(scope="module")
+def madar() -> Charter:
+    entry = load_manifest(MANIFEST_FILE).get("MADAR")
+    return Charter(json.loads(entry.unit_charter.model_dump_json()))
+
+
+def _axes(**pairs) -> dict:
+    """A row as the connector hands it over: six fields, axes as a JSON blob."""
+    return {"weight": "", "weight_unit": "", "product_name": "", "product_name_ar": "",
+            "variant_axes": json.dumps(pairs, ensure_ascii=False), "variant_axes_ar": ""}
+
+
+def test_a_size_axis_stating_a_weight_is_read(madar):
+    """Offer 1642's sibling rows said 3.25 kg and could not say who told them.
+    The axis had said it all along."""
+    r = madar.resolve(_axes(Size="3.25 Kg"))
+
+    assert r is not None, "«المقاس» states the weight and the charter still ignores it"
+    assert (r.unit, r.quantity) == ("kg", 3.25)
+    assert r.provenance == "stated_field"
+
+
+def test_the_arabic_axis_answers_in_its_own_language(madar):
+    """Bilingual capture is the standing rule; a reading carries which language
+    answered so «3 كجم» is visibly the Arabic field, not a translation."""
+    row = {"weight": "", "weight_unit": "", "product_name": "", "product_name_ar": "",
+           "variant_axes": "", "variant_axes_ar": json.dumps({"المقاس": "3 كجم"},
+                                                             ensure_ascii=False)}
+    r = madar.resolve(row)
+
+    assert r is not None and (r.unit, r.quantity) == ("kg", 3.0)
+    assert r.raw_lang == "ar"
+
+
+def test_a_container_still_outranks_a_bare_weight(madar):
+    """THE RANKING THAT MATTERS. «4 كجم/صندوق» is a box you buy and four
+    kilograms you get. The container witness is ranked first precisely so this
+    new one cannot demote a box back to the four kilograms 0060 rescued it
+    from. Measured over 3,550 live offers: zero container readings altered."""
+    row = {"weight": "", "weight_unit": "", "product_name": "", "product_name_ar": "",
+           "variant_axes": "",
+           "variant_axes_ar": json.dumps({"المقاس": "4 كجم/صندوق"}, ensure_ascii=False)}
+    r = madar.resolve(row)
+
+    assert r is not None
+    assert r.unit == "box", "the box became four kilograms again"
+    assert r.content_quantity == 4.0 and r.content_unit == "kg"
+
+
+@pytest.mark.parametrize("axis", [
+    {"amperage": "20A"}, {"amperage": "20 A"}, {"gangs": "1 Gang"},
+    {"Poles": "1P"}, {"Feature": "2BB"}, {"Size": "8 In"},
+])
+def test_a_word_that_is_not_a_measurement_can_never_be_a_selling_unit(madar, axis):
+    """DEFENCE ONE — units.py's own vocabulary. Amperes, gangs, poles, bearing
+    counts and inches are not measurements this project knows, so no charter
+    can admit them however its pack list is written. These option values are
+    real and counted live: amperage on 54 offers, gangs on 190."""
+    assert madar.resolve(_axes(**axis)) is None
+
+
+def test_a_real_measurement_that_is_not_a_selling_unit_here_is_refused(madar):
+    """DEFENCE TWO — the pack allow-list, and the one that can be widened by
+    mistake. A millimetre IS a measurement; it is not what one of these is. 57
+    live offers carry «Size: 20 mm».
+
+    I first wrote that the allow-list refused the amperage cases too. It does
+    not — they never reach it. Two mechanisms, and only this one is a list
+    someone can edit."""
+    assert madar.resolve(_axes(Size="20 mm")) is None
+    assert madar.resolve(_axes(Size="18 cm")) is None
+
+
+def test_a_tonne_of_steel_is_a_thing_this_shop_sells(madar):
+    """tonne IS on the pack list, so «Size: 1 Ton» resolves. Recorded because it
+    is a consequence of this charter that a reader should not have to discover
+    from the data."""
+    r = madar.resolve(_axes(Size="1 Ton"))
+
+    assert r is not None and (r.unit, r.quantity) == ("tonne", 1.0)
+
+
+def test_a_dimension_and_a_weight_together_take_the_weight(madar):
+    """Option values carry several axes at once. The pack list picks the one
+    that can be a selling unit and leaves the rest alone."""
+    r = madar.resolve(_axes(Size="500 g", Feature="Wooden Handle"))
+
+    assert r is not None and (r.unit, r.quantity) == ("gm", 500.0)
+
+
+def test_the_charter_still_answers_nothing_where_the_shop_says_nothing(madar):
+    """3,411 of MADAR's offers state no unit anywhere, and the owner's ruling is
+    that the column stays empty rather than being filled by inference —
+    «الحقائق الخام فقط»."""
+    assert madar.resolve(_axes(Color="White")) is None
+    assert madar.resolve(_axes(**{"Cement Type": "Sulphate Resistant Cement"})) is None

--- a/tests/test_units_madar.py
+++ b/tests/test_units_madar.py
@@ -113,12 +113,23 @@ def test_madar_declares_no_weight_witness_and_the_reason_is_written_down():
     in writing, and what the owner ruled on 2026-07-29: «الحقائق الخام فقط».
 
     A store-wide weight_unit is the shop saying "my weight numbers are in kg".
-    It is not the shop saying what one of THIS product is."""
+    It is not the shop saying what one of THIS product is.
+
+    THE ASSERTION HERE CHANGED ON 2026-08-04, and the reason is worth keeping.
+    It read `all(shape == "container")` — a proxy for "no weight witness",
+    written when a weight witness was the only addition anyone was
+    contemplating. MADAR then gained a `quantity` witness on its own option
+    values («المقاس: 3.25 Kg»), which is the shop stating what one of these is
+    and is exactly what this charter is for. The proxy failed it. The rule
+    being defended was never "every witness is a container"; it was "no witness
+    reads `weight`", so that is what is asserted now — narrower in letter and
+    stronger in fact, because it names the field instead of a shape."""
     charter = charter_for(_madar())
 
-    assert all(shape == "container" for shape in charter.shapes), (
-        "MADAR gained a witness that is not a container; if it reads `weight`, "
-        "it is asserting a unit for thousands of rows the shop never gave one")
+    assert all(field != "weight" for field, *_ in charter.witnesses), (
+        "MADAR gained a witness on `weight`; that asserts a unit for thousands "
+        "of rows the shop never gave one")
+    assert all(field != "weight_unit" for field, *_ in charter.witnesses)
 
     # And the state that would have been resolved stays silent, as ruled.
     assert charter.resolve({"weight": "1000", "weight_unit": "kg"}) is None


### PR DESCRIPTION
The owner ran a full rebuild of MADAR on 2026-08-04 expecting it to settle the 74 offers carrying a unit nobody could source. **All 74 came back identical.**

That is my error to own: migration `0060` and my own report both recorded that a re-crawl was the fix. **Re-fetching cannot teach a charter to look at a field it was never pointed at.**

## The field was there the whole time

The container witnesses already read `variant_axes` for «4 كجم/صندوق». The same option value on other products says «المقاس: 3.25 Kg» — the shop stating what one of these is — and nothing read it as a weight.

## Measured before the charter was touched, over all 3,550 active offers

| | |
|---|---|
| **55** legacy rows | gain a witness with **no number changing** — the axis says 3.25 Kg and the row already said 3.25 kg, it just could not say who told it |
| **32** offers | carry no unit at all today (basis 1.0, unit NULL) and gain one the shop states, e.g. «Size: 320 g» |
| **0** container readings | altered — the new witnesses rank *below* them, so the box `0060` rescued stays a box |
| **0** stored units | contradicted |

## I corrected what I first wrote about why this is safe

These option values also carry «amperage: 20A» on **54** offers, «gangs: 1 Gang» on **190**, «Poles: 1P», «Feature: 2BB», «Size: 8 In» and «Size: 20 mm». I wrote that the pack allow-list refuses all of them. **It does not — two separate mechanisms do**, and conflating them would have left the wrong one under test:

- `A`, `Gang`, `P`, `BB`, `In` are refused by `units.py`'s `UNIT_WORDS`: they are not measurements at all. Adding `a` to the pack list changes nothing — verified.
- `mm` and `cm` **are** measurements, refused by the pack list, which says which measurements can be a *selling* unit here. **That is the line someone can widen by mistake**, and it is now the one guarded.

«Size: 1 Ton» does resolve, to one tonne. Recorded rather than left for a reader to find in the data.

## An existing guard changed, on intent

`test_madar_declares_no_weight_witness` asserted `all(shape == "container")` — a proxy for *"no weight witness"*, written when a weight witness was the only addition anyone was contemplating. A quantity witness on the shop's own option values is not that, and the proxy failed it. The rule being defended was never "every witness is a container"; it is **"no witness reads `weight`"**, so that is what it asserts now — narrower in letter, stronger in fact.

**My first rewrite of it was decoration.** `charter.witnesses` holds `(field, lang, provenance)` triples, so comparing each to the string `"weight"` was always true. Caught by mutating the charter to add a weight witness and watching the guard stay green. It now unpacks the triple, and the same mutation turns it red.

## Mutations, all proved to bite

removing both witnesses (4 fail) · widening the pack list with `mm` (1) · ranking the size witness above the container (1) · giving MADAR a `weight` witness (1)

## What this does not do

The remaining 19 of the 74 are not touched here. **13** are stated by the product's `size` specification, which the connector does not put on the price row — that needs a connector change. **4** rest only on the `weight` field, ruled out for cause. **2** contradict the shop outright (stored 25 kg, site says «20 Kg») and need a standing retire-on-replacement rule, not a one-off migration.

## Gates

`pytest` full suite · contract parity · extension 19/0 · `validate-manifest` — green.