### PR TITLE
The store listing text, checked against what the manifest declares

### DIFF
--- a/docs/design-system/SCRAPEX_GLOBAL_MAPPING.md
+++ b/docs/design-system/SCRAPEX_GLOBAL_MAPPING.md
@@ -1,20 +1,43 @@
 # ScrapeX → MbiX Design System Mapping
 
 **Repository audited:** `C:/Users/User01/source/repos/ScrapeX`  
-**Purpose:** Map every significant UI/design concept discovered in ScrapeX into the candidate MbiX classification buckets.  
+**Purpose:** Map every significant UI/design concept discovered in ScrapeX into the corrected MbiX classification buckets, reflecting owner decisions from the documentation correction pass.  
 **Rule:** Read-only audit evidence only. No production code modified.
+
+---
+
+## Owner Decisions Recorded
+
+1. **Palette registry architecture:**
+   - `brand` is the default palette.
+   - `alternatives` is an extensible collection of optional palettes.
+   - `blue` is the first registered entry inside `alternatives`.
+   - Additional alternative palettes may be registered later.
+   - Every registered palette provides `light` and `dark` schemes.
+   - Device/System selects the effective scheme; it is **not** a palette.
+   - Future canonical concept/file: `color-palettes`.
+2. **Teal is deprecated.** Any remaining teal values are **legacy color residue / future migration debt**. Teal is **not** ScrapeX brand, MbiX global brand, a future palette, or global token evidence.
+3. **Production identifiers:** `whatsapp` and `github` remain untouched **legacy compatibility aliases** for `brand` and the first `alternatives` entry (`blue`).
+4. **Components consume semantic roles** (`accent`, `on-accent`, `surface`, `on-surface`, etc.) and must not depend directly on `brand`, `blue`, or future palette identifiers.
+5. **Shared inside ScrapeX ≠ global MbiX contract.** Copied CSS/JS files and ScrapeX API endpoints are classified as **SCRAPEX INTERNAL SHARED LAYER**. Concepts that look reusable beyond ScrapeX are classified separately as **SHARED CONTRACT CANDIDATE**.
+6. **LOCAL-WEB PROFILE** is explicit for the FastAPI/Jinja workspace surfaces.
+
+---
 
 ## Classification Buckets
 
 | Bucket | Meaning |
 |---|---|
-| **GLOBAL BRAND** | Identity-level concepts that could apply across the whole MbiX ecosystem. |
+| **GLOBAL BRAND** | Identity-level concepts that could apply across the whole MbiX ecosystem. (None identified from ScrapeX evidence.) |
 | **GLOBAL SEMANTIC** | Meaning-based concepts (colors, states, roles) that are product-agnostic. |
-| **SHARED CONTRACT** | Reusable components, tokens, or sync contracts already shared across ScrapeX surfaces. |
+| **SHARED CONTRACT CANDIDATE** | Concepts with existing ScrapeX evidence that could become MbiX-wide shared contracts after comparison with other products. |
+| **SCRAPEX INTERNAL SHARED LAYER** | Files, APIs, and modules physically shared between the ScrapeX extension and local Web UI, but not automatically global MbiX contracts. |
+| **SCRAPEX PRODUCT INTEGRATION CONTRACT** | Cross-surface contracts that tie the ScrapeX extension and engine/local Web UI to ScrapeX-specific behavior. |
 | **EXTENSION PROFILE** | Chrome extension-specific patterns that should stay in the extension domain. |
-| **SCRAPEX-SPECIFIC** | Domain model and workflows unique to the ScrapeX product. |
+| **LOCAL-WEB PROFILE** | FastAPI/Jinja local workspace-specific patterns (sidebar, responsive drawer, data pages, logs, jobs, review, schema, exports). |
+| **PRODUCT-SPECIFIC** | Domain model and workflows unique to the ScrapeX product. |
 | **CHROME-NATIVE** | Chrome platform APIs and constraints, not design-system concepts. |
-| **LEGACY** | Backwards-compatibility or outdated patterns. |
+| **LEGACY** | Backwards-compatibility, outdated patterns, or deprecated values. |
 | **PENDING OTHER PRODUCT AUDITS** | Cannot decide globally until mbiXsite, mbiXaddin, Xadd-in, Local Web UI, and mobile are audited. |
 
 ---
@@ -23,16 +46,14 @@
 
 | Concept | Evidence | Notes |
 |---|---|---|
-| ScrapeX teal accent (`#00adb5` / `#35c8ce`) | `design/tokens.css:24` | Strong product-family identifier; candidate for **ScrapeX product brand**, not necessarily umbrella MbiX brand. |
-| Custom `x-mark.svg` brand mark | `extension/icons/x-mark.svg`, `scrapex/webui/static/x-mark.svg`, `--brand-mark` | Used as CSS mask logo across surfaces. |
-| "Local-first data workspace" tagline | `templates/base.html:82` | Product positioning, not global. |
+| *None identified from ScrapeX evidence.* | — | ScrapeX's brand mark (`x-mark.svg`) and `brand` palette are product-level identifiers, not proven global MbiX brand candidates. |
 
 ## 2. Global Semantic
 
 | Concept | Evidence | Notes |
 |---|---|---|
-| Light / Dark / Device color scheme | `extension/appearance.js:100-106`, `design/tokens.css:161-232` | Generic scheme selection concept. |
-| Primary / on-primary / primary-container | `design/tokens.css:121-124` | M3 semantic roles. |
+| Light / Dark scheme selection | `extension/appearance.js:100-106`, `design/tokens.css:161-232` | Generic scheme concept. Device/System selects the effective scheme. |
+| Primary / on-primary / primary-container / on-primary-container | `design/tokens.css:121-124` | M3 semantic roles. |
 | Surface / on-surface / surface-subtle / surface-raised | `design/tokens.css:12-15`, `114-116` | Generic elevation/surface roles. |
 | Outline / outline-variant | `design/tokens.css:119-120` | Generic border roles. |
 | Success / ready | `.dot.on`, `.ok-text`, `.badge.ok` | Candidate global status semantic. |
@@ -46,32 +67,65 @@
 | Connected / disconnected / offline | Engine reachability states | Candidate global connectivity state. |
 | Ready | Engine connected + compatible + DB healthy | Candidate global readiness state. |
 
-## 3. Shared Contract
+## 3. Shared Contract Candidate
+
+Concepts that already exist in ScrapeX and could become MbiX-wide contracts once other products are audited.
 
 | Concept | Evidence | Notes |
 |---|---|---|
