### PR TITLE
An axis is a detail until you promote it

### DIFF
--- a/scrapex/fields.py
+++ b/scrapex/fields.py
@@ -239,6 +239,55 @@ def apply_schema(conn: sqlite3.Connection, source_key: str, header: list[str],
 # an attribute became a column only where the site published it as a facet, so
 # madar got 64 and sika, whose shop publishes none, got nothing at all.
 
+# An axis and an attribute can share a name — madar publishes «المقاس» as both a
+# variation axis and a product specification — so a promotion has to say WHICH
+# it promoted. The prefix is stored, never displayed.
+AXIS_PREFIX = "axis:"
+
+
+def promotable_axes(conn: sqlite3.Connection, source_key: str) -> list[dict]:
+    """Every variation axis this source publishes, with how many products carry it.
+
+    An axis is what the SHOP varies a product by — a 20mm blade against a 30mm
+    one. Until now every axis became a main-table column the moment it was
+    first seen, with no way to send it back, because the chooser only ever read
+    source_product_attribute. Madar reached 59 of them, 33 non-empty on under
+    1% of its rows, and the owner asked three times to have them moved.
+
+    Counted per PRODUCT rather than per variant, so the number means the same
+    thing as the attribute counts beside it in the chooser.
+    """
+    rows = conn.execute(
+        "SELECT sv.variant_axes, sv.variant_axes_ar, sp.source_product_id "
+        "FROM source_variant sv "
+        "JOIN source_product sp ON sp.source_product_id = sv.source_product_id "
+        "JOIN source_site ss ON ss.source_id = sp.source_id "
+        "WHERE ss.source_key = ? AND sv.status = 'active' AND sp.status = 'active'",
+        (source_key,)).fetchall()
+    seen: dict[str, set] = {}
+    for axes_en, axes_ar, product in rows:
+        for blob in (axes_en, axes_ar):
+            try:
+                parsed = json.loads(blob or "{}") or {}
+            except (TypeError, ValueError):
+                continue
+            for name in parsed:
+                seen.setdefault(name, set()).add(product)
+    total = conn.execute(
+        "SELECT COUNT(*) FROM source_product sp "
+        "JOIN source_site ss ON ss.source_id = sp.source_id "
+        "WHERE ss.source_key = ? AND sp.status = 'active'", (source_key,)).fetchone()[0] or 0
+    chosen = promoted_attributes(conn, source_key)
+    return [{"attribute_code": AXIS_PREFIX + name, "label": name, "group": "",
+             "lang": "", "products": len(products), "of_products": total,
+             # Never "the site said so": a site filter is the shop saying this
+             # is how people shop for it, and an axis is only how it varies.
+             "by_the_site": False, "promoted": AXIS_PREFIX + name in chosen,
+             "is_column": AXIS_PREFIX + name in chosen, "kind": "axis"}
+            for name, products in sorted(seen.items(),
+                                         key=lambda kv: (-len(kv[1]), kv[0]))]
+
+
 def promotable_attributes(conn: sqlite3.Connection, source_key: str) -> list[dict]:
     """Every detail this source publishes that COULD be a column, with the
     count of products that actually fill it, and whether it is a column now.
@@ -277,7 +326,7 @@ def promotable_attributes(conn: sqlite3.Connection, source_key: str) -> list[dic
                 # Two different reasons a detail is a column, and the owner
                 # should tell them apart: the site said so, or he did.
                 "by_the_site": bool(r[5]), "promoted": r[0] in chosen,
-                "is_column": bool(r[5]) or r[0] in chosen}
+                "is_column": bool(r[5]) or r[0] in chosen, "kind": "detail"}
                for r in rows
                # A code that covers exactly ONE product is that product's own
                # row, not a KIND of fact — sika publishes 535 image_N and 202
@@ -287,7 +336,10 @@ def promotable_attributes(conn: sqlite3.Connection, source_key: str) -> list[dic
                # already a column stays listed whatever its coverage, so a
                # choice can always be undone.
                if r[4] > 1 or bool(r[5]) or r[0] in chosen]
-    return offered
+    # The axes ride the same list, so the panel that already reads it gains
+    # them without a second endpoint — and the owner sees details and axes in
+    # one place, ranked by how much of his data each actually fills.
+    return offered + promotable_axes(conn, source_key)
 
 
 def promoted_attributes(conn: sqlite3.Connection, source_key: str) -> set[str]:

--- a/scrapex/reports.py
+++ b/scrapex/reports.py
@@ -10,6 +10,7 @@ import sqlite3
 from dataclasses import dataclass, field
 
 from . import fields, rates, tax
+from .fields import AXIS_PREFIX
 from .normalize import option_axes_from
 from .vocab import BLOCK_ORDER, Block, DETAIL_GROUP_ORDER
 
@@ -1254,7 +1255,8 @@ def export_source_table(conn: sqlite3.Connection, source_key: str,
                       or option_axes_from(row["option_axes"]))
         parsed.append(merged)
     return _with_axis_columns(list(EXPORT_HEADER), table, parsed,
-                              _filter_groups(conn, source_key))
+                              _filter_groups(conn, source_key),
+                              fields.promoted_attributes(conn, source_key))
 
 
 def _filter_values(conn: sqlite3.Connection, source_key: str) -> dict[int, dict[str, str]]:
@@ -1331,6 +1333,7 @@ def _group_sorted(labels: list[str], groups: dict[str, str]) -> list[str]:
 
 def _with_axis_columns(header: list[str], table: list[list],
                        parsed: list[dict], groups: dict[str, str] | None = None,
+                       promoted: set[str] | None = None,
                        ) -> tuple[list[str], list[list]]:
     """The per-source columns: one per variation AXIS, one per site FILTER.
 
@@ -1356,10 +1359,28 @@ def _with_axis_columns(header: list[str], table: list[list],
                 names.append(name)
     if not names:
         return header, table
-    if groups:
-        axis_names = [name for name in names if name not in groups]
-        filter_names = [name for name in names if name in groups]
-        names = axis_names + _group_sorted(filter_names, groups)
+    groups = groups or {}
+    axis_names = [name for name in names if name not in groups]
+    filter_names = [name for name in names if name in groups]
+    # AN AXIS IS A DETAIL UNTIL THE OWNER PROMOTES IT. Measured on madar:
+    # 59 axis columns, and 33 of them non-empty on under 1% of its 3,550 rows —
+    # «الكثافة (كجم/م3)» filled on four. The table opened at 112 columns and the
+    # owner asked three times to have them moved to the details.
+    #
+    # Nothing is lost by not printing them: `variant` and `variant_ar` sit at
+    # columns 3 and 4 and already carry the same words in both languages —
+    # "Width (mm): 610" / «العرض (ملم): 610». Verified across every source that
+    # publishes axes at all (madar, spark, elsewedy, heidelberg, samehgabriel):
+    # ZERO variants carry an axis without carrying it in `variant` too.
+    #
+    # A SITE FILTER IS NOT GATED HERE. The shop's own listing pages slice by
+    # it, which is the shop saying it is a way people shop for this — that rule
+    # already lives in promotable_attributes as `by_the_site`.
+    if promoted is not None:
+        axis_names = [name for name in axis_names if AXIS_PREFIX + name in promoted]
+    names = axis_names + _group_sorted(filter_names, groups)
+    if not names:
+        return header, table
     at = header.index("variant_ar") + 1
     widened = header[:at] + names + header[at:]
     rows = [row[:at] + [axes.get(name, "") for name in names] + row[at:]

--- a/tests/test_an_axis_is_a_detail_until_you_promote_it.py
+++ b/tests/test_an_axis_is_a_detail_until_you_promote_it.py
@@ -1,0 +1,134 @@
+"""Fifty-nine columns nobody agreed to, and no door to send them back through.
+
+The owner asked three times to have the many un-agreed columns moved to the
+details. Measured on his MADAR: 112 columns in the table, 59 of them variation
+axes, and 33 of those non-empty on under 1% of its 3,550 rows — «الكثافة
+(كجم/م3)» filled on four.
+
+They could not be moved. fields.promotable_attributes — the chooser that shows
+each detail with the count of products that fill it, so "an attribute two
+products carry is a column of blanks" is visible BEFORE choosing — read
+source_product_attribute only. An axis was never in the list, so there was no
+way to demote one however much the owner wanted to.
+
+NOTHING IS LOST BY NOT PRINTING THEM. variant and variant_ar already carry the
+same words in both languages — "Width (mm): 610" / «العرض (ملم): 610».
+Verified across every source that publishes axes at all: zero variants carry an
+axis without carrying it in `variant` too.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scrapex import db as dbmod, fields, reports
+
+
+@pytest.fixture()
+def conn(tmp_path):
+    c = dbmod.connect(tmp_path / "w.db")
+    dbmod.migrate(c)
+    c.execute("INSERT INTO source_site (source_id, source_key, source_name_ar, source_name,"
+              " base_url, platform, currency, timezone, authority, active) "
+              "VALUES (1,'SHOP','م','Shop','http://s','magento-graphql','SAR','UTC','shop',1)")
+    for pid, axes in enumerate([{"Thickness (mm)": "3"}, {"Density (Kg/M3)": "40"}], start=1):
+        c.execute("INSERT INTO source_product (source_product_id, source_id, "
+                  " external_product_id, product_name, product_name_ar, status) "
+                  "VALUES (?,1,?,'P','ب','active')", (pid, str(pid)))
+        blob = json.dumps(axes, ensure_ascii=False)
+        label = ", ".join(f"{k}: {v}" for k, v in axes.items())
+        c.execute("INSERT INTO source_variant (source_variant_id, source_product_id, "
+                  " external_variant_id, variant, variant_ar, variant_axes, "
+                  " variant_axes_ar, status) VALUES (?,?,?,?,?,?,?,'active')",
+                  (pid, pid, str(pid), label, label, blob, blob))
+        # A row only reaches the table through the price join, so the fixture
+        # has to carry an offer and an observation or the export is empty and
+        # every assertion below passes for the wrong reason.
+        c.execute("INSERT INTO source_offer (offer_id, source_variant_id, "
+                  " country_code_alpha2, customer_segment, basis_quantity, currency, "
+                  " tax_included, status) VALUES (?,?,'SA','retail',1,'SAR',1,'active')",
+                  (pid, pid))
+        c.execute("INSERT OR IGNORE INTO crawl_run (run_id, source_id, started_at, status) "
+                  "VALUES (1,1,'2026-08-04T00:00:00Z','success')")
+        c.execute("INSERT INTO price_observation (offer_id, run_id, observed_at, "
+                  " business_date, price, currency, tax_included, availability, "
+                  " record_hash, price_hash, price_fields, provenance) "
+                  "VALUES (?,1,'2026-08-04T00:00:00Z','2026-08-04',10,'SAR',1,'in_stock',"
+                  "?,?,'effective','observed')", (pid, f"rh{pid}", f"ph{pid}"))
+    c.commit()
+    return c
+
+
+def _axes_offered(conn) -> dict[str, int]:
+    return {a["label"]: a["products"] for a in fields.promotable_axes(conn, "SHOP")}
+
+
+def test_the_chooser_offers_the_axes_with_how_much_they_fill(conn):
+    """THE MISSING DOOR. The count is the whole point — the owner should see
+    that an axis covers one product in two before he chooses, not after he
+    exports."""
+    offered = _axes_offered(conn)
+
+    assert offered == {"Thickness (mm)": 1, "Density (Kg/M3)": 1}
+
+
+def test_the_axes_ride_the_same_list_the_details_already_use(conn):
+    """One endpoint, one panel, one place to decide — rather than a second
+    chooser the owner has to discover. The panel that already reads
+    promotable_attributes gains them without any change."""
+    codes = {a["attribute_code"] for a in fields.promotable_attributes(conn, "SHOP")}
+
+    assert fields.AXIS_PREFIX + "Thickness (mm)" in codes
+
+
+def test_an_axis_and_a_detail_that_share_a_name_stay_apart(conn):
+    """madar publishes «المقاس» as BOTH a variation axis and a product
+    specification. A promotion has to say which one it promoted, or promoting
+    the spec would silently promote the axis too."""
+    assert fields.AXIS_PREFIX + "Size" != "Size"
+    assert all(a["attribute_code"].startswith(fields.AXIS_PREFIX)
+               for a in fields.promotable_axes(conn, "SHOP"))
+
+
+def test_an_axis_is_not_a_column_until_it_is_promoted(conn):
+    """The default the owner asked for. 112 columns is not a table anyone
+    reads."""
+    header, _ = reports.export_source_table(conn, "SHOP", limit=50)
+
+    assert "Thickness (mm)" not in header
+    assert "Density (Kg/M3)" not in header
+
+
+def test_promoting_one_brings_exactly_that_one_back(conn):
+    """Reversible by construction, and specific: promoting the axis that fills
+    40% of the rows must not drag in the one that fills four of them."""
+    fields.set_promotion(conn, "SHOP", fields.AXIS_PREFIX + "Thickness (mm)", True)
+
+    header, _ = reports.export_source_table(conn, "SHOP", limit=50)
+
+    assert "Thickness (mm)" in header
+    assert "Density (Kg/M3)" not in header
+
+
+def test_demoting_it_again_sends_it_back(conn):
+    """The row IS the promotion, so nothing has to remember a previous shape."""
+    code = fields.AXIS_PREFIX + "Thickness (mm)"
+    fields.set_promotion(conn, "SHOP", code, True)
+    fields.set_promotion(conn, "SHOP", code, False)
+
+    header, _ = reports.export_source_table(conn, "SHOP", limit=50)
+
+    assert "Thickness (mm)" not in header
+
+
+def test_the_fact_is_still_on_the_row(conn):
+    """THE REASON THIS IS SAFE. Demoting an axis hides a duplicate, not a fact:
+    `variant` and `variant_ar` sit near the front of the table and carry the
+    same words. If this ever stops being true, demoting starts losing data."""
+    header, rows = reports.export_source_table(conn, "SHOP", limit=50)
+    at, at_ar = header.index("variant"), header.index("variant_ar")
+
+    assert any("Thickness (mm): 3" == row[at] for row in rows)
+    assert any("Thickness (mm): 3" == row[at_ar] for row in rows)

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -5,7 +5,7 @@ import sqlite3
 
 import pytest
 
-from scrapex import db as dbmod
+from scrapex import db as dbmod, fields
 from scrapex.reports import (BILINGUAL_COLUMNS, CATEGORY_LEVELS,
                             _category_leaf, fold_variant_rows,
                             recent_observations, source_summary,
@@ -255,6 +255,12 @@ def test_each_variation_axis_becomes_its_own_export_column(conn):
         one_row(external_variant_id="v2", variant_ar="Color: أخضر",
                 variant_axes_ar='{"Color":"أخضر"}', price="99.00"),
     ])])
+    # An axis is a detail until the owner promotes it (2026-08-04): madar
+    # reached 59 axis columns, 33 of them non-empty on under 1% of its rows.
+    # This test's finding is about the SHAPE a column takes when there IS
+    # one - welding two facts into one cell would still be wrong - so it
+    # asks for the column, then asserts exactly what it always asserted.
+    fields.set_promotion(conn, "ELSEWEDYSHOP", fields.AXIS_PREFIX + "Color", True)
     header, table = export_source_table(conn, "ELSEWEDYSHOP")
 
     assert "Color" in header, "the axis never became a column"
@@ -273,6 +279,9 @@ def test_site_columns_share_one_group_order_in_table_and_export(conn):
     ingest_payloads(conn, make_entry(), [make_payload([
         one_row(variant_ar="Color: أحمر",
                 variant_axes_ar='{"Color":"أحمر"}')])])
+    # The subject here is the FILTER order; the axis proves it sits ahead
+    # of them, so it is asked for rather than expected unbidden.
+    fields.set_promotion(conn, "ELSEWEDYSHOP", fields.AXIS_PREFIX + "Color", True)
     product_id = conn.execute(
         "SELECT source_product_id FROM source_product").fetchone()[0]
     attributes = [


### PR DESCRIPTION
The owner asked **three times** to have the many un-agreed columns moved to the details. Measured on his MADAR: **112 columns** in the table, **59 of them variation axes**, and **33 of those non-empty on under 1% of its 3,550 rows** — «الكثافة (كجم/م3)» filled on four.

## He could not move them, and that is the actual defect

`fields.promotable_attributes` is exactly the right door. It lists every detail with the count of products that fill it, so *"an attribute two products carry is a column of blanks"* is visible **before** choosing rather than after exporting.

It read `source_product_attribute` **only**. An axis was never in the list, so there was no way to send one back however much he wanted to — axes became columns the moment they were first seen and stayed columns forever.

## Nothing is lost by not printing them

This is why it is safe rather than a trade. `variant` and `variant_ar` sit near the front of the table and **already carry the same words in both languages** — `Width (mm): 610` / «العرض (ملم): 610».

Verified on the live warehouse across **every** source that publishes axes — madar, spark, elsewedy, heidelberg, samehgabriel: **zero** variants carry an axis without carrying it in `variant` too. Demoting hides a duplicate, not a fact, and the per-axis column is one click away for anyone who wants to filter or pivot on it.

MADAR's export goes from **112 columns to 67**. Promoting one adds exactly it.

## What is not gated

**A site filter.** The shop's own listing pages slice by it, which is the shop saying *this is a way people shop for it* — a rule that already lives in `promotable_attributes` as `by_the_site`.

An axis and a detail can share a name — madar publishes «المقاس» as both a variation axis and a product specification — so promotions carry an `axis:` prefix. Stored, never displayed.

The axes ride **the list the panel already reads**, so the control room gains them with no second endpoint and no UI change: details and axes in one place, ranked by how much of the owner's data each actually fills.

## Two existing tests changed, on intent

`test_each_variation_axis_becomes_its_own_export_column` encoded the old default. Its finding is about the **shape** a column takes when there is one — the owner exported `Color: أحمر` welded into a single cell and refused a fix that split the string at the far end — and that is untouched. It now asks for the column and asserts exactly what it always asserted.

`test_site_columns_share_one_group_order`'s subject is the **filter order**, with the axis proving it sits ahead of them. Same treatment.

## Mutations, both proved to bite

reverting to every-axis-a-column (3 fail) · promoting every axis rather than the chosen one (1)

## Gates

`pytest` full suite · contract parity · extension 19/0 · `validate-manifest` — green.