### PR TITLE
A panel edit keeps every field the model has

### DIFF
--- a/scrapex/manifest_io.py
+++ b/scrapex/manifest_io.py
@@ -14,8 +14,48 @@ import yaml
 from .config import MANIFEST_FILE, IdentityRules, SourceEntry, load_manifest
 
 # Field order in the written block — matches the hand-authored entries (readability).
+# THIS IS AN ORDERING HINT, NEVER THE SET OF FIELDS THAT SURVIVE. It was both
+# for a year, and everything the model grew afterwards was deleted in silence by
+# the first panel edit: source_name_ar on every bilingual source,
+# default_language, brand, api, taxonomy, user_agent, tax — and unit_charter,
+# which is days of measured per-source rules. See _remaining_fields below.
 _FIELD_ORDER = ("source_key", "source_name", "base_url", "family", "cadence",
                 "authority", "fetcher", "currency", "default_region", "vat_mode", "active")
+
+# Written by name above, or by the hand-maintained tail of entry_to_block.
+# Everything else reaches the file through _remaining_fields.
+_EXPLICIT = frozenset(_FIELD_ORDER) | {
+    "extract", "fallback_families", "auth_required", "fold_variants", "identity",
+    "min_expected_rows", "max_drop_pct", "notes"}
+
+
+def _remaining_fields(dumped: dict) -> dict:
+    """Every model field the block above does not name, unless it is a default.
+
+    A source is edited by REPLACING its block with what this function helps
+    build, so a field missing here is a field deleted from the manifest. The
+    old code listed the fields to keep, which meant every field added to
+    SourceEntry afterwards was dropped by the next edit and nothing said so —
+    an English shop's `default_language: en` would revert to the Arabic default
+    and re-file 1,789 product names under the wrong column, and MADAR's unit
+    charter would simply cease to exist.
+
+    Defaults are still omitted, so a simple source's YAML stays as short as a
+    hand-written one: the value round-trips to the same thing either way.
+    """
+    out: dict = {}
+    for name, field in SourceEntry.model_fields.items():
+        if name in _EXPLICIT:
+            continue
+        value = dumped.get(name)
+        if not field.is_required():
+            default = field.get_default(call_default_factory=True)
+            if hasattr(default, "model_dump"):
+                default = default.model_dump(mode="json")
+            if value == default:
+                continue
+        out[name] = value
+    return out
 
 
 class DuplicateSourceError(ValueError):
@@ -48,6 +88,7 @@ def entry_to_block(entry: SourceEntry) -> str:
     for opt in ("min_expected_rows", "max_drop_pct", "notes"):
         if dumped.get(opt) is not None:
             body[opt] = dumped[opt]
+    body.update(_remaining_fields(dumped))
 
     raw = yaml.safe_dump([body], sort_keys=False, allow_unicode=True, default_flow_style=False)
     return "\n".join("  " + line if line else line for line in raw.splitlines()) + "\n"