-| `design/tokens.css` → `extension/tokens.css` + `scrapex/webui/static/tokens.css` | `tools/sync_design_assets.py:31-34` | Token file sync contract. |
-| `design/components.css` → `extension/components.css` + `scrapex/webui/static/components.css` | `tools/sync_design_assets.py:35-38` | Component CSS sync contract. |
-| `design/appearance.js` → both surfaces | `tools/sync_design_assets.py:21-24` | Theme engine sync contract. |
-| `design/split-button.js` → both surfaces | `tools/sync_design_assets.py:27-30` | Split-button behavior sync contract. |
-| Material Symbols SVG sprite | `tools/sync_design_assets.py:39-46` | Shared icon sprite contract. |
-| `sx-icon` icon component | `design/components.css:126-144` | Shared icon use pattern. |
-| Button primitives (primary, ghost, danger, link, icon, compact) | `design/components.css:345-489` | Shared action contract. |
-| Input / select / textarea primitives | `design/components.css:490-540` | Shared form control contract. |
-| Card / banner / chip / badge / dot | `design/components.css:295-343`, `328-343`, `575-631`, `616-631` | Shared container/feedback contract. |
-| `.srow` list / settings row | `design/components.css:639-654` | Shared row contract. |
-| `.empty` empty state | `design/components.css:899-903` | Shared empty-state contract. |
-| `.icon-tile` | `design/components.css:210-235` | Shared icon-tile contract. |
-| `.appearance-editor` / `.appearance-scheme-picker` / `.appearance-switch` | `design/components.css:953-1301` | Shared appearance-control contract. |
-| `.split-button` | `design/components.css:1310-1451` + `split-button.js` | Shared split-button contract. |
-| `scrapex/ui_manifest.py` navigation + run modes | `scrapex/ui_manifest.py:58-114` | Shared cross-surface navigation/run-mode data contract. |
-| `/api/ui` endpoint | `scrapex/webui/app.py` serves `ui_manifest()` | Shared navigation payload contract. |
-| `/api/appearance` + `/api/timezone` | `scrapex/webui/app.py:98-127`, `161-188`, `extension/appearance.js:322-377`, `extension/timezone.js` | Shared preference-sync contracts. |
-| `timezone.js` + `_time.html` | `scrapex/webui/templates/_time.html`, `extension/timezone.js` | Shared time-display contract. |
-| `ScrapeXUI.icon` helper | `scrapex/webui/static/ui.js` | Shared icon helper. |
-| Version/capability contracts (`version-vectors.json`, `capability-baseline.json`) | `contracts/` | Shared cross-language contract. |
+| Button primitives (primary, ghost, danger, link, icon, compact) | `design/components.css:345-489` | Generic action vocabulary. |
+| Input / select / textarea primitives | `design/components.css:490-540` | Generic form control vocabulary. |
+| Checkbox / radio row wrappers | `design/components.css:531-540`, `.source-selection-row` | Generic selection pattern. |
+| Switch / toggle | `.appearance-switch` (`design/components.css:1215-1277`) | Generic on/off control. |
+| Segmented control | `.appearance-scheme-picker` (`design/components.css:1001-1077`) | Generic single-select group. |
+| Extensible palette registry concept | `color-palettes` with `brand` default + `alternatives` collection | Generic theme architecture candidate; `blue` is first alternative entry in ScrapeX. |
+| Card | `.card`, `.card.hi`, `.card.warn` (`design/components.css:295-326`) | Generic surface/container. |
+| Banner / alert | `.banner`, `.banner.info`, `.banner.danger` (`design/components.css:328-343`) | Generic status block. |
+| Chip / badge / dot | `.chip`, `.badge`, `.dot` (`design/components.css:575-631`, `616-631`) | Generic status/label indicators. |
+| List / settings row | `.srow` (`design/components.css:639-654`) | Generic row container. |
+| Empty state | `.empty` (`design/components.css:899-903`) | Generic empty feedback. |
+| Icon button / icon tile | `.icon-button` (`design/components.css:445-461`), `.icon-tile` (`210-235`) | Generic icon-driven affordances. |
+| Split button | `.split-button` + `split-button.js` (`design/components.css:1310-1451`) | Generic primary + menu action. |
+| Semantic token vocabulary | `design/tokens.css:11-143` | Roles such as surface, on-surface, line, focus, disabled. |
+| Reference token vocabulary | `design/tokens.css:57-111` | Spacing, radii, typography, motion, z-index. |
+| M3 semantic aliases | `design/tokens.css:113-129` | `primary`, `on-primary`, `surface-container`, `outline`, `switch-track`, etc. |
+| Focus-visible outline pattern | `design/components.css:557-567` | Generic accessible focus style. |
+| Reduced motion / forced-colors support | `design/components.css:925-948` | Generic accessibility behavior. |
 
-## 4. Extension Profile
+## 4. ScrapeX Internal Shared Layer
+
+Files, modules, and endpoints physically shared between the ScrapeX extension and the local Web UI. These keep the two ScrapeX surfaces consistent but are not automatically MbiX global contracts.
+
+| Concept | Evidence | Notes |
+|---|---|---|
+| `design/tokens.css` → `extension/tokens.css` + `scrapex/webui/static/tokens.css` | `tools/sync_design_assets.py:31-34` | Shared token file inside ScrapeX. |
+| `design/components.css` → `extension/components.css` + `scrapex/webui/static/components.css` | `tools/sync_design_assets.py:35-38` | Shared component CSS inside ScrapeX. |
+| `design/appearance.js` → both surfaces | `tools/sync_design_assets.py:21-24` | Shared theme engine inside ScrapeX. |
+| `design/split-button.js` → both surfaces | `tools/sync_design_assets.py:27-30` | Shared split-button behavior inside ScrapeX. |
+| Material Symbols SVG sprite copies | `tools/sync_design_assets.py:39-46` | Shared icon sprite inside ScrapeX. |
+| `x-mark.svg` and `google-g.png` copies | `tools/sync_design_assets.py:50-57` | Shared brand/third-party assets inside ScrapeX. |
+| `scrapex/ui_manifest.py` | `scrapex/ui_manifest.py:58-114` | Single source of truth for ScrapeX navigation and run modes. |
+| `/api/ui` endpoint | `scrapex/webui/app.py` serves `ui_manifest()` | Payload consumed by the ScrapeX panel. |
+| `/api/appearance` + `/api/timezone` | `scrapex/webui/app.py:98-188`, `extension/appearance.js:322-377`, `extension/timezone.js` | ScrapeX preference-sync endpoints. |
+| `timezone.js` + `_time.html` | `scrapex/webui/templates/_time.html`, `extension/timezone.js` | Shared ScrapeX time-display implementation. |
+| `ScrapeXUI.icon` helper | `scrapex/webui/static/ui.js` | Shared ScrapeX icon helper. |
+| `design/gallery.html` | `design/gallery.html` | ScrapeX-internal UI kit catalogue. |
+
+## 5. ScrapeX Product Integration Contract
+
+Cross-surface contracts that are specifically about integrating the ScrapeX extension with the ScrapeX engine/local Web UI.
+
+| Concept | Evidence | Notes |
+|---|---|---|
+| `PROTOCOL_VERSION` handshake | `extension/transport.js:25`, `scrapex/native.py:48` | Extension-engine protocol contract. |
+| `/api/health` shape (`running`, `version`, `protocol_version`, `databases`, `sources_with_data`) | `extension/engine.js:20-47`, `scrapex/webui/app.py` | Engine health payload contract. |
+| `/api/version` + capability report | `extension/version.js`, `scrapex/version.py:318-368` | Version/capability negotiation. |
+| `contracts/version-vectors.json` | `contracts/version-vectors.json` | Cross-language capability problem test vectors. |
+| `contracts/capability-baseline.json` | `contracts/capability-baseline.json` | ScrapeX capability baseline. |
+| Native-host manifest allowlist reused for CORS | `scrapex/webui/app.py:273-296`, `scrapex/nativehost.py:86-104` | Extension-origin access contract. |
+| `/api/native-host/register` | `scrapex/webui/app.py:848-881` | Allowlist repair contract. |
+
+## 6. Extension Profile
 
 | Concept | Evidence | Notes |
 |---|---|---|
@@ -89,26 +143,41 @@
 | Version notice / refusal card at top of panel | `extension/app.js:446-542`, `2052-2069` | Panel-specific compatibility gate. |
 | Onboarding page layout | `extension/onboarding.html`, `extension/onboarding.css` | First-install extension page. |
 
-## 5. ScrapeX-Specific
+## 7. Local-Web Profile
 
 | Concept | Evidence | Notes |
 |---|---|---|
-| Source / offer / dataset / observation / crawl domain | `scrapex/`, `sources.yaml` | Core product domain. |
+| FastAPI/Jinja2 server-rendered workspace | `scrapex/webui/app.py:22-28`, `templates/base.html` | Local web app architecture. |
+| Fixed left sidebar navigation | `templates/base.html:22-56`, `scrapex/webui/static/webui.css:68-100` | Workspace wayfinding shell. |
+| Grouped sidebar nav from `ui_manifest.py` | `scrapex/ui_manifest.py:58-95` | Browse / Automation / Outputs / System grouping. |
+| Mobile drawer (< 900 px) | `scrapex/webui/static/webui.css:116-138` | Responsive local-web navigation. |
+| Workspace footer with engine/DB health | `templates/base.html:79-101` | Local-web status footer. |
+| Wide-page / wrap-wide layout | `scrapex/webui/static/webui.css:16-19` | Local-web content layout. |
+| Settings category vertical tablist | `templates/settings.html:28-61`, `scrapex/webui/static/pages/settings.css` | Local-web settings navigation. |
+| Tabulator-based data grids | `scrapex/webui/static/grid.js`, `grid-theme.css`, `templates/source.html`, `templates/datasets.html` | Local-web data browsing surface. |
+| Data model diagram page | `scrapex/webui/static/pages/data-model.js`, `templates/data_model.html` | Local-web warehouse diagram. |
+| Jobs / schedules / logs / review / schema / export pages | `templates/jobs.html`, `schedules.html`, `logs.html`, `review.html`, `schema.html`, `exports.html`, `excel.html` | Deep local-web surfaces. |
+| Database unavailable fallback page | `templates/database_unavailable.html` | Local-web DB error surface. |
+
+## 8. Product-Specific
+
+| Concept | Evidence | Notes |
+|---|---|---|
+| Source / offer / dataset / observation / crawl domain | `scrapex/`, `sources.yaml` | Core ScrapeX domain. |
+| Custom `x-mark.svg` brand mark | `extension/icons/x-mark.svg`, `scrapex/webui/static/x-mark.svg`, `--brand-mark` | ScrapeX product logo. |
+| "Local-first data workspace" tagline | `templates/base.html:82` | ScrapeX product positioning. |
 | Source identity display order | `design/components.css:661-772`, `templates/_source_identity.html` | Domain-specific identity component. |
