### PR TITLE
The two release paths were welded together in two places, and neither was visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,10 @@ has it.
 
 Minimum supported extension: `0.2.0`.
 
-- **compatibility_notice** — Be told, rather than left to find out, when the installed extension is older than the features the engine deploys. _Runs in: panel._
+- **compatibility_notice** (7ca7a75) — Be told, rather than left to find out, when the installed extension is older than the features the engine deploys. _Runs in: panel._
 - **crawl_pace** (c63ec21) — Choose whether each site's requested crawl delay is honoured, and set the minimum seconds between requests and the request timeout. _Runs in: panel, engine._
 - **crawl_parallel_sources** (63dc24b) — Crawl several different sites at the same time. Two sources on the SAME site still take turns, so no site is asked for more than before. _Runs in: panel, engine._
 - **crawl_resume** (56a50d1) — Continue an interrupted crawl from the pages it already kept, without fetching any of them again. _Runs in: panel, engine._
 - **display_method_and_unit** (55ae064) — Record how a site displays a product and what one unit of its price buys, so a per-metre price is never read as a per-piece one. _Runs in: engine._
 - **source_admin** (412785b) — Edit, rename, stop tracking or erase a source from the panel, with a rename moving the rows in all nine tables in one transaction. _Runs in: panel, engine._
-- **version_visibility** — See which version of the extension and which version of the engine are actually running, each named for the side it belongs to. _Runs in: panel, engine._
+- **version_visibility** (7ca7a75) — See which version of the extension and which version of the engine are actually running, each named for the side it belongs to. _Runs in: panel, engine._

--- a/extension/tests/version-compat.test.mjs
+++ b/extension/tests/version-compat.test.mjs
@@ -33,12 +33,39 @@ test("every frozen case produces the same sentence in both languages", () => {
   }
 });
 