--- a/tests/test_a_panel_edit_keeps_every_field.py
+++ b/tests/test_a_panel_edit_keeps_every_field.py
@@ -1,0 +1,72 @@
+"""Editing a source from the panel used to delete eight of its fields.
+
+The owner's standing rule is that the extension is the control room — every
+web feature must be reachable from it. Editing a source is, and the edit path
+REPLACES the whole YAML block with one rebuilt from a hand-written list of
+field names. Anything SourceEntry grew after that list was written fell out of
+the file, silently, on the first edit:
+
+    source_name_ar   every bilingual source's Arabic name
+    default_language an English shop reverts to the Arabic default, and 1,789
+                     product names are re-filed under the wrong column
+    unit_charter     MADAR's per-source unit rules cease to exist
+    brand api taxonomy user_agent tax
+
+Nothing failed. The manifest still validated, because every one of those
+fields is optional.
+
+This test does not name those eight. It round-trips every source the project
+actually ships and compares every field the model has, so a field added
+tomorrow is covered without anyone remembering this file exists.
+"""
+
+from __future__ import annotations
+
+import yaml
+import pytest
+
+from scrapex.config import MANIFEST_FILE, SourceEntry, load_manifest
+from scrapex.manifest_io import entry_to_block
+
+_SOURCES = load_manifest(MANIFEST_FILE).sources
+
+
+@pytest.mark.parametrize("entry", _SOURCES, ids=lambda e: e.source_key)
+def test_a_panel_edit_returns_the_source_unchanged(entry):
+    """THE ONE THAT MATTERS. An edit is a replacement, so a field this cannot
+    write is a field the edit deletes."""
+    rebuilt = SourceEntry.model_validate(yaml.safe_load(entry_to_block(entry))[0])
+
+    lost = [name for name in SourceEntry.model_fields
+            if getattr(entry, name, None) != getattr(rebuilt, name, None)]
+
+    assert lost == [], (
+        f"editing {entry.source_key} from the panel would delete {lost} — the "
+        "block is rebuilt from a list of field names, and these are not on it")
+
+
+def test_the_charter_survives_because_it_is_the_expensive_one():
+    """Named on its own because losing it is not a cosmetic loss: a charter is
+    days of measurement against a live site, and it is the difference between
+    «4 كجم/صندوق» being a box and being four kilograms."""
+    madar = load_manifest(MANIFEST_FILE).get("MADAR")
+    rebuilt = SourceEntry.model_validate(yaml.safe_load(entry_to_block(madar))[0])
+
+    assert rebuilt.unit_charter is not None
+    assert rebuilt.unit_charter == madar.unit_charter
+
+
+def test_a_default_is_still_omitted_so_the_yaml_stays_short():
+    """The fix must not turn every entry into a wall of nulls. A value equal to
+    the model's own default round-trips to the same thing whether it is written
+    or not, so it stays out."""
+    plain = SourceEntry(source_key="PLAIN", source_name="Plain",
+                        base_url="http://x", family="shopify-json", cadence="daily",
+                        authority="shop", currency="EGP", default_region="EG",
+                        vat_mode="incl",
+                        extract=[{"kind": "product_prices", "scope": "census"}])
+    block = yaml.safe_load(entry_to_block(plain))[0]
+
+    assert "unit_charter" not in block
+    assert "default_language" not in block, "the Arabic default does not need writing"
+    assert SourceEntry.model_validate(block).default_language == "ar"


### PR DESCRIPTION
Editing **any** source from the extension deleted **eight** of its fields. The edit path replaces the whole YAML block with one rebuilt from a hand-written list of field names, and everything `SourceEntry` grew after that list was written fell out of the file:

| field | what the edit destroyed |
|---|---|
| `source_name_ar` | every bilingual source's Arabic name |
| `default_language` | an English shop reverts to the Arabic default — **re-filing 1,789 product names under the wrong column**, the exact defect #91 was written to stop |
| `unit_charter` | MADAR's per-source unit rules **cease to exist** |
| `brand` `api` `taxonomy` `user_agent` `tax` | silently gone |

**Nothing failed.** The manifest still validated, because every one of those fields is optional. Verified by round-tripping the shipped manifest before the fix: MADAR loses its Arabic name, its language, and its entire charter.

The charter is the expensive one — days of measurement against a live site, and the difference between «4 كجم/صندوق» being a box and being four kilograms, which migration `0060` spent 58 lines rescuing.

This matters more than it looks because of the owner's standing rule: **the extension is the control room.** Source editing is meant to live there. The one surface he is told to use was the one that quietly destroyed the work.

## The fix is not adding eight names

That leaves the ninth to be deleted in silence by whoever adds it.

`_FIELD_ORDER` stays what it always should have been — an ordering hint for readability — and a final pass writes every model field it does not name, **unless the value equals the model's own default**. Defaults stay omitted, so a simple source's YAML is still as short as a hand-written one.

The test does not name the eight either. It round-trips **every source the project ships** and compares **every field `SourceEntry` has**, so a field added tomorrow is covered without anyone remembering the test exists.

## Mutations, both proved to bite

dropping the catch-all (12 fail) · keeping it but excluding `unit_charter` (3)

## Provenance

Found by an adversarial review of #90, which asked what else reads or writes `default_language` and found the writer that does not.

## Gates

`pytest` full suite · contract parity — green.