### PR TITLE
The engine upgrades its own warehouse instead of sending the owner to a terminal

### DIFF
--- a/scrapex/archive.py
+++ b/scrapex/archive.py
@@ -18,6 +18,14 @@ def backup_database(db_path: Path | str, tag: str = "rebuild") -> Path:
     """Consistent point-in-time copy of harvest.db, using SQLite's online backup
     (never a raw file copy — WAL means a copy mid-write can be torn)."""
     src = Path(db_path)
+    # A BACKUP OF NOTHING IS NOT A BACKUP. sqlite3.connect CREATES the file it
+    # is handed, so backing up a path that does not exist produced an empty
+    # database and reported success. Every caller here uses the result to decide
+    # it is safe to proceed — the engine's own upgrade will not migrate without
+    # one — and a guard that cannot fail is not a guard. Found by a test that
+    # expected the missing-file case to refuse and watched it migrate.
+    if not src.is_file():
+        raise FileNotFoundError(f"there is no database at {src} to back up")
     stamp = utc_now_iso().replace(":", "").replace("-", "")
     dst = src.with_name(f"{src.stem}.{tag}-{stamp}.backup{src.suffix or '.db'}")
     source = sqlite3.connect(str(src))

--- a/scrapex/cli.py
+++ b/scrapex/cli.py
@@ -678,6 +678,72 @@ def _cmd_export(args: argparse.Namespace) -> int:
     return _publish_with(args, LocalSink(), "exported")
 
 
+# The one status that means "behind, and nothing else is wrong". Matched
+# exactly, so "Needs a newer ScrapeX" (a DOWNgrade, never) and "Integrity check
+# failed" (damage, never) both fall through to the refusal below.
+BEHIND = "Needs upgrade"
+
+
+def _upgrade_what_is_only_behind(registry, report: dict) -> dict:
+    """Back up and migrate a warehouse whose only fault is that it is behind.
+
+    THIS REVERSES A DECISION THIS PROJECT HAD WRITTEN DOWN, at the owner's
+    instruction on 2026-08-05, and the reversal is recorded rather than
+    smuggled. registry.ensure_ready still says — truthfully — that IT never
+    migrates an existing database, "advancing the schema of a file that already
+    holds the owner's data is their decision (spec 40)". Its contract ends with
+    "the caller decides what to do with a report that is not ok", and this is
+    the caller deciding.
+
+    WHY IT CHANGED. Migration 0061 merged and was never applied here, so the
+    next time the engine started it refused — correctly, and with the exact
+    command to run — and the owner saw only a dead engine. The rule protected
+    the data and cost him the product, because the one person the refusal
+    speaks to is the one who does not read a log. He asked for the upgrade to
+    become part of the procedure instead.
+
+    WHAT THE OLD RULE WAS PROTECTING IS KEPT, all of it:
+
+      - A BACKUP FIRST, ALWAYS. If the copy cannot be made, nothing is
+        migrated and the engine refuses exactly as before. There is no path
+        through here that advances a schema without a restorable copy beside
+        it, and the retention policy keeps those copies from piling up.
+      - ONLY FORWARD, and only from "behind". A database written by a NEWER
+        build reports a different status and is never touched — downgrading is
+        how a warehouse dies.
+      - ONLY WHEN NOTHING ELSE IS WRONG. A damaged file reports "Integrity
+        check failed", and migrating damage is how a small corruption becomes
+        an unrecoverable one.
+      - IT SAYS SO, on stdout and in the log, naming the backup by path. Silent
+        would have been the real breach.
+
+    Returns the report after the attempt — the caller re-reads `ok` and does
+    not have to know whether anything happened.
+    """
+    from .archive import backup_database
+
+    behind = [state for state in report["databases"].values()
+              if not state["ok"] and state["status"] == BEHIND]
+    if not behind or len(behind) != sum(1 for s in report["databases"].values() if not s["ok"]):
+        return report                      # something else is wrong; do not touch it
+
+    for state in behind:
+        path = Path(state["path"])
+        try:
+            made = backup_database(path, tag="pre-upgrade")
+        except Exception as exc:           # noqa: BLE001 — no backup, no migration
+            print(f"error: the {state['kind']} database is behind but could not be "
+                  f"backed up, so it was not upgraded ({exc})", file=sys.stderr)
+            return report
+        print(f"backed up the {state['kind']} database to {made} before upgrading")
+
+    applied = registry.initialize()
+    for kind, versions in applied.items():
+        if versions:
+            print(f"upgraded the {kind} database: applied {versions}")
+    return registry.ensure_ready()
+
+
 def _cmd_ui(args: argparse.Namespace) -> int:
     # THE ENGINE FIRST OF ALL. Launched from the Startup folder it runs
     # under pythonw, which hands the process no stdout and no stderr at
