### PR TITLE
The release must install the tests it runs, and run the ones that cover it

### DIFF
--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -153,17 +153,41 @@ jobs:
           exit 1
 
       - name: Install
+        # `dev` IS THE EXTRA THAT CARRIES PYTEST, and leaving it out is how the
+        # first real dispatch of this workflow died: `No module named pytest`,
+        # after five minutes of installing everything else. Nothing that reads
+        # this file could have caught it — the step named a suite it had no way
+        # to run — so a guard that reads pyproject for whichever extra provides
+        # pytest now sits in tests/test_the_two_release_paths.py.
+        #
+        # `browser` and the Chromium download are here because the step below
+        # runs the WHOLE suite, and the panel tests in it drive a real browser.
         run: |
-          pip install -e ".[ui,local,commodity]"
+          pip install -e ".[dev,browser,ui,local,commodity]"
+          python -m playwright install chromium
           pip install pyinstaller
 
       - name: The engine must pass its own tests before it is shipped
-        # `-m "not extension"` is wrong here on purpose: two of the extension
-        # files guard the ENGINE as well, and a release is the last moment to
-        # start skipping tests. See tests/test_the_extension_gate_is_complete.py.
+        # THE WHOLE SUITE, with no marker filter, and that is a correction.
+        #
+        # This used to run `-m "not extension"` while its own comment argued
+        # that doing so was wrong — and the test guarding it asserted the
+        # filter was present under a docstring saying it was "deliberately NOT
+        # used". Three statements of intent, two of them contradicting the code.
+        #
+        # The intent was the right one. `-m "not extension"` skips eleven files,
+        # and TWO OF THEM GUARD THE ENGINE: tests/test_version.py holds the
+        # capability ledger the compatibility floor is derived from, and
+        # tests/test_native.py holds PROTOCOL_VERSION, which decides whether the
+        # extension can speak to this binary at all. Skipping those at the
+        # moment of shipping is skipping the two things a release can most
+        # expensively get wrong.
+        #
+        # It costs the panel suite's minutes on a workflow that runs monthly.
+        # See tests/test_the_extension_gate_is_complete.py.
         env:
           SCRAPEX_FULL_MIGRATIONS: "1"
-        run: python -m pytest -q -m "not extension"
+        run: python -m pytest -q
 
       - name: Build
         run: python packaging/build_engine.py

--- a/packaging/engine_entry.py
+++ b/packaging/engine_entry.py
@@ -18,9 +18,38 @@ KNOWN_COMMANDS = frozenset({
 })
 
 
+#: Asked BEFORE anything else, because the rule below deliberately sends every
+#: dash-argument to the native host and would swallow these too.
+VERSION_FLAGS = frozenset({"--version", "-V"})
+
+
 def main() -> int:
     from scrapex.cli import main as cli_main
     from scrapex.native import serve
+    from scrapex.version import VERSION
+
+    # WHAT IS THIS BINARY? — answered first, and on stdout.
+    #
+    # It is the only question that can be asked of an engine you have just
+    # downloaded and do not yet trust, and until this existed there was NO WAY
+    # TO ASK IT. `--version` starts with a dash, the filter below dropped it,
+    # `argv` came out empty, and the executable quietly became a native
+    # messaging host waiting on stdin for framed JSON. It printed nothing and
+    # looked like a hang.
+    #
+    # The release workflow's "the thing that was built must actually run" step
+    # is what found this, on its first real run, by getting an empty string back
+    # from a flag it had assumed existed.
+    #
+    # Chrome never passes these: its launch arguments are the host manifest
+    # path, the calling origin, and on Windows `--parent-window=<handle>`. An
+    # exact match on two spellings cannot collide with any of them, which is why
+    # this is a membership test and not a prefix test.
+    if VERSION_FLAGS & set(sys.argv[1:]):
+        from scrapex.native import PROTOCOL_VERSION
+
+        print(f"ScrapeX-Engine {VERSION} (protocol {PROTOCOL_VERSION})")
+        return 0
 
     # Chrome passes the host manifest path and an origin argument whose shape
     # varies by Chrome build. Testing for "looks like a manifest" was fragile —

--- a/scrapex/cli.py
+++ b/scrapex/cli.py
@@ -958,7 +958,17 @@ def _cmd_run_due(args) -> int:
 
 
 def build_parser() -> argparse.ArgumentParser:
+    from .native import PROTOCOL_VERSION      # local, as everywhere else here
+
     parser = argparse.ArgumentParser(prog="scrapex", description=__doc__)
