### PR TITLE
The documents the store needs cannot wait for a release

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,90 @@
+name: Publish the documents the store links to
+
+# THE ORDERING PROBLEM THIS SOLVES, found the moment the website went up.
+#
+# mbiXsite's ScrapeX pages render `privacy-policy.md` and `support.md` straight
+# from mbiX-hub rather than keeping their own copy — which is right, and was
+# asked for in docs/SITE-BRIEF.md, because a retyped policy stops matching the
+# extension the tests check it against.
+#
+# But those two files were published ONLY by release-engine.yml's publish job,
+# which is gated on an `engine-v*` tag. So all three pages went live and
+# rendered nothing, and the chain behind that is worse than an empty page:
+#
+#   the Chrome Web Store will not accept a listing without a WORKING privacy
+#   policy URL  ->  the URL is the website page  ->  the page needs the markdown
+#   in the hub  ->  the markdown needed a release  ->  the release is part of
+#   the milestone the listing belongs to.
+#
+# The documents are not release artifacts. They describe what the extension asks
+# for and how to get help, and both are true before anything is tagged. So they
+# can be published on their own, whenever, by hand.
+#
+# THEY STILL GO OUT WITH EVERY RELEASE TOO, and that is not a duplicate. The
+# policy's promises are asserted against the SHIPPED manifest by
+# tests/test_the_privacy_policy_is_true.py — it must name every OAuth scope the
+# extension asks for and every host it can reach — so each release republishing
+# them is what keeps the published text describing the build that is out.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "docs/privacy-policy.md"
+      - "docs/support.md"
+
+permissions:
+  contents: read
+
+# The same group as the release path: both write into mbiX-hub through the
+# Contents API, and two writers on one file is a lost update.
+concurrency:
+  group: release-engine
+  cancel-in-progress: false
+
+env:
+  PUBLIC_REPO: muhammadbayoumi/mbiX-hub
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: The promises must still be true of what ships
+        # PUBLISHING IS NOT COPYING. This is the file that says which scopes the
+        # extension asks for and which hosts it can reach, and it is checked
+        # against the real manifest rather than trusted. Publishing it without
+        # that check would put a policy on the web that describes an extension
+        # nobody built.
+        run: |
+          pip install -e .[dev]
+          python -m pytest -q tests/test_the_privacy_policy_is_true.py
+
+      - name: Publish to the public delivery endpoint
+        env:
+          GH_TOKEN: ${{ secrets.PUBLIC_SITE_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::PUBLIC_SITE_TOKEN is not set."
+            echo "The documents were checked and nothing was published."
+            echo "Create a fine-grained personal access token with Contents:"
+            echo "write on $PUBLIC_REPO and add it as the repository secret"
+            echo "PUBLIC_SITE_TOKEN, then re-run this workflow."
+            exit 1
+          fi
+          . .github/workflows/put-to-hub.sh
+          for doc in privacy-policy support; do
+            put_to_hub "ScrapeX/docs/$doc.md" "docs/$doc.md" \
+              "ScrapeX docs, published from ${GITHUB_SHA:0:7}"
+          done
+
+          echo ""
+          echo "The website's ScrapeX pages read these directly:"
+          echo "  https://muhammadbayoumi.github.io/mbiXsite/scrapex-privacy.html"
+          echo "  https://muhammadbayoumi.github.io/mbiXsite/scrapex-support.html"

--- a/tests/test_the_two_release_paths.py
+++ b/tests/test_the_two_release_paths.py
@@ -511,3 +511,69 @@ def test_the_engine_runs_the_suite_that_covers_it(engine):
     assert "SCRAPEX_FULL_MIGRATIONS" in engine, (
         "the release does not replay the real migration stream, so it ships "
         "against the test-only schema template")
+
+
+# ---- the documents are not release artifacts ---------------------------------
+
+DOCS = WORKFLOWS / "publish-docs.yml"
+
+
+def test_the_store_documents_can_be_published_without_cutting_a_release(engine):
+    """THE ORDERING PROBLEM, FOUND WHEN THE WEBSITE WENT UP.
+
+    mbiXsite's ScrapeX pages render privacy-policy.md and support.md straight
+    from the hub instead of keeping a copy — which is right, and is what
+    docs/SITE-BRIEF.md asked for, because a retyped policy stops matching the
+    extension the tests check it against.
+
+    But the only thing publishing them was the release path's tag-gated job. So
+    three pages went live rendering nothing, and behind that sat a circle: the
+    store needs a WORKING privacy policy URL, the URL is the page, the page
+    needs the markdown, the markdown needed a release, and the release is part
+    of the same milestone as the listing.
+
+    They are not release artifacts. They describe what the extension asks for
+    and how to get help, and both are true before anything is tagged.
+    """
+    yaml = pytest.importorskip("yaml")
+    assert DOCS.is_file(), "nothing can publish the documents on their own"
+
+    parsed = yaml.safe_load(DOCS.read_text(encoding="utf-8"))
+    triggers = parsed.get(True) or parsed.get("on")
+    assert "workflow_dispatch" in triggers, (
+        "the documents still cannot be published by hand")
+
+    # AND STILL WITH EVERY RELEASE, which is not a duplicate: the policy is
+    # asserted against the SHIPPED manifest, so republishing on each release is
+    # what keeps the published text describing the build that is out.
+    assert 'put_to_hub "ScrapeX/docs/$doc.md"' in engine, (
+        "a release no longer republishes the documents, so the published policy "
+        "can describe a build that is no longer the one shipping")
+
+
+def test_publishing_a_document_checks_it_before_putting_it_on_the_web(engine):
+    """Publishing is not copying. This file says which OAuth scopes the
+    extension asks for and which hosts it can reach, and it is checked against
+    the real manifest rather than trusted — so the check has to run on the way
+    out, or the web gets a policy describing an extension nobody built."""
+    text = DOCS.read_text(encoding="utf-8")
+    assert "tests/test_the_privacy_policy_is_true.py" in text
+
+    yaml = pytest.importorskip("yaml")
+    steps = [s.get("name", "") for s in
+             yaml.safe_load(text)["jobs"]["publish"]["steps"] if "name" in s]
+    assert steps.index("The promises must still be true of what ships") < \
+        steps.index("Publish to the public delivery endpoint")
+
+
+def test_the_two_writers_into_the_hub_cannot_race(engine):
+    """Both this and the release path write into mbiX-hub through the Contents
+    API. Two writers on one file is a lost update, and the one that finishes
+    last wins rather than the one that is right."""
+    yaml = pytest.importorskip("yaml")
+    docs = yaml.safe_load(DOCS.read_text(encoding="utf-8"))
+    release = yaml.safe_load(engine)
+
+    assert docs["concurrency"]["group"] == release["concurrency"]["group"], (
+        "the two workflows that write into the hub are in different "
+        "concurrency groups, so they can run at the same time")


### PR DESCRIPTION
Found when mbiXsite's ScrapeX pages went up: all three return HTTP 200 and render nothing, because the markdown they fetch does not exist yet.

The site session did its half exactly right — the pages fetch `privacy-policy.md` and `support.md` from mbiX-hub rather than keeping a copy, which is what [docs/SITE-BRIEF.md](docs/SITE-BRIEF.md) asked for.

**The fault is mine.** Those files were published only by the release path's tag-gated job, which closes a circle: the store needs a working privacy policy URL → the URL is the page → the page needs the markdown → the markdown needed a release → the release is in the same milestone as the listing.

They are not release artifacts. `publish-docs.yml` publishes them on dispatch, and on any push that changes them, while every release still republishes them so the published text keeps describing the build that is out.

Three guards, proved by mutation: no manual trigger · its own concurrency group · the check moved after the publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)