### PR TITLE
M6a: how much of a site a crawl may fetch, chosen per source

### DIFF
--- a/db/engine/migrations/0003_a_source_says_how_deep_its_crawl_goes.sql
+++ b/db/engine/migrations/0003_a_source_says_how_deep_its_crawl_goes.sql
@@ -1,0 +1,19 @@
+-- Every source carries its own crawl scope, because 14 minutes and 34 hours are
+-- two products and not two settings of one (owner, 2026-08-05).
+--
+-- Measured on muqawil.org: the listing is 860 pages; every detail page is
+-- 121,157 requests. Change-tracking repeats whichever was chosen, so the
+-- difference is not paid once.
+--
+-- DEFAULTS TO THE CHEAPEST ON PURPOSE. A default that costs thirty-four hours
+-- is a default that runs before anyone has understood what they asked for, and
+-- existing rows have never been asked.
+--
+-- `crawl_slice` is the city or grade that makes listing_plus_slice affordable.
+-- NULL is correct for the other two scopes and scrapex/crawlscope.py refuses
+-- listing_plus_slice without it, rather than quietly meaning "everything".
+
+ALTER TABLE site_profile ADD COLUMN crawl_scope TEXT NOT NULL DEFAULT 'listing_only';
+ALTER TABLE site_profile ADD COLUMN crawl_slice TEXT;
+
+PRAGMA user_version = 3;

