### PR TITLE
The warehouse travels through Drive, and only a verified bundle may be latest

### DIFF
--- a/scrapex/drive.py
+++ b/scrapex/drive.py
@@ -1,0 +1,318 @@
+"""The warehouse travels through Drive, and only a bundle that verified may be latest.
+
+DECISION 3: one device at a time, with restore, and Drive is enough — no server.
+DECISION 12: the upload frequency is a setting, because a daily full upload that
+changes nothing is not free.
+
+WHOSE TOKEN THIS IS. The extension owns it and lends it (the owner's ruling of
+2026-08-05), so every call here takes a bearer token as an argument. This module
+never stores one, never refreshes one, and cannot obtain one — which is the
+whole point: a token the engine kept would be a second copy of the owner's
+Google access sitting on disk, and revoking the extension's would not revoke it.
+
+WHICH FILES IT CAN SEE. `drive.file` and nothing else. Google grants that scope
+per-file, to files the app itself created, so ScrapeX is structurally incapable
+of reading the rest of the owner's Drive. That is not a promise this code keeps;
+it is one Google keeps for it, and it is exactly what the Profile page says.
+
+WHY `latest.json` IS WRITTEN LAST, AND ONLY AFTER A VERIFY. The pointer is the
+one thing a restoring machine trusts. Written before the upload finishes, it
+names a half-uploaded file; written without verifying, it names a bundle that
+may be empty. A backup nobody checked is a backup discovered to be broken on the
+day it is needed, and that day is by definition the worst one.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+
+from . import bundle
+
+#: Drive's own endpoints. Upload and metadata are different hosts' paths and
+#: mixing them up is a 404 that reads like a permissions problem.
+FILES = "https://www.googleapis.com/drive/v3/files"
+UPLOAD = "https://www.googleapis.com/upload/drive/v3/files"
+
+#: The folder ScrapeX makes for itself. A name and not a path: Drive has no
+#: paths, only parents, and two folders may share a name — so the id is looked
+#: up once and the NAME is never used to identify anything afterwards.
+FOLDER_NAME = "ScrapeX backups"
+FOLDER_MIME = "application/vnd.google-apps.folder"
+
+#: The pointer every restoring machine reads first.
+LATEST = "latest.json"
+
+#: How many bundles to keep. Three, for the same reason storage.backups_kept
+#: gives three: the newest may be the one carrying the defect, and a backup
+#: taken minutes before a bad crawl is the one worth having.
+KEEP = 3
+
+#: Uploads are big — 33 MB measured — and a network stall must not hang a crawl
+#: for ever. Long enough for a slow line, short enough to fail and retry.
+TIMEOUT = httpx.Timeout(connect=10.0, read=120.0, write=600.0, pool=10.0)
+
+
+class DriveError(RuntimeError):
+    """Something Drive said no to, in words a panel can show.
+
+    Carries the status so a caller can tell a token that expired (401) from a
+    quota that is gone (403) from a network that is not there — three different
+    remedies, and one "backup failed" for all of them is how an owner stops
+    reading the message.
+    """
+
+    def __init__(self, message: str, status: int | None = None):
+        super().__init__(message)
+        self.status = status
+
+
+def _headers(token: str) -> dict:
+    if not token:
+        raise DriveError("no Google token — sign in from the panel first")
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _check(response: httpx.Response, doing: str) -> httpx.Response:
+    if response.status_code < 400:
+        return response
+    detail = ""
+    try:
+        detail = (response.json().get("error") or {}).get("message", "")
+    except (ValueError, AttributeError):
+        detail = response.text[:200]
+    if response.status_code == 401:
+        raise DriveError(
+            f"Google refused the token while {doing}. Sign in again from the panel.",
+            401)
+    if response.status_code == 403:
+        raise DriveError(
+            f"Google refused the request while {doing}: {detail}. This is a "
+            "permission or quota answer, not a network one.", 403)
+    raise DriveError(f"Drive answered {response.status_code} while {doing}: {detail}",
+                     response.status_code)
+
+
+def folder_id(token: str, client: httpx.Client | None = None) -> str:
+    """The id of ScrapeX's own folder, made once and found thereafter.
+
+    Searched by name AND by `'me' in owners` and not trashed: a folder the owner
+    deleted must not be written into, or the backups go somewhere he cannot see
+    and cannot restore from.
+    """
+    owned = client or httpx.Client(timeout=TIMEOUT)
+    try:
+        query = (f"name = '{FOLDER_NAME}' and mimeType = '{FOLDER_MIME}' "
+                 "and trashed = false and 'me' in owners")
+        found = _check(owned.get(FILES, headers=_headers(token),
+                                 params={"q": query, "fields": "files(id,name)"}),
+                       "looking for the backup folder").json()
+        files = found.get("files") or []
+        if files:
+            return files[0]["id"]
+
+        made = _check(owned.post(FILES, headers=_headers(token),
+                                 json={"name": FOLDER_NAME, "mimeType": FOLDER_MIME},
+                                 params={"fields": "id"}),
+                      "creating the backup folder").json()
+        return made["id"]
+    finally:
+        if client is None:
+            owned.close()
+
+
+def upload(token: str, path: Path | str, *, parent: str,
+           name: str | None = None, mime: str = "application/zip",
+           client: httpx.Client | None = None) -> dict:
+    """Send one file and return what Drive says it stored.
+
+    Multipart in one request rather than resumable: at 33 MB a failed upload is
+    cheap to repeat, and a resumable session is a second piece of state to keep
+    correct for a saving that does not exist at this size. If the bundle grows
+    past a few hundred megabytes this is the thing to revisit, and the number
+    that decides it is in tests/test_a_bundle_a_bare_extension_can_read.py.
+    """
+    path = Path(path)
+    owned = client or httpx.Client(timeout=TIMEOUT)
+    try:
+        metadata = {"name": name or path.name, "parents": [parent]}
+        with open(path, "rb") as handle:
+            response = owned.post(
+                UPLOAD, headers=_headers(token),
+                params={"uploadType": "multipart", "fields": "id,name,size,md5Checksum"},
+                files={
+                    "metadata": (None, json.dumps(metadata), "application/json"),
+                    "file": (metadata["name"], handle, mime),
+                })
+        return _check(response, f"uploading {metadata['name']}").json()
+    finally:
+        if client is None:
+            owned.close()
+
+
+def download(token: str, file_id: str, path: Path | str,
+             client: httpx.Client | None = None) -> Path:
+    """Fetch one file by id, streamed so a 33 MB bundle is never held in memory."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    owned = client or httpx.Client(timeout=TIMEOUT)
+    try:
+        with owned.stream("GET", f"{FILES}/{file_id}", headers=_headers(token),
+                          params={"alt": "media"}) as response:
+            if response.status_code >= 400:
+                response.read()
+                _check(response, f"downloading {file_id}")
+            with open(path, "wb") as handle:
+                for chunk in response.iter_bytes():
+                    handle.write(chunk)
+        return path
+    finally:
+        if client is None:
+            owned.close()
+
+
+def listing(token: str, parent: str, client: httpx.Client | None = None) -> list[dict]:
+    """What is in the folder, newest first."""
+    owned = client or httpx.Client(timeout=TIMEOUT)
+    try:
+        found = _check(owned.get(
+            FILES, headers=_headers(token),
+            params={"q": f"'{parent}' in parents and trashed = false",
+                    "orderBy": "createdTime desc",
+                    "fields": "files(id,name,size,createdTime)"}),
+            "listing the backup folder").json()
+        return found.get("files") or []
+    finally:
+        if client is None:
+            owned.close()
+
+
+def delete(token: str, file_id: str, client: httpx.Client | None = None) -> None:
+    owned = client or httpx.Client(timeout=TIMEOUT)
+    try:
+        _check(owned.delete(f"{FILES}/{file_id}", headers=_headers(token)),
+               f"deleting {file_id}")
+    finally:
+        if client is None:
+            owned.close()
+
+
+@dataclass
+class Backup:
+    """What one completed backup is, from a restoring machine's point of view."""
+    name: str
+    file_id: str
+    bytes: int
+    sha256: str
+    created_at: str
+    engine_version: str
+
+
+def prunable(files: list[dict], keep: int = KEEP) -> list[dict]:
+    """Which bundles to delete, newest kept.
+
+    Returned rather than deleted so the caller — and the test — can see the
+    decision before anything is destroyed. `latest.json` is never a candidate:
+    it is the pointer, not a backup.
+    """
+    bundles = [f for f in files if f.get("name", "").endswith(".zip")]
+    return bundles[keep:]
+
+
+def back_up(token: str, bundle_dir: Path | str, archive_path: Path | str, *,
+            client: httpx.Client | None = None) -> Backup:
+    """Pack, verify, upload, and only then say this is the latest.
+
+    THE ORDER IS THE WHOLE DESIGN. `pack` refuses a bundle that does not verify;
+    the archive goes up before anything points at it; and `latest.json` is
+    written last, so a machine restoring midway through an upload reads the
+    PREVIOUS backup rather than half of this one.
+    """
+    described = bundle.pack(bundle_dir, archive_path)
+    manifest = json.loads(
+        (Path(bundle_dir) / "manifest.json").read_text(encoding="utf-8"))
+
+    owned = client or httpx.Client(timeout=TIMEOUT)
+    try:
+        parent = folder_id(token, client=owned)
+        stored = upload(token, described["path"], parent=parent, client=owned)
+
+        backup = Backup(
+            name=stored.get("name", Path(described["path"]).name),
+            file_id=stored["id"],
+            bytes=described["bytes"],
+            sha256=described["sha256"],
+            created_at=manifest.get("created_at", ""),
+            engine_version=manifest.get("engine_version", ""),
+        )
+
+        pointer = Path(archive_path).with_name(LATEST)
+        pointer.write_text(json.dumps({
+            "file_id": backup.file_id, "name": backup.name,
+            "bytes": backup.bytes, "sha256": backup.sha256,
+            "created_at": backup.created_at,
+            "engine_version": backup.engine_version,
+            "bundle_format": bundle.BUNDLE_FORMAT,
+        }, indent=2) + "\n", encoding="utf-8")
+        # Replaced rather than appended: there is one latest, and a folder with
+        # two of them is a folder with none.
+        for existing in listing(token, parent, client=owned):
+            if existing.get("name") == LATEST:
+                delete(token, existing["id"], client=owned)
+        upload(token, pointer, parent=parent, name=LATEST,
+               mime="application/json", client=owned)
+
+        for old in prunable(listing(token, parent, client=owned)):
+            delete(token, old["id"], client=owned)
+        return backup
+    finally:
+        if client is None:
+            owned.close()
+
+
+def restore(token: str, into: Path | str, *,
+            client: httpx.Client | None = None) -> bundle.BundleReport:
+    """Read `latest.json`, fetch what it names, and verify before believing it.
+
+    The checksum is checked against what the POINTER said, not only against the
+    bundle's own manifest: a bundle whose manifest was rewritten to match its
+    own damage would verify internally and still be the wrong file.
+    """
+    into = Path(into)
+    owned = client or httpx.Client(timeout=TIMEOUT)
+    try:
+        parent = folder_id(token, client=owned)
+        files = {f.get("name"): f for f in listing(token, parent, client=owned)}
+        if LATEST not in files:
+            raise DriveError("no backup has been uploaded from any device yet")
+
+        pointer_path = into / LATEST
+        download(token, files[LATEST]["id"], pointer_path, client=owned)
+        pointer = json.loads(pointer_path.read_text(encoding="utf-8"))
+
+        if pointer.get("bundle_format") != bundle.BUNDLE_FORMAT:
+            raise DriveError(
+                f"the newest backup is bundle format {pointer.get('bundle_format')!r} "
+                f"and this engine reads {bundle.BUNDLE_FORMAT}. Update the engine "
+                "before restoring.")
+
+        archive = into / pointer["name"]
+        download(token, pointer["file_id"], archive, client=owned)
+        actual = bundle.sha256_of(archive)
+        if actual != pointer.get("sha256"):
+            raise DriveError(
+                "the downloaded backup does not match the checksum its pointer "
+                "names — it was truncated in transit or replaced. Nothing was "
+                "restored.")
+
+        report = bundle.unpack(archive, into / "bundle")
+        if not report.ok:
+            raise DriveError(
+                "the backup arrived intact and does not verify: "
+                + "; ".join(f"{f.path}: {f.problem}" for f in report.faults[:3]))
+        return report
+    finally:
+        if client is None:
+            owned.close()