-| Run workflow (update / initial crawl / full rebuild / history backfill) | `scrapex/ui_manifest.py:100-114`, `extension/app.html:89-119` | Product workflow. |
+| Run workflow (update / initial crawl / full rebuild / history backfill) | `scrapex/ui_manifest.py:100-114`, `extension/app.html:89-119` | ScrapeX workflow. |
 | Site selection checklist | `extension/app.html:57-76`, `extension/app.js:1217-1259` | Run-view selection pattern. |
 | Activity panel / live log / job progress | `extension/app.html:122-183`, `extension/app.js:2120-2406` | Crawl monitoring UI. |
-| Google Finance rate UI | `extension/app.html`, `extension/app.js:730-968` | Domain-specific integration. |
-| Capability ledger keys | `scrapex/version.py:113-193` | Product capability model. |
-| Schema-lag banner | `extension/app.js:366-386` | Product migration state. |
-| Excel / Apps Script / Google Drive destination UI | `templates/sync.html`, `excel.html`, `exports.html` | Product output integrations. |
-| Review queue / changes / price history | `templates/review.html`, `changes.html`, `history.html` | Product curation workflows. |
-| Compaction / retention / storage settings | `templates/settings.html`, `_storage.html`, `_retention.html` | Product lifecycle UI. |
-| Data model / schema documentation pages | `templates/data_model.html`, `schema.html` | Product warehouse docs. |
-| Tabulator-based source data grid | `scrapex/webui/static/grid.js`, `grid-theme.css` | Domain-specific data grid skin. |
-| Database unavailable fallback page | `templates/database_unavailable.html` | Product DB error surface. |
+| Google Finance rate UI | `extension/app.html`, `extension/app.js:730-968` | ScrapeX integration. |
+| Capability ledger keys | `scrapex/version.py:113-193` | ScrapeX capability model. |
+| Schema-lag banner | `extension/app.js:366-386` | ScrapeX migration state. |
+| Excel / Apps Script / Google Drive destination UI | `templates/sync.html`, `excel.html`, `exports.html` | ScrapeX output integrations. |
+| Review queue / changes / price history | `templates/review.html`, `changes.html`, `history.html` | ScrapeX curation workflows. |
+| Compaction / retention / storage settings | `templates/settings.html`, `_storage.html`, `_retention.html` | ScrapeX lifecycle UI. |
 
-## 6. Chrome-Native
+## 9. Chrome-Native
 
 | Concept | Evidence | Notes |
 |---|---|---|
@@ -124,30 +193,33 @@
 | Host permissions for loopback / Google APIs | `extension/manifest.json:34-39` | Platform security model. |
 | Extension origin allowlist / CORS regex | `scrapex/webui/app.py:265-296` | Platform access control. |
 
-## 7. Legacy
+## 10. Legacy
 
 | Concept | Evidence | Notes |
 |---|---|---|
+| Teal accent (`#00adb5` / `#35c8ce`) | `design/tokens.css:24` | **Deprecated legacy color residue.** Not ScrapeX brand, not global brand, not a future palette. |
+| `whatsapp` palette identifier | `extension/appearance.js:8-56` | Legacy implementation alias for the default `brand` palette. |
+| `github` palette identifier | `extension/appearance.js:57-99` | Legacy implementation alias for the first `alternatives` entry (`blue`). |
 | `scrapex-appearance-v1` localStorage key | `extension/appearance.js:5`, `150-155` | Backwards-compatibility fallback. |
-| Grid localStorage v1 → v2 key migration | `scrapex/webui/static/grid.js` (reported by explore) | Old saved preferences. |
-| `ensure_schema()` single-file warehouse migration | `scrapex/db.py` (reported by explore) | Old DB shape support. |
+| Grid localStorage v1 → v2 key migration | `scrapex/webui/static/grid.js` | Old saved preferences. |
+| `ensure_schema()` single-file warehouse migration | `scrapex/db.py` | Old DB shape support. |
 | Hard-coded px/rem values in page CSS | `pages/*.css`, `webui.css` | Pre-token styling residue. |
 | Undefined `--font-sans` usage | `extension/app.css:1605, 1742, 1782` | Mistyped / stale token. |
 | `::root` typo | `extension/onboarding.css:1` | Invalid selector. |
 | Outdated vendor README (Tabulator usage claim) | `scrapex/webui/static/vendor/README.md` | Documentation drift. |
 
-## 8. Pending Other Product Audits
+## 11. Pending Other Product Audits
 
 | Concept | Why Pending |
 |---|---|
-| Exact global accent color | Need comparison with mbiXsite/mbiXaddin brand colors. |
+| Exact global accent color | Need comparison with mbiXsite/mbiXaddin brand colors. The ScrapeX `brand` palette is product-level. |
 | Global typography scale (font family, sizes, weights) | Website uses monospace as profile characteristic; ScrapeX uses Segoe UI. Need reconcile. |
 | Global density profile | Website is comfortable/editorial; ScrapeX is compact/dense. Need decide if global system supports multiple density profiles. |
 | Global radius / shadow language | ScrapeX radii may be product-specific; need compare. |
 | Global button shape (pill vs rounded rect) | Website uses pill CTAs; ScrapeX uses rounded rect (`--radius`). Need decide. |
 | Global navigation pattern (rail vs sidebar vs top nav) | Need see mbiXaddin / Local Web UI / mobile. |
 | Global icon system (Material Symbols vs custom) | Need compare with mbiXsite iconography. |
-| Global theme palette strategy (device colors, fixed palettes) | Need see how mbiXsite handles color styles. |
+| Global theme palette strategy (default + extensible alternatives registry, device colors) | Need see how mbiXsite handles color styles and whether it supports a `brand` + `alternatives` registry model. |
 | Global status component names (Banner vs Alert vs Status) | Need compare vocabulary across products. |
 | Global form control sizing / touch targets | Need compare add-in and mobile requirements. |
 
@@ -157,13 +229,16 @@
 
 | Category | Count of Concepts | Strongest Examples |
 |---|---|---|
-| **GLOBAL BRAND** | 2 | ScrapeX teal, x-mark logo |
+| **GLOBAL BRAND** | 0 | None identified from ScrapeX evidence. |
 | **GLOBAL SEMANTIC** | 16 | primary/on-primary, surface, success/warning/error, ready/pending/disabled |
-| **SHARED CONTRACT** | 24 | tokens, components.css, appearance.js, split-button, ui_manifest.py, /api/appearance |
-| **EXTENSION PROFILE** | 12 | right-side rail, launcher sheet, miniplayer, 48 px targets, onboarding |
-| **SCRAPEX-SPECIFIC** | 18 | source identity, run workflow, activity log, Google Finance, capability ledger |
+| **SHARED CONTRACT CANDIDATE** | 16 | buttons, inputs, cards, banners, chips, badges, switches, segmented controls, semantic/reference tokens |
+| **SCRAPEX INTERNAL SHARED LAYER** | 12 | tokens.css, components.css, appearance.js, split-button.js, icon sprite, ui_manifest.py, /api/ui, /api/appearance, /api/timezone |
+| **SCRAPEX PRODUCT INTEGRATION CONTRACT** | 6 | PROTOCOL_VERSION, /api/health, /api/version, version-vectors.json, capability-baseline.json, native-host allowlist |
+| **EXTENSION PROFILE** | 12 | right-side rail, launcher sheet, miniplayer, 48 px targets, onboarding, refusal card |
+| **LOCAL-WEB PROFILE** | 11 | FastAPI/Jinja shell, left sidebar, mobile drawer, Tabulator grids, data model, jobs/logs/review/schema/exports |
+| **PRODUCT-SPECIFIC** | 18 | source identity, run workflow, activity log, Google Finance, capability ledger, x-mark brand mark |
 | **CHROME-NATIVE** | 11 | MV3, sidePanel API, native messaging, identity, storage |
