### PR TITLE
The engine row says what it knows, instead of "unknown"

### DIFF
--- a/extension/app.html
+++ b/extension/app.html
@@ -1092,7 +1092,7 @@
           <div class="kv"><span>Status</span><span id="engine-status">Checking…</span></div>
           <div class="kv"><span>Installed version</span>
             <span class="tech" id="engine-installed-version">—</span></div>
-          <div class="kv"><span>Latest on GitHub</span>
+          <div class="kv"><span>Latest released</span>
             <span class="tech" id="engine-latest-version">—</span></div>
           <div class="kv"><span>Protocol</span>
             <span class="tech" id="engine-protocol-row">—</span></div>

--- a/extension/app.js
+++ b/extension/app.js
@@ -1956,10 +1956,18 @@ async function renderEngines() {
 
   if (!latestRelease) latestRelease = await latestEngineRelease();
   const latest = latestRelease;
+  // "unknown" MEANS WE COULD NOT FIND OUT, and for `none` that is false: we
+  // asked, the endpoint answered, and the answer was that nothing has been
+  // released. Collapsing the two threw away a distinction the reader is built
+  // to make — and the row then contradicted the sentence directly beneath it,
+  // which said we had checked. Found by looking at the panel, not by a test:
+  // four guards cover the reader and none covered the row that displays it.
   $("engine-latest-version").textContent =
-    latest.state === "ok" ? latest.version : "unknown";
-  // The detail line carries WHY it is unknown, which is the whole difference
-  // between a row worth reading and a row nobody reads twice.
+    latest.state === "ok" ? latest.version
+    : latest.state === "none" ? "none yet"
+    : "unknown";
+  // The detail line carries WHY, which is the whole difference between a row
+  // worth reading and a row nobody reads twice.
   $("engine-latest-detail").textContent = latest.state === "ok"
     ? (latest.installer
         ? ""

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -3058,10 +3058,37 @@ def test_the_engine_page_reports_what_is_installed_and_what_is_available(open_pa
 
     # THE DEFAULT IS TODAY'S TRUTH: no engine release has been cut, so the
     # version manifest is not on the delivery endpoint yet and the request 404s.
-    # The page says that in words. A bare em dash here would read as "we could
-    # not check", which is a different fact with a different remedy.
-    assert text_of(page, "#engine-latest-version") == "unknown"
+    #
+    # THIS ASSERTION USED TO SAY "unknown" AND WAS PINNING A DEFECT. "unknown"
+    # means we could not find out; here we asked, the endpoint answered, and the
+    # answer was that nothing is released. The row therefore contradicted the
+    # sentence directly beneath it, which said we had checked. Found by looking
+    # at the panel — four guards covered the reader and none covered the row.
+    assert text_of(page, "#engine-latest-version") == "none yet"
     assert "No engine has been released yet" in text_of(page, "#engine-latest-detail")
+
+
+def test_the_latest_row_never_contradicts_the_sentence_under_it(open_panel):
+    """THE GENERAL FORM OF THE DEFECT ABOVE, so it cannot come back in another
+    state. The reader distinguishes four outcomes; the row is allowed to
+    summarise them, but never to say the opposite of the line beneath it.
+
+    "unknown" is a claim about OUR knowledge, and it may only appear when we
+    genuinely could not find out.
+    """
+    page = open_panel()
+    page.click("#tab-engines")
+    page.wait_for_function(
+        "() => document.getElementById('engine-latest-detail').textContent !== ''",
+        timeout=10_000)
+
+    value = text_of(page, "#engine-latest-version")
+    detail = text_of(page, "#engine-latest-detail")
+
+    if "has been released yet" in detail:
+        assert value != "unknown", (
+            f"the row says {value!r} — we could not find out — while the "
+            f"sentence under it says we did: {detail!r}")
 
 
 def test_a_published_engine_release_is_shown_by_its_version(open_panel):


### PR DESCRIPTION
The engine row says what it knows, instead of "unknown"

Found by looking at the panel, not by a test. The Engine page showed

    Latest released     unknown
    No engine has been released yet.

and those two lines contradict each other. "unknown" is a claim about OUR
knowledge -- we could not find out. Here we asked, the endpoint answered with a
404, and the answer was that nothing is released. The reader distinguishes four
outcomes on purpose; the row collapsed every one that was not `ok` into a single
word and threw the distinction away.

It says "none yet" for `none` now, matching "Available: None yet" on the card
below it.

AND THE LABEL WAS STALE. "Latest on GitHub" was true while the panel read the
GitHub releases API. It has read a version manifest on raw.githubusercontent.com
since this morning, and the row is about the latest RELEASE, not about where it
was looked up.

THE TEST WAS PINNING THE DEFECT. test_panel_dom asserted the row equals
"unknown", which is why nothing caught this: the guard agreed with the bug. Four
tests cover the reader and none covered the row that displays what it worked out.

There is a general guard now: when the detail line says a release was checked
for, the row may not claim we could not find out. Proved by mutation.

Extension gate green, pytest exit 0. 43 JavaScript tests pass.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