@@ -702,6 +768,10 @@ def _cmd_ui(args: argparse.Namespace) -> int:
         report = registry.ensure_ready()
         for kind in report["created"]:
             print(f"created the {kind} database")
+        if not report["ok"]:
+            # Starting the engine IS the setup, and a schema that is merely
+            # behind is setup rather than a fault the owner must go and fix.
+            report = _upgrade_what_is_only_behind(registry, report)
         if not report["ok"]:
             for state in report["databases"].values():
                 if not state["ok"]:

--- a/scrapex/databases/registry.py
+++ b/scrapex/databases/registry.py
@@ -116,6 +116,19 @@ class DatabaseRegistry:
         a database that is behind is reported with the command that upgrades it
         rather than upgraded behind their back. The caller decides what to do
         with a report that is not ok; this method never refuses on its own.
+
+        AND SINCE 2026-08-05 ONE CALLER DECIDES TO UPGRADE. `scrapex ui` — the
+        single path every launch takes, terminal or panel button or autostart —
+        backs the file up and migrates it when its ONLY fault is being behind
+        (cli._upgrade_what_is_only_behind). The owner asked for that after
+        migration 0061 merged, was never applied here, and the engine refused to
+        start with the exact command to fix it in a log he had no reason to
+        read: the rule protected his data and cost him the product.
+
+        This sentence stays true of THIS method, and the protections spec 40
+        existed for are kept in the caller — a backup first without exception,
+        forward only, never over damage, and said out loud. Nothing else in the
+        codebase may migrate an existing file.
         """
         created: list[str] = []
         for database in (self.general, self.marketlens):

--- a/tests/test_database_notification.py
+++ b/tests/test_database_notification.py
@@ -126,11 +126,25 @@ def test_a_reachable_engine_on_an_unusable_database_does_not_report_ok(tmp_path)
 
 def test_the_engine_refuses_to_start_with_the_action_not_a_traceback(tmp_path, capsys):
     """A database the engine cannot use must stop it — half-serving is worse. But
-    the owner has to be told what to run, and a stack trace does not tell them."""
+    the owner has to be told what to run, and a stack trace does not tell them.
+
+    THE FAULT THIS USES CHANGED ON 2026-08-05. It rewound the schema by one and
+    asserted the refusal, because being behind was a fault the owner had to go
+    and fix. It is not any more: `scrapex ui` now backs the file up and migrates
+    it when behind is the ONLY thing wrong, and this test would have been
+    asserting that the engine still refuses to do the thing it was just taught
+    to do.
+
+    So it uses a fault the engine still cannot fix and never will — a database
+    written by a LATER build, where the way out is to update ScrapeX and never
+    to touch the file. The rule under test is unchanged: stop, and say what to
+    do. The behind-and-upgraded path is covered in
+    test_the_engine_upgrades_its_own_warehouse.py, where it can be driven
+    without starting a server that would then not stop."""
     from scrapex.cli import main
 
     registry = make_registry(tmp_path)
-    rewind(registry.marketlens, registry.marketlens.latest_schema_version - 1)
+    rewind(registry.marketlens, registry.marketlens.latest_schema_version + 1)
     pointer = registry.pointer_file
 
     import scrapex.cli as cli
