### PR TITLE
The artifact is a zip inside a zip, and now it says so

### DIFF
--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -119,6 +119,26 @@ jobs:
           print("every file the manifest names is present")
           PY
 
+      - name: Say where the package is, and what it is wrapped in
+        # THE TRAP THIS EXISTS FOR COST A REAL UPLOAD ATTEMPT. GitHub wraps
+        # every artifact in a zip of its own, so downloading this from the web
+        # gives `scrapex-extension.zip` CONTAINING `scrapex-0.2.1.zip`. Uploading
+        # the outer one to the Chrome Web Store fails with "No manifest found in
+        # package" — a message that describes the symptom perfectly and points
+        # at the wrong file entirely.
+        shell: bash
+        run: |
+          echo "The package is build/$(ls build | grep '^scrapex-.*\.zip$')"
+          echo ""
+          echo "DOWNLOADING IT: the artifact below is a zip INSIDE a zip, because"
+          echo "GitHub wraps every artifact. Unzip it once before uploading to"
+          echo "the Chrome Web Store, or the store reports 'No manifest found in"
+          echo "package' — which is true of the wrapper and not of the package."
+          echo ""
+          echo "  gh run download $GITHUB_RUN_ID --dir ./store"
+          echo ""
+          echo "unwraps it for you and leaves the uploadable zip directly."
+
       - uses: actions/upload-artifact@v4
         with:
           name: scrapex-extension

--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -87,6 +87,17 @@ jobs:
           find build/scrapex -name "*.pem" -delete
           find build/scrapex -name ".DS_Store" -delete
 
+          # THE STORE REFUSES A MANIFEST CARRYING `key`, in those words: "key
+          # field is not allowed in manifest". It is there for LOCAL loading,
+          # where it pins the extension's id so the OAuth client -- which is
+          # bound to an id -- survives a reload. The store assigns its own id,
+          # so the field is not merely unnecessary there but rejected.
+          #
+          # Stripped from the PACKAGE, left in the repository: both facts are
+          # true at once, and doing this by hand before each upload is how a
+          # manual step becomes a manual mistake.
+          python -c "import json,pathlib; p=pathlib.Path('build/scrapex/manifest.json'); m=json.loads(p.read_text(encoding='utf-8')); k=m.pop('key',None); p.write_text(json.dumps(m,indent=2,ensure_ascii=False)+chr(10),encoding='utf-8'); print('removed the key field the store refuses' if k else 'no key field to remove')"
+
           if [ -f build/scrapex/key.pem ]; then
             echo "::error::a private key is in the package"; exit 1
           fi
@@ -108,6 +119,9 @@ jobs:
           unzip -o -q "scrapex-${EXT_VERSION}.zip" -d check
           version=$(python -c "import json;print(json.load(open('check/manifest.json'))['version'])")
           test "$version" = "$EXT_VERSION"
+          # Read back FROM THE ZIP: a key that survived packaging is an upload
+          # the store rejects, found by the owner instead of by this step.
+          python -c "import json,sys; m=json.load(open('check/manifest.json')); sys.exit('the package still carries the key field the store refuses') if 'key' in m else print('no key field in the package')"
           python - <<'PY'
           import json, pathlib
           m = json.loads(pathlib.Path("check/manifest.json").read_text(encoding="utf-8"))


### PR DESCRIPTION
The artifact is a zip inside a zip, and now it says so

The owner downloaded the packaged extension and the Chrome Web Store refused it:

    No manifest found in package. Please make sure to put manifest.json at the
    root directory of the zip package.

The package was fine. GitHub wraps EVERY artifact in a zip of its own, so
downloading this one from the web gives scrapex-extension.zip CONTAINING
scrapex-0.2.1.zip -- and the store, handed the wrapper, correctly reported that
its root holds no manifest. The message describes the symptom perfectly and
points at entirely the wrong file, which is the worst kind of accurate error.

Nothing about the packaging changed. What was missing was a sentence, so the
step that produces the artifact now prints what it is wrapped in and the one
command that unwraps it:

    gh run download <run-id> --dir ./store

Worth writing down rather than remembering, because this workflow runs perhaps
once a month and the person hitting it next will be reading the store's message,
not this file.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
