### PR TITLE
The walker: everything about a crawl that is not about the site

### DIFF
--- a/scrapex/pagewalk.py
+++ b/scrapex/pagewalk.py
@@ -1,0 +1,169 @@
+"""The walker: everything about a crawl that is NOT about the site.
+
+Step 2 of docs/GENERIC-FETCH-SEAM.md, and the other half of `pagesource.py`.
+That file says what one site knows about its own layout; this one fetches,
+paces, counts, decides how deep to go, and hands each page on. The split is
+deliberate and `pagesource.py` states why:
+
+    A `PageSource` that reaches past this line is the reason two sources will
+    one day differ for no reason anybody can name.
+
+So the walker owns pacing, the request budget, the scope, and what happens when
+one page fails — and every site gets the same answer to all four.
+
+IT DOES NOT PARSE, AND IT DOES NOT STORE. A page is handed to `on_page` exactly
+as it arrived. What a page MEANS is decided later, against the stored copy,
+which is what makes a wrong parse a re-read rather than a re-crawl. On a source
+measured at thirty-four hours that distinction is the product.
+
+THE ONE NUMBER THAT MATTERS. muqawil's listing is 860 pages — fourteen minutes
+at the shipped pace. Its detail pages are 121,157: thirty-four hours. The scope
+is what stands between those two, and the walker is where the scope is
+enforced rather than merely recorded.
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Callable, Iterable
+
+from .crawlscope import CrawlScope, plan as plan_scope
+from .pagesource import FetchedPage, PageKind, PageSource, SliceNotSupported
+
+#: What the fetcher is: a url in, the page's text out. Anything that raises is
+#: a failed page, and the walk goes on — see `WalkReport.failures`.
+Fetch = Callable[[str], str]
+
+#: Where a page goes once it has arrived. The walker never inspects it.
+OnPage = Callable[[FetchedPage], None]
+
+
+@dataclass
+class WalkReport:
+    """What a walk did, in the terms the owner asked the question in.
+
+    Counted rather than inferred from the sink, because the sink may reject a
+    page and the owner's question — "how much of the site did we fetch?" — is
+    about requests made, not rows stored.
+    """
+
+    scope: CrawlScope
+    listing_pages: int = 0
+    detail_pages: int = 0
+    #: (url, reason) for every page that did not arrive. Never raised: one dead
+    #: detail page out of 121,157 must not discard the 121,156 that worked.
+    failures: list[tuple[str, str]] = field(default_factory=list)
+    #: Detail pages the slice ruled out. Named separately from `failures`
+    #: because "we chose not to" and "we could not" are different answers.
+    skipped: int = 0
+    stopped_early: str = ""
+
+    @property
+    def requests(self) -> int:
+        return self.listing_pages + self.detail_pages + len(self.failures)
+
+
+class PageWalker:
+    """One crawl of one site, at one scope."""
+
+    def __init__(self, source: PageSource, fetch: Fetch, *,
+                 pace_s: float = 1.0, sleep: Callable[[float], None] = time.sleep) -> None:
+        self._source = source
+        self._fetch = fetch
+        self._pace_s = pace_s
+        # Injected so a test can prove the pace is honoured without waiting for
+        # it. A test that sets pace_s to 0 proves nothing about the shipped
+        # value; one that records the sleeps proves exactly what was asked for.
+        self._sleep = sleep
+        self._fetched_any = False
+
+    def walk(self, base_url: str, scope: CrawlScope, *, slice_of: str = "",
+             max_requests: int | None = None, on_page: OnPage | None = None) -> WalkReport:
+        """Fetch what the scope allows, and no more.
+
+        `max_requests` is a ceiling the caller sets, not a default: a walk that
+        silently stopped at some built-in number would report a partial crawl as
+        a complete one. When it bites, `stopped_early` says so.
+        """
+        # REFUSED BEFORE THE FIRST REQUEST. `plan_scope` raises SliceRequired
+        # for a slice scope with no slice named, and asking it here means the
+        # refusal costs nothing instead of arriving after fourteen minutes of
+        # listing pages.
+        plan_scope(scope, listing_pages=0, detail_pages=0, slice_of=slice_of)
+
+        report = WalkReport(scope=scope)
+        for url in self._source.listing_urls(base_url):
+            if self._over(report, max_requests):
+                return report
+            page = self._get(url, PageKind.LISTING, report)
+            if page is None:
+                continue
+            report.listing_pages += 1
+            if on_page is not None:
+                on_page(page)
+
+            if scope is CrawlScope.LISTING_ONLY:
+                continue
+            for detail in self._details_wanted(page, scope, slice_of, report):
+                if self._over(report, max_requests):
+                    return report
+                fetched = self._get(detail, PageKind.DETAIL, report)
+                if fetched is None:
+                    continue
+                report.detail_pages += 1
+                if on_page is not None:
+                    on_page(fetched)
+        return report
+
+    # -- the four things that are the walker's and never the site's ----------
+
+    def _get(self, url: str, kind: PageKind, report: WalkReport) -> FetchedPage | None:
+        """Pace, fetch, and turn a failure into a record rather than an end.
+
+        THE PACE IS PAID BEFORE THE REQUEST AND NOT AFTER, and never before the
+        first: a crawl that sleeps after its last page bills the owner for a
+        second it did not need, and one that sleeps before its first delays
+        every run by a second for nothing.
+        """
+        if self._fetched_any and self._pace_s > 0:
+            self._sleep(self._pace_s)
+        self._fetched_any = True
+        try:
+            html = self._fetch(url)
+        except Exception as exc:                      # noqa: BLE001
+            # NOT RAISED. One dead page out of a hundred thousand must not
+            # discard the rest, and a crawl that stops at the first 404 of a
+            # thirty-four hour run is a crawl nobody can finish.
+            report.failures.append((url, f"{type(exc).__name__}: {exc}"))
+            return None
+        return FetchedPage(url=url, html=html, kind=kind)
+
+    def _details_wanted(self, page: FetchedPage, scope: CrawlScope,
+                        slice_of: str, report: WalkReport) -> Iterable[str]:
+        """Which detail pages this listing page earns, under this scope."""
+        urls = list(self._source.detail_urls(page))
+        if scope is CrawlScope.FULL_THEN_LISTING:
+            return urls
+        wanted = []
+        for index, url in enumerate(urls):
+            try:
+                if self._source.belongs_to_slice(page, index, slice_of):
+                    wanted.append(url)
+                else:
+                    report.skipped += 1
+            except SliceNotSupported:
+                # SURFACED, NOT SWALLOWED. Treating a site that cannot answer as
+                # a site that answered "no" would produce an empty crawl wearing
+                # the clothes of a successful one — which is the exact failure
+                # `SliceNotSupported` was created to prevent.
+                raise
+        return wanted
+
+    @staticmethod
+    def _over(report: WalkReport, max_requests: int | None) -> bool:
+        if max_requests is not None and report.requests >= max_requests:
+            report.stopped_early = (
+                f"stopped at the {max_requests}-request ceiling the caller set; "
+                "this crawl is PARTIAL")
+            return True
+        return False

--- a/tests/test_the_walker_honours_the_scope.py
+++ b/tests/test_the_walker_honours_the_scope.py
@@ -1,0 +1,224 @@
+"""The walker fetches what the scope allows and not one page more.
+
+The scope is not paperwork. muqawil's listing is 860 pages — fourteen minutes at
+the shipped pace — and its detail pages are 121,157, which is thirty-four hours.
+A walker that quietly fetched a detail page under `listing_only` would turn a
+fourteen-minute crawl into a day and a half, and the only way anyone would find
+out is by watching it not finish.
+
+So every test here is about a page that must NOT be fetched, or a failure that
+must not end the walk. Nothing here touches the network.
+"""
+from __future__ import annotations
+
+import pytest
+
+from scrapex.crawlscope import CrawlScope, SliceRequired
+from scrapex.pagesource import FetchedPage, PageKind, SliceNotSupported
+from scrapex.pagewalk import PageWalker
+
+
+class FakeSite:
+    """Three listing pages, two rows each, and it knows its own cities."""
+
+    site_key = "fakesite"
+
+    def __init__(self, pages: int = 3, can_slice: bool = True) -> None:
+        self._pages = pages
+        self._can_slice = can_slice
+        #: Whether the walker ever ASKED this site about slice membership.
+        #: Under listing_only it must not — see the test that reads it.
+        self.slice_questions = 0
+
+    def listing_urls(self, base_url: str):
+        for n in range(1, self._pages + 1):
+            yield f"{base_url}/list?page={n}"
+
+    def detail_urls(self, page: FetchedPage):
+        n = page.url.rsplit("=", 1)[-1]
+        return [f"https://fake.test/entity/{n}a", f"https://fake.test/entity/{n}b"]
+
+    def belongs_to_slice(self, page: FetchedPage, row_index: int, slice_of: str) -> bool:
+        self.slice_questions += 1
+        if not self._can_slice:
+            raise SliceNotSupported("this site does not publish the city on its listing")
+        # The first row of every page is in Cairo, the second is not.
+        return slice_of == "Cairo" and row_index == 0
+
+
+class Recorder:
+    """Every url the walker asked for, in order."""
+
+    def __init__(self, fails: set[str] | None = None) -> None:
+        self.asked: list[str] = []
+        self._fails = fails or set()
+
+    def __call__(self, url: str) -> str:
+        self.asked.append(url)
+        if url in self._fails:
+            raise TimeoutError("the site did not answer")
+        return f"<html>{url}</html>"
+
+
+def walker(site=None, fetch=None, pace_s=1.0):
+    sleeps: list[float] = []
+    w = PageWalker(site or FakeSite(), fetch or Recorder(),
+                   pace_s=pace_s, sleep=sleeps.append)
+    return w, sleeps
+
+
+def test_listing_only_never_fetches_a_detail_page():
+    """THE ONE THAT PAYS FOR THIS FILE. On muqawil the difference between
+    obeying this and not is fourteen minutes against thirty-four hours.
+
+    THE FIRST VERSION OF THIS TEST DID NOT BITE, and it is worth recording why.
+    It asserted only that no detail url was fetched — and with the scope check
+    deleted from the walker it still passed, because this fake answers "not in
+    the slice" for the empty slice `listing_only` carries. The guard was
+    redundant with the fixture rather than proven by it.
+
+    So what is asserted now is that the site is never ASKED. Under listing_only
+    the depth is settled before the site is consulted at all, which is the thing
+    that actually has to be true: a site whose `belongs_to_slice` happened to
+    answer True would otherwise crawl for thirty-four hours under the name of
+    the fourteen-minute scope.
+    """
+    site = FakeSite()
+    fetch = Recorder()
+    w, _ = walker(site=site, fetch=fetch)
+
+    report = w.walk("https://fake.test", CrawlScope.LISTING_ONLY)
+
+    assert report.listing_pages == 3
+    assert report.detail_pages == 0
+    assert all("/list?page=" in url for url in fetch.asked), (
+        f"a detail page was fetched under listing_only: {fetch.asked}")
+    assert site.slice_questions == 0, (
+        "the walker asked the site about slice membership under listing_only — "
+        "so the depth is being decided by the site's answer instead of by the "
+        "scope, and a site that answered True would crawl every detail page")
+    assert report.skipped == 0, (
+        "detail pages were 'skipped' under a scope that never considers them; "
+        "skipped means the slice ruled a row out, and listing_only rules on "
+        "nothing")
+
+
+def test_the_slice_fetches_only_the_rows_that_are_in_it():
+    fetch = Recorder()
+    w, _ = walker(fetch=fetch)
+
+    report = w.walk("https://fake.test", CrawlScope.LISTING_PLUS_SLICE,
+                    slice_of="Cairo")
+
+    assert report.listing_pages == 3
+    assert report.detail_pages == 3, "one row per page is in Cairo"
+    assert report.skipped == 3, "the other row per page was ruled out, not lost"
+    assert [u for u in fetch.asked if "/entity/" in u] == [
+        "https://fake.test/entity/1a",
+        "https://fake.test/entity/2a",
+        "https://fake.test/entity/3a"], "the wrong rows were followed"
+
+
+def test_a_slice_scope_with_no_slice_named_is_refused_before_the_first_request():
+    """The refusal must cost nothing. Discovering it after fourteen minutes of
+    listing pages is the same failure with a bill attached."""
+    fetch = Recorder()
+    w, _ = walker(fetch=fetch)
+
+    with pytest.raises(SliceRequired):
+        w.walk("https://fake.test", CrawlScope.LISTING_PLUS_SLICE)
+
+    assert fetch.asked == [], "it started crawling before checking it could finish"
+
+
+def test_a_site_that_cannot_slice_says_so_instead_of_crawling_nothing():
+    """SliceNotSupported must reach the caller. Swallowed, it would read as
+    'no row is in the slice' and produce an empty crawl wearing the clothes of
+    a successful one."""
+    w, _ = walker(site=FakeSite(can_slice=False))
+
+    with pytest.raises(SliceNotSupported):
+        w.walk("https://fake.test", CrawlScope.LISTING_PLUS_SLICE, slice_of="Cairo")
+
+
+def test_full_then_listing_takes_every_detail_page():
+    fetch = Recorder()
+    w, _ = walker(fetch=fetch)
+
+    report = w.walk("https://fake.test", CrawlScope.FULL_THEN_LISTING)
+
+    assert report.listing_pages == 3 and report.detail_pages == 6
+    assert report.skipped == 0
+
+
+def test_one_dead_page_does_not_end_the_crawl():
+    """A crawl that stops at the first 404 of a thirty-four hour run is a crawl
+    nobody can finish. The failure is recorded and named, and the rest goes on."""
+    fetch = Recorder(fails={"https://fake.test/entity/2a"})
+    w, _ = walker(fetch=fetch)
+
+    report = w.walk("https://fake.test", CrawlScope.FULL_THEN_LISTING)
+
+    assert report.detail_pages == 5, "the other five detail pages were abandoned"
+    assert [url for url, _ in report.failures] == ["https://fake.test/entity/2a"]
+    assert "TimeoutError" in report.failures[0][1], (
+        "the failure does not say what happened, so nobody can act on it")
+
+
+def test_a_dead_listing_page_costs_only_its_own_details():
+    fetch = Recorder(fails={"https://fake.test/list?page=2"})
+    w, _ = walker(fetch=fetch)
+
+    report = w.walk("https://fake.test", CrawlScope.FULL_THEN_LISTING)
+
+    assert report.listing_pages == 2
+    assert report.detail_pages == 4, "pages 1 and 3 still yielded their details"
+    assert len(report.failures) == 1
+
+
+def test_the_pace_is_paid_between_requests_and_never_before_the_first():
+    """A crawl that sleeps before its first page delays every run for nothing,
+    and one that sleeps after its last bills for a second it did not need."""
+    w, sleeps = walker(pace_s=1.5)
+
+    w.walk("https://fake.test", CrawlScope.LISTING_ONLY)
+
+    assert sleeps == [1.5, 1.5], (
+        f"three pages should cost two waits, not {len(sleeps)}")
+
+
+def test_every_page_reaches_the_sink_exactly_once_and_says_which_kind_it_is():
+    seen: list[FetchedPage] = []
+    w, _ = walker()
+
+    w.walk("https://fake.test", CrawlScope.FULL_THEN_LISTING, on_page=seen.append)
+
+    assert len(seen) == 9
+    assert [p.kind for p in seen[:3]] == [
+        PageKind.LISTING, PageKind.DETAIL, PageKind.DETAIL], (
+        "the sink cannot tell a listing from a detail, so it cannot store either")
+    assert len({p.url for p in seen}) == 9, "a page was handed over twice"
+    assert all(p.html for p in seen), "a page arrived with no html"
+
+
+def test_the_ceiling_stops_the_walk_and_says_the_crawl_is_partial():
+    """A walk that stopped at some built-in number and said nothing would report
+    a partial crawl as a complete one — which is how a warehouse quietly stops
+    growing."""
+    fetch = Recorder()
+    w, _ = walker(fetch=fetch)
+
+    report = w.walk("https://fake.test", CrawlScope.FULL_THEN_LISTING,
+                    max_requests=4)
+
+    assert report.requests <= 4
+    assert "PARTIAL" in report.stopped_early
+    assert len(fetch.asked) <= 4
+
+
+def test_a_walk_that_finished_does_not_claim_to_have_stopped_early():
+    w, _ = walker()
+
+    report = w.walk("https://fake.test", CrawlScope.LISTING_ONLY, max_requests=99)
+
+    assert report.stopped_early == ""


### PR DESCRIPTION
Step 2 of `docs/GENERIC-FETCH-SEAM.md`. `pagesource.py` said what a site knows about its own layout and drew a hard line — a `PageSource` may not fetch, pace, count, decide depth, or touch the database. **This is the other side of that line.**

## What the scope is worth

muqawil's listing is **860 pages — fourteen minutes** at the shipped pace. Its detail pages are **121,157 — thirty-four hours**. A walker that quietly followed a detail link under `listing_only` turns one into the other, and the only way anyone finds out is by watching it not finish.

So the scope is *enforced* here, not merely recorded.

## Four decisions worth the words they cost

- **A slice scope with no slice named is refused before the first request.** The refusal is the same either way; arriving at it after fourteen minutes of listing pages is the same refusal with a bill attached.
- **`SliceNotSupported` is re-raised, never swallowed.** Treated as "no row is in the slice" it would produce an empty crawl wearing the clothes of a successful one — the exact failure that exception exists to prevent.
- **A failed page is recorded and the walk goes on.** A crawl that stops at the first 404 of a thirty-four hour run is a crawl nobody can finish.
- **The pace is paid between requests** — never before the first, never after the last — and `sleep` is injected so a test proves it without waiting for it.

## A test that did not bite, and why it is recorded in the file

The first version of `test_listing_only_never_fetches_a_detail_page` asserted only that no detail url was fetched. **With the scope check deleted from the walker it still passed** — the fake site answers "not in the slice" for the empty slice `listing_only` carries, so the guard was redundant with the fixture rather than proven by it.

It now asserts the site is never **asked**, which fails with `6 != 0` when the guard goes:

> AssertionError: the walker asked the site about slice membership under listing_only — so the depth is being decided by the site's answer instead of by the scope

The docstring keeps the story, because the next person to write a scope test will reach for the same weaker assertion.

## Verified

11 tests, no network in any of them. Full suite green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)