### PR TITLE
Backups stop growing without end

### DIFF
--- a/scrapex/settings.py
+++ b/scrapex/settings.py
@@ -97,6 +97,11 @@ SETTINGS: dict[str, Setting] = {s.key: s for s in [
     Setting("ui_time_zone", "", label="Shared display time zone"),
     # --- Storage (spec 17) ---
     Setting("backup_folder", "", label="Folder for backups"),
+    # Backups grew to 1.61 GB against a 100 MB warehouse — 16x — because
+    # nothing ever removed one, and the `rebuild` lineage alone held ten
+    # files. Kept PER KIND rather than in total, so a run of rebuilds can
+    # never evict the only pre-wipe copy of a source erased months ago.
+    Setting("backups_kept_per_tag", "3", label="Backups kept of each kind"),
     # --- Logs and diagnostics (spec 33) ---
     Setting("log_retention_days", "30", label="Keep job logs for"),
 ]}

--- a/scrapex/storage.py
+++ b/scrapex/storage.py
@@ -588,6 +588,7 @@ def health(db_path: Path | str) -> dict:
         "status": "healthy", "ok": True, "problems": [], "foreign_key_problems": 0,
         "reclaimable_bytes": reclaimable,
         "undeclared_sources": forgotten,
+        "prunable_backup_bytes": sum(b["bytes"] for b in prunable_backups(path)),
         "detail": ("No problems found." + (
             f" Compacting would return about {reclaimable:,} bytes of free pages."
             if reclaimable else "") + (
@@ -636,9 +637,71 @@ def list_backups(db_path: Path | str, folder: Path | None = None) -> list[dict]:
     if not where.is_dir():
         return []
     found = [{"path": str(p), "name": p.name, "bytes": _size(p),
-              "modified_at": _mtime_iso(p)}
-             for p in where.glob(f"{base_stem(path)}.*backup*")]
+              "modified_at": _mtime_iso(p), "tag": backup_tag(p, path)}
+             # SQLite leaves `-shm` and `-wal` beside a database it has opened,
+             # and the glob was matching them: the Restore list offered a
+             # write-ahead log as something you could make live again.
+             for p in where.glob(f"{base_stem(path)}.*backup*")
+             if p.suffix == Path(path).suffix or p.suffix == ".db"]
     return sorted(found, key=lambda b: b["modified_at"], reverse=True)
+
+
+# What backup_database writes: <stem>.<tag>-<stamp>.backup<suffix>. Reset writes
+# <stem>.reset-backup-<stamp><suffix>, which is the same fact in a different
+# order and predates the helper. Both are read, and ANYTHING ELSE IS NOT OURS —
+# a file a person named by hand has no tag, is never grouped, and is never
+# pruned. That is the whole safety rule: the policy removes only what this
+# product itself wrote.
+_STAMP = r"(?:\d{8}T\d{6}Z|\d{8}-\d{6}|[\d-]{10}T[\d:]{8}Z)"
+
+
+def backup_tag(backup_path: Path | str, db_path: Path | str) -> str:
+    """Which lineage this backup belongs to, or "" if this product did not name it."""
+    stem = re.escape(base_stem(db_path))
+    match = re.match(rf"^{stem}\.(?:(?P<tag>.+?)-{_STAMP}\.backup|reset-backup-{_STAMP})$",
+                     Path(backup_path).stem)
+    if match is None:
+        return ""
+    return match.group("tag") or "reset"
+
+
+BACKUPS_KEPT_PER_TAG = 3
+
+
+def backups_kept(conn: sqlite3.Connection) -> int:
+    """How many of each lineage to keep. Three, unless the owner says otherwise.
+
+    Three rather than one because the reason to keep a backup at all is that
+    the newest one might be the one carrying the defect: measured on the
+    owner's warehouse, a rebuild backup taken minutes before a bad crawl is
+    indistinguishable from a good one until the data is read.
+    """
+    try:
+        saved = int(settings.get(conn, "backups_kept_per_tag") or BACKUPS_KEPT_PER_TAG)
+    except (TypeError, ValueError):
+        return BACKUPS_KEPT_PER_TAG
+    return max(1, saved)
+
+
+def prunable_backups(db_path: Path | str, folder: Path | None = None,
+                     keep: int = BACKUPS_KEPT_PER_TAG) -> list[dict]:
+    """The backups a keep-N-per-lineage policy would remove, newest kept.
+
+    Untagged files are absent by construction — see backup_tag. Grouping by
+    lineage rather than by age is what stops a run of rebuild backups evicting
+    the one pre-wipe copy of a source that was erased months ago: measured on
+    the owner's warehouse, `rebuild` alone held 10 files and 491 MB while
+    `pre-wipe-SIKAEGSHOP` held the only copy of 13.7 MB nothing else has.
+    """
+    by_tag: dict[str, list[dict]] = {}
+    for backup in list_backups(db_path, folder):
+        if backup.get("tag"):
+            by_tag.setdefault(backup["tag"], []).append(backup)
+    drop: list[dict] = []
+    for entries in by_tag.values():
+        # list_backups is already newest-first, so the tail is the old ones.
+        drop.extend(entries[max(1, keep):])
+    return sorted(drop, key=lambda b: b["modified_at"], reverse=True)
 
 
 def _mtime_iso(path: Path) -> str:
@@ -649,6 +712,42 @@ def _mtime_iso(path: Path) -> str:
     except OSError:
         return ""
     return stamp.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def prune_backups(conn: sqlite3.Connection, db_path: Path | str,
+                  keep: int | None = None) -> RunResult:
+    """Remove the backups the policy no longer keeps. Returns what it freed.
+
+    The owner's warehouse reached 1.61 GB of backups against a 100 MB database
+    — 16x — because nothing ever removed one. He asked for a policy rather than
+    a one-off sweep, and this is it: it runs after each new backup, so a
+    lineage cannot grow past its keep count in the first place.
+
+    Deliberately NOT a sweep of everything old. It only ever removes files this
+    product named (backup_tag), it keeps the newest of every lineage, and it
+    never touches the live database or its sidecars.
+    """
+    keep = backups_kept(conn) if keep is None else keep
+    folder = backup_folder(conn, db_path)
+    doomed = prunable_backups(db_path, folder, keep)
+    freed, removed = 0, []
+    for backup in doomed:
+        target = Path(backup["path"])
+        try:
+            size = _size(target)
+            target.unlink()
+        except OSError:
+            # A backup held open by another process is not an error worth
+            # failing a crawl over — it is simply still there next time.
+            continue
+        freed += size
+        removed.append(target.name)
+    return RunResult(
+        ok=True, rows=len(removed), location=str(folder),
+        detail=(f"Removed {len(removed)} superseded backup(s), freeing "
+                f"{freed:,} bytes; keeping the {keep} newest of each kind."
+                if removed else
+                f"Nothing to remove: every kind is within its {keep} newest."))
 
 
 def backup_now(conn: sqlite3.Connection, db_path: Path | str, tag: str = "manual") -> RunResult:
