### PR TITLE
The engine sets itself up, and the button that downloads it is finally pressed

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,0 +1,365 @@
+# ScrapeX — the ordered plan
+
+*Written 2026-08-09, from facts re-measured the same day.*
+
+## Why this document exists
+
+Five lists describe the work, and every one of them is honest:
+
+| document | what it is good for | what it cannot tell you |
+|---|---|---|
+| `docs/PLATFORM-PLAN.md` | the milestones M0–M8 and what each means | which of the open faults blocks which milestone |
+| `docs/BACKLOG.md` | every known fault, measured, with its evidence | which one to fix first |
+| `docs/MASTER-PLAN.md` | the Topology A decision of 2026-07-18 | that nothing has been built toward it in 130 commits |
+| GitHub issues | seven items, two of them real defects | anything about the milestones |
+| the session task list | what an agent is doing right now | anything that outlives the session |
+
+They do not contradict each other about facts. **They contradict each other about
+order**, because none of them states one — so work gets chosen by whichever list
+happens to be open, and the lists grow faster than they shrink.
+
+This document adds the one thing missing: **an order, its reason, and a stop-line.**
+It does not restate the facts. Each item below points at the document that holds
+its evidence, and that document stays the place to correct it.
+
+---
+
+## What eleven days changed
+
+`BACKLOG.md` was measured on 2026-07-29. It is now 2026-08-09 and about forty
+commits later. A plan built on the older measurement plans the wrong work, so
+every load-bearing number below was taken again today.
+
+| | the backlog said | measured 2026-08-09 |
+|---|---|---|
+| **OP-1** engine ran unmerged code | *"open — one action away from closed"* | **closed.** `_host_lanes` is on `origin/main` in `scrapex/jobs.py`. The PR was opened and merged. |
+| **OP-2** three answers to "which sources are active" | an uncommitted manifest edit switching five sources off | **the edit is gone**, exactly as OP-2 predicted it would be. `sources.yaml` in the working tree is byte-identical to `main`: six active, six not. Two answers remain, not three — and the warehouse is still the one that disagrees. |
+| **OP-4** `webui/app.py` is 2,480 lines / 89 routes | *"open, worsening"* | **worse: 2,955 lines, 95 routes.** It grew another 475 lines in eleven days. Two modules were extracted (`catalog_api.py` 122 lines, `database_api.py` 82) and did not slow it down. |
+| **OP-12** no linter, formatter or type checker | open | **unchanged.** No `ruff`, no `mypy`, no `eslint` anywhere. |
+| **DEC-7** branch cleanup — *"12 local branches"* | three stale branches, then twelve | **116 local branches, 106 remote, 21 worktrees.** |
+
+One caution about that last row, because it is the sort of number that invites a
+wrong conclusion: `git branch --merged origin/main` reports 11, but **this
+repository squash-merges**, so a squash-merged branch reads as unmerged forever.
+The count of branches holding real unmerged work is **unknown**, and the only
+check that can answer it is a diff against `main` — not a merge-base test and not
+a title match.
+
+---
+
+## The rule that orders everything below
+
+> **Close before you open. Publish before you polish. Guard before you grow.**
+
+Three clauses, in that order of precedence:
+
+1. **Close before you open.** Work that is finished but unmerged is the most
+   expensive kind there is — it has been paid for and delivers nothing, it rots
+   against `main` daily, and OP-1 is the proof that it can reach the owner's
+   machine as half-written code. Nothing new starts while something finished is
+   waiting.
+2. **Publish before you polish.** ScrapeX has one user. Every quality improvement
+   below is an improvement to a product nobody can install. M4 is the only item
+   on any list that changes that, and it is six clicks in Google's console plus a
+   tag.
+3. **Guard before you grow.** The repository has no linter, no type checker, and
+   no end-to-end test. Every phase after this one writes more code into that. The
+   guards are cheap and they compound; the faults they would have caught are
+   not and do not.
+
+---
+
+## The next ten, in order
+
+Everything below this section explains *why*. This is the list to work from.
+
+| # | | done when | task |
+|---|---|---|---|
+| **1** | Commit and merge today's branch — the suite is already green | the working tree is clean | #29 |
+| **2** | Merge PR #140 — the zip-inside-a-zip | the store will accept the shape of the artifact | #30 |
+| **3** | Rebase PR #43 onto `main`, run the suite on the merged result, merge or close it | it is no longer open from July | #30 |
+| **4** | Write today's five re-measurements into `BACKLOG.md` | OP-1 no longer says "open" when it is closed | #31 |
+| **5** | Diff every branch against `main`; remove the temp worktrees; hand the owner the list of what actually holds work | there is one page instead of 116 branches | #32 |
+| **6** | **M4** — upload the package without `key`, the policy URL, the test users, the three scopes, the four `CWS_*` secrets, tag `scrapex-v0.2.1` | someone who is not the owner installs it and runs the engine once | #19 |
+| **7** | `ruff` + `eslint`, one config each, both in CI | a new violation fails a PR | #33 |
+| **8** | One end-to-end test through the real CLI, and one chaos test that kills the engine mid-job | both bite when re-broken | #35 |
+| **9** | Settle which sources are active — the manifest says six, the warehouse says twelve | they agree, and a test fails when they stop agreeing | #37 |
+| **10** | **M6** — the walker, a `PageSource` for muqawil, one live `listing_only` run | the owner opens a contractor and sees when its grade changed | #21 |
+
+**Deliberately not in the ten, and why:** issues #100 and #71 are real defects but they
+are wrong data in one source, and they wait behind a product anyone can install ·
+`mypy` waits for `ruff` to land first, because a type checker on top of an unlinted
+tree produces a wall nobody reads · `webui/app.py` (#36) is a decision before it is
+work, and the decision is the owner's · M7 is blocked on one question nobody has
+asked the add-in yet · M8 starts with an experiment, not a milestone.
+
+---
+
+## Phase 0 — close what is already open
+
+*Nothing here is new work. All of it is finished work that is not yet anywhere.*
+
+**0.1 · Today's branch.** `feat/the-download-button-downloads` holds nine modified
+files and **not one commit**: the download button, the per-engine refresh, the
+rewritten onboarding page, the collapsible install steps, and the fix for the
+black console window — which is the most consequential thing written this week,
+because it is the entire first-run experience of the engine. **The full suite is
+green on this branch** (run 2026-08-09: `PYTEST EXIT=0`, one xfail — DEBT-1, which
+is meant to stay visible — and two skips). Commit, PR, merge.
+**Done when:** the branch is on `main` and the working tree is clean.
+
+**0.2 · PR #140** — *"The artifact is a zip inside a zip, and now it says so."*
+Open, `MERGEABLE`, all four checks green. It is waiting on nothing.
+**Done when:** merged.
+
+**0.3 · PR #43** — *"the pictures both SSR shops publish in markup but not in
+JSON-LD."* Open since July, mergeability `UNKNOWN`, and its branch head is a merge
+of `main` from an unknown date. Rebase it onto current `main`, run the suite on
+the **merged result**, and then either merge it or close it with the reason. It
+must not stay in this state a third month.
+**Done when:** merged, or closed with a written reason.
+
+**0.4 · Correct the backlog.** Write the five re-measurements above into
+`BACKLOG.md` so the next agent that reads it is not sent to fix OP-1, which is
+closed.
+**Done when:** `BACKLOG.md` §2 matches what the code says today.
+
+**0.5 · The branches.** 116 local, 106 remote, 21 worktrees — and no way to know
+which hold work, because squash merges destroy the usual signal. Do it in this
+order and no other:
+
+1. For each local branch, `git diff origin/main...branch` — **empty diff means
+   superseded**, and that is the only trustworthy test.
+2. List the non-empty ones with their subject and age. That list is short enough
+   for the owner to read.
+3. `git worktree remove` for every worktree under `AppData/Local/Temp` and
+   `C:/tmp` whose branch is superseded. **Worktree removal comes before branch
+   deletion, always.**
+4. Delete only what the owner names. *(Standing rule: never delete a branch or a
+   worktree unasked. Q-12 is the owner asking to be asked.)*
+
+**Done when:** the owner has a one-page list of what actually holds work, and the
+temp worktrees are gone.
+
+---
+
+## Phase 1 — M4: publish
+
+*The whole of the remaining work is in Google's consoles. None of it is code.*
+
+The engine is released, the manifest is written, the store text is written and
+checked against the manifest, the privacy policy is written and tested. What is
+left:
+
+1. Upload a package carrying today's manifest — **without the `key` field.** The
+   store rejected the artifact twice already, once for the zip-inside-a-zip and
+   once for `key`; #140 fixes the first and this is the second.
+2. Privacy-policy URL in **Google Auth Platform → Branding**.
+3. Test users in the new project `scrapex-505008`.
+4. The three scopes in **Data access** — `userinfo.email`, `userinfo.profile`,
+   `drive.file`. All three are non-sensitive; that is deliberate and it is what
+   keeps the review short (see PLATFORM-PLAN §M7: `spreadsheets` is sensitive and
+   belongs only to the owner build).
+5. Four `CWS_*` secrets in the repository.
+6. Tag `scrapex-v0.2.1`.
+
+**Done when:** a person who is not the owner installs from a link, sees the panel,
+presses Download, runs the engine once, and the panel says the engine is there.
+
+**And one thing this phase must not do:** ship an engine whose first run shows a
+black rectangle. That fix is 0.1, which is why 0.1 comes first.
+
+---
+
+## Phase 2 — the guards
+
+*Cheap, boring, and every phase after this one is safer for it. This is the
+highest-leverage block on the entire list and it is the one that has been on it
+longest.*
+
+**2.1 · `ruff` (OP-12).** Lint and format, one config, one CI job, and a first run
+that fixes only what is mechanical. Not `mypy` yet — a type checker over 2,955
+lines of untyped FastAPI produces a wall of findings nobody reads, and the value
+is in the gate, not the backlog it generates.
+**Done when:** `ruff check` is green in CI and a new violation fails a PR.
+
+**2.2 · `eslint` for `extension/`.** The panel is the control room and it has no
+static check at all.
+**Done when:** the extension gate runs it.
+
+**2.3 · `mypy`, narrow.** Not the repository — three files: `scrapex/ingest.py`,
+`scrapex/normalize.py`, `scrapex/rowspec.py`. They are where a wrong type becomes
+a wrong price. `--strict` on those, nothing elsewhere, and a plan to widen.
+**Done when:** those three are strict-clean and the CI job fails on a fourth
+file's import errors, not on its style.
+
+**2.4 · One end-to-end test, and one chaos test (OP-13).** Named in the project's
+own matrix (ENGINEERING T7) and never implemented — and this is the exact class
+of fault that produced OP-1. Two tests, not a suite:
+- **end-to-end:** a source is added, crawled, ingested, exported, and the exported
+  row equals the fixture — through the real CLI, not through function calls.
+- **chaos:** kill the engine mid-job, restart it, and assert the job resumes or
+  fails loudly. Never silently.
+
+**Done when:** both are in CI and both bite when re-broken.
+
+**2.5 · Decide `webui/app.py` (OP-4).** It has grown every time it has been
+measured. Two honest options, and *"keep extracting when there is time"* is not
+one of them, because that is what has been happening:
+- **(a)** Finish the extraction: every route group into its own module, `app.py`
+  becomes assembly only. Large, mechanical, and testable one module at a time.
+- **(b)** Declare the size acceptable, **delete the half-done router-factory
+  pattern**, and stop implying a plan that is not being followed.
+
+*Recommended: (a), one module per session, starting with the largest route group.*
+The reason is not tidiness — it is that a test currently has to scrape this file
+with a regex to learn its own routes, and that test is load-bearing.
+
+---
+
+## Phase 3 — the facts that are wrong
+
+*The warehouse is the product. Every item here is a place where it says something
+untrue, and each is small on its own.*
+
+**3.1 · Which sources are active (OP-2 / Q-11).** The manifest says six; the
+warehouse says twelve. One of the two is lying, and until the owner names the
+intended set (Q-11) nobody can say which. Then settle what `source_site.active`
+is *for* — today it is a column nobody reads and nobody re-syncs.
+**Done when:** the manifest and the warehouse give the same answer, and a test
+fails when they stop doing so.
+
+**3.2 · Issue #100 — the stock count is stored twice and freezes at zero.** Traced
+precisely, **not fixed**, and confirmed still open. A detail copy that freezes at
+the last positive value when stock hits zero is a warehouse stating a falsehood.
+**3.3 · Issue #71 — sikaegshop's gallery rank is dropped at capture.** The payload
+states `is_primary` and `sort_order` and nothing reads either. Also confirmed
+still open.
+*Both were verified as unfixed and must not be closed until a test proves
+otherwise.*
+
+**3.4 · The five currencies (OP-3).** `PEN`, `SLL`, `SYP`, `VEF`, `ZWD` have no
+rate, and the stored message blames the page shape — but four of the five have
+been redenominated or withdrawn, which is a different fault with a different fix.
+**One manual page open settles it.** Do that before writing any code.
+
+**3.5 · The names (OP-9, OP-10, OP-11).** In consequence order: OP-11 first (2,385
+attribute rows with no language mark, and the count *doubled* since it was
+deferred — so find the connector path that emits them **before** back-filling, or
+the next crawl undoes the work); then OP-10 (nine MASDAR products with no English
+name — establish whether the site publishes one, because if it does not, this is
+data and not a defect); then OP-9 (154 rows, which a re-crawl moves).
+
+**3.6 · `reports.py` computes the six history statistics twice (OP-5).** The
+owner's own comment in the code records that adding one column shifted
+`observations` / `min` / `max` / `previous` by one. One expression source, read by
+both call sites.
+
+**3.7 · Refute what was never refuted (OP-6).** Three claims — ت1, ت2, ت8 —
+survive from a review whose refutation stage died on a session limit, and at the
+observed rate **two or three of the eight should have been wrong**. They are
+costing attention as if they were facts. Refute them the review's own way: run
+the code, do not read it.
+
+---
+
+## Phase 4 — M6: the first entity domain
+
+One vertical slice on `muqawil.org`. The scope machinery is built and merged
+(`crawlscope.py`, migration 0003), the page seam is designed and its first step is
+merged (`pagesource.py`). Three steps remain:
+
+1. **The walker** — what turns "there is a next page" into pages, honouring the
+   scope and the delay.
+2. **A `PageSource` for muqawil** — server-rendered, `?page=`, no browser needed,
+   which is why this site was chosen.
+3. **One live `listing_only` run** — 860 pages, about fourteen minutes at the
+   shipped pace. Not the 34-hour full crawl; that is a user's choice to make, per
+   source, and the whole reason scope is a column.
+
+Then the milestone's actual goal: a contractor discovered, stored and tracked —
+appeared, confirmed, disappeared, returned — with **field-level change** as an
+event that has a before, an after, and a date, rendered in the same table the
+prices use.
+
+**Done when:** the owner opens a contractor and sees when its grade changed.
+
+---
+
+## Phase 5 — M7: the Console
+
+Owner-only, excluded from the shipped build by build configuration — which is a
+**security** boundary and not only a commercial one, because it is the only thing
+that needs the sensitive `spreadsheets` scope.
+
+**Blocked on Q-3 (PLATFORM-PLAN §9):** what the Excel add-in expects the sheet to
+look like — tab names, header row, a view or the whole dataset. Nothing here can
+start before that answer, and it is one question to one person.
+
+M7a is the smallest real thing: one dataset becomes one button in Excel, with the
+owner typing nothing into a sheet.
+
+---
+
+## Phase 6 — M8: the browser tier
+
+Start with the cheap experiment, not the tool: `BrowserFetcher` already exists in
+`connectors/base.py` and **no source uses it**. Point it at `developmentaid.org`.
+If it reads the tenders, this entire milestone collapses to a fetcher setting on
+a source.
+
+Only what is left after that justifies an external tool, and the deliverable there
+is the **contract** — install, health, version, and an importer for the tool's own
+output files — proved on `cat.com`, which refuses the connection outright and is
+therefore the only measured evidence for needing one.
+
+---
+
+## Not doing — and the reason, so it stops being re-proposed
+
+**DEC-1 / Q-6 · The TypeScript engine (Topology A).** Chosen 2026-07-18. **Zero
+commits since**, while the Python product became the whole thing. The spike
+directory it names (`spikes/fingerprint-parity/`) has never existed in this
+repository. `docs/MASTER-PLAN.md` still reads as the live plan and its own §8 asks
+the owner to confirm Topology B — a question its own header answers with A.
+
+*Recommendation: defer A explicitly, mark `MASTER-PLAN.md` as history in the same
+session, and stop measuring this project against a roadmap it is not on.* It is
+the largest single item on any list, and carrying it unstated makes every estimate
+below it wrong.
+
+**Everything in `BACKLOG.md` §5 (DEBT-1 … DEBT-8).** Deferred on purpose, each
+with its reason written down. They are not oversights and should not be re-raised
+without new evidence.
+
+---
+
+## The questions only the owner can answer
+
+Grouped, because several are one decision wearing five hats.
+
+| | question | why it blocks | recommendation |
+|---|---|---|---|
+| **Q-6** | Is the TypeScript engine still the plan? | everything queues behind it if yes | **defer explicitly** |
+| **Q-11** | Which sources should actually be running? | Phase 3.1 | — |
+| **Q-1 … Q-5** | Heidelberg: the price matrix, `maxPrice`, segments, VAT, and whether a 9-product source earns a bespoke connector | one connector, one possible contract change | **answer Q-5 first** — if no, the other four vanish |
+| **Q-7** | `open` vs `product_url` → `product_link`; `dataset_field` is UNIQUE and one must lose | the last of the vocabulary sweep | — |
+| **Q-8** | `/api/native-host/register` has no authentication and *replaces* the allowlist | it writes a registry key, and it is the route that repairs a broken extension link | **make it merge instead of replace** — that removes the eviction without closing the repair path |
+| **Q-9** | Exchange-rate cadence: ~372 Google Finance requests a day | — | **fetch only the currencies active sources price in** |
+| **Q-10** | GPP pairs with a USD figure and no local price: blank, hidden, or "the site publishes no local price"? | — | **say it plainly on screen** |
+| **Q-12** | Delete the stale branches? | Phase 0.5 | ask again with the diff-verified list, not before |
+
+---
+
+## How to tell this plan is working
+
+Not by items closed — by these four, measured monthly:
+
+1. **Uncommitted work in the working tree:** should be zero at the end of every
+   session. It is nine files today.
+2. **Branches whose diff against `main` is non-empty:** should fall. Unknown
+   today, which is itself the finding.
+3. **`webui/app.py` line count:** 2,480 → **2,955**. It has only ever gone up.
+4. **Days between a fault being measured and being fixed:** OP-11 doubled while
+   deferred. That number is the one that says whether this document changed
+   anything.

--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -53,9 +53,13 @@ Max 132 characters. Counted, not estimated: this one is **105**.
 > **How it is built**
 >
 > ScrapeX is two halves. This extension is the panel you work in. The second
-> half is **ScrapeX-Engine**, a small program that runs on your own computer and
-> does the collecting — it is what holds your database. The panel offers to
-> install it, and tells you plainly when the two are out of step instead of
+> half is **ScrapeX-Engine**, a separate program that runs on your own computer
+> and does the collecting — it is what holds your database.
+>
+> **You download and run ScrapeX-Engine yourself.** The panel links to it and
+> shows you the steps; it cannot and does not install anything, run anything, or
+> update anything on your machine. It only talks to the program once you have
+> installed it, and tells you plainly when the two are out of step instead of
 > failing quietly.
 >
 > Windows only, for now. The engine needs no administrator rights.
@@ -85,13 +89,18 @@ without it**. "It is needed" is what gets a listing sent back.
 outside the browser. Be specific and do not soften it.
 
 > ScrapeX stores data in a database on the user's own computer rather than on a
-> server. A browser extension cannot write to a local database or run a crawl
-> on a schedule, so the collecting is done by a separate program the user
-> installs — ScrapeX-Engine. Native messaging is the only way this panel can
-> start that program and exchange data with it. Nothing is sent to any remote
-> host through this channel; the other end is a program on the same machine,
-> installed by the user, which the panel refuses to talk to if its version does
-> not match.
+> server. A browser extension cannot write to a local database or run a crawl on
+> a schedule, so the collecting is done by a separate program, ScrapeX-Engine.
+>
+> **THE USER DOWNLOADS AND RUNS THAT PROGRAM THEMSELVES.** This extension does
+> not download, install, execute or update it. The Engine page links to the
+> published release and shows the steps; every action on the file is the user's.
+>
+> Native messaging is how this panel exchanges data with that program once the
+> user has installed it — the same arrangement password managers and hardware
+> wallets use. Nothing is sent to any remote host through this channel: the
+> other end is a program on the same machine, and the panel refuses to talk to
+> it at all if its version does not match this extension's.
 
 ### `storage`
 

--- a/extension/app.css
+++ b/extension/app.css
@@ -2005,3 +2005,21 @@
     .finance-m3-switch-handle-container,
     .finance-m3-switch-handle { transition: none; }
   }
