### PR TITLE
The pictures salla publishes in its markup — the half whose measurement still holds

### DIFF
--- a/scrapex/connectors/jsonld.py
+++ b/scrapex/connectors/jsonld.py
@@ -81,11 +81,45 @@ class WalkTally:
     unreachable: int = 0
     skipped: int = 0
     english_lost: int = 0
+    # The fuller picture route (below): pages whose OWN picture record was
+    # readable, and pages that published pictures in their JSON-LD while that
+    # record could not be found. The second is the number that matters — it is
+    # how a theme update announces itself instead of silently halving the
+    # images a source lands.
+    pictures_read: int = 0
+    pictures_route_lost: int = 0
     unreadable_children: list[str] = None  # type: ignore[assignment]
 
     def __post_init__(self) -> None:
         if self.unreadable_children is None:
             self.unreadable_children = []
+
+    def picture_route_defects(self) -> list[str]:
+        """Stated as a DEFECT, not a warning, when the route stops matching.
+
+        A CSS class or a bootstrap variable is a contract the shop's theme can
+        end without telling anyone, and the failure mode is silence: the reader
+        matches nothing, every product keeps the one picture its JSON-LD names,
+        and the run reports plain success while the catalogue quietly loses the
+        rest. base.py draws the line — a warning says something went wrong and
+        was contained, a defect says the data this run produced is KNOWN to be
+        degraded, and only a defect reaches crawl_run.errors_count.
+
+        The rule is deliberately blunt: the route failing on MORE pages than it
+        worked on is not a handful of odd products, it is the shape having
+        changed. That covers the total case (`pictures_read == 0`) without
+        needing a second threshold for it.
+        """
+        if self.pictures_route_lost and self.pictures_route_lost > self.pictures_read:
+            return [
+                f"the page's own picture list could not be read on "
+                f"{self.pictures_route_lost} product page(s) that publish images, "
+                f"against {self.pictures_read} where it could — the shop's theme "
+                "has almost certainly changed and this run stored only the "
+                "pictures the JSON-LD summary names. The images are NOT gone "
+                "from the site; the reader stopped matching and needs updating."
+            ]
+        return []
 
     def notes(self) -> list[str]:
         notes: list[str] = []
@@ -111,6 +145,12 @@ class WalkTally:
                 "product JSON-LD could not be read (unreachable, unparsable, or "
                 "a different product) — their English columns are empty and "
                 "were never translated or guessed")
+        if self.pictures_route_lost:
+            notes.append(
+                f"{self.pictures_route_lost} product page(s) publish images in "
+                "their JSON-LD but carry no readable picture list of their own — "
+                "those products kept only the pictures the summary names, and "
+                "none were guessed at")
         return notes
 
 
@@ -275,7 +315,85 @@ def product_row(builder, node: dict, url: str, source, vat: str, pid: str,
     )
 
 
-def enrichment_rows(builder, node: dict, pid: str) -> list[list[str]]:
+@dataclass(frozen=True)
+class Picture:
+    """One picture a product page publishes.
+
+    `identity` is how the SITE tells two pictures apart, and it is deliberately
+    NOT the URL. A shop publishes the same picture at several sizes, and
+    advancedcastle names it at `.../thumbs/<uuid>-thumbnail-1000x1000-70.jpg`
+    in its JSON-LD while its own gallery renders `.../<uuid>.jpg`. MEASURED on
+    the full 168-product catalogue: of 435 JSON-LD image URLs, exactly 0 appear
+    as a gallery `<img src>` string, and yet 0 name a picture the gallery does
+    not have. Deduplicating on the URL would therefore have stored one picture
+    twice, under two attribute codes, on every product that has one — the
+    "two codes holding one URL" defect, arrived at from the other direction.
+
+    So the connector says what identity means for ITS shop: a media id where
+    the platform states one (zid publishes an image uuid), the URL itself where
+    the shop publishes each picture at exactly one address (salla does).
+
+    `label` is the alternative text the SITE wrote, empty when it wrote none.
+    Never invented and never translated: advancedcastle publishes ONE alt_text
+    per picture and serves the SAME Arabic string on its English locale, so
+    there is no second language to capture and no `_ar` pair to make.
+    """
+
+    identity: str
+    url: str
+    label: str = ""
+
+
+def merge_pictures(record: Iterable[Picture],
+                   summary: Iterable[Picture]) -> list[Picture]:
+    """Every picture the page publishes, the shop's own order, each one once.
+
+    `record` is the page's own picture list — the fuller truth — and `summary`
+    is what the machine-readable summary named. The record LEADS because its
+    order is the order the shop displays: schema.org allows `image` to name one
+    representative picture, and on 44 of advancedcastle's 168 products the
+    picture it names is not the gallery's first. Taking the summary's order
+    would put a middle picture where the main one belongs.
+
+    The summary is still merged in rather than replaced by, because it is not
+    always a subset: on 4 of those 168 products the page's own list and the
+    JSON-LD disagree about which pictures the product has, and 6 pictures exist
+    only in the JSON-LD. Dropping them would be a regression wearing the
+    clothes of an improvement — this run must never store less than the last.
+    """
+    out: list[Picture] = []
+    seen: set[str] = set()
+    for picture in [*record, *summary]:
+        if not picture.url or not picture.identity or picture.identity in seen:
+            continue
+        seen.add(picture.identity)
+        out.append(picture)
+    return out
+
+
+def jsonld_pictures(node: dict,
+                    identity: Callable[[str], str] | None = None) -> list[Picture]:
+    """The pictures schema.org `image` names.
+
+    Allowed to be a single URL or a list of them, and advancedcastle publishes
+    both forms (a string on single-image products, a list otherwise), so both
+    are read and neither is guessed at. `identity` is how the caller's shop
+    tells two pictures apart; without one the URL stands in, which is the right
+    answer for a shop that publishes each picture at exactly one address.
+    """
+    images = node.get("image")
+    if isinstance(images, str):
+        images = [images]
+    pictures: list[Picture] = []
+    for href in images or []:
+        if isinstance(href, str) and href.startswith("http"):
+            pictures.append(Picture(
+                identity=(identity(href) if identity else href), url=href))
+    return pictures
+
+
+def enrichment_rows(builder, node: dict, pid: str,
+                    pictures: Iterable[Picture] | None = None) -> list[list[str]]:
     """The pictures and prose the product page's JSON-LD already carried.
 
     Written for salla and left in salla, so the SECOND SSR family to want
@@ -286,9 +404,10 @@ def enrichment_rows(builder, node: dict, pid: str) -> list[list[str]]:
     caller's argument rather than a connector importing another connector
     (base.py). Nothing else here is site-specific.
 
-    schema.org allows `image` as a single URL or a list of them; advancedcastle
-    publishes both forms (a string on single-image products, a list otherwise),
-    so both are read and neither is guessed at.
+    `pictures` is the merged list the CALLER assembled from its shop's own
+    picture record and the JSON-LD summary (merge_pictures). Passing none keeps
+    the original behaviour — the JSON-LD's `image` alone — which is the honest
+    answer for a family whose pages publish nothing richer.
     """
     rows: list[list[str]] = []
 