@@ -676,6 +775,12 @@ def backup_now(conn: sqlite3.Connection, db_path: Path | str, tag: str = "manual
         result.detail += (" This backup is on the same disk as the database, so it "
                           "does not survive that drive failing. Set a backup folder "
                           "on another disk to protect against that.")
+    # Pruned AFTER the new copy exists, never before: a policy that made room
+    # first would, on the one run where the backup then failed, have deleted
+    # the old one for nothing.
+    swept = prune_backups(conn, path)
+    if swept.rows:
+        result.detail += f" {swept.detail}"
     settings.set_state(conn, "storage_last", result.as_state())
     return result
 

--- a/tests/test_backups_stop_growing_without_end.py
+++ b/tests/test_backups_stop_growing_without_end.py
@@ -1,0 +1,149 @@
+"""1.61 GB of backups against a 100 MB warehouse, because nothing removed one.
+
+Measured on the owner's machine 2026-08-04: 37 database files beside a 100 MB
+warehouse, 16x its size, the oldest three weeks old. The `rebuild` lineage
+alone held 10 files and 491 MB — four of them taken within twenty minutes of
+each other on 2026-07-23.
+
+He asked for a policy rather than a one-off sweep, and the distinction matters:
+a sweep leaves the next month to grow the same way.
+
+THE SAFETY RULE IS THAT THE POLICY ONLY REMOVES WHAT THIS PRODUCT NAMED.
+Three of his files — marketlens.pre0056.backup.db and two like it — were named
+by hand before a migration. They carry no stamp, so backup_tag returns "" and
+they are never grouped and never pruned.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from scrapex import db as dbmod, storage
+
+
+@pytest.fixture()
+def warehouse(tmp_path):
+    db = tmp_path / "marketlens.db"
+    conn = dbmod.connect(db)
+    dbmod.migrate(conn)
+    conn.commit()
+    return conn, db
+
+
+def _make(db: pathlib.Path, name: str, order: int) -> pathlib.Path:
+    """A file standing in for a backup, with a distinct modification time."""
+    path = db.with_name(name)
+    path.write_bytes(b"x" * (1024 * order))
+    import os
+    os.utime(path, (1_780_000_000 + order * 60, 1_780_000_000 + order * 60))
+    return path
+
+
+def test_a_backup_this_product_named_knows_its_lineage(warehouse):
+    """Both spellings, because reset predates the shared helper and writes the
+    same fact in a different order."""
+    _conn, db = warehouse
+
+    assert storage.backup_tag(db.with_name("marketlens.rebuild-20260804T120539Z.backup.db"), db) == "rebuild"
+    assert storage.backup_tag(db.with_name("marketlens.reset-backup-20260722T050619Z.db"), db) == "reset"
+    assert storage.backup_tag(
+        db.with_name("marketlens.pre-wipe-GPP_ENERGY-20260722T115752Z.backup.db"), db
+    ) == "pre-wipe-GPP_ENERGY"
+
+
+def test_a_file_a_person_named_has_no_lineage_and_is_never_pruned(warehouse):
+    """THE SAFETY RULE. Three of the owner's files are hand-named copies taken
+    before a migration. A policy that guessed at them would delete the only
+    copy of a warehouse state nobody can reproduce."""
+    _conn, db = warehouse
+    for i in range(4):
+        _make(db, f"marketlens.pre005{i}.backup.db", i + 1)
+
+    assert storage.backup_tag(db.with_name("marketlens.pre0056.backup.db"), db) == ""
+    assert storage.prunable_backups(db) == []
+
+
+def test_only_the_newest_of_each_lineage_survives(warehouse):
+    """Five rebuilds, keep two."""
+    _conn, db = warehouse
+    for i in range(1, 6):
+        _make(db, f"marketlens.rebuild-2026080{i}T120000Z.backup.db", i)
+
+    doomed = {b["name"] for b in storage.prunable_backups(db, keep=2)}
+
+    assert doomed == {"marketlens.rebuild-20260801T120000Z.backup.db",
+                      "marketlens.rebuild-20260802T120000Z.backup.db",
+                      "marketlens.rebuild-20260803T120000Z.backup.db"}
+
+
+def test_a_run_of_one_kind_never_evicts_the_only_copy_of_another(warehouse):
+    """GROUPING BY LINEAGE IS THE POINT. On the owner's warehouse `rebuild`
+    held 10 files while `pre-wipe-SIKAEGSHOP` held the ONLY copy of a source
+    that was erased in July. A policy that kept "the newest N backups" would
+    have deleted it to make room for a rebuild taken this morning."""
+    _conn, db = warehouse
+    for i in range(1, 8):
+        _make(db, f"marketlens.rebuild-2026080{i}T120000Z.backup.db", 10 + i)
+    _make(db, "marketlens.pre-wipe-SIKAEGSHOP-20260725T070151Z.backup.db", 1)
+
+    doomed = {b["name"] for b in storage.prunable_backups(db, keep=3)}
+
+    assert not any("SIKAEGSHOP" in name for name in doomed)
+    assert len(doomed) == 4
+
+
+def test_the_live_database_and_its_sidecars_are_not_backups(warehouse):
+    """SQLite leaves -shm and -wal beside a database it has opened, and the
+    glob was matching them: the Restore list offered a write-ahead log as
+    something you could make live again. 71 entries where there were 25."""
+    _conn, db = warehouse
+    _make(db, "marketlens.rebuild-20260804T120000Z.backup.db", 3)
+    _make(db, "marketlens.rebuild-20260804T120000Z.backup.db-wal", 1)
+    _make(db, "marketlens.rebuild-20260804T120000Z.backup.db-shm", 1)
+
+    listed = {b["name"] for b in storage.list_backups(db)}
+
+    assert listed == {"marketlens.rebuild-20260804T120000Z.backup.db"}
+
+
+def test_pruning_removes_them_and_says_what_it_freed(warehouse):
+    """Reversible it is not, so it reports rather than working in silence."""
+    conn, db = warehouse
+    for i in range(1, 6):
+        _make(db, f"marketlens.rebuild-2026080{i}T120000Z.backup.db", i)
+
+    result = storage.prune_backups(conn, db, keep=2)
+
+    assert result.ok and result.rows == 3
+    assert "freeing" in result.detail
+    assert len(storage.list_backups(db)) == 2
+
+
+def test_a_new_backup_prunes_after_itself_never_before(warehouse):
+    """A policy that made room FIRST would, on the one run where the backup
+    then failed, have deleted the old copies for nothing."""
+    conn, db = warehouse
+    for i in range(1, 5):
+        _make(db, f"marketlens.manual-2026080{i}T120000Z.backup.db", i)
+
+    storage.backup_now(conn, db, tag="manual")
+
+    kept = storage.list_backups(db)
+    assert len(kept) == storage.backups_kept(conn)
+    # The one just taken is among them: a policy that pruned first could have
+    # left the newest copy missing.
+    assert kept[0]["bytes"] > 0
+
+
+def test_the_warehouse_says_what_the_policy_would_free(warehouse):
+    """A number nobody can see is a number nobody acts on. It rides the verdict
+    the Storage page already reads on every visit."""
+    conn, db = warehouse
+    for i in range(1, 6):
+        _make(db, f"marketlens.rebuild-2026080{i}T120000Z.backup.db", i)
+
+    verdict = storage.health(db)
+
+    assert verdict["prunable_backup_bytes"] > 0


### PR DESCRIPTION
Measured on the owner's machine 2026-08-04: **1.61 GB of backups beside a 100 MB warehouse** — 16x — 37 files, the oldest three weeks old. The `rebuild` lineage alone held **10 files and 491 MB**, four of them taken within twenty minutes of each other on 2026-07-23. Nothing had ever removed one.

He asked for a **policy** rather than a sweep, and the distinction is the whole design: a sweep leaves next month to grow the same way. This runs after every new backup, so a lineage cannot pass its keep count in the first place.

## The safety rule: it only removes what this product named

`backup_database` writes `<stem>.<tag>-<stamp>.backup<suffix>`, and reset writes the same fact in the older order. **Anything else has no tag, is never grouped, and is never pruned.**

Three of the owner's files — `marketlens.pre0056.backup.db` and two like it — were named by hand before a migration and carry no stamp. They are the only copies of warehouse states nobody can reproduce, and a policy that guessed at them would delete exactly those.

## Kept per lineage, not per age

Measured: `rebuild` held 10 files while `pre-wipe-SIKAEGSHOP` held the **only** copy of a source erased in July. *"Keep the newest N backups"* would have deleted it to make room for a rebuild taken this morning.

Three per kind, because the reason to keep a backup at all is that the newest one may be the one carrying the defect. The owner can change it — a registered setting, so the panel reaches it like every other.

## Pruned after the new copy exists, never before

A policy that made room first would, on the one run where the backup then failed, have deleted the old ones **for nothing**.

## A defect found while measuring

`list_backups` globbed `<stem>.*backup*` and matched SQLite's `-shm` and `-wal` sidecars, so **the Restore list offered a write-ahead log as something you could make live again** — 71 entries where there are 25. Now suffix-filtered.

## What it does on the owner's warehouse

Frees **391 MB** of the 710 MB the product itself wrote. `health()` now reports that figure on the page he already opens, rather than leaving it to be found by listing a folder.

## Mutations, all four proved to bite

pruning untagged files · keeping the newest N overall instead of per lineage · letting the sidecars count again · pruning before the new copy is taken

## Gates

`pytest` full suite · contract parity · extension 19/0 — green.