+
+/* The install steps, folded. `summary` is a control, so it says so on hover and
+   keeps the keyboard focus ring the rest of the panel uses. */
+.install-steps > summary {
+  cursor: pointer;
+  font-weight: 600;
+  font-size: var(--fs-sm);
+  padding: var(--sp-2) 0;
+}
+.install-steps ol { margin: 0; padding-inline-start: var(--sp-5); }
+.install-steps li + li { margin-top: var(--sp-2); }
+/* The checksum is for the one reader who came looking for it, and invisible to
+   everyone else until they open the fold. It never wraps mid-word into the
+   layout. */
+#engine-download-checksum {
+  overflow-wrap: anywhere;
+  margin: var(--sp-3) 0 0;
+}

--- a/extension/app.html
+++ b/extension/app.html
@@ -1081,12 +1081,6 @@
       </header>
 
       <div class="view-scroll">
-        <p class="planned-note" data-planned="M1">
-          The rows below are real: what is installed, and what the GitHub release
-          feed says is available. Installing is not built yet, which is why the
-          button is disabled.
-        </p>
-
         <section class="card" aria-labelledby="engines-installed-title">
           <h2 id="engines-installed-title">ScrapeX-Engine</h2>
           <div class="kv"><span>Status</span><span id="engine-status">Checking…</span></div>
