### PR TITLE
A button change no longer runs the engine suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # The scope step below diffs against the base branch, which needs
+          # more than the single commit a shallow checkout fetches.
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -21,8 +25,49 @@ jobs:
         run: |
           pip install -e .[dev,browser]
           python -m playwright install --with-deps chromium
+
+      - name: What did this change touch?
+        id: scope
+        # THIS DECIDES WHICH SUITE RUNS, AND IT IS A STEP RATHER THAN A JOB
+        # FILTER ON PURPOSE. A workflow- or job-level `paths:` filter makes the
+        # job not exist, and a required check that does not exist stays pending
+        # forever — the pull request can never merge. A step that always runs and
+        # sets an output leaves the job reporting on every change, which is what
+        # branch protection needs.
+        #
+        # The rule is deliberately one-sided. `extension-only` means every
+        # changed file is inside extension/ or docs/; anything else — one line
+        # in scrapex/, one line in tests/, a workflow edit — runs the whole
+        # suite exactly as before. An unknown event, an empty diff, or a failure
+        # to compute the base all fall through to "run everything", because the
+        # expensive mistake here is skipping a suite, never running one twice.
+        run: |
+          set -euo pipefail
+          base=""
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+          elif [ -n "${{ github.event.before }}" ] && \
+               [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+            base="${{ github.event.before }}"
+          fi
+
+          scope=full
+          if [ -n "$base" ] && git cat-file -e "$base^{commit}" 2>/dev/null; then
+            changed=$(git diff --name-only "$base" "${{ github.sha }}")
+            if [ -n "$changed" ] && ! echo "$changed" | grep -qvE '^(extension/|docs/)'; then
+              scope=extension
+            fi
+            echo "changed files:"
+            echo "$changed" | sed 's/^/  /'
+          else
+            echo "no usable base commit; running everything"
+          fi
+          echo "scope=$scope" >> "$GITHUB_OUTPUT"
+          echo "SCOPE: $scope"
+
       - name: Validate the manifest (S5 gate — a broken contract can't merge)
         run: python -m scrapex.cli validate-manifest
+
       - name: The panel suite must RUN, not skip
         # tests/test_panel_dom.py opens with pytest.importorskip("playwright"),
         # so before this job installed the browser it skipped in CI on every
@@ -37,7 +82,28 @@ jobs:
           count=$(python -m pytest tests/test_panel_dom.py --collect-only -q | tr -d '\r' | grep -oE ': [0-9]+$' | grep -oE '[0-9]+' | tail -1)
           echo "panel tests collected: ${count:-0}"
           test "${count:-0}" -ge 40
+
+      - name: The extension gate must not have emptied
+        # The same reasoning as the line above, for the set the split depends
+        # on. 325 of 2020 tests carried the mark when the split was made; a file
+        # that reads extension/ and forgets the mark stops running on exactly
+        # the pull requests it was written for, and nothing goes red.
+        # tests/test_the_extension_gate_is_complete.py catches the missing mark;
+        # this catches the set being emptied some other way.
+        run: |
+          count=$(python -m pytest -m extension --collect-only -q | tr -d '\r' | grep -oE '^[0-9]+/[0-9]+ tests collected' | grep -oE '^[0-9]+')
+          echo "extension gate collected: ${count:-0}"
+          test "${count:-0}" -ge 300
+
+      - name: Extension gate only (this change touched nothing else)
+        if: steps.scope.outputs.scope == 'extension'
+        # THE POINT OF THE SPLIT. A button change runs the 325 tests that guard
+        # the extension and stops there. The engine suite is not skipped by
+        # being unreachable — it is skipped because nothing it tests changed.
+        run: python -m pytest -m extension
+
       - name: Tests (Python engine + Python-vs-frozen contract)
+        if: steps.scope.outputs.scope != 'extension'
         # tests/conftest.py restores a prebuilt schema template instead of
         # replaying 57 migrations per test, which is what turns a ~30-minute
         # local suite into ~6 minutes. It is a developer-loop convenience, and
@@ -52,6 +118,10 @@ jobs:
   contract-parity:
     # The two-engine guardrail: the JS engine must reproduce the FROZEN contract
     # vectors byte-for-byte, or two engines could fork one warehouse's history.
+    #
+    # Always runs, on every change, and is never scoped: it is seconds long, it
+    # needs no Python, and it is the one gate that would go unwatched if either
+    # side of the split forgot it.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,10 +90,18 @@ jobs:
         # the pull requests it was written for, and nothing goes red.
         # tests/test_the_extension_gate_is_complete.py catches the missing mark;
         # this catches the set being emptied some other way.
+        #
+        # The per-file lines are summed rather than read off pytest's
+        # `N/M tests collected` summary: `addopts` carries `-q`, and under `-q`
+        # that summary is not printed at all — the tail of the output is the
+        # warnings block. The first version of this step grepped for the
+        # summary, matched nothing, and failed the build with `count` empty,
+        # which is at least the safe direction to be wrong in.
         run: |
-          count=$(python -m pytest -m extension --collect-only -q | tr -d '\r' | grep -oE '^[0-9]+/[0-9]+ tests collected' | grep -oE '^[0-9]+')
-          echo "extension gate collected: ${count:-0}"
-          test "${count:-0}" -ge 300
+          python -m pytest -m extension --collect-only -q | tr -d '\r' | tee /tmp/gate.txt | tail -20
+          count=$(grep -oE ': [0-9]+$' /tmp/gate.txt | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
+          echo "extension gate collected: ${count}"
+          test "${count}" -ge 300
 
       - name: Extension gate only (this change touched nothing else)
         if: steps.scope.outputs.scope == 'extension'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,4 +60,12 @@ include = ["scrapex*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-q"
+addopts = "-q --strict-markers"
+markers = [
+    # A test file that reads extension/ sources is guarding the EXTENSION, and
+    # a change to a button must run it. `--strict-markers` above makes a typo
+    # in the name an error instead of a test that silently stops being in the
+    # set. tests/test_the_extension_gate_is_complete.py is what keeps the set
+    # honest: a new file that reads extension/ and forgets the mark fails.
+    "extension: guards the Chrome extension; runs on an extension-only change",
+]

--- a/tests/test_design_system.py
+++ b/tests/test_design_system.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+import pytest
+
+# Guards the extension: this file reads extension/ sources, so a change to a
+# button must run it. See tests/test_the_extension_gate_is_complete.py.
+pytestmark = pytest.mark.extension
 
 
 ROOT = Path(__file__).resolve().parent.parent

--- a/tests/test_display_time_zone.py
+++ b/tests/test_display_time_zone.py
@@ -32,6 +32,10 @@ from scrapex.ingest import ingest_payloads  # noqa: E402
 from scrapex.webui.app import create_app  # noqa: E402
 from tests.test_ingest import make_entry, make_payload, one_row  # noqa: E402
 
+# Guards the extension: this file reads extension/ sources, so a change to a
+# button must run it. See tests/test_the_extension_gate_is_complete.py.
+pytestmark = pytest.mark.extension
+
 ROOT = Path(__file__).resolve().parent.parent
 EXT = ROOT / "extension"
 STATIC = ROOT / "scrapex" / "webui" / "static"

--- a/tests/test_native.py
+++ b/tests/test_native.py
@@ -16,6 +16,10 @@ from scrapex import db as dbmod
 from scrapex.native import PROTOCOL_VERSION, handle, read_message, write_message
 from scrapex.nativehost import HOST_NAME, build_manifest, install, manifest_path
 
+# Guards the extension: this file reads extension/ sources, so a change to a
+# button must run it. See tests/test_the_extension_gate_is_complete.py.
+pytestmark = pytest.mark.extension
+
 ROOT = Path(__file__).resolve().parent.parent
 
 # The data commands this host used to answer, each of them a second definition

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -75,6 +75,10 @@ from playwright.sync_api import sync_playwright  # noqa: E402
 
 import panel_harness as harness  # noqa: E402
 
+# Guards the extension: this file reads extension/ sources, so a change to a
+# button must run it. See tests/test_the_extension_gate_is_complete.py.
+pytestmark = pytest.mark.extension
+
 SOURCE_TAB = 'nav.side-rail button[data-view="source"]'
 RUN_TAB = 'nav.side-rail button[data-view="run"]'
 DATA_TAB = 'nav.side-rail button[data-view="data"]'

--- a/tests/test_panel_wiring.py
+++ b/tests/test_panel_wiring.py
@@ -19,6 +19,10 @@ from pathlib import Path
 
 import pytest
 
+# Guards the extension: this file reads extension/ sources, so a change to a
+# button must run it. See tests/test_the_extension_gate_is_complete.py.
+pytestmark = pytest.mark.extension
+
 EXT = Path(__file__).resolve().parent.parent / "extension"
 HTML = (EXT / "app.html").read_text(encoding="utf-8")
 JS = (EXT / "app.js").read_text(encoding="utf-8")

--- a/tests/test_settings_live_in_the_extension.py
+++ b/tests/test_settings_live_in_the_extension.py
@@ -14,6 +14,11 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+import pytest
+
+# Guards the extension: this file reads extension/ sources, so a change to a
+# button must run it. See tests/test_the_extension_gate_is_complete.py.
+pytestmark = pytest.mark.extension
 
 ROOT = Path(__file__).resolve().parent.parent
 WEB_SETTINGS = ROOT / "scrapex" / "webui" / "templates" / "settings.html"

--- a/tests/test_the_columns_you_could_not_see.py
+++ b/tests/test_the_columns_you_could_not_see.py
@@ -26,6 +26,10 @@ import pytest
 
 from scrapex import reports
 
+# Guards the extension: this file reads extension/ sources, so a change to a
+# button must run it. See tests/test_the_extension_gate_is_complete.py.
+pytestmark = pytest.mark.extension
+
 
 def test_the_four_are_declared_as_columns_with_a_meaning():
     """A column with no note renders a blank meaning cell on /schema — the

--- a/tests/test_the_extension_gate_is_complete.py
+++ b/tests/test_the_extension_gate_is_complete.py
@@ -1,0 +1,113 @@
+"""The set of tests that guard the extension must not shrink by accident.
+
+CI runs `pytest -m extension` when a change touches only `extension/`, so that
+a button change stops dragging the 2020-test engine suite behind it. The whole
+value of that depends on one thing: the marked set really being every test that
+guards the extension.
+
+MEASURED when the split was made: eleven files under tests/ read `extension/`
+sources — 325 of 2020 tests. The largest are the panel DOM suite (112), the
+vendored-asset gates (58), the native host (32) and the version ledger (32).
+
+THE FAILURE THIS PREVENTS IS SILENT AND HAS HAPPENED HERE BEFORE. The panel
+suite opened with `pytest.importorskip("playwright")` and reported green for
+months in CI while 48 behavioural tests — including the panel's only XSS guard
+— skipped without a word. A split is the second way to get exactly that: write
+a new test file that reads `extension/`, forget the mark, and it simply stops
+running on the pull requests it was written for. Nothing goes red. Nothing
+looks different.
+
+WHY THE SPLIT IS ASYMMETRIC, and why there is no `-m "not extension"` anywhere.
+Two of the eleven guard the ENGINE as well — `test_version.py` covers the
+engine's own ledger, `test_native.py` covers the native messaging host — so
+excluding the marked set from the engine run would drop them on engine changes.
+An extension-only change runs the marked subset; everything else runs the whole
+suite, exactly as before. Neither direction loses a test.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+pytestmark = pytest.mark.extension
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+#: A file "reads the extension" if it names the directory in any of the forms
+#: this repository uses. Deliberately broad: a false positive costs one marker,
+#: a false negative costs a guard nobody notices is gone.
+READS_EXTENSION = re.compile(r'"extension"|\bextension/')
+
+#: The floor, not the count. It is a floor because tests are added constantly
+#: and an equality would fail on every one of them; it is CHECKED because
+#: without it the marked set can be emptied one file at a time while CI keeps
+#: reporting a green extension gate over nothing.
+LEAST_TESTS_IN_THE_GATE = 300
+
+
+def _test_files() -> list[pathlib.Path]:
+    return sorted((ROOT / "tests").glob("test_*.py"))
+
+
+def test_every_test_file_that_reads_the_extension_carries_the_mark():
+    """THE GUARD. Without it the split is a promise rather than a mechanism."""
+    unmarked = []
+    for path in _test_files():
+        source = path.read_text(encoding="utf-8")
+        if not READS_EXTENSION.search(source):
+            continue
+        if "pytest.mark.extension" not in source:
+            unmarked.append(path.name)
+
+    assert not unmarked, (
+        "these test files read extension/ sources and would stop running on an "
+        "extension-only change:\n  " + "\n  ".join(unmarked) + "\n\nAdd "
+        "`pytestmark = pytest.mark.extension` after the imports.")
+
+
+def test_the_mark_is_declared_so_a_typo_cannot_be_silent():
+    """`--strict-markers` turns `pytest.mark.extenson` into an error.
+
+    Without it an unknown mark is a warning, the file quietly leaves the set,
+    and the gate keeps passing — the same shape of failure as the one above,
+    arrived at by a different route.
+    """
+    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+
+    # `addopts`, not the file: the flag is named in the comment beside the
+    # marker declaration, so a plain substring search finds its own explanation
+    # and passes with the flag switched off — measured, on the first attempt.
+    addopts = re.search(r'^addopts = "([^"]*)"', pyproject, re.M)
+    assert addopts, "pyproject.toml no longer sets addopts"
+    assert "--strict-markers" in addopts.group(1), (
+        "an unknown marker is only a warning again, so a misspelt "
+        "`pytest.mark.extension` silently removes a file from the gate")
+    assert re.search(r'^\s*"extension:', pyproject, re.M), (
+        "the extension marker is no longer declared in pyproject.toml")
+
+
+def test_the_gate_still_holds_enough_tests_to_be_a_gate(pytestconfig):
+    """A floor, because a gate that collects nothing passes fastest of all.
+
+    Counted by reading the marks rather than by running pytest inside pytest:
+    the number that matters is how many tests CARRY the mark, and that is a
+    fact about the files.
+    """
+    marked_files = [p for p in _test_files()
+                    if "pytest.mark.extension" in p.read_text(encoding="utf-8")]
+    assert len(marked_files) >= 10, (
+        f"only {len(marked_files)} files are in the extension gate; eleven were "
+        "measured when the split was made")
+
+    # `def test_` at the start of a line, which is how every test in this
+    # repository is written. Parametrised cases multiply this, so the real
+    # collected count is higher — which is the safe direction for a floor.
+    functions = sum(
+        len(re.findall(r"^def test_", p.read_text(encoding="utf-8"), re.M))
+        for p in marked_files)
+    assert functions >= LEAST_TESTS_IN_THE_GATE - 60, (
+        f"the extension gate is down to {functions} test functions; it was "
+        f"measured at 325 collected tests when the split was made")

--- a/tests/test_ui_kit.py
+++ b/tests/test_ui_kit.py
@@ -39,6 +39,10 @@ import re
 
 import pytest
 
+# Guards the extension: this file reads extension/ sources, so a change to a
+# button must run it. See tests/test_the_extension_gate_is_complete.py.
+pytestmark = pytest.mark.extension
+
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 
 #: Stylesheets whose rules are available to the markup checked below. The two

--- a/tests/test_ui_manifest.py
+++ b/tests/test_ui_manifest.py
@@ -13,6 +13,11 @@ from scrapex.ui_manifest import (
     RUN_MODE_OPTIONS, WORKSPACE_DESTINATIONS, ui_manifest,
     workspace_navigation_groups,
 )
+import pytest
+
+# Guards the extension: this file reads extension/ sources, so a change to a
+# button must run it. See tests/test_the_extension_gate_is_complete.py.
+pytestmark = pytest.mark.extension
 
 
 def test_every_destination_names_a_route_the_app_actually_serves():

--- a/tests/test_vendor.py
+++ b/tests/test_vendor.py
@@ -16,6 +16,10 @@ import struct
 
 import pytest
 
+# Guards the extension: this file reads extension/ sources, so a change to a
+# button must run it. See tests/test_the_extension_gate_is_complete.py.
+pytestmark = pytest.mark.extension
+
 ROOT = Path(__file__).resolve().parent.parent
 VENDOR = ROOT / "scrapex" / "webui" / "static" / "vendor"
 TEMPLATES = ROOT / "scrapex" / "webui" / "templates"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -47,6 +47,10 @@ from scrapex.version import (
     version_report,
 )
 
+# Guards the extension: this file reads extension/ sources, so a change to a
+# button must run it. See tests/test_the_extension_gate_is_complete.py.
+pytestmark = pytest.mark.extension
+
 ROOT = Path(__file__).resolve().parent.parent
 CONTRACTS = ROOT / "contracts"
 MANIFEST = ROOT / "extension" / "manifest.json"


### PR DESCRIPTION
M0's last piece. An extension-only change now runs the **325 tests that guard the extension and stops there** — 2m41s instead of 4m13s locally. The engine's 2020-test suite is not skipped by being *unreachable*; it is skipped because nothing it tests changed.

## Measured first, and the measurement changed the design twice

Eleven test files under `tests/` read `extension/` sources — **325 of 2020 tests**:

| tests | file |
|---:|---|
| 112 | `test_panel_dom.py` |
| 58 | `test_vendor.py` |
| 32 | `test_native.py` |
| 32 | `test_version.py` |
| 17 | `test_panel_wiring.py` |
| 11 | `test_settings_live_in_the_extension.py` |
| … | and five more |

The plan's estimate was 134 and a reviewer's was 154. Both were counting one file.

## The split is asymmetric, and there is no `-m "not extension"` anywhere

**Two of the eleven guard the engine as well** — `test_version.py` covers the engine's own ledger, `test_native.py` covers the native messaging host. Excluding the marked set from the engine run would have dropped them on engine changes.

So: an extension-only change runs the marked subset; **everything else runs the whole suite exactly as before.** Neither direction loses a test.

## The scope is a step, not a job filter

A workflow- or job-level `paths:` filter makes the job **not exist**, and a required check that does not exist stays pending forever — the pull request can never merge. A step that always runs and sets an output leaves the job reporting on every change.

The rule is one-sided on purpose. Nine cases checked:

```
extension/app.js                      -> extension
extension/app.js + extension/app.css  -> extension
extension/app.js + docs/UI-KIT.md     -> extension
extension/app.js + scrapex/version.py -> full
tests/test_panel_dom.py               -> full
.github/workflows/ci.yml              -> full
design/components.css                 -> full
(empty diff)                          -> full
extensions-elsewhere/foo.js           -> full     <- the anchored pattern
```

## What keeps the set honest

The panel suite once reported green **for months** in CI while 48 behavioural tests — including the panel's only XSS guard — skipped silently behind an `importorskip`. A split is the second way to get exactly that.

- the marker is declared and `--strict-markers` is on
- a new test file that reads `extension/` without the mark fails
- CI carries a collected-count floor for the gate, beside the one the panel suite already has

## Mutations

```
a new extension guard forgets the mark   BITES
the mark is misspelt                     BITES
strict-markers is turned off             BITES
the biggest file drops out of the gate   BITES
```

The third was **SILENT** on the first run: the guard searched the whole of `pyproject.toml` for `--strict-markers` and found the flag *named in the comment that explains it*. It now reads `addopts`. Third time this session a guard has been caught reading its own documentation.

## Note on this PR's own CI

This PR touches `.github/`, `pyproject.toml` and `tests/`, so its scope is `full` — which is correct, and proves the unchanged path still passes. The extension-only path is verified against CI immediately after merge with a branch that touches nothing but `extension/`.

2022 python tests · 32 node tests · parity · validate-manifest — all green.