-| **LEGACY** | 7 | appearance-v1, hard-coded values, `--font-sans`, `::root` typo |
+| **LEGACY** | 10 | teal, whatsapp/github aliases (for `brand` / first `alternatives` entry), appearance-v1, hard-coded values, `--font-sans`, `::root` typo |
 | **PENDING** | 10 | accent color, typography, density, radius, nav pattern, icon system, palettes |
 
 ---

--- a/docs/design-system/SCRAPEX_UI_AUDIT.md
+++ b/docs/design-system/SCRAPEX_UI_AUDIT.md
@@ -4,6 +4,19 @@
 **Scope:** Chrome extension (`extension/`) and local Web UI (`scrapex/webui/`).  
 **Rule:** This document is read-only evidence. No production code was modified.
 
+**Owner corrections recorded in this pass:**
+- `brand` is the default palette.
+- `alternatives` is an extensible collection of optional palettes; `blue` is the first registered entry.
+- Additional alternative palettes may be registered later.
+- Every registered palette provides `light` and `dark` schemes.
+- Device/System selects the effective scheme; it is not a palette.
+- Components consume semantic roles and must not depend directly on palette identifiers (`brand`, `blue`, or future entries).
+- Future canonical registry/file concept: `color-palettes`.
+- Production identifiers `whatsapp` and `github` remain untouched legacy compatibility aliases.
+- Teal is **deprecated legacy color residue**, not ScrapeX brand, not global brand, not a future palette.
+- Copied CSS/JS files and ScrapeX API endpoints are **SCRAPEX INTERNAL SHARED LAYER**, not automatically global MbiX contracts.
+- **LOCAL-WEB PROFILE** is explicit for the FastAPI/Jinja workspace.
+
 ---
 
 ## 1. Technology Stack
@@ -24,7 +37,7 @@
 | **Browser APIs** | `chrome.sidePanel`, `chrome.runtime` (native messaging, onInstalled), `chrome.tabs`, `chrome.windows`, `chrome.identity.getAuthToken`, `chrome.storage`, `fetch`, `navigator.clipboard` | `extension/background.js:3-12`, `extension/identity.js:71-77`, `extension/transport.js:68-78` |
 | **Engine integration** | HTTP health poll to `127.0.0.1:8000` + Chrome Native Messaging for start/repair/upgrade | `extension/engine.js:20-47`, `extension/transport.js:20-150` |
 
-**Classification:** Manifest V3, side-panel entrypoint, service worker, identity, and native messaging are **CHROME-NATIVE**. Vanilla JS + direct DOM updates are **EXTENSION PROFILE**. The token-driven CSS and shared JS modules are **SHARED COMPONENT CONTRACT / GLOBAL SEMANTIC CANDIDATES**.
+**Classification:** Manifest V3, side-panel entrypoint, service worker, identity, and native messaging are **CHROME-NATIVE**. Vanilla JS + direct DOM updates are **EXTENSION PROFILE** / **LOCAL-WEB PROFILE**. The token-driven CSS and shared JS modules are **SCRAPEX INTERNAL SHARED LAYER**; the generic concepts inside them are **SHARED CONTRACT CANDIDATES**.
 
 ---
 
@@ -87,13 +100,13 @@ All primitives live in the canonical `design/components.css`, copied to `extensi
 
 | Component | Class(es) | States / Variants | Classification |
 |---|---|---|---|
-| Primary button | `button`, `.button` | default, hover, active, disabled / `aria-disabled="true"` | SHARED CONTRACT |
-| Ghost / secondary | `.ghost` | hover, active, disabled | SHARED CONTRACT |
-| Danger | `.danger` | hover, active | SHARED CONTRACT |
-| Link button | `.link` | hover | SHARED CONTRACT |
-| Icon button | `.icon-button` | `.compact` | SHARED CONTRACT |
-| Section toggle | `.sect` | full-width disclosure row | SHARED CONTRACT |
-| Split button | `.split-button` + `.split-button-primary` / `.split-button-trigger` | open/closed menu, primary + menu items | SHARED CONTRACT |
+| Primary button | `button`, `.button` | default, hover, active, disabled / `aria-disabled="true"` | SHARED CONTRACT CANDIDATE |
+| Ghost / secondary | `.ghost` | hover, active, disabled | SHARED CONTRACT CANDIDATE |
+| Danger | `.danger` | hover, active | SHARED CONTRACT CANDIDATE |
+| Link button | `.link` | hover | SHARED CONTRACT CANDIDATE |
+| Icon button | `.icon-button` | `.compact` | SHARED CONTRACT CANDIDATE |
+| Section toggle | `.sect` | full-width disclosure row | SHARED CONTRACT CANDIDATE |
+| Split button | `.split-button` + `.split-button-primary` / `.split-button-trigger` | open/closed menu, primary + menu items | SHARED CONTRACT CANDIDATE |
 
 ### Forms
 
@@ -102,7 +115,7 @@ All primitives live in the canonical `design/components.css`, copied to `extensi
 | Text / URL / number / search / time / textarea | `input`, `select`, `textarea` | Full-width; token borders; `aria-invalid` styling. |
 | Checkbox / radio | Native inside `.check` wrapper | Native controls, custom wrappers for selectable rows. |
 | Custom single-select | `.sx-select` + `.sx-select-trigger` + `.sx-select-list` | Hidden native `<select>`; custom listbox with keyboard support. |
-| Switch / toggle | `.appearance-switch` (compact WhatsApp-style) | Native checkbox hidden, visual thumb/track. |
+| Switch / toggle | `.appearance-switch` (compact rounded switch) | Native checkbox hidden, visual thumb/track. |
 | Segmented control | `.appearance-scheme-picker` | Light / Dark / Device with sliding indicator. |
 
 ### Containers
@@ -164,7 +177,7 @@ All primitives live in the canonical `design/components.css`, copied to `extensi
 - **Active state:** `aria-current="page"` on active link (`templates/base.html:33`).
 - **Footer status:** Engine / database health links.
 
-**Classification:** Right-side icon rail, narrow panel constraints, and workspace launcher are **EXTENSION PROFILE**. Left sidebar / mobile drawer pattern is a generic **GLOBAL SEMANTIC / SHARED CONTRACT** candidate, though its specific width and grouping are **SCRAPEX-SPECIFIC**.
+**Classification:** Right-side icon rail, narrow panel constraints, and workspace launcher are **EXTENSION PROFILE**. Left sidebar / mobile drawer pattern is **LOCAL-WEB PROFILE**; its generic pattern is a **SHARED CONTRACT CANDIDATE**, though its specific width and grouping are product-level.
 
 ---
 
@@ -201,7 +214,7 @@ All primitives live in the canonical `design/components.css`, copied to `extensi
 - `.appearance-scheme-picker`: Light / Dark / Device in a pill-shaped container with a sliding `::before` indicator.
 - Buttons use `aria-pressed`; `:has()` selector drives indicator position.
 
-**Classification:** Form primitives are strong **SHARED COMPONENT CONTRACT** candidates. The custom select overlay behavior and switch sizing are **EXTENSION PROFILE** influenced by the compact panel.
+**Classification:** Form primitives are strong **SHARED CONTRACT CANDIDATES**. The custom select overlay behavior and switch sizing are **EXTENSION PROFILE** influenced by the compact panel.
 
 ---
 
@@ -233,7 +246,7 @@ All primitives live in the canonical `design/components.css`, copied to `extensi
 - `.empty`: centered muted block with large vertical padding.
 - `.skeleton`: generic loading block (color/shape defined by consumers).
 
-**Classification:** Card, banner, list row, empty state are **SHARED COMPONENT CONTRACT** candidates. Source identity is **SCRAPEX-SPECIFIC**.
+**Classification:** Card, banner, list row, empty state are **SHARED CONTRACT CANDIDATES**. Source identity is **PRODUCT-SPECIFIC**.
 
 ---
 
@@ -267,7 +280,7 @@ All primitives live in the canonical `design/components.css`, copied to `extensi
 | Action unavailable | `disabled` |
 | Job executing | `running` |
 