--- a/scrapex/crawlscope.py
+++ b/scrapex/crawlscope.py
@@ -1,0 +1,113 @@
+"""How much of a site a crawl is allowed to fetch, chosen per source.
+
+THIS IS AN OWNER DECISION, NOT A PROJECT ONE (2026-08-05), and the numbers are
+why. Measured on muqawil.org, the first entity source:
+
+    the listing            860 pages     14 minutes at the shipped 1s pace
+    every detail page    121,157 requests    34 hours at 1s, 17 at 0.5s
+
+Fourteen minutes and thirty-four hours are not two settings of one product; they
+are two products. And change-tracking means repeating whichever was chosen, so
+the difference is not paid once. Which of them a user wants is theirs to say.
+
+NOT `ExtractScope`, WHICH ALREADY EXISTS AND MEANS SOMETHING ELSE.
+`vocab.ExtractScope` is CONTRACT WIDTH for a price payload — TARGETED, CENSUS,
+LATEST_ONLY — and it answers "how many fields may this payload carry". This
+answers "how many pages may this crawl fetch". Two unrelated questions, and
+giving them one name would make every later reader work out which was meant.
+
+MUQAWIL IS THE EXAMPLE, NOT THE RULE. It happens to publish grade, status,
+rating and city on the listing page itself, so LISTING_ONLY may be its whole
+answer — a fact about one site, discovered when it is added, never a default the
+schema assumes on another site's behalf.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class CrawlScope(StrEnum):
+    """How deep a crawl of one source goes."""
+
+    #: The fields the listing pages already show, and nothing else. On a site
+    #: that publishes what matters in its listing, this is the whole product.
+    LISTING_ONLY = "listing_only"
+
+    #: The listing, plus detail pages for a slice the user names — a city, a
+    #: grade. The slice is what makes this affordable; without one it is the
+    #: same thirty-four hours under a gentler word.
+    LISTING_PLUS_SLICE = "listing_plus_slice"
+
+    #: One founding crawl of everything, then the listing catches the changes.
+    #: The expensive pass happens ONCE and deliberately, rather than on every
+    #: run — which is the only way "everything" is affordable to track.
+    FULL_THEN_LISTING = "full_then_listing"
+
+
+#: What a source gets if nobody chose. The cheapest of the three ON PURPOSE: a
+#: default that costs thirty-four hours is a default that runs before anyone has
+#: understood what they asked for.
+DEFAULT = CrawlScope.LISTING_ONLY
+
+
+@dataclass(frozen=True)
+class Plan:
+    """What a scope means for one crawl, in numbers the caller can act on."""
+
+    scope: CrawlScope
+    listing_pages: int
+    detail_pages: int
+    #: The slice the user named, when the scope needs one.
+    slice_of: str = ""
+
+    @property
+    def requests(self) -> int:
+        return self.listing_pages + self.detail_pages
+
+    def seconds_at(self, pace_s: float) -> float:
+        return self.requests * pace_s
+
+    def hours_at(self, pace_s: float) -> float:
+        return self.seconds_at(pace_s) / 3600
+
+
+class SliceRequired(ValueError):
+    """LISTING_PLUS_SLICE was chosen without naming the slice.
+
+    Refused rather than defaulted, because the obvious default — every detail
+    page — is exactly the thirty-four hours the scope exists to avoid, and it
+    would arrive labelled as the cheap option.
+    """
+
+
+def plan(scope: CrawlScope, *, listing_pages: int, detail_pages: int,
+         slice_pages: int = 0, slice_of: str = "") -> Plan:
+    """Turn a scope and a site's measured size into what a crawl will cost.
+
+    The caller supplies the measurements because only the caller has them:
+    860 pages is a fact about muqawil, discovered by looking, and this module
+    must never carry one site's numbers as if they were every site's.
+    """
+    if scope is CrawlScope.LISTING_ONLY:
+        return Plan(scope, listing_pages, 0)
+
+    if scope is CrawlScope.LISTING_PLUS_SLICE:
+        if not slice_of:
+            raise SliceRequired(
+                "listing_plus_slice needs the slice named — a city, a grade. "
+                "Without one the only honest reading is 'every detail page', "
+                "which is the whole crawl under a cheaper-sounding name.")
+        return Plan(scope, listing_pages, slice_pages, slice_of)
+
+    return Plan(scope, listing_pages, detail_pages)
+
+
+def is_expensive(plan: Plan, *, pace_s: float, over_hours: float = 1.0) -> bool:
+    """Whether this crawl is long enough that a user should be told first.
+
+    Not a refusal — the owner may genuinely want the thirty-four hours, and
+    FULL_THEN_LISTING exists precisely so they can have it. It is the difference
+    between a choice and a surprise.
+    """
+    return plan.hours_at(pace_s) > over_hours

--- a/tests/test_how_much_of_a_site_a_crawl_may_fetch.py
+++ b/tests/test_how_much_of_a_site_a_crawl_may_fetch.py
@@ -1,0 +1,126 @@
+"""Fourteen minutes and thirty-four hours are two products, not two settings.
+
+The owner decided on 2026-08-05 that crawl depth is a PER-SOURCE choice, and the
+measurements on muqawil.org are the argument:
+
+    the listing            860 pages          14 minutes at 1s
+    every detail page    121,157 requests     34 hours at 1s, 17 at 0.5s
+
+Change-tracking repeats whichever was chosen, so the difference is not paid once.
+
+WHAT THESE TESTS PROTECT. Not arithmetic — the arithmetic is three lines. They
+protect two decisions that are easy to erode later, both in the direction of
+costing a user a day and a half they never agreed to:
+
+  · the DEFAULT stays the cheapest one
+  · naming a slice is REQUIRED, not defaulted to "everything"
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from scrapex.crawlscope import (
+    DEFAULT, CrawlScope, SliceRequired, is_expensive, plan,
+)
+
+#: Measured on muqawil.org and used only as a realistic size. No production code
+#: carries these — one site's numbers are not every site's.
+MUQAWIL_LISTING = 860
+MUQAWIL_DETAILS = 121_157
+
+
+def test_listing_only_fetches_the_listing_and_nothing_else():
+    p = plan(CrawlScope.LISTING_ONLY,
+             listing_pages=MUQAWIL_LISTING, detail_pages=MUQAWIL_DETAILS)
+
+    assert p.detail_pages == 0
+    assert p.requests == MUQAWIL_LISTING
+    assert round(p.seconds_at(1.0) / 60) == 14, "the measured fourteen minutes"
+
+
+def test_the_full_crawl_is_the_thirty_four_hours_it_says_it_is():
+    """The expensive option is not hidden or discouraged — it is offered with
+    its price attached. FULL_THEN_LISTING exists so an owner who wants
+    everything can have it deliberately."""
+    p = plan(CrawlScope.FULL_THEN_LISTING,
+             listing_pages=MUQAWIL_LISTING, detail_pages=MUQAWIL_DETAILS)
+
+    assert round(p.hours_at(1.0)) == 34
+    assert round(p.hours_at(0.5)) == 17, "the measured half-pace figure"
+
+
+def test_a_slice_must_be_named_and_is_never_assumed():
+    """THE DECISION MOST EASILY ERODED. The obvious default for a missing slice
+    is 'all of them' — which is the thirty-four hours, arriving under the name
+    of the cheap option. It is refused instead."""
+    with pytest.raises(SliceRequired, match="needs the slice named"):
+        plan(CrawlScope.LISTING_PLUS_SLICE,
+             listing_pages=MUQAWIL_LISTING, detail_pages=MUQAWIL_DETAILS)
+
+    p = plan(CrawlScope.LISTING_PLUS_SLICE, listing_pages=MUQAWIL_LISTING,
+             detail_pages=MUQAWIL_DETAILS, slice_pages=1_200, slice_of="Riyadh")
+
+    assert p.slice_of == "Riyadh"
+    assert p.detail_pages == 1_200, "the slice, not every detail page"
+    assert p.hours_at(1.0) < 1, "a slice that costs hours is not a slice"
+
+
+def test_the_default_is_the_cheapest_one():
+    """A default that costs thirty-four hours is a default that runs before
+    anyone has understood what they asked for."""
+    assert DEFAULT is CrawlScope.LISTING_ONLY
+
+
+def test_an_expensive_crawl_can_be_told_apart_before_it_starts():
+    """Not a refusal — the owner may want it. The difference between a choice
+    and a surprise."""
+    cheap = plan(CrawlScope.LISTING_ONLY,
+                 listing_pages=MUQAWIL_LISTING, detail_pages=MUQAWIL_DETAILS)
+    dear = plan(CrawlScope.FULL_THEN_LISTING,
+                listing_pages=MUQAWIL_LISTING, detail_pages=MUQAWIL_DETAILS)
+
+    assert not is_expensive(cheap, pace_s=1.0)
+    assert is_expensive(dear, pace_s=1.0)
+    # Even at half pace it is seventeen hours, so the pace is not the answer.
+    assert is_expensive(dear, pace_s=0.5)
+
+
+def test_it_is_not_the_scope_that_already_exists():
+    """`vocab.ExtractScope` is CONTRACT WIDTH for a price payload — how many
+    fields it may carry. This is how many PAGES a crawl may fetch. One name for
+    both would make every later reader work out which was meant."""
+    from scrapex.vocab import ExtractScope
+
+    assert not set(CrawlScope) & set(ExtractScope), (
+        "the two scopes share a value, so a stored string no longer says which "
+        "question it answers")
+
+
+# ---- and the database carries it, per source --------------------------------
+
+def test_every_source_carries_its_own_scope(tmp_path):
+    """Per-source is the whole decision. A project-wide setting would make one
+    site's affordable answer another site's day and a half."""
+    from scrapex.databases.domain import EngineDatabase
+
+    db = EngineDatabase(tmp_path / "scrapex-engine.db")
+    db.initialize()
+
+    con = db.connect()
+    try:
+        con.execute(
+            "INSERT INTO site_profile (site_key, display_name, base_url, lifecycle) "
+            "VALUES ('muqawil', 'muqawil.org', 'https://muqawil.org/', 'draft')")
+        con.commit()
+        scope, sl = con.execute(
+            "SELECT crawl_scope, crawl_slice FROM site_profile "
+            "WHERE site_key='muqawil'").fetchone()
+    finally:
+        con.close()
+
+    # A row that was never asked gets the cheapest answer, not the dearest.
+    assert scope == DEFAULT.value
+    assert sl is None, "a slice was invented for a scope that does not use one"