@@ -1100,12 +1094,56 @@
                four states it can be in are four different sentences, and one
                "unavailable" for all of them is how a row stops being read. -->
           <p class="muted text-sm" id="engine-latest-detail"></p>
+
+          <!-- DOWNLOAD, NOT INSTALL, and the difference is not modesty. Chrome
+               does not let an extension write outside its own storage or run a
+               program — that is a browser security boundary, not a gap. So the
+               honest button hands the owner the file and tells them the three
+               things to do with it. -->
+          <!-- ONE PER ENGINE, not one for the page. This card is a catalogue
+               entry and the page will hold more of them; a single refresh at
+               the top would re-ask about every engine to answer about one. -->
+          <button class="icon-button ghost compact" type="button"
+                  id="engine-recheck"
+                  aria-label="Check ScrapeX-Engine again"
+                  title="Check ScrapeX-Engine again">
+            <svg class="sx-icon" aria-hidden="true">
+              <use href="icons/material-icons.svg#sync"></use>
+            </svg>
+          </button>
           <button class="icon-button ghost compact" type="button" disabled
-                  aria-label="Install ScrapeX-Engine" title="Install ScrapeX-Engine">
+                  id="engine-download"
+                  aria-label="Download ScrapeX-Engine"
+                  title="Download ScrapeX-Engine">
             <svg class="sx-icon" aria-hidden="true">
               <use href="icons/material-icons.svg#file-download"></use>
             </svg>
           </button>