-**Classification:** The underlying semantics (`ready`, `warning`, `error`, `pending`, `disabled`, `running`) are **GLOBAL SEMANTIC CANDIDATES**. ScrapeX-specific copy ("Setup required", "Schema lag", protocol-version facts) is **SCRAPEX-SPECIFIC**.
+**Classification:** The underlying semantics (`ready`, `warning`, `error`, `pending`, `disabled`, `running`) are **GLOBAL SEMANTIC CANDIDATES**. ScrapeX-specific copy ("Setup required", "Schema lag", protocol-version facts) and the exact presentation are **PRODUCT-SPECIFIC** / **EXTENSION PROFILE** / **LOCAL-WEB PROFILE**.
 
 ---
 
@@ -295,23 +308,55 @@ All primitives live in the canonical `design/components.css`, copied to `extensi
 
 - Google Finance view in side panel (`view-finance`) with rate table, refresh settings, save state.
 
-**Classification:** Source identity and selection flows are **SCRAPEX-SPECIFIC**. The underlying list/checkbox/select patterns are **SHARED CONTRACT** candidates.
+**Classification:** Source identity and selection flows are **PRODUCT-SPECIFIC**. The underlying list/checkbox/select patterns are **SHARED CONTRACT CANDIDATES**.
 
 ---
 
 ## 9. Theme Architecture
 
+### Future palette registry (owner decision)
+
+The future canonical palette architecture is an extensible registry under a neutral concept such as `color-palettes`:
+
+```
+color-palettes
+├── brand                 (default palette)
+│   ├── light
+│   └── dark
+└── alternatives          (extensible collection)
+    ├── blue              (first registered alternative)
+    │   ├── light
+    │   └── dark
+    └── future entries…
+```
+
+- **`brand`** is the default palette.
+- **`alternatives`** is an extensible collection of optional palettes.
+- **`blue`** is currently the first registered entry inside `alternatives`.
+- Additional alternative palettes may be registered later.
+- **Every registered palette provides `light` and `dark` schemes.**
+- **Device/System selects the effective `light`/`dark` scheme; it is not a palette.**
+- **Components consume semantic roles** (`accent`, `on-accent`, `surface`, `on-surface`, etc.) and must not depend directly on `brand`, `blue`, or future palette identifiers.
+- Future canonical files and APIs must use color-agnostic names under the `color-palettes` concept. Names such as `green-theme`, `whatsapp-theme`, `github-theme`, or `teal-theme` must not be used.
+
+### Production identifiers
+
+- The production code currently uses the legacy identifiers `whatsapp` (maps to `brand`) and `github` (maps to `blue`).
+- These identifiers are **not renamed now**; they are classified as **legacy compatibility/migration aliases**.
+- Server validates allowlist: `palette in {"whatsapp", "github"}` (`scrapex/webui/app.py:115-116`) — this boundary uses legacy identifiers until a migration is planned.
+
 ### Theme selection
 
-- Three scheme modes: **Light**, **Dark**, **Device**.
-- Default: `mode: "device"`, `scheme: "light"`, `palette: "github"`, `deviceColors: true` (`extension/appearance.js:100-106`).
+- Three scheme-mode UI choices: **Light**, **Dark**, **Device**.
+- Default state in `appearance.js`: `mode: "device"`, `scheme: "light"`, `palette: "github"` (legacy `blue`), `deviceColors: true` (`extension/appearance.js:100-106`).
 - Manual mode sets `data-theme="light"` / `"dark"`; Device mode removes `data-theme` and relies on `prefers-color-scheme` (`extension/tokens.css:197-232`).
 
 ### Color styles (palettes)
 
-- Two hard-coded palettes: **WhatsApp** (green) and **GitHub** (blue/neutral).
+- Palette values are hard-coded in `appearance.js` lines 8–99.
+- The `brand` palette (currently aliased by `whatsapp`) supplies green-family values.
+- The `blue` palette (currently aliased by `github`) supplies blue-family values and is the first entry in the future `alternatives` registry.
 - Selecting a palette writes ~30 CSS properties inline on `<html>` via `appearance.js` (`extension/appearance.js:188-208`).
-- Server validates allowlist: `palette in {"whatsapp", "github"}` (`scrapex/webui/app.py:115-116`).
 
 ### Device colors
 
@@ -329,25 +374,24 @@ All primitives live in the canonical `design/components.css`, copied to `extensi
 - Files synchronized: `tokens.css`, `components.css`, `appearance.js`, `split-button.js`, `material-icons.svg`, `google-g.png`, `x-mark.svg`.
 
 **Classification:**
-- Light/Dark/Device switching logic and palette concept are **SHARED COMPONENT CONTRACT** candidates.
-- WhatsApp/GitHub palettes are user-chosen **SCRAPEX PRODUCT** profiles, not global brand.
-- Device-color use of system accent is a **CHROME-NATIVE / GLOBAL SEMANTIC** pattern.
+- The copied files and the `/api/appearance` / `/api/timezone` endpoints are **SCRAPEX INTERNAL SHARED LAYER**.
+- The generic Light/Dark/Device scheme-switching concept and palette concept are **SHARED CONTRACT CANDIDATES**.
+- The `brand` default palette and the `alternatives` collection (with `blue` as its first entry) are **PRODUCT-SPECIFIC** profiles.
+- `whatsapp` / `github` identifiers are **LEGACY** aliases.
+- Device-color use of system accent is a **SHARED CONTRACT CANDIDATE** / platform capability.
 - The `scrapex-appearance-v1` fallback is **LEGACY**.
 
 ---
 
 ## 10. Visual Foundation
 
-### Brand colors
+### Brand / accent color status
 
-| Token | Value | Role |
-|---|---|---|
-| `--accent` | `light-dark(#00adb5, #35c8ce)` | Primary brand / action color (ScrapeX teal) |
-| `--accent-hover` | `light-dark(#009ba3, #51d3d8)` | Hover |
-| `--accent-active` | `light-dark(#008990, #21b9c0)` | Active |
-| `--accent-ink` | `light-dark(#006b70, #69e1e5)` | Text on subtle surface |
-| `--accent-contrast` | `light-dark(#062b2d, #071f20)` | Text on accent |
-| `--accent-weak` | `light-dark(#d8f4f5, #073a3d)` | Subtle background |
+- **Teal (`#00adb5` / `#35c8ce`) is deprecated.** It appears in `design/tokens.css:24` as the current `--accent` value but is **legacy color residue / future migration debt**.
+- **Teal must not be classified as:** ScrapeX brand, MbiX global brand, a future palette, or global token evidence.
+- The owner-preferred brand direction is **green**, implemented by the `brand` default palette (currently aliased by `whatsapp` in `appearance.js`).
+- The optional alternatives collection currently has one entry: `blue` (currently aliased by `github`). Additional alternatives may be registered later.
+- No global brand color candidates are identified from ScrapeX evidence.
 
 ### Semantic colors
 
@@ -358,6 +402,8 @@ All primitives live in the canonical `design/components.css`, copied to `extensi
 | `--danger-contrast` | `#ffffff` | Text on danger |
 | `--focus` | `light-dark(#007b83, #69e1e5)` | Focus ring base |
 | `--selection` | `color-mix(in srgb, var(--accent) 20%, transparent)` | Text selection |
+
+> **Note:** `--accent` currently resolves to teal as legacy residue; the semantic role of `accent` is a **GLOBAL SEMANTIC CANDIDATE**, but the current teal value is **LEGACY**.
 
 ### Neutrals / surfaces
 