@@ -306,14 +425,16 @@ def enrichment_rows(builder, node: dict, pid: str) -> list[list[str]]:
             value_url=url_value, lang="",
             attribute_group=decided if recognised else (group or decided)))
 
-    images = node.get("image")
-    if isinstance(images, str):
-        images = [images]
-    for position, href in enumerate(images or []):
-        if not isinstance(href, str) or not href.startswith("http"):
-            continue
+    if pictures is None:
+        pictures = jsonld_pictures(node)
+    for position, picture in enumerate(pictures):
+        # The shop's own alternative text when it wrote one, the file name when
+        # it did not — the same standing-in woocommerce and shopify already do,
+        # so the panel always has something to render an <img> alt with. The
+        # URL in value_url is the record and is never touched.
         add(f"image_{position}" if position else "image", "Image",
-            href.rsplit("/", 1)[-1], url_value=href, group=DetailGroup.MEDIA)
+            picture.label or picture.url.rsplit("/", 1)[-1],
+            url_value=picture.url, group=DetailGroup.MEDIA)
 
     add("description", "Description", node.get("description"), group="Description")
     add("sku", "SKU", node.get("sku"), group="Specs")

--- a/scrapex/connectors/salla.py
+++ b/scrapex/connectors/salla.py
@@ -9,11 +9,38 @@ we fall back to an AggregateOffer lowPrice, and skip a product with no usable
 price (its real variant prices need the extension's session capture — later).
 The pure parsers (`sitemap_locs`, `parse_product_jsonld`, `offer_price`) are
 unit-tested against fixtures; only the fetch loop touches the network.
+
+THE PICTURES (2026-07-30). This shop's JSON-LD names ONE picture per product
+while the page's slider names the set, and the picture the JSON-LD names is
+often not even the first slide. MEASURED over the whole alsweed catalogue,
+1,231 of 1,233 products fetched once each (2 pages did not answer; the site
+never objected): JSON-LD names 1,170 pictures, the sliders name 3,322 — a gap
+of 2,162 across 749 products. 61 products publish no picture at all and stay
+honestly blank.
+
+So the slider leads and the summary is merged in behind it (page_pictures
+below, merge_pictures in jsonld). It costs no request: the slider is in the
+SAME response the price is read from, which this connector previously
+discarded by walking with `walk_products` instead of `walk_product_pages`.
+
+The merge is keyed on the URL here, and that is checked rather than assumed:
+1,160 of the 1,170 JSON-LD image URLs are byte-identical to a slide href. The
+10 that are not are YouTube thumbnails the JSON-LD lists as product images and
+the slider files as `data-type="youtube"` slides; they are kept, because a run
+must never store less than the one before it.
+
+That reader is markup, and markup is a contract a theme update can end without
+telling anyone — silently, since the prices would still land and every product
+would keep the one picture its JSON-LD names. WalkTally counts the pages where
+it stops matching and raises a DEFECT, not a note, when it fails on more pages
+than it works on.
 """
 from __future__ import annotations
 
 import re
 from typing import Iterable
+
+from bs4 import BeautifulSoup
 
 from ..localinbox import safe_token
 from ..normalize import brand_pair
@@ -28,9 +55,10 @@ from .base import HttpFetcher, ScrapedTable, declare_frontier
 # generic; the /p{id} id scheme below is the salla-specific part. enrichment_rows
 # moved to jsonld when zid needed the same pictures-and-prose reading — it is
 # imported here rather than left behind so both families share one copy.
-from .jsonld import (WalkTally, brand_name, category_path, enrichment_rows,
+from .jsonld import (Picture, WalkTally, brand_name, category_path,
+                     enrichment_rows, jsonld_pictures, merge_pictures,
                      offer_price, parse_product_jsonld, product_row,
-                     sitemap_locs, sitemap_products, walk_products)
+                     sitemap_locs, sitemap_products, walk_product_pages)
 
 _PRODUCT_ID = re.compile(r"/p(\d{5,})")
 
@@ -44,6 +72,68 @@ def _salla_id(url: str, node: dict) -> str:
     """
     found = _PRODUCT_ID.search(url)
     return found.group(1) if found else str(node.get("sku") or url)
+
+
+def _product_key(url: str) -> str:
+    """The numeric /p{id} the slider keys its slides on, "" when the URL has none.
+
+    Deliberately NOT _salla_id: that falls back to the sku or the whole URL so
+    a price row always has an id, and neither of those is what
+    `data-fslightbox="product_…"` is built from. A URL with no numeric id has
+    no slider to find, and "" says exactly that.
+    """
+    found = _PRODUCT_ID.search(url)
+    return found.group(1) if found else ""
+
+
+def page_pictures(html: str, pid: str) -> list[Picture]:
+    """The pictures the product's own slider lists, in the shop's order.
+
+    THE ANCHOR, not the `<img>`, and not a CSS class. Each slide is
+    `<a data-fslightbox="product_{id}" data-img-id=… data-slid-index=… href=…>`,
+    and every part of that earns its place:
+
+    * `data-fslightbox="product_{id}"` ties the slide to THIS product, so a
+      page carrying a related-products carousel cannot leak its pictures in.
+    * `href` is the full-size URL and is always present. The `<img>` inside is
+      lazy-loaded — MEASURED on alsweed, only the first slide has a real `src`
+      and the rest carry `cdn.salla.network/images/s-empty.png` — so reading
+      `<img src>` would have stored the same placeholder as several pictures.
+    * the anchors appear ONCE per picture while the `<img>`s appear twice (the
+      slider renders a thumbnail strip as well), so this route is free of the
+      duplication a container-wide `img` sweep would have to undo.
+
+    `swiper-slide` and `magnify-wrapper` are on the same element and are the
+    theme's and a JS library's; they are deliberately not what this matches.
+
+    VIDEOS ARE NOT PICTURES. 7 of 787 slides on the alsweed sample are
+    `data-type="youtube"`, whose href is a video, so only `image` slides are
+    read here. The store's JSON-LD separately names some YouTube *thumbnails*
+    as product images; those rows already exist and the merge keeps them
+    rather than quietly dropping what this source already stored.
+    """
+    if not pid:
+        return []
+    soup = BeautifulSoup(html or "", "lxml")
+    pictures: list[Picture] = []
+    for slide in soup.select(f'a[data-fslightbox="product_{pid}"]'):
+        if str(slide.get("data-type") or "").strip().lower() != "image":
+            continue
+        href = str(slide.get("href") or "").strip()
+        if not href.startswith("http"):
+            continue
+        # Identity is the URL, and it is checked rather than assumed: on the
+        # alsweed census every JSON-LD image URL that names a picture (270 of
+        # 270) is byte-identical to a slide href, and no product repeats an
+        # href. Unlike zid, this shop publishes one picture at one address, so
+        # the URL tells two pictures apart correctly. `data-img-id` is a
+        # stronger identity if that ever stops being true — but it is not on
+        # the JSON-LD side, and an identity only one route can compute would
+        # store the overlap twice.
+        pictures.append(Picture(
+            identity=href, url=href,
+            label=str(slide.get("data-caption") or "").strip()))
+    return pictures
 
 
 def one_url_per_product(urls: list[str]) -> list[str]:
@@ -92,7 +182,11 @@ class SallaConnector:
                                for spec in source.extract)
         tally = WalkTally()
 
