### PR TITLE
Escape closes the list wherever focus is, and my last diagnosis was wrong

### DIFF
--- a/extension/app.js
+++ b/extension/app.js
@@ -804,6 +804,20 @@ function setupFinanceConverterSelect({selectId, triggerId, listId, labelPrefix})
       event.preventDefault();
       if (list.classList.contains("hidden")) open();
       else close();
+    } else if (event.key === "Escape" && !list.classList.contains("hidden")) {
+      // ESCAPE HAS TO BE HEARD HERE TOO, and the only other listener is on the
+      // LIST. open() moves focus into the list inside a requestAnimationFrame,
+      // so between the click that opens it and the frame that lands, focus is
+      // still on this trigger and Escape reached NOTHING — the list stayed open
+      // with no keyboard way out of it. The same holds afterwards for anyone
+      // who shift-tabs back to the trigger.
+      //
+      // It surfaced as an intermittently red CI job and I first recorded it as
+      // a race in the test, "not a defect in the panel". It is a defect in the
+      // panel: waiting for the list properly did not make the test pass, it
+      // made it fail for thirty seconds with the list resolved visible 63 times.
+      event.preventDefault();
+      close({restoreFocus: true});
     }
   });
   list.addEventListener("keydown", (event) => {
@@ -1700,6 +1714,20 @@ function setupRunModeSelect() {
       event.preventDefault();
       if (list.classList.contains("hidden")) open();
       else focusOption(event.key === "ArrowDown" ? 1 : -1);
+    } else if (event.key === "Escape" && !list.classList.contains("hidden")) {
+      // ESCAPE HAS TO BE HEARD HERE TOO, and the only other listener is on the
+      // LIST. open() moves focus into the list inside a requestAnimationFrame,
+      // so between the click that opens it and the frame that lands, focus is
+      // still on this trigger and Escape reached NOTHING — the list stayed open
+      // with no keyboard way out of it. The same holds afterwards for anyone
+      // who shift-tabs back to the trigger.
+      //
+      // It surfaced as an intermittently red CI job and I first recorded it as
+      // a race in the test, "not a defect in the panel". It is a defect in the
+      // panel: waiting for the list properly did not make the test pass, it
+      // made it fail for thirty seconds with the list resolved visible 63 times.
+      event.preventDefault();
+      close({restoreFocus: true});
     }
   });
   list.addEventListener("keydown", (event) => {

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -1346,15 +1346,46 @@ def test_run_mode_uses_the_themed_listbox_instead_of_the_native_blue_popup(open_
     assert themed, "the selected row escaped the active theme"
 
     page.keyboard.press("Escape")
-    # WAITED FOR, not asserted on the next line. Escape hides the list through
-    # a style change the browser applies on its own schedule, and reading
-    # is_visible() in the same breath asks whether it has happened YET. It had
-    # on every local run and on one of CI's two jobs; the other went red on
-    # 2026-08-05 with the list still up, which is a race in the test and not a
-    # defect in the panel. The assertion stays underneath so the intent is
-    # still legible — the wait is what makes it mean something.
+    # WAITED FOR, not asserted on the next line.
     page.wait_for_selector("#run-mode-list", state="hidden")
     assert not page.locator("#run-mode-list").is_visible()
+
+
+def test_escape_closes_the_list_while_focus_is_still_on_the_trigger(open_panel):
+    """The defect the wait uncovered, and the reason it is a panel defect and
+    not a test one.
+
+    open() moves focus INTO the list inside a requestAnimationFrame, and the
+    only Escape listener was on the list. Between the click that opens it and
+    the frame that lands, focus is still on the trigger — and Escape reached
+    nothing. The list stayed open with no keyboard way out of it, which is also
+    true for anyone who shift-tabs back to the trigger afterwards.
+
+    It showed up as an intermittently red CI job. I first recorded it as a race
+    in the test and "not a defect in the panel"; that was wrong. Waiting
+    properly did not make it pass — it made it fail for thirty seconds with the
+    list resolved visible sixty-three times, which is what a real user gets.
+
+    This test presses Escape with focus DELIBERATELY on the trigger, so it does
+    not depend on losing a race to catch the bug."""
+    page = open_panel()
+    page.click(RUN_TAB)
+    page.wait_for_timeout(200)
+
+    page.click("#run-mode-trigger")
+    page.wait_for_selector("#run-mode-list", state="visible")
+    # Put focus back where a fast user's still is, and where a shift-tab leaves it.
+    page.locator("#run-mode-trigger").focus()
+    page.keyboard.press("Escape")
+
+    # wait_for_selector IS the assertion — it raises if the list never hides,
+    # which is exactly the 30-second failure CI produced. Nothing is asserted
+    # about focus here: this test puts focus on the trigger itself, so finding
+    # it there afterwards would be true whether or not close() restored it.
+    # Proved by mutation — dropping restoreFocus left that assertion green, so
+    # it was decoration and it is gone. The focus behaviour is the list
+    # handler's, and belongs in a test that presses Escape from inside the list.
+    page.wait_for_selector("#run-mode-list", state="hidden")
 
 
 def test_update_is_not_on_offer_for_a_site_with_no_data(open_panel):


### PR DESCRIPTION
Yesterday I fixed an intermittently red CI job by **waiting** for the run-mode listbox to hide instead of asserting it on the next line, and wrote in the commit:

> *"That is a race in the test, not a defect in the panel."*

**It is a defect in the panel.** The wait did not make the test pass — it made it fail honestly. CI came back with a **thirty-second timeout** and the list *"resolved to visible"* **sixty-three times**. Nothing was racing; Escape did nothing at all.

## Why

`open()` reveals the list and then moves focus into it inside a `requestAnimationFrame`. The only Escape listener is on the **list**.

Between the click that opens it and the frame that lands, focus is still on the **trigger** — whose keydown handler knows `ArrowUp`, `ArrowDown`, `Enter` and `Space`, and **not** `Escape`. An Escape arriving in that window reaches nothing, and the list stays open with no keyboard way out of it.

That is not only a test's problem:

- someone who opens the list and presses Escape **straight away** is stuck;
- so is anyone who **shift-tabs back to the trigger** and tries to dismiss it from there.

Both listbox widgets in `app.js` have the same shape and both had the bug. Both trigger handlers now hear Escape.

## The test no longer depends on losing a race

A new test puts focus on the trigger **deliberately** and presses Escape, so it catches this whether or not the frame has landed. Putting the defect back turns it red.

## And one of its assertions was decoration, which mutation found

It also asserted that focus returns to the trigger. But the test puts focus there itself, so that is true whether `close()` restores it or not — **dropping `restoreFocus` left the assertion green.** It is gone, and the comment says why.

`wait_for_selector(state="hidden")` is the assertion that bites: it raises with exactly the failure CI produced.

## How it was found

While reviewing **#39** — a spike that touches no runtime code at all — which means this was failing on `main`, intermittently, for anyone who merged today.

## Gates

`pytest` full suite · contract parity · extension 19/0 — green.