-test("the extension's own manifest is the version the file describes", () => {
-  // The panel reads chrome.runtime.getManifest() and nothing else. If that file
-  // fell behind, every verdict computed above would be computed about a version
-  // nobody is running.
+test("the extension's manifest is its OWN number, and new enough to be run", () => {
+  // THE ASSERTION THAT EXPIRED, and the reason this now asserts the opposite of
+  // what it used to.
+  //
+  // It read `assert.equal(manifest.version, VECTORS.version)`, and
+  // VECTORS.version is the ENGINE's number (scrapex/version.py: export_vectors
+  // returns {"version": VERSION, ...}). That was right while both shipped from
+  // one checkout. It stopped being right when the owner settled two release
+  // paths — PLATFORM-PLAN Decision 21: the extension is tagged and uploaded to
+  // the Chrome Web Store, the engine is tagged and published to GitHub
+  // Releases, and NEITHER TRIGGERS THE OTHER.
+  //
+  // MEASURED, in both directions: bump only extension/manifest.json to 0.3.0,
+  // which is exactly what a store release is, and this file failed with
+  // `actual: '0.3.0', expected: '0.2.0'`. Bump only the engine and it failed
+  // the other way. CI refused the release path the plan is built on, and the
+  // Python side had already dropped this equality on 2026-08-05
+  // (tests/test_version.py: test_the_extension_carries_its_own_number_and_may_differ).
+  // The JavaScript copy never followed.
+  //
+  // What is still true, and is what this asserts instead: the manifest must
+  // carry a real MAJOR.MINOR.PATCH — Chrome refuses anything else — and it must
+  // not be older than the minimum the engine will talk to, because a build the
+  // engine would refuse must never be the one uploaded to the store.
   const manifest = JSON.parse(readFileSync(join(HERE, "..", "manifest.json"), "utf8"));
-  assert.equal(manifest.version, VECTORS.version);
+
+  assert.match(manifest.version, /^\d+\.\d+\.\d+$/,
+    "Chrome requires a numeric MAJOR.MINOR.PATCH in the manifest");
+  assert.deepEqual(parseVersion(manifest.version).length, 3);
+  assert.ok(!isOlder(manifest.version, VECTORS.minimum_extension_version),
+    `the manifest says ${manifest.version}, older than the ` +
+    `${VECTORS.minimum_extension_version} the engine will talk to — this build ` +
+    `would be refused by the engine it ships beside`);
 });
 
 test("versions order numerically, not as text", () => {

--- a/scrapex/version.py
+++ b/scrapex/version.py
@@ -113,7 +113,7 @@ class Capability:
 CAPABILITIES: tuple[Capability, ...] = (
     Capability(
         key="crawl_pace",
-        since=VERSION,
+        since="0.2.0",
         summary="Choose whether each site's requested crawl delay is honoured, and "
                 "set the minimum seconds between requests and the request timeout.",
         surfaces=(Surface.PANEL, Surface.ENGINE),
@@ -126,7 +126,7 @@ CAPABILITIES: tuple[Capability, ...] = (
     ),
     Capability(
         key="crawl_parallel_sources",
-        since=VERSION,
+        since="0.2.0",
         summary="Crawl several different sites at the same time. Two sources on the "
                 "SAME site still take turns, so no site is asked for more than before.",
         surfaces=(Surface.PANEL, Surface.ENGINE),
@@ -139,7 +139,7 @@ CAPABILITIES: tuple[Capability, ...] = (
     ),
     Capability(
         key="crawl_resume",
-        since=VERSION,
+        since="0.2.0",
         summary="Continue an interrupted crawl from the pages it already kept, "
                 "without fetching any of them again.",
         surfaces=(Surface.PANEL, Surface.ENGINE),
@@ -149,7 +149,7 @@ CAPABILITIES: tuple[Capability, ...] = (
     ),
     Capability(
         key="source_admin",
-        since=VERSION,
+        since="0.2.0",
         summary="Edit, rename, stop tracking or erase a source from the panel, with a "
                 "rename moving the rows in all nine tables in one transaction.",
         surfaces=(Surface.PANEL, Surface.ENGINE),
@@ -159,27 +159,27 @@ CAPABILITIES: tuple[Capability, ...] = (
     ),
     Capability(
         key="version_visibility",
-        since=VERSION,
+        since="0.2.0",
         summary="See which version of the extension and which version of the engine "
                 "are actually running, each named for the side it belongs to.",
         surfaces=(Surface.PANEL, Surface.ENGINE),
         panel_control="about-extension-version",
         settings=(),
-        commit="",  # landing in this release
+        commit="7ca7a75",  # landing in this release
     ),
     Capability(
         key="compatibility_notice",
-        since=VERSION,
+        since="0.2.0",
         summary="Be told, rather than left to find out, when the installed extension "
                 "is older than the features the engine deploys.",
         surfaces=(Surface.PANEL,),
         panel_control="version-notice",
         settings=(),
-        commit="",  # landing in this release
+        commit="7ca7a75",  # landing in this release
     ),
     Capability(
         key="display_method_and_unit",
-        since=VERSION,
+        since="0.2.0",
         summary="Record how a site displays a product and what one unit of its price "
                 "buys, so a per-metre price is never read as a per-piece one.",
         # ENGINE alone on purpose, and it is the case that proves the split is
@@ -232,6 +232,24 @@ def _newest(versions: tuple[str, ...]) -> str:
 # the number already installed is not a remedy, it is a loop.
 CAPABILITY_REPORTING_SINCE = "0.2.0"
 
+# THE FLOOR IS THE NEWEST PANEL CAPABILITY, AND A CAPABILITY'S `since` IS A
+# FROZEN LITERAL — never `VERSION`.
+#
+# Every one of the seven capabilities used to record `since=VERSION`, which made
+# this line always equal VERSION however it was written. MEASURED: bump the
+# engine alone to 0.4.0 and the floor became 0.4.0, so the engine declared the
+# extension in the Chrome Web Store — 0.2.0, reviewed by Google, installed on
+# every machine — too old to talk to. Every engine release did that, to an
+# extension that had not changed.
+#
+# That is the exact opposite of PLATFORM-PLAN Decision 21 ("neither triggers the
+# other"), and no test could see it, because with `since=VERSION` the floor and
+# the head move together and every comparison stays true.
+#
+# The literal is the version the capability WAS INTRODUCED IN, and it never
+# moves again. A new capability is written with the number it ships in; the old
+# ones keep theirs. Then the floor rises only when the panel genuinely needs a
+# newer extension, which is the only thing it was ever meant to say.
 MINIMUM_EXTENSION_VERSION = _newest(tuple(
     capability.since for capability in CAPABILITIES
     if Surface.PANEL in capability.surfaces

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -430,3 +430,90 @@ def test_the_changelog_carries_the_evidence_for_the_two_incidents():
     assert "c63ec21" in committed, "the crawl pace lost the commit that built it"
     assert "63dc24b" in committed, "crawling several sites at once lost its commit"
     assert f"## {VERSION}" in committed
+
+
+# ---- the two release paths, and the line that quietly welded them together ----
+
+def test_no_capability_dates_itself_by_the_version_it_is_read_in():
+    """THE DEFECT NO TEST COULD SEE, because it made every comparison true.
+
+    All seven capabilities recorded `since=VERSION`. MINIMUM_EXTENSION_VERSION is
+    the newest `since` among the panel's capabilities, so the floor was VERSION —
+    always, however it was written. MEASURED: move the engine alone to 0.4.0 and
+    the floor became 0.4.0, so the engine declared the extension sitting in the
+    Chrome Web Store — 0.2.0, reviewed by Google, installed on every machine —
+    too old to talk to. Every engine release did that, to an extension that had
+    not changed, which is the exact opposite of PLATFORM-PLAN Decision 21.
+
+    Nothing caught it because with `since=VERSION` the floor and the head move
+    together and every assertion about them stays true. The defect is in the
+    SOURCE, so this is the one guard that has to read the source.
+
+    A capability's `since` is the version it was INTRODUCED in. It is written as
+    a literal, once, and never moves again.
+    """
+    # Comments stripped first: the rule is explained at length beside the
+    # constant it protects, and the explanation necessarily quotes the mistake.
+    # A guard that reads its own documentation as a violation is a guard that
+    # forces the documentation out.
+    source = "\n".join(
+        line for line in (ROOT / "scrapex" / "version.py").read_text(
+            encoding="utf-8").splitlines()
+        if not line.lstrip().startswith("#"))
+
+    assert "since=VERSION" not in source, (
+        "a capability dates itself by whatever VERSION happens to be, so the "
+        "minimum extension version follows the engine's head and every engine "
+        "release orphans the published extension")
+
+
+def test_an_engine_release_does_not_raise_the_floor_under_the_published_extension():
+    """The same claim, computed rather than read.
+
+    The floor is derived from the ledger, so a hypothetical newer engine is
+    simulated by asking what the floor WOULD be — no monkeypatching of a module
+    whose import runs a validator.
+    """
+    from scrapex.version import CAPABILITIES, MINIMUM_EXTENSION_VERSION, Surface, _newest
+
+    panel_sinces = tuple(c.since for c in CAPABILITIES if Surface.PANEL in c.surfaces)
+    assert panel_sinces, "the panel executes no capability at all"
+    assert _newest(panel_sinces) == MINIMUM_EXTENSION_VERSION
+
+    # Every `since` is a literal, so the floor is a fact about what the panel
+    # NEEDS and not about which engine is reading it. Tagging engine-v0.4.0
+    # changes VERSION and nothing here.
+    assert all(s != "" for s in panel_sinces)
+    assert MINIMUM_EXTENSION_VERSION == "0.2.0", (
+        "the floor moved without a capability being added; if that was "
+        "deliberate, the published extension must be republished first")
+
+
+def test_the_extension_may_be_tagged_for_the_store_on_its_own():
+    """PLATFORM-PLAN Decision 21: two release paths, neither triggering the other.
+
+    The JavaScript suite asserted `manifest.version === VECTORS.version`, and
+    VECTORS.version is the ENGINE's number. Bumping only extension/manifest.json
+    — which is exactly what a Chrome Web Store release is — failed with
+    `actual: '0.3.0', expected: '0.2.0'`. Python had already dropped that
+    equality (see test_the_extension_carries_its_own_number_and_may_differ); the
+    JavaScript copy never followed, so CI refused the release path the plan is
+    built on.
+
+    This asserts the JS side no longer welds them, from the Python side, because
+    the Python suite is the one that runs on every change.
+    """
+    # Comments stripped, for the same reason: the replacement records the
+    # equality it replaced, verbatim, so the next reader knows what expired.
+    js = "\n".join(
+        line for line in (ROOT / "extension" / "tests" /
+                          "version-compat.test.mjs").read_text(
+            encoding="utf-8").splitlines()
+        if not line.lstrip().startswith("//"))
+
+    assert "assert.equal(manifest.version, VECTORS.version)" not in js, (
+        "the extension's manifest is pinned to the engine's version again; a "
+        "store release with the engine untouched will fail CI")
+    assert "minimum_extension_version" in js, (
+        "the manifest is no longer checked against the floor the engine will "
+        "talk to, so a build the engine would refuse could be uploaded")


### PR DESCRIPTION
Decision 21 says the extension and the engine are tagged separately and **neither triggers the other**. Two things made that impossible — so M0, which PR #104 was meant to complete, is **not done**.

Found by an adversarial review of my own recommendation about M0. Three independent skeptics were asked to refute it; all three did, and this is the part of what they found that I verified myself and could fix today.

---

## First weld — a test

`extension/tests/version-compat.test.mjs` asserted `manifest.version === VECTORS.version`, and **`VECTORS.version` is the engine's number** (`scrapex/version.py: export_vectors` returns `{"version": VERSION, ...}`).

Measured, in both directions:

```
bump only extension/manifest.json to 0.3.0   ->  actual: '0.3.0', expected: '0.2.0'
bump only the engine                          ->  fails the other way
```

Bumping the manifest alone **is** a Chrome Web Store release. Python had already dropped this equality on 2026-08-05 (`test_the_extension_carries_its_own_number_and_may_differ`); the JavaScript copy never followed, so CI refused both release paths.

Replaced by the contract that is actually true: the manifest must be a real `MAJOR.MINOR.PATCH`, and **not older than the minimum the engine will talk to** — a build the engine would refuse must never be the one uploaded.

## Second weld — not a test artifact

All seven capabilities recorded `since=VERSION`. `MINIMUM_EXTENSION_VERSION` is the newest `since` among the panel's capabilities, so **the floor was `VERSION`** — always, however it was written.

> Move the engine alone to 0.4.0 and the floor became 0.4.0. The engine then declared the extension sitting in the Chrome Web Store — 0.2.0, reviewed by Google, installed on every machine — **too old to talk to**. Every engine release did that, to an extension that had not changed.

Nothing caught it because with `since=VERSION` the floor and the head move together and every assertion about them stays true.

A capability's `since` is now the version it was **introduced** in, written as a literal, once. `contracts/version-vectors.json` is byte-identical afterwards: **invisible today, decisive at the next release.**

The ledger then demanded what it always said it would — a capability dated older than the build must cite the commit that built it, *"read out of git log, never remembered"*. Both were established from git, not memory:

```
git log -S version_visibility --reverse                     -> 7ca7a75
git log -S compatibility_notice --reverse                   -> 7ca7a75
git log -S about-extension-version -- extension/ --reverse  -> 7ca7a75
git log -S version-notice -- extension/ --reverse           -> 7ca7a75
```

---

## Proven end to end — after a first attempt that proved nothing

My first proof run reported both paths green. It was **false**: `export-version` was crashing under captured output, so the vectors never moved and the green was green about the old numbers. With that fixed:

| | |
|---|---|
| **Path A** — Chrome Web Store, manifest alone → 0.3.0 | green |
| **Path B** — GitHub Release, engine alone → 0.4.0 | green |
| | engine 0.4.0 still talks to extensions ≥ 0.2.0 |

## Mutations

```
a capability dates itself by VERSION again   BITES
the manifest is welded to the engine again   BITES
the floor check stops naming the floor       BITES
```

Two of the new guards had to learn to strip comments first: the rule is explained at length beside the constant it protects, and the explanation quotes the mistake verbatim. A guard that reads its own documentation as a violation is a guard that forces the documentation out.

2013 python tests · 32 node tests · parity · validate-manifest — all green.