### PR TITLE
Nine assertions that need no wait, judged one at a time

### DIFF
--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -7,6 +7,58 @@ capturing, so the broken opening screen was never photographed.
 
 These tests drive the panel's own HTML, CSS and JS through the same harness the
 screenshots use, and assert what a person would see and do.
+
+WHY MOST `.is_visible()` ASSERTIONS HERE CARRY NO WAIT, DELIBERATELY.
+
+Nine of them read `.is_visible()` on the line after a click, a key press or a
+fill. That is measured, not assumed — and the rule is narrower than it looks.
+
+The load-bearing property is NOT "the handler did it". It is that the change
+lands inside the action's own INPUT TASK, and the driver does not acknowledge the
+action until that whole task is done. Three of the nine are applied by no
+listener at all: both `<details>` sites and the Enter-on-an-option site flip in
+the ACTIVATION BEHAVIOUR, which Blink runs after the event has finished
+propagating. Measured — at the last window bubble listener the closing disclosure
+still reads visible, and Enter changes nothing in any keydown listener; Blink
+synthesises a click as the keydown's default action, and that second event's
+listener is what closes the list. Both are still correct on the very next line,
+because the action does not return until the task ends. Do not restate this as
+"synchronous inside the handler": that is false for a third of the sites it
+covers, and someone applying it to a new site would get the wrong answer.
+
+The remaining six are CSS with nothing to defer: `.hidden {display: none
+!important}` and `[data-save-state="saved"] {display: none}`, neither of them a
+transitionable property.
+
+A wait at any of the nine would wait for something already done, and the day the
+panel stops showing or hiding the element it would convert a one-line assertion
+failure into a timeout. Add one only where a state change is genuinely deferred,
+and name the deferral when you do.
+
+WHAT PROTECTS THE *SHOW* ASSERTIONS IS THINNER THAN IT LOOKS. Playwright's
+predicate is `checkVisibility()` AND `visibility != hidden` AND a non-empty rect;
+opacity is not in it. So `#view-appearance` is read while its entry animation is
+still running and computes to `opacity: 0`, and passes anyway. The listboxes are
+read at `select-menu-in` currentTime 0, where the box is non-empty only because
+the 0% keyframe is `scale(.98)`: change it to an ordinary `scaleY(0)` and the
+identical assertion reads not-visible on a 226x0 box — measured. If you touch
+`@keyframes select-menu-in` (extension/app.css) or the keyframes in `showView`,
+re-measure these. What protects them is the animated property, not the structure
+of the code.
+
+Measure before adding one, by performing the action inside the page and reading
+the visibility in the same JavaScript task. Read it with `checkVisibility()`:
+`getBoundingClientRect()` on a descendant of a CLOSED `<details>` still reports
+the last laid-out size, because Chromium skips that subtree rather than resizing
+it, so a rect-based check calls a shut disclosure visible and invents a race that
+is not there.
+
+Do NOT reach for a slow machine or CPU throttling to settle it. Throttling hides
+a deferred change instead of exposing it: it stretches the round trip between the
+action and the read far more than the work in between, so the deferred thing has
+landed by the time you look. Measured — a build broken on purpose to defer one of
+these failed 15/15 unthrottled and passed 15/15 at 20x. A green run under load is
+not evidence of synchrony; the same-task read is.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
**This adds 52 lines of documentation to one file and changes no test logic.** No
wait was added, no assertion touched, no panel code modified. The deliverable is
the verdict and its reasons; the diff is where they are recorded so the next
person to scan for this pattern finds them.

## The question

A scan for `assert ....is_visible()` within three lines of a click, a key press,
a fill or a dispatch, with no wait between, finds nine sites besides the one
already wrapped in a wait. Do they need `page.wait_for_selector(...)`?

**No — none of the nine.** Judged one at a time, not as a class. A wait added
everywhere would hide the next real regression behind a 30-second timeout.

## What makes them safe, and what I got wrong first

The property is **not** "the handler applied it synchronously" — that phrasing is
false for a third of them. It is that the change lands inside the action's own
**input task**, and the driver does not acknowledge the action until that task
ends.