-        for url, token, node in walk_products(
+        # walk_product_pages rather than walk_products: the page's own slider
+        # is the only place this shop states its whole picture set, so the HTML
+        # the price was read from has to stay in hand. It costs no request —
+        # it is the SAME response, which the previous view simply discarded.
+        for url, token, html, node in walk_product_pages(
                 self._fetcher, self._product_urls(f"{base}/ar/sitemap.xml", tally),
                 self.skip_tokens, safe_token, tally):
             # ONE TABLE PER PRODUCT, journaled as fetched. This connector used
@@ -112,8 +206,21 @@ class SallaConnector:
                 # The pictures and descriptions the SAME page already carried,
                 # under the SAME token: one product is journaled once, so a
                 # resume cannot land its price without its details.
+                #
+                # The JSON-LD names ONE picture per product on this shop while
+                # the slider names the set — MEASURED on the alsweed catalogue,
+                # a roughly threefold difference — so the slider leads and the
+                # summary is merged in behind it, by identity, never twice.
+                summary = jsonld_pictures(node)
+                record = page_pictures(html, _product_key(url))
+                if record:
+                    tally.pictures_read += 1
+                elif summary:
+                    tally.pictures_route_lost += 1
                 extra = RowBuilder(ENRICHMENT)
-                attribute_rows = enrichment_rows(extra, node, _salla_id(url, node))
+                attribute_rows = enrichment_rows(
+                    extra, node, _salla_id(url, node),
+                    pictures=merge_pictures(record, summary))
                 if attribute_rows:
                     yield ScrapedTable(source.source_key, ENRICHMENT.kind, base,
                                        extra.header, attribute_rows,
@@ -125,14 +232,20 @@ class SallaConnector:
         # lowPrice, no meta amount, no inline figure — there is genuinely
         # nothing to read, so the skip is right and saying it is mandatory.
         notes = tally.notes()
-        if notes:
+        # The slider is markup, and markup is a contract a theme update can end
+        # without notice. If it stops matching, every price still lands and
+        # every product keeps the one picture its JSON-LD names, so the run
+        # would look clean while the catalogue lost two thirds of its images.
+        # A defect, not a note, because only a defect is counted as an error.
+        defects = tally.picture_route_defects()
+        if notes or defects:
             # A summary carrying only the counts, deliberately UNTOKENIZED: the
             # counts describe this attempt, and capture.clear_untokenized drops
             # them on resume so a resumed run reports its own rather than
             # inheriting numbers from the attempt before it.
             yield ScrapedTable(source.source_key, PRODUCT_PRICES.kind, base,
                                RowBuilder(PRODUCT_PRICES).header, [],
-                               warnings=notes)
+                               warnings=notes, defects=defects)
 
     def _product_urls(self, sitemap_url: str, tally: WalkTally) -> list[str]:
         """Salla's two rules: /p{id} marks a product, and one URL per product id

--- a/sources.yaml
+++ b/sources.yaml
@@ -253,6 +253,24 @@ sources:
       need the Salla options XHR or an extension capture. Crawl canonical slug
       URLs from the ar sitemap (short /-/p{id} URLs redirect-loop).
 
+
+      PICTURES: the JSON-LD summary names ONE image per product; the page's own
+      lightbox slides carry the rest. Measured over the whole catalogue
+      2026-07-30, 1,231 of 1,233 products fetched once each — the summary names
+      1,170 pictures, the slides name 3,322. A gap of 2,162 across 749
+      products, and 61 products publish no picture at all and stay honestly
+      blank. The slides are read from the page the price already paid for, so
+      this costs no extra request.
+
+
+      AND THE LABEL CHANGES WITH IT. An image row's raw_value was the file
+      name; it is now the slide's own data-caption — the merchant's words, in
+      the merchant's language. The ingest upsert key is (source_product_id,
+      attribute_code, raw_value), so on the first crawl after this lands every
+      existing ALSWEED image row is written anew and the old one retires.
+      Nothing is lost and nothing is rewritten; the count of image rows for
+      this source will roughly double once, and then settle.
+
   - source_key: ELBUROJ
     source_name_ar: البروج
     source_name: Elburoj

--- a/tests/fixtures/live/alsweed_product_pictures_2026-07-30.trimmed.html
+++ b/tests/fixtures/live/alsweed_product_pictures_2026-07-30.trimmed.html
@@ -1,0 +1,54 @@
+<!-- LIVE CAPTURE 2026-07-30 from https://alsweed.sa/ar/كرسي-افرنجي-مقاس-30-سم/p448819456 (HTTP 200).
+     Original HTML was 263073 bytes; trimmed to the
+     <script type="application/ld+json"> Product block and the product slider's
+     own slide anchors, each reproduced byte-for-byte.
+
+     WHY THIS PRODUCT: the JSON-LD names 1 picture and the slider names
+     8, the JSON-LD's
+     picture is NOT the first slide, and the slides carry 3 DIFFERENT
+     data-caption values — so this one page pins the gap, the ordering and the
+     per-picture label at once. Note the <img> inside every slide after the
+     first: its src is cdn.salla.network/images/s-empty.png, the lazy-load
+     placeholder. That is why the reader takes the anchor's href and not the
+     <img src>. -->
+<!doctype html>
+<html lang="ar" dir="rtl"><head>
+<script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Product","name":"كرسي أفرنجي مقاس 30 سم | ستامينا STAMINA","description":"يمنحك كرسي افرنجي ستامينا الراحة عند استخدامه نظرًا لمتانته وحجمه الكبير، كما أنه لن يتسبب في إزعاجك بفضل امتلاكه غطاءً هيدروليكيًا يضمن له الإغلاق الناعم بدون...","sku":"كرسي-افرنجي-مقاس-30-سم/p448819456","offers":{"@type":"Offer","url":"https://alsweed.sa/ar/كرسي-افرنجي-مقاس-30-سم/p448819456","availability":"https://schema.org/InStock","price":748.01,"priceCurrency":"SAR","priceValidUntil":"2026-08-30T14:13:24+03:00","seller":{"@type":"Organization","name":"السويد للسباكة"}},"brand":{"@type":"Brand","name":"ستامينا Stamina"},"aggregateRating":{"@type":"AggregateRating","ratingCount":1,"ratingValue":5},"review":[{"@type":"Review","author":{"@type":"Person","name":"Majedah Almajed"},"datePublished":"2022-09-08","reviewBody":"ممتاز","reviewRating":{"@type":"Rating","worstRating":1,"bestRating":5,"ratingValue":5}}],"image":"https://cdn.salla.sa/RPNxP/492ec600-be1e-4b77-b6a8-c38395eb0825-1000x1000-xp7Jmbrc615earHjJCBB345epJTBKEy8jyjfE3pF.jpg"}]}</script>
+</head><body>
+<salla-slider auto-height="" class="details-slider rounded-md image-slider" id="details-slider-448819456" listen-to-thumbnails-option="" loop="false" show-controls="false" show-thumbs-controls="false" type="thumbs">
+<div slot="items">
+<a aria-label="كرسي أفرنجي مقاس 30 سم | ستامينا STAMINA" class="swiper-slide magnify-wrapper homeslider__slide" data-caption="كرسي أفرنجي مقاس 30 سم أبيض" data-fslightbox="product_448819456" data-img-id="154313364" data-infinite="false" data-slid-index="0" data-type="image" href="https://cdn.salla.sa/RPNxP/8167aca6-acee-4e92-abe7-05e320054616-1000x1000-nzNjaSr4tKi6rPiJ3186SOWbNg80Kyv8ZGxG6rsA.jpg" id="magnify-image" style="display:block;width:100%;margin:0">
+<img alt="كرسي أفرنجي مقاس 30 سم أبيض" class="h-full object-cover w-full" fetchpriority="high" id="154313364" loading="eager" src="https://cdn.salla.sa/RPNxP/8167aca6-acee-4e92-abe7-05e320054616-1000x1000-nzNjaSr4tKi6rPiJ3186SOWbNg80Kyv8ZGxG6rsA.jpg"/>
+<div class="gallery-cursor" style="background:url(https://cdn.assets.salla.network/themes/581928698/1.198.0/images/plus.png) no-repeat center"></div>
+</a>
+<a aria-label="كرسي أفرنجي مقاس 30 سم | ستامينا STAMINA" class="swiper-slide magnify-wrapper homeslider__slide" data-caption="كرسي أفرنجي مقاس 30 سم أبيض" data-fslightbox="product_448819456" data-img-id="154314243" data-infinite="false" data-slid-index="1" data-type="image" href="https://cdn.salla.sa/RPNxP/391f7a4d-76d7-4830-893d-8bebc6df6554-1000x1000-5zxSIB4TNF6GQ3nMsLPwziBXFZVIrVyj01w23qmW.jpg" id="magnify-image">
+<img alt="كرسي أفرنجي مقاس 30 سم أبيض" class="lazy h-full object-cover w-full" data-src="https://cdn.salla.sa/RPNxP/391f7a4d-76d7-4830-893d-8bebc6df6554-1000x1000-5zxSIB4TNF6GQ3nMsLPwziBXFZVIrVyj01w23qmW.jpg" id="154314243" src="https://cdn.salla.network/images/s-empty.png?v=2.0.5"/>
+<div class="gallery-cursor" style="background:url(https://cdn.assets.salla.network/themes/581928698/1.198.0/images/plus.png) no-repeat center"></div>
+</a>
+<a aria-label="كرسي أفرنجي مقاس 30 سم | ستامينا STAMINA" class="swiper-slide magnify-wrapper homeslider__slide" data-caption="كرسي أفرنجي مقاس 30 سم أسود" data-fslightbox="product_448819456" data-img-id="154314267" data-infinite="false" data-slid-index="2" data-type="image" href="https://cdn.salla.sa/RPNxP/86b6e3ad-91eb-4373-9c5a-ba9665aa8737-1000x1000-ftPz68uK5n08VFjqlDNqrXRfZRl8SFlq2Jl90uED.jpg" id="magnify-image">
+<img alt="كرسي أفرنجي مقاس 30 سم أسود" class="lazy h-full object-cover w-full" data-src="https://cdn.salla.sa/RPNxP/86b6e3ad-91eb-4373-9c5a-ba9665aa8737-1000x1000-ftPz68uK5n08VFjqlDNqrXRfZRl8SFlq2Jl90uED.jpg" id="154314267" src="https://cdn.salla.network/images/s-empty.png?v=2.0.5"/>
+<div class="gallery-cursor" style="background:url(https://cdn.assets.salla.network/themes/581928698/1.198.0/images/plus.png) no-repeat center"></div>
+</a>
+<a aria-label="كرسي أفرنجي مقاس 30 سم | ستامينا STAMINA" class="swiper-slide magnify-wrapper homeslider__slide" data-caption="كرسي أفرنجي مقاس 30 سم أبيض" data-fslightbox="product_448819456" data-img-id="154312888" data-infinite="false" data-slid-index="3" data-type="image" href="https://cdn.salla.sa/RPNxP/6e4d8b7f-35aa-4b62-9ce3-ac4721cc8b56-1000x1000-j5qbJcPjUwsJYeY9DdxGBA0ae5FEEM6QLwkNHCpp.jpg" id="magnify-image">
+<img alt="كرسي أفرنجي مقاس 30 سم أبيض" class="lazy h-full object-cover w-full" data-src="https://cdn.salla.sa/RPNxP/6e4d8b7f-35aa-4b62-9ce3-ac4721cc8b56-1000x1000-j5qbJcPjUwsJYeY9DdxGBA0ae5FEEM6QLwkNHCpp.jpg" id="154312888" src="https://cdn.salla.network/images/s-empty.png?v=2.0.5"/>
+<div class="gallery-cursor" style="background:url(https://cdn.assets.salla.network/themes/581928698/1.198.0/images/plus.png) no-repeat center"></div>
+</a>
+<a aria-label="كرسي أفرنجي مقاس 30 سم | ستامينا STAMINA" class="swiper-slide magnify-wrapper homeslider__slide" data-caption="كرسي أفرنجي مقاس 30 سم أبيض" data-fslightbox="product_448819456" data-img-id="154312895" data-infinite="false" data-slid-index="4" data-type="image" href="https://cdn.salla.sa/RPNxP/442b66db-2ff4-44b7-af93-08170652d5df-1000x1000-KL2KUGc4uLFp26s4MT0Tmsnm4kFyAiWh8XWOAXrg.jpg" id="magnify-image">
+<img alt="كرسي أفرنجي مقاس 30 سم أبيض" class="lazy h-full object-cover w-full" data-src="https://cdn.salla.sa/RPNxP/442b66db-2ff4-44b7-af93-08170652d5df-1000x1000-KL2KUGc4uLFp26s4MT0Tmsnm4kFyAiWh8XWOAXrg.jpg" id="154312895" src="https://cdn.salla.network/images/s-empty.png?v=2.0.5"/>
+<div class="gallery-cursor" style="background:url(https://cdn.assets.salla.network/themes/581928698/1.198.0/images/plus.png) no-repeat center"></div>
+</a>
+<a aria-label="كرسي أفرنجي مقاس 30 سم | ستامينا STAMINA" class="swiper-slide magnify-wrapper homeslider__slide" data-caption="كرسي أفرنجي مقاس 30 سم أسود" data-fslightbox="product_448819456" data-img-id="154312891" data-infinite="false" data-slid-index="5" data-type="image" href="https://cdn.salla.sa/RPNxP/6c438943-4203-4e66-916a-c432bc19ac30-1000x1000-7k6J2rDytqoE5vQlktzs6qAhfzj7uVzvdcKaMRS2.jpg" id="magnify-image">
+<img alt="كرسي أفرنجي مقاس 30 سم أسود" class="lazy h-full object-cover w-full" data-src="https://cdn.salla.sa/RPNxP/6c438943-4203-4e66-916a-c432bc19ac30-1000x1000-7k6J2rDytqoE5vQlktzs6qAhfzj7uVzvdcKaMRS2.jpg" id="154312891" src="https://cdn.salla.network/images/s-empty.png?v=2.0.5"/>
+<div class="gallery-cursor" style="background:url(https://cdn.assets.salla.network/themes/581928698/1.198.0/images/plus.png) no-repeat center"></div>
+</a>
+<a aria-label="كرسي أفرنجي مقاس 30 سم | ستامينا STAMINA" class="swiper-slide magnify-wrapper homeslider__slide" data-caption="كرسي أفرنجي مقاس 30 سم أسود" data-fslightbox="product_448819456" data-img-id="154312893" data-infinite="false" data-slid-index="6" data-type="image" href="https://cdn.salla.sa/RPNxP/7fbfc752-1da3-4b13-87ae-a641932831d7-1000x1000-Bc00KHX9rbmRHLn8UxOZ1Df6TGWCEprfPqjmpbd4.jpg" id="magnify-image">
+<img alt="كرسي أفرنجي مقاس 30 سم أسود" class="lazy h-full object-cover w-full" data-src="https://cdn.salla.sa/RPNxP/7fbfc752-1da3-4b13-87ae-a641932831d7-1000x1000-Bc00KHX9rbmRHLn8UxOZ1Df6TGWCEprfPqjmpbd4.jpg" id="154312893" src="https://cdn.salla.network/images/s-empty.png?v=2.0.5"/>
+<div class="gallery-cursor" style="background:url(https://cdn.assets.salla.network/themes/581928698/1.198.0/images/plus.png) no-repeat center"></div>
+</a>
+<a aria-label="كرسي أفرنجي مقاس 30 سم | ستامينا STAMINA" class="swiper-slide magnify-wrapper homeslider__slide" data-caption="كرسي أفرنجي مقاس 30 سم" data-fslightbox="product_448819456" data-img-id="154312890" data-infinite="false" data-slid-index="7" data-type="image" href="https://cdn.salla.sa/RPNxP/492ec600-be1e-4b77-b6a8-c38395eb0825-1000x1000-xp7Jmbrc615earHjJCBB345epJTBKEy8jyjfE3pF.jpg" id="magnify-image">
+<img alt="كرسي أفرنجي مقاس 30 سم" class="lazy h-full object-cover w-full" data-src="https://cdn.salla.sa/RPNxP/492ec600-be1e-4b77-b6a8-c38395eb0825-1000x1000-xp7Jmbrc615earHjJCBB345epJTBKEy8jyjfE3pF.jpg" id="154312890" src="https://cdn.salla.network/images/s-empty.png?v=2.0.5"/>
+<div class="gallery-cursor" style="background:url(https://cdn.assets.salla.network/themes/581928698/1.198.0/images/plus.png) no-repeat center"></div>
+</a>
+</div>
+</salla-slider>
+</body></html>

--- a/tests/fixtures/live/product_pictures_2026-07-30.CAPTURE.md
+++ b/tests/fixtures/live/product_pictures_2026-07-30.CAPTURE.md
@@ -1,0 +1,98 @@
+# Live capture — the pictures a page publishes but its JSON-LD does not, 2026-07-30
+
+Two product pages, one per server-rendered family, captured for
+`tests/test_product_pictures.py`. Both were fetched anonymously, one request
+each, ≥1.2 s apart from every other request in the session, and both answered
+**HTTP 200**. Nothing was retried and neither site was asked for anything it
+disallows: `advancedcastle.com/robots.txt` allows `/products/` (it disallows
+`/api/`, `/cart` and the review paths), and `alsweed.sa/robots.txt` allows `/`
+with no crawl delay addressed to anyone.
+
+The user agents are the ones the crawl itself uses: the Chrome string
+`sources.yaml` declares for ADVANCEDCASTLE, which 403s generic clients, and
+`ScrapeX/0.1 (+contact: owner)` for ALSWEED, which does not.
+
+**No image file was downloaded.** The URL is the record.
+
+## Why these two products
+
+Each was picked off a full-catalogue census (below) as the page that pins the
+most claims at once, so a single fixture can carry a test rather than four.
+
+### `advancedcastle_product_pictures_2026-07-30.trimmed.html`
+
+`GET https://advancedcastle.com/products/لمبة-تحذير-فلاشر` — 555,707 bytes,
+trimmed to 9,917. Kept byte-for-byte: the `hreflang` alternates, the
+`<script type="application/ld+json">` Product block, the page's own
+`var productImages` bootstrap, and the theme's `#product-images` gallery.
+
+- Its JSON-LD names **3** pictures; its own bootstrap names **6**.
+- The picture the JSON-LD calls the product's `image` is **not** the one the
+  shop shows first — true on 44 of the catalogue's 168 products.
+- **5 of the 6** carry the merchant's own `alt_text`, and one carries none, so
+  the same fixture covers the label and the fall-back to the file name.
+- The gallery markup is kept alongside the bootstrap deliberately: it is what a
+  `carousel-img` reader would have matched, and keeping it lets the test show
+  the two routes name the same pictures at different addresses.
+
+### `alsweed_product_pictures_2026-07-30.trimmed.html`
+
+`GET https://alsweed.sa/ar/كرسي-افرنجي-مقاس-30-سم/p448819456` — 263,073 bytes,
+trimmed to 9,133. Kept byte-for-byte: the Product JSON-LD and the slider's
+slide anchors.
+
+- Its JSON-LD names **1** picture; the slider names **8**.
+- The JSON-LD's picture is the **eighth** slide, not the first.
+- The slides carry **3 different** `data-caption` values, so the per-picture
+  label is real on this shop and not one string repeated.
+- Every slide after the first has `src="…/s-empty.png"` — the lazy-load
+  placeholder. It is kept on purpose: reading `<img src>` would have stored one
+  placeholder as several pictures, which is why the reader takes the anchor's
+  `href`. A test asserts the trap is still in the fixture.
+
+## The censuses these came from
+
+Both were full passes, not samples, and both are the evidence for the numbers
+in the PR. One request per product, ≥1.2 s apart, honest UA, and the script
+stops the moment a site answers 403 or 429. Neither did.
+
+> **SCOPE OF THE TABLE BELOW: the early sample, not the finished census.** It
+> is kept because it is what the two fixtures were captured against. The
+> whole-catalogue figures live in `salla.py`'s header and are larger: 1,231 of
+> 1,233 products, 1,170 JSON-LD pictures against 3,322 slide pictures, 1,160
+> byte-identical and 10 YouTube thumbnails. Two numbers for one measurement is
+> a contradiction only when neither says which measurement it is.
+>
+> **The ADVANCEDCASTLE column does not ship in this branch.** Its zid reader was
+> split out and held: re-checked 2026-08-05, that site's sitemap now lists 2
+> product URLs, 8 of 8 stored product links answer 404, and the URL this fixture
+> was captured from is itself 404. The measurement below was true when taken and
+> is not true of the site today, so the half that rested on it is not merged.
+
+| | ADVANCEDCASTLE (not shipping) | ALSWEED |
+|---|---|---|
+| products | 168 of 168 | 1,233 (one URL per product; the sitemap lists each twice) |
+| JSON-LD pictures | 435 | measured per product, ~1 each |
+| the page's own list | 493 | ~3× the JSON-LD |
+| JSON-LD URLs that are string-equal to a gallery/slide URL | **0** | **270 of 270** |
+| JSON-LD pictures the page's list does not have | 6 | 5 (all YouTube thumbnails) |
+
+The two rows at the bottom are why identity is per-connector: advancedcastle
+publishes one picture at five addresses, so the URL cannot identify it and the
+image uuid does; alsweed publishes each picture at exactly one address, and its
+JSON-LD URL is byte-identical to the slide's `href`, so there the URL is right.
+
+## What was NOT captured, and why
+
+- **No `/api/` request to either store.** advancedcastle's robots.txt disallows
+  `/api/`, so a Zid platform API is off the table on politeness grounds even
+  where one exists. The in-page bootstrap answers the same question for free.
+- **No English page for ALSWEED.** The salla connector fetches one page per
+  product; asking for a second locale to read English captions would double
+  every crawl, and this project's politeness budget is a stated value. The
+  Arabic caption is captured as published and never translated.
+- **No ELBUROJ capture.** It is `active: false` and asks for a 10-second crawl
+  delay, so a 3,441-product census would be ~9.5 hours of knocking. It runs the
+  same connector as ALSWEED and is expected to behave the same; that is stated
+  as an expectation, not measured, and is the one ceiling in this work that a
+  future crawl should confirm rather than assume.

--- a/tests/test_product_pictures.py
+++ b/tests/test_product_pictures.py
@@ -1,0 +1,273 @@
+"""The pictures a page publishes in its markup but not in its machine-readable
+summary — and, above all, the run saying so when it stops being able to read them.
+
+WHY THIS FILE EXISTS. schema.org `image` is a summary: it is allowed to name one
+representative picture, and on both server-rendered families it does exactly
+that while the page itself publishes the whole set. Measured on the FULL
+catalogues, 2026-07-30:
+
+    ADVANCEDCASTLE (zid)   168 products   JSON-LD 435   page's own list 493
+    ALSWEED        (salla) 1,233 products JSON-LD 1 per product, slider ~3x
+
+The reader that closes that gap is markup, and markup is a contract a theme
+update can end without telling anyone. Its failure mode is SILENCE — it matches
+nothing, every product keeps the one picture its JSON-LD names, the prices still
+land and the run reports plain success. So the tests that matter most here are
+not the ones counting the extra pictures; they are the ones that FAIL IF A DRIFT
+GOES UNANNOUNCED.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from scrapex.config import ExtractSpec, SourceEntry
+from scrapex.connectors.jsonld import (Picture, WalkTally, jsonld_pictures,
+                                       merge_pictures, parse_product_jsonld)
+from scrapex.connectors.salla import SallaConnector
+from scrapex.connectors.salla import page_pictures as salla_pictures
+from scrapex.rowspec import ENRICHMENT, RowView
+from scrapex.vocab import DetailGroup, ExtractKind, ExtractScope
+
+LIVE = Path(__file__).parent / "fixtures" / "live"
+SALLA_PAGE = (LIVE / "alsweed_product_pictures_2026-07-30.trimmed.html"
+              ).read_text(encoding="utf-8")
+
+CHROME_UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/125.0.0.0 Safari/537.36"
+SALLA_PID = "448819456"
+
+
+# --------------------------------------------------------------------------
+# harness
+# --------------------------------------------------------------------------
+class _Resp:
+    def __init__(self, text): self.text = text
+
+
+class _SallaSite:
+    SITEMAP = ("<?xml version='1.0' encoding='UTF-8'?><urlset>"
+               f"<url><loc>https://alsweed.sa/ar/seat/p{SALLA_PID}</loc></url>"
+               "</urlset>")
+
+    def __init__(self, page: str = SALLA_PAGE):
+        self.page = page
+        self.requests_count = 0
+
+    def get(self, url, **kwargs):
+        self.requests_count += 1
+        if url.endswith("sitemap.xml"):
+            return _Resp(self.SITEMAP)
+        if re.search(r"/p\d{5,}", url):
+            return _Resp(self.page)
+        raise RuntimeError("404 " + url)
+
+    def close(self): pass
+
+
+def _entry(key, base, family, ua=None) -> SourceEntry:
+    return SourceEntry.model_validate(dict(
+        source_key=key, source_name=key, base_url=base, family=family,
+        currency="SAR", default_region="SA", vat_mode="incl", user_agent=ua,
+        extract=[ExtractSpec(kind=ExtractKind.PRODUCT_PRICES, scope=ExtractScope.CENSUS),
+                 ExtractSpec(kind=ExtractKind.ENRICHMENT, scope=ExtractScope.CENSUS)],
+    ))
+
+
+def salla_entry(): return _entry("ALSWEED", "https://alsweed.sa", "salla-html")
+
+
+def run(connector, entry):
+    """(image rows as dicts, warnings, defects) across every table yielded."""
+    images, warnings, defects = [], [], []
+    for table in connector.fetch(entry):
+        warnings.extend(table.warnings)
+        defects.extend(table.defects)
+        if str(table.kind) != "enrichment":
+            continue
+        view = RowView(ENRICHMENT, table.header)
+        for row in table.rows:
+            if str(view.get(row, "attribute_code")).startswith("image"):
+                images.append({k: view.get(row, k) for k in
+                               ("attribute_code", "raw_value", "value_url",
+                                "attribute_group")})
+    return images, warnings, defects
+
+
+def drifted(html: str, pattern: str) -> str:
+    """The same page after a theme update that renamed what we read."""
+    out = re.sub(pattern, "THEME-CHANGED", html, count=0)
+    assert out != html, "the drift fixture changed nothing — the test is vacuous"
+    return out
+
+
+# --------------------------------------------------------------------------
+# 1. THE GUARD THAT MATTERS: a drift must never pass silently
+# --------------------------------------------------------------------------
+def test_a_salla_theme_that_renames_its_slides_is_announced():
+    site = _SallaSite(drifted(SALLA_PAGE, r"data-fslightbox"))
+    images, warnings, defects = run(SallaConnector(site), salla_entry())
+
+    assert defects, (
+        "the slide anchors matched nothing and the run reported no defect — "
+        "this source would drop from 8 pictures to 1 in silence")
+    assert len(images) == 1, "the JSON-LD picture must still land"
+
+
+def test_the_defect_fires_only_when_the_route_fails_more_than_it_works():
+    """A handful of odd products is not a theme change, and must not cry wolf.
+
+    The rule is stated once, in WalkTally, so both families share it: the route
+    failing on MORE pages than it worked on is a shape change; failing on fewer
+    is the ordinary raggedness of a real catalogue.
+    """
+    assert WalkTally(pictures_read=100, pictures_route_lost=3).picture_route_defects() == []
+    assert WalkTally(pictures_read=0, pictures_route_lost=1).picture_route_defects()
+    assert WalkTally(pictures_read=10, pictures_route_lost=11).picture_route_defects()
+    # Nothing read and nothing lost is a source with no pictures at all, not a drift.
+    assert WalkTally().picture_route_defects() == []
+
+
+# --------------------------------------------------------------------------
+# 2. no duplicates — the defect this design exists to avoid
+# --------------------------------------------------------------------------
+def test_salla_reads_the_whole_slider_not_the_one_picture_the_summary_names():
+    images, _w, _d = run(SallaConnector(_SallaSite()), salla_entry())
+    assert len(images) == 8, "JSON-LD named 1; the slider names 8"
+
+
+def test_salla_lazy_placeholders_are_never_stored_as_pictures():
+    """Every slide but the first carries s-empty.png in its <img src>.
+
+    Reading `<img src>` would have stored one placeholder as several different
+    pictures. The anchor's href is always the real one, which is why the reader
+    takes it.
+    """
+    assert "s-empty.png" in SALLA_PAGE, "the fixture must still contain the trap"
+    images, _w, _d = run(SallaConnector(_SallaSite()), salla_entry())
+    assert not any("s-empty" in i["value_url"] for i in images)
+
+
+def test_a_video_slide_is_not_a_picture():
+    """7 of 787 alsweed slides are data-type="youtube"; a video is not a photo."""
+    page = SALLA_PAGE.replace('data-type="image"', 'data-type="youtube"', 1)
+    pictures = salla_pictures(page, SALLA_PID)
+    assert len(pictures) == len(salla_pictures(SALLA_PAGE, SALLA_PID)) - 1
+
+
+def test_nothing_is_fetched_beyond_the_pages_the_prices_already_cost():
+    """No extra request. The pictures ride the response the price came from."""
+    site = _SallaSite()
+    list(SallaConnector(site).fetch(salla_entry()))
+    assert site.requests_count == 2, (
+        f"one sitemap and one product page, not {site.requests_count} — a "
+        "second fetch per product would multiply every crawl")
+
+
+def test_the_slider_of_another_product_is_never_read():
+    """`data-fslightbox="product_{id}"` is why a related-products carousel on
+    the same page cannot leak its pictures into this product's rows."""
+    assert salla_pictures(SALLA_PAGE, "999999999") == []
+    assert salla_pictures(SALLA_PAGE, "") == []
+
+
+# --------------------------------------------------------------------------
+# salvaged from the tests that covered BOTH readers before the zid half was
+# split out — the behaviour is salla's too, and dropping the file would have
+# dropped the cover with it
+# --------------------------------------------------------------------------
+
+def test_a_healthy_run_raises_no_picture_defect():
+    """The guard has to be quiet when nothing is wrong, or it is noise."""
+    _images, _warnings, defects = run(SallaConnector(_SallaSite()), salla_entry())
+
+    assert defects == [], f"a healthy page raised {defects}"
+
+
+def test_no_two_image_rows_share_a_url_or_a_code():
+    images, _w, _d = run(SallaConnector(_SallaSite()), salla_entry())
+
+    assert len(images) == 8
+    urls = [i["value_url"] for i in images]
+    codes = [i["attribute_code"] for i in images]
+    assert len(set(urls)) == len(urls), f"one picture stored twice: {urls}"
+    assert len(set(codes)) == len(codes), f"one code used twice: {codes}"
+
+
+def test_a_picture_only_the_summary_names_is_never_dropped():
+    """The merge must never store less than the route it replaces. A reader
+    that simply swapped one route for the other would lose whatever only the
+    summary knows about."""
+    only_in_summary = Picture(identity="https://example.com/ghost.jpg",
+                              url="https://example.com/ghost.jpg")
+    record = list(salla_pictures(SALLA_PAGE, SALLA_PID))
+
+    merged = merge_pictures(record, [only_in_summary])
+
+    assert merged[-1].url == "https://example.com/ghost.jpg"
+    assert len(merged) == len(record) + 1
+
+
+def test_a_page_with_no_pictures_at_all_yields_no_image_rows():
+    """A page with none gets none, and nothing is substituted for it."""
+    # The reader selects a[data-fslightbox="product_<pid>"]; renaming that
+    # attribute is how a page with no readable slides looks to it.
+    bare = SALLA_PAGE.replace(f'data-fslightbox="product_{SALLA_PID}"',
+                              'data-nothing-here="1"')
+    bare = re.sub(r'"image":\s*(\[[^\]]*\]|"[^"]*")', '"image": []', bare)
+
+    images, _w, defects = run(SallaConnector(_SallaSite(bare)), salla_entry())
+
+    assert images == []
+    assert defects == [], "no pictures published is not a drift"
+
+
+# --------------------------------------------------------------------------
+# the two the review asked for
+# --------------------------------------------------------------------------
+
+def test_the_merge_keys_on_identity_and_not_on_the_url():
+    """THE SEAM THE WHOLE `Picture.identity` FIELD EXISTS FOR, and until now
+    nothing exercised it.
+
+    For salla, identity IS the url — the shop publishes each picture at exactly
+    one address — so every shipping caller has the two agreeing, and swapping
+    identity-keyed dedup for url-keyed dedup passed the entire suite. That is a
+    field with a docstring and no test.
+
+    A platform that names a picture once and serves it at several sizes is why
+    the field is there. Driven directly here rather than through a connector,
+    because no shipping connector produces the disagreement."""
+    one_picture_two_addresses = [
+        Picture(identity="media-7", url="https://example.com/big/7.jpg"),
+        Picture(identity="media-7", url="https://example.com/thumb/7.jpg"),
+    ]
+
+    merged = merge_pictures(one_picture_two_addresses, [])
+
+    assert len(merged) == 1, "one picture at two sizes was stored twice"
+    assert merged[0].url == "https://example.com/big/7.jpg", (
+        "the record's own first address is the one the shop leads with")
+
+
+def test_the_label_is_the_shops_own_caption_not_the_file_name():
+    """A BEHAVIOUR CHANGE THIS BRANCH MAKES, pinned because nothing pinned it.
+
+    Before this reader, an ALSWEED image row's `raw_value` was the file name.
+    It is now the slide's own `data-caption` — the merchant's words, in the
+    merchant's language. That is better, and it is not free: the ingest upsert
+    key is (source_product_id, attribute_code, raw_value), so every existing
+    ALSWEED image row inserts anew and the old one retires on the next crawl.
+
+    Deleting the caption and falling back to the file name passed the whole
+    suite, so the improvement was undefended."""
+    images, _w, _d = run(SallaConnector(_SallaSite()), salla_entry())
+
+    labels = [i["raw_value"] for i in images]
+    assert all(labels), "an image row was stored with no label at all"
+    assert not any(label.endswith((".jpg", ".png", ".webp")) for label in labels), (
+        "the row fell back to the file name; the shop's own caption was dropped")
+    assert any("كرسى" in label or "كرسي" in label
+               for label in labels), "the caption is not the merchant's own words"
+


### PR DESCRIPTION
**This is #43's salla half, split out and merged alone**, at the owner's direction.

#43's **zid half rests on a census of a site that has changed.** Re-checked 2026-08-05: advancedcastle.com's sitemap now lists **2** product URLs, **8 of 8** stored product links answer 404, and the URL its fixture was captured from is **itself 404**. The *"435 → 499, +64 pictures across 48 products"* prize does not exist for that source today, so that reader is held.

The salla half's measurement **still holds live**.

## What it does

Alsweed's JSON-LD names **one** picture per product while the page's own lightbox slides name the set — and the one the summary names is often not even the first slide.

Measured over the whole catalogue on 2026-07-30, 1,231 of 1,233 products fetched once each:

| | |
|---|---|
| pictures the JSON-LD summary names | **1,170** |
| pictures the slides name | **3,322** |
| the gap | **2,162 across 749 products** |
| products publishing no picture at all | 61 — they stay honestly blank |

It costs **no extra request**: the slides are in the same response the price is already read from.

## Three things the review asked for, and why each mattered

**1. A test that could not fail.** `Picture.identity` exists so a platform that names one picture and serves it at several sizes is not stored twice. But for salla the identity **is** the url, so every shipping caller has the two agreeing — and swapping identity-keyed dedup for url-keyed dedup **passed the entire suite**. A field with a docstring and no test. It is now driven directly with the two disagreeing, because no shipping connector produces that.

**2. An undocumented behaviour change.** An image row's `raw_value` was the file name and is now the slide's own `data-caption` — the merchant's words, in the merchant's language. The ingest upsert key is `(source_product_id, attribute_code, raw_value)`, so on the first crawl after this lands **every existing ALSWEED image row is written anew and the old one retires**. Nothing is lost and nothing is rewritten. Now stated in `sources.yaml` beside the source it changes, and pinned — deleting the caption used to pass everything.

**3. Two numbers for one measurement.** The capture document carried the early sample (270 of 270) while `salla.py` carried the finished census (1,170 of 3,322). Neither was wrong; neither said which measurement it was. The document now says, and its ADVANCEDCASTLE column states out loud that it does not ship here and why.

## And one the review did not catch, which was mine

My first draft of the `sources.yaml` note said the slides give 1,170 *"where the summary alone gave 270"* — mixing the sample's number into the census's sentence. The summary names 1,170; the slides name 3,322.

## Tests

Seven salla tests come across unchanged. **Four more were parameterised over both readers** and would have lost their cover when the zid half left, so their salla halves are salvaged rather than deleted. Two are new, and **both bite**: url-keyed dedup, and falling back to the file name.

## Gates

`pytest` full suite · contract parity · extension 19/0 · `validate-manifest` — green.

## What happens on the next crawl

ALSWEED's stored pictures roughly triple, and its image rows re-key once. That is the intended effect and it is disclosed here rather than discovered.