### PR TITLE
The size the shop states in its specifications, and a rule that outlives one migration

### DIFF
--- a/scrapex/connectors/magento.py
+++ b/scrapex/connectors/magento.py
@@ -422,7 +422,31 @@ def _quantity_facts(child: dict) -> tuple[str, str, str]:
             "" if decimal is None else ("1" if decimal else "0"))
 
 
-def _apply_charter(row: list[str], charter) -> None:
+def _spec_size(product: dict | None) -> str:
+    """The `size` the shop states in a product's Specifications panel.
+
+    «إسمنت السعودية» carries no size on its variants at all — its option value
+    is «Cement Type: Sulphate Resistant» — and states «المقاس: 50 Kg» in its
+    specifications, which is the shop saying what one bag is. 48 madar products
+    state a mass or volume this way.
+
+    Read from the response the price row is already built from: when a source
+    declares enrichment, this crawl asks _QUERY_ENRICHED and custom_attributesV2
+    arrives with the price. It costs no request.
+    """
+    if not product:
+        return ""
+    for item in ((product.get("custom_attributesV2") or {}).get("items")) or []:
+        if str(item.get("code") or "") not in ("size", "size_ar"):
+            continue
+        selected = item.get("selected_options") or []
+        if selected:
+            return str(selected[0].get("label") or "")
+        return str(item.get("value") or "")
+    return ""
+
+
+def _apply_charter(row: list[str], charter, product: dict | None = None) -> None:
     """Let a declared charter decide the unit, from the row this crawl built.
 
     Applied AFTER the row exists rather than inside the three call sites of
@@ -446,6 +470,12 @@ def _apply_charter(row: list[str], charter) -> None:
         "variant_axes_ar": row[at("variant_axes_ar")],
         "product_name": row[at("product_name")],
         "product_name_ar": row[at("product_name_ar")],
+        # Not a row column: the shop's Specifications value, handed straight to
+        # the charter. It describes the FAMILY, so any charter that reads it
+        # must rank it below the variant's own axes — a product-level size
+        # printed on every variant is how a family's figure becomes each
+        # member's, which is the mistake reports.py already names in writing.
+        "spec_size": _spec_size(product),
     })
     if resolution is None:
         return
@@ -565,7 +595,7 @@ class MagentoGraphqlConnector:
             for product in items:
                 made = self._product_rows(builder, product, ctx)
                 for built in made:
-                    _apply_charter(built, charter)
+                    _apply_charter(built, charter, product)
                 page_rows.extend(made)
                 if made and wants_enrichment:
                     # Details hang off the PRICE row's product, so the

--- a/scrapex/ingest.py
+++ b/scrapex/ingest.py
@@ -681,6 +681,39 @@ def _apply_unit_facts(conn, offer_id: int, r: dict) -> None:
     )
 
 
+def _retire_replaced_readings(conn, variant_id: int, offer_id: int) -> None:
+    """Retire a legacy reading of this variant that THIS offer now answers for.
+
+    Migration 0060 did exactly this once, by hand, for the 18 madar offers that
+    read "4 kg" where the shop's own option says «4 كجم/صندوق». It ran on one
+    warehouse on one day. Nothing made it a rule, so the next charter that
+    learns to read a field recreates the same pair: one row written by code that
+    could not name a witness, one by code that can, both active, the same
+    product answering "what is one of these" twice.
+
+    It happens again the moment a charter grows a witness. MADAR's
+    Specifications size resolves «20 Kg» for two offers stored as 25 kg with
+    provenance legacy_unwitnessed — a different basis_quantity, so a NEW offer
+    is minted beside the old one rather than replacing it, which is right for
+    two STATED units and wrong for two readings of one.
+
+    Only a row that says of itself that nobody can name its source is touched,
+    and only when the row replacing it names one. Nothing is deleted:
+    price_observation is append-only and the history stays; `status` is the
+    lifecycle 0032 defined, and read paths show 'active'.
+    """
+    conn.execute(
+        "UPDATE source_offer SET status = 'superseded' "
+        " WHERE source_variant_id = ? AND offer_id <> ? AND status = 'active' "
+        "   AND unit_basis_provenance = 'legacy_unwitnessed' "
+        "   AND EXISTS (SELECT 1 FROM source_offer replacement "
+        "                WHERE replacement.offer_id = ? "
+        "                  AND replacement.unit_basis_provenance IS NOT NULL "
+        "                  AND replacement.unit_basis_provenance "
+        "                      NOT IN ('', 'legacy_unwitnessed'))",
+        (variant_id, offer_id, offer_id))
+
+
 def _get_offer_id(conn, variant_id: int, r: dict) -> int:
     vat = 1 if r["tax_included"] == "1" else 0
     unit_id = _get_unit_id(conn, canonical_unit(r.get("unit", ""), r.get("currency", "")))
@@ -700,6 +733,7 @@ def _get_offer_id(conn, variant_id: int, r: dict) -> int:
     if found is not None:
         if unit_id:
             _apply_unit_facts(conn, found, r)
+            _retire_replaced_readings(conn, variant_id, found)
         _apply_quantity_facts(conn, found, quantity)
         return found
     # AN OFFER LEARNING ITS UNIT IS NOT A SECOND OFFER. The rule above is right
@@ -730,8 +764,9 @@ def _get_offer_id(conn, variant_id: int, r: dict) -> int:
                 (unit_id, basis, *unit_facts.values(),
                  content["content_quantity"], content["content_unit_id"], unstated))
             _apply_quantity_facts(conn, unstated, quantity)
+            _retire_replaced_readings(conn, variant_id, unstated)
             return unstated
-    return _insert(conn, "source_offer", {
+    minted = _insert(conn, "source_offer", {
         "source_variant_id": variant_id,
         "country_code_alpha2": r["country_code_alpha2"],
         "currency": r["currency"],
@@ -742,6 +777,9 @@ def _get_offer_id(conn, variant_id: int, r: dict) -> int:
         **(_content_facts(conn, r) if unit_id else {}),
         **quantity,
     })
+    if unit_id:
+        _retire_replaced_readings(conn, variant_id, minted)
+    return minted
 
 
 def _witness_for(r: dict) -> tuple[str, str]:

--- a/sources.yaml
+++ b/sources.yaml
@@ -176,6 +176,30 @@ sources:
         #    pack list and a tonne of steel is a thing this shop sells.
         - {field: variant_axes_ar, lang: ar, provenance: stated_field, shape: quantity}
         - {field: variant_axes,    lang: en, provenance: stated_field, shape: quantity}
+        #
+        # 5. THE SIZE THE SHOP STATES IN ITS SPECIFICATIONS, ranked last of all.
+        #    «إسمنت السعودية» carries no size on its variants — its option value
+        #    is «Cement Type: Sulphate Resistant» — and states «المقاس: 50 Kg»
+        #    in its Specifications panel, which is the shop saying what one bag
+        #    is. 48 madar products state a mass or volume that way.
+        #
+        #    LAST BECAUSE IT DESCRIBES THE FAMILY, not the member. A product
+        #    with variants that differ in size states the family's figure here,
+        #    and printing it on each member is the exact mistake reports.py
+        #    names in writing about product-level attributes. Nine of the 48
+        #    have more than one variant, so the ordering is load-bearing rather
+        #    than theoretical: the variant's own axis answers first wherever it
+        #    speaks, and this is heard only where the variant is silent.
+        #
+        #    Measured over all 3,550 active offers before it was added:
+        #      13 agree with what is stored, changing no number
+        #      53 carry no unit today and gain the one the shop states
+        #       2 CONTRADICT — stored 25 kg where the shop's own panel says
+        #         «20 Kg», both provenance legacy_unwitnessed, both written by
+        #         code that could not name a field. The charter answers 20, and
+        #         the retirement rule below is what stops the 25 standing
+        #         beside it.
+        - {field: spec_size, lang: und, provenance: stated_field, shape: quantity}
       # The site writes the SAME container in two languages, and this maps both
       # to one code. Measured: without it «صندوق» (16) and "box" (24) become two
       # different selling units for one shop's box, and two prices for the same

--- a/tests/test_the_size_the_shop_states_in_its_specifications.py
+++ b/tests/test_the_size_the_shop_states_in_its_specifications.py
@@ -1,0 +1,205 @@
+"""«المقاس: 50 Kg» in the Specifications panel, which no charter could read.
+
+MADAR's «إسمنت السعودية» carries no size on its variants at all — its option
+value is «Cement Type: Sulphate Resistant Cement» — and states «المقاس: 50 Kg»
+in its Specifications. That is the shop saying what one bag is, and 48 of its
+products state a mass or volume that way.
+
+The charter was handed six fields and none of them was this one, so those
+readings kept the units pre-charter code invented for them and kept saying, in
+their own provenance, that nobody could name where they came from.
+
+MEASURED OVER ALL 3,550 ACTIVE OFFERS BEFORE THE WITNESS WAS ADDED:
+  13 agree with what is already stored, changing no number
+  53 carry no unit at all today and gain the one the shop states
+   2 CONTRADICT: stored 25 kg where the shop's own panel says «20 Kg»
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import tempfile
+
+import pytest
+
+from scrapex import db as dbmod
+from scrapex.config import MANIFEST_FILE, load_manifest
+from scrapex.connectors.magento import _spec_size
+from scrapex.units import Charter
+
+
+@pytest.fixture(scope="module")
+def madar() -> Charter:
+    entry = load_manifest(MANIFEST_FILE).get("MADAR")
+    return Charter(json.loads(entry.unit_charter.model_dump_json()))
+
+
+def _fields(**over) -> dict:
+    base = {"weight": "", "weight_unit": "", "variant_axes": "", "variant_axes_ar": "",
+            "product_name": "", "product_name_ar": "", "spec_size": ""}
+    base.update(over)
+    return base
+
+
+def test_the_specifications_size_is_read_where_the_variant_is_silent(madar):
+    """The cement case. Its only option value names a cement TYPE, so every
+    axis witness above this one has nothing to say."""
+    r = madar.resolve(_fields(spec_size="50 Kg"))
+
+    assert r is not None and (r.unit, r.quantity) == ("kg", 50.0)
+    assert r.provenance == "stated_field"
+
+
+def test_the_variant_own_axis_still_answers_first(madar):
+    """THE RANKING THAT MATTERS, and it is load-bearing rather than
+    theoretical: nine of the 48 products that state a size have more than one
+    variant. A product-level figure printed on each member is how a family's
+    size becomes every member's — the exact mistake reports.py names in writing
+    about product-level attributes."""
+    r = madar.resolve(_fields(spec_size="50 Kg", variant_axes='{"Size":"3.25 Kg"}'))
+
+    assert r is not None and (r.unit, r.quantity) == ("kg", 3.25)
+
+
+def test_a_specification_that_is_not_a_selling_unit_is_refused(madar):
+    """The pack list governs this witness like every other."""
+    assert madar.resolve(_fields(spec_size="20 mm")) is None
+    assert madar.resolve(_fields(spec_size="Sulphate Resistant Cement")) is None
+
+
+def test_the_connector_reads_both_shapes_the_api_returns():
+    """A dropdown arrives as selected_options and a text value as `value`.
+    Reading only one of them would have left half the catalogue silent."""
+    dropdown = {"custom_attributesV2": {"items": [
+        {"code": "size", "selected_options": [{"label": "50 Kg"}]}]}}
+    text = {"custom_attributesV2": {"items": [{"code": "size", "value": "20 Kg"}]}}
+
+    assert _spec_size(dropdown) == "50 Kg"
+    assert _spec_size(text) == "20 Kg"
+    assert _spec_size({"custom_attributesV2": {"items": [
+        {"code": "manufacturer", "value": "SABIC"}]}}) == ""
+    assert _spec_size(None) == ""
+
+
+# ---- the rule that stops the corrected reading standing beside the wrong one --
+
+@pytest.fixture()
+def conn():
+    path = pathlib.Path(tempfile.mkdtemp()) / "retire.db"
+    c = dbmod.connect(path)
+    dbmod.migrate(c)
+    c.execute("INSERT INTO source_site (source_id, source_key, source_name_ar, source_name,"
+              " base_url, platform, currency, timezone, authority, active) "
+              "VALUES (1,'S','س','S','http://s','magento-graphql','SAR','UTC','shop',1)")
+    c.execute("INSERT INTO source_product (source_product_id, source_id, "
+              " external_product_id, product_name, product_name_ar) VALUES (1,1,'p','P','ب')")
+    c.execute("INSERT INTO source_variant (source_variant_id, source_product_id, "
+              " external_variant_id) VALUES (1,1,'v')")
+    c.execute("INSERT INTO selling_unit (selling_unit_id, unit_code, name, name_ar) "
+              "VALUES (2,'kg','kilogram','كيلوجرام')")
+    return c
+
+
+_LEGACY = ("pre-0058: written without a charter; the field it was read from was "
+           "not recorded")
+
+_CORRECTED = {"country_code_alpha2": "SA", "currency": "SAR", "tax_included": "1",
+              "unit": "kg", "basis_quantity": "20",
+              "unit_basis_provenance": "stated_field",
+              "unit_basis_witness": "spec_size@und/v1: 20 Kg"}
+
+
+def _legacy_offer(conn, quantity: float) -> int:
+    return conn.execute(
+        "INSERT INTO source_offer (source_variant_id, country_code_alpha2, "
+        " customer_segment, basis_quantity, currency, tax_included, selling_unit_id, "
+        " unit_basis_provenance, unit_basis_witness) "
+        "VALUES (1,'SA','retail',?,'SAR',1,2,'legacy_unwitnessed',?)",
+        (quantity, _LEGACY)).lastrowid
+
+
+def test_a_corrected_reading_retires_the_one_it_replaces(conn):
+    """Migration 0060 did this once, by hand, for 18 offers on one warehouse on
+    one day. Nothing made it a RULE — so the next charter that learns to read a
+    field recreates the same pair: two rows, both active, one product answering
+    "what is one of these" twice.
+
+    It happens again here: the shop's panel says «20 Kg» where the row says 25,
+    and a different basis_quantity mints a NEW offer rather than replacing one —
+    which is right for two STATED units and wrong for two readings of one."""
+    from scrapex.ingest import _get_offer_id
+    stale = _legacy_offer(conn, 25.0)
+
+    fresh = _get_offer_id(conn, 1, dict(_CORRECTED))
+
+    states = dict(conn.execute("SELECT offer_id, status FROM source_offer"))
+    assert fresh != stale
+    assert states[stale] == "superseded", "the unsourced 25 kg is still a current price"
+    assert states[fresh] == "active"
+
+
+def test_a_legacy_reading_nothing_replaces_is_left_alone(conn):
+    """The condition 0060 was careful about, kept. Retiring a reading with no
+    replacement erases a unit and puts nothing in its place — the owner would
+    lose an answer to gain a principle. MADAR carried 92 unwitnessed offers and
+    only 18 had a witnessed sibling; the other 74 had to survive.
+
+    THE CRAWL IS RUN, not just the row inserted. An earlier version of this
+    test asserted on a row it had written itself and never called
+    _get_offer_id, so deleting the whole "unless something replaced it" clause
+    left it green — a guard for the condition that matters, guarding nothing."""
+    from scrapex.ingest import _get_offer_id
+    alone = _legacy_offer(conn, 25.0)
+    other = _legacy_offer(conn, 30.0)
+
+    # The variant is crawled again by code that still cannot name a witness.
+    # Writing an offer is not the same as answering for one, and a row with no
+    # witness can never be another row's replacement.
+    _get_offer_id(conn, 1, {"country_code_alpha2": "SA", "currency": "SAR",
+                            "tax_included": "1", "unit": "kg", "basis_quantity": "30"})
+
+    states = dict(conn.execute("SELECT offer_id, status FROM source_offer"))
+    assert states[alone] == "active", (
+        "a reading nothing witnessed replaced was retired; that erases a unit "
+        "and puts nothing in its place")
+    assert states[other] == "active"
+
+
+def test_a_witnessed_reading_never_retires_another_witnessed_one(conn):
+    """Two STATED units are two offers — "15 per litre" and "15 per gallon" —
+    and ingest has said so in writing since the sika fix. Only a row that says
+    of ITSELF that nobody can name its source may be retired."""
+    from scrapex.ingest import _get_offer_id
+    witnessed = conn.execute(
+        "INSERT INTO source_offer (source_variant_id, country_code_alpha2, "
+        " customer_segment, basis_quantity, currency, tax_included, selling_unit_id, "
+        " unit_basis_provenance, unit_basis_witness) "
+        "VALUES (1,'SA','retail',25,'SAR',1,2,'stated_field','variant_axes: 25 Kg')"
+    ).lastrowid
+
+    _get_offer_id(conn, 1, dict(_CORRECTED))
+
+    assert conn.execute("SELECT status FROM source_offer WHERE offer_id = ?",
+                        (witnessed,)).fetchone()[0] == "active"
+
+
+def test_nothing_is_deleted(conn):
+    """Retiring is the lifecycle state 0032 defined. price_observation is
+    append-only and what was observed was observed."""
+    from scrapex.ingest import _get_offer_id
+    stale = _legacy_offer(conn, 25.0)
+    conn.execute("INSERT INTO crawl_run (run_id, source_id, started_at, status) "
+                 "VALUES (1,1,'2026-08-04T00:00:00Z','success')")
+    conn.execute(
+        "INSERT INTO price_observation (offer_id, run_id, observed_at, business_date, "
+        " price, currency, tax_included, availability, record_hash, price_hash, "
+        " price_fields, provenance) VALUES (?,1,'2026-08-04T00:00:00Z','2026-08-04',"
+        "10,'SAR',1,'in_stock','rh','ph','effective','observed')", (stale,))
+
+    _get_offer_id(conn, 1, dict(_CORRECTED))
+
+    assert conn.execute("SELECT COUNT(*) FROM source_offer WHERE offer_id = ?",
+                        (stale,)).fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM price_observation WHERE offer_id = ?",
+                        (stale,)).fetchone()[0] == 1