### PR DESCRIPTION
First slice of **M6**. No connector yet — this is the axis the connector will be crawled along.

### Fourteen minutes and thirty-four hours are two products

Measured on muqawil.org:

| | |
|---|---|
| the listing | 860 pages — **14 minutes** at 1s |
| every detail page | 121,157 requests — **34 hours** at 1s, 17 at 0.5s |

Change-tracking repeats whichever was chosen, so the difference is not paid once. The owner decided (2026-08-05) that this is a per-source choice; migration 0003 puts it on `site_profile`, where a per-source choice belongs.

### Not called `Scope`, and that is the first decision

`vocab.ExtractScope` already exists and means **contract width** for a price payload — how many *fields* it may carry. This means how many *pages* a crawl may fetch. One name for both would make every later reader work out which was meant. A test asserts the two enums share no value, so a stored string keeps saying which question it answers.

### Two decisions guarded, because both erode the same way

Toward costing a user a day and a half they never agreed to.

- **The default is the cheapest.** A default that costs 34 hours runs before anyone has understood what they asked for — and every existing row has never been asked.
- **Naming a slice is required.** The obvious default for a missing slice is *all of them* — the 34 hours, arriving under the name of the cheap option. `SliceRequired` is raised instead.

`is_expensive()` does **not** refuse. The owner may genuinely want the full crawl and `FULL_THEN_LISTING` exists so they can have it. The point is the difference between a choice and a surprise.

The module carries no site's numbers: 860 is a fact about muqawil, discovered by looking, and the caller supplies it.

### A prediction, half right

I said 0003 would wake the two tests that skip on a measured stream length. Compaction's **woke and passes**. Migration drift **still skips** — its stop point is migration 30 and we have three. The mechanism works; my arithmetic about which tests it reaches did not.

Full suite green under `SCRAPEX_FULL_MIGRATIONS=1`, pytest exit 0.

Generated with [Claude Code](https://claude.com/claude-code)