@@ -427,8 +473,9 @@ Tokens map global primitives to M3 roles: `--primary`, `--on-primary`, `--primar
 - Web UI page sheets: arbitrary `border-radius: 10px/12px`, `.84rem`/`.78rem` font sizes (`scrapex/webui/static/webui.css`, `pages/*.css`).
 - Undefined `--font-sans` referenced in `extension/app.css` (token is `--font`).
 - `extension/onboarding.css` uses invalid `::root` selector (should be `:root`).
+- Teal `--accent` value in `design/tokens.css:24` is deprecated legacy residue.
 
-**Classification:** Color semantics, spacing, typography, radii, shadows, and M3 aliases are **GLOBAL SEMANTIC / REFERENCE CANDIDATES**. ScrapeX teal is a **GLOBAL BRAND CANDIDATE** *for the ScrapeX product family*. Hard-coded values are **LEGACY / DUPLICATE** or **NEEDS REVIEW**.
+**Classification:** Color semantics, spacing, typography, radii, shadows, and M3 aliases are **GLOBAL SEMANTIC / SHARED CONTRACT CANDIDATES**. The current teal value is **LEGACY**. Hard-coded values are **LEGACY / DUPLICATE** or **NEEDS REVIEW**.
 
 ---
 
@@ -453,7 +500,7 @@ ScrapeX is **compact to dense**, especially the extension side panel, which beha
 
 The known mbiXsite profile is **comfortable/editorial**: larger spacing, cream/mint surfaces, pill CTAs, technical grid. ScrapeX is materially denser, especially in the extension, because it must fit actionable controls into a narrow Chrome side panel and satisfy 48 px touch targets.
 
-**Classification:** Density is **EXTENSION PROFILE** / **SCRAPEX-SPECIFIC**. It should not be forced onto the website profile, nor should website density be assumed for ScrapeX.
+**Classification:** Extension density is **EXTENSION PROFILE**. Local-web density is **LOCAL-WEB PROFILE**. Density should not be forced onto the website profile, nor should website density be assumed for ScrapeX.
 
 ---
 
@@ -482,7 +529,7 @@ The known mbiXsite profile is **comfortable/editorial**: larger spacing, cream/m
 
 - Global `prefers-reduced-motion: reduce` disables animations and transitions (`design/components.css:925-934`; `extension/app.css:1996-2007`).
 
-**Classification:** Motion tokens are **GLOBAL REFERENCE CANDIDATES**. Specific panel animations are **EXTENSION PROFILE**.
+**Classification:** Motion tokens are **GLOBAL REFERENCE / SHARED CONTRACT CANDIDATES**. Specific panel animations are **EXTENSION PROFILE**; drawer animation is **LOCAL-WEB PROFILE**.
 
 ---
 
@@ -507,7 +554,7 @@ The known mbiXsite profile is **comfortable/editorial**: larger spacing, cream/m
 - **`innerHTML` templating:** `app.js` builds many UI strings with `innerHTML` after escaping via `esc()`, but `innerHTML` remains a sink. Any future omission is a potential XSS risk.
 - **No observed CSP** in Web UI templates; local-only binding reduces risk but no policy was found.
 
-**Classification:** Accessibility primitives (focus-visible, reduced motion, visually-hidden, semantic roles) are **GLOBAL SEMANTIC CANDIDATES**. Chrome-specific focus management of the rail/launcher is **EXTENSION PROFILE**. The gaps are **NEEDS REVIEW**.
+**Classification:** Accessibility primitives (focus-visible, reduced motion, visually-hidden, semantic roles) are **GLOBAL SEMANTIC / SHARED CONTRACT CANDIDATES**. Chrome-specific focus management of the rail/launcher is **EXTENSION PROFILE**. The gaps are **NEEDS REVIEW**.
 
 ---
 
@@ -531,10 +578,7 @@ The known mbiXsite profile is **comfortable/editorial**: larger spacing, cream/m
 
 ### Global Brand Candidates
 
-| Finding | Rationale |
-|---|---|
-| ScrapeX teal accent (`#00adb5` / `#35c8ce`) | Strong product-family identifier within ScrapeX; may become a **product brand** token, not necessarily the umbrella MbiX brand. |
-| Custom `x-mark.svg` brand mark | Used as CSS mask for logo across surfaces. |
+No global brand candidates are identified from ScrapeX evidence. The ScrapeX `x-mark.svg` brand mark and `brand` palette are **PRODUCT-SPECIFIC**. Teal is **LEGACY**.
 
 ### Global Semantic Candidates
 
@@ -546,7 +590,7 @@ The known mbiXsite profile is **comfortable/editorial**: larger spacing, cream/m
 | `disabled`, `focus`, `border`, `line`, `muted` | Already tokenized. |
 | Status semantics: `ready`, `warning`, `error`, `pending`, `loading`, `disabled`, `running` | Engine/runtime state mapping. |
 
-### Shared Component Contract Candidates
+### Shared Contract Candidates
 
 | Component | Evidence |
 |---|---|
@@ -566,83 +610,136 @@ The known mbiXsite profile is **comfortable/editorial**: larger spacing, cream/m
 
 ---
 
-## 16. Extension Profile Characteristics
+## 16. ScrapeX Internal Shared Layer
+
+These files, modules, and endpoints are physically shared between the ScrapeX extension and local Web UI. They keep ScrapeX surfaces consistent but are **not automatically MbiX global contracts**.
+
+- `design/tokens.css` → `extension/tokens.css` + `scrapex/webui/static/tokens.css`
+- `design/components.css` → `extension/components.css` + `scrapex/webui/static/components.css`
+- `design/appearance.js` → both surfaces
+- `design/split-button.js` → both surfaces
+- Material Symbols SVG sprite + `x-mark.svg` + `google-g.png` copies
+- `scrapex/ui_manifest.py` navigation + run modes
+- `/api/ui` endpoint
+- `/api/appearance` + `/api/timezone` endpoints
+- `timezone.js` + `_time.html`
+- `ScrapeXUI.icon` helper
+
+---
+
+## 17. ScrapeX Product Integration Contracts
+
+Cross-surface contracts specifically about integrating the ScrapeX extension with the ScrapeX engine/local Web UI.
+
+- `PROTOCOL_VERSION` handshake (`extension/transport.js`, `scrapex/native.py`)
+- `/api/health` shape
+- `/api/version` + capability report
+- `contracts/version-vectors.json`
+- `contracts/capability-baseline.json`
+- Native-host manifest allowlist reuse for CORS
+- `/api/native-host/register`
+
+---
+
+## 18. Extension Profile Characteristics
 
 These are patterns that belong to the **Chrome extension as a platform client**, not to a global design system.
 
-- **Right-side icon rail** with grouped tablists and sliding indicator (`extension/app.html:1517-1632`, `extension/app.css:966-1048`).
-- **Narrow side-panel layout** (min ~320 px, `overflow: hidden`, `* { min-width: 0; }`).
-- **Workspace launcher sheet** opening full pages in new tabs.
-- **Active crawl miniplayer** fixed at the bottom of the content column (`extension/app.html:1494-1515`).
-- **Touch-target override** `--control-height: var(--touch-target)` (48 px) for panel buttons/select triggers.
-- **Icon-only rail items** with visually-hidden labels.
-- **Profile/Engine/Source/Run/Data/Finance panel workflow** shaped by the side-panel real estate.
-- **Google Identity sign-in button** and profile avatar fallback.
-- **Native-messaging-driven** start / repair / upgrade actions.
+- Right-side icon rail with grouped tablists and sliding indicator.
+- Narrow side-panel layout (min ~320 px, `overflow: hidden`, `* { min-width: 0; }`).
+- Workspace launcher sheet opening full pages in new tabs.
+- Active crawl miniplayer fixed at the bottom of the content column.
+- Touch-target override `--control-height: var(--touch-target)` (48 px) for panel buttons/select triggers.
+- Icon-only rail items with visually-hidden labels.
+- Profile/Engine/Source/Run/Data/Finance panel workflow shaped by side-panel real estate.
+- Google Identity sign-in button and profile avatar fallback.
+- Native-messaging-driven start / repair / upgrade actions.
+- Version notice / refusal card at the top of the panel.
+- Onboarding page.
 
 ---
 
-## 17. ScrapeX-Specific Characteristics
+## 19. Local-Web Profile Characteristics
+
+These patterns belong to the **FastAPI/Jinja local workspace**, distinct from both the extension and a public website.
+
+- Server-rendered Jinja2 pages with page-specific CSS/JS.
+- Fixed left sidebar navigation (`--workspace-sidebar-width: 17.75rem`).
+- Sidebar grouping from `scrapex/ui_manifest.py` (Browse / Automation / Outputs / System).
+- Mobile drawer below 900 px.
+- Workspace footer with engine / database health.
+- Settings category vertical tablist.
+- Tabulator-based data grids (`grid.js`, `grid-theme.css`).
+- Data model diagram page.
+- Deep tool pages: Jobs, Schedules, Logs, Review, Schema, Exports, Excel.
+- Database unavailable fallback page.
+
+---
+
+## 20. Product-Specific Characteristics
 
 These concepts are meaningful only inside the ScrapeX product domain.
 
-- **Source / offer / dataset / observation / crawl** domain model.
-- **Source identity component** display order (domain → English → Arabic → key → metric).
-- **Run workflow:** Choose sites → Run mode → Start update / crawl / rebuild / history backfill (`scrapex/ui_manifest.py` `RUN_MODE_OPTIONS`).
-- **Activity panel / live log / job miniplayer** specific to crawl monitoring.
-- **Google Finance rate refresh UI**.
-- **Capability ledger** (`crawl_pace`, `crawl_parallel_sources`, `crawl_resume`, etc.) and version handshake (`PROTOCOL_VERSION`).
-- **Schema-lag banner** and "Database is behind the engine" messaging.
-- **Onboarding copy** (install Python, pip install, register native host, start engine).
-- **Excel / Apps Script / Google Drive destination UI**.
-- **Review queue, changes, price history, compaction, retention** workflows.
+- Source / offer / dataset / observation / crawl domain model.
+- Source identity display order (domain → English → Arabic → key → metric).
+- Run workflow: update / initial crawl / full rebuild / history backfill.
+- Activity panel / live log / job miniplayer.
+- Google Finance rate UI.
+- Capability ledger and protocol handshake.
+- Schema-lag banner and "Database is behind the engine" messaging.
+- Onboarding copy (install Python, pip install, register native host, start engine).
+- Excel / Apps Script / Google Drive destination UI.
+- Review queue, changes, price history, compaction, retention.
 
 ---
 
-## 18. Technical Debt / Duplication
+## 21. Technical Debt / Duplication
 
 | Issue | Evidence | Severity |
 |---|---|---|
 | Three physical copies of design files | `extension/`, `scrapex/webui/static/`, `design/` | Managed by sync script; intentional but still duplication risk. |
+| Teal `--accent` value in canonical tokens | `design/tokens.css:24` | **Legacy residue** — future migration to `brand` palette green. |
+| `whatsapp` / `github` palette identifiers | `extension/appearance.js:8-99` | **Legacy aliases** for `brand` / first `alternatives` entry (`blue`). |
 | Hard-coded values in page stylesheets | `pages/*.css`, `webui.css` | Moderate — drift from tokens. |
 | Undefined `--font-sans` token | `extension/app.css:1605, 1742, 1782` | Minor — falls back to browser default. |
 | `::root` typo in onboarding CSS | `extension/onboarding.css:1` | Minor — invalid selector. |
 | Google button fixed px values | `design/components.css:254-292` | Low — third-party brand requirement. |
 | Monolithic `grid.js` (~3,200 lines) | `scrapex/webui/static/grid.js` | Moderate — mixes data fetching, table workarounds, rendering, export, a11y patches. |
 | Inline `<script>` blocks in templates | `source.html`, `datasets.html`, `excel.html`, `sync.html`, `data-model.html` | Moderate — harder to lint/cache. |
-| Outdated vendor README claim | `static/vendor/README.md` says Tabulator is only on Datasets page, but `source.html` also loads it. | Low |
+| Outdated vendor README claim | `static/vendor/README.md` | Low |
 | Generic class names colliding with shared components | `.field`, `.state`, `.toolbar`, `.value`, `.ok`, `.err` in `manage.css` / `datasets.css` | Moderate — clashing risk. |
 | `innerHTML` templating in `app.js` | `extension/app.js:18-23`, `1217-1259`, `2426-2435` | Moderate — XSS risk if escaping slips. |
 
 ---
 
-## 19. Risks
+## 22. Risks
 
 1. **Premature globalization.** The side-panel density and right-rail navigation are Chrome-extension solutions. Forcing them onto a website or add-in would degrade those surfaces.
-2. **Palette confusion.** WhatsApp/GitHub are user-selectable product profiles; treating them as global MbiX brand palettes would create false identity.
-3. **Engine-state semantics are useful globally, but copy is not.** "Setup required" and "Schema lag" are ScrapeX-specific. Any global status contract should abstract to `ready`/`warning`/`error`/`pending`.
-4. **Accessibility gaps in custom controls.** If the custom select or icon-only rail patterns are promoted to shared contracts, the `aria-activedescendant` and persistent-label gaps must be fixed first.
-5. **Hard-coded values in page CSS.** As the design system matures, page-level sheets may silently diverge from tokens.
-6. **`innerHTML` + escaping pattern.** A shared component library should avoid `innerHTML` in favor of safer DOM construction.
+2. **Palette / teal confusion.** Teal is legacy residue, not brand. `brand` is the default palette; `blue` is the first entry in an extensible `alternatives` registry. Neither is a global MbiX brand palette. The `whatsapp`/`github` identifiers must not leak into future global vocabulary.
+3. **Naming with brand colors.** Future canonical files and APIs must avoid color names (`green-theme`, `teal-theme`, etc.) and use the neutral `color-palettes` concept with semantic identifiers (`brand`, `alternatives`, `accent`, `surface`).
+4. **Engine-state semantics are useful globally, but copy is not.** "Setup required" and "Schema lag" are ScrapeX-specific. Any global status contract should abstract to `ready`/`warning`/`error`/`pending`.
+5. **Accessibility gaps in custom controls.** If the custom select or icon-only rail patterns are promoted to shared contracts, the `aria-activedescendant` and persistent-label gaps must be fixed first.
+6. **Hard-coded values in page CSS.** As the design system matures, page-level sheets may silently diverge from tokens.
+7. **`innerHTML` + escaping pattern.** A shared component library should avoid `innerHTML` in favor of safer DOM construction.
 
 ---
 
-## 20. Recommended Future Mapping
+## 23. Recommended Future Mapping
 
 | ScrapeX Evidence | Future Mapping |
 |---|---|
-| `tokens.css` reference tokens (spacing, radii, typography, motion, z-index) | Adopt as **global reference tokens** after comparison with mbiXsite/mbiXaddin. |
-| `tokens.css` semantic tokens (surface, text, line, accent, success/warning/error) | Adopt as **global semantic tokens**, but expect profile-specific values. |
+| `tokens.css` reference tokens (spacing, radii, typography, motion, z-index) | Evaluate as **global reference tokens** after comparison with mbiXsite/mbiXaddin. |
+| `tokens.css` semantic tokens (surface, text, line, accent, success/warning/error) | Evaluate as **global semantic tokens**, but expect profile-specific values. |
 | M3 aliases (`primary`, `on-surface`, etc.) | Keep as a **shared semantic vocabulary**; map to global tokens. |
-| Buttons, inputs, cards, chips, badges, empty states | Promote to **shared component contracts**. |
+| Buttons, inputs, cards, chips, badges, empty states | Promote to **shared component contracts** after other product audits. |
 | Custom select, switch, segmented control | Promote behavior to **shared contract** after fixing a11y gaps. |
 | Right-side rail, workspace launcher, miniplayer | Keep as **Extension Profile**; do not globalize. |
-| Source identity, run workflow, activity log | Keep as **ScrapeX-Specific**. |
+| Source identity, run workflow, activity log, Google Finance UI | Keep as **Product-Specific**. |
 | Engine status semantics (`ready`/`warning`/`error`/`pending`/`disabled`) | Extract into a **global status-semantic contract**; presentation stays product-level. |
-| WhatsApp/GitHub palettes | Keep as **ScrapeX product profiles**; global theme system should allow profile registration. |
-| Device color mode | Keep as **Extension / Platform Profile** capability; concept is reusable. |
-| `appearance.js` sync protocol (`/api/appearance`) | Use as a **shared cross-surface theme-sync contract** where applicable. |
+| `brand` default + `alternatives` registry (`blue` as first entry) | Keep as **ScrapeX product profiles**; global theme system should support a default palette plus an extensible alternatives registry. |
+| Device color mode | Keep as a **platform capability**; concept is reusable. |
+| `appearance.js` sync protocol (`/api/appearance`) | Use as a **ScrapeX internal shared layer**; global theme sync may follow a similar shape. |
 
 ---
 
-*End of SCRAPEX_UI_AUDIT.md*
+*End of SCRAPEX_UI_AUDIT.md — corrected documentation pass.*

--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -1,0 +1,200 @@
+# Chrome Web Store listing — ScrapeX 0.2.1
+
+Draft for the owner to review, edit and paste. Every claim here is checked
+against what the extension actually declares — the permissions and scopes below
+are read from `extension/manifest.json`, not remembered — because a listing that
+promises something the manifest does not do is the one thing a reviewer is
+looking for.
+
+**Visibility:** Unlisted · **Publish target:** Trusted testers (Decision 6).
+
+---
+
+## Single purpose
+
+Chrome requires one sentence, and it is the field a reviewer reads first. A
+purpose that sounds like two products is the commonest rejection.
+
+> ScrapeX collects published product and price information from websites the
+> user chooses, and stores it in a database on the user's own computer.
+
+---
+
+## Short description
+
+Max 132 characters. Counted, not estimated: this one is **105**.
+
+> Collect published prices from sites you choose into a database on your own
+> computer. Nothing is uploaded.
+
+*(A second option, **123** characters, if you prefer leading with the tracking:)*
+
+> Track published prices from the sites you choose. Everything stays in a
+> database on your own machine — nothing is uploaded.
+
+---
+
+## Detailed description
+
+> **ScrapeX collects published prices into a database on your own computer.**
+>
+> You choose the sites. ScrapeX visits their public pages, reads the product and
+> price information they publish, and keeps it in a database on your machine —
+> not on anybody's server. If your computer is off, nothing runs.
+>
+> **What it does**
+>
+> - Collects published product and price information from sites you add.
+> - Keeps the history, so you can see when a price changed and what it was
+>   before.
+> - Exports to Excel, or to a Google Sheet you choose.
+> - Backs up to your own Google Drive, when you ask it to.
+>
+> **How it is built**
+>
+> ScrapeX is two halves. This extension is the panel you work in. The second
+> half is **ScrapeX-Engine**, a small program that runs on your own computer and
+> does the collecting — it is what holds your database. The panel offers to
+> install it, and tells you plainly when the two are out of step instead of
+> failing quietly.
+>
+> Windows only, for now. The engine needs no administrator rights.
+>
+> **What it does not do**
+>
+> - It does not send your collected data anywhere except your own Google Drive,
+>   and only when you ask.
+> - It contains no analytics, no telemetry and no advertising.
+> - It does not sign in to any website on your behalf, and reads nothing behind
+>   a login.
+> - There is no account and no subscription. It is not a service.
+>
+> Privacy policy: https://muhammadbayoumi.github.io/mbiXsite/scrapex-privacy.html
+> Support: https://muhammadbayoumi.github.io/mbiXsite/scrapex-support.html
+
+---
+
+## Permission justifications
+
+One field per permission, and each has to say **why this extension cannot work
+without it**. "It is needed" is what gets a listing sent back.
+
+### `nativeMessaging`
+
+**The one that gets read hardest**, because it is the permission that reaches
+outside the browser. Be specific and do not soften it.
+
+> ScrapeX stores data in a database on the user's own computer rather than on a
+> server. A browser extension cannot write to a local database or run a crawl
+> on a schedule, so the collecting is done by a separate program the user
+> installs — ScrapeX-Engine. Native messaging is the only way this panel can
+> start that program and exchange data with it. Nothing is sent to any remote
+> host through this channel; the other end is a program on the same machine,
+> installed by the user, which the panel refuses to talk to if its version does
+> not match.
+
+### `storage`
+
+> Remembers the user's own settings — the sites they added, crawl pacing,
+> display preferences, time zone and backup schedule — between sessions. No
+> collected data is kept here; that lives in the local database.
+
+### `sidePanel`
+
+> The entire interface is a side panel. Without this permission there is no user
+> interface at all.
+
+### `activeTab`
+
+> When the user presses "Test site" or adds the page they are looking at,
+> ScrapeX reads the current tab's address to work out which site it is and
+> whether it can be read. It is used only in response to that press, never in
+> the background.
+
+### `tabs`
+
+> The panel is opened next to the page being worked on and needs to know which
+> tab it belongs to, so the panel follows the user's tab rather than showing
+> another one's state.
+
+### `identity`
+
+> Used only for "Sign in with Google", which the user starts. It is what obtains
+> permission to write a backup to the user's own Google Drive and to export to a
+> Google Sheet they choose. ScrapeX works without signing in; the sign-in buys
+> Drive and Sheets and nothing else.
+
+---
+
+## Host permission justifications
+
+### `http://127.0.0.1/*` and `http://localhost/*`
+
+> ScrapeX-Engine runs on the user's own machine and serves its data over
+> loopback. This is how the panel reads the database. It never leaves the
+> computer.
+
+### `https://raw.githubusercontent.com/*`
+
+> Reads one small file that says which version of ScrapeX-Engine is the newest,
+> so the panel can tell the user an update exists. It is a plain public file
+> fetch and carries no information about the user.
+
+### `https://www.googleapis.com/*`
+
+> Google's own endpoints, used only after the user signs in: the name and
+> picture of the signed-in account, Google Drive for backups the user asks for,
+> and Google Sheets for exports the user asks for.
+
+---
+
+## OAuth scope justifications
+
+The Google consent screen asks for these separately from the store.
+
+| scope | why |
+|---|---|
+| `userinfo.email` | To show which account is signed in, so the user can tell whose Drive a backup went to. |
+| `userinfo.profile` | The account's name and picture, shown in the panel so the signed-in account is visible at a glance. |
+| `drive.file` | To write backups to the user's own Drive. **This scope only ever sees files ScrapeX itself created** — it cannot read anything else in the user's Drive. |
+| `spreadsheets` | To write an export into a spreadsheet **the user chooses**. This is the "use my existing sheet" option; without it ScrapeX could only ever create new sheets and never write into one the user already has. |
+
+**Note for the privacy-practices form:** `drive.file` is non-sensitive.
+`spreadsheets` **is a sensitive scope**. While the listing is unlisted and
+published to trusted testers this needs no Google verification. It would
+trigger verification if the extension is ever published to a wide audience —
+that is the cost Decision 28 accepts in exchange for the "use my existing sheet"
+button.
+
+---
+
+## Data usage disclosures
+
+Answer these consistently with the privacy policy, which is tested against the
+manifest on every build.
+
+- **Does it collect personally identifiable information?** No — except the
+  signed-in account's own name, email and picture, which are shown to the user
+  and never sent anywhere.
+- **Health information?** No. **Financial information?** No — ScrapeX reads
+  published shop prices, not the user's own payments.
+- **Authentication information?** No. ScrapeX never asks for or stores a
+  password for any site.
+- **Personal communications, location, web history, user activity?** No.
+- **Website content?** **Yes** — the published pages of the sites the user
+  explicitly adds. This is the product's purpose and must be declared.
+- **Do you sell or transfer data to third parties?** No.
+- **Do you use it for anything unrelated to the single purpose?** No.
+- **Do you use it to determine creditworthiness or for lending?** No.
+
+---
+
+## Still needed from the owner
+
+- [ ] **One screenshot, 1280×800.** The panel with real data is the honest
+      choice — but check it for anything you do not want public: source keys,
+      supplier names, the shape of your own price data.
+- [ ] Category and language for the listing.
+- [ ] The store item ID, once created — **compare it against the pinned key's
+      id `hlamngednfddacoabhoapfkpaedgbapp` before anything else.** If they
+      differ, Google sign-in will break in the published build only.


### PR DESCRIPTION
Draft for review, not for pasting unread.

Every permission and scope justified here is **read out of `extension/manifest.json`**, not remembered — a listing that promises something the manifest does not do is the first thing a reviewer looks for.

### `nativeMessaging` gets the longest justification on purpose

It is the permission that reaches outside the browser and the one read hardest. Softening it is the wrong instinct; the honest version is stronger:

> ScrapeX keeps data on the user's own machine. A browser extension cannot write to a local database or run a crawl on a schedule, so native messaging is the only channel to the program that does. The other end is on the same machine, installed by the user, and the panel refuses to talk to it when the versions disagree.

### The two uncomfortable answers are given plainly

- **Website content IS collected** — that is the product, and hiding it in a "no" is how a listing gets pulled later.
- **`spreadsheets` IS a sensitive scope.** It costs nothing while the listing is unlisted to trusted testers, and would trigger Google verification if ever published widely. That is the price Decision 28 accepts for the "use my existing sheet" button.

### And the character counts are counted

I wrote 119 and 128 from impression. They are **105** and **123**. Both fit under the 132 limit — but a number nobody measured had no business sitting next to a hard limit the owner is about to paste against.

### Still needed from the owner

- One screenshot, 1280×800 — the panel with real data is the honest choice, but check it for source keys and supplier names you do not want public
- Category and language
- **The store item id, compared against the pinned key's `hlamngednfddacoabhoapfkpaedgbapp` before anything else** — if they differ, Google sign-in breaks in the published build only

Generated with [Claude Code](https://claude.com/claude-code)