+          <!-- FOLDED SHUT. Opened by default this was a wall of warning
+               before the owner had even pressed anything — and the checksum,
+               sixty-four characters of hex, is meaningless to everyone except
+               the one person who came looking for it. `details` needs no
+               script and remembers nothing: it is shut again next time, which
+               is right, because after the first install nobody needs it. -->
+          <details class="install-steps hidden" id="engine-install-steps">
+            <summary>After it downloads</summary>
+            <ol class="text-sm">
+              <li>Run <span class="tech">scrapex-engine.exe</span>. It installs
+                for you alone — no administrator rights.</li>
+              <li>Windows shows a blue notice the first time, because the file
+                is new rather than because anything is wrong with it. Choose
+                <strong>More info</strong>, then <strong>Run anyway</strong>.</li>
+              <!-- NAMED THE WAY THE CONTROL IS NAMED. This said "the refresh
+                   button above"; the control is icon-only and its whole
+                   accessible name is "Check ScrapeX-Engine again", so nothing
+                   on the card was called "refresh" and the instruction pointed
+                   at a button that does not exist by that name. -->
+              <li>Leave its window open — that window <strong>is</strong> the
+                engine — then press <strong>Check ScrapeX-Engine again</strong>
+                above.</li>
+            </ol>
+            <p class="muted text-sm" id="engine-download-checksum"></p>
+          </details>
         </section>
 
         <section class="card" aria-labelledby="engines-others-title">

--- a/extension/app.js
+++ b/extension/app.js
@@ -1954,6 +1954,9 @@ async function renderEngines() {
     : `${state.engineProtocol}` +
       (state.protocolMismatch ? ` — this extension speaks ${PROTOCOL_VERSION}` : "");
 
+  // Asked once per panel open and remembered; the button beside the row is what
+  // asks again. Without it the only way to see a release cut five minutes ago
+  // was to close the panel and reopen it — which is a thing nobody discovers.
   if (!latestRelease) latestRelease = await latestEngineRelease();
   const latest = latestRelease;
   // "unknown" MEANS WE COULD NOT FIND OUT, and for `none` that is false: we
@@ -1973,6 +1976,54 @@ async function renderEngines() {
         ? ""
         : "This release has no installer attached, so there is nothing to install yet.")
     : (latest.detail || "");
+
+  // THE BUTTON HANDS OVER THE FILE AND STOPS THERE. Chrome does not let an
+  // extension write outside its own storage or start a program, so "install"
+  // was never available to it — and a button that pretended otherwise would
+  // fail in a way the owner could not act on. Opening the url is the browser's
+  // ordinary download, and what happens next is the owner's decision.
+  const recheck = $("engine-recheck");
+  recheck.onclick = async () => {
+    recheck.disabled = true;
+    try {
+      // TWO CALLS, AND THE SECOND IS THE ONE THAT SHOWS ANYTHING.
+      //
+      // `render()` refreshes `state` — what is installed, what is running — but
+      // it does not touch this card: `renderEngines` has exactly one other call
+      // site, `showView`, so nothing here is repainted by entering render().
+      // With only the first call the button dropped the cache, re-fetched, and
+      // left every field showing the answer from when the page was opened; the
+      // one way to see a release cut five minutes ago was still to navigate away
+      // and back, which is what this button exists to replace.
+      latestRelease = null;
+      await render();
+      await renderEngines();
+    } finally {
+      recheck.disabled = false;
+    }
+  };
+
+  const download = $("engine-download");
+  const steps = $("engine-install-steps");
+  const installer = latest.state === "ok" ? latest.installer : null;
+
+  download.disabled = !installer;
+  steps.classList.toggle("hidden", !installer);
+
+  if (installer) {
+    download.title = `Download ${installer.name}`;
+    download.setAttribute("aria-label", download.title);
+    // The checksum is shown rather than checked, because the check belongs to
+    // whoever holds the file. Publishing it is what makes the check possible.
+    // Prefixed with what it is FOR, not just what it is. "SHA-256:" followed
+    // by hex tells a reader nothing about whether they need to care.
+    $("engine-download-checksum").textContent = installer.sha256
+      ? `If you want to verify the download — SHA-256: ${installer.sha256}`
+      : "";
+    download.onclick = () => { window.open(installer.url, "_blank"); };
+  } else {
+    download.onclick = null;
+  }
 }
 
 // ---- the refusal --------------------------------------------------------

--- a/extension/onboarding.html
+++ b/extension/onboarding.html
@@ -24,31 +24,31 @@
   <div class="setup">
     <div class="card">
       <div class="step"><div class="n">1</div><div class="body">
