### PR TITLE
A branch's first push has no previous tip, so every change ran everything

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,25 @@ jobs:
             base="${{ github.event.before }}"
           fi
 
+          # A BRANCH'S FIRST PUSH HAS NO PREVIOUS TIP. `github.event.before` is
+          # forty zeros, so the block above leaves `base` empty and everything
+          # falls through to the full suite — measured: an extension-only change
+          # ran 9m59s on its push and 3m28s on its pull request, paying for the
+          # engine suite once anyway. Compare against main instead, which is
+          # what the change will actually be merged into.
+          #
+          # On main itself this deliberately finds nothing: `origin/main` IS the
+          # commit, the diff is empty, and an empty diff already means "run
+          # everything". The branch that everything merges into is the last
+          # place to run a subset.
+          if [ -z "$base" ] && [ "${{ github.ref }}" != "refs/heads/main" ]; then
+            git fetch --quiet origin main 2>/dev/null || true
+            if git rev-parse --verify --quiet origin/main >/dev/null; then
+              base=$(git merge-base origin/main "${{ github.sha }}" 2>/dev/null || true)
+              echo "no previous tip; comparing against main at ${base:-<none>}"
+            fi
+          fi
+
           scope=full
           if [ -n "$base" ] && git cat-file -e "$base^{commit}" 2>/dev/null; then
             changed=$(git diff --name-only "$base" "${{ github.sha }}")

--- a/extension/app.js
+++ b/extension/app.js
@@ -54,6 +54,7 @@ const state = {
 };
 
 // ---- views ----------------------------------------------------------------
+// (one comment line, used to prove the CI split picks the extension gate)
 const VIEWS = [
   // profile and engines lead: the agreed shape opens on "who am I" and "what is
   // installed" before anything can be run. console is the owner build's page and


### PR DESCRIPTION
The split worked on pull requests and not on pushes.

**Measured** on the branch that verified #115 — an extension-only change:

| event | scope | duration |
|---|---|---|
| `pull_request` | extension | **3m28s** |
| `push` | full | **9m59s** |

It paid for the whole engine suite once anyway, which is most of what the split was for.

`github.event.before` is forty zeros on a branch's first push, so `base` was empty and everything fell through to *run everything*. That fallback is right in general and useless here, because there **is** a sensible base: `main`, which is what the change will be merged into.

On `main` itself this deliberately finds nothing — `origin/main` *is* the commit, the diff is empty, and an empty diff already means run everything. The branch everything merges into is the last place to run a subset.

This PR's own scope is `full`, because it touches `.github/` — which is correct. A follow-up push of the extension-only line is what exercises the short path.