### PR TITLE
The extension and the engine carry their own numbers

### DIFF
--- a/scrapex/version.py
+++ b/scrapex/version.py
@@ -1,11 +1,24 @@
 """The product version, and the ledger that says which version has what.
 
-ONE number, THREE places that have to carry it: this module (the authority),
-`pyproject.toml` (the installer reads it) and `extension/manifest.json` (Chrome
-reads it). Neither of the other two can import Python, so they are MIRRORS, and
-`tests/test_version.py` reads them back and fails the build the moment one of
-them drifts — the same arrangement `PROTOCOL_VERSION` already has across
-`scrapex/native.py` and `extension/transport.js`.
+THE ENGINE's number, and one mirror: this module is the authority and
+`pyproject.toml` carries a copy because the installer cannot import Python.
+`tests/test_version.py` reads it back and fails the build the moment it drifts —
+the same arrangement `PROTOCOL_VERSION` has across `scrapex/native.py` and
+`extension/transport.js`.
+
+THE EXTENSION'S NUMBER IS NOT HERE, and since 2026-08-05 it is not this one
+either. It lives in `extension/manifest.json`, which is the only thing Chrome
+reads, and the two are allowed to differ — because they ship down separate
+paths (PLATFORM-PLAN Decision 21): the extension is reviewed by Google and then
+pushed to every user automatically, while the engine is published to GitHub and
+installed when the owner accepts. Chrome can therefore move the extension
+tonight while a user's engine is last month's, and no equality rule can stop
+that — it can only stop the repository from saying so.
+
+WHAT REFUSES AN INCOMPATIBLE PAIR is `PROTOCOL_VERSION` and the ledger below,
+never a comparison of the two stamps. `capability_problem` already takes the two
+versions separately and names both in every sentence it produces; that was
+written before the split and needed no change for it.
 
 TWO NUMBERS, BECAUSE THERE ARE TWO QUESTIONS — the split the funnel payload
 contract already made for itself (`scrapex/payload.py`), applied here:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -8,9 +8,16 @@ sites at once (`63dc24b` in the engine, `76a4b14` in the panel eleven commits
 later). Both times the version string said 0.1.0, which it had said for 130
 commits, and so said nothing at all.
 
-So: one number with three copies that cannot drift, a ledger that cannot hold a
-capability without a version, and a baseline that cannot let the capability set
-move while the number stands still.
+So: a ledger that cannot hold a capability without a version, and a baseline
+that cannot let the capability set move while the number stands still.
+
+TWO NUMBERS SINCE 2026-08-05, not one. The engine's version lives here and is
+mirrored into `pyproject.toml`, which cannot import Python; the extension's
+lives in `extension/manifest.json`, which is the only thing Chrome reads. They
+are allowed to differ, and they will: the two ship down separate release paths,
+one reviewed by Google and pushed automatically, one published to GitHub and
+installed on acceptance. What refuses an incompatible pair is the protocol and
+the capability ledger — never a comparison of the two stamps.
 """
 from __future__ import annotations
 
@@ -69,20 +76,36 @@ def test_the_installer_carries_the_same_number():
         "bump both or neither")
 
 
-def test_the_extension_manifest_carries_the_same_number():
-    """THE mirror that matters, and the one nothing else could have caught.
+def test_the_extension_carries_its_own_number_and_may_differ():
+    """THE ASSUMPTION THAT EXPIRED, and the reason this test now asserts the
+    opposite of what it used to.
 
-    Chrome reads this file and nothing else to decide what version is loaded, so
-    it is what `chrome.runtime.getManifest()` reports back to the panel. A
-    manifest left behind at 0.1.0 while the engine moved would make the panel
-    announce itself as outdated forever — or, worse the other way, announce
-    itself as current while missing everything the release added.
+    It read: "the extension and the engine ship from one checkout and carry one
+    number", and enforced `manifest["version"] == VERSION`. That was true while
+    both shipped together. It stopped being true on 2026-08-05, when the owner
+    settled two release paths (PLATFORM-PLAN Decision 21): the extension is
+    tagged, uploaded to the Chrome Web Store, REVIEWED by Google, and then
+    pushed to every user automatically — while the engine is tagged separately,
+    published to GitHub Releases, reviewed by nobody, and installed only when
+    the owner accepts.
+
+    Chrome can therefore update the extension tonight while a user's engine is
+    last month's. Enforcing one number does not prevent that; it only prevents
+    the repository from DESCRIBING it, and a version that cannot describe what
+    is running is the exact failure this whole file was written about.
+
+    What replaces the equality is not nothing. Both must still be real versions,
+    the manifest is still the only thing Chrome reads, and the refusal rules
+    (`capability_problem` and its JS twin) already take the two numbers
+    separately and name both in every sentence they produce. The gate was never
+    the equality — it is the protocol and the ledger (Decision, 2026-08-05).
     """
     manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
-    assert manifest["version"] == VERSION, (
-        f"extension/manifest.json says {manifest['version']} and scrapex/version.py "
-        f"says {VERSION}; the extension and the engine ship from one checkout and "
-        "carry one number")
+
+    parse_version(manifest["version"])          # raises if it is not MAJOR.MINOR.PATCH
+    parse_version(VERSION)
+
+    assert manifest["version"] != "" and VERSION != ""
 
 
 # ---- the two numbers, and which one is derived -------------------------------


### PR DESCRIPTION
**Milestone 0.** The compatibility check the owner asked for — the extension reading the installed engine and refusing an incompatible pair — **could not be built**, because one number was enforced across three files. There is no such state as *"incompatible"* when both always move together.

## What this turned out to be

Almost nothing, because the machinery was already there and already right.

| | |
|---|---|
| `extension/version.js` | reads its own version **from the manifest Chrome loaded**, never from a constant — with the reason beside it: a constant could say `0.2.0` in a folder Chrome loaded before the file changed. |
| `capabilityProblem` | already takes `extensionVersion` and `engineVersion` **separately**, and names both in all three of its refusals — a distinct sentence for *too old to say*, *does not deploy it*, and *extension too old*. |
| `capability_problem` | the Python twin, pinned to the same sentences by `contracts/version-vectors.json`. |
| `MINIMUM_EXTENSION_VERSION` | derived from the ledger, never typed, and already excludes engine-only capabilities so a change the extension cannot see does not force a reload. |

All of it was written for two independent versions. **One test bound them.**

## What changed

`test_the_extension_manifest_carries_the_same_number` asserted `manifest["version"] == VERSION`, explaining itself as *"the extension and the engine ship from one checkout and carry one number."*

That was **true when written**, and expired on 2026-08-05 when the owner settled two release paths (Decision 21): the extension is tagged, uploaded to the Web Store, **reviewed by Google** and pushed to every user automatically; the engine is tagged separately, published to GitHub, reviewed by nobody, installed on acceptance.

Chrome can therefore update the extension **tonight** while a user's engine is last month's. Enforcing equality never prevented that — it only prevented the repository from *describing* it, which is the exact failure this file was written about.

The test now asserts what is actually required: both are real `MAJOR.MINOR.PATCH` versions, and **they may differ**.

## Proved both ways

- an extension at `0.7.0` beside an engine at `0.2.0` → **passes** (the whole point)
- a manifest saying `banana` → **fails**

## What refuses an incompatible pair

The **protocol and the capability ledger** — never a comparison of the two stamps (owner's decision, 2026-08-05). `version.py`'s own docstring said *"ONE number, THREE places"*; it now says what it does.

## Gates

`pytest` full suite · contract parity · extension 19/0 · `validate-manifest` — green.