Three of the nine are applied by no listener at all:

| site | mechanism | measured |
|---|---|---|
| 892, 1069 (`<details>`) | flip in the **activation behaviour**, which Blink runs after the event finishes propagating | at the last `window` bubble listener the closing disclosure still reads **visible**; hidden the moment `page.click()` returns |
| 972 (Enter on an option) | Enter changes nothing in any keydown listener; Blink synthesises a click as the default action and *that* listener runs `close()` | keydown dispatch `True`, synthesised click dispatch `False` |

The other six are CSS with nothing to defer: `.hidden {display: none !important}`
and `[data-save-state="saved"] {display: none}`, neither transitionable.

I originally wrote "inside the action's own event dispatch". It reaches the right
conclusion by the wrong route, and anyone applying that wording to a new site
would get the wrong answer. The docstring now states the task rule.

## Evidence

- **Same-task reads** with `checkVisibility()` — the predicate Playwright
  actually uses. A rect-based check reports a descendant of a *closed*
  `<details>` at its last laid-out size (Chromium skips the subtree rather than
  resizing it); that artefact made site 1069 look asynchronous on the first pass.
- **Nine mutations, each caught at its own line, immediately.** The view kept
  hidden, a dirty form left `display:none`, a disclosure refusing the toggle,
  each listbox never unhidden, the closed disclosure still rendering. Re-run
  after #99 changed `app.js`, and again after the docstring moved the lines —
  9/9 each time. This is the half that matters: it shows the bare assertions
  still bite.
- **Five adversarial lenses, all returning "cannot refute" at high confidence**,
  each with a positive control that failed so the null results mean something:
  9,265 real Playwright actions with 0 mismatches; every duration forced to 5s
  under both `prefers-reduced-motion` settings, 144/144 with zero settle; the
  fill path dispatching exactly one input event already carrying the final value.

## Worth a reviewer's attention

**The show assertions are protected by thinner things than they look.**
Playwright's predicate excludes opacity, so `#view-appearance` is read while its
entry animation still computes to `opacity: 0` and passes anyway. The listboxes
are read at `select-menu-in` `currentTime 0`, where the box is non-empty **only**
because the 0% keyframe is `scale(.98)` — substituting an ordinary `scaleY(0)`
makes the identical assertion read not-visible on a 226x0 box. Anyone editing
`@keyframes select-menu-in` must re-measure these.

**A method that looks like evidence and is not.** I first offered a green run
under saturated CPU as support. It is worth nothing: throttling stretches the
round trip between the action and the read (9.5ms → 170ms) far more than the work
in between, so a deferred change has landed by the time you look. The same
deliberately-broken build fails 15/15 unthrottled and passes 15/15 at 20x. The
docstring says so now, so the next person does not repeat it.

## Two things found, neither fixed here

- **Site 886 is a weak assertion.** It asserts NOT visible, so its default answer
  is "pass": while the status fetch is in flight, `saved` is null, `dirty` can
  never be true, and the button is hidden whatever happens. It stayed green under
  an injected 120ms deferral that site 868 caught.
- **Nothing in the suite presses Escape on either converter listbox.** Their
  Escape handler is one source line instantiated twice, and disabling it turns no
  test red. #99 gave their triggers an Escape branch too, untested for the same
  reason.

## Correcting myself on #99's site

I reported that the wait guarding the Escape assertion did not address its race,
and measured the losing case: with focus deferred past the key press the test
failed in 33.0s on the 30s timeout rather than on the assertion. The diagnosis
was right — the deferral is FOCUS, not a style change — but the remedy I proposed
was wrong. Waiting for focus to reach the list would have made the test green
over a real defect: a user who opened the list and pressed Escape before the
frame landed had no keyboard way out. #99 fixed it in the panel, where it
belonged. Nothing to change on the test side; that wait stays.

## Gates

`pytest tests/test_panel_dom.py` — full file, green on this rebase. Mutation
re-run 9/9. Tree clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