### PR DESCRIPTION
MADAR's «إسمنت السعودية» carries **no size on its variants at all** — its option value is «Cement Type: Sulphate Resistant Cement» — and states «المقاس: 50 Kg» in its Specifications panel. That is the shop saying what one bag is, and **48** of its products state a mass or volume that way.

The charter was handed six fields and none of them was this one, so those readings kept the units pre-charter code invented for them and kept saying, in their own provenance, that nobody could name where they came from.

**It costs no request.** When a source declares enrichment this crawl already asks `_QUERY_ENRICHED`, and `custom_attributesV2` arrives in the same response the price row is built from.

## Measured over all 3,550 active offers, before the witness was written

| | |
|---|---|
| **13** | agree with what is stored — changing no number |
| **53** | carry no unit at all today and gain the one the shop states |
| **2** | **contradict**: stored 25 kg where the shop's own panel says «20 Kg», both `legacy_unwitnessed` |

## Ranked last, and that is load-bearing

A product-level size describes the **family**. Nine of the 48 have more than one variant, so printing the family's figure on each member is not a theoretical risk — it is the exact mistake `reports.py` names in writing about product-level attributes. The variant's own axis answers wherever it speaks; this is heard only where the variant is silent.

## 0060's rule becomes a rule

Migration `0060` retired 18 replaced readings **once, by hand, on one warehouse on one day**. Nothing made it standing, so the next charter that learns to read a field recreates the same pair: one row written by code that could not name a witness, one by code that can, both active, the same product answering *"what is one of these"* twice.

That is exactly what those 2 contradicting offers would have done — a different `basis_quantity` mints a **new** offer rather than replacing one, which is right for two *stated* units and wrong for two *readings* of one.

Ingest now retires a `legacy_unwitnessed` reading at the moment something witnessed answers for it, and keeps 0060's careful condition: only a row that says of **itself** that nobody can name its source, and only when something replaced it. Nothing is deleted — `price_observation` is append-only and the history stays.

## A hole in my own test, found by mutating

`test_a_legacy_reading_nothing_replaces_is_left_alone` asserted on a row it had inserted itself and **never called `_get_offer_id`**, so deleting the entire *"unless something replaced it"* clause left it green. A guard for the condition that matters, guarding nothing. It now runs the crawl path with two unwitnessed readings present, and the same deletion turns it red.

## Mutations, all five proved to bite

dropping the witness · ranking it above the variant axes · the connector no longer reading dropdown values · retirement touching a witnessed sibling · retirement firing with no replacement

## Gates

`pytest` full suite · contract parity · extension 19/0 · `validate-manifest` — green.

## What remains of the original 74

**4** rest only on the `weight` field, ruled out for cause and measured: price/weight p99 1,253, max 38,923. Those stay honestly marked as unwitnessed.