### PR TITLE
A backup a bare extension can read, and a lease a dead machine cannot hold

### DIFF
--- a/scrapex/bundle.py
+++ b/scrapex/bundle.py
@@ -1,0 +1,349 @@
+"""A backup a machine can restore, and a bare extension can read.
+
+DECISION 8 and §5 of the platform plan: a fresh machine, signed in, with no
+engine installed, must show the owner his data and export it.
+
+The expensive reading of that is "run SQLite in the extension". Spike 2 measured
+it (`spikes/opfs-sqlite/FINDINGS.md`): the schema runs under MV3 and survives a
+restart, but OPFS loses WAL, an access handle is exclusive, the service worker
+cannot write, and `wa-sqlite` is **70-208x slower than Python on the Data page's
+own query** — with a fast VFS that cannot open an existing database at all.
+
+None of that is needed, because viewing and exporting is READ-ONLY. So a backup
+is a BUNDLE:
+
+    warehouse.db          the restorable artefact, for a machine that installs
+                          the engine. Taken with sqlite3's own backup API, so
+                          it is consistent even while something is writing.
+    datasets/<KEY>/*      a plain export per dataset — JSON Lines and CSV —
+                          which is what a bare extension reads.
+    manifest.json         what is inside, how many rows, and a checksum for
+                          every file.
+
+ONE WRITER, ONE READER, and no database in a browser.
+
+THE EXPORT IS NOT A FOURTH READER. `reports.export_source_table` and its two
+companions already produce exactly what the Google Sheet and the Excel workbook
+carry; this writes the same rows to files. A bundle with its own SQL would drift
+from the three surfaces that already agree, which is the failure
+`fields.column_order` exists to prevent.
+
+WHY CHECKSUMS ARE NOT DECORATION. `latest.json` may only ever point at a bundle
+that `verify()` has passed. A backup nobody checked is a backup discovered to be
+empty on the day it is needed, and that day is by definition the worst one.
+"""
+from __future__ import annotations
+
+import csv
+import hashlib
+import io
+import json
+import shutil
+import sqlite3
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .archive import backup_database
+from .reports import (export_details_table, export_history_table,
+                      export_source_table, list_sources)
+from .payload import utc_now_iso
+from .version import VERSION
+
+#: The bundle's own shape, separate from the engine's version and from the
+#: database schema's. A restoring reader checks this first: it can refuse a
+#: layout it does not understand instead of half-reading one.
+BUNDLE_FORMAT = 1
+
+#: Read in 1 MiB blocks. The warehouse is 112 MB today and grows; hashing it in
+#: one read would hold the whole file in memory for no gain.
+_BLOCK = 1024 * 1024
+
+
+def sha256_of(path: Path) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        while chunk := handle.read(_BLOCK):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+@dataclass
+class Fault:
+    """Something wrong with a bundle, in the words a reader needs.
+
+    `path` is relative to the bundle root so the message is the same wherever
+    the bundle was downloaded to.
+    """
+    path: str
+    problem: str
+
+
+@dataclass
+class BundleReport:
+    root: Path
+    files: int = 0
+    bytes: int = 0
+    datasets: dict = field(default_factory=dict)
+    faults: list[Fault] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.faults
+
+
+def _write_table(directory: Path, name: str, header: list[str],
+                 rows: list[list]) -> dict:
+    """One table, twice: JSON Lines for a reader, CSV for a spreadsheet.
+
+    Both, and not one: JSON Lines keeps a number a number and an empty cell
+    distinguishable from an empty string, which is what the panel needs to show
+    the data honestly; CSV is what the owner double-clicks. Writing only the
+    first would make "export it" mean "write a converter first".
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    jsonl = directory / f"{name}.jsonl"
+    with open(jsonl, "w", encoding="utf-8", newline="\n") as handle:
+        for row in rows:
+            handle.write(json.dumps(dict(zip(header, row)), ensure_ascii=False))
+            handle.write("\n")
+
+    comma = directory / f"{name}.csv"
+    # newline="" is required by csv on Windows or every row gains a blank line.
+    # utf-8-sig so Excel opens Arabic without being told the encoding.
+    with open(comma, "w", encoding="utf-8-sig", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(header)
+        writer.writerows(rows)
+
+    return {"rows": len(rows), "columns": len(header),
+            "files": [jsonl.name, comma.name]}
+
+
+def build(db_path: Path | str, out_dir: Path | str, *,
+          source_keys: list[str] | None = None) -> BundleReport:
+    """Write a complete bundle into `out_dir`, which is created if absent.
+
+    The `.db` is copied through sqlite3's own backup API rather than the
+    filesystem: a plain copy of a database being written to is a copy of a
+    half-written page, and archive.backup_database already refuses to "back up
+    nothing" when the source is missing.
+    """
+    db_path, out_dir = Path(db_path), Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    copied = backup_database(db_path, tag="bundle")
+    warehouse = out_dir / "warehouse.db"
+    shutil.move(str(copied), warehouse)
+
+    conn = sqlite3.connect(f"file:{warehouse}?mode=ro", uri=True)
+    try:
+        available = [s.source_key for s in list_sources(conn)]
+        wanted = available if source_keys is None else [
+            key for key in source_keys if key in available]
+
+        datasets: dict[str, dict] = {}
+        for key in wanted:
+            folder = out_dir / "datasets" / key
+            tables: dict[str, dict] = {}
+            header, rows = export_source_table(conn, key)
+            # A source with no priced rows is not a fault: it is a source that
+            # has been configured and never crawled, and the plan names that
+            # state on the Library page. It is recorded with zero rows rather
+            # than left out, so a reader can tell "nothing yet" from "missing".
+            tables["current"] = _write_table(folder, "current", header, rows)
+            for name, table in (("details", export_details_table(conn, key)),
+                                ("history", export_history_table(conn, key))):
+                extra_header, extra_rows = table
+                if extra_rows:
+                    tables[name] = _write_table(folder, name, extra_header, extra_rows)
+            datasets[key] = tables
+    finally:
+        conn.close()
+
+    manifest = {
+        "bundle_format": BUNDLE_FORMAT,
+        "engine_version": VERSION,
+        "created_at": utc_now_iso(),
+        "source": str(db_path),
+        "datasets": datasets,
+        # Every file, with its size and digest. The manifest itself is not in
+        # here — it cannot contain its own hash — which is why verify() checks
+        # the manifest is READABLE separately from checking the files it names.
+        "files": {},
+    }
+    for path in sorted(out_dir.rglob("*")):
+        if not path.is_file() or path.name == "manifest.json":
+            continue
+        relative = path.relative_to(out_dir).as_posix()
+        manifest["files"][relative] = {"bytes": path.stat().st_size,
+                                       "sha256": sha256_of(path)}
+
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return verify(out_dir)
+
+
+def verify(bundle_dir: Path | str) -> BundleReport:
+    """Read a bundle back and check it is what its manifest says.
+
+    Every fault is reported, not just the first: a caller deciding whether to
+    publish this as `latest` needs the whole picture, and stopping at the first
+    bad file hides how bad it is.
+    """
+    root = Path(bundle_dir)
+    report = BundleReport(root=root)
+
+    manifest_path = root / "manifest.json"
+    if not manifest_path.is_file():
+        report.faults.append(Fault("manifest.json", "missing"))
+        return report
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (ValueError, OSError) as error:
+        report.faults.append(Fault("manifest.json", f"unreadable: {error}"))
+        return report
+
+    fmt = manifest.get("bundle_format")
+    if fmt != BUNDLE_FORMAT:
+        # Refused whole rather than half-read. A newer bundle may have moved
+        # anything, and guessing which parts are still compatible is how a
+        # restore silently loses a dataset.
+        report.faults.append(Fault(
+            "manifest.json",
+            f"bundle_format {fmt!r}, and this engine reads {BUNDLE_FORMAT}"))
+        return report
+
+    named = manifest.get("files") or {}
+    if not named:
+        report.faults.append(Fault("manifest.json", "names no files"))
+
+    for relative, expected in sorted(named.items()):
+        path = root / relative
+        if not path.is_file():
+            report.faults.append(Fault(relative, "named in the manifest and missing"))
+            continue
+        size = path.stat().st_size
+        if size != expected.get("bytes"):
+            report.faults.append(Fault(
+                relative, f"{size} bytes, manifest says {expected.get('bytes')}"))
+            continue
+        actual = sha256_of(path)
+        if actual != expected.get("sha256"):
+            report.faults.append(Fault(relative, "checksum does not match"))
+            continue
+        report.files += 1
+        report.bytes += size
+
+    # A file nobody named is as much a problem as a file that went missing:
+    # something wrote into this bundle after it was sealed.
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.name == "manifest.json":
+            continue
+        relative = path.relative_to(root).as_posix()
+        if relative not in named:
+            report.faults.append(Fault(relative, "present and not in the manifest"))
+
+    # The row counts, read back from the files rather than trusted. A truncated
+    # export has a valid checksum for its truncated self.
+    for key, tables in (manifest.get("datasets") or {}).items():
+        counts = {}
+        for name, described in tables.items():
+            jsonl = root / "datasets" / key / f"{name}.jsonl"
+            if not jsonl.is_file():
+                continue
+            with open(jsonl, encoding="utf-8") as handle:
+                rows = sum(1 for line in handle if line.strip())
+            counts[name] = rows
+            if rows != described.get("rows"):
+                report.faults.append(Fault(
+                    f"datasets/{key}/{name}.jsonl",
+                    f"{rows} rows, manifest says {described.get('rows')}"))
+        report.datasets[key] = counts
+
+    return report
+
+
+def read_dataset(bundle_dir: Path | str, source_key: str,
+                 table: str = "current") -> list[dict]:
+    """What a reader without an engine gets: rows, as dictionaries.
+
+    This is the whole of Decision 8 on the reading side, and it is deliberately
+    this short — no SQL, no schema, no database. The panel does the same thing
+    in JavaScript over the same file.
+    """
+    path = Path(bundle_dir) / "datasets" / source_key / f"{table}.jsonl"
+    if not path.is_file():
+        return []
+    with open(path, encoding="utf-8") as handle:
+        return [json.loads(line) for line in handle if line.strip()]
+
+
+# ---- what actually travels ---------------------------------------------------
+# MEASURED on the owner's own warehouse, 2026-08-06:
+#
+#     warehouse.db   116 MB
+#     exports         93 MB   (64 jsonl + 29 csv)
+#     ----------------------
+#     bundle         209 MB
+#     zipped          33 MB   6.3x smaller, in one second
+#
+# Decision 12 makes the upload frequency a setting because "a daily full upload
+# that changes nothing is not free". 209 MB would have made that setting a
+# necessity; 33 MB makes it a preference, and one second of CPU is not a cost
+# worth arguing about.
+#
+# It also gives `latest.json` ONE artefact to point at and one checksum to name,
+# instead of seventy-one.
+
+
+def pack(bundle_dir: Path | str, archive_path: Path | str) -> dict:
+    """Compress a verified bundle into one file, and describe it.
+
+    Refuses to pack a bundle that does not verify. The whole point of
+    `latest.json` naming only a validated bundle is lost if the validation can
+    be skipped by packing first and checking later.
+    """
+    root, archive = Path(bundle_dir), Path(archive_path)
+    report = verify(root)
+    if not report.ok:
+        raise ValueError(
+            "refusing to pack a bundle that does not verify: "
+            + "; ".join(f"{f.path}: {f.problem}" for f in report.faults[:3]))
+
+    archive.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED, compresslevel=6) as out:
+        for path in sorted(root.rglob("*")):
+            if path.is_file():
+                out.write(path, path.relative_to(root).as_posix())
+    return {"path": str(archive), "bytes": archive.stat().st_size,
+            "sha256": sha256_of(archive), "files": report.files,
+            "uncompressed_bytes": report.bytes}
+
+
+def unpack(archive_path: Path | str, out_dir: Path | str) -> BundleReport:
+    """Extract a bundle and verify it, refusing anything that escapes the folder.
+
+    A bundle arrives from Drive, which is outside this machine. A zip entry
+    named `../../autorun` or `C:/Windows/...` is the oldest trick there is, and
+    Python's `extractall` has historically obliged. Every name is resolved
+    against the destination and refused if it lands outside it.
+    """
+    archive, root = Path(archive_path), Path(out_dir)
+    root.mkdir(parents=True, exist_ok=True)
+    destination = root.resolve()
+
+    with zipfile.ZipFile(archive) as bundled:
+        for entry in bundled.infolist():
+            if entry.is_dir():
+                continue
+            target = (destination / entry.filename).resolve()
+            if not target.is_relative_to(destination):
+                raise ValueError(
+                    f"refusing an archive entry that escapes the bundle: "
+                    f"{entry.filename!r}")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with bundled.open(entry) as source, open(target, "wb") as handle:
+                shutil.copyfileobj(source, handle)
+
+    return verify(root)

--- a/scrapex/lease.py
+++ b/scrapex/lease.py
@@ -1,0 +1,217 @@
+"""One device writes at a time, and a dead one does not hold the warehouse forever.
+
+DECISION 3: one device at a time, with restore. Drive is enough — no server, no
+shared SQLite file over a network — and a lease is the whole of what stops two
+machines writing the same warehouse and silently forking its history.
+
+WHY A LEASE AND NOT A LOCK. A lock is held until it is released, and the machine
+that holds this one can be closed, unplugged or reinstalled. Nobody would ever
+release it, and the owner would be locked out of his own data by a laptop that no
+longer exists. A lease EXPIRES, so the failure mode is "wait a while", not "lose
+everything".
+
+WHY IT IS RENEWED AND NOT TAKEN ONCE. A crawl of muqawil's details ran 34 hours.
+A lease long enough to cover that would leave a crashed machine holding the
+warehouse for a day and a half; a lease short enough to recover from a crash
+quickly would expire in the middle of the crawl. Renewing while working settles
+both: the lease is short, and it stays alive exactly as long as something is
+alive to keep renewing it.
+
+WHAT THIS IS NOT. It is not a security boundary. Anyone with the owner's Drive
+can delete the file; the lease exists to stop an ACCIDENT — the same person on
+two machines — which is the only case Decision 3 is about.
+"""
+from __future__ import annotations
+
+import json
+import os
+import platform
+import socket
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+#: How long a lease is good for without being renewed. Short enough that a
+#: machine which died is forgotten within a coffee break, long enough that an
+#: ordinary pause — a sleeping laptop, a slow upload — does not lose it.
+LEASE_MINUTES = 15
+
+#: How often a working device renews. A third of the term, so two renewals can
+#: be missed entirely before anything is at risk.
+RENEW_MINUTES = 5
+
+_ISO = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc).replace(microsecond=0)
+
+
+def _stamp(moment: datetime) -> str:
+    return moment.strftime(_ISO)
+
+
+def _read_stamp(text: str) -> datetime | None:
+    try:
+        return datetime.strptime(text, _ISO).replace(tzinfo=timezone.utc)
+    except (TypeError, ValueError):
+        return None
+
+
+def device_id(state_dir: Path | str) -> str:
+    """This machine's identity, made once and kept.
+
+    NOT the hostname, and not a MAC address. Two machines can share a hostname,
+    a hostname changes, and a MAC is a different value per adapter and per VPN
+    state — an identity that changes when the network does would make one
+    machine look like several and break the lease exactly when it is needed.
+
+    A random id in a file beside the database is stable for as long as the
+    installation is, which is the thing being identified.
+    """
+    path = Path(state_dir) / "device.json"
+    if path.is_file():
+        try:
+            stored = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(stored.get("device_id"), str) and stored["device_id"]:
+                return stored["device_id"]
+        except (ValueError, OSError):
+            pass  # unreadable is the same as absent: make a new one and say so
+
+    made = uuid.uuid4().hex
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({
+        "device_id": made,
+        # For the owner reading the lease, never for identity: he needs to
+        # recognise WHICH of his machines is holding it, and a bare uuid does
+        # not tell him that.
+        "label": f"{platform.system()} · {socket.gethostname()}",
+        "made_at": _stamp(_now()),
+    }, indent=2), encoding="utf-8")
+    return made
+
+
+def device_label(state_dir: Path | str) -> str:
+    path = Path(state_dir) / "device.json"
+    try:
+        return json.loads(path.read_text(encoding="utf-8")).get("label", "")
+    except (ValueError, OSError):
+        return ""
+
+
+@dataclass
+class Lease:
+    device: str
+    label: str
+    taken_at: str
+    expires_at: str
+
+    def expired(self, now: datetime | None = None) -> bool:
+        moment = _read_stamp(self.expires_at)
+        if moment is None:
+            # A lease with an unreadable expiry cannot be trusted to expire, so
+            # it is treated as already gone. The alternative is a malformed file
+            # holding the warehouse for ever.
+            return True
+        return (now or _now()) >= moment
+
+    def to_json(self) -> str:
+        return json.dumps({
+            "device": self.device, "label": self.label,
+            "taken_at": self.taken_at, "expires_at": self.expires_at,
+        }, indent=2) + "\n"
+
+    @classmethod
+    def from_json(cls, text: str) -> "Lease | None":
+        try:
+            data = json.loads(text)
+        except (ValueError, TypeError):
+            return None
+        if not isinstance(data, dict) or not isinstance(data.get("device"), str):
+            return None
+        return cls(device=data["device"], label=data.get("label", ""),
+                   taken_at=data.get("taken_at", ""),
+                   expires_at=data.get("expires_at", ""))
+
+
+@dataclass
+class Verdict:
+    """Whether this device may write, and what to say when it may not."""
+    allowed: bool
+    lease: Lease | None = None
+    reason: str = ""
+    action: str = ""
+
+
+def read(path: Path | str) -> Lease | None:
+    path = Path(path)
+    if not path.is_file():
+        return None
+    try:
+        return Lease.from_json(path.read_text(encoding="utf-8"))
+    except OSError:
+        return None
+
+
+def claim(path: Path | str, device: str, label: str = "",
+          now: datetime | None = None,
+          minutes: int = LEASE_MINUTES) -> Verdict:
+    """Take or renew the lease, or refuse and say who holds it.
+
+    Renewing is the same call as taking: a device that already holds the lease
+    simply pushes the expiry out. Making renewal a separate operation is how a
+    long crawl ends up holding a lease it forgot to keep.
+    """
+    path = Path(path)
+    moment = now or _now()
+    held = read(path)
+
+    if held is not None and held.device != device and not held.expired(moment):
+        remaining = _read_stamp(held.expires_at)
+        minutes_left = max(
+            0, int((remaining - moment).total_seconds() // 60)) if remaining else 0
+        return Verdict(
+            allowed=False, lease=held,
+            reason=(f"another device holds this warehouse"
+                    + (f" — {held.label}" if held.label else "")),
+            action=(f"Stop ScrapeX there, or wait {minutes_left} minute"
+                    f"{'' if minutes_left == 1 else 's'} for its lease to expire."))
+
+    taken_at = held.taken_at if (held and held.device == device and held.taken_at) \
+        else _stamp(moment)
+    fresh = Lease(device=device, label=label, taken_at=taken_at,
+                  expires_at=_stamp(moment + timedelta(minutes=minutes)))
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Written whole and then moved into place. A reader that arrives mid-write
+    # would otherwise find half a lease, and `from_json` would call it garbage
+    # — which reads as "nobody holds this" and is the one wrong answer here.
+    temporary = path.with_suffix(path.suffix + ".partial")
+    temporary.write_text(fresh.to_json(), encoding="utf-8")
+    os.replace(temporary, path)
+    return Verdict(allowed=True, lease=fresh)
+
+
+def release(path: Path | str, device: str) -> bool:
+    """Give the lease up on a clean stop. Another device can start at once.
+
+    Only the holder may release: a device that lost the lease while it was
+    asleep must not delete the one that took over from it.
+    """
+    held = read(path)
+    if held is None or held.device != device:
+        return False
+    Path(path).unlink(missing_ok=True)
+    return True
+
+
+def may_write(path: Path | str, device: str, label: str = "",
+              now: datetime | None = None) -> Verdict:
+    """The question the engine asks before it writes anything.
+
+    A refusal names the machine and the wait, because "locked" with no idea by
+    whom or for how long is the same dead end as an engine that refuses on a
+    stderr nobody reads.
+    """
+    return claim(path, device, label=label, now=now)

--- a/tests/test_a_bundle_a_bare_extension_can_read.py
+++ b/tests/test_a_bundle_a_bare_extension_can_read.py
@@ -1,0 +1,315 @@
+"""A backup that restores a machine AND feeds an extension with no engine.
+
+Decision 8: a fresh machine, signed in, with no engine installed, shows the data
+and exports it. The expensive reading of that was "run SQLite in the browser",
+and spike 2 measured it dead: OPFS loses WAL, an access handle is exclusive, the
+service worker cannot write, and `wa-sqlite` is 70-208x slower than Python on
+the Data page's own query, with a fast VFS that cannot open an existing database
+at all.
+
+So the backup is a BUNDLE — the `.db` for a machine that installs the engine,
+a plain per-dataset export for one that has not, and a manifest with a checksum
+for every file. Viewing and exporting is read-only, so no database is needed in
+a browser at all.
+
+MEASURED ON THE OWNER'S OWN WAREHOUSE, 2026-08-06:
+
+    warehouse.db   116 MB          built in 20.6 s
+    exports         93 MB          64 jsonl + 29 csv, 12 datasets, 71 files
+    ---------------------
+    bundle         209 MB
+    zipped          33 MB          6.3x smaller, in one second
+
+Decision 12 makes the upload frequency a setting because "a daily full upload
+that changes nothing is not free". 209 MB would have made that a necessity;
+33 MB makes it a preference.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from scrapex import bundle
+from scrapex import db as dbmod
+
+
+@pytest.fixture()
+def warehouse(tmp_path):
+    """A small real warehouse: two sources, one of them never crawled.
+
+    Built through the real migration stream, because a bundle of a hand-made
+    schema would prove nothing about the one the owner has.
+    """
+    path = tmp_path / "marketlens.db"
+    conn = dbmod.connect(path)
+    dbmod.migrate(conn)
+    conn.execute(
+        "INSERT INTO source_site (source_id, source_key, source_name_ar, source_name,"
+        " base_url, platform, currency, timezone, authority, active) "
+        "VALUES (1,'SHOP','متجر','Shop','http://s','magento-graphql','SAR','UTC','shop',1)")
+    conn.execute(
+        "INSERT INTO source_site (source_id, source_key, source_name_ar, source_name,"
+        " base_url, platform, currency, timezone, authority, active) "
+        "VALUES (2,'NEVER','لم يُزحف','Never crawled','http://n','shopify-json',"
+        "'SAR','UTC','shop',1)")
+    conn.execute("INSERT INTO source_product (source_product_id, source_id, "
+                 " external_product_id, product_name, product_name_ar) "
+                 "VALUES (1,1,'p','Cement','أسمنت')")
+    conn.execute("INSERT INTO source_variant (source_variant_id, source_product_id, "
+                 " external_variant_id) VALUES (1,1,'v')")
+    conn.execute("INSERT INTO source_offer (offer_id, source_variant_id, "
+                 " country_code_alpha2, customer_segment, basis_quantity, currency, "
+                 " tax_included) VALUES (1,1,'SA','retail',50,'SAR',1)")
+    conn.execute("INSERT INTO crawl_run (run_id, source_id, started_at, status) "
+                 "VALUES (1,1,'2026-08-01T00:00:00Z','success')")
+    conn.execute(
+        "INSERT INTO price_observation (offer_id, run_id, observed_at, business_date,"
+        " price, currency, tax_included, availability, record_hash, price_hash,"
+        " price_fields, provenance) VALUES (1,1,'2026-08-01T00:00:00Z','2026-08-01',"
+        "23.5,'SAR',1,'in_stock','rh','ph','effective','observed')")
+    conn.commit()
+    conn.close()
+    return path
+
+
+def test_a_bundle_carries_the_database_the_export_and_a_manifest(warehouse, tmp_path):
+    """The three parts, and each is for a different reader."""
+    out = tmp_path / "bundle"
+
+    report = bundle.build(warehouse, out)
+
+    assert report.ok, [f"{f.path}: {f.problem}" for f in report.faults]
+    assert (out / "warehouse.db").is_file(), "nothing for a machine to restore"
+    assert (out / "datasets" / "SHOP" / "current.jsonl").is_file()
+    assert (out / "datasets" / "SHOP" / "current.csv").is_file()
+    assert (out / "manifest.json").is_file()
+
+    manifest = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["bundle_format"] == bundle.BUNDLE_FORMAT
+    assert manifest["engine_version"]
+    assert manifest["created_at"].endswith("Z")
+
+
+def test_a_source_that_was_never_crawled_is_recorded_and_not_dropped(warehouse, tmp_path):
+    """"Configured, never run" is a state the Library page already names, and a
+    bundle that simply omitted it would make "nothing yet" indistinguishable
+    from "missing" on the machine restoring it."""
+    out = tmp_path / "bundle"
+
+    report = bundle.build(warehouse, out)
+
+    assert "NEVER" in report.datasets, "the never-crawled source vanished"
+    assert report.datasets["NEVER"]["current"] == 0
+    assert (out / "datasets" / "NEVER" / "current.jsonl").is_file()
+
+
+def test_the_rows_are_readable_with_no_database_and_no_engine(warehouse, tmp_path):
+    """DECISION 8, on the reading side, and deliberately this short.
+
+    No SQL, no schema, no SQLite. The panel does the same thing in JavaScript
+    over the same file — which is the whole reason the export exists.
+    """
+    out = tmp_path / "bundle"
+    bundle.build(warehouse, out)
+
+    rows = bundle.read_dataset(out, "SHOP")
+
+    assert len(rows) == 1
+    # The column names are reports.EXPORT_HEADER's, not this test's invention:
+    # the bundle writes what the Sheet and the workbook already carry, so a
+    # reader that knows one knows all three.
+    assert rows[0]["product_name_ar"] == "أسمنت", (
+        "the Arabic name did not survive the round trip")
+    assert rows[0]["product_name"] == "Cement"
+    # A number stays a number. This is why the export is JSON Lines and not only
+    # CSV: a panel reading "23.5" as a string sorts 100 before 23.5.
+    assert isinstance(rows[0]["price"], (int, float))
+
+
+def test_the_csv_opens_in_excel_with_its_arabic_intact(warehouse, tmp_path):
+    """utf-8-sig, because Excel guesses the encoding of a plain UTF-8 file wrong
+    and the owner's data is half Arabic."""
+    out = tmp_path / "bundle"
+    bundle.build(warehouse, out)
+
+    raw = (out / "datasets" / "SHOP" / "current.csv").read_bytes()
+
+    assert raw.startswith(b"\xef\xbb\xbf"), "no BOM, so Excel will mangle the Arabic"
+    assert "أسمنت" in raw.decode("utf-8-sig")
+
+
+# ---- the checks that make `latest.json` mean something -----------------------
+
+def test_a_file_that_changed_after_the_bundle_was_sealed_is_caught(warehouse, tmp_path):
+    """The whole reason for checksums. A backup nobody verified is a backup
+    discovered to be empty on the day it is needed."""
+    out = tmp_path / "bundle"
+    bundle.build(warehouse, out)
+
+    (out / "datasets" / "SHOP" / "current.csv").write_text("tampered", encoding="utf-8")
+
+    report = bundle.verify(out)
+    assert not report.ok
+    assert any("current.csv" in f.path for f in report.faults)
+
+
+def test_a_byte_changed_without_changing_the_size_is_still_caught(warehouse, tmp_path):
+    """THE CASE ONLY THE CHECKSUM CAN SEE, and the reason it is a separate test.
+
+    The tamper above rewrote the file and changed its length, so the byte count
+    caught it first and the checksum comparison was never exercised — proved by
+    mutation: deleting the sha256 comparison left the whole suite green. Bit rot
+    and a half-flushed write do not change the length.
+    """
+    out = tmp_path / "bundle"
+    bundle.build(warehouse, out)
+    target = out / "datasets" / "SHOP" / "current.csv"
+
+    raw = bytearray(target.read_bytes())
+    raw[-1] ^= 0x01                      # one bit, same length
+    target.write_bytes(bytes(raw))
+
+    report = bundle.verify(out)
+    assert not report.ok
+    assert any("checksum" in f.problem for f in report.faults), (
+        [f"{f.path}: {f.problem}" for f in report.faults])
+
+
+def test_a_missing_file_is_caught_by_name(warehouse, tmp_path):
+    out = tmp_path / "bundle"
+    bundle.build(warehouse, out)
+
+    (out / "warehouse.db").unlink()
+
+    report = bundle.verify(out)
+    assert not report.ok
+    assert any(f.path == "warehouse.db" and "missing" in f.problem
+               for f in report.faults)
+
+
+def test_a_file_nobody_named_is_as_wrong_as_one_that_vanished(warehouse, tmp_path):
+    """Something wrote into this bundle after it was sealed. A verifier that
+    only checked the files it expected would call that bundle good."""
+    out = tmp_path / "bundle"
+    bundle.build(warehouse, out)
+
+    (out / "datasets" / "SHOP" / "extra.jsonl").write_text("{}\n", encoding="utf-8")
+
+    report = bundle.verify(out)
+    assert not report.ok
+    assert any("extra.jsonl" in f.path for f in report.faults)
+
+
+def test_a_truncated_export_is_caught_by_its_row_count(warehouse, tmp_path):
+    """A truncated file has a perfectly valid checksum FOR ITS TRUNCATED SELF
+    once someone rewrites the manifest. Counting the rows back is the check
+    that does not depend on the manifest being honest about the bytes."""
+    out = tmp_path / "bundle"
+    bundle.build(warehouse, out)
+
+    jsonl = out / "datasets" / "SHOP" / "current.jsonl"
+    jsonl.write_text("", encoding="utf-8")
+    # Rewrite the manifest so the byte and hash checks pass and only the row
+    # count can catch it.
+    manifest = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
+    manifest["files"]["datasets/SHOP/current.jsonl"] = {
+        "bytes": 0, "sha256": bundle.sha256_of(jsonl)}
+    (out / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    report = bundle.verify(out)
+    assert not report.ok
+    assert any("rows" in f.problem for f in report.faults)
+
+
+def test_a_bundle_from_a_later_format_is_refused_whole(tmp_path):
+    """Not half-read. A newer bundle may have moved anything, and guessing
+    which parts are still compatible is how a restore silently loses a
+    dataset."""
+    out = tmp_path / "bundle"
+    out.mkdir()
+    (out / "manifest.json").write_text(json.dumps(
+        {"bundle_format": bundle.BUNDLE_FORMAT + 1, "files": {}}), encoding="utf-8")
+
+    report = bundle.verify(out)
+    assert not report.ok
+    assert "bundle_format" in report.faults[0].problem
+
+
+def test_every_fault_is_reported_and_not_only_the_first(warehouse, tmp_path):
+    """A caller deciding whether to publish this as `latest` needs the whole
+    picture; stopping at the first bad file hides how bad it is."""
+    out = tmp_path / "bundle"
+    bundle.build(warehouse, out)
+
+    (out / "warehouse.db").unlink()
+    (out / "datasets" / "SHOP" / "current.csv").write_text("x", encoding="utf-8")
+
+    report = bundle.verify(out)
+    assert len(report.faults) >= 2, [f.path for f in report.faults]
+
+
+# ---- what actually travels ---------------------------------------------------
+
+def test_packing_refuses_a_bundle_that_does_not_verify(warehouse, tmp_path):
+    """`latest.json` naming only a validated bundle is worth nothing if the
+    validation can be skipped by packing first and checking afterwards."""
+    out = tmp_path / "bundle"
+    bundle.build(warehouse, out)
+    (out / "warehouse.db").unlink()
+
+    with pytest.raises(ValueError, match="does not verify"):
+        bundle.pack(out, tmp_path / "b.zip")
+
+
+def test_a_packed_bundle_unpacks_and_still_verifies(warehouse, tmp_path):
+    """The round trip, which is the only thing that proves a restore works."""
+    out = tmp_path / "bundle"
+    built = bundle.build(warehouse, out)
+    archive = tmp_path / "b.zip"
+
+    described = bundle.pack(out, archive)
+    restored = bundle.unpack(archive, tmp_path / "restored")
+
+    assert described["bytes"] < built.bytes, "compression made it bigger"
+    assert described["sha256"]
+    assert restored.ok, [f"{f.path}: {f.problem}" for f in restored.faults]
+    assert restored.datasets == built.datasets
+    assert bundle.read_dataset(
+        tmp_path / "restored", "SHOP")[0]["product_name_ar"] == "أسمنت"
+
+
+def test_an_archive_entry_that_escapes_the_folder_is_refused(tmp_path):
+    """A bundle arrives from Drive, which is outside this machine.
+
+    `../../autorun` is the oldest trick there is, and Python's `extractall` has
+    historically obliged. Every name is resolved against the destination.
+    """
+    archive = tmp_path / "evil.zip"
+    with zipfile.ZipFile(archive, "w") as out:
+        out.writestr("manifest.json", "{}")
+        out.writestr("../escaped.txt", "outside")
+
+    with pytest.raises(ValueError, match="escapes the bundle"):
+        bundle.unpack(archive, tmp_path / "dest")
+
+    assert not (tmp_path / "escaped.txt").exists(), "the file was written anyway"
+
+
+def test_the_database_in_the_bundle_is_a_real_openable_warehouse(warehouse, tmp_path):
+    """The .db is the artefact a machine restores FROM, so it has to be a
+    database and not a copy of a half-written page. sqlite3's own backup API is
+    what makes that true even while something is writing."""
+    out = tmp_path / "bundle"
+    bundle.build(warehouse, out)
+
+    conn = sqlite3.connect(f"file:{out / 'warehouse.db'}?mode=ro", uri=True)
+    try:
+        assert conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        assert conn.execute("SELECT COUNT(*) FROM price_observation").fetchone()[0] == 1
+    finally:
+        conn.close()

--- a/tests/test_one_device_writes_at_a_time.py
+++ b/tests/test_one_device_writes_at_a_time.py
@@ -1,0 +1,216 @@
+"""Two machines, one warehouse, and no server to arbitrate between them.
+
+Decision 3: one device at a time, with restore. Drive is enough — no server, no
+shared SQLite file over a network — and a lease is the whole of what stops two
+machines writing the same warehouse and silently forking its history.
+
+A LEASE AND NOT A LOCK. A lock is held until released, and the machine holding
+this one can be closed, unplugged or reinstalled. Nobody would ever release it
+and the owner would be locked out of his own data by a laptop that no longer
+exists. A lease expires, so the worst case is "wait", not "lose everything".
+
+RENEWED AND NOT TAKEN ONCE. muqawil's details crawl ran 34 hours. A lease long
+enough to cover that leaves a crashed machine holding the warehouse for a day
+and a half; a lease short enough to recover from a crash quickly expires in the
+middle of the crawl. Renewing while working settles both.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from scrapex import lease
+
+LAPTOP = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+DESKTOP = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+
+def at(minutes: int) -> datetime:
+    """A fixed clock. Every instant in these tests is stated, because a test
+    that takes the real one is a test that fails for six hours a year."""
+    return datetime(2026, 8, 6, 12, 0, tzinfo=timezone.utc) + timedelta(minutes=minutes)
+
+
+@pytest.fixture()
+def lease_file(tmp_path):
+    return tmp_path / "lease.json"
+
+
+def test_an_unclaimed_warehouse_is_taken_without_argument(lease_file):
+    verdict = lease.may_write(lease_file, LAPTOP, "Windows · laptop", now=at(0))
+
+    assert verdict.allowed
+    assert verdict.lease.device == LAPTOP
+    assert lease_file.is_file()
+
+
+def test_a_second_device_is_refused_and_told_who_and_how_long(lease_file):
+    """THE CASE THE MILESTONE IS NAMED FOR.
+
+    "Locked" with no idea by whom or for how long is the same dead end as an
+    engine that refuses on a stderr nobody reads. The refusal names the machine
+    and the wait.
+    """
+    lease.may_write(lease_file, LAPTOP, "Windows · laptop", now=at(0))
+
+    verdict = lease.may_write(lease_file, DESKTOP, "Windows · desktop", now=at(1))
+
+    assert not verdict.allowed
+    assert "laptop" in verdict.reason, "the owner cannot tell which machine to stop"
+    assert "14 minutes" in verdict.action, verdict.action
+    assert verdict.lease.device == LAPTOP
+
+
+def test_the_holder_renews_rather_than_fighting_itself(lease_file):
+    """Renewing is the same call as taking. Making it separate is how a long
+    crawl ends up holding a lease it forgot to keep."""
+    first = lease.may_write(lease_file, LAPTOP, now=at(0))
+
+    later = lease.may_write(lease_file, LAPTOP, now=at(5))
+
+    assert later.allowed
+    assert later.lease.taken_at == first.lease.taken_at, (
+        "renewing restarted the clock on when this device took the warehouse")
+    assert later.lease.expires_at > first.lease.expires_at
+
+
+def test_a_crawl_that_outlives_the_term_keeps_the_warehouse(lease_file):
+    """34 hours of muqawil details, renewed every five minutes."""
+    lease.may_write(lease_file, LAPTOP, now=at(0))
+    for minute in range(5, 34 * 60, lease.RENEW_MINUTES):
+        assert lease.may_write(lease_file, LAPTOP, now=at(minute)).allowed
+
+    # And the other machine was refused the whole way through.
+    assert not lease.may_write(lease_file, DESKTOP, now=at(34 * 60 - 1)).allowed
+
+
+def test_a_machine_that_died_does_not_hold_the_warehouse_for_ever(lease_file):
+    """THE RECOVERY PATH, and it needs nothing from the dead machine.
+
+    This is why it is a lease. The laptop is gone — reinstalled, stolen, at the
+    bottom of a lake — and the desktop takes over by waiting, not by asking.
+    """
+    lease.may_write(lease_file, LAPTOP, "Windows · laptop", now=at(0))
+
+    refused = lease.may_write(lease_file, DESKTOP, now=at(lease.LEASE_MINUTES - 1))
+    taken = lease.may_write(lease_file, DESKTOP, "Windows · desktop",
+                            now=at(lease.LEASE_MINUTES))
+
+    assert not refused.allowed
+    assert taken.allowed
+    assert taken.lease.device == DESKTOP
+    assert lease.read(lease_file).device == DESKTOP
+
+
+def test_a_clean_stop_hands_the_warehouse_over_at_once(lease_file):
+    """Waiting fifteen minutes after closing ScrapeX on purpose would be the
+    product punishing the owner for being tidy."""
+    lease.may_write(lease_file, LAPTOP, now=at(0))
+
+    assert lease.release(lease_file, LAPTOP)
+    assert lease.may_write(lease_file, DESKTOP, now=at(1)).allowed
+
+
+def test_a_device_that_lost_the_lease_cannot_release_the_one_that_took_it(lease_file):
+    """The laptop wakes from sleep long after its lease expired and tidies up
+    on the way out. Without this it would delete the desktop's lease and both
+    machines would be writing."""
+    lease.may_write(lease_file, LAPTOP, now=at(0))
+    lease.may_write(lease_file, DESKTOP, now=at(lease.LEASE_MINUTES))
+
+    assert not lease.release(lease_file, LAPTOP)
+    assert lease.read(lease_file).device == DESKTOP
+
+
+def test_a_lease_nobody_can_read_is_treated_as_gone(lease_file):
+    """A half-written or corrupted file must not hold the warehouse for ever.
+
+    The dangerous reading is the opposite one: `from_json` returning None for a
+    torn file means "nobody holds this", and a reader arriving mid-write would
+    take a lease somebody else has. That is why the file is written whole and
+    moved into place — see the next test.
+    """
+    lease_file.write_text("{ this is not json", encoding="utf-8")
+
+    assert lease.read(lease_file) is None
+    assert lease.may_write(lease_file, DESKTOP, now=at(0)).allowed
+
+
+def test_a_lease_with_an_unreadable_expiry_is_already_expired(lease_file):
+    """Not "held for ever". A malformed expiry cannot be trusted to arrive."""
+    lease_file.write_text(json.dumps(
+        {"device": LAPTOP, "expires_at": "whenever"}), encoding="utf-8")
+
+    assert lease.read(lease_file).expired(at(0))
+    assert lease.may_write(lease_file, DESKTOP, now=at(0)).allowed
+
+
+def test_the_file_is_written_whole_and_never_seen_half_finished(lease_file):
+    """A reader arriving mid-write must not find half a lease — `from_json`
+    would call it garbage, which reads as "nobody holds this", which is the one
+    wrong answer here."""
+    lease.may_write(lease_file, LAPTOP, now=at(0))
+
+    assert not list(lease_file.parent.glob("*.partial")), (
+        "a partial file was left behind, so a reader can see one")
+    assert lease.read(lease_file) is not None
+
+
+# ---- the device's own identity -----------------------------------------------
+
+def test_a_device_keeps_one_identity_across_restarts(tmp_path):
+    first = lease.device_id(tmp_path)
+    second = lease.device_id(tmp_path)
+
+    assert first == second
+    assert len(first) == 32
+
+
+def test_the_identity_is_not_the_hostname_or_the_network(tmp_path):
+    """Two machines can share a hostname, a hostname changes, and a MAC address
+    is different per adapter and per VPN state. An identity that changes when
+    the network does would make one machine look like several and break the
+    lease exactly when it matters."""
+    import platform
+    import socket
+
+    made = lease.device_id(tmp_path)
+
+    assert socket.gethostname() not in made
+    assert platform.node() not in made
+
+    # The hostname IS kept, as a label — the owner has to recognise which of
+    # his machines is holding the warehouse, and a bare uuid does not tell him.
+    assert socket.gethostname() in lease.device_label(tmp_path)
+
+
+def test_two_installations_on_one_machine_are_two_devices(tmp_path):
+    """THE PROPERTY THAT ACTUALLY MATTERS, and the one the test above missed.
+
+    Proved by mutation: replacing the random id with a hex-encoded hostname
+    passed everything, because "the hostname is not literally in the string" is
+    a weaker claim than "this identifies the installation".
+
+    Two state directories are two installations — a reinstall, a second profile,
+    a restored backup opened beside the original — and they must not both claim
+    to be the same device, or one would silently renew the other's lease and
+    both would be writing.
+    """
+    first = lease.device_id(tmp_path / "one")
+    second = lease.device_id(tmp_path / "two")
+
+    assert first != second, (
+        "two installations share an identity, so each can renew the other's "
+        "lease and both write at once")
+
+
+def test_an_unreadable_identity_file_makes_a_new_one_rather_than_crashing(tmp_path):
+    (tmp_path / "device.json").write_text("torn", encoding="utf-8")
+
+    made = lease.device_id(tmp_path)
+
+    assert len(made) == 32
+    assert json.loads((tmp_path / "device.json").read_text(encoding="utf-8"))["device_id"] == made


### PR DESCRIPTION
M2's two halves that need nothing outside this machine. Drive comes next; both of these are complete and provable today.

---

## The bundle

Decision 8 asks that a fresh machine — signed in, with **no engine installed** — shows the owner his data and exports it.

The expensive reading of that is *"run SQLite in the extension"*, and spike 2 measured it dead: OPFS loses WAL, an access handle is exclusive, the service worker cannot write, and `wa-sqlite` is **70–208× slower** than Python on the Data page's own query — with a fast VFS that cannot open an existing database at all.

**None of it is needed, because viewing and exporting is read-only.**

```
warehouse.db   the restorable artefact, for a machine that installs the engine
datasets/…     a plain per-dataset export — what a bare extension reads
manifest.json  row counts and a checksum for every file
```

### Measured on the owner's own warehouse

| | |
|---|---|
| `warehouse.db` | 116 MB, built in 20.6 s |
| exports | 93 MB — 64 jsonl + 29 csv, 12 datasets, 71 files |
| **bundle** | **209 MB** |
| **zipped** | **33 MB** — 6.3× smaller, in one second |

Decision 12 makes the upload frequency a setting because *"a daily full upload that changes nothing is not free"*. 209 MB would have made that a **necessity**; 33 MB makes it a **preference** — and it gives `latest.json` one artefact to name instead of seventy-one.

### It is not a fourth reader

`reports.export_source_table` and its two companions already produce what the Sheet and the workbook carry. This writes the same rows to files. JSON Lines **and** CSV — a number must stay a number for the panel, and Excel must open the Arabic without being told the encoding.

### What `verify()` catches

Every fault, not the first: a caller deciding whether to publish this as `latest` needs the whole picture.

- a changed file · a missing one
- **a file nobody named** — something wrote into this bundle after it was sealed
- **a truncated export**, which has a perfectly valid checksum *for its truncated self*

`unpack()` refuses an archive entry that escapes the folder. A bundle arrives from Drive, which is outside this machine, and `../../autorun` is the oldest trick there is.

---

## The lease

Decision 3: one device at a time, with restore.

**A lease and not a lock**, because the machine holding a lock can be closed, unplugged or reinstalled. Nobody would release it, and the owner would be locked out of his own data by a laptop that no longer exists.

**Renewed and not taken once**: muqawil's details crawl ran 34 hours. A term long enough to cover that leaves a crashed machine holding the warehouse for a day and a half; a term short enough to recover quickly expires mid-crawl. Fifteen minutes, renewed every five, settles both.

The refusal **names the machine and the wait** — *"locked"* with no idea by whom or for how long is the same dead end as an engine refusing on a stderr nobody reads.

The identity is a random id in a file, **not a hostname and not a MAC**: two machines can share a hostname, a hostname changes, and a MAC differs per adapter and per VPN state. An identity that moved with the network would make one machine look like several and break the lease exactly when it matters.

The file is written whole and moved into place, because a reader arriving mid-write would find half a lease, `from_json` would call it garbage, and garbage reads as *"nobody holds this"* — the one wrong answer here.

---

## Mutations

Fifteen, all biting. **Two were silent first, and both were real gaps in my tests:**

> The tamper test rewrote a file and **changed its length**, so the byte count caught it before the checksum was ever compared — deleting the `sha256` comparison left the suite green. There is now a same-length bit flip, which is the only thing a checksum catches that a size cannot.

> The device-id test asserted the hostname was not *literally* in the string, and a hex-encoded hostname passed it. The property that matters is that two **installations** differ — a reinstall, a second profile, a restored backup opened beside the original — or each would renew the other's lease.

2079 python tests · 42 node tests · parity · validate-manifest — all green.