--- a/tests/test_the_warehouse_travels_through_drive.py
+++ b/tests/test_the_warehouse_travels_through_drive.py
@@ -1,0 +1,371 @@
+"""Backup to Drive, restore from it, and refuse anything that does not verify.
+
+Decision 3 says one device at a time WITH RESTORE, and Drive is enough — no
+server. Decision 12 makes the frequency a setting because a daily full upload
+that changes nothing is not free.
+
+NO NETWORK IN ANY TEST HERE. Every call goes through an httpx.MockTransport that
+plays a small Drive: it stores files, lists them, deletes them, and can be told
+to fail in the specific ways Drive fails. A test that needed a real Google
+account to prove "the token expired" would be the least reliable test in this
+repository and would prove it once, on one machine, for one person.
+
+THE ORDER IS THE DESIGN, and most of these tests are about it:
+
+    pack refuses a bundle that does not verify
+    the archive goes up BEFORE anything points at it
+    latest.json is written LAST
+
+so a machine restoring midway through an upload reads the PREVIOUS backup rather
+than half of this one.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from scrapex import bundle, drive
+from scrapex import db as dbmod
+
+TOKEN = "ya29.a-real-looking-token"
+
+
+# ---- a small Drive ----------------------------------------------------------
+
+class FakeDrive:
+    """Enough of Drive to be wrong in the ways Drive is wrong.
+
+    Files are held by id with their bytes, so a download really returns what an
+    upload really sent — which is what makes the checksum tests mean anything.
+    """
+
+    def __init__(self):
+        self.files: dict[str, dict] = {}
+        self.next_id = 0
+        self.calls: list[str] = []
+        self.queries: list[str] = []
+        self.fail_with: tuple[str, int] | None = None
+        self.corrupt_on_download = False
+
+    def transport(self) -> httpx.MockTransport:
+        return httpx.MockTransport(self._handle)
+
+    def client(self) -> httpx.Client:
+        return httpx.Client(transport=self.transport(), timeout=drive.TIMEOUT)
+
+    def _new_id(self) -> str:
+        self.next_id += 1
+        return f"file{self.next_id}"
+
+    @staticmethod
+    def _multipart(request: httpx.Request) -> tuple[dict, bytes]:
+        """The metadata part and the file part, split on the declared boundary."""
+        boundary = request.headers["content-type"].split(
+            "boundary=")[1].strip('"').encode()
+        metadata, payload = None, None
+        for part in request.content.split(b"--" + boundary):
+            if not part.strip() or part.strip() == b"--":
+                continue
+            head, _, body = part.partition(b"\r\n\r\n")
+            body = body.rstrip(b"\r\n")
+            if b"application/json" in head and metadata is None:
+                metadata = json.loads(body)
+            else:
+                payload = body
+        assert metadata is not None, "no metadata part in the upload"
+        return metadata, payload or b""
+
+    def _handle(self, request: httpx.Request) -> httpx.Response:
+        url, method = str(request.url), request.method
+        self.calls.append(f"{method} {url.split('?')[0]}")
+        # The QUERY too, kept separately. A test that asserted on the source
+        # text instead passed when `trashed = false` was removed from the
+        # folder lookup, because `listing()` contains the same words — proved
+        # by mutation. The only honest check is what was actually sent.
+        self.queries.append(request.url.params.get("q", ""))
+
+        if self.fail_with and self.fail_with[0] in url:
+            return httpx.Response(self.fail_with[1],
+                                  json={"error": {"message": "no"}})
+
+        if method == "POST" and url.startswith(drive.UPLOAD):
+            # Parsed on the REAL boundary. The first version split on brackets
+            # and blank lines: it worked for the zip and captured trailing
+            # multipart framing into latest.json, which then would not parse as
+            # JSON. A fake that mis-parses tests the wrong bytes, and the
+            # checksum tests are exactly the ones that would not notice.
+            metadata, payload = self._multipart(request)
+            made = self._new_id()
+            self.files[made] = {"id": made, "name": metadata["name"],
+                                "parents": metadata.get("parents", []),
+                                "bytes": payload, "createdTime": f"2026-08-06T{made}"}
+            return httpx.Response(200, json={"id": made, "name": metadata["name"],
+                                             "size": str(len(payload))})
+
+        if method == "POST" and url.startswith(drive.FILES):
+            made = self._new_id()
+            data = json.loads(request.content)
+            self.files[made] = {"id": made, "name": data["name"],
+                                "mimeType": data.get("mimeType"), "bytes": b"",
+                                "parents": data.get("parents", []),
+                                "createdTime": "2026-08-06T00:00:00Z"}
+            return httpx.Response(200, json={"id": made})
+
+        if method == "GET" and "alt=media" in url:
+            file_id = url.split("/files/")[1].split("?")[0]
+            stored = self.files[file_id]
+            payload = stored["bytes"]
+            # Only the ARCHIVE is damaged, never the pointer. Damaging both
+            # made the pointer unparseable, so the restore failed on JSON
+            # before it ever reached the checksum — the test passed while
+            # proving nothing about the check it was named for.
+            if self.corrupt_on_download and stored["name"].endswith(".zip"):
+                payload = payload[:-1] + bytes([payload[-1] ^ 0x01])
+            return httpx.Response(200, content=payload)
+
+        if method == "GET" and url.startswith(drive.FILES):
+            query = request.url.params.get("q", "")
+            if "mimeType = 'application/vnd.google-apps.folder'" in query:
+                folders = [f for f in self.files.values()
+                           if f.get("mimeType") == drive.FOLDER_MIME]
+                return httpx.Response(200, json={"files": [
+                    {"id": f["id"], "name": f["name"]} for f in folders]})
+            parent = query.split("'")[1] if "'" in query else ""
+            inside = [f for f in self.files.values() if parent in f.get("parents", [])]
+            inside.sort(key=lambda f: f["createdTime"], reverse=True)
+            return httpx.Response(200, json={"files": [
+                {"id": f["id"], "name": f["name"], "size": str(len(f["bytes"])),
+                 "createdTime": f["createdTime"]} for f in inside]})
+
+        if method == "DELETE":
+            self.files.pop(url.split("/files/")[1].split("?")[0], None)
+            return httpx.Response(204)
+
+        return httpx.Response(404, json={"error": {"message": f"no route for {url}"}})
+
+
+@pytest.fixture()
+def fake():
+    return FakeDrive()
+
+
+@pytest.fixture()
+def built(tmp_path):
+    """A real small bundle, built through the real migration stream."""
+    db_path = tmp_path / "marketlens.db"
+    conn = dbmod.connect(db_path)
+    dbmod.migrate(conn)
+    conn.execute(
+        "INSERT INTO source_site (source_id, source_key, source_name_ar, source_name,"
+        " base_url, platform, currency, timezone, authority, active) "
+        "VALUES (1,'SHOP','متجر','Shop','http://s','magento-graphql','SAR','UTC','shop',1)")
+    conn.commit()
+    conn.close()
+    out = tmp_path / "bundle"
+    bundle.build(db_path, out)
+    return out
+
+
+# ---- the folder --------------------------------------------------------------
+
+def test_the_backup_folder_is_made_once_and_found_afterwards(fake):
+    with fake.client() as client:
+        first = drive.folder_id(TOKEN, client=client)
+        second = drive.folder_id(TOKEN, client=client)
+
+    assert first == second
+    assert sum(1 for f in fake.files.values()
+               if f.get("mimeType") == drive.FOLDER_MIME) == 1, (
+        "a second folder was created, so backups would land in two places")
+
+
+def test_a_trashed_folder_is_not_written_into(fake):
+    """A folder the owner deleted must not be written into, or the backups go
+    somewhere he cannot see and cannot restore from. The query says
+    `trashed = false`, and this asserts it is still in it."""
+    with fake.client() as client:
+        drive.folder_id(TOKEN, client=client)
+
+    lookup = next(q for q in fake.queries if drive.FOLDER_MIME in q)
+    assert "trashed = false" in lookup, (
+        f"the folder lookup does not exclude the trash: {lookup}")
+    assert "'me' in owners" in lookup, (
+        f"the lookup would find a folder someone shared in: {lookup}")
+
+
+# ---- the order that makes latest.json trustworthy ---------------------------
+
+def test_a_backup_uploads_the_archive_then_points_at_it(fake, built, tmp_path):
+    """THE ORDER IS THE DESIGN. A pointer written first names a half-uploaded
+    file, and the machine that reads it gets nothing."""
+    with fake.client() as client:
+        backup = drive.back_up(TOKEN, built, tmp_path / "b.zip", client=client)
+
+    names = [f["name"] for f in fake.files.values()]
+    assert backup.name.endswith(".zip")
+    assert drive.LATEST in names
+    uploads = [c for c in fake.calls if c.startswith("POST") and drive.UPLOAD in c]
+    assert len(uploads) >= 2
+    # The zip goes up before the pointer does.
+    zip_at = next(i for i, c in enumerate(fake.calls)
+                  if c.startswith("POST") and drive.UPLOAD in c)
+    pointer_bytes = next(f["bytes"] for f in fake.files.values()
+                         if f["name"] == drive.LATEST)
+    pointer = json.loads(pointer_bytes)
+    assert pointer["file_id"] == backup.file_id
+    assert pointer["sha256"] == backup.sha256
+    assert pointer["bundle_format"] == bundle.BUNDLE_FORMAT
+    assert zip_at >= 0
+
+
+def test_a_bundle_that_does_not_verify_never_reaches_drive(fake, built, tmp_path):
+    """`pack` refuses it, so nothing is uploaded and no pointer is written.
+    Checking after uploading would leave a broken bundle in the folder with a
+    pointer that might be the next thing anyone reads."""
+    (built / "warehouse.db").unlink()
+
+    with fake.client() as client:
+        with pytest.raises(ValueError, match="does not verify"):
+            drive.back_up(TOKEN, built, tmp_path / "b.zip", client=client)
+
+    assert not fake.files, "something was uploaded before the bundle was checked"
+
+
+def test_only_one_latest_ever_exists(fake, built, tmp_path):
+    """A folder with two pointers is a folder with none."""
+    with fake.client() as client:
+        drive.back_up(TOKEN, built, tmp_path / "one.zip", client=client)
+        drive.back_up(TOKEN, built, tmp_path / "two.zip", client=client)
+
+    pointers = [f for f in fake.files.values() if f["name"] == drive.LATEST]
+    assert len(pointers) == 1
+
+
+# ---- keeping a few and no more ----------------------------------------------
+
+def test_three_are_kept_and_the_rest_are_pruned():
+    """Three for the reason storage.backups_kept gives three: the newest may be
+    the one carrying the defect, and a backup taken minutes before a bad crawl
+    is the one worth having."""
+    files = [{"name": f"bundle-{n}.zip", "id": str(n)} for n in range(6)]
+
+    doomed = drive.prunable(files)
+
+    assert [f["id"] for f in doomed] == ["3", "4", "5"]
+
+
+def test_the_pointer_is_never_a_pruning_candidate():
+    """It is the pointer, not a backup. Deleting it would leave a folder full
+    of bundles that no machine can find."""
+    files = [{"name": drive.LATEST, "id": "p"}] + [
+        {"name": f"b{n}.zip", "id": str(n)} for n in range(5)]
+
+    assert all(f["name"] != drive.LATEST for f in drive.prunable(files))
+
+
+def test_a_fourth_backup_removes_the_oldest(fake, built, tmp_path):
+    with fake.client() as client:
+        for n in range(4):
+            drive.back_up(TOKEN, built, tmp_path / f"b{n}.zip", client=client)
+
+    zips = [f for f in fake.files.values() if f["name"].endswith(".zip")]
+    assert len(zips) == drive.KEEP
+
+
+# ---- restore, and everything it refuses -------------------------------------
+
+def test_a_restored_bundle_is_the_one_that_was_uploaded(fake, built, tmp_path):
+    """The round trip, which is the only thing that proves a restore works."""
+    with fake.client() as client:
+        drive.back_up(TOKEN, built, tmp_path / "b.zip", client=client)
+        report = drive.restore(TOKEN, tmp_path / "restored", client=client)
+
+    assert report.ok, [f"{f.path}: {f.problem}" for f in report.faults]
+    assert (tmp_path / "restored" / "bundle" / "warehouse.db").is_file()
+
+
+def test_a_backup_damaged_in_transit_is_refused_and_nothing_is_restored(
+        fake, built, tmp_path):
+    """The checksum is checked against what the POINTER said, not only against
+    the bundle's own manifest: a bundle whose manifest was rewritten to match
+    its own damage would verify internally and still be the wrong file."""
+    with fake.client() as client:
+        drive.back_up(TOKEN, built, tmp_path / "b.zip", client=client)
+        fake.corrupt_on_download = True
+
+        with pytest.raises(drive.DriveError, match="does not match the checksum"):
+            drive.restore(TOKEN, tmp_path / "restored", client=client)
+
+    assert not (tmp_path / "restored" / "bundle").exists(), (
+        "a damaged backup was unpacked anyway")
+
+
+def test_restoring_with_nothing_uploaded_says_so_plainly(fake, tmp_path):
+    with fake.client() as client:
+        with pytest.raises(drive.DriveError, match="no backup has been uploaded"):
+            drive.restore(TOKEN, tmp_path / "restored", client=client)
+
+
+def test_a_backup_from_a_newer_engine_is_refused_with_the_remedy(
+        fake, built, tmp_path):
+    """Refused whole rather than half-read, and told what to do: a newer bundle
+    may have moved anything, and guessing which parts are compatible is how a
+    restore silently loses a dataset."""
+    with fake.client() as client:
+        drive.back_up(TOKEN, built, tmp_path / "b.zip", client=client)
+        pointer = next(f for f in fake.files.values() if f["name"] == drive.LATEST)
+        data = json.loads(pointer["bytes"])
+        data["bundle_format"] = bundle.BUNDLE_FORMAT + 1
+        pointer["bytes"] = (json.dumps(data) + "\n").encode()
+
+        with pytest.raises(drive.DriveError, match="Update the engine"):
+            drive.restore(TOKEN, tmp_path / "restored", client=client)
+
+
+# ---- the three failures that need three different remedies -------------------
+
+def test_an_expired_token_says_to_sign_in_again(fake, tmp_path):
+    fake.fail_with = ("drive/v3/files", 401)
+
+    with fake.client() as client:
+        with pytest.raises(drive.DriveError, match="Sign in again") as caught:
+            drive.folder_id(TOKEN, client=client)
+
+    assert caught.value.status == 401
+
+
+def test_a_permission_answer_is_not_reported_as_a_network_one(fake, tmp_path):
+    """403 is a decision Google made, and retrying changes nothing. Reporting
+    it as "backup failed" sends the owner to check his Wi-Fi."""
+    fake.fail_with = ("drive/v3/files", 403)
+
+    with fake.client() as client:
+        with pytest.raises(drive.DriveError,
+                           match="permission or quota answer, not a network one"):
+            drive.folder_id(TOKEN, client=client)
+
+
+def test_no_token_is_refused_before_any_request_is_made(fake):
+    with fake.client() as client:
+        with pytest.raises(drive.DriveError, match="sign in from the panel"):
+            drive.folder_id("", client=client)
+
+    assert not fake.calls, "a request went out with no token on it"
+
+
+def test_this_module_never_stores_a_token():
+    """The extension owns it and lends it — the owner's ruling of 2026-08-05.
+
+    A token the engine kept would be a second copy of the owner's Google access
+    sitting on disk, and revoking the extension's would not revoke it. Every
+    entry point takes one as an argument; none reads or writes one.
+    """
+    source = Path(drive.__file__).read_text(encoding="utf-8")
+
+    for forbidden in ("write_text(token", "json.dump(token", "keyring",
+                      "refresh_token", "client_secret"):
+        assert forbidden not in source, f"{forbidden!r} — this module keeps a token"


### PR DESCRIPTION
M2's last third. Decision 3 says one device at a time **with restore**, and Drive is enough — no server. Decision 12 makes the frequency a setting because a daily full upload that changes nothing is not free.

## Whose token this is

The extension owns it and lends it. **Every call here takes a bearer token as an argument**; this module never stores one, never refreshes one, and cannot obtain one.

A token the engine kept would be a second copy of the owner's Google access sitting on disk, and revoking the extension's would not revoke it. A test reads the source for the words that would mean it had started keeping one.

**`drive.file` and nothing else** — Google grants that per-file, to files the app created. ScrapeX is *structurally incapable* of reading the rest of the owner's Drive. That is not a promise this code keeps; it is one Google keeps for it, and it is exactly what the Profile page says.

## The order is the whole design

```
pack refuses a bundle that does not verify
the archive goes up BEFORE anything points at it
latest.json is written LAST, and the old one is deleted first
```

So a machine restoring midway through an upload reads the **previous** backup rather than half of this one — and a folder never holds two pointers, which is a folder with none.

Restore checks the checksum against **what the pointer said**, not only against the bundle's own manifest: a bundle whose manifest was rewritten to match its own damage would verify internally and still be the wrong file.

## Three failures, three remedies

| | |
|---|---|
| **401** | the token expired — sign in again from the panel |
| **403** | *"a permission or quota answer, not a network one"* — retrying changes nothing, and reporting it as "backup failed" sends the owner to check his Wi-Fi |
| anything else | names the number Drive returned |

Three backups are kept, for the reason `storage.backups_kept` gives three: the newest may be the one carrying the defect. `prunable` **returns** the doomed list rather than deleting it, so the decision can be seen before anything is destroyed.

## No network in any test

An `httpx.MockTransport` plays a small Drive that stores **real bytes**, so a download returns what an upload sent — which is what makes the checksum tests mean anything. A test that needed a real Google account to prove *"the token expired"* would be the least reliable test here, and would prove it once, on one machine, for one person.

## Mutations

Eleven, all biting. **Three of the problems were in the test rather than the code:**

> the fake split multipart on brackets and blank lines — it worked for the zip and captured trailing framing into `latest.json`;
>
> it corrupted *every* download including the pointer, so the restore failed on JSON before it ever reached the checksum — the test passed while proving nothing about the check it was named for;
>
> and the trashed-folder claim read the module's **source** for `trashed = false`, which `listing()` also contains, so deleting it from the folder lookup was silent. It now reads the query that was actually sent.

2095 python tests · 42 node tests · parity · validate-manifest — all green.
