### PR TITLE
0.2.1 — the version the first listing carries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ work predates this file, the commit that built it — evidence read out of
 record of what was done; this file answers a narrower question: which version
 has it.
 
+## 0.2.1
+
+Minimum supported extension: `0.2.0`.
+
+No new capabilities. Fixes and internal change only — an extension and an engine that spoke to each other before this version still do.
+
+
 ## 0.2.0
 
 Minimum supported extension: `0.2.0`.

--- a/contracts/capability-baseline.json
+++ b/contracts/capability-baseline.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.0",
+  "version": "0.2.1",
   "minimum_extension_version": "0.2.0",
   "capabilities": {
     "crawl_pace": "0.2.0",

--- a/contracts/version-vectors.json
+++ b/contracts/version-vectors.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.0",
+  "version": "0.2.1",
   "minimum_extension_version": "0.2.0",
   "capability_reporting_since": "0.2.0",
   "note": "Both copies of capabilityProblem must reproduce every `problem` string exactly. Python: scrapex/version.py. JavaScript: extension/version.js.",
@@ -7,8 +7,8 @@
     {
       "name": "in step — the engine deploys it and the extension is new enough",
       "key": "crawl_parallel_sources",
-      "extension_version": "0.2.0",
-      "engine_version": "0.2.0",
+      "extension_version": "0.2.1",
+      "engine_version": "0.2.1",
       "deployed": {
         "crawl_pace": {
           "since": "0.2.0",
@@ -46,7 +46,7 @@
       "name": "the extension is behind the engine",
       "key": "crawl_parallel_sources",
       "extension_version": "0.1.0",
-      "engine_version": "0.2.0",
+      "engine_version": "0.2.1",
       "deployed": {
         "crawl_pace": {
           "since": "0.2.0",
@@ -78,12 +78,12 @@
         }
       },
       "update_instructions": "Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards.",
-      "problem": "«Crawl several different sites at the same time. Two sources on the SAME site still take turns, so no site is asked for more than before.» needs ScrapeX extension 0.2.0; this extension is 0.1.0 and the engine is 0.2.0. Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards."
+      "problem": "«Crawl several different sites at the same time. Two sources on the SAME site still take turns, so no site is asked for more than before.» needs ScrapeX extension 0.2.0; this extension is 0.1.0 and the engine is 0.2.1. Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards."
     },
     {
       "name": "the engine is behind and says so",
       "key": "crawl_parallel_sources",
-      "extension_version": "0.2.0",
+      "extension_version": "0.2.1",
       "engine_version": "0.1.0",
       "deployed": {
         "crawl_pace": {
@@ -112,22 +112,22 @@
         }
       },
       "update_instructions": "Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards.",
-      "problem": "«crawl_parallel_sources» is not deployed by this ScrapeX engine (0.1.0); this extension is 0.2.0. Update the engine to 0.2.0 or newer."
+      "problem": "«crawl_parallel_sources» is not deployed by this ScrapeX engine (0.1.0); this extension is 0.2.1. Update the engine to 0.2.1 or newer."
     },
     {
       "name": "the engine is too old to say anything",
       "key": "crawl_parallel_sources",
-      "extension_version": "0.2.0",
+      "extension_version": "0.2.1",
       "engine_version": "0.1.0",
       "deployed": null,
       "update_instructions": "Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards.",
-      "problem": "«crawl_parallel_sources» cannot be confirmed: the ScrapeX engine reports version 0.1.0 and is too old to say which features it deploys. This extension is 0.2.0. Update the engine to 0.2.0."
+      "problem": "«crawl_parallel_sources» cannot be confirmed: the ScrapeX engine reports version 0.1.0 and is too old to say which features it deploys. This extension is 0.2.1. Update the engine to 0.2.1."
     },
     {
       "name": "an extension newer than the requirement is not refused for being newer",
       "key": "crawl_parallel_sources",
       "extension_version": "9.9.9",
-      "engine_version": "0.2.0",
+      "engine_version": "0.2.1",
       "deployed": {
         "crawl_pace": {
           "since": "0.2.0",

--- a/docs/design-system/SCRAPEX_GLOBAL_MAPPING.md
+++ b/docs/design-system/SCRAPEX_GLOBAL_MAPPING.md
@@ -1,0 +1,171 @@
+# ScrapeX → MbiX Design System Mapping
+
+**Repository audited:** `C:/Users/User01/source/repos/ScrapeX`  
+**Purpose:** Map every significant UI/design concept discovered in ScrapeX into the candidate MbiX classification buckets.  
+**Rule:** Read-only audit evidence only. No production code modified.
+
+## Classification Buckets
+
+| Bucket | Meaning |
+|---|---|
+| **GLOBAL BRAND** | Identity-level concepts that could apply across the whole MbiX ecosystem. |
+| **GLOBAL SEMANTIC** | Meaning-based concepts (colors, states, roles) that are product-agnostic. |
+| **SHARED CONTRACT** | Reusable components, tokens, or sync contracts already shared across ScrapeX surfaces. |
+| **EXTENSION PROFILE** | Chrome extension-specific patterns that should stay in the extension domain. |
+| **SCRAPEX-SPECIFIC** | Domain model and workflows unique to the ScrapeX product. |
+| **CHROME-NATIVE** | Chrome platform APIs and constraints, not design-system concepts. |
+| **LEGACY** | Backwards-compatibility or outdated patterns. |
+| **PENDING OTHER PRODUCT AUDITS** | Cannot decide globally until mbiXsite, mbiXaddin, Xadd-in, Local Web UI, and mobile are audited. |
+
+---
+
+## 1. Global Brand
+
+| Concept | Evidence | Notes |
+|---|---|---|
+| ScrapeX teal accent (`#00adb5` / `#35c8ce`) | `design/tokens.css:24` | Strong product-family identifier; candidate for **ScrapeX product brand**, not necessarily umbrella MbiX brand. |
+| Custom `x-mark.svg` brand mark | `extension/icons/x-mark.svg`, `scrapex/webui/static/x-mark.svg`, `--brand-mark` | Used as CSS mask logo across surfaces. |
+| "Local-first data workspace" tagline | `templates/base.html:82` | Product positioning, not global. |
+
+## 2. Global Semantic
+
+| Concept | Evidence | Notes |
+|---|---|---|
+| Light / Dark / Device color scheme | `extension/appearance.js:100-106`, `design/tokens.css:161-232` | Generic scheme selection concept. |
+| Primary / on-primary / primary-container | `design/tokens.css:121-124` | M3 semantic roles. |
+| Surface / on-surface / surface-subtle / surface-raised | `design/tokens.css:12-15`, `114-116` | Generic elevation/surface roles. |
+| Outline / outline-variant | `design/tokens.css:119-120` | Generic border roles. |
+| Success / ready | `.dot.on`, `.ok-text`, `.badge.ok` | Candidate global status semantic. |
+| Warning | `.card.warn`, `.banner`, `.chip.amber`, `.badge.off`, `.dot` default | Candidate global status semantic. |
+| Error / danger | `.card.warn`, `.banner.danger`, `.chip.danger`, `.badge.danger`, `.dot.off` | Candidate global status semantic. |
+| Info | `.banner.info`, `.card.hi` | Candidate global status semantic. |
+| Disabled | `button:disabled`, `.button[aria-disabled="true"]` | Candidate global action state. |
+| Focus | `--focus`, `focus-visible` outline | Candidate global interactive state. |
+| Loading / pending | `.skeleton`, checking states, indeterminate progress | Candidate global feedback state. |
+| Running | Job running / miniplayer | Candidate global execution state. |
+| Connected / disconnected / offline | Engine reachability states | Candidate global connectivity state. |
+| Ready | Engine connected + compatible + DB healthy | Candidate global readiness state. |
+
+## 3. Shared Contract
+
+| Concept | Evidence | Notes |
+|---|---|---|
+| `design/tokens.css` → `extension/tokens.css` + `scrapex/webui/static/tokens.css` | `tools/sync_design_assets.py:31-34` | Token file sync contract. |
+| `design/components.css` → `extension/components.css` + `scrapex/webui/static/components.css` | `tools/sync_design_assets.py:35-38` | Component CSS sync contract. |
+| `design/appearance.js` → both surfaces | `tools/sync_design_assets.py:21-24` | Theme engine sync contract. |
+| `design/split-button.js` → both surfaces | `tools/sync_design_assets.py:27-30` | Split-button behavior sync contract. |
+| Material Symbols SVG sprite | `tools/sync_design_assets.py:39-46` | Shared icon sprite contract. |
+| `sx-icon` icon component | `design/components.css:126-144` | Shared icon use pattern. |
+| Button primitives (primary, ghost, danger, link, icon, compact) | `design/components.css:345-489` | Shared action contract. |
+| Input / select / textarea primitives | `design/components.css:490-540` | Shared form control contract. |
+| Card / banner / chip / badge / dot | `design/components.css:295-343`, `328-343`, `575-631`, `616-631` | Shared container/feedback contract. |
+| `.srow` list / settings row | `design/components.css:639-654` | Shared row contract. |
+| `.empty` empty state | `design/components.css:899-903` | Shared empty-state contract. |
+| `.icon-tile` | `design/components.css:210-235` | Shared icon-tile contract. |
+| `.appearance-editor` / `.appearance-scheme-picker` / `.appearance-switch` | `design/components.css:953-1301` | Shared appearance-control contract. |
+| `.split-button` | `design/components.css:1310-1451` + `split-button.js` | Shared split-button contract. |
+| `scrapex/ui_manifest.py` navigation + run modes | `scrapex/ui_manifest.py:58-114` | Shared cross-surface navigation/run-mode data contract. |
+| `/api/ui` endpoint | `scrapex/webui/app.py` serves `ui_manifest()` | Shared navigation payload contract. |
+| `/api/appearance` + `/api/timezone` | `scrapex/webui/app.py:98-127`, `161-188`, `extension/appearance.js:322-377`, `extension/timezone.js` | Shared preference-sync contracts. |
+| `timezone.js` + `_time.html` | `scrapex/webui/templates/_time.html`, `extension/timezone.js` | Shared time-display contract. |
+| `ScrapeXUI.icon` helper | `scrapex/webui/static/ui.js` | Shared icon helper. |
+| Version/capability contracts (`version-vectors.json`, `capability-baseline.json`) | `contracts/` | Shared cross-language contract. |
+
+## 4. Extension Profile
+
+| Concept | Evidence | Notes |
+|---|---|---|
+| Right-side icon navigation rail | `extension/app.html:1517-1632`, `extension/app.css:966-1048` | Chrome side-panel navigation pattern. |
+| Sliding rail indicator | `extension/app.css:1002-1018`, `extension/app.js:143-150` | Side-panel active-state pattern. |
+| Rail keyboard arrow navigation | `extension/app.js:3434-3445` | Side-panel interaction pattern. |
+| Workspace launcher sheet | `extension/app.html:1637-1654`, `extension/app.js:156-186` | Extension-to-workpage launcher. |
+| Active crawl miniplayer | `extension/app.html:1494-1515`, `extension/app.css:942-963` | Persistent job progress in panel. |
+| Narrow panel width constraints (~320 px min) | `extension/app.css:17-18`, `738-751`, `1825-1844` | Side-panel viewport constraint. |
+| 48 px touch-target override | `extension/app.css:6` (`--control-height: var(--touch-target)`) | Compact Android-style panel targets. |
+| Icon-only rail items with `title` + visually-hidden label | `extension/app.html:1525-1631` | Side-panel icon density pattern. |
+| Profile / Engine / Source / Run / Data / Finance panel views | `extension/app.html:26-1490` | Side-panel workflow chrome. |
+| Google Identity avatar fallback in rail | `extension/app.html:1533-1537` | Extension-specific account surface. |
+| Native-messaging action UI (start engine, upgrade DB, autostart) | `extension/transport.js`, `extension/app.js:3061-3136` | Extension-to-engine control surface. |
+| Version notice / refusal card at top of panel | `extension/app.js:446-542`, `2052-2069` | Panel-specific compatibility gate. |
+| Onboarding page layout | `extension/onboarding.html`, `extension/onboarding.css` | First-install extension page. |
+
+## 5. ScrapeX-Specific
+
+| Concept | Evidence | Notes |
+|---|---|---|
+| Source / offer / dataset / observation / crawl domain | `scrapex/`, `sources.yaml` | Core product domain. |
+| Source identity display order | `design/components.css:661-772`, `templates/_source_identity.html` | Domain-specific identity component. |
+| Run workflow (update / initial crawl / full rebuild / history backfill) | `scrapex/ui_manifest.py:100-114`, `extension/app.html:89-119` | Product workflow. |
+| Site selection checklist | `extension/app.html:57-76`, `extension/app.js:1217-1259` | Run-view selection pattern. |
+| Activity panel / live log / job progress | `extension/app.html:122-183`, `extension/app.js:2120-2406` | Crawl monitoring UI. |
+| Google Finance rate UI | `extension/app.html`, `extension/app.js:730-968` | Domain-specific integration. |
+| Capability ledger keys | `scrapex/version.py:113-193` | Product capability model. |
+| Schema-lag banner | `extension/app.js:366-386` | Product migration state. |
+| Excel / Apps Script / Google Drive destination UI | `templates/sync.html`, `excel.html`, `exports.html` | Product output integrations. |
+| Review queue / changes / price history | `templates/review.html`, `changes.html`, `history.html` | Product curation workflows. |
+| Compaction / retention / storage settings | `templates/settings.html`, `_storage.html`, `_retention.html` | Product lifecycle UI. |
+| Data model / schema documentation pages | `templates/data_model.html`, `schema.html` | Product warehouse docs. |
+| Tabulator-based source data grid | `scrapex/webui/static/grid.js`, `grid-theme.css` | Domain-specific data grid skin. |
+| Database unavailable fallback page | `templates/database_unavailable.html` | Product DB error surface. |
+
+## 6. Chrome-Native
+
+| Concept | Evidence | Notes |
+|---|---|---|
+| Manifest V3 | `extension/manifest.json:2` | Platform version. |
+| `side_panel` permission & default path | `extension/manifest.json:20-22`, `30` | Platform API. |
+| `background.service_worker` | `extension/manifest.json:26` | Platform runtime. |
+| `activeTab`, `identity`, `nativeMessaging`, `storage`, `tabs` permissions | `extension/manifest.json:26-33` | Platform permissions. |
+| OAuth2 client id & scopes | `extension/manifest.json:40-47` | Platform identity. |
+| `chrome.sidePanel.setPanelBehavior` | `extension/background.js:3-5` | Platform side-panel behavior. |
+| `chrome.runtime.sendNativeMessage` | `extension/transport.js:20-150` | Platform native messaging. |
+| `chrome.identity.getAuthToken` | `extension/identity.js:71-77` | Platform sign-in. |
+| `chrome.storage.local` | `extension/engine.js:10-16` | Platform storage. |
+| Host permissions for loopback / Google APIs | `extension/manifest.json:34-39` | Platform security model. |
+| Extension origin allowlist / CORS regex | `scrapex/webui/app.py:265-296` | Platform access control. |
+
+## 7. Legacy
+
+| Concept | Evidence | Notes |
+|---|---|---|
+| `scrapex-appearance-v1` localStorage key | `extension/appearance.js:5`, `150-155` | Backwards-compatibility fallback. |
+| Grid localStorage v1 → v2 key migration | `scrapex/webui/static/grid.js` (reported by explore) | Old saved preferences. |
+| `ensure_schema()` single-file warehouse migration | `scrapex/db.py` (reported by explore) | Old DB shape support. |
+| Hard-coded px/rem values in page CSS | `pages/*.css`, `webui.css` | Pre-token styling residue. |
+| Undefined `--font-sans` usage | `extension/app.css:1605, 1742, 1782` | Mistyped / stale token. |
+| `::root` typo | `extension/onboarding.css:1` | Invalid selector. |
+| Outdated vendor README (Tabulator usage claim) | `scrapex/webui/static/vendor/README.md` | Documentation drift. |
+
+## 8. Pending Other Product Audits
+
+| Concept | Why Pending |
+|---|---|
+| Exact global accent color | Need comparison with mbiXsite/mbiXaddin brand colors. |
+| Global typography scale (font family, sizes, weights) | Website uses monospace as profile characteristic; ScrapeX uses Segoe UI. Need reconcile. |
+| Global density profile | Website is comfortable/editorial; ScrapeX is compact/dense. Need decide if global system supports multiple density profiles. |
+| Global radius / shadow language | ScrapeX radii may be product-specific; need compare. |
+| Global button shape (pill vs rounded rect) | Website uses pill CTAs; ScrapeX uses rounded rect (`--radius`). Need decide. |
+| Global navigation pattern (rail vs sidebar vs top nav) | Need see mbiXaddin / Local Web UI / mobile. |
+| Global icon system (Material Symbols vs custom) | Need compare with mbiXsite iconography. |
+| Global theme palette strategy (device colors, fixed palettes) | Need see how mbiXsite handles color styles. |
+| Global status component names (Banner vs Alert vs Status) | Need compare vocabulary across products. |
+| Global form control sizing / touch targets | Need compare add-in and mobile requirements. |
+
+---
+
+## Summary Matrix
+
+| Category | Count of Concepts | Strongest Examples |
+|---|---|---|
+| **GLOBAL BRAND** | 2 | ScrapeX teal, x-mark logo |
+| **GLOBAL SEMANTIC** | 16 | primary/on-primary, surface, success/warning/error, ready/pending/disabled |
+| **SHARED CONTRACT** | 24 | tokens, components.css, appearance.js, split-button, ui_manifest.py, /api/appearance |
+| **EXTENSION PROFILE** | 12 | right-side rail, launcher sheet, miniplayer, 48 px targets, onboarding |
+| **SCRAPEX-SPECIFIC** | 18 | source identity, run workflow, activity log, Google Finance, capability ledger |
+| **CHROME-NATIVE** | 11 | MV3, sidePanel API, native messaging, identity, storage |
+| **LEGACY** | 7 | appearance-v1, hard-coded values, `--font-sans`, `::root` typo |
+| **PENDING** | 10 | accent color, typography, density, radius, nav pattern, icon system, palettes |
+
+---
+
+*End of SCRAPEX_GLOBAL_MAPPING.md*

--- a/docs/design-system/SCRAPEX_UI_AUDIT.md
+++ b/docs/design-system/SCRAPEX_UI_AUDIT.md
@@ -1,0 +1,648 @@
+# ScrapeX UI / Design System Audit
+
+**Repository audited:** `C:/Users/User01/source/repos/ScrapeX`  
+**Scope:** Chrome extension (`extension/`) and local Web UI (`scrapex/webui/`).  
+**Rule:** This document is read-only evidence. No production code was modified.
+
+---
+
+## 1. Technology Stack
+
+| Layer | Finding | Evidence |
+|---|---|---|
+| **Extension manifest** | Chrome Manifest V3 | `extension/manifest.json:2` |
+| **Extension entry surface** | Side panel only (`side_panel.default_path: "app.html"`); no popup, no `options_page` | `extension/manifest.json:20-22` |
+| **Background runtime** | MV3 service worker | `extension/background.js:1-13` |
+| **Frontend framework** | Vanilla JavaScript / ES modules + IIFE helpers; no SPA framework | `extension/app.html:1656`, `extension/app.js` |
+| **HTML rendering** | Static HTML shell; JS toggles `hidden`, sets `innerHTML`, and binds listeners | `extension/app.js:40-42`, `extension/app.js:1217-1259` |
+| **CSS approach** | CSS custom-property token system; three physical copies of canonical files | `design/tokens.css`, `extension/tokens.css`, `scrapex/webui/static/tokens.css` |
+| **Build system** | No build step for the extension; `tools/sync_design_assets.py` copies canonical design assets | `tools/sync_design_assets.py:20-58` |
+| **Backend / Web UI** | FastAPI + Jinja2 + static files; optional `JobRunner` thread | `scrapex/webui/app.py:22-28` |
+| **State management** | Plain JS `state` object (extension); server-side context + page JS (Web UI) | `extension/app.js:46-64` |
+| **Storage / settings** | `chrome.storage.local` for engine backend URL; `localStorage` for appearance/timezone; SQLite `scrapex_meta` for server-side UI settings | `extension/engine.js:10-16`, `extension/appearance.js:150-168`, `scrapex/settings.py` |
+| **Icon system** | SVG sprite of Google Material Symbols + custom `x-mark.svg` brand mark | `extension/icons/material-icons.svg`, `design/components.css:126-144` |
+| **Browser APIs** | `chrome.sidePanel`, `chrome.runtime` (native messaging, onInstalled), `chrome.tabs`, `chrome.windows`, `chrome.identity.getAuthToken`, `chrome.storage`, `fetch`, `navigator.clipboard` | `extension/background.js:3-12`, `extension/identity.js:71-77`, `extension/transport.js:68-78` |
+| **Engine integration** | HTTP health poll to `127.0.0.1:8000` + Chrome Native Messaging for start/repair/upgrade | `extension/engine.js:20-47`, `extension/transport.js:20-150` |
+
+**Classification:** Manifest V3, side-panel entrypoint, service worker, identity, and native messaging are **CHROME-NATIVE**. Vanilla JS + direct DOM updates are **EXTENSION PROFILE**. The token-driven CSS and shared JS modules are **SHARED COMPONENT CONTRACT / GLOBAL SEMANTIC CANDIDATES**.
+
+---
+
+## 2. UI Surface Map
+
+### Chrome Extension surfaces
+
+| Surface | File / Trigger | Notes |
+|---|---|---|
+| **Side panel** | `extension/app.html` | Always-available control UI opened by toolbar icon via `chrome.sidePanel.setPanelBehavior`. |
+| **Onboarding / setup page** | `extension/onboarding.html` | Opened on `chrome.runtime.onInstalled`; engine-status + copyable install commands. |
+| **Workspace pages (launcher)** | `extension/app.js:78-106` fallback + `workspace-menu` | Detailed tools open in a full browser tab from the side-panel launcher. |
+| **No popup / no options page** | — | Manifest has no `options_page`, `options_ui`, or `browser_action` popup. |
+
+### In-panel destinations (side panel)
+
+Rendered as `role="tabpanel"` sections toggled by the right-side rail (`extension/app.html:26-1490`, `extension/app.js:68-75`):
+
+- `view-profile`
+- `view-engines`
+- `view-source`
+- `view-run`
+- `view-data`
+- `view-sources` (Library)
+- `view-source-edit`
+- `view-appearance`
+- `view-finance`
+- `view-console`
+- `view-settings`
+
+### Local Web UI surfaces
+
+The Web UI shell is in `templates/base.html`. Navigation is data-driven by `scrapex/ui_manifest.py`.
+
+| Route / Template | Purpose |
+|---|---|
+| `overview.html` `/` | Command center / pipeline health |
+| `data.html`, `source.html` | Per-source data browser (Tabulator grid) |
+| `changes.html` | Recent price / availability changes |
+| `history.html` | Past runs and outcomes |
+| `review.html` | Resolve proposed record matches |
+| `jobs.html` | Start and monitor collection jobs |
+| `schedules.html` | Automatic collection times |
+| `sync.html` | Google Sheets / Drive sync |
+| `excel.html`, `exports.html` | Excel / local export configuration |
+| `data_model.html`, `schema.html` | Warehouse docs and column meanings |
+| `settings.html` | Runtime, storage, policy |
+| `manage.html` | Source management (older, minimal styling) |
+| `offer.html` | Single-offer detail |
+| `google_finance_dataset.html` | Google Finance rate view |
+| `database_unavailable.html` | Database-attention fallback page |
+
+---
+
+## 3. Component Inventory
+
+All primitives live in the canonical `design/components.css`, copied to `extension/components.css` and `scrapex/webui/static/components.css`.
+
+### Actions
+
+| Component | Class(es) | States / Variants | Classification |
+|---|---|---|---|
+| Primary button | `button`, `.button` | default, hover, active, disabled / `aria-disabled="true"` | SHARED CONTRACT |
+| Ghost / secondary | `.ghost` | hover, active, disabled | SHARED CONTRACT |
+| Danger | `.danger` | hover, active | SHARED CONTRACT |
+| Link button | `.link` | hover | SHARED CONTRACT |
+| Icon button | `.icon-button` | `.compact` | SHARED CONTRACT |
+| Section toggle | `.sect` | full-width disclosure row | SHARED CONTRACT |
+| Split button | `.split-button` + `.split-button-primary` / `.split-button-trigger` | open/closed menu, primary + menu items | SHARED CONTRACT |
+
+### Forms
+
+| Component | Class(es) / Markup | Notes |
+|---|---|---|
+| Text / URL / number / search / time / textarea | `input`, `select`, `textarea` | Full-width; token borders; `aria-invalid` styling. |
+| Checkbox / radio | Native inside `.check` wrapper | Native controls, custom wrappers for selectable rows. |
+| Custom single-select | `.sx-select` + `.sx-select-trigger` + `.sx-select-list` | Hidden native `<select>`; custom listbox with keyboard support. |
+| Switch / toggle | `.appearance-switch` (compact WhatsApp-style) | Native checkbox hidden, visual thumb/track. |
+| Segmented control | `.appearance-scheme-picker` | Light / Dark / Device with sliding indicator. |
+
+### Containers
+
+| Component | Class(es) | Notes |
+|---|---|---|
+| Card | `.card`, `.card.hi`, `.card.warn` | Default surface with border, shadow, hover lift on `a.card`. |
+| Banner | `.banner`, `.banner.info`, `.banner.danger` | Status / attention block. |
+| Settings row / list row | `.srow` | Bordered, rounded, hover state. |
+| Source identity | `.source-identity` (+ compact variant) | Domain → English/Arabic name → key → metric. |
+| Icon tile | `.icon-tile` | Tinted square icon marker; accent/amber/danger variants. |
+
+### Navigation
+
+| Component | Class(es) / Markup | Notes |
+|---|---|---|
+| Right-side rail | `nav.side-rail`, `.rail-item` | Chrome side panel only; grouped tablists. |
+| Workspace sidebar | `.workspace-sidebar`, `.wsnav-links` | Web UI left rail; grouped by `ui_manifest.py`. |
+| Settings category nav | `.settings-nav`, `.settings-nav-item` | Vertical tablist in `settings.html`. |
+| Page header | `.view-heading`, `.page-header` | Sticky headings in panel, hero headers in workspace. |
+
+### Feedback / Status
+
+| Component | Class(es) | Notes |
+|---|---|---|
+| Dot | `.dot`, `.dot.on`, `.dot.off` | 9px circular status indicator. |
+| Chip / badge | `.chip`, `.badge` | Pill labels; accent/amber/danger/off variants. |
+| Empty state | `.empty` | Centered muted message block. |
+| Skeleton | `.skeleton` | Loading placeholder. |
+
+### Overlays
+
+| Component | Implementation | Notes |
+|---|---|---|
+| Workspace launcher sheet | `#workspace-menu` + `#workspace-backdrop` | Fixed sheet with focus management. |
+| Custom select dropdown | `.sx-select-list` | Positioned listbox. |
+| Split-button menu | `<details class="split-button-menu">` | Native disclosure enhanced with roles. |
+| Confirmation flows | `window.confirm` / `window.prompt` | Used for destructive actions. |
+
+---
+
+## 4. Navigation Architecture
+
+### Side panel (extension)
+
+- **Page shell:** CSS Grid `1fr` content + `--panel-rail-width` (3.5 rem) rail. Body `overflow: hidden` (`extension/app.css:11-15`).
+- **Right-side rail:** `nav.side-rail` with three semantic groups — extension-owned pages (Profile, Engine), engine-owned pages (Source, Run, Data, Google Finance), utility/settings (Appearance, Library, Console, Settings) — plus the Workspace launcher (`extension/app.html:1517-1632`).
+- **Active state:** A sliding accent indicator (`#rail-indicator`) and `is-rail-active` class; `aria-selected`, `aria-current="page"`, `tabindex` managed in JS (`extension/app.css:1002-1018`, `extension/app.js:143-150`, `219-228`).
+- **Keyboard:** Arrow Up/Down/Home/End move focus and change view (`extension/app.js:3434-3445`).
+- **Workspace launcher:** Fixed sheet with backdrop; focus moves to first link on open, returns to toggle on close; Escape closes (`extension/app.js:156-186`).
+- **Scroll containment:** Most views are self-scrolling (`overflow-y: auto`); Run/Finance/Settings use a nested `.view-scroll`; Data/Sources keep headings fixed and scroll lists inside cards (`extension/app.css:204-277`, `314-337`).
+- **Width assumptions:** Designed for a minimum panel width of ~320 px; `* { min-width: 0; }`; responsive breakpoints at 340/390/430 px (`extension/app.css:17-18`, `738-751`, `1825-1844`).
+
+### Local Web UI
+
+- **Shell:** `.workspace-shell` CSS Grid with fixed left sidebar width `--workspace-sidebar-width: 17.75rem` (`scrapex/webui/static/webui.css:68-70`).
+- **Sidebar:** Sticky, scrollable, collapses to mobile drawer below 900 px (`scrapex/webui/static/webui.css:116-138`).
+- **Navigation source of truth:** `scrapex/ui_manifest.py` `WORKSPACE_DESTINATIONS`; same data served via `GET /api/ui` to the panel.
+- **Active state:** `aria-current="page"` on active link (`templates/base.html:33`).
+- **Footer status:** Engine / database health links.
+
+**Classification:** Right-side icon rail, narrow panel constraints, and workspace launcher are **EXTENSION PROFILE**. Left sidebar / mobile drawer pattern is a generic **GLOBAL SEMANTIC / SHARED CONTRACT** candidate, though its specific width and grouping are **SCRAPEX-SPECIFIC**.
+
+---
+
+## 5. Forms & Controls
+
+### Buttons (`design/components.css:345-489`)
+
+- **Base:** `min-height: var(--control-height)` (2.5 rem canonical, overridden to 3 rem in extension), `padding: var(--sp-2) var(--sp-4)`, `border-radius: var(--radius)` (0.5625 rem), `font-weight: var(--fw-medium)`.
+- **Primary:** `background: var(--button-bg)` (accent), `color: var(--button-text)` (contrast).
+- **Ghost:** `background: var(--control-bg)`, `border-color: var(--line)`, `color: var(--text)`.
+- **Danger:** `background: var(--red)`, `color: var(--danger-contrast)`.
+- **Disabled:** `opacity: 0.5`, `cursor: not-allowed`, `transform: none`.
+
+### Inputs (`design/components.css:490-540`)
+
+- `min-height: var(--control-height)`, `border: 1px solid var(--line)`, `border-radius: var(--radius)`, `background: var(--control-bg)`.
+- Focus/hover transition on border and background.
+- Invalid state: `border-color: var(--red)` when `aria-invalid="true"`.
+
+### Custom select (extension)
+
+- Implementation: hidden native `<select>` (`tabindex="-1"`, `aria-hidden="true"`) + `.sx-select-trigger` + `.sx-select-list` (`role="listbox"`).
+- Trigger `min-height: var(--touch-target)` (3 rem), list max-height `min(17rem, 50vh)`.
+- Keyboard: Arrow keys, Home, End, Escape; selection updates `aria-selected` on options (`extension/app.js:1694-1808`).
+- **Accessibility note:** No `aria-activedescendant` synchronization while arrowing; trigger has `aria-controls` but no live option id.
+
+### Switch
+
+- `.appearance-switch`: 48 px touch target wrapping a 2.5 rem × 1.5 rem track.
+- Uses hidden native checkbox for state; focus-visible outline on span.
+
+### Segmented control
+
+- `.appearance-scheme-picker`: Light / Dark / Device in a pill-shaped container with a sliding `::before` indicator.
+- Buttons use `aria-pressed`; `:has()` selector drives indicator position.
+
+**Classification:** Form primitives are strong **SHARED COMPONENT CONTRACT** candidates. The custom select overlay behavior and switch sizing are **EXTENSION PROFILE** influenced by the compact panel.
+
+---
+
+## 6. Cards / Panels / Lists
+
+### Card (`.card`)
+
+- `background: var(--surface)`, `border: 1px solid var(--line)`, `border-radius: var(--radius-lg)` (0.75 rem), `padding: var(--sp-4)`, `box-shadow: var(--shadow-xs)`.
+- Variants: `.card.hi` (accent border), `.card.warn` (red-tinted border + red-weak background).
+- Anchor cards lift on hover (`translateY(-1px)`, shadow grow).
+
+### Banner (`.banner`)
+
+- `padding: var(--sp-3) var(--sp-4)`, `border-radius: var(--radius-lg)`, default amber-weak background.
+- Variants: `.info` (accent-weak), `.danger` (red-weak).
+
+### List row (`.srow`)
+
+- `display: flex`, `justify-content: space-between`, `gap: var(--sp-2)`, `padding: var(--sp-2) var(--sp-3)`, `border-radius: var(--radius)`.
+- Hover: border-color and background shift to subtle.
+
+### Source selection row (`.source-selection-row`)
+
+- Grid layout with checkbox + source identity.
+- Hover background; focus-visible outline delegated to `:has(input:focus-visible)`.
+
+### Empty / loading
+
+- `.empty`: centered muted block with large vertical padding.
+- `.skeleton`: generic loading block (color/shape defined by consumers).
+
+**Classification:** Card, banner, list row, empty state are **SHARED COMPONENT CONTRACT** candidates. Source identity is **SCRAPEX-SPECIFIC**.
+
+---
+
+## 7. Status & Feedback States
+
+### Engine / runtime status
+
+| State | UI Presentation | Evidence |
+|---|---|---|
+| **Engine running** | Green dot + "Ready · engine vX.Y.Z" | `extension/app.js:402-408` |
+| **Engine not running / setup required** | Red dot + "Setup required"; setup card with start button | `extension/app.js:402-408`, `extension/app.html:34-54` |
+| **Checking / starting** | Onboarding `.status.checking` + spinner dot | `extension/onboarding.html:18-22`, `extension/onboarding.js:42-57` |
+| **Connection error** | No answer on `/api/health`; reachable=false path | `extension/engine.js:44-45` |
+| **Protocol mismatch** | Refusal card with five facts | `extension/app.js:2001-2011` |
+| **Extension too old** | Refusal card + disabled run + missing capabilities list | `extension/app.js:2037-2047` |
+| **Database needs upgrade / startup blocked** | Runtime issue card with "Upgrade database" action | `extension/app.js:291-360` |
+| **Schema lag** | `#schema-lag` banner | `extension/app.js:366-386` |
+| **No sites available** | "No sites yet" muted row | `extension/app.js:1212-1215` |
+| **Sites selected** | Count chip; run enabled when engine OK | `extension/app.js:2071-2086` |
+| **Job running / queued / paused** | Activity section + miniplayer at bottom | `extension/app.js:2209-2414`, `extension/app.html:1494-1515` |
+
+### Semantic mapping candidates
+
+| ScrapeX Concept | Candidate Global Semantic |
+|---|---|
+| Engine running + compatible + DB healthy | `ready` |
+| Engine stopped / unreachable | `disconnected` / `offline` |
+| Reachable but protocol/version/DB issue | `warning` |
+| Unreachable / crash / startup blocked | `error` |
+| Starting / checking / polling | `pending` / `loading` |
+| Action unavailable | `disabled` |
+| Job executing | `running` |
+
+**Classification:** The underlying semantics (`ready`, `warning`, `error`, `pending`, `disabled`, `running`) are **GLOBAL SEMANTIC CANDIDATES**. ScrapeX-specific copy ("Setup required", "Schema lag", protocol-version facts) is **SCRAPEX-SPECIFIC**.
+
+---
+
+## 8. Data / Selection Interfaces
+
+### Source identity
+
+- Canonical component: `.source-identity` (`design/components.css:661-772`).
+- Display order: domain (primary), English then Arabic name, stable key, contextual metric.
+- Handles bidirectional text with `unicode-bidi: plaintext` and `direction: ltr` for domain/key.
+
+### Site selection (Run view)
+
+- Search input + checklist of `.srow` rows with checkboxes.
+- Bulk actions: Select all / Clear.
+- Selected count displayed; run button disabled until at least one site selected and engine OK.
+
+### Dataset / data browser (Web UI)
+
+- Tabulator grid heavily customized via `grid-theme.css` and `grid.js`.
+- Inline source-filter popover (`_picker.html`, `.source-filter-menu`).
+- Data model diagram in `pages/data-model.js` (canvas-based).
+
+### Currency / Google Finance
+
+- Google Finance view in side panel (`view-finance`) with rate table, refresh settings, save state.
+
+**Classification:** Source identity and selection flows are **SCRAPEX-SPECIFIC**. The underlying list/checkbox/select patterns are **SHARED CONTRACT** candidates.
+
+---
+
+## 9. Theme Architecture
+
+### Theme selection
+
+- Three scheme modes: **Light**, **Dark**, **Device**.
+- Default: `mode: "device"`, `scheme: "light"`, `palette: "github"`, `deviceColors: true` (`extension/appearance.js:100-106`).
+- Manual mode sets `data-theme="light"` / `"dark"`; Device mode removes `data-theme` and relies on `prefers-color-scheme` (`extension/tokens.css:197-232`).
+
+### Color styles (palettes)
+
+- Two hard-coded palettes: **WhatsApp** (green) and **GitHub** (blue/neutral).
+- Selecting a palette writes ~30 CSS properties inline on `<html>` via `appearance.js` (`extension/appearance.js:188-208`).
+- Server validates allowlist: `palette in {"whatsapp", "github"}` (`scrapex/webui/app.py:115-116`).
+
+### Device colors
+
+- When enabled, uses CSS `AccentColor` / `AccentColorText` and derives tonal surfaces with `color-mix` (`extension/tokens.css:149-159`, `241-275`).
+
+### Persistence & sync
+
+- `localStorage` key `scrapex-appearance-v2`; legacy `scrapex-appearance-v1` read as fallback.
+- Cross-tab sync via `storage` event.
+- Engine sync: `POST /api/appearance` on change, `GET /api/appearance` every 2 s when engine up (`extension/appearance.js:322-377`); stored in SQLite `scrapex_meta` via `scrapex/settings.py`.
+
+### Token sync mechanism
+
+- Canonical authored files in `design/` are copied byte-for-byte to `extension/` and `scrapex/webui/static/` by `tools/sync_design_assets.py`.
+- Files synchronized: `tokens.css`, `components.css`, `appearance.js`, `split-button.js`, `material-icons.svg`, `google-g.png`, `x-mark.svg`.
+
+**Classification:**
+- Light/Dark/Device switching logic and palette concept are **SHARED COMPONENT CONTRACT** candidates.
+- WhatsApp/GitHub palettes are user-chosen **SCRAPEX PRODUCT** profiles, not global brand.
+- Device-color use of system accent is a **CHROME-NATIVE / GLOBAL SEMANTIC** pattern.
+- The `scrapex-appearance-v1` fallback is **LEGACY**.
+
+---
+
+## 10. Visual Foundation
+
+### Brand colors
+
+| Token | Value | Role |
+|---|---|---|
+| `--accent` | `light-dark(#00adb5, #35c8ce)` | Primary brand / action color (ScrapeX teal) |
+| `--accent-hover` | `light-dark(#009ba3, #51d3d8)` | Hover |
+| `--accent-active` | `light-dark(#008990, #21b9c0)` | Active |
+| `--accent-ink` | `light-dark(#006b70, #69e1e5)` | Text on subtle surface |
+| `--accent-contrast` | `light-dark(#062b2d, #071f20)` | Text on accent |
+| `--accent-weak` | `light-dark(#d8f4f5, #073a3d)` | Subtle background |
+
+### Semantic colors
+
+| Token | Value | Role |
+|---|---|---|
+| `--amber` / `--amber-weak` | `#9a5c0a` / `#fff4d6` | Warning |
+| `--red` / `--red-hover` / `--red-weak` | `#b8322a` / `#9f2923` / `#fde9e7` | Danger / error |
+| `--danger-contrast` | `#ffffff` | Text on danger |
+| `--focus` | `light-dark(#007b83, #69e1e5)` | Focus ring base |
+| `--selection` | `color-mix(in srgb, var(--accent) 20%, transparent)` | Text selection |
+
+### Neutrals / surfaces
+
+| Token | Light | Dark | Role |
+|---|---|---|---|
+| `--bg` | `#f5f7f9` | `#0f1216` | Page background |
+| `--surface` | `#ffffff` | `#171b21` | Cards / elevated surfaces |
+| `--surface-subtle` | `#f9fafb` | `#1c2128` | Hover / subtle fill |
+| `--surface-raised` | `#ffffff` | `#20262e` | Higher elevation |
+| `--line` | `#dfe3e8` | `#2c333d` | Borders |
+| `--line-strong` | `#c5cbd3` | `#434d5a` | Stronger borders |
+| `--text` | `#171a1f` | `#e9edf2` | Primary text |
+| `--muted` | `#626c7a` | `#a9b2bf` | Secondary text |
+| `--text-subtle` | `#7c8795` | `#8994a3` | Tertiary / placeholder |
+| `--chip` | `#edf1f4` | `#242b34` | Pill backgrounds |
+
+### Typography
+
+| Token | Value |
+|---|---|
+| `--font` | `"Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Noto Sans Arabic", sans-serif` |
+| `--font-mono` | `ui-monospace, "Cascadia Code", Consolas, monospace` |
+| `--fs-2xs` | 0.6875 rem |
+| `--fs-xs` | 0.75 rem |
+| `--fs-sm` | 0.8125 rem |
+| `--fs` | 0.875 rem |
+| `--fs-md` | 1 rem |
+| `--fs-lg` | 1.125 rem |
+| `--fs-xl` | 1.375 rem |
+| `--fs-2xl` | 1.75 rem |
+| `--fw-regular` | 400 |
+| `--fw-medium` | 500 |
+| `--fw-bold` | 600 |
+| `--fw-heavy` | 700 |
+| `--lh-tight` | 1.25 |
+| `--lh` | 1.5 |
+| `--lh-relaxed` | 1.65 |
+
+### Spacing
+
+4 px base grid: `--sp-1: 0.25rem` through `--sp-8: 3rem`.
+
+### Shape / elevation
+
+| Token | Value |
+|---|---|
+| `--radius-xs` | 0.25 rem |
+| `--radius-sm` | 0.375 rem |
+| `--radius` / `--radius-md` | 0.5625 rem |
+| `--radius-lg` | 0.75 rem |
+| `--radius-xl` | 1 rem |
+| `--radius-sheet` | 1.75 rem |
+| `--radius-pill` | 999 px |
+| `--shadow-xs` | `0 1px 2px rgb(16 24 40 / 0.08)` |
+| `--shadow-sm` | `0 2px 8px rgb(16 24 40 / 0.08)` |
+| `--shadow-lg` | `0 18px 40px rgb(16 24 40 / 0.16)` |
+| `--overlay` | `rgb(15 18 22 / 0.42)` |
+
+### Material 3 aliases
+
+Tokens map global primitives to M3 roles: `--primary`, `--on-primary`, `--primary-container`, `--on-primary-container`, `--surface-container`, `--on-surface`, `--outline`, `--switch-track`, etc. (`design/tokens.css:113-129`).
+
+### Hard-coded / legacy values observed
+
+- Google Sign-In button dimensions: `min-height: 40px`, `padding: 0 12px`, `gap: 10px`, `font-size: 14px`, `line-height: 20px` (`design/components.css:254-292`).
+- Extension app-specific: `.step-number { width: 20px; height: 20px; }`, `.logbox { max-height: 220px; }`, scrollbar widths `.45rem` (`extension/app.css`).
+- Web UI page sheets: arbitrary `border-radius: 10px/12px`, `.84rem`/`.78rem` font sizes (`scrapex/webui/static/webui.css`, `pages/*.css`).
+- Undefined `--font-sans` referenced in `extension/app.css` (token is `--font`).
+- `extension/onboarding.css` uses invalid `::root` selector (should be `:root`).
+
+**Classification:** Color semantics, spacing, typography, radii, shadows, and M3 aliases are **GLOBAL SEMANTIC / REFERENCE CANDIDATES**. ScrapeX teal is a **GLOBAL BRAND CANDIDATE** *for the ScrapeX product family*. Hard-coded values are **LEGACY / DUPLICATE** or **NEEDS REVIEW**.
+
+---
+
+## 11. Density
+
+### Overall profile
+
+ScrapeX is **compact to dense**, especially the extension side panel, which behaves like a compact Android app.
+
+| Surface | Evidence | Density |
+|---|---|---|
+| **Extension controls** | `--control-height: var(--touch-target)` (3 rem / 48 px) in `extension/app.css:6` | Dense touch targets |
+| **Extension small controls** | `--control-height-sm: 2.5rem` | Compact |
+| **Canonical controls** | `--control-height: 2.5rem` in `tokens.css:53` | Compact |
+| **Rail items** | 3.5 rem wide rail, 1.5 rem icons | Dense |
+| **Side panel cards** | `padding: var(--sp-4)` (1 rem), gap `var(--sp-3)` (0.75 rem) | Compact |
+| **Checklist rows** | `.srow` padding `var(--sp-2) var(--sp-3)` (0.5/0.75 rem) | Dense |
+| **Web UI sidebar nav** | `min-height: 44px` rows, `.84rem` font | Comfortable-compact |
+| **Web UI content** | `padding: var(--sp-5)` hero, larger `page-title` | More open than panel |
+
+### Comparison with website profile
+
+The known mbiXsite profile is **comfortable/editorial**: larger spacing, cream/mint surfaces, pill CTAs, technical grid. ScrapeX is materially denser, especially in the extension, because it must fit actionable controls into a narrow Chrome side panel and satisfy 48 px touch targets.
+
+**Classification:** Density is **EXTENSION PROFILE** / **SCRAPEX-SPECIFIC**. It should not be forced onto the website profile, nor should website density be assumed for ScrapeX.
+
+---
+
+## 12. Motion
+
+### Timing / easing tokens
+
+| Token | Value |
+|---|---|
+| `--dur-fast` | 0.12 s |
+| `--dur` | 0.18 s |
+| `--dur-slow` | 0.26 s |
+| `--ease` | `cubic-bezier(0.2, 0.8, 0.2, 1)` |
+
+### Used in
+
+- Button hover/active transitions (`background-color`, `border-color`, `color`, `box-shadow`, `transform`).
+- Card hover lift (`translateY(-1px)`).
+- Custom select menu open animation (`select-menu-in`).
+- Split-button menu open animation (`split-button-options-in`).
+- Segmented control sliding indicator.
+- Switch thumb/track transitions.
+- Workspace mobile drawer slide (`transform`, `transition`).
+
+### Reduced motion
+
+- Global `prefers-reduced-motion: reduce` disables animations and transitions (`design/components.css:925-934`; `extension/app.css:1996-2007`).
+
+**Classification:** Motion tokens are **GLOBAL REFERENCE CANDIDATES**. Specific panel animations are **EXTENSION PROFILE**.
+
+---
+
+## 13. Accessibility
+
+### Strengths
+
+- **Semantic HTML:** `main`, `nav`, `section`, `header`, `article`, `fieldset`/`legend`, native labels throughout.
+- **Landmark / roles:** `role="tablist"`/`tab`/`tabpanel`, `role="status"`, `role="progressbar"`, `role="listbox"`, `role="menu"`, `role="radiogroup"`, `role="switch"`.
+- **ARIA states:** `aria-selected`, `aria-expanded`, `aria-pressed`, `aria-checked`, `aria-controls`, `aria-haspopup`, `aria-current="page"`, `aria-label`, `aria-live="polite"`, `aria-invalid`.
+- **Focus-visible:** 3 px outline using `color-mix` with `--focus`; applies to buttons, links, inputs, selects, textareas, summaries, `[tabindex]`.
+- **Keyboard navigation:** Rail arrow keys, custom select Arrow/Home/End/Escape, split-button Escape, workspace menu Escape.
+- **Visually hidden:** `.visually-hidden` class for screen-reader-only labels.
+- **Reduced motion & forced colors:** respected globally.
+- **Focus management:** Workspace launcher moves focus to first link and returns on close.
+- **Bidirectional text:** `unicode-bidi: plaintext` and `dir="auto"` for Arabic content inside LTR chrome.
+
+### Gaps / needs review
+
+- **Custom select:** native `<select>` is `aria-hidden`; trigger has `aria-controls` but no `aria-activedescendant` synchronization while arrowing through options.
+- **Icon-only rail items:** rely on `title` attributes and visually-hidden spans; `title` is not reliable for touch/keyboard users.
+- **`innerHTML` templating:** `app.js` builds many UI strings with `innerHTML` after escaping via `esc()`, but `innerHTML` remains a sink. Any future omission is a potential XSS risk.
+- **No observed CSP** in Web UI templates; local-only binding reduces risk but no policy was found.
+
+**Classification:** Accessibility primitives (focus-visible, reduced motion, visually-hidden, semantic roles) are **GLOBAL SEMANTIC CANDIDATES**. Chrome-specific focus management of the rail/launcher is **EXTENSION PROFILE**. The gaps are **NEEDS REVIEW**.
+
+---
+
+## 14. Chrome-Specific Constraints
+
+| Constraint | Evidence | Classification |
+|---|---|---|
+| MV3 service worker background | `extension/background.js:1-13` | CHROME-NATIVE |
+| Side Panel API + `sidePanel` permission | `extension/manifest.json:20-22`, `extension/manifest.json:30` | CHROME-NATIVE |
+| Action click opens side panel via `chrome.sidePanel.setPanelBehavior` | `extension/background.js:3-5` | CHROME-NATIVE |
+| Permissions: `activeTab`, `identity`, `nativeMessaging`, `sidePanel`, `storage`, `tabs` | `extension/manifest.json:26-33` | CHROME-NATIVE |
+| Host permissions for loopback + Google APIs | `extension/manifest.json:34-39` | CHROME-NATIVE |
+| OAuth2 / Identity for Google sign-in | `extension/manifest.json:40-47`, `extension/identity.js:14-109` | CHROME-NATIVE |
+| Native Messaging host `com.scrapex.engine` | `extension/transport.js:20-150` | CHROME-NATIVE |
+| Panel width minimum (~320 px) and overflow containment | `extension/app.css:17-18`, `738-751` | EXTENSION PROFILE |
+| No persistent long-lived port; panel re-reads state on reconnect | `extension/transport.js:16-18` | EXTENSION PROFILE |
+
+---
+
+## 15. Global Candidates
+
+### Global Brand Candidates
+
+| Finding | Rationale |
+|---|---|
+| ScrapeX teal accent (`#00adb5` / `#35c8ce`) | Strong product-family identifier within ScrapeX; may become a **product brand** token, not necessarily the umbrella MbiX brand. |
+| Custom `x-mark.svg` brand mark | Used as CSS mask for logo across surfaces. |
+
+### Global Semantic Candidates
+
+| Concept | Evidence |
+|---|---|
+| `primary` / `on-primary` / `primary-container` / `on-primary-container` | M3 aliases in `tokens.css`. |
+| `surface` / `on-surface` / `surface-subtle` / `surface-raised` | Generic elevation roles. |
+| `success` / `warning` / `error` / `info` | ScrapeX maps these to accent/amber/red/info banners. |
+| `disabled`, `focus`, `border`, `line`, `muted` | Already tokenized. |
+| Status semantics: `ready`, `warning`, `error`, `pending`, `loading`, `disabled`, `running` | Engine/runtime state mapping. |
+
+### Shared Component Contract Candidates
+
+| Component | Evidence |
+|---|---|
+| Button (primary, ghost, danger, link, icon, compact) | `design/components.css:345-489` |
+| Input / select / textarea | `design/components.css:490-540` |
+| Checkbox / radio (native + row wrappers) | `design/components.css:531-540`, `.source-selection-row` |
+| Switch | `.appearance-switch` |
+| Segmented control | `.appearance-scheme-picker` |
+| Card / banner | `.card`, `.banner` |
+| Chip / badge / dot | `.chip`, `.badge`, `.dot` |
+| List / settings row | `.srow` |
+| Empty state | `.empty` |
+| Split button | `.split-button` + `split-button.js` |
+| Icon system (`sx-icon`, Material sprite) | `design/components.css:126-144` |
+| Appearance editor | `.appearance-editor` |
+| Timezone display contract | `timezone.js`, `_time.html`, `/api/timezone` |
+
+---
+
+## 16. Extension Profile Characteristics
+
+These are patterns that belong to the **Chrome extension as a platform client**, not to a global design system.
+
+- **Right-side icon rail** with grouped tablists and sliding indicator (`extension/app.html:1517-1632`, `extension/app.css:966-1048`).
+- **Narrow side-panel layout** (min ~320 px, `overflow: hidden`, `* { min-width: 0; }`).
+- **Workspace launcher sheet** opening full pages in new tabs.
+- **Active crawl miniplayer** fixed at the bottom of the content column (`extension/app.html:1494-1515`).
+- **Touch-target override** `--control-height: var(--touch-target)` (48 px) for panel buttons/select triggers.
+- **Icon-only rail items** with visually-hidden labels.
+- **Profile/Engine/Source/Run/Data/Finance panel workflow** shaped by the side-panel real estate.
+- **Google Identity sign-in button** and profile avatar fallback.
+- **Native-messaging-driven** start / repair / upgrade actions.
+
+---
+
+## 17. ScrapeX-Specific Characteristics
+
+These concepts are meaningful only inside the ScrapeX product domain.
+
+- **Source / offer / dataset / observation / crawl** domain model.
+- **Source identity component** display order (domain → English → Arabic → key → metric).
+- **Run workflow:** Choose sites → Run mode → Start update / crawl / rebuild / history backfill (`scrapex/ui_manifest.py` `RUN_MODE_OPTIONS`).
+- **Activity panel / live log / job miniplayer** specific to crawl monitoring.
+- **Google Finance rate refresh UI**.
+- **Capability ledger** (`crawl_pace`, `crawl_parallel_sources`, `crawl_resume`, etc.) and version handshake (`PROTOCOL_VERSION`).
+- **Schema-lag banner** and "Database is behind the engine" messaging.
+- **Onboarding copy** (install Python, pip install, register native host, start engine).
+- **Excel / Apps Script / Google Drive destination UI**.
+- **Review queue, changes, price history, compaction, retention** workflows.
+
+---
+
+## 18. Technical Debt / Duplication
+
+| Issue | Evidence | Severity |
+|---|---|---|
+| Three physical copies of design files | `extension/`, `scrapex/webui/static/`, `design/` | Managed by sync script; intentional but still duplication risk. |
+| Hard-coded values in page stylesheets | `pages/*.css`, `webui.css` | Moderate — drift from tokens. |
+| Undefined `--font-sans` token | `extension/app.css:1605, 1742, 1782` | Minor — falls back to browser default. |
+| `::root` typo in onboarding CSS | `extension/onboarding.css:1` | Minor — invalid selector. |
+| Google button fixed px values | `design/components.css:254-292` | Low — third-party brand requirement. |
+| Monolithic `grid.js` (~3,200 lines) | `scrapex/webui/static/grid.js` | Moderate — mixes data fetching, table workarounds, rendering, export, a11y patches. |
+| Inline `<script>` blocks in templates | `source.html`, `datasets.html`, `excel.html`, `sync.html`, `data-model.html` | Moderate — harder to lint/cache. |
+| Outdated vendor README claim | `static/vendor/README.md` says Tabulator is only on Datasets page, but `source.html` also loads it. | Low |
+| Generic class names colliding with shared components | `.field`, `.state`, `.toolbar`, `.value`, `.ok`, `.err` in `manage.css` / `datasets.css` | Moderate — clashing risk. |
+| `innerHTML` templating in `app.js` | `extension/app.js:18-23`, `1217-1259`, `2426-2435` | Moderate — XSS risk if escaping slips. |
+
+---
+
+## 19. Risks
+
+1. **Premature globalization.** The side-panel density and right-rail navigation are Chrome-extension solutions. Forcing them onto a website or add-in would degrade those surfaces.
+2. **Palette confusion.** WhatsApp/GitHub are user-selectable product profiles; treating them as global MbiX brand palettes would create false identity.
+3. **Engine-state semantics are useful globally, but copy is not.** "Setup required" and "Schema lag" are ScrapeX-specific. Any global status contract should abstract to `ready`/`warning`/`error`/`pending`.
+4. **Accessibility gaps in custom controls.** If the custom select or icon-only rail patterns are promoted to shared contracts, the `aria-activedescendant` and persistent-label gaps must be fixed first.
+5. **Hard-coded values in page CSS.** As the design system matures, page-level sheets may silently diverge from tokens.
+6. **`innerHTML` + escaping pattern.** A shared component library should avoid `innerHTML` in favor of safer DOM construction.
+
+---
+
+## 20. Recommended Future Mapping
+
+| ScrapeX Evidence | Future Mapping |
+|---|---|
+| `tokens.css` reference tokens (spacing, radii, typography, motion, z-index) | Adopt as **global reference tokens** after comparison with mbiXsite/mbiXaddin. |
+| `tokens.css` semantic tokens (surface, text, line, accent, success/warning/error) | Adopt as **global semantic tokens**, but expect profile-specific values. |
+| M3 aliases (`primary`, `on-surface`, etc.) | Keep as a **shared semantic vocabulary**; map to global tokens. |
+| Buttons, inputs, cards, chips, badges, empty states | Promote to **shared component contracts**. |
+| Custom select, switch, segmented control | Promote behavior to **shared contract** after fixing a11y gaps. |
+| Right-side rail, workspace launcher, miniplayer | Keep as **Extension Profile**; do not globalize. |
+| Source identity, run workflow, activity log | Keep as **ScrapeX-Specific**. |
+| Engine status semantics (`ready`/`warning`/`error`/`pending`/`disabled`) | Extract into a **global status-semantic contract**; presentation stays product-level. |
+| WhatsApp/GitHub palettes | Keep as **ScrapeX product profiles**; global theme system should allow profile registration. |
+| Device color mode | Keep as **Extension / Platform Profile** capability; concept is reusable. |
+| `appearance.js` sync protocol (`/api/appearance`) | Use as a **shared cross-surface theme-sync contract** where applicable. |
+
+---
+
+*End of SCRAPEX_UI_AUDIT.md*

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "ScrapeX",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArfnVDeMHNrrQdewml95GDw+k4BByx8zaG/VBDX14KWXZ3ZxGFm4e8afdj9qFa3+7B0i/xm8aYOhBZK1QQnXEApVB5rmw0R9uFJXxx3oKcMka5tAmvaRmPH4wug4cRoS2r+zH6Px0rHr7Q7UnhyUv9Qk6ZlxvCwcWpNTlkxKRSyqoXArZtIsV3Ig/hFH/LTdpZj2HG3dUA/2IdC765gXNw+eIZYCA1AJvu9S+jOWycBEoZj6IjVm3vFIwiuDM8WUBYEDJ2IUGgQod8XGmsZ2xxsp4DVhSvjOHbLB7golTG2YiTV6kYY+xHrKcyvuMluPoImHEQNm9GICcx/XGqPelHQIDAQAB",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A local scraping tool: capture prices from the sites you browse into a warehouse on your own machine.",
   "icons": {
     "16": "icons/x-mark-original-16.png",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "scrapex"
 # A MIRROR of scrapex/version.py:VERSION — setuptools cannot import the package
 # to ask. tests/test_version.py reads this line back and fails when they drift.
-version = "0.2.0"
+version = "0.2.1"
 description = "ScrapeX ecosystem: contract-driven web data collection into a SQLite price-tracking warehouse"
 requires-python = ">=3.12"
 dependencies = [

--- a/scrapex/cli.py
+++ b/scrapex/cli.py
@@ -384,6 +384,17 @@ def _render_changelog() -> str:
         "has it.",
         "",
     ]
+    # A RELEASE THAT ADDED NO CAPABILITY STILL HAPPENED, and must still appear.
+    # This file is generated from the capability ledger, so a fixes-only version
+    # produced no section at all — and a released version missing from its own
+    # changelog is a gap a reader reads as "that version does not exist".
+    #
+    # Found by 0.2.1: the first version deliberately cut with no new capability.
+    # `since` stays a frozen literal on every existing one, which is the rule
+    # that makes the compatibility floor mean anything, so the fix belongs here
+    # and not in the ledger.
+    by_version.setdefault(version.VERSION, [])
+
     for release in sorted(by_version, key=version.parse_version, reverse=True):
         capabilities = sorted(by_version[release], key=lambda c: c.key)
         lines.append(f"## {release}")
@@ -391,6 +402,11 @@ def _render_changelog() -> str:
         minimum = version.MINIMUM_EXTENSION_VERSION
         lines.append(f"Minimum supported extension: `{minimum}`.")
         lines.append("")
+        if not capabilities:
+            lines.append("No new capabilities. Fixes and internal change only — "
+                         "an extension and an engine that spoke to each other "
+                         "before this version still do.")
+            lines.append("")
         for capability in capabilities:
             surfaces = ", ".join(s.value for s in capability.surfaces)
             evidence = f" ({capability.commit})" if capability.commit else ""

--- a/scrapex/version.py
+++ b/scrapex/version.py
@@ -73,7 +73,7 @@ from enum import StrEnum
 # The release stamp. Bump it for a functional, architectural or behavioural
 # change (issue 32 section 1.1), and regenerate the baseline + CHANGELOG in the
 # same commit: python -m scrapex.cli export-version
-VERSION = "0.2.0"
+VERSION = "0.2.1"
 
 
 class Surface(StrEnum):

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -2205,14 +2205,22 @@ def _about_panel(page):
 
 
 def test_about_names_the_side_every_version_belongs_to(open_panel):
-    """A version shown without saying whose version it is, is the bug."""
-    page = open_panel(extension_version="0.2.0", engine_version="0.2.0")
+    """A version shown without saying whose version it is, is the bug.
+
+    THE NUMBERS COME FROM THE SOURCE, not from literals. Pinned as "0.2.0" this
+    passed until the day 0.2.1 was cut, then failed for a reason that had
+    nothing to do with what it tests — and a test that has to be edited on every
+    bump is a test that will one day be edited without being read.
+    """
+    from scrapex.version import MINIMUM_EXTENSION_VERSION, VERSION
+
+    page = open_panel(extension_version=VERSION, engine_version=VERSION)
     _about_panel(page)
 
-    assert text_of(page, "#about-extension-version") == "0.2.0"
-    assert text_of(page, "#about-version") == "0.2.0"
-    assert text_of(page, "#about-latest-version") == "0.2.0"
-    assert text_of(page, "#about-minimum-version") == "0.2.0"
+    assert text_of(page, "#about-extension-version") == VERSION
+    assert text_of(page, "#about-version") == VERSION
+    assert text_of(page, "#about-latest-version") == VERSION
+    assert text_of(page, "#about-minimum-version") == MINIMUM_EXTENSION_VERSION
     about = page.inner_text("#s-about")
     assert "This extension" in about and "Engine" in about
     # "Latest" must say where latest came from: there is no update server.
@@ -2273,7 +2281,12 @@ def test_an_extension_older_than_its_engine_is_told_all_five_facts(open_panel):
 def test_an_extension_in_step_with_its_engine_is_not_nagged(open_panel):
     """A warning that fires when nothing is wrong is a warning people click
     past — the same reasoning that keeps engine-only changes out of the gate."""
-    page = open_panel(extension_version="0.2.0", engine_version="0.2.0")
+    # In step means AT THE CURRENT VERSION, whatever it is. As a literal this
+    # said "in step" until 0.2.1 was cut, after which it meant "one behind" —
+    # and the notice it asserts is absent was correctly being shown.
+    from scrapex.version import VERSION
+
+    page = open_panel(extension_version=VERSION, engine_version=VERSION)
     assert not page.locator("#version-notice").is_visible()
     assert not page.js_errors
 


### PR DESCRIPTION
The owner chose a fixes-only number for the first public release rather than 1.0.0 — and it turned out to be the more informative choice, because it **found a gap**.

### `pyproject.toml` carries the version too

I missed it. The guard said exactly what it should: *"bump both or neither"*.

### A release with no capabilities produced no changelog section

`CHANGELOG.md` is generated from the capability ledger, so 0.2.1 — fixes only — produced **no section at all**. A released version missing from its own changelog reads as a version that does not exist, and this number is about to go on a store listing.

The short fix was to move a capability's `since` to 0.2.1 so a section appeared. **That would have been wrong.** `since` is a frozen literal saying when a capability was actually born; moving it raises the compatibility floor for no reason, and the engine would then refuse extensions it can speak to perfectly well.

The fault was the generator assuming every release carries a capability. It now emits the release with a true sentence:

> No new capabilities. Fixes and internal change only — an extension and an engine that spoke to each other before this version still do.

0.2.1 is the first version deliberately cut with no new capability, so without this choice the gap would have surfaced later, in front of users.

### The same lesson, for the third time today

Two panel tests pinned `"0.2.0"` as literals. After the bump that string stopped meaning *in step* and started meaning *one behind* — so the version notice they assert is absent was being shown **correctly**. The tests had become wrong; the code had not. Silencing the notice would have broken a warning that works.

They read `VERSION` and `MINIMUM_EXTENSION_VERSION` from the source now.

> A test that must be edited every time a number moves is a test that will one day be edited without being read.

Full suite green under `SCRAPEX_FULL_MIGRATIONS=1`, pytest exit 0.

Generated with [Claude Code](https://claude.com/claude-code)
