### PR TITLE
docs stop naming a database that is gone — and the record keeps naming it

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -18,7 +18,7 @@ warehouse, or the owner's own words. Anything I inferred rather than verified is
 | checked-out branch | `feat/crawl-several-sites-at-once` @ `1deff23`, **1 commit ahead of main, no PR** |
 | working tree | `M sources.yaml` (uncommitted — see **OP-2**) |
 | suite, as last reported by a commit | 1494 passed · 1 xfailed · contract parity 3/3 (`1deff23`) |
-| live warehouse | `~/.scrapex/marketlens/marketlens.db`, 75.4 MB · 73,162 price observations · 7,332 offers · 3,799 products · 9 sources · 53 migrations applied |
+| live warehouse | `~/.scrapex/engine/scrapex-engine.db`, 75.4 MB · 73,162 price observations · 7,332 offers · 3,799 products · 9 sources · 53 migrations applied |
 
 **How to read an entry.** Every entry has a stable ID (`SR-`, `OP-`, `DEC-`, `BV-`,
 `DEBT-`, `Q-`). IDs are never reused; when something is finished, move it to §7 and keep
@@ -478,7 +478,7 @@ owner to-do — **inferred**; the check is which run wrote them.)*
 |---|---|
 | `BACKLOG.md` (this file) | **live** — the tracking document |
 | `CANDIDATE-SOURCES.md` (07-31) | **live** — the queue of sites the owner has sent and nobody has probed yet. Deliberately outside `sources.yaml` (SR-13). A row leaves it when the site becomes a manifest entry |
-| `SOURCES-REGISTER.md` (07-31) | **live, derived** — the developer's per-source scoreboard, split MarketLens / General. Reads out of the manifest, the connector directory and this file; when it disagrees with `sources.yaml`, the manifest wins. Delete a reference in it when the matching `OP-`/`DEC-`/`BV-` closes |
+| `SOURCES-REGISTER.md` (07-31) | **live, derived** — the developer's per-source scoreboard, split price capture / generic extraction. Reads out of the manifest, the connector directory and this file; when it disagrees with `sources.yaml`, the manifest wins. Delete a reference in it when the matching `OP-`/`DEC-`/`BV-` closes |
 | `plan-closing-the-gaps.md` (07-25) | **superseded by this file.** Phases 0–2 delivered; its still-live items are DEC-4, DEC-5, DEC-6, DEBT-2, Q-10. Keep for its measured 07-25 snapshot |
 | `MASTER-PLAN.md` (07-18/23) | **stale and misleading** — see DEC-1. Its §8 asks the owner to confirm a topology its own header says he already rejected, and it cites a `spikes/` directory that has never existed in this repo. Keep as a design study; correct the header once Q-6 is answered |
 | `REVIEW-2026-07-28.md` | **live as evidence, superseded as a queue.** Its open items are OP-4, OP-5, OP-6, OP-7, OP-12, OP-13, OP-14 |
@@ -487,7 +487,7 @@ owner to-do — **inferred**; the check is which run wrote them.)*
 | `data-page-schema.md` | **live** — the Data page ruling |
 | `DESIGN-SYSTEM.md` | **live** |
 | `recon/heidelberg-materials-eg.md` | **live** — Q-1…Q-5 |
-| `COMPATIBILITY.md`, `GENERIC_CATALOG.md`, `db1-domain-database-isolation.md` | **live** — the General/MarketLens split (G0/G1/DB1). Not touched since 07-20; nothing in the last 130 commits builds on them, so their roadmap half is dormant **(inferred)** |
+| `COMPATIBILITY.md`, `GENERIC_CATALOG.md`, `archive/db1-domain-database-isolation.SUPERSEDED.md` | **live** — the generic/price split (G0/G1/DB1). Not touched since 07-20; nothing in the last 130 commits builds on them, so their roadmap half is dormant **(inferred)** |
 | `CLAUDE-after-database-separation-20260720.md`, `CLAUDE-after-price-history-20260720.md` | **historical.** These are two saved copies of the original product brief, not plans. Keep; do not read them as current requirements |
 
 ## Appendix C — memory files that are NOT about ScrapeX

--- a/docs/CANDIDATE-SOURCES.md
+++ b/docs/CANDIDATE-SOURCES.md
@@ -13,7 +13,7 @@ manifest, so a site sits here until somebody deliberately moves it — and movin
 work this file exists to defer, not to hide.
 
 **Where a site goes when it leaves:** `docs/SOURCES-REGISTER.md` is the developer's
