### PR TITLE
The platform plan, and the plan it replaces

### DIFF
--- a/docs/PLATFORM-PLAN.md
+++ b/docs/PLATFORM-PLAN.md
@@ -1,0 +1,478 @@
+# ScrapeX Platform Plan
+
+**Status:** the agreed plan, revised 2026-08-05 from fourteen owner decisions.
+**Supersedes:** `scrapeX-architecture-and-implementation-plan` in full.
+**Subordinate to:** `CLAUDE.md`, except where a decision below overrides it — each override is named.
+
+Two products and one contract:
+
+- **ScrapeX** — the Chrome extension. The control room, and the only interface.
+- **Engine** — the local Python program ScrapeX installs. It crawls, stores, and tracks.
+
+Everything else — open-source crawlers, the Console — hangs off those two.
+
+---
+
+## 1. The decisions
+
+| # | Decision | Consequence |
+|---|---|---|
+| 1 | An engine is a **separate installed program**. | ScrapeX needs an install / launch / monitor / version contract, not a plugin loader. |
+| 2 | **Engine crawls everything, not only prices.** Prices are one domain beside contractors, tenders, equipment, jobs. | The name `MarketLens` retires. The schema stops being price-shaped. |
+| 3 | **One device at a time, with restore.** | Drive is enough. No server, no shared SQLite file. A lease stops two devices at once. |
+| 4 | **Updates are tracked through GitHub Releases**, not self-updating. | **Overrides `CLAUDE.md`'s "silent OTA updates" requirement.** The brief must be amended. |
+| 5 | The existing Excel add-in **reads from a Google Sheet**. | The Console's job is to write that Sheet. Sheets is a publishing target, never the configuration store. |
+| 6 | First publish: **owner plus a few testers, unlisted**. | A privacy policy and a support contact are required; the repository has neither. OAuth stays in testing mode (100 users), so the `spreadsheets` scope needs no verification yet. |
+| 7 | **Engine gets ONE database** covering every crawl type it performs. | `general.db` retires. One migration stream. A question can cross types: *which contractor also sells?* |
+| 8 | On a new device with no engine, the owner **sees his data and exports it**. | The backup bundle must carry a plain export beside the `.db`. See §5. |
+| 9 | Databases are **managed only through ScrapeX** — location, backup, restore, migration. | The controls live in the extension; Engine executes them. A browser extension cannot create a SQLite file. |
+| 10 | Open-source tools **hand their output to Engine**, which imports it. | The tool writes its own files in its own shape and never touches Engine's database — so there is no interference and no third SQLite. |
+| 11 | Open-source tools come **last, one at a time**, each for a stated need. | The install contract is proved once with Engine, then widened by one tool that has a real requirement behind it. |
+| 12 | Drive upload frequency is **a user setting**. | Default: compressed, after any crawl that changed something. The warehouse is 112 MB; a daily full upload that changes nothing is not free. |
+| 13 | Entity tracking records **appearance, disappearance, AND field-level change**. | A contractor's grade moving 3rd → 2nd, a tender's closing date slipping, are events — not just "still there". |
+| 14 | The extension is **ScrapeX**; the local engine is **Engine**. | In the catalogue: `Engine — installed, v1.2.3` beside `Scrapy — not installed`. Ours by role, theirs by name. |
+| 16 | **An audited source and a user-added one are visibly different.** | `sources.yaml` carries 12 audited sources today with no field telling them apart. A user who adds a site and gets poor data must see *why* — `audited` beside `you added this` — or they will read it as the product being broken. |
+| 17 | **Crawl scope is a per-source setting**, not a project-wide rule. | listing only · listing + details for a named slice · full once then listing. See M6. |
+| 18 | **For external tools, build the seam and not the tools.** | The install/health/import contract is laid so it can be used when a need appears; if Engine does the job, the matter is dropped. See M8. |
+| 19 | **The data path is a published Google Sheet.** Engine writes the table there; the Console puts its TSV link in `SOURCE_URI`. | The only path that works today with no change to XaddIn and from any machine. A local file passes the validator and is refused by the ingester at `DataIngestionService.cs:734` — see §5b. The table is readable by anyone holding the URL; acceptable for the owner's own data, a separate decision at commercialisation. |
+| 15 | **The Python package stays `scrapex/`.** `Engine` is the product name, not the directory. | The user never sees a directory. Renaming costs 748 import lines in tests alone, 188 `python -m scrapex` call sites in CI, docs and JS, a reinstall of the editable package, and five hard-coded paths — for nothing anyone can see. A capitalised `Engine/` would also work on Windows and fail on Linux, where CI runs. |
+
+---
+
+## 2. What the previous plan got factually wrong
+
+Measured against the repository and the live warehouse on 2026-08-05.
+
+| The plan said | Measured |
+|---|---|
+| `apps/extension`, `apps/marketlens`, `apps/engine-host` | The tree is `scrapex/ extension/ contract/ contracts/ db/ tests/ packaging/ apps_script/ docs/ spikes/ design/ tools/`. Relocating touches **620 tracked files and 1,044 import lines**, and breaks five hard-coded root paths including the migration directory and `sources.yaml`. Deleted — see §7. |
+| scrapeX 0.6.0 · MarketLens 0.9.2 · protocol 2 | **0.2.0 · 0.2.0 · protocol 1** — and one gate enforces the same number across three files, which is why the compatibility check in Decision 4 is impossible today. |
+| MarketLens is a stores-and-products engine | **GPP_ENERGY alone is 67,677 of 88,286 price observations — 76.7%** — fuel prices from a static HTML table. Decision 2 settles it. |
+| Five connector families | **Eleven connector modules**: aramco, custom_json, gpp, heidelberg, hybris, jsonld, magento, salla, shopify, woocommerce, zid. |
+| Domain Engines: Price, Listing, **Table** | "Table" is an *extraction method*, not a domain — the exact collapse `CLAUDE.md` §40 forbids. §4 separates the two axes. |
+| §4.3 SQLite is the writer · §13 Drive is where the data lives | Twenty lines apart and incompatible. Decision 3 settles it: **Drive is backup and restore; the local database is the writer.** |
+| Phase 1 = relocate the monorepo | `CLAUDE.md` forbids it three times, including *"Do not rename, relocate, or rewrite stable modules."* |
+
+---
+
+## 3. What already exists, so it is never budgeted twice
+
+- **The generic model is already built.** Eleven tables exist in the general stream and are unused: `dataset_definition`, `dataset_schema_version`, `field_definition`, `generic_record`, `generic_record_revision`, `generic_ingestion`, `generic_page_snapshot`, `dataset_relationship`, `relationship_field_pair`, `schema_version_field`, `site_profile`.
+- **The lifecycle Decision 13 asks for is already built and tested**, on the price side: `first_seen_at`, `last_seen_at`, `status`, and `absence_period` with `missing_since` / `returned_at`. *Appeared, was confirmed, disappeared, came back* is generic machinery — a price is just one thing hung on it.
+- **Two databases with typed registries**, distinct `application_id`s, independent migration streams, locks, health, backup and restore. Decision 7 collapses them; the machinery stays.
+- **60 migrations**, in two streams sharing one directory — a hazard that has broken the engine twice.
+- **Google Drive + Sheets in the engine**, least-privilege `drive.file` + `spreadsheets`, chosen to stay out of sensitive-scope verification.
+- **Native messaging for control, local HTTP for data** — a deliberate split. Nine data commands were removed from native messaging once; they do not return.
+- **A side panel and a full workspace**, job persistence, pause/resume/cancel, checkpoints, a mini-player.
+- **A price model with real semantics**: `price_hash`, price periods, absence periods, append-only observations, unit charters with ranked witnesses, and row-level provenance enforced by triggers.
+- **PyInstaller one-file packaging**, 109 test files, and a curated `sources.yaml` of 12 audited sources.
+
+---
+
+## 4. The architecture
+
+```text
+ScrapeX (extension) — the control room, and the only interface
+    profile · engines · sources · jobs · browse · export · console
+        │
+        │  control: native messaging — small, paginated commands
+        │  data:    HTTP on 127.0.0.1 — records, logs, exports
+        ▼
+Engine (installed) ─────────────────────► one database
+    fetch ─→ extract ─→ domain ─→ store        prices + entities together
+                                                  │
+open-source tool ─→ its own output files ─────────┘  imported by Engine
+                                                  │
+                                                  ▼
+                              Google Drive — backup, restore, lease
+                              Google Sheets — what the Excel add-in reads
+```
+
+### Two axes that must never collapse
+
+`CLAUDE.md` §40 forbids one enum meaning both *what the data is* and *how it was obtained*. Engine keeps them apart:
+
+```text
+extraction method          domain
+  html_table                 prices      offers, periods, witnessed units
+  repeated_dom               entities    contractors, tenders, equipment, jobs
+  json / json_ld
+  rest_api
+  rendered (browser)
+```
+
+A tender in an HTML table goes `html_table → entities`. A price in the same table goes `html_table → prices`. Same extractor, different meaning.
+
+### Four rules that follow
+
+1. **The local database is the writer.** Drive holds versioned backups and one lease, which names the device and expires, with a recovery path for a stale one.
+2. **Engine owns exactly one database.** An open-source tool never writes to it; it writes its own files and Engine imports them, so its output gains the same lifecycle and provenance as everything else.
+3. **Control and data use different transports.**
+4. **Sheets is an output.** The product is fully usable with no Google account.
+
+---
+
+## 5. The new-device requirement, and why it is cheap
+
+Decision 8 asks that a fresh machine, signed in, with no engine installed, shows the data and exports it.
+
+The expensive reading is "run SQLite in the extension". Spike 2 measured that (`spikes/opfs-sqlite/FINDINGS.md`): the schema runs in MV3 and survives restart, but OPFS loses WAL, an access handle is exclusive, the service worker cannot write, and `wa-sqlite` is **70–208× slower** than Python on the Data page's own query, with a fast VFS that cannot open an existing database.
+
+**None of that is needed.** Viewing and exporting is read-only:
+
+> Every Drive backup is a **bundle**: the `.db`, **plus a plain per-dataset export** (JSON Lines and CSV), **plus a manifest** with row counts and checksums. The extension downloads the bundle and reads the plain export.
+
+The `.db` stays the restorable artefact for a machine that installs Engine. The plain export is what a bare extension reads. One writer in the backup path and a reader in the panel, against months for a browser-side database.
+
+---
+
+## 5b. The ecosystem: ScrapeX, Engine, and XaddIn
+
+The Console exists for one reason, and it is narrower and more concrete than
+"edit some sheets".
+
+### What XaddIn already is
+
+`mbiXaddin` is a VSTO Excel add-in of **49,600 lines across 144 files** — a mature
+product, not a sketch. It already owns:
+
+```text
+DataIngestionService     1,591 lines   pulls sources, maps, upserts
+LocalDbManager             844 lines   builds and maintains its OWN SQLite
+SyncManager                679 lines   scheduling and reconciliation
+ValidationOrchestrator   1,012 lines   refuses a bad configuration
+RibbonControlService       980 lines   renders the Excel menus
+LicenseService             752 lines   tiers, device fingerprint, activation
+UpdateService              610 lines   its own update channel
+```
+
+**ScrapeX must not rebuild any of it.** Ingestion, the local database, sync,
+validation, licensing and updates are XaddIn's, and duplicating them is the
+single easiest way to waste months.
+
+### How XaddIn is driven
+
+Six configuration sheets, published on Google Sheets and pulled as TSV, define
+everything: `TableDefinition` (the entity), `SchemaRule` (its fields),
+`DataSource` (where the data comes from), `DataMap` (column mapping),
+`ExportViews` (named views), `RibbonControls` (the Excel buttons).
+
+The owner fills all six **by hand** today.
+
+Their vocabularies are closed enums in the C# — the Console must emit these
+exact strings or XaddIn rejects the row:
+
+```text
+EntityType        COST PERF REF COMP CONVERSION COST_ENG AUDIT ASSEMBLY LIBRARY SYSTEM
+BusinessDomain    MATERIAL LABOR EQUIPMENT VENDOR PROJECT FINANCE SYSTEM GARB
+UpdateStrategy    ReplaceAll MergeUpsert Append
+ColumnDataType    TEXT DECIMAL INT BOOL DATE DATETIME GUID JSON PERCENTAGE BLOB
+SemanticRole      NONE PRICE QTY TOTAL UNIT NAME CONV_* and eleven MENU_*
+MapSourceType     Header Index Context Constant Formula
+MapMatchMode      Exact Contains StartsWith Regex Fuzzy
+SyncFrequency     Manual Hourly Daily Weekly Monthly
+```
+
+### The two systems already share their central idea
+
+`SchemaRuleEntity.cs` says, in its own comment, that the menu builder binds **by
+role, not by physical column name, so a rename is safe**. That is exactly
+ScrapeX's `dataset_field`: `field_key` is stable and internal, `display_name` is
+a presentation choice, `display_order` and `is_hidden` are the owner's. The two
+products invented the same rule independently.
+
+And `SemanticRole` names `PRICE`, `QTY`, `UNIT` — three things ScrapeX already
+knows about every row it stores, down to **which field of the site stated the
+unit and who witnessed it**.
+
+### The data path is a published Google Sheet, and the code decides that
+
+**Decision 19 (owner, 2026-08-05): Engine writes the table to a Google Sheet, and
+the Console puts that sheet's published TSV link into `DataSource.SOURCE_URI`.**
+
+The alternatives were investigated and one of them is a trap worth recording,
+because it passes every check a reader would think to make.
+
+`SourceUriValidator.cs` accepts **any** `http(s)` URL *or a local path* (`C:\...`,
+`/path/to/file`), and `SourceType` declares `LocalCsv`, `LocalSqlite` and
+`RestApi`. A local file therefore looks supported from every angle a
+configuration author can see.
+
+**It is not.** `DataIngestionService.cs:734`:
+
+```csharp
+if (!source.SOURCE_URI.StartsWith("http"))
+{
+    _log.LogError($"[CONFIG ERROR] Source '{source.SOURCE_KEY}' has an INVALID URL...");
+    prep.EarlyResult = IngestionResult.Fail(...);
+}
+```
+
+The validator accepts it; the ingester refuses it. The only file the service ever
+opens with `File.OpenRead` is the staging file **it downloaded over HTTP itself**.
+`LocalSqlite` and `RestApi` appear in the entity and in one task-pane info builder
+and nowhere else — enum values with no implementation behind them.
+
+Recorded because the failure is silent and misattributed: a configuration written
+that way validates, then fails at the first pull with `[CONFIG ERROR] INVALID
+URL`, and the obvious suspect is the Console having written a bad link.
+
+So every path must be HTTP, which leaves three:
+
+```text
+published Google Sheet   works today, no change to XaddIn, any machine
+                         — and the table is readable by anyone with the URL
+a Drive share link       still needs "anyone with the link", so same exposure,
+                         because XaddIn sends no credentials at all
+127.0.0.1 endpoint       the only genuinely private one — same machine, Engine running
+```
+
+**A published sheet is public to whoever holds the URL.** Signing in with Google
+grants the *write*; the link XaddIn reads is a Publish-to-web link, and
+`DataSourceEntity.cs:667` says so in its own words: *"Currently all sources are
+public (Google Sheets published URLs — no auth needed)."* `HttpClientService`
+sends a request id and a user agent, and nothing else.
+
+For the owner's own data that is acceptable. **At commercialisation it is a
+different decision**, and the way out is then open: teaching XaddIn to read a
+local file is a few lines at that same line 734.
+
+The six **configuration** sheets stay on Google regardless — that is where XaddIn
+reads its own settings from.
+
+### What this does not change
+
+`SourceUriValidator.cs` accepts **any** `http://` or `https://` URL, or a local
+path (`C:\...` or `/path/to/file`). Google Sheets appears only in its help text.
+The one HTTP rule is that the domain must contain a dot — which
+`http://127.0.0.1:8000/...` satisfies.
+
+`SourceType` also declares `LocalSqlite` and `RestApi`, **but only TSV is built**
+(owner, 2026-08-05): those two enum values appear in the entity and in a task-pane
+info builder, and nowhere else. So the integration is TSV, and TSV can come from:
+
+```text
+a local file        Engine writes  …\scrapex\exports\T_MATERIALS.tsv
+a local endpoint    Engine serves  http://127.0.0.1:8000/export/T_MATERIALS.tsv
+```
+
+Either removes Google from the **data** path entirely — no upload, no API quota,
+no lag, and no sensitive scope standing between the product and a public listing.
+The six **configuration** sheets stay where they are, because that is where
+XaddIn reads its own settings from.
+
+Google keeps what Decision 3 gave it: backup, restore, and working from another
+machine.
+
+### What the Console therefore is
+
+> **The Console turns one crawled dataset into one working Excel ribbon button,
+> by generating the six rows that describe it — and keeps them true when the
+> schema changes.**
+
+Not a sheet editor. A generator with a validator, whose output is judged by one
+question: does the button appear in Excel and fetch the right table?
+
+---
+
+## 6. Milestones
+
+Each leaves the product runnable and ends in something the owner can open.
+
+**The order was wrong in the first draft and is corrected here.** It ran M0 → M1 →
+one database → entities, which is three milestones before anything new is visible.
+But the single database is a prerequisite for the entity work and **for nothing
+else** — backup, restore, the bare-extension view and publishing do not need it.
+
+So the schema is left alone until there is a published, backed-up, multi-device
+product. There are 88,286 price observations from 12 audited sources running daily
+today; that is the thing to protect, not to rebuild around a capability that does
+not exist yet.
+
+### M0 — separate the three products *(nothing else works without this)*
+
+Decision 4 asks the extension to detect an incompatible engine. **That is impossible while one version number covers both** — there is no "incompatible" when they always move together.
+
+- Split the versions: ScrapeX and Engine get their own, and **the protocol number becomes the contract between them**.
+- Move the panel tests to the extension. 134 Python tests drive a JavaScript UI today — they are not wrong, they caught a real `Escape` defect, but they bind the two products so a button change runs the whole engine suite. This needs a browser runner on the JS side and is the only real work in M0.
+- Split CI by path, so an extension change does not rebuild the engine.
+
+**Done when:** a button change runs the extension suite alone, and the two products carry different version numbers.
+
+### M1 — sign in, and state the version truth
+
+- Google sign-in moves to the extension (`identity`, an `oauth2` client, the same `drive.file` + `spreadsheets` scopes). The extension owns the token and lends it to Engine.
+- The extension reads Engine's installed version and protocol and **states compatibility before any job can start**, with the exact action when it is insufficient.
+- A GitHub Release feed is the source of truth for "latest Engine" (Decision 4).
+
+**Done when:** an intentionally mismatched engine is refused with a named action, instead of a dead panel.
+
+### M2 — backup, restore, and the lease
+
+- The bundle of §5: `.db` + plain per-dataset export + manifest + checksums.
+- Drive upload with the frequency setting of Decision 12.
+- `latest.json` pointing only at a validated bundle; retention of N versions.
+- A lease with device id and expiry, and a stale-lease recovery path.
+
+**Done when:** a second machine restores the warehouse and refuses to run while the
+first holds the lease.
+
+### M3 — the bare-extension view
+
+The panel reads the plain export from the bundle and shows datasets, rows and
+history with no engine installed, and exports to XLSX/CSV.
+
+### M4 — publish, unlisted
+
+Privacy policy, data-handling and deletion statement, support contact — **none
+exist today**. Chrome Web Store developer account, unlisted listing, OAuth consent
+screen in testing mode.
+
+**Done when:** a tester installs from a link, signs in, and restores the owner's
+data. *At this point the product is real: published, backed up, portable.*
+
+### M5 — one database
+
+- Collapse `general.db` into Engine's single database, and the two migration streams into one. `general.db` holds six rows, five of them bookkeeping — there is no data to migrate, only a schema to unify.
+- Bring the eleven generic tables in beside the priced offers.
+- Rename `MarketLens` → `Engine` throughout: kind marker, `~/.scrapex/` path, package name, docs.
+
+**Done when:** one file, one migration stream, and every existing price test still passes.
+
+### M6 — the first entity domain
+
+One vertical slice, end to end, on `muqawil.org` — chosen because it is
+server-rendered with `?page=` pagination and needs no browser.
+
+**CRAWL SCOPE IS A PER-SOURCE SETTING, NOT A PROJECT DECISION** (owner, 2026-08-05).
+Measured on muqawil to show why it has to be one: the listing is 860 pages — at the
+shipped 1s pace, **14 minutes**. Every detail page is **121,157 requests: 34 hours
+at 1s, 17 at 0.5s.** One crawl would take a day and a half, and change-tracking
+means repeating it. Fourteen minutes and thirty-four hours are different products,
+and which one a user wants is theirs to say.
+
+So every source carries a scope, chosen in ScrapeX:
+
+```text
+listing only        the fields the listing page already shows
+listing + details   details for a slice the user names — a city, a grade
+full, then listing  one founding crawl, then the listing catches the changes
+```
+
+muqawil is the example, not the rule. It happens to publish grade, status, rating
+and city **on the listing page itself**, so `listing only` may be the whole answer
+there — but that is a fact about one site, discovered when it is added, not a
+decision the schema should assume.
+
+- A contractor is discovered, stored, and tracked: appeared, confirmed, disappeared, returned.
+- **Field-level change** (Decision 13): a grade moving 3rd → 2nd is an event with a before, an after, and a date.
+- It renders in the same table the prices use, from the dataset's own schema.
+
+**Done when:** the owner opens a contractor and sees when its grade changed.
+
+### M7 — the Console
+
+See §5b for what XaddIn is and why the seam is narrow. The Console is an
+owner-only module inside ScrapeX, authorised at the write layer and excluded from
+the commercial build by build configuration.
+
+**M7a — one dataset becomes one button.** The smallest thing that is real:
+
+1. Engine writes a TSV for one dataset — a local file, or served at
+   `127.0.0.1`, per the setting.
+2. The Console generates the rows that describe it: one `TableDefinition`, its
+   `SchemaRule` fields, one `DataSource` pointing at that TSV, its `DataMap`, one
+   `ExportViews` entry, one `RibbonControls` button.
+3. It writes them into the six Google Sheets XaddIn already reads.
+4. XaddIn pulls, builds its own local database, and the button appears.
+
+**Done when:** the owner crawls a source, presses one thing in ScrapeX, opens
+Excel, and the table is there — having typed nothing into a sheet.
+
+**M7b — keep them true.** A schema that changes must not leave a stale
+`SchemaRule` behind: a new column appears, a hidden one stops being exported, a
+display name changes. The Console re-generates and reports what moved.
+
+**What ScrapeX can fill on its own** — `ENTITY_KEY`, `DISPLAY_NAME`,
+`ATTRIBUTE_KEY`, `DISPLAY_HEADER`, `ORDINAL_POS`, `IS_VISIBLE`, `SOURCE_URI`,
+`VERSION_TAG`, and the `DataMap` rows: all of it is already in `dataset_field`,
+`sources.yaml` and the export header.
+
+**What it can derive** — `DATA_TYPE` from the stored values, and `SEMANTIC_ROLE`
+for `PRICE`, `QTY` and `UNIT`, which Engine knows per row and can name the
+witness for.
+
+**What will always be typed** — `SCREEN_TIP`, `SUPER_TIP`, `ICON`, `LICENSE_TIER`,
+`BUSINESS_DOMAIN`, and where a button sits in the ribbon tree. These are
+judgements, not facts, and the Console's job is to ask for them once and remember.
+
+**A ceiling to know now, not at M4.** Reading a Sheet the app did not create needs
+the `spreadsheets` scope, which Google classes as sensitive. In testing mode (100
+users) that needs no verification and Decision 6 is safe. **Going public later
+does** — and a crawling tool asking for a user's spreadsheets is not a formality.
+It is also an argument for keeping the DATA path local: only the six configuration
+sheets need Google at all.
+
+**What breaks if the Console writes a row wrongly.** XaddIn's
+`ValidationOrchestrator` (1,012 lines) refuses a bad configuration — so the
+failure mode is a button that does not appear, not corrupted data. The guard is to
+generate against the same closed vocabularies the C# declares (§5b) and to refuse
+to write a row whose enum value is not one of them.
+
+**Never rebuilt here:** ingestion, the local database, sync, validation, licensing
+and updates are XaddIn's, and it already has all six.
+
+### M8 — the browser tier, and only then a tool
+
+`developmentaid.org` returns an almost empty page to a plain fetch, and `cat.com`
+refuses the connection outright. Those two are the browser tier.
+
+**BUILD THE SEAM, NOT THE TOOLS** (owner, 2026-08-05): the foundation is laid so
+it can be used when a need appears, and if Engine does the job the matter is
+dropped.
+
+`BrowserFetcher` exists in `connectors/base.py` — Playwright, an owner decision from
+day one — and **no source uses it today**. The stated reason for installing an
+external tool is "sites that need JavaScript", which is exactly what that class
+does. Point it at developmentaid first. If it reads the tenders, this milestone is
+a fetcher setting on a source and nothing more.
+
+What an external tool genuinely buys is what we do not have: rotation,
+fingerprinting, getting past a refusal. `cat.com` closing the connection outright
+is evidence for that; a JavaScript page is not.
+
+So the deliverable here is the **contract** — install, health, version, and an
+importer that takes a tool's own output files into Engine's database (Decision 10)
+— proved by one tool, for one site that actually blocked us. Not a catalogue.
+
+---
+
+## 7. Deleted, and why
+
+- **The `apps/` relocation.** Its goal is met in place: `extension/package.json`, CI split by path, `scrapex-vX` and `engine-vY` tags, two distribution channels. Zero files move.
+- **Four uncommitted backends** with "exact domain role TBD". M8 replaces them with one tool for one measured need.
+- **MSIX and AppInstaller.** A code-signing certificate and a hosted feed, for an update mechanism Decision 4 replaced. PyInstaller already produces the artefact; GitHub Releases distributes it.
+- **"Domain Engines: Price / Listing / Table."** No such modules; the taxonomy collapses domain into extraction method.
+- **Google Sheets as the configuration store.** Decision 5 makes it a publishing target.
+- **Hand-typed version numbers.** They come from the ledger the build gate enforces.
+
+---
+
+## 8. `CLAUDE.md` amendments
+
+- **"Local Runtime Distribution and Updates"** requires silent OTA updates. Decision 4 replaces this with GitHub-Release-driven checks and an explicit install. The intent — a non-technical user never touches a command line or `pip` — still binds.
+- **Cross-Cutting Gate DB1** mandates two physically separate databases. Decision 7 replaces it with one database per *engine*, which is what the gate was protecting: no engine may write into another's store.
+
+Everything else stands, including the sections the previous plan omitted: bilingual capture and RTL, the price-history semantics of §15, OS resource limits, proxy and anti-bot handling, and adapter drift.
+
+---
+
+## 9. Still open
+
+1. **Is there a Chrome Web Store developer account, and which Google account owns it?** M6 cannot start without one.
+2. **Which Google Cloud project owns the OAuth client?** The consent screen, test-user list and scopes live there.
+3. **What does the Excel add-in expect the Sheet to look like** — tab names, header
+   row, a view or the whole dataset? M7's shape depends on it.
+4. **How much of the register a user wants**, per source, is the scope setting in M6
+   — but the DEFAULT for a newly added source is not decided. `listing only` is the
+   safe one: it can never cost 34 hours by accident.

