### PR TITLE
The panel stops telling the owner there are two databases

### DIFF
--- a/extension/app.html
+++ b/extension/app.html
@@ -330,19 +330,21 @@
             <div class="source-choice-panel-inner">
       <div id="source-detail">
 
-      <!-- WHICH SYSTEM. They are genuinely two: a store goes to MarketLens,
-           which understands prices, offers and history; General is the generic
-           extractor with its own catalogue of sites, datasets and fields, and
-           its own database. Asked FIRST because the answer decides which form
-           the owner fills and which database the site is written to — there is
-           no converting one into the other afterwards. -->
+      <!-- WHICH KIND OF CAPTURE. They are genuinely two, and it is no longer
+           two databases: price capture understands prices, offers and history;
+           generic extraction has its own catalogue of sites, datasets and
+           fields. M5 put both in one file and changed nothing about the shapes,
+           so the question stays and the reason for it narrows — sharing a file
+           is not sharing a shape. Asked FIRST because the answer decides which
+           form the owner fills, and there is no converting one into the other
+           afterwards. -->
       <fieldset class="fieldset" id="add-system">
         <legend>What kind of site is this?</legend>
         <label class="check">
           <input type="radio" name="add-system" value="store" checked>
           <span><strong>Store — track prices</strong>
             <span class="hint muted">Products, prices and the history of every
-              change. This is MarketLens, the system you are working in.</span></span>
+              change.</span></span>
         </label>
         <label class="check">
           <input type="radio" name="add-system" value="general">

--- a/extension/app.js
+++ b/extension/app.js
@@ -2894,7 +2894,7 @@ async function probe() {
     $("f-cadence").value = s.cadence || "daily";
     $("f-kind").value = s.kind || "product_prices";
     $("f-scope").value = s.scope || "census";
-    // The probe suggests a MarketLens key. Re-spell it for the chosen system:
+    // The probe suggests a price-capture key. Re-spell it for the chosen kind:
     // a lower_snake catalogue would otherwise be handed an UPPER_SNAKE key and
     // reject it at save time, after the form looked filled in correctly.
     applyAddSystem();
@@ -2910,18 +2910,22 @@ async function probe() {
   } finally { btn.disabled = false; btn.textContent = "Test site"; }
 }
 
-// ---- which system a new site belongs to -------------------------------------
-// MarketLens and General are two systems with two databases, not two modes of
-// one. MarketLens understands products, offers, prices and the history of every
-// change; General is the generic extractor with its own catalogue of sites,
-// datasets and fields. A site is registered in one of them, and nothing here
-// converts one into the other afterwards — so the choice is asked before the
-// form is filled, and the form follows the answer.
+// ---- which kind of capture a new site belongs to ----------------------------
+// TWO CAPTURE MODELS, ONE DATABASE. They used to be two databases as well, and
+// this comment said so; M5 collapsed the storage and left the models untouched,
+// so the sentence had to change and the choice did not.
 //
-// They do not even spell a key the same way: MarketLens keys are UPPER_SNAKE
-// (manifest.SourceEntry), General keys are lower_snake (catalog_models
+// Price capture understands products, offers, prices and the history of every
+// change. Generic extraction has its own catalogue of sites, datasets and
+// fields. A site is registered under one of them, and nothing here converts one
+// into the other afterwards — so the choice is asked before the form is filled,
+// and the form follows the answer. That is unchanged: sharing a file is not
+// sharing a shape.
+//
+// They do not even spell a key the same way: price keys are UPPER_SNAKE
+// (manifest.SourceEntry), generic keys are lower_snake (catalog_models
 // .KEY_PATTERN). Validating one against the other would reject a correct key
-// with a message about the wrong system.
+// with a message about the wrong kind.
 const SYSTEMS = {
   store: {
     label: "Add site",
@@ -2929,8 +2933,7 @@ const SYSTEMS = {
     keyHint: "UPPER_SNAKE_CASE, 3–64 characters.",
     keyError: "Use UPPER_SNAKE_CASE, 3–64 characters, starting with a letter.",
     normalizeKey: (v) => v.trim().toUpperCase(),
-    note: "Prices, offers and the full history of every change. Written to the " +
-          "MarketLens database.",
+    note: "Prices, offers and the full history of every change.",
   },
   general: {
     label: "Add to General",


### PR DESCRIPTION
The "what kind of site is this?" question carried its reason on its face — a store goes to MarketLens, the generic extractor has *its own database* — and M5 made that reason false while leaving the question correct.

**Only the false part changed.** The choice is still real and still asked first: price capture and generic extraction have different shapes, different catalogues, and genuinely different key spellings (`UPPER_SNAKE` from `manifest.SourceEntry`, `lower_snake` from `catalog_models.KEY_PATTERN`), and nothing converts one into the other afterwards.

> Sharing a file is not sharing a shape.

A blanket rename would have been wrong in **both** directions here: it would have kept a sentence about two databases with a new word in it, or removed a question that is still needed. What became untrue was the reason, not the question.

`extension/` no longer contains the name at all. Extension gate green (pytest exit 0) and 43 JavaScript tests pass — the ones that drive this form for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)