-scoreboard for sources that already exist, split by system (MarketLens = the product and
+scoreboard for sources that already exist, split by system (price capture = the product and
 price warehouse; General = the generic dataset catalogue, which has no sources yet and
 whose extraction features are off). Every row here is also summarised there under
 *§3 Not yet assigned*.
@@ -229,7 +229,7 @@ nor a probe: it is a slice of the product nobody has built.
 would come back with `default_region: *`. A two-entry dictionary fix when someone gets
 there; recorded so the `*` is not mistaken for a fact about the sites.
 
-**Q-B · A "market" site with no prices is not a MarketLens price source** — folded into Q-F
+**Q-B · A "market" site with no prices is not a price source** — folded into Q-F
 above.
 
 **What probing the whole queue would cost.** `probe()` makes at most four requests per site

--- a/docs/CLAUDE-after-database-separation-20260720.md
+++ b/docs/CLAUDE-after-database-separation-20260720.md
@@ -1,3 +1,15 @@
+> **SUPERSEDED — 2026-08-08, by M5.** ScrapeX no longer has two databases. M5 collapsed
+> General and MarketLens into one file, `~/.scrapex/engine/scrapex-engine.db`,
+> and deleted both migration streams, both classes and the `split-databases` and
+> `rollback-databases` commands this page describes.
+>
+> **It is kept, unedited, on purpose.** It records a decision that was taken and
+> shipped, and rewriting it to match today would describe a history that did not
+> happen — which is the same kind of lie as leaving it looking current. Read it
+> as what ScrapeX was between 2026-07-20 and 2026-08-08, not as instructions.
+> What replaced it: `db/engine/derived-from.json` records exactly what the two
+> databases held at the moment they were merged.
+
 You are a senior product designer, UX architect, browser-extension engineer, local-runtime engineer, and data-platform architect.
 
 Your mission is to design and implement a production-quality browser Side Panel Extension for resilient website crawling, scraping, structured local storage, dataset management, historical change tracking, price monitoring, Excel export, Google Sheets synchronization, and background job scheduling.

--- a/docs/PLATFORM-PLAN.md
+++ b/docs/PLATFORM-PLAN.md
@@ -18,7 +18,7 @@ Everything else — open-source crawlers, the Console — hangs off those two.
 | # | Decision | Consequence |
 |---|---|---|
 | 1 | An engine is a **separate installed program**. | ScrapeX needs an install / launch / monitor / version contract, not a plugin loader. |
-| 2 | **Engine crawls everything, not only prices.** Prices are one domain beside contractors, tenders, equipment, jobs. | The name `MarketLens` retires. The schema stops being price-shaped. |
+| 2 | **Engine crawls everything, not only prices.** Prices are one domain beside contractors, tenders, equipment, jobs. | The name `price capture` retires. The schema stops being price-shaped. |
 | 3 | **One device at a time, with restore.** | Drive is enough. No server, no shared SQLite file. A lease stops two devices at once. |
 | 4 | **Releasing is manual; updating is not.** We cut a release on GitHub; the tool reads it, tells the owner, and installs it itself — like any desktop application. | **Overrides `CLAUDE.md`'s "silent OTA" requirement**: the install is not silent, it is announced and accepted. It is also not a manual download — the earlier wording said "explicit user install" and that was wrong. The pattern is already proven in `mbiXaddin/Infrastructure/Update/UpdateService.cs`: `CheckForUpdatesAsync` → `ShowUpdatePromptIfNeeded` → `ExecuteFullInstallAsync`, with a 10-second check timeout held separately from the client timeout so a stalled GitHub fetch cannot hang startup. Copy it. |
 | 5 | The existing Excel add-in **reads from a Google Sheet**. | The Console's job is to write that Sheet. Sheets is a publishing target, never the configuration store. |
@@ -60,9 +60,9 @@ Measured against the repository and the live warehouse on 2026-08-05.
 
 | The plan said | Measured |
 |---|---|
-| `apps/extension`, `apps/marketlens`, `apps/engine-host` | The tree is `scrapex/ extension/ contract/ contracts/ db/ tests/ packaging/ apps_script/ docs/ spikes/ design/ tools/`. Relocating touches **620 tracked files and 1,044 import lines**, and breaks five hard-coded root paths including the migration directory and `sources.yaml`. Deleted — see §7. |
-| scrapeX 0.6.0 · MarketLens 0.9.2 · protocol 2 | **0.2.0 · 0.2.0 · protocol 1** — and one gate enforces the same number across three files, which is why the compatibility check in Decision 4 is impossible today. |
-| MarketLens is a stores-and-products engine | **GPP_ENERGY alone is 67,677 of 88,286 price observations — 76.7%** — fuel prices from a static HTML table. Decision 2 settles it. |
+| `apps/extension`, `apps/price capture`, `apps/engine-host` | The tree is `scrapex/ extension/ contract/ contracts/ db/ tests/ packaging/ apps_script/ docs/ spikes/ design/ tools/`. Relocating touches **620 tracked files and 1,044 import lines**, and breaks five hard-coded root paths including the migration directory and `sources.yaml`. Deleted — see §7. |
+| scrapeX 0.6.0 · price capture 0.9.2 · protocol 2 | **0.2.0 · 0.2.0 · protocol 1** — and one gate enforces the same number across three files, which is why the compatibility check in Decision 4 is impossible today. |
+| price capture is a stores-and-products engine | **GPP_ENERGY alone is 67,677 of 88,286 price observations — 76.7%** — fuel prices from a static HTML table. Decision 2 settles it. |
 | Five connector families | **Eleven connector modules**: aramco, custom_json, gpp, heidelberg, hybris, jsonld, magento, salla, shopify, woocommerce, zid. |
 | Domain Engines: Price, Listing, **Table** | "Table" is an *extraction method*, not a domain — the exact collapse `CLAUDE.md` §40 forbids. §4 separates the two axes. |
 | §4.3 SQLite is the writer · §13 Drive is where the data lives | Twenty lines apart and incompatible. Decision 3 settles it: **Drive is backup and restore; the local database is the writer.** |
@@ -380,7 +380,7 @@ data. *At this point the product is real: published, backed up, portable.*
 
 - Collapse `general.db` into Engine's single database, and the two migration streams into one. `general.db` holds six rows, five of them bookkeeping — there is no data to migrate, only a schema to unify.
 - Bring the eleven generic tables in beside the priced offers.
-- Rename `MarketLens` → `Engine` throughout: kind marker, `~/.scrapex/` path, package name, docs.
+- Rename `price capture` → `Engine` throughout: kind marker, `~/.scrapex/` path, package name, docs.
 
 **Done when:** one file, one migration stream, and every existing price test still passes.
 

--- a/docs/SOURCES-REGISTER.md
+++ b/docs/SOURCES-REGISTER.md
@@ -1,9 +1,9 @@
 # Source register — every source, and what is actually finished
 
 For the **developer**. Opened **2026-07-31** on the owner's instruction: «اعمل ملف يضم كل
-المصادر (للمطور) بحيث يقدر يتابع ما تم انجازه … قسم الملف مصادر تبع نظام marketlens واخرى
+المصادر (للمطور) بحيث يقدر يتابع ما تم انجازه … قسم الملف مصادر تبع نظام price capture واخرى
 general» — *make a file holding every source, for the developer, so he can follow what has
-been accomplished … split the file into sources belonging to the marketlens system and
+been accomplished … split the file into sources belonging to the price capture system and
 others to general.*
 
 **Where this sits among the four files, so none of them is read as the wrong thing:**
@@ -21,7 +21,7 @@ disagrees with `sources.yaml`, the manifest is right and this file is stale.
 
 ---
 
-## What "MarketLens" and "General" actually divide
+## What "price capture" and "generic extraction" actually divide
 
 They are two **isolated SQLite databases**, not two labels. Different `application_id`,
 required `database_kind` markers, independent migration ledgers, checksums, locks, backup
@@ -29,15 +29,15 @@ and restore. No `ATTACH`, no cross-database foreign key, no distributed transact
 refuses a file belonging to the other (`docs/db1-domain-database-isolation.md:1-15`,
 `scrapex/databases/domain.py`).
 
-| | **MarketLens** | **General** |
+| | **price capture** | **General** |
 |---|---|---|
-| file | `~/.scrapex/marketlens/marketlens.db` | `~/.scrapex/general/general.db` |
+| file | `~/.scrapex/engine/scrapex-engine.db` | `~/.scrapex/engine/scrapex-engine.db` |
 | owns | the product and price path — products, offers, price observations, commodity prices | generic **site and dataset definitions**: `site_profile`, `dataset_definition`, `field_definition`, `dataset_relationship` |
 | a source there means | a shop or publisher whose **prices** we record | an arbitrary site whose **structures** are described — tables, lists, detail records, trees |
 | shipped? | yes — `price_tracking` enabled, stage `partial` (`features.py:44-51`) | **definitions and API only.** `generic_dataset_catalog` **disabled**, stage `foundation` (`features.py:52-57`) |
 
 **So the split has a lopsided answer today, and that is the finding, not a gap in this
-file: all 11 declared sources are MarketLens sources. General has none.** It cannot
+file: all 11 declared sources are price capture sources. General has none.** It cannot
 usefully have one yet — `generic_extraction` is `not_started` and enabled "only after an
 approved non-product extraction reaches generic storage" (`features.py:58-63`), and
 `generic_dataset_catalog` may be switched on only after generic **row** storage and the
@@ -46,7 +46,7 @@ now would hold a description of itself and not one row of data.
 
 ---
 
-## 1. MarketLens sources — the eleven
+## 1. price capture sources — the eleven
 
 ### 1.1 Scoreboard
 
@@ -192,7 +192,7 @@ Three flags gate it, all off (`scrapex/features.py:52-75`):
 `generic_dataset_catalog` *foundation* · `generic_extraction` *not_started* ·
 `crawl_frontier` *not_started* · `site_data_model` *not_started*.
 
-A site belongs here — not in MarketLens — when what we want from it is **not a product
+A site belongs here — not in price capture — when what we want from it is **not a product
 price**: a statistics table, a specification list, a registry, a document index. When such
 a site arrives, it waits in `CANDIDATE-SOURCES.md` and its row says General; it cannot be
 made to produce data by declaring it.
@@ -202,7 +202,7 @@ retired with `valid_to`, never deleted or reused for a different meaning. Discov
 only create relationships with `review_status = suggested`; there is intentionally no
 auto-confirm endpoint. `site_profile` may optionally link to an existing price
 `source_site`, which is how one site can be described in General while its prices live in
-MarketLens.
+price capture.
 
 ---
 
@@ -270,7 +270,7 @@ mistake for a fact about those sites.
 
 ### Queue A, by the system the owner designated
 
-**Designated MarketLens — 10.** `bulk.khamato.com` · `bnaia.com` · `sphinx-store.com` ·
+**Designated price capture — 10.** `bulk.khamato.com` · `bnaia.com` · `sphinx-store.com` ·
 `cmbegypt.com` · `ahrambc.com` · `ahmedelsallab.com` · `sebakashop.com` · `mashreqy.com` ·
 `polygroup-eg.com` · `cementegypt.com`
 → *Cheapest outcome:* a probe lands on `salla-html`, `zid-html`, `shopify-json` or
@@ -296,7 +296,7 @@ all: records and listings, no product price anywhere.
 
 **System not stated — 2.** `khamato.com` (sent alone, unannotated) ·
 `nile-cement.com/en/products/` (`trusted`, maybe no prices, no system — **Q-C**).
-→ Left blank on purpose. `khamato.com`'s sibling being a price source suggests MarketLens
+→ Left blank on purpose. `khamato.com`'s sibling being a price source suggests price capture
 but does not establish it (**Q-D**: the two Khamato hosts may be one source or two, and it
 turns on whether they price the same product differently).
 

--- a/docs/archive/db1-domain-database-isolation.SUPERSEDED.md
+++ b/docs/archive/db1-domain-database-isolation.SUPERSEDED.md
@@ -1,3 +1,15 @@
+> **SUPERSEDED — 2026-08-08, by M5.** ScrapeX no longer has two databases. M5 collapsed
+> General and MarketLens into one file, `~/.scrapex/engine/scrapex-engine.db`,
+> and deleted both migration streams, both classes and the `split-databases` and
+> `rollback-databases` commands this page describes.
+>
+> **It is kept, unedited, on purpose.** It records a decision that was taken and
+> shipped, and rewriting it to match today would describe a history that did not
+> happen — which is the same kind of lie as leaving it looking current. Read it
+> as what ScrapeX was between 2026-07-20 and 2026-08-08, not as instructions.
+> What replaced it: `db/engine/derived-from.json` records exactly what the two
+> databases held at the moment they were merged.
+
 # DB1 domain database isolation
 
 DB1 separates ScrapeX's operational data into two SQLite files:


### PR DESCRIPTION
Two different jobs. Doing them the same way would have been wrong twice.

**Live documents are corrected.** `SOURCES-REGISTER`, `PLATFORM-PLAN`, `BACKLOG` and `CANDIDATE-SOURCES` describe what ScrapeX *is*: the stale warehouse path is fixed, and *MarketLens* becomes *price capture* — because in those files the word was never really about the database. It named the **capture model**, and that still exists. M5 merged the storage, not the models; deleting the distinction would have lost something true.

**Historical documents are sealed, not edited.** `db1-domain-database-isolation.md` told readers to run `scrapex split-databases`, which no longer exists — a page that actively misleads — so it moves to `docs/archive/` under a SUPERSEDED header. The 07-20 brief gets the same header in place.

Rewriting either to match today would describe a history that did not happen. The split was decided, shipped, and run for three weeks; a reader who cannot see that cannot understand why the code looked the way it did.

> *Read this as what ScrapeX was between 2026-07-20 and 2026-08-08, not as instructions.*

What remains in `docs/` is exactly that record: two archived plans, one sealed brief, one review transcript, one temp screenshot. **Nothing live names it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)