### PR TITLE
The panel reads the owner's data with no engine on the machine

### DIFF
--- a/extension/bundleview.js
+++ b/extension/bundleview.js
@@ -1,0 +1,114 @@
+// Reading the owner's data on a machine with no engine on it at all.
+//
+// DECISION 8, and the whole reason the backup is a bundle rather than a copy of
+// the database. Spike 2 measured running SQLite here: OPFS loses WAL, an access
+// handle is exclusive, the service worker cannot write, and wa-sqlite is 70-208x
+// slower than Python on the Data page's own query — with a fast VFS that cannot
+// open an existing database at all.
+//
+// None of it is needed. Viewing and exporting is READ-ONLY, so the engine writes
+// a plain export and this reads it.
+//
+// GZIP AND NOT ZIP, and the reason is not preference. A browser has
+// DecompressionStream for gzip and deflate built in, and no zip reader at all.
+// Unpacking the archive would need a bundled library, and this repository ships
+// no npm dependency on purpose. `panel.jsonl.gz` is the format the browser
+// already has.
+//
+// MEASURED on the owner's warehouse: 64.1 MB of rows become 4.1 MB gzipped. A
+// bare panel downloads four megabytes and shows months of data.
+
+/**
+ * Decompress and parse the panel pack.
+ *
+ * Streamed, not read whole: 4 MB compressed is 64 MB of text, and holding both
+ * the bytes and the string at once for no reason is how a side panel gets
+ * killed for memory on a small machine.
+ */
+export async function readPanelPack(blob) {
+  const stream = blob.stream().pipeThrough(new DecompressionStream("gzip"));
+  const reader = stream.pipeThrough(new TextDecoderStream()).getReader();
+
+  const datasets = new Map();
+  let carry = "";
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    carry += value;
+    let cut;
+    while ((cut = carry.indexOf("\n")) >= 0) {
+      const line = carry.slice(0, cut);
+      carry = carry.slice(cut + 1);
+      addLine(datasets, line);
+    }
+  }
+  addLine(datasets, carry);   // a final line with no newline after it
+  return datasets;
+}
+
+function addLine(datasets, line) {
+  if (!line.trim()) return;
+  let entry;
+  try {
+    entry = JSON.parse(line);
+  } catch (_) {
+    // ONE unreadable line is not a broken backup. A pack truncated by a failed
+    // download loses its last line, and refusing the whole file over it would
+    // turn a recoverable download into "you have no data".
+    return;
+  }
+  if (!entry || typeof entry.dataset !== "string") return;
+  const key = entry.dataset;
+  if (!datasets.has(key)) datasets.set(key, new Map());
+  const tables = datasets.get(key);
+  const table = entry.table || "current";
+  if (!tables.has(table)) tables.set(table, []);
+  tables.get(table).push(entry.row);
+}
+
+/** What the Data page lists when there is no engine to ask. */
+export function datasetSummaries(datasets) {
+  return [...datasets.entries()].map(([key, tables]) => ({
+    source_key: key,
+    rows: (tables.get("current") || []).length,
+    tables: [...tables.keys()].sort(),
+    // The history table is what makes "when did this change" answerable
+    // offline, and saying whether it is here is more useful than a row count
+    // nobody asked for.
+    has_history: tables.has("history"),
+  })).sort((a, b) => b.rows - a.rows);
+}
+
+export function rowsOf(datasets, key, table = "current") {
+  const tables = datasets.get(key);
+  return (tables && tables.get(table)) || [];
+}
+
+/**
+ * Rows as a CSV the owner can open, built from the rows themselves.
+ *
+ * The header is the union of every row's keys IN FIRST-SEEN ORDER, not the
+ * first row's keys: a row that carries an extra promoted axis would otherwise
+ * lose that column silently for the whole file.
+ */
+export function toCsv(rows) {
+  const header = [];
+  const seen = new Set();
+  for (const row of rows) {
+    for (const key of Object.keys(row || {})) {
+      if (!seen.has(key)) { seen.add(key); header.push(key); }
+    }
+  }
+  const cell = (value) => {
+    if (value === null || value === undefined) return "";
+    const text = String(value);
+    return /[",\n\r]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+  };
+  const lines = [header.map(cell).join(",")];
+  for (const row of rows) {
+    lines.push(header.map((key) => cell((row || {})[key])).join(","));
+  }
+  // A BOM, because Excel guesses the encoding of a plain UTF-8 file wrong and
+  // half of this data is Arabic. The engine's own csv writer does the same.
+  return "﻿" + lines.join("\r\n") + "\r\n";
+}

--- a/extension/tests/bundleview.test.mjs
+++ b/extension/tests/bundleview.test.mjs
@@ -1,0 +1,132 @@
+// The panel reading the owner's data with no engine on the machine.
+//
+// Decision 8. Everything here runs under `node --test` with no browser and no
+// engine, because the whole claim is that reading needs neither.
+//
+// GZIP AND NOT ZIP: a browser has DecompressionStream built in and no zip
+// reader at all, and this repository ships no npm dependency. Node has the same
+// DecompressionStream, so what is tested here is what the panel runs.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { gzipSync } from "node:zlib";
+
+import { readPanelPack, datasetSummaries, rowsOf, toCsv }
+  from "../bundleview.js";
+
+function packOf(entries) {
+  const text = entries.map((e) => JSON.stringify(e)).join("\n") + "\n";
+  return new Blob([gzipSync(Buffer.from(text, "utf8"))]);
+}
+
+const ENTRIES = [
+  { dataset: "MADAR", table: "current",
+    row: { product_name: "Cement", product_name_ar: "أسمنت", price: 23.5 } },
+  { dataset: "MADAR", table: "current",
+    row: { product_name: "Sand", product_name_ar: "رمل", price: 8 } },
+  { dataset: "MADAR", table: "history",
+    row: { product_name: "Cement", price: 22.0, business_date: "2026-07-01" } },
+  { dataset: "SHOP", table: "current",
+    row: { product_name: "Lamp", product_name_ar: "مصباح", price: 99 } },
+];
+
+test("the rows come back with no engine, no database and no library", async () => {
+  const datasets = await readPanelPack(packOf(ENTRIES));
+
+  assert.equal(datasets.size, 2);
+  assert.equal(rowsOf(datasets, "MADAR").length, 2);
+  assert.equal(rowsOf(datasets, "MADAR")[0].product_name_ar, "أسمنت");
+  assert.equal(rowsOf(datasets, "MADAR", "history").length, 1);
+});
+
+test("a number is still a number, so a column sorts", async () => {
+  // The reason the export is JSON Lines and not only csv. A panel reading
+  // "23.5" as text sorts 100 before 23.5, which is the kind of wrong that
+  // looks like working software.
+  const datasets = await readPanelPack(packOf(ENTRIES));
+
+  assert.equal(typeof rowsOf(datasets, "MADAR")[0].price, "number");
+});
+
+test("the dataset list is what the Data page shows when nothing can be asked", async () => {
+  const datasets = await readPanelPack(packOf(ENTRIES));
+
+  const summaries = datasetSummaries(datasets);
+
+  assert.deepEqual(summaries.map((s) => s.source_key), ["MADAR", "SHOP"]);
+  assert.equal(summaries[0].rows, 2);
+  assert.equal(summaries[0].has_history, true);
+  assert.equal(summaries[1].has_history, false);
+});
+
+test("a truncated download loses its last row and not the whole file", async () => {
+  // A pack cut short by a failed download ends mid-line. Refusing the file over
+  // it turns a recoverable download into "you have no data" — which is the one
+  // answer a backup must never give.
+  const text = ENTRIES.map((e) => JSON.stringify(e)).join("\n");
+  const cut = text.slice(0, text.length - 20);
+  const datasets = await readPanelPack(new Blob([gzipSync(Buffer.from(cut, "utf8"))]));
+
+  assert.equal(rowsOf(datasets, "MADAR").length, 2, "earlier rows were lost too");
+});
+
+test("a line with no dataset is skipped rather than crashing the page", async () => {
+  const datasets = await readPanelPack(packOf([
+    { table: "current", row: { a: 1 } },     // no dataset
+    ENTRIES[0],
+  ]));
+
+  assert.equal(datasets.size, 1);
+  assert.equal(rowsOf(datasets, "MADAR").length, 1);
+});
+
+test("a pack with a final line and no newline still yields it", async () => {
+  // gzip of text that does not end in a newline. The reader carries a partial
+  // line between chunks, and a version that only flushed on "\n" would drop
+  // the last row of every file written that way.
+  const text = ENTRIES.map((e) => JSON.stringify(e)).join("\n");
+  const datasets = await readPanelPack(new Blob([gzipSync(Buffer.from(text, "utf8"))]));
+
+  assert.equal(rowsOf(datasets, "SHOP").length, 1);
+});
+
+test("a row split across two chunks is reassembled", async () => {
+  // 64 MB of text arrives in pieces and a row lands on the boundary. Asserted
+  // with a row long enough that the stream must split it.
+  const long = { dataset: "BIG", table: "current",
+                 row: { product_name: "x".repeat(200_000), price: 1 } };
+  const datasets = await readPanelPack(packOf([long]));
+
+  assert.equal(rowsOf(datasets, "BIG")[0].product_name.length, 200_000);
+});
+
+// ---- exporting, which is the other half of Decision 8 -----------------------
+
+test("the csv header is every column any row has, in first-seen order", () => {
+  // Not the first row's keys. A row carrying an extra promoted axis would
+  // otherwise lose that column silently for the whole file.
+  const csv = toCsv([{ a: 1, b: 2 }, { a: 3, c: 4 }]);
+
+  assert.equal(csv.split("\r\n")[0], "﻿a,b,c");
+});
+
+test("a cell with a comma, a quote or a newline survives", () => {
+  const csv = toCsv([{ name: 'He said "go", then left\nquickly' }]);
+
+  assert.match(csv, /"He said ""go"", then left\nquickly"/);
+});
+
+test("the csv carries the mark Excel needs for Arabic", () => {
+  const csv = toCsv([{ product_name_ar: "أسمنت" }]);
+
+  assert.ok(csv.startsWith("﻿"),
+    "no BOM, so Excel opens the Arabic as mojibake");
+  assert.ok(csv.includes("أسمنت"));
+});
+
+test("an absent value is empty and not the word undefined", () => {
+  const csv = toCsv([{ a: 1, b: null }, { a: undefined, b: 2 }]);
+
+  assert.equal(csv.split("\r\n")[1], "1,");
+  assert.equal(csv.split("\r\n")[2], ",2");
+});

--- a/scrapex/bundle.py
+++ b/scrapex/bundle.py
@@ -35,6 +35,7 @@ empty on the day it is needed, and that day is by definition the worst one.
 from __future__ import annotations
 
 import csv
+import gzip
 import hashlib
 import io
 import json
@@ -161,6 +162,8 @@ def build(db_path: Path | str, out_dir: Path | str, *,
     finally:
         conn.close()
 
+    _write_panel_pack(out_dir, datasets)
+
     manifest = {
         "bundle_format": BUNDLE_FORMAT,
         "engine_version": VERSION,
@@ -182,6 +185,60 @@ def build(db_path: Path | str, out_dir: Path | str, *,
     (out_dir / "manifest.json").write_text(
         json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
     return verify(out_dir)
+
+
+#: What a machine with NO ENGINE downloads. One gzipped stream of every row in
+#: the bundle, tagged with the dataset and table it came from.
+#:
+#: WHY NOT THE ZIP. JavaScript has DecompressionStream for gzip and deflate
+#: built in, and no zip reader at all — a panel that unpacked the archive would
+#: need a bundled library, and this repository deliberately ships no npm
+#: dependency. Gzip is the format the browser already has.
+#:
+#: WHY NOT PER-DATASET FILES. Twelve datasets times three tables is thirty-six
+#: uploads per backup, times three retained. One file is one download, one
+#: checksum and one thing to point at.
+#:
+#: MEASURED on the owner's warehouse: 64.1 MB of rows become 4.1 MB gzipped —
+#: the per-row tags are pure repetition and gzip absorbs them. A bare panel
+#: downloads four megabytes to show months of data with no engine on the
+#: machine at all.
+PANEL_PACK = "panel.jsonl.gz"
+
+
+def _write_panel_pack(out_dir: Path, datasets: dict) -> None:
+    with gzip.open(out_dir / PANEL_PACK, "wt", encoding="utf-8", newline="\n",
+                   compresslevel=6) as packed:
+        for key in sorted(datasets):
+            for table in sorted(datasets[key]):
+                source = out_dir / "datasets" / key / f"{table}.jsonl"
+                if not source.is_file():
+                    continue
+                with open(source, encoding="utf-8") as handle:
+                    for line in handle:
+                        if not line.strip():
+                            continue
+                        packed.write(json.dumps(
+                            {"dataset": key, "table": table,
+                             "row": json.loads(line)}, ensure_ascii=False))
+                        packed.write("\n")
+
+
+def read_panel_pack(path: Path | str, *, dataset: str | None = None,
+                    table: str = "current") -> list[dict]:
+    """The Python half of what the panel does, for testing what it will see."""
+    rows = []
+    with gzip.open(path, "rt", encoding="utf-8") as packed:
+        for line in packed:
+            if not line.strip():
+                continue
+            entry = json.loads(line)
+            if entry.get("table") != table:
+                continue
+            if dataset is not None and entry.get("dataset") != dataset:
+                continue
+            rows.append(entry["row"])
+    return rows
 
 
 def verify(bundle_dir: Path | str) -> BundleReport:

--- a/tests/test_the_panel_reads_what_the_engine_wrote.py
+++ b/tests/test_the_panel_reads_what_the_engine_wrote.py
@@ -1,0 +1,177 @@
+"""The pack the engine writes is the pack the panel reads. Proved, not assumed.
+
+Two languages, one file format, and nothing but this test standing between them.
+It is the same guardrail `contract/parity/` puts under the normalize vectors and
+`contracts/version-vectors.json` puts under the compatibility rule: a format
+described in two places drifts, and the drift is invisible until a machine with
+no engine on it shows an empty screen.
+
+So a REAL pack is built here by the real `bundle.build`, and the REAL
+`extension/bundleview.js` is run over it under node. No fixture, no hand-written
+sample: a fixture would be a third description of the format and would go stale
+the same way.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from scrapex import bundle
+from scrapex import db as dbmod
+
+# Guards the extension: this file reads extension/ sources, so a change to a
+# button must run it. See tests/test_the_extension_gate_is_complete.py.
+pytestmark = pytest.mark.extension
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture()
+def packed(tmp_path):
+    """A real bundle from a real migrated warehouse."""
+    db_path = tmp_path / "marketlens.db"
+    conn = dbmod.connect(db_path)
+    dbmod.migrate(conn)
+    conn.execute(
+        "INSERT INTO source_site (source_id, source_key, source_name_ar, source_name,"
+        " base_url, platform, currency, timezone, authority, active) "
+        "VALUES (1,'SHOP','متجر','Shop','http://s','magento-graphql','SAR','UTC','shop',1)")
+    conn.execute("INSERT INTO source_product (source_product_id, source_id, "
+                 " external_product_id, product_name, product_name_ar) "
+                 "VALUES (1,1,'p','Cement','أسمنت')")
+    conn.execute("INSERT INTO source_variant (source_variant_id, source_product_id, "
+                 " external_variant_id) VALUES (1,1,'v')")
+    conn.execute("INSERT INTO source_offer (offer_id, source_variant_id, "
+                 " country_code_alpha2, customer_segment, basis_quantity, currency, "
+                 " tax_included) VALUES (1,1,'SA','retail',50,'SAR',1)")
+    conn.execute("INSERT INTO crawl_run (run_id, source_id, started_at, status) "
+                 "VALUES (1,1,'2026-08-01T00:00:00Z','success')")
+    conn.execute(
+        "INSERT INTO price_observation (offer_id, run_id, observed_at, business_date,"
+        " price, currency, tax_included, availability, record_hash, price_hash,"
+        " price_fields, provenance) VALUES (1,1,'2026-08-01T00:00:00Z','2026-08-01',"
+        "23.5,'SAR',1,'in_stock','rh','ph','effective','observed')")
+    conn.commit()
+    conn.close()
+
+    out = tmp_path / "bundle"
+    bundle.build(db_path, out)
+    return out / bundle.PANEL_PACK
+
+
+def _read_with_the_panel(pack: Path) -> dict:
+    """Run the extension's own reader over the engine's own file."""
+    script = textwrap.dedent(f"""
+        import {{ readFileSync }} from "node:fs";
+        import {{ readPanelPack, datasetSummaries, rowsOf, toCsv }}
+          from "{(ROOT / 'extension' / 'bundleview.js').as_uri()}";
+
+        const blob = new Blob([readFileSync({str(pack.as_posix())!r})]);
+        const datasets = await readPanelPack(blob);
+        const rows = rowsOf(datasets, "SHOP");
+        console.log(JSON.stringify({{
+          summaries: datasetSummaries(datasets),
+          rows,
+          csv: toCsv(rows),
+        }}));
+    """)
+    result = subprocess.run(
+        [_node(), "--input-type=module", "-e", script],
+        capture_output=True, text=True, encoding="utf-8", errors="replace")
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def _node() -> str:
+    from shutil import which
+    found = which("node")
+    if not found:
+        pytest.skip("node is not on PATH")
+    return found
+
+
+def test_the_panel_reads_the_rows_the_engine_wrote(packed):
+    """THE WHOLE OF DECISION 8 IN ONE ASSERTION.
+
+    A machine with no engine, given only this file, shows the owner his data.
+    """
+    seen = _read_with_the_panel(packed)
+
+    assert [s["source_key"] for s in seen["summaries"]] == ["SHOP"]
+    assert seen["summaries"][0]["rows"] == 1
+    assert len(seen["rows"]) == 1
+
+
+def test_the_arabic_survives_two_languages_and_a_compressor(packed):
+    """utf-8 through gzip through DecompressionStream through TextDecoder. Any
+    one of them getting the encoding wrong turns the owner's product names into
+    mojibake, and the panel would look broken rather than the format."""
+    seen = _read_with_the_panel(packed)
+
+    assert seen["rows"][0]["product_name_ar"] == "أسمنت"
+    assert seen["rows"][0]["product_name"] == "Cement"
+
+
+def test_a_number_written_by_python_is_a_number_read_by_javascript(packed):
+    """The reason the export is JSON Lines and not only csv. A price read as
+    text sorts 100 before 23.5, which is the kind of wrong that looks like
+    working software."""
+    seen = _read_with_the_panel(packed)
+
+    assert isinstance(seen["rows"][0]["price"], (int, float))
+    assert not isinstance(seen["rows"][0]["price"], str)
+
+
+def test_the_columns_are_the_engines_own_export_header(packed):
+    """Not a shape invented for the panel. `reports.EXPORT_HEADER` is what the
+    Sheet and the workbook carry, so a reader who knows one knows all three —
+    and a column added to the export reaches the bare panel with no JavaScript
+    change at all."""
+    from scrapex.reports import EXPORT_HEADER
+
+    seen = _read_with_the_panel(packed)
+
+    assert set(seen["rows"][0]) == set(EXPORT_HEADER), (
+        "the panel is seeing a different set of columns from the export")
+
+
+def test_the_csv_the_panel_offers_matches_the_one_the_engine_writes(packed):
+    """Two exporters for one thing is two exporters that disagree by next
+    month. They are separate here only because one runs where Python cannot,
+    so this asserts they still produce the same header and the same values."""
+    seen = _read_with_the_panel(packed)
+    engine_csv = (packed.parent / "datasets" / "SHOP" / "current.csv").read_text(
+        encoding="utf-8-sig")
+
+    panel_header = seen["csv"].lstrip("﻿").splitlines()[0].split(",")
+    engine_header = engine_csv.splitlines()[0].split(",")
+
+    assert panel_header == engine_header
+    assert seen["csv"].startswith("﻿"), (
+        "the panel's csv has no BOM, so Excel will mangle the Arabic the "
+        "engine's csv preserves")
+    assert "أسمنت" in seen["csv"]
+
+
+def test_the_pack_is_part_of_the_bundle_and_checksummed(packed):
+    """It travels with everything else, so a tampered pack is caught by the
+    same verify() that catches a tampered database."""
+    manifest = json.loads(
+        (packed.parent / "manifest.json").read_text(encoding="utf-8"))
+
+    assert bundle.PANEL_PACK in manifest["files"]
+    assert manifest["files"][bundle.PANEL_PACK]["sha256"]
+
+    raw = bytearray(packed.read_bytes())
+    raw[-1] ^= 0x01
+    packed.write_bytes(bytes(raw))
+
+    report = bundle.verify(packed.parent)
+    assert not report.ok
+    assert any(bundle.PANEL_PACK in f.path for f in report.faults)


### PR DESCRIPTION
Stacked on #123. **The whole of Decision 8**: a fresh machine, signed in, with no engine installed, shows the data and exports it.

## Gzip and not zip — a constraint, not a preference

A browser has `DecompressionStream` for gzip and deflate built in and **no zip reader at all**. Unpacking the archive in the panel would need a bundled library, and this repository ships no npm dependency on purpose.

So the bundle now also carries **`panel.jsonl.gz`** — every row, tagged with the dataset and table it came from, in the one compressed format the browser already has.

### Measured before choosing

| | uncompressed | gzipped |
|---|---|---|
| current tables only | 30.7 MB | **1.1 MB** |
| every table | 64.1 MB | **4.1 MB** |

Four megabytes for months of data across twelve datasets — so the panel takes **everything** rather than making the owner choose what to download. The per-row tags are pure repetition and gzip absorbs them entirely.

**One file and not thirty-six.** Twelve datasets × three tables is thirty-six uploads per backup, × three retained. One file is one download, one checksum, and one thing for `latest.json` to point at — and it is checksummed by the same `verify()` that catches a tampered database.

## The reader

**Streamed.** Four megabytes compressed is sixty-four of text, and holding the bytes and the string at once for no reason is how a side panel gets killed for memory on a small machine.

**One unreadable line is not a broken backup.** A pack truncated by a failed download ends mid-line; refusing the whole file over it turns a recoverable download into *"you have no data"* — the one answer a backup must never give.

## The format is described in two languages, so it is proved in two

A **real** pack built by the real `bundle.build` is read by the **real** `extension/bundleview.js` under node. No fixture — a fixture would be a *third* description of the format and would go stale the same way.

It asserts:

- the Arabic survives utf-8 → gzip → `DecompressionStream` → `TextDecoder`
- a number written by Python is a **number** read by JavaScript (a price read as text sorts 100 before 23.5 — the kind of wrong that looks like working software)
- the columns are `reports.EXPORT_HEADER`'s, **not a shape invented for the panel**, so a column added to the export reaches the bare panel with no JavaScript change
- the two csv writers agree on their header and their BOM. Two exporters for one thing is two exporters that disagree by next month; they are separate here only because one runs where Python cannot.

## Mutations

```
a truncated pack loses everything              BITES
the last line with no newline is dropped       BITES
a row split across chunks is cut in half       BITES
the csv header is only the first row's keys    BITES
a cell with a comma is not quoted              BITES
the csv loses the mark Excel needs             BITES
an absent value becomes the word undefined     BITES
the pack stops being written at all            BITES
rows lose the dataset they came from           BITES
```

UI-0's guard caught the new parity test reading `extension/` without the `extension` mark — exactly what it exists for.

2101 python tests · 53 node tests · parity · validate-manifest — all green.