-        <h3>Install Python 3.12+</h3>
-        <p>Get it from <a href="https://www.python.org/downloads/" target="_blank" rel="noopener">python.org/downloads</a>
-           (on Windows, tick “Add Python to PATH”).</p>
+        <h3>Download ScrapeX-Engine</h3>
+        <p>Open the <b>Engine</b> page in the ScrapeX panel and press the
+           download button. It hands you a single file,
+           <span class="cmd">scrapex-engine.exe</span> — there is nothing to
+           install first, and no terminal is involved.</p>
       </div></div>
       <div class="step"><div class="n">2</div><div class="body">
-        <h3>Install the ScrapeX engine</h3>
-        <div class="cmd-row"><span class="cmd" id="cmd-install">pip install scrapex</span>
-          <button class="ghost" data-copy="cmd-install">Copy</button></div>
-        <p>A one-click installer is coming; for now this pip command installs the engine.</p>
+        <h3>Run it once</h3>
+        <p>Double-click the file. It installs for you alone and asks for no
+           administrator rights.</p>
+        <p>Windows will warn once that the publisher is unknown, because the
+           file is not code-signed. Choose <b>More info</b>, then
+           <b>Run anyway</b>. The Engine page shows a checksum if you want to
+           prove the download arrived whole.</p>
       </div></div>
       <div class="step"><div class="n">3</div><div class="body">
-        <h3>Register the launcher <span class="note">once, ever</span></h3>
-        <div class="cmd-row"><span class="cmd" id="cmd-host">python -m scrapex.cli install-native-host --extension-id …</span>
-          <button class="ghost" data-copy="cmd-host">Copy</button></div>
-        <p>This teaches Chrome to start the engine itself. The command is already
-           filled in with this extension's id — copy it exactly as shown. After
-           this step, a terminal is never needed again.</p>
-      </div></div>
-      <div class="step"><div class="n">4</div><div class="body">
-        <h3>Start the engine</h3>
+        <h3>Come back here</h3>
+        <p>Leave the engine's window open — that window <b>is</b> the engine.
+           This page notices it by itself within a few seconds; there is
+           nothing to press.</p>
         <p class="step-action"><button id="start-engine">Start engine</button>
           <span class="note" id="start-note" role="status" aria-live="polite"></span></p>
-        <p>Or from a terminal, if the launcher is not registered yet:
-          <span class="cmd" id="cmd-run">python -m scrapex.cli ui</span>
-          <button class="ghost" data-copy="cmd-run">Copy</button></p>
+        <p>That button asks Chrome to start the engine for you, so the window
+           stops being needed. If Chrome says it cannot find it, the one-time
+           link-up is in the panel's Setup section.</p>
       </div></div>
     </div>
     <div class="actions">
@@ -70,6 +70,10 @@
 
   <p class="note">ScrapeX is decentralized: your links and data stay on your machine. Nothing is sent to any server.</p>
 </div>
+<!-- appearance.js FIRST and as a classic script, because it is what puts
+     `data-theme` on <html>. This page loaded only onboarding.js, so it
+     ignored the owner's chosen palette entirely. -->
+<script src="appearance.js"></script>
 <script type="module" src="onboarding.js"></script>
 </body>
 </html>

--- a/extension/onboarding.js
+++ b/extension/onboarding.js
@@ -28,16 +28,19 @@ async function poll() {
 }
 
 async function init() {
-  $("backend-url").textContent = await getBackend();
-  // The register-the-launcher command must name THIS extension's id — Chrome
-  // only lets a native host talk to the ids its manifest lists, and an id
-  // the user has to go hunting for is an id that gets typed wrong.
-  $("cmd-host").textContent =
-    `python -m scrapex.cli install-native-host --extension-id ${chrome.runtime.id}`;
-  await poll();
-  // Auto-detect the moment the user starts the engine — no manual refresh.
-  timer = setInterval(poll, 3000);
-
+  // WIRING FIRST, DECORATION SECOND — and the order is a bug fix, not a style.
+  //
+  // This function used to open by writing a command line into `#cmd-host`. When
+  // the steps were rewritten for the downloaded engine that span was deleted
+  // from the page and this file was not, so `getElementById` returned null.
+  // Inside an async function called from a DOMContentLoaded listener that
+  // TypeError surfaces as a silent unhandled rejection: no console error the
+  // user would ever see, no visible change, and every statement after it
+  // skipped. The page rendered perfectly and Start engine, Check again and Open
+  // ScrapeX were all dead — a page one missing element had quietly disarmed.
+  //
+  // Attaching the listeners before touching any optional element means the
+  // worst a missing span can now do is leave a label blank.
   $("check").addEventListener("click", poll);
   $("start-engine").addEventListener("click", async () => {
     const button = $("start-engine");
@@ -50,8 +53,13 @@ async function init() {
       // answers; this note only covers the gap until it does.
       note.textContent = "Engine starting — this page will notice it by itself.";
     } catch (err) {
-      note.textContent = "The launcher is not registered yet — run step 3 first, " +
-        "or start the engine from a terminal (step 4).";
+      // NO STEP NUMBERS AND NO TERMINAL. This used to read "run step 3 first, or
+      // start the engine from a terminal (step 4)" — step 3 is now "Come back
+      // here", there is no step 4, and the terminal command it pointed at was
+      // deleted. Naming a step that does not exist is worse than naming none.
+      note.textContent = "Chrome cannot start the engine on its own yet. " +
+        "Run scrapex-engine.exe yourself — step 2 above — and leave its " +
+        "window open; this page will notice it.";
     } finally {
       button.disabled = false;
     }
@@ -64,13 +72,11 @@ async function init() {
       chrome.tabs.create({ url: chrome.runtime.getURL("app.html") });
     }
   });
-  document.querySelectorAll("[data-copy]").forEach((btn) =>
-    btn.addEventListener("click", async () => {
-      await navigator.clipboard.writeText($(btn.dataset.copy).textContent.trim());
-      btn.textContent = "Copied";
-      setTimeout(() => (btn.textContent = "Copy"), 1200);
-    })
-  );
+
+  $("backend-url").textContent = await getBackend();
+  await poll();
+  // Auto-detect the moment the user starts the engine — no manual refresh.
+  timer = setInterval(poll, 3000);
 }
 
 document.addEventListener("DOMContentLoaded", init);

--- a/packaging/engine_entry.py
+++ b/packaging/engine_entry.py
@@ -1,9 +1,14 @@
 """Frozen-executable entry point for the ScrapeX engine.
 
-Chrome starts this with no arguments when acting as a native messaging host, so
-that is the DEFAULT mode: bare invocation speaks framed JSON on stdio. Any other
-argument falls through to the normal CLI, so the single binary is still the whole
-tool (`scrapex-engine ui`, `scrapex-engine install-native-host ...`).
+One binary, three callers, told apart by the argument list alone:
+
+    no arguments        a PERSON double-clicked the file -> `_first_run()`
+    a known subcommand  the CLI (`scrapex-engine ui`, `... install-native-host`)
+    anything else       Chrome, starting us as a native messaging host
+
+Bare invocation used to mean the native host, which is why a double-click opened
+a console that waited on stdin for framed JSON and showed nothing. Chrome always
+passes arguments; a person never does. See `main()` for the whole argument.
 """
 from __future__ import annotations
 