+    # Answered without a subcommand, and it has to be: `--version` is what you
+    # ask a tool you are not yet sure of, and a required subcommand would turn
+    # the question into a usage error. argparse's `version` action exits before
+    # that check runs. The frozen executable answers the same question in
+    # packaging/engine_entry.py, which cannot reach this parser at all.
+    parser.add_argument(
+        "--version", "-V", action="version",
+        version=f"ScrapeX-Engine {version.VERSION} (protocol {PROTOCOL_VERSION})")
     sub = parser.add_subparsers(dest="command", required=True)
 
     p = sub.add_parser(

--- a/tests/test_native.py
+++ b/tests/test_native.py
@@ -139,6 +139,91 @@ def test_frozen_entry_defaults_to_the_native_host():
     assert "chrome-extension://abcdef/" not in module.KNOWN_COMMANDS
 
 
+def test_the_frozen_entry_answers_what_version_it_is_without_starting_the_host():
+    """THE DEFECT THIS PINS WAS SHIPPED AND UNASKABLE.
+
+    `--version` starts with a dash, so the filter that protects Chrome dropped
+    it, `argv` came out empty, and the executable quietly became a native
+    messaging host waiting on stdin for framed JSON. It printed nothing and
+    looked like a hang — and there was no other way to ask a downloaded binary
+    what it was.
+
+    Found by the release workflow's "the thing that was built must actually run"
+    step on its first real run, which got an empty string back from a flag it
+    had assumed existed. Nothing else in the suite touched it.
+    """
+    import importlib.util, io, contextlib
+
+    entry = Path(__file__).resolve().parent.parent / "packaging" / "engine_entry.py"
+    spec = importlib.util.spec_from_file_location("scrapex_engine_entry_v", entry)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    from scrapex.native import PROTOCOL_VERSION
+    from scrapex.version import VERSION
+
+    called = []
+    for flag in ("--version", "-V"):
+        with monkeypatched_argv(module, ["scrapex-engine.exe", flag]):
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                code = module.main()
+        said = out.getvalue().strip()
+        called.append(said)
+
+        assert code == 0, f"{flag} exited {code}"
+        # ON STDOUT, not stderr: the release greps the captured output, and a
+        # version written to stderr reads as an empty answer.
+        assert VERSION in said, (
+            f"{flag} printed {said!r}, which does not contain the version — "
+            "this is the empty string the release workflow got")
+        assert str(PROTOCOL_VERSION) in said, (
+            "the protocol is not stated, so a binary cannot be told apart from "
+            "one that cannot speak to this extension")
+
+    assert called[0] == called[1], "the two spellings disagree"
+
+
+class monkeypatched_argv:
+    """`sys.argv` for the duration of a block, restored however it exits."""
+
+    def __init__(self, module, argv):
+        self._argv = argv
+        self._sys = module.sys
+
+    def __enter__(self):
+        self._saved = self._sys.argv
+        self._sys.argv = self._argv
+
+    def __exit__(self, *exc):
+        self._sys.argv = self._saved
+        return False
+
+
+def test_the_release_greps_for_a_flag_the_engine_actually_implements():
+    """The workflow asked for `--version` and nothing implemented it. Both sides
+    read from here on, so inventing a flag in the YAML fails at once instead of
+    ten minutes into a release."""
+    import re
+
+    workflow = (Path(__file__).resolve().parent.parent /
+                ".github" / "workflows" / "release-engine.yml").read_text(encoding="utf-8")
+    asked = set(re.findall(r"scrapex-engine\.exe (--?[\w-]+)", workflow))
+    assert asked, "the release no longer asks the built engine anything"
+
+    import importlib.util
+    entry = Path(__file__).resolve().parent.parent / "packaging" / "engine_entry.py"
+    spec = importlib.util.spec_from_file_location("scrapex_engine_entry_f", entry)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    unhandled = asked - set(module.VERSION_FLAGS)
+    assert not unhandled, (
+        f"the release runs the built engine with {sorted(unhandled)}, which the "
+        f"entry point does not handle — every dash-argument it does not know "
+        f"becomes a native host that prints nothing")
+
+
 def test_manifest_path_is_per_platform(monkeypatch, tmp_path):
     assert manifest_path("linux").name == f"{HOST_NAME}.json"
     assert manifest_path("win32") != manifest_path("darwin")

--- a/tests/test_the_two_release_paths.py
+++ b/tests/test_the_two_release_paths.py
@@ -279,6 +279,41 @@ def test_what_the_workflow_writes_is_what_the_panel_can_read(engine, tmp_path):
     assert got["protocol"] == manifest["protocol_version"]
 
 
+def test_a_workflow_that_runs_pytest_installs_the_extra_that_provides_it(
+        engine, extension):
+    """THE DEFECT THIS EXISTS FOR ACTUALLY HAPPENED, on the first real dispatch.
+
+    The engine path installed `.[ui,local,commodity]`, spent five minutes doing
+    it, and then died on `No module named pytest` — because pytest lives in the
+    `dev` extra and nothing named it. Every assertion in this file passed: the
+    step was there, it was ordered correctly, it named the right environment
+    variable. It simply could not run.
+
+    So the extra is not typed here. It is READ OUT OF pyproject.toml — whichever
+    extra declares pytest is the one a workflow that runs pytest must install —
+    and moving pytest to a different extra tomorrow moves this guard with it.
+    """
+    tomllib = pytest.importorskip("tomllib")
+    extras = tomllib.loads(
+        (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )["project"]["optional-dependencies"]
+
+    providing = sorted(name for name, deps in extras.items()
+                       if any(d.split(">=")[0].split("[")[0].strip() == "pytest"
+                              for d in deps))
+    assert providing, "no extra declares pytest, so nothing here can be checked"
+
+    for label, text in (("engine", engine), ("extension", extension)):
+        if "python -m pytest" not in text:
+            continue
+        install = next((line for line in text.splitlines()
+                        if "pip install -e" in line), "")
+        assert any(f"{name}" in install for name in providing), (
+            f"the {label} path runs pytest but installs {install.strip()!r}, "
+            f"which brings in none of {providing} — the step will die on "
+            f"'No module named pytest' AFTER the install has spent its minutes")
+
+
 def test_the_documents_the_store_requires_are_published_with_the_release(engine):
     """THE STORE WILL NOT ACCEPT A LISTING WITHOUT A PUBLIC PRIVACY POLICY URL,
     and the website renders these two rather than keeping its own copy.
@@ -458,8 +493,21 @@ def test_neither_path_can_publish_from_a_manual_run_by_accident(engine, extensio
 def test_the_engine_runs_the_suite_that_covers_it(engine):
     """`-m "not extension"` is deliberately NOT used: two of the marked files
     guard the engine as well, and a release is the last moment to start
-    skipping tests."""
-    assert 'pytest -q -m "not extension"' in engine
+    skipping tests.
+
+    THIS DOCSTRING WAS TRUE AND THE ASSERTION UNDER IT WAS NOT. It required the
+    filter it says must not be there, and the workflow carried a comment arguing
+    against the very flag it passed — three statements of intent, two of them
+    contradicting the code. Nothing caught it because everything agreed with the
+    thing that was wrong.
+
+    tests/test_version.py holds the capability ledger the compatibility floor is
+    derived from and tests/test_native.py holds PROTOCOL_VERSION. Both are
+    marked `extension`, and both decide whether this binary can be spoken to.
+    """
+    assert 'run: python -m pytest -q\n' in engine, (
+        "the release filters its own suite; the two extension-marked files that "
+        "guard the ENGINE would be skipped at the moment of shipping")
     assert "SCRAPEX_FULL_MIGRATIONS" in engine, (
         "the release does not replay the real migration stream, so it ships "
         "against the test-only schema template")


### PR DESCRIPTION
Both defects surfaced on the first real `workflow_dispatch` of the engine path
([run 31255390249](https://github.com/muhammadbayoumi/ScrapeX/actions/runs/31255390249)), and neither was findable by reading the file.

### `No module named pytest`

The install step named `.[ui,local,commodity]`. pytest is in `dev`. Five minutes
of installing, then nothing to run. Every existing assertion passed — the step
was present, ordered before the build, and named `SCRAPEX_FULL_MIGRATIONS`.

The new guard reads `pyproject.toml` for whichever extra declares pytest rather
than hard-coding `dev`, so moving pytest later moves the guard with it.

### The suite was filtered while every comment said it must not be

The step ran `-m "not extension"` under a comment arguing that flag was wrong,
and the test guarding it asserted the flag was **present** under a docstring
saying it was *"deliberately NOT used"*. Three statements of intent, two
contradicting the code.

The intent was right. That filter skips eleven files and two of them guard the
**engine**: `tests/test_version.py` (the capability ledger the compatibility
floor derives from) and `tests/test_native.py` (`PROTOCOL_VERSION`). The release
now runs the whole suite; `browser` and the Chromium download joined the install
for it.

### What passed already

Both new release guards ran for the first time and passed — including the
published-version check, which correctly reported *"nothing is published yet;
0.2.0 will be the first"*. The **extension** path passed this dispatch unchanged,
all ten steps, with the upload job correctly skipped because a manual run is not
a tag.

Both fixes proved by mutation, the first by restoring the exact install line that
failed in the run above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)