### PR TITLE
The hover ring follows the Google asset instead of the touch target

### DIFF
--- a/extension/app.css
+++ b/extension/app.css
@@ -1185,6 +1185,13 @@
     width: 180px;
     height: auto;
     pointer-events: none;
+    /* 2.5px is MEASURED off the official asset, not chosen: the first opaque
+       pixel along its top edge is 10px into a 720px-wide @4x file, and it is
+       drawn at 180px, so the painted corner is 10 x 180/720 = 2.5px. The hover
+       ring below is a box-shadow, and a box-shadow follows the element's own
+       radius -- without this it draws SQUARE corners around a rounded button. */
+    border-radius: 2.5px;
+    transition: box-shadow var(--dur) var(--ease);
   }
   /* The Google button is a transparent wrapper around an official PNG asset.
      Extension-wide `button:hover/active/disabled` rules must not paint the
@@ -1196,7 +1203,7 @@
     border-color: transparent;
     background: transparent;
     color: inherit;
-    box-shadow: 0 0 0 1px var(--line-strong), var(--shadow-sm);
+    box-shadow: none;
     transform: none;
     opacity: 1;
   }
@@ -1204,9 +1211,23 @@
     border-color: transparent;
     background: transparent;
     color: inherit;
-    box-shadow: 0 0 0 1px var(--line-strong);
+    box-shadow: none;
     transform: none;
     opacity: 1;
+  }
+  /* THE RING IS ON THE IMAGE, NOT THE BUTTON, and the difference is the whole
+     defect. The button is 180x48 -- 48 to keep the 48px touch target -- while
+     the asset is 180x40, so a ring on the button floated 4px above and below
+     the visible button with square corners, which is what it looked like: a
+     hard box drawn around a rounded control. On the image it hugs exactly what
+     the eye reads as the button.
+     Still OUTSIDE the asset: a box-shadow paints beyond the border box, so
+     nothing recolours, crops, or moves Google's pixels. */
+  .profile-signin:hover:not(:disabled) .profile-signin-img {
+    box-shadow: 0 0 0 1px var(--line), var(--shadow-sm);
+  }
+  .profile-signin:active:not(:disabled) .profile-signin-img {
+    box-shadow: 0 0 0 1px var(--line-strong);
   }
   .profile-signin:disabled {
     border-color: transparent;

--- a/tests/test_signing_in_says_what_happened.py
+++ b/tests/test_signing_in_says_what_happened.py
@@ -438,6 +438,51 @@ def test_the_welcome_mark_is_visible_in_dark_scheme(open_panel):
     assert "0, 0, 0" not in box["background"], "the mark is still drawn black"
 
 
+def test_the_hover_indicator_hugs_the_google_asset_and_not_the_touch_target(open_panel):
+    """WHAT THE OWNER ACTUALLY SAW: a hard square box round a rounded button.
+
+    The hover ring is a box-shadow, and a box-shadow follows the border box and
+    the border-radius of whatever element carries it. It was on the WRAPPER --
+    180x48, because 48 is the touch target, and `border-radius: 0` -- while the
+    thing a person reads as the button is the official asset inside it, 180x40
+    with corners painted 2.5px round. So the indicator sat 4px proud of the
+    control top and bottom, with square corners. Every CSS-text assertion passed:
+    they checked a box-shadow was declared, never where it landed.
+
+    This measures the rendered result, which is the only place the defect was
+    visible.
+    """
+    page = open_panel()
+    page.wait_for_selector("#welcome-signed-out:visible")
+    page.hover("#signin")
+    page.wait_for_timeout(300)
+
+    geometry = page.evaluate("""() => {
+      const button = document.querySelector('#signin');
+      const image = button.querySelector('img[data-scheme]:not(.hidden)');
+      const shadowed = getComputedStyle(image).boxShadow;
+      const bare = getComputedStyle(button).boxShadow;
+      const b = button.getBoundingClientRect(), i = image.getBoundingClientRect();
+      return {
+        onImage: shadowed !== 'none',
+        onButton: bare !== 'none',
+        radius: parseFloat(getComputedStyle(image).borderRadius) || 0,
+        overhang: Math.max(i.top - b.top, b.bottom - i.bottom),
+      };
+    }""")
+
+    assert geometry["onImage"], (
+        "hovering paints no indicator on the Google asset, so the button gives "
+        "no feedback at all")
+    assert not geometry["onButton"], (
+        f"the indicator is on the {geometry['overhang']*2 + 40:.0f}px-tall touch "
+        "target rather than the 40px asset, so it draws a box standing proud of "
+        "the control the owner can see")
+    assert geometry["radius"] > 0, (
+        "the asset carries no border-radius, so the ring is drawn with SQUARE "
+        "corners around a button whose corners are painted round")
+
+
 def test_a_missing_email_hides_the_email_paragraph(open_panel):
     """Google may return an account without an email. The signed-in state must
     not show an empty labelled paragraph."""

--- a/tests/test_the_google_button_follows_googles_rules.py
+++ b/tests/test_the_google_button_follows_googles_rules.py
@@ -152,10 +152,18 @@ def test_the_google_button_wrapper_shows_a_neutral_hover_indicator():
     assert "border-color: transparent" in rule
     assert "transform: none" in rule
     assert "opacity: 1" in rule
-    # A visible external indicator, not the old invisible state.
-    assert "box-shadow:" in rule
-    assert "box-shadow: none" not in rule
+    # THE INDICATOR IS ON THE IMAGE, and this assertion moved with it. It used
+    # to read the wrapper's own rule, which is how a ring drawn round a 180x48
+    # box with square corners passed while the button it appears to outline is
+    # 180x40 and rounded. What the owner saw was a hard rectangle floating 4px
+    # above and below the control. The rendered geometry is pinned in
+    # tests/test_signing_in_says_what_happened.py; this only checks it exists.
+    ring = _css_rule(APP_CSS, ".profile-signin:hover:not(:disabled) .profile-signin-img")
+    assert "box-shadow:" in ring and "box-shadow: none" not in ring
     img = _css_rule(APP_CSS, ".profile-signin-img")
+    assert "border-radius" in img, (
+        "the asset is drawn with rounded corners; without a matching radius the "
+        "box-shadow ring is drawn SQUARE around it")
     assert "filter" not in img, "hover must not recolour the official image"
     assert "opacity" not in img, "hover must not dim the official image"
 
@@ -167,8 +175,8 @@ def test_the_google_button_wrapper_shows_a_neutral_active_indicator():
     assert "background: transparent" in rule
     assert "transform: none" in rule
     assert "opacity: 1" in rule
-    assert "box-shadow:" in rule
-    assert "box-shadow: none" not in rule
+    ring = _css_rule(APP_CSS, ".profile-signin:active:not(:disabled) .profile-signin-img")
+    assert "box-shadow:" in ring and "box-shadow: none" not in ring
 
 
 def test_the_google_button_wrapper_does_not_dim_when_disabled():


### PR DESCRIPTION
The owner sent two screenshots. The hover indicator was **a hard, square-cornered rectangle standing proud of a rounded button.** It was doing exactly what it was told to.

## The geometry

A `box-shadow` follows the border box **and the border-radius of whatever element carries it**. The ring was on the wrapper:

| | size | radius |
|---|---|---|
| `.profile-signin` (wrapper) | 180 × **48** — 48 is the touch target | **0** |
| the official asset inside it | 180 × **40** | **2.5px**, painted into the PNG |

So the ring stood 4px proud top and bottom, and squared off every corner.

**2.5px is measured, not chosen:** the first opaque pixel along the asset's top edge is 10px into a 720px-wide `@4x` file drawn at 180px — 10 × 180/720 = 2.5.

## The fix

The ring moves onto the image, with that radius. The 48px touch target is untouched. Nothing touches Google's pixels — a box-shadow paints *outside* the border box, so there is no recolour, no crop, no transform.

## Why nothing caught it

Both guarding tests read `app.css` as text and asked whether a `box-shadow` was **declared** on the hover rule. Neither asked **where it landed**. They passed the whole time.

The new test opens the panel, hovers, and measures the rendered result: the indicator is on the asset and not on the wrapper, and the asset's radius is above zero.

> **Proved to bite:** putting the ring back on the wrapper fails with
> `hovering paints no indicator on the Google asset, so the button gives no feedback at all`

The text assertions moved with the rule rather than being deleted, so the "declared, and not `none`" check survives alongside the rendered one.

## Verified

Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)