--- a/docs/PLATFORM-PLAN.md
+++ b/docs/PLATFORM-PLAN.md
@@ -20,7 +20,7 @@ Everything else — open-source crawlers, the Console — hangs off those two.
 | 1 | An engine is a **separate installed program**. | ScrapeX needs an install / launch / monitor / version contract, not a plugin loader. |
 | 2 | **Engine crawls everything, not only prices.** Prices are one domain beside contractors, tenders, equipment, jobs. | The name `MarketLens` retires. The schema stops being price-shaped. |
 | 3 | **One device at a time, with restore.** | Drive is enough. No server, no shared SQLite file. A lease stops two devices at once. |
-| 4 | **Updates are tracked through GitHub Releases**, not self-updating. | **Overrides `CLAUDE.md`'s "silent OTA updates" requirement.** The brief must be amended. |
+| 4 | **Releasing is manual; updating is not.** We cut a release on GitHub; the tool reads it, tells the owner, and installs it itself — like any desktop application. | **Overrides `CLAUDE.md`'s "silent OTA" requirement**: the install is not silent, it is announced and accepted. It is also not a manual download — the earlier wording said "explicit user install" and that was wrong. The pattern is already proven in `mbiXaddin/Infrastructure/Update/UpdateService.cs`: `CheckForUpdatesAsync` → `ShowUpdatePromptIfNeeded` → `ExecuteFullInstallAsync`, with a 10-second check timeout held separately from the client timeout so a stalled GitHub fetch cannot hang startup. Copy it. |
 | 5 | The existing Excel add-in **reads from a Google Sheet**. | The Console's job is to write that Sheet. Sheets is a publishing target, never the configuration store. |
 | 6 | First publish: **owner plus a few testers, unlisted**. | A privacy policy and a support contact are required; the repository has neither. OAuth stays in testing mode (100 users), so the `spreadsheets` scope needs no verification yet. |
 | 7 | **Engine gets ONE database** covering every crawl type it performs. | `general.db` retires. One migration stream. A question can cross types: *which contractor also sells?* |