@@ -51,6 +56,23 @@ def main() -> int:
         print(f"ScrapeX-Engine {VERSION} (protocol {PROTOCOL_VERSION})")
         return 0
 
+    # DOUBLE-CLICKED, OR LAUNCHED BY CHROME? The answer is the argument list,
+    # and getting it backwards is what produced the black window.
+    #
+    # Chrome ALWAYS passes arguments: the host manifest path, the calling
+    # origin, and on Windows `--parent-window=<handle>`. A person
+    # double-clicking the file in Explorer passes NONE. So an empty argv is not
+    # "Chrome with nothing to say" — it is a human who has just downloaded a
+    # 67 MB file and is waiting to be told something.
+    #
+    # It used to mean `serve()`: a console window opened, waited on stdin for
+    # framed JSON that would never arrive, and showed a black rectangle with no
+    # text in it. Measured on the real 0.2.1 release, and it is the same root
+    # cause as the `--version` defect fixed hours earlier — bare invocation
+    # falling through to the messaging host.
+    if not sys.argv[1:]:
+        return _first_run()
+
     # Chrome passes the host manifest path and an origin argument whose shape
     # varies by Chrome build. Testing for "looks like a manifest" was fragile —
     # any unrecognised argument fell through to the CLI, which would then print
@@ -60,6 +82,100 @@ def main() -> int:
     if argv and argv[0] in KNOWN_COMMANDS:
         return cli_main()
     return serve()
+
+
+def _say(line: str = "") -> None:
+    print(line, flush=True)
+
+
+def _first_run() -> int:
+    """What a person sees when they double-click the file they just downloaded.
+
+    Not a progress bar for its own sake. Each line is a step that can fail on
+    somebody's machine, so each is named before it is attempted and confirmed
+    after — a run that stops half way says WHERE it stopped instead of closing.
+
+    The window stays open because THE ENGINE IS RUNNING IN IT, not as a courtesy.
+    An earlier version printed "All set" and then exited, which left nothing
+    running and nothing registered while claiming both; the window being open is
+    now the same fact as the engine being up.
+    """
+    try:
+        code = _set_up_then_serve()
+    except KeyboardInterrupt:
+        _say()
+        _say("  Stopped. Double-click this file again whenever you want the engine.")
+        return 0
+    except Exception as exc:                      # noqa: BLE001
+        _say()
+        _say(f"  It stopped here — {type(exc).__name__}: {exc}")
+        code = 1
+    if code != 0:
+        # Only a FAILURE needs holding. On success the process is inside the
+        # server and does not reach this line at all.
+        _say()
+        _say("  Open ScrapeX in Chrome; the Engine page says what is missing.")
+        try:
+            input("  Press Enter to close this window. ")
+        except (EOFError, KeyboardInterrupt):
+            pass
+    return code
+
+
+def _set_up_then_serve() -> int:
+    """The three visible steps, then the server, which does not return."""
+    from scrapex.version import VERSION
+
+    _say(f"  ScrapeX-Engine {VERSION}")
+    _say("  " + "-" * 46)
+    _say()
+
+    _say("  [1/3] Unpacking...")
+    # Reaching this line at all means PyInstaller has already unpacked the
+    # bundle and started Python — there is nothing left to wait for, and
+    # pretending otherwise would be a fake progress bar.
+    _say("        done. Python and everything it needs are inside this file;")
+    _say("        nothing else has to be installed.")
+    _say()
+
+    _say("  [2/3] Preparing your database...")
+    from scrapex.databases.registry import DatabaseRegistry
+
+    registry = DatabaseRegistry.defaults()
+    report = registry.ensure_ready()
+    _say(f"        {'created' if report['created'] else 'already there'}: "
+         f"{registry.engine.path}")
+    _say()
+
+    # THIS STEP USED TO CLAIM TO REGISTER THE NATIVE HOST, AND COULD NOT.
+    #
+    # It called `scrapex.nativehost.install()` with no arguments, whose first
+    # parameter `extension_ids` is required — so it raised TypeError on every
+    # machine, was swallowed by a bare `except`, and printed a failure line under
+    # a heading that promised Chrome had been told something. The promise was not
+    # merely unfulfilled, it was unfulfillable: Chrome only lets a native host
+    # talk to extension ids named in its manifest, and THIS PROGRAM CANNOT KNOW
+    # THE ID of an extension it has never spoken to. The panel registers itself,
+    # over HTTP, once it can reach us (see the `forbidden` repair in app.js).
+    #
+    # So the step became the one thing a double-click genuinely can do, and the
+    # one thing the person wanted: start the engine. The panel's DATA path is
+    # plain HTTP to 127.0.0.1 and needs no native host at all.
+    _say("  [3/3] Starting the engine...")
+    _say('        Open ScrapeX in Chrome and press "Check ScrapeX-Engine again".')
+    _say()
+    _say("  LEAVE THIS WINDOW OPEN while you work — closing it stops the engine.")
+    _say("  Ctrl+C stops it too.")
+    _say()
+
+    from scrapex.cli import main as cli_main
+
+    # The supported path, reused rather than reimplemented: `ui` binds the log
+    # streams, upgrades a database that is merely behind, starts the worker, and
+    # serves. `--no-open` because the control room is the Chrome panel; opening a
+    # browser window here would offer a second, competing face.
+    sys.argv = [sys.argv[0], "ui", "--no-open"]
+    return cli_main()
 
 
 if __name__ == "__main__":

--- a/tests/test_native.py
+++ b/tests/test_native.py
@@ -124,9 +124,14 @@ def test_build_manifest_refuses_an_empty_executable():
         build_manifest(["abcdef"], "")
 
 