@@ -144,5 +158,6 @@ def test_the_engine_refuses_to_start_with_the_action_not_a_traceback(tmp_path, c
 
     assert code == 1, "the engine served requests against a database it cannot read"
     err = capsys.readouterr().err
-    assert "needs upgrade" in err
-    assert "init-db" in err, "the message named no way out"
+    assert "needs a newer scrapex" in err.lower()
+    assert "Update ScrapeX" in err, "the message named no way out"
+    assert "Traceback" not in err, "it answered with a stack trace"

--- a/tests/test_the_engine_upgrades_its_own_warehouse.py
+++ b/tests/test_the_engine_upgrades_its_own_warehouse.py
@@ -1,0 +1,177 @@
+"""The engine refused to start, said exactly how to fix it, and nobody read it.
+
+Migration 0061 merged on 2026-08-04 and was never applied to the owner's live
+warehouse. The next time the engine started it refused — correctly, and with the
+command to run — and what he saw was a dead engine. The rule protected his data
+and cost him the product, because the one person a refusal on stderr speaks to
+is the one who does not read logs.
+
+He asked for the upgrade to become part of the procedure. That reverses what
+registry.ensure_ready has said in writing since spec 40 — "advancing the schema
+of a file that already holds the owner's data is their decision" — and that
+sentence is still true of ensure_ready. The decision moved to its caller, which
+is where its own docstring always said the decision lived.
+
+EVERYTHING SPEC 40 WAS PROTECTING IS KEPT, and every one of those is a test
+below: a backup first without exception, forward only, never over damage, and
+said out loud.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from scrapex import cli
+
+
+class _FakeRegistry:
+    """A registry that reports what the test wants and records what was asked of it."""
+
+    def __init__(self, states: dict, after: dict | None = None):
+        self._states = states
+        self._after = after
+        self.initialized = False
+
+    def initialize(self):
+        self.initialized = True
+        return {"marketlens": [59], "general": []}
+
+    def ensure_ready(self):
+        states = self._after if self._after is not None else self._states
+        return {"ok": all(s["ok"] for s in states.values()),
+                "created": [], "databases": states}
+
+
+def _state(kind: str, path, ok: bool, status: str) -> dict:
+    return {"kind": kind, "path": str(path), "ok": ok, "status": status,
+            "action": "", "schema_version": 58, "application_id": None}
+
+
+@pytest.fixture()
+def warehouse(tmp_path):
+    """A real SQLite file, because the backup is a real sqlite3 backup."""
+    import sqlite3
+    path = tmp_path / "marketlens.db"
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE t (x)")
+    conn.execute("INSERT INTO t VALUES (1)")
+    conn.commit()
+    conn.close()
+    return path
+
+
+def _report(states):
+    return {"ok": all(s["ok"] for s in states.values()), "created": [],
+            "databases": states}
+
+
+def test_a_warehouse_that_is_only_behind_is_backed_up_and_upgraded(warehouse, capsys):
+    """The case that cost the owner his engine."""
+    states = {"marketlens": _state("marketlens", warehouse, False, "Needs upgrade"),
+              "general": _state("general", warehouse, True, "Healthy")}
+    healthy = {k: dict(v, ok=True, status="Healthy") for k, v in states.items()}
+    registry = _FakeRegistry(states, after=healthy)
+
+    result = cli._upgrade_what_is_only_behind(registry, _report(states))
+
+    assert registry.initialized
+    assert result["ok"]
+    said = capsys.readouterr().out
+    assert "backed up" in said and "upgraded" in said, (
+        "the upgrade happened in silence; silent is the real breach")
+
+
+def test_the_backup_exists_before_anything_is_migrated(warehouse):
+    """A BACKUP FIRST, WITHOUT EXCEPTION. There is no path through here that
+    advances a schema without a restorable copy beside it."""
+    states = {"marketlens": _state("marketlens", warehouse, False, "Needs upgrade")}
+    registry = _FakeRegistry(states, after={k: dict(v, ok=True, status="Healthy")
+                                            for k, v in states.items()})
+
+    cli._upgrade_what_is_only_behind(registry, _report(states))
+
+    copies = list(warehouse.parent.glob("marketlens.pre-upgrade-*.backup.db"))
+    assert len(copies) == 1
+    assert copies[0].stat().st_size > 0
+
+
+def test_nothing_is_migrated_when_the_backup_cannot_be_made(tmp_path, capsys):
+    """If the copy fails the engine refuses exactly as it did before. An upgrade
+    with no way back is the one thing spec 40 was written to prevent."""
+    missing = tmp_path / "not-there.db"
+    states = {"marketlens": _state("marketlens", missing, False, "Needs upgrade")}
+    registry = _FakeRegistry(states)
+
+    result = cli._upgrade_what_is_only_behind(registry, _report(states))
+
+    assert not registry.initialized, "it migrated a database it could not back up"
+    assert not result["ok"]
+    assert "could not be backed up" in capsys.readouterr().err
+
+
+def test_a_database_from_a_newer_build_is_never_touched(warehouse):
+    """FORWARD ONLY. Downgrading is how a warehouse dies, and a file written by
+    a later ScrapeX reports its own status precisely so this can refuse it."""
+    states = {"marketlens": _state("marketlens", warehouse, False, "Needs a newer ScrapeX")}
+    registry = _FakeRegistry(states)
+
+    cli._upgrade_what_is_only_behind(registry, _report(states))
+
+    assert not registry.initialized
+    assert not list(warehouse.parent.glob("*pre-upgrade*"))
+
+
+def test_a_damaged_database_is_never_migrated(warehouse):
+    """NEVER OVER DAMAGE. Migrating a corrupt file is how a small corruption
+    becomes an unrecoverable one."""
+    for status in ("Integrity check failed", "Failed"):
+        states = {"marketlens": _state("marketlens", warehouse, False, status)}
+        registry = _FakeRegistry(states)
+
+        cli._upgrade_what_is_only_behind(registry, _report(states))
+
+        assert not registry.initialized, f"it migrated a database reported as {status!r}"
+
+
+def test_one_behind_beside_one_damaged_upgrades_neither(warehouse):
+    """THE MIXED CASE. Two databases, one merely behind and one damaged: the
+    run is not partly safe, so nothing is touched and the engine reports as
+    before. Upgrading the healthy half would leave a pair that has never
+    existed together."""
+    states = {"marketlens": _state("marketlens", warehouse, False, "Needs upgrade"),
+              "general": _state("general", warehouse, False, "Integrity check failed")}
+    registry = _FakeRegistry(states)
+
+    result = cli._upgrade_what_is_only_behind(registry, _report(states))
+
+    assert not registry.initialized
+    assert not result["ok"]
+
+
+def test_a_healthy_pair_is_left_entirely_alone(warehouse):
+    """The overwhelmingly common start. Nothing is copied, nothing is migrated,
+    and no disk is spent saying so."""
+    states = {"marketlens": _state("marketlens", warehouse, True, "Healthy"),
+              "general": _state("general", warehouse, True, "Healthy")}
+    registry = _FakeRegistry(states)
+
+    cli._upgrade_what_is_only_behind(registry, _report(states))
+
+    assert not registry.initialized
+    assert not list(warehouse.parent.glob("*pre-upgrade*"))
+
+
+def test_the_reversal_is_recorded_where_the_rule_was_written():
+    """spec 40 has no document — the citation in registry.py IS the record. A
+    rule reversed without amending the place it was stated is a rule two people
+    can still read opposite ways."""
+    source = pathlib.Path(
+        __import__("scrapex.databases.registry", fromlist=["x"]).__file__
+    ).read_text(encoding="utf-8")
+
+    assert "spec 40" in source, "the rule's own citation has gone"
+    assert "_upgrade_what_is_only_behind" in source, (
+        "ensure_ready still reads as though nothing may ever upgrade an "
+        "existing database, and one caller now does")


### PR DESCRIPTION
Migration `0061` merged on 2026-08-04 and was **never applied to the owner's live warehouse**. The next time the engine started it refused — correctly, and with the exact command to run — and what he saw was a dead engine and no reason.

The rule protected his data and cost him the product, because the one person a refusal on stderr speaks to is the one who does not read logs.

He asked for the upgrade to become part of the procedure, and chose **the engine** over a step in a merge routine — because a routine lives in someone's memory, and this one had just failed.

## This reverses a decision the project had written down

`registry.ensure_ready` still says, truthfully, that **it** never migrates an existing file: *"advancing the schema of a file that already holds the owner's data is their decision (spec 40)"*. Its contract has always ended *"the caller decides what to do with a report that is not ok"* — and `scrapex ui` is now a caller that decides.

**spec 40 has no document; that citation is the record**, so the reversal is written there: what changed, why, and the name of the function that does it.

One place covers every launch — terminal, the panel's start button, autostart and relaunch all run `python -m scrapex.cli ui`.

## What spec 40 was protecting is kept, and each part is a test

| | |
|---|---|
| **A backup first, without exception** | no path advances a schema without a restorable copy beside it; if the copy fails, nothing is migrated |
| **Forward only** | a database from a *newer* build reports its own status and is never touched — downgrading is how a warehouse dies |
| **Never over damage** | `Integrity check failed` is a different status; migrating a corrupt file is how small corruption becomes unrecoverable |
| **Not partly** | one behind beside one damaged upgrades **neither** — a pair half-advanced has never existed together |
| **It says so** | naming the backup by path. Silent would have been the breach |

## A defect the tests found, in code this one relies on

`archive.backup_database` **"succeeded" on a path that does not exist.** `sqlite3.connect` *creates* the file it is handed, so it produced an empty database and reported it as a backup — and every caller uses that result to decide it is safe to proceed.

The missing-file test expected a refusal and watched a migration instead. It now refuses: **a backup of nothing is not a backup.**

## An existing guard moved to a fault that is still a fault

`test_the_engine_refuses_to_start_with_the_action_not_a_traceback` rewound the schema by one and asserted the refusal. Behind is no longer something the owner must go and fix, so the test would have been asserting that the engine still refuses to do what it was just taught to do.

It now uses a database written by a **later** build — a fault the engine cannot fix and never will — and the rule it guards is unchanged: stop, and say what to do, not a stack trace.

## Rehearsed on a copy of the live warehouse

Never the original. 101 MB put back to v58, then handed to this code: backup taken, migration 59 applied, status `Healthy`, **83,633 observations unchanged**, `quick_check: ok`.

## Mutations, all five proved to bite

migrating without a backup · accepting any failing status · upgrading the behind half of a mixed pair · backing up a database that is not there · doing it in silence

## Gates

`pytest` full suite · contract parity · extension 19/0 — green.