@@ -304,6 +304,10 @@ Decision 4 asks the extension to detect an incompatible engine. **That is imposs
 - Google sign-in moves to the extension (`identity`, an `oauth2` client, the same `drive.file` + `spreadsheets` scopes). The extension owns the token and lends it to Engine.
 - The extension reads Engine's installed version and protocol and **states compatibility before any job can start**, with the exact action when it is insufficient.
 - A GitHub Release feed is the source of truth for "latest Engine" (Decision 4).
+  Three calls, mirroring what XaddIn already does: check on startup (with its own
+  short timeout, so a stalled fetch never delays the panel), prompt when there is
+  something newer, install on acceptance. The owner is never sent to a browser to
+  fetch an installer.
 
 **Done when:** an intentionally mismatched engine is refused with a named action, instead of a dead panel.
 
@@ -460,7 +464,11 @@ importer that takes a tool's own output files into Engine's database (Decision 1
 
 ## 8. `CLAUDE.md` amendments
 
-- **"Local Runtime Distribution and Updates"** requires silent OTA updates. Decision 4 replaces this with GitHub-Release-driven checks and an explicit install. The intent — a non-technical user never touches a command line or `pip` — still binds.
+- **"Local Runtime Distribution and Updates"** requires silent OTA updates.
+  Decision 4 replaces *silent* with *announced*: the tool checks GitHub, says
+  there is a newer version, and installs it itself on acceptance. The brief's
+  intent — that a non-technical user never touches a command line, `pip`, or a
+  download page — is not weakened by this; it is how it gets delivered.
 - **Cross-Cutting Gate DB1** mandates two physically separate databases. Decision 7 replaces it with one database per *engine*, which is what the gate was protecting: no engine may write into another's store.
 
 Everything else stands, including the sections the previous plan omitted: bilingual capture and RTL, the price-history semantics of §15, OS resource limits, proxy and anti-bot handling, and adapter drift.

--- a/docs/PLATFORM-PLAN.md
+++ b/docs/PLATFORM-PLAN.md
@@ -22,7 +22,7 @@ Everything else — open-source crawlers, the Console — hangs off those two.
 | 3 | **One device at a time, with restore.** | Drive is enough. No server, no shared SQLite file. A lease stops two devices at once. |
 | 4 | **Releasing is manual; updating is not.** We cut a release on GitHub; the tool reads it, tells the owner, and installs it itself — like any desktop application. | **Overrides `CLAUDE.md`'s "silent OTA" requirement**: the install is not silent, it is announced and accepted. It is also not a manual download — the earlier wording said "explicit user install" and that was wrong. The pattern is already proven in `mbiXaddin/Infrastructure/Update/UpdateService.cs`: `CheckForUpdatesAsync` → `ShowUpdatePromptIfNeeded` → `ExecuteFullInstallAsync`, with a 10-second check timeout held separately from the client timeout so a stalled GitHub fetch cannot hang startup. Copy it. |
 | 5 | The existing Excel add-in **reads from a Google Sheet**. | The Console's job is to write that Sheet. Sheets is a publishing target, never the configuration store. |
-| 6 | First publish: **owner plus a few testers, unlisted**. | A privacy policy and a support contact are required; the repository has neither. OAuth stays in testing mode (100 users), so the `spreadsheets` scope needs no verification yet. |
+| 6 | First publish: **owner plus a few testers, unlisted**. | A privacy policy and a support contact are required; the repository has neither. The shipped build needs only `drive.file`, which is not sensitive — see Decision 20 — so verification is not a gate here or later. |
 | 7 | **Engine gets ONE database** covering every crawl type it performs. | `general.db` retires. One migration stream. A question can cross types: *which contractor also sells?* |
 | 8 | On a new device with no engine, the owner **sees his data and exports it**. | The backup bundle must carry a plain export beside the `.db`. See §5. |
 | 9 | Databases are **managed only through ScrapeX** — location, backup, restore, migration. | The controls live in the extension; Engine executes them. A browser extension cannot create a SQLite file. |
@@ -34,6 +34,7 @@ Everything else — open-source crawlers, the Console — hangs off those two.
 | 16 | **An audited source and a user-added one are visibly different.** | `sources.yaml` carries 12 audited sources today with no field telling them apart. A user who adds a site and gets poor data must see *why* — `audited` beside `you added this` — or they will read it as the product being broken. |
 | 17 | **Crawl scope is a per-source setting**, not a project-wide rule. | listing only · listing + details for a named slice · full once then listing. See M6. |
 | 18 | **For external tools, build the seam and not the tools.** | The install/health/import contract is laid so it can be used when a need appears; if Engine does the job, the matter is dropped. See M8. |
+| 20 | **The Console is the owner's alone and is never published.** | It therefore carries the only Google scope that is sensitive, and the shipped build asks for `drive.file` only — see below. Excluding it is a security decision, not just a commercial one. |
 | 19 | **The data path is a published Google Sheet.** Engine writes the table there; the Console puts its TSV link in `SOURCE_URI`. | The only path that works today with no change to XaddIn and from any machine. A local file passes the validator and is refused by the ingester at `DataIngestionService.cs:734` — see §5b. The table is readable by anyone holding the URL; acceptable for the owner's own data, a separate decision at commercialisation. |
 | 15 | **The Python package stays `scrapex/`.** `Engine` is the product name, not the directory. | The user never sees a directory. Renaming costs 748 import lines in tests alone, 188 `python -m scrapex` call sites in CI, docs and JS, a reinstall of the editable package, and five hard-coded paths — for nothing anyone can see. A capitalised `Engine/` would also work on Windows and fail on Linux, where CI runs. |
 
@@ -364,10 +365,29 @@ Judgements, not facts. The Console asks once and remembers.
 `ValidationOrchestrator` is the second line, not the first — relying on it would
 mean discovering mistakes in Excel instead of in ScrapeX.
 
-**A ceiling to know now, not at M4.** Reading a Sheet the app did not create needs
-the `spreadsheets` scope, which Google classes as sensitive. In testing mode (100
-users) it needs no verification and Decision 6 is safe. Going public later does,
-and a crawling tool asking for a user's spreadsheets is not a formality.
+**THE SCOPE CEILING IS GONE, AND THIS MILESTONE IS WHY.**
+
+Reading a Sheet the app did not create needs `https://www.googleapis.com/auth/spreadsheets`,
+which Google classes as sensitive: verification to go public, and a 100-user cap
+until then. Earlier drafts of this plan treated that as a standing cost of the
+product.
+
+It is not. **Only the Console needs it** — it is the only thing that touches the
+six sheets the owner wrote by hand. Everything else writes to spreadsheets
+ScrapeX created itself (`gdrive.ensure_spreadsheet` creates them inside the
+app's own folder), and `drive.file` covers app-created files completely.
+
+So, given Decision 20:
+
+```text
+shipped build     drive.file only        non-sensitive · no verification · no cap
+owner build       + spreadsheets         the Console, never published
+```
+
+The scope must be declared in the owner build alone, not in the published
+`manifest.json`. That makes excluding the Console a **security** decision as well
+as a commercial one, and it removes what was the single largest obstacle between
+this product and a public listing.
 
 ### M8 — the browser tier, and only then a tool
 

--- a/docs/PLATFORM-PLAN.md
+++ b/docs/PLATFORM-PLAN.md
@@ -126,41 +126,51 @@ The `.db` stays the restorable artefact for a machine that installs Engine. The 
 
 ---
 
-## 5b. The ecosystem: ScrapeX, Engine, and XaddIn
+## 5b. The XaddIn boundary
 
-The Console exists for one reason, and it is narrower and more concrete than
-"edit some sheets".
+**XaddIn is a separate product in a separate repository, and this plan does not
+touch it.** ScrapeX serves it. That is the whole relationship, and the section is
+organised around the boundary rather than around either side.
 
-### What XaddIn already is
-
-`mbiXaddin` is a VSTO Excel add-in of **49,600 lines across 144 files** — a mature
-product, not a sketch. It already owns:
+### Two products, one contract
 
 ```text
-DataIngestionService     1,591 lines   pulls sources, maps, upserts
-LocalDbManager             844 lines   builds and maintains its OWN SQLite
-SyncManager                679 lines   scheduling and reconciliation
-ValidationOrchestrator   1,012 lines   refuses a bad configuration
-RibbonControlService       980 lines   renders the Excel menus
-LicenseService             752 lines   tiers, device fingerprint, activation
-UpdateService              610 lines   its own update channel
+        THIS PLAN                    │            NOT THIS PLAN
+                                     │
+  ScrapeX (extension)                │   mbiXaddin (VSTO, C#, 49,600 lines)
+  Engine  (python)                   │     ingestion · its own SQLite · sync
+  Console (module in ScrapeX)        │     validation · licensing · updates
+                                     │     ribbon rendering · icons
+        produces ──────────────────► │ ◄────────────────── consumes
+                                     │
+            one TSV per dataset      │
+            six configuration rows   │
 ```
 
-**ScrapeX must not rebuild any of it.** Ingestion, the local database, sync,
-validation, licensing and updates are XaddIn's, and duplicating them is the
-single easiest way to waste months.
+Everything on the right already exists and works. **ScrapeX rebuilds none of it**
+— duplicating ingestion, a local database, sync, validation, licensing or an
+update channel is the easiest way to lose months to work already done.
 
-### How XaddIn is driven
+Everything crossing the line is data and configuration. No code, no library, no
+shared runtime, no build dependency. The two repositories never import each
+other.
 
-Six configuration sheets, published on Google Sheets and pulled as TSV, define
-everything: `TableDefinition` (the entity), `SchemaRule` (its fields),
-`DataSource` (where the data comes from), `DataMap` (column mapping),
-`ExportViews` (named views), `RibbonControls` (the Excel buttons).
+### What ScrapeX must produce — the entire obligation
 
-The owner fills all six **by hand** today.
+1. **A TSV per dataset**, reachable at an `http(s)` URL. Decision 19: a published
+   Google Sheet.
+2. **Six rows describing it**, written into the six configuration sheets XaddIn
+   already reads: one `TableDefinition`, its `SchemaRule` fields, one
+   `DataSource`, its `DataMap`, one `ExportViews`, one `RibbonControls` button.
 
-Their vocabularies are closed enums in the C# — the Console must emit these
-exact strings or XaddIn rejects the row:
+That is all. If both are right, the button appears in Excel. If either is wrong,
+XaddIn's own validator refuses the row and the button does not appear — which is
+the failure mode we want, because it cannot corrupt anything.
+
+### The vocabularies ScrapeX must emit exactly
+
+The configuration columns are closed enums declared in XaddIn's C#. ScrapeX must
+write these strings verbatim, and refuse to write anything else:
 
 ```text
 EntityType        COST PERF REF COMP CONVERSION COST_ENG AUDIT ASSEMBLY LIBRARY SYSTEM
@@ -173,105 +183,45 @@ MapMatchMode      Exact Contains StartsWith Regex Fuzzy
 SyncFrequency     Manual Hourly Daily Weekly Monthly
 ```
 
-### The two systems already share their central idea
+These are the contract. They change only when XaddIn changes them, and then
+ScrapeX follows — never the other way round.
 
-`SchemaRuleEntity.cs` says, in its own comment, that the menu builder binds **by
-role, not by physical column name, so a rename is safe**. That is exactly
-ScrapeX's `dataset_field`: `field_key` is stable and internal, `display_name` is
-a presentation choice, `display_order` and `is_hidden` are the owner's. The two
-products invented the same rule independently.
+### What is deliberately NOT ScrapeX's problem
 
-And `SemanticRole` names `PRICE`, `QTY`, `UNIT` — three things ScrapeX already
-knows about every row it stores, down to **which field of the site stated the
-unit and who witnessed it**.
+- **How XaddIn stores what it pulls.** It has `LocalDbManager` and builds its own
+  SQLite. Engine's database and XaddIn's database are unrelated files that never
+  meet.
+- **How the ribbon renders.** `RibbonControlService` owns that.
+- **Licensing.** `LicenseService`, device fingerprinting and tiers are XaddIn's.
+  ScrapeX writes a `LICENSE_TIER` string into a row and knows nothing else about
+  it.
+- **Sync scheduling on the Excel side.** ScrapeX writes `SyncFrequency`; XaddIn
+  decides when to act on it.
 
-### The data path is a published Google Sheet, and the code decides that
+### What would require changing XaddIn — a different project's backlog
 
-**Decision 19 (owner, 2026-08-05): Engine writes the table to a Google Sheet, and
-the Console puts that sheet's published TSV link into `DataSource.SOURCE_URI`.**
+Recorded so it is never smuggled into a ScrapeX milestone:
 
-The alternatives were investigated and one of them is a trap worth recording,
-because it passes every check a reader would think to make.
+- **Reading a local file.** `DataIngestionService.cs:734` refuses any URI not
+  starting with `http`, although the validator accepts local paths and
+  `SourceType` declares `LocalCsv`, `LocalSqlite` and `RestApi`. Those three have
+  no implementation. Teaching it local files is a few lines *there*, and it is
+  what would let the data path stop being public — see Decision 19.
+- **Authenticated fetching.** `HttpClientService` sends a request id and a user
+  agent and nothing else; `DataSourceEntity.cs:667` says so: *"Currently all
+  sources are public (Google Sheets published URLs — no auth needed)."*
 
-`SourceUriValidator.cs` accepts **any** `http(s)` URL *or a local path* (`C:\...`,
-`/path/to/file`), and `SourceType` declares `LocalCsv`, `LocalSqlite` and
-`RestApi`. A local file therefore looks supported from every angle a
-configuration author can see.
+Neither is required for anything in this plan. Both are the reason the data path
+is a published sheet today.
 
-**It is not.** `DataIngestionService.cs:734`:
+### One thing worth copying, not importing
 
-```csharp
-if (!source.SOURCE_URI.StartsWith("http"))
-{
-    _log.LogError($"[CONFIG ERROR] Source '{source.SOURCE_KEY}' has an INVALID URL...");
-    prep.EarlyResult = IngestionResult.Fail(...);
-}
-```
+The two products independently arrived at the same rule. `SchemaRuleEntity` binds
+**by role, not by physical column name, so a rename is safe** — which is exactly
+`dataset_field`'s stable `field_key` against its editable `display_name`. And
+XaddIn's `UpdateService` is the pattern Decision 4 adopts.
 
-The validator accepts it; the ingester refuses it. The only file the service ever
-opens with `File.OpenRead` is the staging file **it downloaded over HTTP itself**.
-`LocalSqlite` and `RestApi` appear in the entity and in one task-pane info builder
-and nowhere else — enum values with no implementation behind them.
-
-Recorded because the failure is silent and misattributed: a configuration written
-that way validates, then fails at the first pull with `[CONFIG ERROR] INVALID
-URL`, and the obvious suspect is the Console having written a bad link.
-
-So every path must be HTTP, which leaves three:
-
-```text
-published Google Sheet   works today, no change to XaddIn, any machine
-                         — and the table is readable by anyone with the URL
-a Drive share link       still needs "anyone with the link", so same exposure,
-                         because XaddIn sends no credentials at all
-127.0.0.1 endpoint       the only genuinely private one — same machine, Engine running
-```
-
-**A published sheet is public to whoever holds the URL.** Signing in with Google
-grants the *write*; the link XaddIn reads is a Publish-to-web link, and
-`DataSourceEntity.cs:667` says so in its own words: *"Currently all sources are
-public (Google Sheets published URLs — no auth needed)."* `HttpClientService`
-sends a request id and a user agent, and nothing else.
-
-For the owner's own data that is acceptable. **At commercialisation it is a
-different decision**, and the way out is then open: teaching XaddIn to read a
-local file is a few lines at that same line 734.
-
-The six **configuration** sheets stay on Google regardless — that is where XaddIn
-reads its own settings from.
-
-### What this does not change
-
-`SourceUriValidator.cs` accepts **any** `http://` or `https://` URL, or a local
-path (`C:\...` or `/path/to/file`). Google Sheets appears only in its help text.
-The one HTTP rule is that the domain must contain a dot — which
-`http://127.0.0.1:8000/...` satisfies.
-
-`SourceType` also declares `LocalSqlite` and `RestApi`, **but only TSV is built**
-(owner, 2026-08-05): those two enum values appear in the entity and in a task-pane
-info builder, and nowhere else. So the integration is TSV, and TSV can come from:
-
-```text
-a local file        Engine writes  …\scrapex\exports\T_MATERIALS.tsv
-a local endpoint    Engine serves  http://127.0.0.1:8000/export/T_MATERIALS.tsv
-```
-
-Either removes Google from the **data** path entirely — no upload, no API quota,
-no lag, and no sensitive scope standing between the product and a public listing.
-The six **configuration** sheets stay where they are, because that is where
-XaddIn reads its own settings from.
-
-Google keeps what Decision 3 gave it: backup, restore, and working from another
-machine.
-
-### What the Console therefore is
-
-> **The Console turns one crawled dataset into one working Excel ribbon button,
-> by generating the six rows that describe it — and keeps them true when the
-> schema changes.**
-
-Not a sheet editor. A generator with a validator, whose output is judged by one
-question: does the button appear in Excel and fetch the right table?
+Copying a proven shape is not coupling. Sharing a library would be.
 
 ---
 
@@ -376,55 +326,48 @@ decision the schema should assume.
 
 ### M7 — the Console
 
-See §5b for what XaddIn is and why the seam is narrow. The Console is an
-owner-only module inside ScrapeX, authorised at the write layer and excluded from
-the commercial build by build configuration.
+**Scope: ScrapeX only.** Nothing in this milestone changes XaddIn, and nothing in
+it may depend on XaddIn changing. See §5b for the boundary.
+
+An owner-only module inside ScrapeX, authorised at the write layer and excluded
+from the commercial build by build configuration.
 
 **M7a — one dataset becomes one button.** The smallest thing that is real:
 
-1. Engine writes a TSV for one dataset — a local file, or served at
-   `127.0.0.1`, per the setting.
-2. The Console generates the rows that describe it: one `TableDefinition`, its
-   `SchemaRule` fields, one `DataSource` pointing at that TSV, its `DataMap`, one
-   `ExportViews` entry, one `RibbonControls` button.
-3. It writes them into the six Google Sheets XaddIn already reads.
-4. XaddIn pulls, builds its own local database, and the button appears.
+1. Engine publishes one dataset's table to a Google Sheet and holds its TSV link.
+2. The Console generates the six rows that describe it.
+3. It writes them into the six configuration sheets.
+4. XaddIn — untouched — pulls, and the button appears.
 
 **Done when:** the owner crawls a source, presses one thing in ScrapeX, opens
-Excel, and the table is there — having typed nothing into a sheet.
+Excel, and the table is there, having typed nothing into a sheet.
 
 **M7b — keep them true.** A schema that changes must not leave a stale
-`SchemaRule` behind: a new column appears, a hidden one stops being exported, a
+`SchemaRule` behind: a column appears, a hidden one stops being exported, a
 display name changes. The Console re-generates and reports what moved.
 
-**What ScrapeX can fill on its own** — `ENTITY_KEY`, `DISPLAY_NAME`,
-`ATTRIBUTE_KEY`, `DISPLAY_HEADER`, `ORDINAL_POS`, `IS_VISIBLE`, `SOURCE_URI`,
-`VERSION_TAG`, and the `DataMap` rows: all of it is already in `dataset_field`,
-`sources.yaml` and the export header.
+**What ScrapeX can fill from what it already stores** — `ENTITY_KEY`,
+`DISPLAY_NAME`, `ATTRIBUTE_KEY`, `DISPLAY_HEADER`, `ORDINAL_POS`, `IS_VISIBLE`,
+`SOURCE_URI`, `VERSION_TAG`, and the `DataMap` rows. All of it is in
+`dataset_field`, `sources.yaml` and the export header today.
 
 **What it can derive** — `DATA_TYPE` from the stored values, and `SEMANTIC_ROLE`
-for `PRICE`, `QTY` and `UNIT`, which Engine knows per row and can name the
-witness for.
+for `PRICE`, `QTY` and `UNIT`, which Engine knows per row and can name the witness
+for.
 
-**What will always be typed** — `SCREEN_TIP`, `SUPER_TIP`, `ICON`, `LICENSE_TIER`,
-`BUSINESS_DOMAIN`, and where a button sits in the ribbon tree. These are
-judgements, not facts, and the Console's job is to ask for them once and remember.
+**What the owner will always type** — `SCREEN_TIP`, `SUPER_TIP`, `ICON`,
+`LICENSE_TIER`, `BUSINESS_DOMAIN`, and where a button sits in the ribbon tree.
+Judgements, not facts. The Console asks once and remembers.
+
+**The guard.** Every enum value written must come from the closed vocabularies in
+§5b, and the Console refuses to write a row carrying anything else. XaddIn's own
+`ValidationOrchestrator` is the second line, not the first — relying on it would
+mean discovering mistakes in Excel instead of in ScrapeX.
 
 **A ceiling to know now, not at M4.** Reading a Sheet the app did not create needs
 the `spreadsheets` scope, which Google classes as sensitive. In testing mode (100
-users) that needs no verification and Decision 6 is safe. **Going public later
-does** — and a crawling tool asking for a user's spreadsheets is not a formality.
-It is also an argument for keeping the DATA path local: only the six configuration
-sheets need Google at all.
-
-**What breaks if the Console writes a row wrongly.** XaddIn's
-`ValidationOrchestrator` (1,012 lines) refuses a bad configuration — so the
-failure mode is a button that does not appear, not corrupted data. The guard is to
-generate against the same closed vocabularies the C# declares (§5b) and to refuse
-to write a row whose enum value is not one of them.
-
-**Never rebuilt here:** ingestion, the local database, sync, validation, licensing
-and updates are XaddIn's, and it already has all six.
+users) it needs no verification and Decision 6 is safe. Going public later does,
+and a crawling tool asking for a user's spreadsheets is not a formality.
 
 ### M8 — the browser tier, and only then a tool
 

--- a/docs/PLATFORM-PLAN.md
+++ b/docs/PLATFORM-PLAN.md
@@ -34,6 +34,7 @@ Everything else — open-source crawlers, the Console — hangs off those two.
 | 16 | **An audited source and a user-added one are visibly different.** | `sources.yaml` carries 12 audited sources today with no field telling them apart. A user who adds a site and gets poor data must see *why* — `audited` beside `you added this` — or they will read it as the product being broken. |
 | 17 | **Crawl scope is a per-source setting**, not a project-wide rule. | listing only · listing + details for a named slice · full once then listing. See M6. |
 | 18 | **For external tools, build the seam and not the tools.** | The install/health/import contract is laid so it can be used when a need appears; if Engine does the job, the matter is dropped. See M8. |
+| 23 | **A newly added source has no default crawl scope — ScrapeX asks, and no crawl starts until the owner answers.** | An extra step per source, deliberately. A default that guesses wrong is a 34-hour crawl nobody asked for; a question is five seconds. |
 | 21 | **Two release paths, and a manual tag starts each.** `scrapex-vX` builds the extension and pushes it to the Chrome Web Store; `engine-vY` builds and publishes a GitHub Release. | The owner decides when each ships. Neither triggers the other, which is what makes them genuinely separate. |
 | 22 | **The engine binary is unsigned for now.** | The owner and a few testers accept one SmartScreen warning. A certificate costs money and identity verification yearly and buys nothing before commercialisation; the release path is built so signing is one step added later. |
 | 20 | **The Console is the owner's alone and is never published.** | It therefore carries the only Google scope that is sensitive, and the shipped build asks for `drive.file` only — see below. Excluding it is a security decision, not just a commercial one. |
@@ -508,6 +509,6 @@ Everything else stands, including the sections the previous plan omitted: biling
 2. **Which Google Cloud project owns the OAuth client?** The consent screen, test-user list and scopes live there.
 3. **What does the Excel add-in expect the Sheet to look like** — tab names, header
    row, a view or the whole dataset? M7's shape depends on it.
-4. **How much of the register a user wants**, per source, is the scope setting in M6
-   — but the DEFAULT for a newly added source is not decided. `listing only` is the
-   safe one: it can never cost 34 hours by accident.
+4. **The Chrome Web Store account and the Google Cloud project** are to be created
+   with the owner, step by step, when M4 begins. Nothing before then depends on
+   them.

--- a/docs/PLATFORM-PLAN.md
+++ b/docs/PLATFORM-PLAN.md
@@ -34,6 +34,8 @@ Everything else — open-source crawlers, the Console — hangs off those two.
 | 16 | **An audited source and a user-added one are visibly different.** | `sources.yaml` carries 12 audited sources today with no field telling them apart. A user who adds a site and gets poor data must see *why* — `audited` beside `you added this` — or they will read it as the product being broken. |
 | 17 | **Crawl scope is a per-source setting**, not a project-wide rule. | listing only · listing + details for a named slice · full once then listing. See M6. |
 | 18 | **For external tools, build the seam and not the tools.** | The install/health/import contract is laid so it can be used when a need appears; if Engine does the job, the matter is dropped. See M8. |
+| 21 | **Two release paths, and a manual tag starts each.** `scrapex-vX` builds the extension and pushes it to the Chrome Web Store; `engine-vY` builds and publishes a GitHub Release. | The owner decides when each ships. Neither triggers the other, which is what makes them genuinely separate. |
+| 22 | **The engine binary is unsigned for now.** | The owner and a few testers accept one SmartScreen warning. A certificate costs money and identity verification yearly and buys nothing before commercialisation; the release path is built so signing is one step added later. |
 | 20 | **The Console is the owner's alone and is never published.** | It therefore carries the only Google scope that is sensitive, and the shipped build asks for `drive.file` only — see below. Excluding it is a security decision, not just a commercial one. |
 | 19 | **The data path is a published Google Sheet.** Engine writes the table there; the Console puts its TSV link in `SOURCE_URI`. | The only path that works today with no change to XaddIn and from any machine. A local file passes the validator and is refused by the ingester at `DataIngestionService.cs:734` — see §5b. The table is readable by anyone holding the URL; acceptable for the owner's own data, a separate decision at commercialisation. |
 | 15 | **The Python package stays `scrapex/`.** `Engine` is the product name, not the directory. | The user never sees a directory. Renaming costs 748 import lines in tests alone, 188 `python -m scrapex` call sites in CI, docs and JS, a reinstall of the editable package, and five hard-coded paths — for nothing anyone can see. A capitalised `Engine/` would also work on Windows and fail on Linux, where CI runs. |
@@ -226,6 +228,58 @@ Copying a proven shape is not coupling. Sharing a library would be.
 
 ---
 
+## 5c. The two release paths
+
+They are not variations of one mechanism. They differ in who reviews, who
+decides, and when the user gets it — and that difference is the reason the
+compatibility check exists.
+
+```text
+EXTENSION                             ENGINE
+tag scrapex-vX                        tag engine-vY
+CI builds the zip                     CI builds on windows-latest (PyInstaller
+CI uploads via the Web Store API      cannot cross-compile), attaches to a
+Google REVIEWS it — a day or three    GitHub Release
+Chrome pushes it to every user,       nothing reviews it
+automatically, without asking         the EXTENSION notices, tells the owner,
+                                      and installs on acceptance
+```
+
+**Google's store does not read GitHub.** It has no idea the repository exists.
+Automation means our workflow pushes *to* the store through its API — the arrow
+points the other way from how it is usually described, and the difference decides
+what secrets are needed.
+
+### What this asymmetry costs, and why M1 exists
+
+Chrome can update the extension **tonight**, silently, while a user's Engine is
+last month's. Nothing prevents that; it is how extension distribution works.
+
+So the extension must state compatibility before any job starts, and refuse with
+a named action rather than failing somewhere further in. That is not defensive
+programming — it is the only thing standing between two independent release
+cadences and a dead panel. The owner has already seen this failure once, on
+2026-08-05, from a migration rather than a version.
+
+### What must exist before the first upload
+
+**Extension:** a Chrome Web Store developer account; a Google Cloud project
+owning an upload client; three GitHub secrets (`client_id`, `client_secret`,
+`refresh_token`); and a privacy policy and support contact — the repository has
+neither today.
+
+**Engine:** `runs-on: windows-latest`, because `packaging/build_engine.py` uses
+PyInstaller and PyInstaller does not cross-compile. It already produces
+`dist/scrapex-engine.exe` as one file; nothing publishes it yet.
+
+### What exists today
+
+Nothing. `.github/workflows/` holds `ci.yml` (one job: tests, parity, extension
+tests, manifest) and `scrapex.yml` (a scheduled crawl). There is no release
+automation of any kind, for either product.
+
+---
+
 ## 6. Milestones
 
 Each leaves the product runnable and ends in something the owner can open.
@@ -280,8 +334,18 @@ history with no engine installed, and exports to XLSX/CSV.
 ### M4 — publish, unlisted
 
 Privacy policy, data-handling and deletion statement, support contact — **none
-exist today**. Chrome Web Store developer account, unlisted listing, OAuth consent
-screen in testing mode.
+exist today**.
+
+Both release paths are built here, and §5c is the specification:
+
+- `engine-vY` → build on `windows-latest`, attach `scrapex-engine.exe` to a
+  GitHub Release. Unsigned (Decision 22).
+- `scrapex-vX` → build the extension zip, upload through the Chrome Web Store
+  API, unlisted listing.
+- Neither tag triggers the other (Decision 21).
+
+Google reviews the extension and does not review the engine, so the two arrive
+on different days by design. M1's compatibility check is what makes that safe.
 
 **Done when:** a tester installs from a link, signs in, and restores the owner's
 data. *At this point the product is real: published, backed up, portable.*

--- a/docs/archive/2026-08-05-architecture-and-implementation-plan.SUPERSEDED.md
+++ b/docs/archive/2026-08-05-architecture-and-implementation-plan.SUPERSEDED.md
@@ -1,0 +1,965 @@
+> **SUPERSEDED 2026-08-05 by [`docs/PLATFORM-PLAN.md`](../PLATFORM-PLAN.md).**
+>
+> Archived rather than deleted, at the owner's instruction, because it is the
+> document the current plan was argued against and several of its decisions
+> survive unchanged. What replaced it, and why, is listed in PLATFORM-PLAN §2
+> and §7 — including the measured reasons the `apps/` relocation, the four
+> uncommitted backends, MSIX, and "Domain Engines: Price / Listing / Table"
+> were dropped.
+>
+> Nothing below has been edited. Read it as history.
+
+---
+
+# scrapeX Ecosystem
+
+## Architecture and Implementation Plan
+
+**Status:** Agreed development architecture  
+**Primary products:** scrapeX, MarketLens, and MBI Console  
+**Repository strategy:** One GitHub monorepo during development, with independently built and versioned applications  
+**Operating model:** Hybrid, local-first, multi-engine architecture with configurable storage
+
+---
+
+## 1. Executive Summary
+
+scrapeX is the Chrome Extension that provides the user interface, Google sign-in, source management, and control of crawling and data-publishing workflows. Through scrapeX, the user selects the Crawler Backend, Database Profile, and Storage Profile for a workspace or job, then sends that configuration to the selected backend.
+
+MarketLens is a standalone local Windows crawler engine for stores and products. It does not use Scrapy, Crawlee, Crawl4AI, or any other external crawler. MarketLens is the only internally defined backend in the current architecture: it has its own crawler implementation, domain engines, and connector families for e-commerce stores and product data. Its current internal domain engines include Price Engine, Listing Engine, and Table Engine; its connector families include Shopify, Magento, WooCommerce, and future store families. Any other type of website or data is handled through the available general-purpose external tools. A separate local Engine Host can launch and monitor the selected backend, but each backend remains independent.
+
+Google Drive is one selectable user-owned backup/synchronization provider. Google Sheets is one selectable configuration and publishing provider used by the spreadsheet/Excel ecosystem. Local files, local XLSX, Drive, Sheets, and future database providers are exposed through Database Profiles and Storage Profiles selected in scrapeX rather than being hard-coded into one workflow. GitHub stores the source code, CI/CD workflows, release metadata, and distributable engine releases; it is not the user's data store.
+
+MBI Console is an owner-only administration module integrated into the scrapeX development build. It provides a browser-based interface for managing the Google Sheets configuration that defines how datasets are represented, validated, mapped, displayed, and exported. It must be isolated as a module so it can be excluded from the future commercial build.
+
+The initial implementation remains a monorepo for speed and coordinated development. scrapeX, the Engine Host, and MarketLens remain separate applications or components inside that repository, with separate versions, tests, build pipelines, and releases. The hybrid model does not make the browser extension a crawler engine: the extension is the control plane, the Engine Host manages independent processes, and MarketLens is a complete independently runnable crawler engine.
+
+---
+
+## 2. Final Architectural Decisions
+
+| Area | Decision |
+|---|---|
+| Repository | Keep one monorepo during development. |
+| Chrome product | `scrapeX` Chrome Extension. |
+| Local product | `MarketLens` standalone Windows crawler engine. |
+| Local engine host | Local scrapeX component that installs, selects, launches, and monitors independent engines. It does not become an engine itself. |
+| Crawler Backends | scrapeX can select MarketLens for stores/products, or an available general-purpose backend for other website/data types. |
+| MarketLens internals | MarketLens contains the Crawler Backend, Domain Engines, and Connector Families that belong to its own ecosystem. |
+| Extension updates | GitHub Actions builds and submits approved packages to the Chrome Web Store; Chrome distributes updates. |
+| Engine updates | GitHub Actions builds a signed MSIX and publishes an AppInstaller/release channel. |
+| Database and storage selection | scrapeX owns the user-facing selection of Database Profiles and Storage Profiles and passes the selected profile to the active backend. Local SQLite is the first certified warehouse; Drive, Sheets, and XLSX are selectable providers. |
+| New-device setup | Sign in with Google, restore the selected workspace profile when applicable, verify the engine/backends, then allow crawling. |
+| Cloud publishing | Publish validated configuration and dataset outputs through the selected Sheets/Drive/export profile. |
+| Engine communication | Chrome Native Messaging between scrapeX and the Engine Host; the host launches the selected backend. |
+| Admin tooling | `MBI Console`, a separately structured owner-only module inside the development extension. |
+| Commercialization | Start privately, then introduce licensing, commercial builds, privacy/legal controls, and support processes. |
+
+---
+
+## 3. System Overview
+
+```text
+┌─────────────────────────┐
+│ scrapeX Chrome Extension│
+│ - Google Login          │
+│ - Sources and controls  │
+│ - Status and setup UI   │
+│ - MBI Console (dev only)│
+└────────────┬────────────┘
+             │ Chrome Native Messaging
+             ▼
+┌─────────────────────────────────────────┐
+│ scrapeX Local Engine Host             │
+│ - Engine Manager                      │
+│ - Install/select/launch/monitor       │
+│ - Shared process and message contract  │
+└──────────┬────────────────────────────┘
+           │
+           ├──────────────────────┐
+           ▼                      ▼
+┌────────────────────────┐   ┌────────────────────────┐
+│ Selected Crawler Backend │   │ Other selectable backends │
+│                          │   │ Scrapy / Crawlee /         │
+│ If MarketLens:           │   │ Crawl4AI / Katana / ...   │
+│ - MarketLens Crawler Core│   │ General-purpose temporarily│
+│ - Price Engine           │   └────────────┬───────────────┘
+│ - Listing Engine         │                │
+│ - Table Engine           │                │
+│ - Connector Families    │                │
+└───────────┬─────────────┘                │
+            └──────────────┬───────────────┘
+                           ▼
+              Selected backend result/output
+                           │
+                           ▼
+┌──────────────────┐   ┌──────────────────────┐
+│ Selected database│   │ Selected providers   │
+│ - SQLite first   │   │ - Local XLSX/CSV     │
+│ - Future adapters │   │ - Google Drive       │
+│ - One writer     │   │ - Google Sheets      │
+└──────────────────┘   │ - Future providers  │
+                       └──────────┬───────────┘
+                                  ▼
+                         Excel / spreadsheet tool
+
+GitHub stores source, workflows, releases, and engine packages.
+```
+
+The extension is the control plane. The Local Engine Host manages independent engine processes but does not replace them. MarketLens is a complete standalone engine with its own internal domain engines and connector families. Other open-source tools are separate engine options and are never silently loaded as MarketLens dependencies. Database, backup, and publishing profiles are selected independently for the active engine/workspace.
+
+---
+
+## 4. Monorepo Structure
+
+```text
+scrapeX/
+├── apps/
+│   ├── extension/                 # scrapeX Chrome Extension
+│   │   ├── src/
+│   │   │   ├── background/
+│   │   │   ├── content/
+│   │   │   ├── popup/
+│   │   │   ├── options/
+│   │   │   ├── setup/
+│   │   │   ├── mbi-console/      # Owner-only development module
+│   │   │   └── integrations/
+│   │   ├── manifest.json
+│   │   └── package.json
+│   │
+│   ├── marketlens/                # Standalone local Windows crawler engine
+│   │   ├── src/
+│   │   │   ├── native_host/
+│   │   │   ├── crawler/
+│   │   │   ├── adapters/
+│   │   │   ├── domain_engines/
+│   │   │   │   ├── price/
+│   │   │   │   ├── listing/
+│   │   │   │   └── table/
+│   │   │   ├── connector_families/
+│   │   │   │   ├── shopify/
+│   │   │   │   ├── woocommerce/
+│   │   │   │   └── magento/
+│   │   │   ├── database_profiles/
+│   │   │   ├── storage_profiles/
+│   │   │   ├── backup/
+│   │   │   ├── publishing/
+│   │   │   ├── runtime/
+│   │   │   └── capabilities/
+│   │   ├── pyproject.toml
+│   │   └── packaging/
+│
+│   └── engine-host/               # Local lifecycle host; not a crawler engine
+│       ├── src/
+│       │   ├── engine_manager/
+│       │   ├── process_launcher/
+│       │   ├── adapter_protocol/
+│       │   ├── health_checks/
+│       │   └── native_messaging/
+│       └── packaging/
+│
+├── packages/
+│   ├── shared-contracts/          # Message, schema, and compatibility contracts
+│   ├── config-rules/              # Validation and mapping rules
+│   ├── crawler-adapter-contract/  # Versioned backend protocol
+│   ├── database-contract/         # Warehouse/provider contract
+│   └── google-integration/        # Drive/Sheets provider adapters
+│
+├── packaging/
+│   ├── msix/                      # MSIX and AppInstaller configuration
+│   └── native-messaging/          # Chrome host manifest and registration
+│
+├── docs/
+├── tests/
+└── .github/
+    └── workflows/
+        ├── extension-ci.yml
+        ├── marketlens-ci.yml
+        ├── publish-scrapex.yml
+        └── release-marketlens.yml
+```
+
+The repository is shared, but the applications are not bundled into one runtime. Each application has its own dependency set, test suite, build artifact, version, and release process.
+
+### Independence and Release Ownership
+
+The components are intentionally independent products connected through stable contracts:
+
+| Component | Owns | Update channel |
+|---|---|---|
+| scrapeX | Central control UI, Google authentication, backend selection, profile selection, MBI Console, and compatibility checks | Chrome Web Store through GitHub Actions |
+| MarketLens | Specialized stores/products crawler, MarketLens Crawler Core, Price/Listing/Table Engines, and store Connector Families | Independent signed MSIX/AppInstaller release |
+| Other Crawler Backends | Their own general-purpose runtimes and community-maintained capabilities | Their upstream/community releases, installed as versioned packs |
+| Engine Host | Installation, launch, monitoring, health checks, and lifecycle management | Released with the local integration/host package |
+
+scrapeX can be upgraded independently when its protocol and profile contracts remain compatible. MarketLens can be upgraded independently when its declared engine contract remains compatible. Other backends can evolve according to their communities and upstream release cycles; scrapeX controls only their adapter, manifest, compatibility status, and installation policy. scrapeX does not own or rewrite their internal implementations.
+
+The only intentional coupling is contractual:
+
+```text
+scrapeX ↔ Engine Host ↔ Selected Backend
+              ↕
+       Versioned Contracts
+              ↕
+Database/Storage Profile Contract
+```
+
+Every component must publish its version, supported protocol versions, capabilities, required profiles, and compatibility status before a job can run. This preserves independent upgrades without allowing an incompatible update to corrupt a workspace or silently change its data behavior.
+
+---
+
+## 4.1 Crawler Backends and MarketLens Scope
+
+scrapeX is the selection and control surface for the Crawler Backends. The current backend catalogue is:
+
+```text
+Scrapy
+Crawlee
+Crawl4AI
+Katana
+MarketLens
+```
+
+MarketLens is a complete, standalone crawler engine. It is not a wrapper around Scrapy, Crawlee, Crawl4AI, Katana, or another external product. It has its own crawler implementation and its own internal data model:
+
+```text
+MarketLens
+├── MarketLens Crawler Core
+│   ├── HTTP/browser transport
+│   ├── discovery and extraction
+│   └── crawl execution
+├── Domain Engines
+│   ├── Price Engine
+│   ├── Listing Engine
+│   └── Table Engine
+├── Connector Families
+│   ├── Shopify
+│   ├── WooCommerce
+│   ├── Magento
+│   ├── Salla
+│   └── Zid
+├── Database/Storage adapters
+│   └── Applied according to scrapeX-selected profiles
+└── Backup/Publishing integration
+```
+
+### Domain Engines inside MarketLens
+
+The Price Engine, Listing Engine, and Table Engine are modules inside MarketLens. Each module owns the meaning of its data, RowSpecs, ingest rules, read models, and schema slice. They are not separate external programs and are not dependencies that the user installs independently.
+
+The current defined MarketLens scope includes Price Engine, Listing Engine, and Table Engine. The initial public focus may still be Price Engine, but the other modules are part of the MarketLens architecture and can be enabled as their implementation becomes ready. The architecture must not force price-specific concepts onto their schemas.
+
+### Connector Families inside MarketLens
+
+Connector Families are also part of MarketLens. They contain the site-shape knowledge required to work with Shopify, WooCommerce, Magento, Salla, Zid, custom JSON, static HTML, and future families. A connector family selects the appropriate MarketLens domain engine and maps the site's response into that engine's canonical records.
+
+### Other Crawler Backends
+
+Scrapy, Crawlee, Crawl4AI, Katana, and future backends are selectable independently through scrapeX for general-purpose website/data collection. Their exact domain responsibilities are intentionally general and not fixed. They are not loaded by MarketLens and MarketLens does not depend on them. When one is selected, the Engine Host launches it as an independent, version-pinned process or pack through the common integration contract.
+
+This distinction is intentional:
+
+```text
+MarketLens selected
+    → MarketLens Crawler Backend
+    → MarketLens Connector Family
+    → MarketLens Domain Engine
+
+Any general backend selected
+    → Its own runtime and configuration
+    → General backend result/output contract
+    → selected Database/Storage Profile
+```
+
+An external backend must never silently become part of MarketLens, use MarketLens's internal modules, or change MarketLens's normalization and history rules. The selected Database Profile and Storage Profile are passed from scrapeX as part of the job/workspace configuration.
+
+### General Backend Result Contract
+
+Because the non-MarketLens backends are general-purpose for now, scrapeX must not force them into the Price, Listing, or Table schemas. They return a generic result envelope that can later be mapped to a domain model when a backend's exact responsibility is defined:
+
+```json
+{
+  "backendId": "scrapy",
+  "jobId": "job-123",
+  "status": "completed",
+  "records": [],
+  "artifacts": [],
+  "provenance": {
+    "sourceUrls": [],
+    "backendVersion": "pinned-version",
+    "collectedAt": "timestamp"
+  },
+  "warnings": []
+}
+```
+
+MarketLens may return its specialized Price, Listing, or Table records in addition to the generic envelope. This keeps the external backends flexible without weakening MarketLens's domain-specific behavior.
+
+---
+
+## 4.2 Pluggable Crawler Backends and Engine Manager
+
+The scrapeX Engine Host includes an Engine Manager. It discovers, installs, health-checks, updates, selects, launches, isolates, and uninstalls independent engine packs. It does not perform crawling and it does not turn MarketLens into a wrapper around another tool.
+
+The core installation should contain the Engine Host, the standalone MarketLens engine, MarketLens's currently implemented modules and connector families, and the shared process/message contract. Other engines are installed on demand:
+
+| Backend/pack | Natural role | Initial integration shape |
+|---|---|---|
+| MarketLens | Standalone local crawler engine containing its own domain engines and connector families | Independently packaged local engine |
+| Scrapy | General-purpose backend; exact domain role TBD | Isolated Python worker |
+| Crawlee | General-purpose backend; exact domain role TBD | Isolated worker or sidecar |
+| Crawl4AI | General-purpose backend; exact domain role TBD | Isolated worker or local service |
+| Katana | General-purpose backend; exact domain role TBD | Versioned binary adapter |
+
+Firecrawl and Heritrix remain future candidates from the wider architecture study, not committed current backends. Their inclusion requires a separate need, integration spike, packaging decision, and license review.
+
+These are candidates, not a promise to bundle every open-source project. Every backend must pass a ScrapeX conformance suite, declare its exact upstream version, expose capabilities and health, and carry its license/notice information.
+
+The adapter protocol should support:
+
+```text
+health
+plan
+run
+cancel
+resume
+diagnostics
+```
+
+During a run, adapters emit structured events such as `discovered`, `fetched`, `artifact`, `candidate_record`, `checkpoint`, `warning`, `blocked`, `failed`, and `completed`. Final artifacts include provenance, canonical URLs, timestamps, content hashes, and references to raw evidence.
+
+The planner may operate in three modes:
+
+```text
+Auto      → recommend a certified backend and explain why
+Recipe    → compose discovery, fetch, render, extract, validate, and archive steps
+Expert    → expose backend-specific settings from its machine-readable schema
+Compare   → run a bounded sample through multiple backends and compare results
+```
+
+Fallbacks must be bounded by request, time, cost, resource, retry, and backend-switch limits. Every backend switch and its reason belongs in the run audit trail.
+
+### Backend and profile selection contract
+
+Every scrapeX workspace/job configuration must carry the selections made in the scrapeX UI:
+
+```json
+{
+  "crawlerBackendId": "marketlens",
+  "databaseProfileId": "local-sqlite",
+  "storageProfileId": "local-drive-backup-sheets",
+  "domainEngineId": "price",
+  "connectorFamilyId": "shopify"
+}
+```
+
+`domainEngineId` and `connectorFamilyId` are required when `crawlerBackendId` is `marketlens`, because those modules belong to MarketLens. For the currently general-purpose backends, those fields remain unset or backend-defined until their responsibilities are decided.
+
+### Backend capability matrix
+
+Before scrapeX activates a combination, it must check the selected backend's declared support for:
+
+```text
+Backend
+Domain mode
+Database Profile
+Storage Profile
+Operating system
+Required runtime/pack
+Authentication/session support
+Resource limits
+```
+
+The UI should disable unsupported combinations and explain why. A backend is not required to support every Database Profile or Storage Profile.
+
+---
+
+## 4.3 Database and Storage Profiles
+
+The application must not hard-code one permanent storage path or one publishing destination. A workspace has a selectable profile composed of a database provider and zero or more backup/publish providers. The user makes this selection in scrapeX; the selected backend receives and applies the profile through the job/workspace contract.
+
+### Database providers
+
+The initial certified provider is local SQLite using the existing append-only warehouse schema. The provider interface must leave room for future certified implementations such as DuckDB or PostgreSQL when a real requirement exists.
+
+```text
+Database Profile
+├── provider: sqlite | future provider
+├── location or connection reference
+├── schema version
+├── migration policy
+├── single-writer/concurrency policy
+└── backup/export policy
+```
+
+The user may select the database profile and local location from scrapeX where supported. A provider is not considered supported merely because it can open a file; it must preserve migrations, append-only history, fingerprints, transactions, locking, and compatibility with the selected backend's data model.
+
+### Storage and publishing profiles
+
+The user can choose or switch among profiles such as:
+
+```text
+Local Only
+    Local database; no cloud egress
+
+Local + XLSX
+    Local database plus explicit workbook export
+
+Local + Google Drive Backup
+    Local database plus versioned Drive backups and restore
+
+Local + Google Sheets Publish
+    Local database plus validated Sheets publishing
+
+Local + Drive Backup + Sheets Publish
+    Combined backup and publishing workflow
+
+Custom Provider Profile
+    Future certified provider selected by the user
+```
+
+For the first certified workflows, local SQLite remains the active writer even when Drive or Sheets is selected. Drive is a backup/restore and synchronization provider, not a directly shared SQLite file. Direct multi-device writes to a remote file would risk corruption and are not part of the initial contract. Additional database providers can become selectable after they pass the same conformance and migration checks.
+
+### Safe switching
+
+Changing a profile is an explicit migration operation:
+
+```text
+Validate the target provider
+        ↓
+Create a verified snapshot of the current workspace
+        ↓
+Export/migrate compatible data and configuration
+        ↓
+Write the new profile manifest
+        ↓
+Verify the target and run a read-back check
+        ↓
+Activate the new profile
+```
+
+The system must never silently switch providers, delete the previous data, or claim that a provider is active before verification succeeds. MBI Console and the main settings UI should show the active profile, available profiles, migration status, and rollback option.
+
+Example independent versions:
+
+```text
+scrapeX:     0.6.0
+MarketLens:  0.9.2
+Protocol:    2
+```
+
+Use independent tags such as:
+
+```text
+scrapex-v0.6.0
+marketlens-v0.9.2
+```
+
+---
+
+## 5. scrapeX Chrome Extension
+
+### Responsibilities
+
+- Authenticate the user with Google OAuth.
+- Identify the signed-in account and load its configuration.
+- Show sources, crawl status, row counts, errors, and engine status.
+- Present the Crawler Backend catalogue and let the user select any installed/certified backend.
+- Let the user select the Database Profile and Storage Profile for each workspace or job.
+- Start, pause, and monitor jobs for the selected backend.
+- Guide the user through first-time installation and updates for the selected backend.
+- Read and write authorized Google Drive and Google Sheets resources.
+- Trigger validation, backup, and publishing workflows.
+- Expose MBI Console only in the development build and only to the owner account.
+
+### Store distribution
+
+The extension may begin as a private or unlisted Chrome Web Store item. The user installs it on any supported device and signs in with Google. A GitHub Actions workflow builds the extension and submits a release to the Chrome Web Store. Chrome then handles distribution and update delivery.
+
+The extension must not download executable JavaScript from GitHub or use GitHub as a remote code source. New extension logic must be included in the reviewed extension package. GitHub may provide release metadata, configuration, or documentation, but not runtime extension code.
+
+### Engine setup experience
+
+If the selected backend is not detected, scrapeX should show a setup wizard. For MarketLens, the flow is:
+
+```text
+Sign in with Google
+        ↓
+Check for MarketLens
+        ↓
+Engine missing? → Download/open installer
+        ↓
+User approves Windows installation
+        ↓
+Register Native Messaging host
+        ↓
+Re-check connection
+        ↓
+Engine Ready
+```
+
+The extension can guide or initiate the download, but Windows installation and update approval remain explicit user actions. Silent installation of a local engine is not part of the design.
+
+---
+
+## 6. MarketLens Standalone Engine
+
+### Responsibilities
+
+- Run as an independent local crawler engine, comparable in role to Scrapy.
+- Accept a job through the versioned crawler adapter protocol.
+- Perform its own supported discovery, fetching, rendering, extraction, and crawl execution.
+- Return canonical crawl artifacts, candidate records, structured events, and backend provenance.
+- Report its own engine version, capabilities, health, progress, warnings, failures, and cancellation state.
+- Keep its runtime and dependencies isolated from other crawler engines.
+
+MarketLens owns its own canonical warehouse, normalization, fingerprinting, deduplication, and domain-engine ingest. It provides database/storage adapters and applies the Database Profile and Storage Profile selected in scrapeX. It does not own MBI Console or the Engine Manager, and it does not use external crawler engines. The Engine Host only launches, monitors, and communicates with MarketLens; it does not replace MarketLens's internal data pipeline.
+
+### Packaging
+
+MarketLens is distributed as an independently versioned Windows MSIX package with an AppInstaller update channel. Its package should include:
+
+- The MarketLens executable and embedded runtime.
+- MarketLens crawler capabilities and configuration support.
+- Its own runtime and dependencies.
+- Adapter-protocol support.
+- Database and storage profile support.
+- Backup and publishing support selected by the user.
+- Native Messaging or local-process registration required by the Engine Host.
+- Installer registration and update metadata.
+
+Other crawler engines such as Scrapy, Crawlee, Crawl4AI, Katana, Firecrawl, or Heritrix are separate packs and releases. The Engine Manager installs them as signed, version-pinned, isolated packages when selected. They remain independent from MarketLens, and the MarketLens installer must not force their runtimes onto every user.
+
+Every distributable package must be digitally signed. Build secrets and signing certificates remain in GitHub Actions secrets or a dedicated secure release system, never in the repository.
+
+### Capability handshake
+
+When scrapeX connects, MarketLens should return a machine-readable status such as:
+
+```json
+{
+  "status": "ready",
+  "engineId": "marketlens",
+  "engineVersion": "0.9.2",
+  "protocolVersion": 2,
+  "domainEngines": ["price", "listing", "table"],
+  "connectorFamilies": ["shopify", "woocommerce", "magento"],
+  "selectedDomainEngine": "price",
+  "selectedConnectorFamily": "shopify",
+  "databaseProfile": "local-sqlite",
+  "storageProfile": "local-drive-backup-sheets",
+  "capabilities": [
+    "marketlens-crawler",
+    "domain-engines",
+    "connector-families",
+    "database-profiles",
+    "storage-profiles",
+    "http-extractor",
+    "tsv-export",
+    "google-drive-backup",
+    "google-sheets-publish"
+  ]
+}
+```
+
+The extension must check minimum engine and protocol versions before starting a job and provide a clear update action when compatibility is insufficient.
+
+---
+
+## 7. Google Login, Drive Backup, and Sheets Publishing
+
+### Google authentication
+
+Use Google OAuth through the extension's identity flow. Store tokens using the platform's secure extension storage mechanisms, never in GitHub, the local database, logs, or exported files.
+
+Use the narrowest practical Google scopes. The preferred Drive model is to operate on files created or explicitly selected by the user rather than requesting unrestricted access to the entire Drive.
+
+### Drive layout
+
+MarketLens should create or use a clear application-owned folder structure:
+
+```text
+MarketLens/
+├── databases/
+├── backups/
+├── exports/
+├── manifests/
+└── locks/
+```
+
+The exact folder IDs should be stored in the user's configuration and re-discovered safely when necessary. The system must never assume that a Drive path is globally unique.
+
+### Backup after changes
+
+After a successful crawl or material database/configuration change, MarketLens follows the active storage profile:
+
+```text
+Update local database
+        ↓
+Run integrity and consistency checks
+        ↓
+Create a compressed, versioned backup
+        ↓
+If Drive is selected → upload backup and update latest manifest
+        ↓
+If Sheets is selected → publish configured Sheets/TSV outputs
+        ↓
+Report completion to scrapeX
+```
+
+For a Local Only profile, the workflow stops after local validation. For a Local + XLSX profile, it creates the configured workbook without requiring Google OAuth. The user can switch profiles later through an explicit, verified migration operation.
+
+Use immutable versioned files instead of overwriting one backup:
+
+```text
+marketlens-db-v105.zip
+marketlens-db-v106.zip
+marketlens-db-v107.zip
+latest.json
+```
+
+`latest.json` should point only to a backup that passed validation. Retain a configurable number of previous versions so a failed or corrupted update can be rolled back.
+
+### Sheets publishing
+
+Google Sheets acts as a structured configuration and publishing layer. MBI Console manages the metadata; MarketLens and scrapeX apply it. Publishing should be transactional at the workflow level: validate first, write the intended ranges, verify the result, then mark the configuration/output as successful.
+
+---
+
+## 8. Multi-Device Restore, Locking, and Versioning
+
+### New device flow
+
+```text
+Install scrapeX
+        ↓
+Sign in with Google
+        ↓
+Install/verify MarketLens
+        ↓
+Read the active database/storage profile
+        ↓
+If Drive backup is selected → discover the user's MarketLens folder
+        ↓
+If a backup exists → download and validate it
+        ↓
+Restore or initialize the selected database profile
+        ↓
+Check backend, database, storage, and protocol compatibility
+        ↓
+Allow a new crawl
+```
+
+The system should not begin a new crawl on a new device until restoration has either completed successfully or the user has explicitly chosen to start a new empty workspace.
+
+### Concurrent-device protection
+
+Before any operation that may change shared state:
+
+1. Read the latest manifest from Drive.
+2. Pull a newer backup if the local copy is behind.
+3. Acquire a user/workspace lock with an owner ID, device ID, version, timestamp, and expiry.
+4. Run the operation locally.
+5. Create and validate a new version.
+6. Upload the new backup and manifest.
+7. Release the lock.
+
+Locks must expire safely, and the UI must provide a recovery path for a stale lock. The system must never silently overwrite a newer backup created by another device.
+
+### Compatibility rules
+
+Maintain separate values for:
+
+```text
+Extension version
+Engine version
+Protocol version
+Database schema version
+Backup format version
+```
+
+Database migrations and backup-format compatibility must be explicit. A newer engine may read older backups when supported, but it must not claim success without completing validation.
+
+---
+
+## 9. MBI Console
+
+### Purpose
+
+MBI Console is an owner-only administration interface for configuring the spreadsheet/Excel data model. It is part of the scrapeX development build initially, but it is an isolated module that can be removed from the commercial build without rewriting the extension.
+
+### Core functions
+
+- Discover datasets and tabs from Google Sheets.
+- Select the standalone engine for a workspace or job; when MarketLens is selected, choose its domain engine and connector family.
+- View installed independent engines, health, provenance, license notices, and update channels.
+- Select the database profile and local storage location where supported.
+- Select a backup/publishing profile such as Local Only, Local + XLSX, Drive Backup, or Sheets Publish.
+- Start a verified profile migration or rollback.
+- Create and edit dataset definitions.
+- Apply data validation and schema rules.
+- Define source-to-dataset mappings.
+- Configure ribbon groups and display order.
+- Define export views and visible columns.
+- Inspect scrapeX and MarketLens integration status.
+- Publish validated changes back to the configured Sheets.
+
+### Managed configuration tables
+
+MBI Console manages these six logical tables:
+
+```text
+DATASOURCE
+TABLE DEFINITION
+SCHEMA RULE
+DATA MAP
+RIBBON CONFIG
+EXPORT VIEW
+```
+
+### Dataset builder
+
+A dataset-creation workflow should collect or infer:
+
+```text
+Dataset name
+Source/TSV URL
+Google Sheets tab
+SQL/local table name
+Primary key
+Domain engine
+Connector family
+Database profile
+Storage/backup profile
+Columns and order
+Data types
+Validation rules
+Mapping rules
+Ribbon group
+Export view
+```
+
+When a new scraped tab is detected, MBI Console should prefill technical information such as tab name, column names, order, row count, and suggested data types. The owner then completes business-facing metadata such as display name, SQL name, visible fields, ribbon placement, and export rules.
+
+### Access control
+
+The interface must not be protected by visual hiding alone. Enforce authorization at the authentication and write-operation layers:
+
+```text
+Google sign-in
+        ↓
+Verify owner/admin identity
+        ↓
+Load MBI Console module
+        ↓
+Authorize every privileged read/write operation
+```
+
+The owner allowlist must be environment-specific and must not be hard-coded into a public commercial build. The commercial build should omit the module and its privileged routes entirely unless a future business requirement explicitly adds an administrative product.
+
+### Suggested module layout
+
+```text
+apps/extension/src/mbi-console/
+├── pages/
+│   ├── Dashboard
+│   ├── Sources
+│   ├── DatasetBuilder
+│   ├── SchemaRules
+│   ├── DataMapping
+│   ├── RibbonConfig
+│   └── ExportViews
+├── google/
+│   ├── driveClient
+│   └── sheetsClient
+└── integrations/
+    ├── scrapeX
+    └── marketlens
+```
+
+---
+
+## 10. GitHub and Update Workflows
+
+### What GitHub stores
+
+- Extension source code.
+- MarketLens source code.
+- Shared contracts and migrations.
+- Dependency manifests and lockfiles.
+- MSIX/AppInstaller packaging configuration.
+- Tests and documentation.
+- Open-source license notices.
+- Release notes and version metadata.
+
+Do not store user databases, Google OAuth tokens, cookies, passwords, backup files, signing certificates, or generated build artifacts in the normal source tree.
+
+### Branching and local development
+
+```text
+main        → stable, releasable code
+develop     → active integration branch
+feature/*   → individual changes
+```
+
+During development, load scrapeX as an unpacked extension locally. Publish to the Chrome Web Store only from a deliberate release process.
+
+### CI/CD behavior
+
+Use path-filtered workflows so an extension change does not unnecessarily rebuild the engine, and vice versa.
+
+```text
+Extension change
+    ↓
+Extension tests and package build
+    ↓
+Chrome Web Store submission on release
+    ↓
+Chrome update delivery
+
+MarketLens change
+    ↓
+Engine tests and Windows package build
+    ↓
+Signed MSIX/AppInstaller release
+    ↓
+User-approved engine update
+```
+
+GitHub Releases are the distribution record for MarketLens binaries. They are not the system of record for user data.
+
+---
+
+## 11. Security and Reliability Requirements
+
+- Use OAuth and least-privilege scopes.
+- Keep access tokens in secure local storage.
+- Never commit secrets or signing keys.
+- Validate every backup before advertising it as latest.
+- Use immutable backup versions and rollback support.
+- Prevent concurrent-device overwrites with leases/locks.
+- Authenticate and authorize MBI Console operations server-side or at the privileged integration boundary.
+- Verify engine identity, version, and protocol before accepting commands.
+- Validate all crawler output before publishing to Sheets.
+- Keep user data out of logs unless explicitly redacted and needed for diagnosis.
+- Track open-source dependencies and comply with their licenses.
+- Add privacy, deletion, and consent documentation before any public commercial release.
+
+---
+
+## 12. Implementation Roadmap
+
+### Phase 1 — Monorepo foundation
+
+- Establish the directory structure and independent package manifests.
+- Define shared message, schema, version, and error contracts.
+- Add basic CI for scrapeX and MarketLens.
+- Add branch, tag, and release conventions.
+
+**Acceptance criteria:** both applications build and test independently from the same repository.
+
+### Phase 2 — Local engine integration
+
+- Implement the Native Messaging host.
+- Add `PING`, capability, version, selected-backend, selected-profile, job-start, progress, cancel, and error messages.
+- Define the versioned engine communication contract and make MarketLens the first complete standalone engine.
+- Define the database and storage provider contracts.
+- Run a first local crawl through the extension using MarketLens's Price Engine and a Shopify connector family.
+- Add local database initialization and migrations.
+
+**Acceptance criteria:** scrapeX can detect MarketLens, start a job, display progress, and receive a verified result.
+
+### Phase 3 — Google identity and persistence
+
+- Implement Google sign-in.
+- Implement the initial database profiles and storage profiles.
+- Create/discover the MarketLens Drive folder only when a Drive profile is selected.
+- Add profile-aware backup creation, validation, upload, manifests, and restore.
+- Add Google Sheets read/write integration as a selectable provider.
+- Add explicit profile switching with snapshot, migration, read-back verification, and rollback.
+
+**Acceptance criteria:** a user can select Local Only, Local + XLSX, or a Google-backed profile; run a crawl; switch profiles safely; and restore the data on another device without losing the last valid state.
+
+### Phase 4 — MBI Console
+
+- Implement the owner-only module within the development extension.
+- Add the six configuration tables and validation rules.
+- Add dataset discovery and the dataset builder.
+- Connect configuration changes to scrapeX, MarketLens, and Sheets publishing.
+
+**Acceptance criteria:** the owner can discover a new dataset, complete its metadata, validate it, and publish the resulting configuration without manually editing the six tables.
+
+### Phase 5 — Packaging and release automation
+
+- Build the signed MarketLens MSIX.
+- Add AppInstaller metadata and update checks.
+- Add Engine Manager pack manifests, health checks, checksums, license notices, and explicit uninstall paths.
+- Package the core Native backend separately from optional certified backend packs.
+- Add extension release submission workflow.
+- Add version/protocol compatibility checks and release notes.
+
+**Acceptance criteria:** a tagged release produces the correct extension package or signed engine installer through the intended release path.
+
+### Phase 6 — Private pilot
+
+- Use a private/unlisted extension distribution model.
+- Test multiple devices and interrupted uploads.
+- Test stale locks, rollback, corrupted backups, and engine mismatch.
+- Test profile switching and at least one optional backend in an isolated worker.
+- Test backend provenance, resource limits, cancellation, and bounded fallback.
+- Confirm that the MBI Console is unavailable to non-owner accounts.
+
+**Acceptance criteria:** the complete workflow is reliable for the owner's real datasets and can recover from expected failures.
+
+### Phase 7 — Commercial preparation
+
+- Create a commercial build configuration that excludes MBI Console.
+- Define which backend packs are included in the core product and which are opt-in downloads.
+- Complete license, attribution, SBOM, compatibility, and security review for every distributable backend.
+- Add licensing and subscription verification through a future dedicated service.
+- Finalize privacy policy, data handling, deletion, support, and open-source notices.
+- Define paid/free/trial entitlements and release channels.
+
+Google Drive remains the user's data-storage location, while licensing must not rely solely on a user-editable Drive file.
+
+---
+
+## 13. Commercial Roadmap
+
+```text
+Development build
+scrapeX + MarketLens + MBI Console + experimental backend/profile options
+
+Private pilot
+Private/unlisted distribution + owner/admin controls + certified backend packs
+
+Commercial build
+scrapeX + MarketLens + selected certified packs, with MBI Console excluded
+
+Future service layer
+License/entitlement API, billing, telemetry only with consent, and support tooling
+```
+
+The local-first design keeps crawling fast and reduces infrastructure cost. The pluggable design lets the product use the best certified backend for a job without allowing external tools to bypass ScrapeX validation and history rules. User-owned Google Drive remains an optional selectable backup provider. A future licensing service can manage free, trial, paid, and expired states without becoming the user's primary data store.
+
+---
+
+## 14. Definition of Done for the Initial Release
+
+The initial release is ready when:
+
+- scrapeX authenticates with Google and can be installed from its intended Store channel.
+- MarketLens installs as a signed Windows package and communicates through Native Messaging.
+- A crawl runs locally through MarketLens and updates its selected database profile.
+- At least one optional backend pack can be installed, health-checked, selected, run, cancelled, and removed safely.
+- At least one validated storage profile works without Google, and a Google-backed profile can create a versioned backup when selected.
+- A new device can restore the selected profile's latest valid backup before crawling when backup/restore is enabled.
+- Concurrent devices cannot silently overwrite one another.
+- Google Sheets configuration and publishing work end to end.
+- Profile switching performs a verified migration and preserves rollback data.
+- MBI Console is available only in the development build and only to the owner.
+- Extension and engine versions/protocols are independently tracked.
+- GitHub workflows build and release the correct artifacts.
+- Secrets, user data, and signing material are excluded from the repository.
+
+This architecture preserves development speed now while keeping a clean path to a private pilot and a future commercial product.


### PR DESCRIPTION
Nineteen owner decisions taken over one day, each with what it costs — and the previous architecture document archived beside it rather than deleted.

## What the previous plan got wrong, measured not argued

| It said | Measured |
|---|---|
| `apps/` + `packages/` relocation | **620 tracked files, 1,044 import lines**, five hard-coded root paths including `db/migrations` and `sources.yaml`. The brief forbids it three times. Its goal — independent build, test, version, release — is met **in place**. |
| scrapeX 0.6.0 · MarketLens 0.9.2 · protocol 2 | **0.2.0 · 0.2.0 · protocol 1**, with one gate enforcing the same number across three files — which is exactly why the compatibility check the owner asked for is impossible today. |
| "MarketLens is for stores" | **GPP_ENERGY alone is 67,677 of 88,286 price observations.** 76.7% of the warehouse is fuel prices from a static HTML table. |
| five connector families | **eleven** connector modules ship. |
| "Table Engine" as a domain | a table is an extraction **method**. The brief forbids collapsing the two axes. |
| §13 "Drive is where the data lives" | contradicted twenty lines earlier by §4.3 "SQLite remains the writer". Settled: **Drive backs up.** |

## What the day settled

The engine crawls **everything**, not only prices — contractors, tenders, equipment, jobs. The lifecycle that needs (*appeared, confirmed, disappeared, returned*) is **already built and tested** on the price side, and eleven generic tables already exist unused.

**One database, one migration stream.** `general.db` holds six rows, five of them bookkeeping.

**The order was wrong in the first draft and is corrected: publish first.** The single database is a prerequisite for the entity work and *nothing else* — and there are 88,286 observations from twelve audited sources running daily that are worth protecting more than a schema is worth rebuilding around a capability that does not exist yet.

## A trap recorded because it passes every check a reader would make

XaddIn's `SourceUriValidator` accepts a local path, and `SourceType` declares `LocalCsv`, `LocalSqlite` and `RestApi`. A local TSV therefore looks supported from every angle a configuration author can see.

**It is not.** `DataIngestionService.cs:734` refuses anything not starting with `http`, and the only file it ever opens is the staging file it downloaded itself. Those three enum values appear in the entity and one task-pane builder and **nowhere else**.

I recommended the local-file path *before* checking the ingester. That was the wrong order, and it is why the finding is in the document rather than in a failed milestone.

So the data path is a **published Google Sheet** — and the document says plainly that such a sheet is readable by anyone holding the URL, quoting the C# that says so: *"Currently all sources are public — no auth needed."*

## What the Console is, narrowed by reading the other side

`mbiXaddin` is **49,600 lines**. It already owns ingestion, its own SQLite, sync, validation, licensing and updates. **ScrapeX rebuilds none of it.**

The seam is one sentence: *one crawled dataset becomes one working Excel ribbon button, by generating six rows and keeping them true.*

The two systems independently invented the same rule — `SchemaRuleEntity` binds *"by role, not physical column name, so a rename is safe"*, which is `dataset_field`'s stable `field_key` against its editable `display_name`.

## Two amendments the brief needs — recorded, not applied

`CLAUDE.md` requires silent OTA updates (replaced by GitHub Releases, Decision 4) and mandates two separate databases in Gate DB1 (replaced by one database per *engine*, Decision 7). **The brief lives outside this repository and is the owner's to change** — §8 records what and why.

## Contents

Documentation only. No code, no tests, no gates affected.