### PR TITLE
[verification] Prove the CI split chooses the extension gate

### DIFF
--- a/extension/app.js
+++ b/extension/app.js
@@ -54,6 +54,7 @@ const state = {
 };
 
 // ---- views ----------------------------------------------------------------
+// (a one-line change used to prove the CI split chooses the extension gate)
 const VIEWS = [
   // profile and engines lead: the agreed shape opens on "who am I" and "what is
   // installed" before anything can be run. console is the owner build's page and


### PR DESCRIPTION
A one-line comment in `extension/app.js` and nothing else. If the split works, this pull request runs `pytest -m extension` — 328 tests — and never reaches the 2022-test engine suite.

Opened to verify #115 against real CI rather than against my own reasoning, and closed once the run is read.