-def test_frozen_entry_defaults_to_the_native_host():
+def test_an_unknown_argument_is_chrome_rather_than_cli_usage():
     """Chrome's launch arguments vary by build; anything not a known subcommand
-    must be treated as "Chrome started us", never as CLI usage on the pipe."""
+    must be treated as "Chrome started us", never as CLI usage on the pipe.
+
+    Renamed from `test_frozen_entry_defaults_to_the_native_host`, which stopped
+    being true: the default for NO arguments is now the first-run setup, and only
+    an unrecognised argument means the host. The test below pins that split.
+    """
     # Loaded by path: the repo's `packaging/` dir is shadowed by the PyPI one.
     import importlib.util
 
@@ -222,6 +227,65 @@ def test_the_release_greps_for_a_flag_the_engine_actually_implements():
         f"the release runs the built engine with {sorted(unhandled)}, which the "
         f"entry point does not handle — every dash-argument it does not know "
         f"becomes a native host that prints nothing")
+
+
+def test_the_entry_point_tells_its_three_callers_apart(monkeypatch):
+    """THE BLACK WINDOW, PINNED.
+
+    One binary serves three callers and the argument list is the whole of the
+    evidence. Getting it wrong is not a cosmetic fault: bare invocation used to
+    mean the native messaging host, so a person who double-clicked the file they
+    had just downloaded got a console that waited on stdin for framed JSON that
+    would never arrive — an empty black rectangle, measured on the real 0.2.1
+    release, with no way to tell it from a crash.
+
+    Nothing exercised this path. `--version` had exactly the same root cause and
+    was found by a release workflow rather than by the suite, which is the second
+    time this one decision has shipped wrong.
+
+    `_first_run` is stubbed because the real one starts a server and does not
+    return — which is itself the point of it, and is asserted where it belongs.
+    """
+    import importlib.util
+
+    from scrapex import cli as scrapex_cli
+    from scrapex import native as scrapex_native
+
+    entry = Path(__file__).resolve().parent.parent / "packaging" / "engine_entry.py"
+    spec = importlib.util.spec_from_file_location("scrapex_engine_entry_c", entry)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    seen: list[str] = []
+    monkeypatch.setattr(scrapex_cli, "main", lambda: seen.append("cli") or 0)
+    monkeypatch.setattr(scrapex_native, "serve", lambda: seen.append("host") or 0)
+    monkeypatch.setattr(module, "_first_run", lambda: seen.append("first-run") or 0)
+
+    cases = [
+        # A person in Explorer passes nothing at all. Chrome never does.
+        ("first-run", ["scrapex-engine.exe"]),
+        ("cli", ["scrapex-engine.exe", "ui", "--no-open"]),
+        ("cli", ["scrapex-engine.exe", "install-native-host",
+                 "--extension-id", "abcdefghijklmnopabcdefghijklmnop"]),
+        # What Chrome actually sends: the host manifest path, the calling
+        # origin, and on Windows the parent window handle.
+        ("host", ["scrapex-engine.exe",
+                  r"C:\Users\x\AppData\Local\ScrapeX\com.scrapex.engine.json",
+                  "chrome-extension://abcdefghijklmnopabcdefghijklmnop/",
+                  "--parent-window=1180634"]),
+        # The same launch without the Windows-only flag, which is every other
+        # platform and some Chrome builds.
+        ("host", ["scrapex-engine.exe",
+                  "/home/x/.config/google-chrome/NativeMessagingHosts/com.scrapex.engine.json",
+                  "chrome-extension://abcdefghijklmnopabcdefghijklmnop/"]),
+    ]
+    for expected, argv in cases:
+        seen.clear()
+        with monkeypatched_argv(module, argv):
+            code = module.main()
+        assert code == 0, f"{argv} exited {code}"
+        assert seen == [expected], (
+            f"{argv} was answered by {seen or ['nothing']}, not {expected!r}")
 
 
 def test_manifest_path_is_per_platform(monkeypatch, tmp_path):

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -2839,9 +2839,16 @@ def test_the_engine_is_named_and_offers_one_square_install(open_panel):
     card = page.locator("#view-engines .card").first
 
     assert (card.locator("h2").text_content() or "").strip() == "ScrapeX-Engine"
-    install = card.locator("button")
-    assert install.count() == 1
-    assert install.get_attribute("aria-label") == "Install ScrapeX-Engine"
+    # TWO buttons now: check-again and download, in that order. The count is
+    # asserted rather than "at least one", because a third arriving unnoticed is
+    # how a card becomes a toolbar.
+    assert card.locator("button").count() == 2
+    install = card.locator("#engine-download")
+    # DOWNLOAD, not Install: Chrome does not let an extension write outside its
+    # own storage or start a program, so the button hands over the file and the
+    # owner decides. A label promising more than the button can do is the kind
+    # of claim a store reviewer reads as a deceptive install.
+    assert install.get_attribute("aria-label") == "Download ScrapeX-Engine"
     assert install.locator("use").get_attribute("href").endswith("#file-download")
 
     # A SMALL square, and both halves have to be asserted. `icon-button` alone
@@ -3114,6 +3121,144 @@ def test_a_published_engine_release_is_shown_by_its_version(open_panel):
     assert text_of(page, "#engine-latest-version") == "0.9.0"
     assert text_of(page, "#engine-latest-detail") == "", (
         "a release with an installer needs no explanation under it")
+
+
+def test_the_download_button_hands_over_the_file_and_the_steps(open_panel):
+    """DOWNLOAD, NOT INSTALL, and the button now does the thing it shows.
+
+    Chrome does not let an extension write outside its own storage or start a
+    program — a browser security boundary, not a gap in this codebase. So the
+    honest button hands the owner the file and says what to do with it, and the
+    decision after that is theirs.
+
+    It sat disabled under a note saying installing "is not built yet", which was
+    true and useless: the row knew a release existed and the owner still had no
+    way to get it.
+    """
+    page = open_panel(engine_manifest={
+        "product": "scrapex-engine", "version": "0.9.0",
+        "installer": {"name": "scrapex-engine.exe",
+                      "url": "https://example.test/scrapex-engine.exe",
+                      "bytes": 24000000, "sha256": "b" * 64},
+    })
+    page.click("#tab-engines")
+    page.wait_for_function(
+        "() => !document.getElementById('engine-download').disabled",
+        timeout=10_000)
+
+    assert not page.locator("#engine-download").is_disabled()
+    assert page.locator("#engine-install-steps").is_visible()
+
+    # The steps are folded shut by default; open them before reading the text.
+    page.click("#engine-install-steps summary")
+    steps = page.inner_text("#engine-install-steps")
+    # The SmartScreen warning is named in the dialog's own words. A warning the
+    # owner was told to expect is a detail; the same one unannounced is where
+    # people stop installing.
+    assert "More info" in steps and "Run anyway" in steps
+    assert "no administrator rights" in steps
+    # THE STEP MUST NAME THE CONTROL THE WAY THE CONTROL NAMES ITSELF, and this
+    # assertion is read off the DOM rather than typed, so the two cannot drift.
+    # It used to be `assert "refresh button" in steps` — which passed while the
+    # step pointed at "the refresh button above" and the only button up there was
+    # icon-only, named "Check ScrapeX-Engine again" by its `aria-label` and by
+    # nothing else. Nothing on the card was called refresh. That is the same
+    # shape as the two defects this suite has already been bitten by: a test
+    # standing over wording the rest of the panel contradicts.
+    recheck_name = page.get_attribute("#engine-recheck", "aria-label")
+    assert recheck_name and recheck_name in steps, (
+        f"the steps tell the owner to press something the card does not call "
+        f"anything: the control's only name is {recheck_name!r}")
+    assert "b" * 64 in text_of(page, "#engine-download-checksum"), (
+        "the checksum is not shown, so a download cannot be proved whole")
+
+
+def test_the_download_button_actually_hands_over_the_file(open_panel):
+    """PRESS IT. Everything else about this button was asserted — that it is
+    enabled, that the steps beside it are right, that the checksum is printed —
+    and the one line that makes the feature exist was observed by nothing.
+
+    The branch this landed on is called `the-download-button-downloads`, and a
+    suite that never clicks the button cannot tell that name from a wish. Found
+    by asking of each assertion what code change would break it, and finding that
+    deleting the `onclick` broke none of them.
+    """
+    page = open_panel(engine_manifest={
+        "product": "scrapex-engine", "version": "0.9.0",
+        "installer": {"name": "scrapex-engine.exe",
+                      "url": "https://example.test/scrapex-engine.exe",
+                      "bytes": 24000000, "sha256": "b" * 64},
+    })
+    page.click("#tab-engines")
+    page.wait_for_function(
+        "() => !document.getElementById('engine-download').disabled",
+        timeout=10_000)
+
+    # Chrome's own download is a navigation the panel does not own, so what is
+    # asserted is the handover itself: the url the panel was given, opened in a
+    # new tab rather than replacing the panel.
+    page.evaluate("""() => {
+      window.__opened = [];
+      window.open = (url, target) => { window.__opened.push([url, target]); return null; };
+    }""")
+    page.click("#engine-download")
+
+    assert page.evaluate("window.__opened") == [
+        ["https://example.test/scrapex-engine.exe", "_blank"]
+    ], "the button did not hand over the url the manifest published"
+
+
+def test_the_recheck_button_repaints_the_engine_card(open_panel):
+    """The button exists so a release cut five minutes ago becomes visible
+    without closing the panel. It called `render()`, which refreshes the panel's
+    state and does not touch this card — `renderEngines` is reached from one
+    other place, entering the view. So the cache was dropped, the feed was
+    re-fetched, and every field went on showing the answer from when the page
+    was opened: the button did nothing a person could see.
+
+    Scribbling over the card first is what makes this bite. Without it the test
+    passes against a button that does nothing, because the right answer is
+    already on screen.
+    """
+    page = open_panel(engine_manifest={
+        "product": "scrapex-engine", "version": "0.9.0",
+        "installer": {"name": "scrapex-engine.exe",
+                      "url": "https://example.test/scrapex-engine.exe",
+                      "bytes": 24000000, "sha256": "b" * 64},
+    })
+    page.click("#tab-engines")
+    page.wait_for_function(
+        "() => document.getElementById('engine-latest-version').textContent === '0.9.0'",
+        timeout=10_000)
+
+    before = page.evaluate(
+        "window.__calls.filter(c => String(c).includes('version.json')).length")
+    page.evaluate(
+        "document.getElementById('engine-latest-version').textContent = 'STALE'")
+
+    page.click("#engine-recheck")
+
+    page.wait_for_function(
+        "() => document.getElementById('engine-latest-version').textContent === '0.9.0'",
+        timeout=10_000)
+    after = page.evaluate(
+        "window.__calls.filter(c => String(c).includes('version.json')).length")
+    assert after > before, (
+        "the card was repainted from the cache — the button drops it precisely "
+        "so the feed is asked again")
+
+
+def test_the_download_button_stays_dead_when_there_is_nothing_to_download(open_panel):
+    """The default state today: nothing released. A button that looks pressable
+    and does nothing is worse than one that is plainly not ready."""
+    page = open_panel()
+    page.click("#tab-engines")
+    page.wait_for_function(
+        "() => document.getElementById('engine-latest-detail').textContent !== ''",
+        timeout=10_000)
+
+    assert page.locator("#engine-download").is_disabled()
+    assert not page.locator("#engine-install-steps").is_visible()
 
 
 def test_a_release_with_no_installer_says_so_before_the_press(open_panel):

--- a/tests/test_panel_wiring.py
+++ b/tests/test_panel_wiring.py
@@ -43,6 +43,49 @@ def test_every_element_the_script_reaches_for_exists():
     assert not missing, f"app.js reaches for ids that app.html does not define: {missing}"
 
 
+def _pages_and_what_their_scripts_reach_for():
+    """Every page in the extension, paired with the ids it defines and the ids
+    the scripts IT loads reach for. Ids a script renders itself count as defined,
+    the same allowance the app-only check above makes."""
+    pairs = []
+    for page in sorted(EXT.glob("*.html")):
+        html = page.read_text(encoding="utf-8")
+        defined = set(re.findall(r'\bid="([\w-]+)"', html))
+        referenced: set[str] = set()
+        for name in re.findall(r'<script[^>]*\bsrc="([\w./-]+)"', html):
+            source_file = EXT / name
+            assert source_file.exists(), f"{page.name} loads {name}, which is not there"
+            source = source_file.read_text(encoding="utf-8")
+            defined |= set(re.findall(r'\bid="([\w-]+)"', source))
+            referenced |= set(re.findall(r'\$\("([\w-]+)"\)', source))
+            referenced |= set(re.findall(r'getElementById\("([\w-]+)"\)', source))
+        pairs.append(pytest.param(page.name, defined, referenced, id=page.name))
+    return pairs
+
+
+@pytest.mark.parametrize("page,defined,referenced",
+                         _pages_and_what_their_scripts_reach_for())
+def test_no_page_reaches_for_an_element_it_does_not_have(page, defined, referenced):
+    """THE SAME CHECK AS ABOVE, FOR EVERY PAGE — because the one page it did not
+    cover is the one that broke.
+
+    `onboarding.html`'s steps were rewritten for the downloaded engine and the
+    `#cmd-host` span went with them. `onboarding.js` still wrote a command into
+    it, as the second statement of an async `init()` called from a
+    DOMContentLoaded listener — so the TypeError became a silent unhandled
+    rejection, every line after it was skipped, and Start engine, Check again and
+    Open ScrapeX were all dead on a page that rendered perfectly.
+
+    The panel had this guard from the day the Add Site form came apart the same
+    way. Onboarding did not, because the guard named two files instead of asking
+    the directory what pages exist.
+    """
+    missing = sorted(referenced - defined)
+    assert not missing, (
+        f"{page} loads a script that reaches for ids the page does not have: "
+        f"{missing} — the first one to be missing kills every binding after it")
+
+
 def test_the_add_site_form_is_reachable_from_the_script():
     """The exact regression: a complete form nothing could ever reveal."""
     assert "source-detail" in DEFINED, "the confirm-and-add form is gone"


### PR DESCRIPTION
Three commits, split by story. Read them in order — the middle one is the reason this exists.

## What was measured, not reasoned

The owner downloaded the real 0.2.1 release, double-clicked it, cleared SmartScreen twice, and got **an empty black rectangle**. The build was fine. Bare invocation meant the native messaging host, which waits on stdin for framed JSON a double-click never sends — the same root cause as the `--version` defect a release workflow had found hours earlier.

## What a review of the working tree then found

Seven defects survived adversarial refutation, four of them blockers, **all of them under a green suite**:

| | |
|---|---|
| `_first_run()` called `nativehost.install()` with no arguments | its first parameter is required — `TypeError` on every machine, swallowed by a bare `except`, under a heading promising Chrome had been told something |
| `onboarding.js` still wrote to `#cmd-host` | the span was deleted from the page; the TypeError became a silent unhandled rejection and **every button on the onboarding page was dead** |
| the per-engine refresh button | re-rendered everything except the engine card |
| nothing clicked the download button | on a branch named for it |

## What is deliberately not here

Another session is working on the Profile page, the Google sign-in button and the manifest key rotation. **None of its files are in this branch** — no `identity.js`, no `manifest.json`, no `privacy-policy.md`, no `panel_harness.py`, no sign-in tests, no icons. It will raise its own PR. Six findings that land in its files are recorded for that review rather than fixed here.

## Proof, not assertion

Every fix had its test proved to bite by re-breaking the fix:

- removing the repaint → the recheck test times out on a value that never returns
- nulling `download.onclick` → the recorded handover comes back empty
- deleting the double-click branch → `['host'] != ['first-run']`
- reinstating `#cmd-host` → the new page-wiring gate names it

The dangling-id gate that has guarded the panel since the Add Site form came apart now covers **every** page, because it named two files instead of asking the directory what pages exist — which is why onboarding was unguarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)