### PR TITLE
A linter, and the two live defects it found on its first run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,38 @@ on:
   pull_request:
 
 jobs:
+  # ITS OWN JOB, and deliberately not a step inside `test`. A style failure that
+  # aborts the suite hides every real failure behind it, and the one thing a
+  # linter must never do is cost someone the answer they actually came for.
+  # It is also seconds long, so the cheap things fail fast.
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      # Pinned: an unpinned linter turns somebody else's release into a red
+      # build on a branch that changed nothing.
+      - name: Install ruff
+        run: pip install ruff==0.16.2
+      # scrapex/ ONLY, and the reason is written down rather than left to be
+      # guessed: tests/ and tools/ carry 376 findings today, nearly all of them
+      # import order, and they are the files a second session is editing right
+      # now. Gating them would mean a conflict per commit for no defect
+      # prevented. The gate covers everything that SHIPS; widening it to the
+      # whole tree is its own task, once that work lands.
+      - name: Lint the code that ships (ruff)
+        run: ruff check scrapex/
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      # Pinned for the same reason ruff is, and installed for the length of one
+      # step: nothing is added to package.json because there ISN'T one, and the
+      # extension's security story is that it ships no third-party JavaScript.
+      - name: Lint the JavaScript (eslint)
+        run: npx --yes eslint@9.39.0 extension scrapex/webui/static contract apps_script --no-warn-ignored
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,138 @@
+// The JavaScript half of the gate. Its Python half lives in pyproject.toml, and
+// the reasoning is the same in both: a chosen rule set, every exception carrying
+// a reason, and no dependency the repository does not already need.
+//
+// NO package.json, ON PURPOSE. `.github/workflows/ci.yml` says it out loud about
+// the node test runner -- "no package.json, no dependencies" -- and that is worth
+// keeping: this repository ships a Chrome extension whose whole security story is
+// that it has no third-party JavaScript in it. CI installs eslint for the length
+// of one step, pinned, and nothing is added to what gets packaged.
+//
+// The globals are listed by hand rather than pulled from the `globals` package,
+// for the same reason: one more dependency to lint 11,000 lines is a bad trade,
+// and being explicit about what each area is allowed to reach for is a feature.
+// A file that suddenly needs `chrome` outside extension/ should have to say so.
+
+const BROWSER = {
+  window: "readonly", document: "readonly", console: "readonly",
+  fetch: "readonly", URL: "readonly", URLSearchParams: "readonly",
+  setTimeout: "readonly", clearTimeout: "readonly",
+  setInterval: "readonly", clearInterval: "readonly",
+  requestAnimationFrame: "readonly", localStorage: "readonly",
+  sessionStorage: "readonly", location: "readonly", navigator: "readonly",
+  alert: "readonly", confirm: "readonly", getComputedStyle: "readonly",
+  CustomEvent: "readonly", Event: "readonly", FormData: "readonly",
+  Blob: "readonly", FileReader: "readonly", AbortController: "readonly",
+  IntersectionObserver: "readonly", MutationObserver: "readonly",
+  ResizeObserver: "readonly", DOMParser: "readonly", Image: "readonly",
+  structuredClone: "readonly", crypto: "readonly", btoa: "readonly",
+  atob: "readonly", TextEncoder: "readonly", TextDecoder: "readonly",
+  cancelAnimationFrame: "readonly", queueMicrotask: "readonly",
+  CSS: "readonly", Node: "readonly", MouseEvent: "readonly",
+  AbortSignal: "readonly", DecompressionStream: "readonly",
+  TextDecoderStream: "readonly", HTMLElement: "readonly",
+  // Loaded from static/vendor/ by a <script> tag, so it is a global here and
+  // named rather than waved through: a typo'd vendor name must still fail.
+  Tabulator: "readonly",
+  // Defined by timezone.js, which app.js's page loads before it as a classic
+  // script. Listing it is the only way `no-undef` can tell this apart from a
+  // function that does not exist -- which is exactly the defect this gate
+  // found in app.js (`el`).
+  ScrapeXTime: "readonly",
+};
+
+const EXTENSION = { ...BROWSER, chrome: "readonly" };
+
+const NODE = {
+  console: "readonly", process: "readonly", Buffer: "readonly",
+  __dirname: "readonly", __filename: "readonly", URL: "readonly",
+  TextEncoder: "readonly", TextDecoder: "readonly", fetch: "readonly",
+  setTimeout: "readonly", structuredClone: "readonly",
+};
+
+// Apps Script runs on Google's own runtime, where these are provided.
+const APPS_SCRIPT = {
+  console: "readonly", SpreadsheetApp: "readonly", UrlFetchApp: "readonly",
+  PropertiesService: "readonly", Utilities: "readonly", Logger: "readonly",
+  HtmlService: "readonly", ScriptApp: "readonly", Session: "readonly",
+  CacheService: "readonly", LockService: "readonly", DriveApp: "readonly",
+};
+
+const RULES = {
+  // THE ONES THAT CATCH DEFECTS. Every one of these is a bug that ships
+  // silently in a language with no compiler.
+  "no-undef": "error",                    // a typo'd name is a runtime crash
+  // caughtErrors: "none" -- `catch (err) {}` where err goes unread is not a
+  // defect, it is a deliberate best-effort read, and there are 60 of them. The
+  // rule's value is unused LOCALS and unused IMPORTS, which stay on.
+  "no-unused-vars": ["error", { args: "none", caughtErrors: "none",
+                                varsIgnorePattern: "^_" }],
+  "no-dupe-keys": "error",                // the second one silently wins
+  "no-dupe-args": "error",
+  "no-dupe-else-if": "error",
+  "no-duplicate-case": "error",
+  "no-unreachable": "error",
+  "no-fallthrough": "error",
+  "no-self-assign": "error",
+  "no-self-compare": "error",
+  "no-constant-condition": ["error", { checkLoops: true }],
+  // "except-parens", not "always": `while ((match = pattern.exec(text)))` is
+  // THE way to walk a global regex in JavaScript, and the extra parentheses are
+  // the language's own way of saying the assignment is deliberate.
+  "no-cond-assign": ["error", "except-parens"],
+  "no-unsafe-negation": "error",
+  "no-unsafe-optional-chaining": "error",
+  "no-sparse-arrays": "error",
+  "no-async-promise-executor": "error",
+  "use-isnan": "error",
+  "valid-typeof": "error",
+  "no-implied-eval": "error",
+  "no-eval": "error",
+  "no-new-func": "error",
+  "no-prototype-builtins": "error",
+  "no-var": "error",                      // `var` hoisting has bitten this file set
+  "eqeqeq": ["error", "smart"],           // "smart" still allows == null
+
+  // NOT ENABLED, each for a reason:
+  // - require-atomic-updates: 20 hits, every one of the form `state.x = await
+  //   f()` in a panel whose handlers do not run concurrently. The rule cannot
+  //   see that, and a rule that is wrong 20 times out of 20 teaches people to
+  //   stop reading the output.
+  // - no-console: the extension's console output IS its diagnostics, and the
+  //   panel has no other place to say what happened on a user's machine.
+  // - camelcase: the contract carries snake_case column names verbatim from
+  //   the database; renaming them at the boundary is how a column silently
+  //   stops matching.
+  // - no-empty: `catch {}` after a best-effort read is deliberate in several
+  //   places and each already carries a comment saying so.
+};
+
+export default [
+  {
+    files: ["extension/**/*.js", "extension/**/*.mjs"],
+    languageOptions: { ecmaVersion: 2023, sourceType: "module", globals: EXTENSION },
+    rules: RULES,
+  },
+  {
+    files: ["scrapex/webui/static/**/*.js"],
+    ignores: ["scrapex/webui/static/vendor/**"],
+    languageOptions: { ecmaVersion: 2023, sourceType: "script", globals: BROWSER },
+    rules: RULES,
+  },
+  {
+    // The extension's own node:test files run on node, not in a page.
+    files: ["extension/tests/**/*.mjs", "extension/tests/**/*.js"],
+    languageOptions: { ecmaVersion: 2023, sourceType: "module", globals: NODE },
+    rules: RULES,
+  },
+  {
+    files: ["contract/**/*.mjs", "contract/**/*.js"],
+    languageOptions: { ecmaVersion: 2023, sourceType: "module", globals: NODE },
+    rules: RULES,
+  },
+  {
+    files: ["apps_script/**/*.js"],
+    languageOptions: { ecmaVersion: 2023, sourceType: "script", globals: APPS_SCRIPT },
+    rules: RULES,
+  },
+];

--- a/extension/app.js
+++ b/extension/app.js
@@ -15,6 +15,17 @@ import { latestEngineRelease } from "./releases.js";
 import { getToken, accountFor, forgetToken } from "./identity.js";
 
 const $ = (id) => document.getElementById(id);
+// Called by renderSchemaLag since c4ea06b and DEFINED NOWHERE until now, so the
+// banner that tells the owner his database is behind the engine threw
+// ReferenceError instead of rendering -- and only ever in the one situation it
+// exists for. Nothing caught it: the early return above it means the normal
+// case never reaches these lines, and no test supplied a pending migration.
+const el = (tag, className = "", text = "") => {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text) node.textContent = text;
+  return node;
+};
 const esc = (v) => String(v ?? "").replace(/[&<>"']/g,
   (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
 const ICON_SPRITE = "icons/material-icons.svg";
@@ -570,6 +581,12 @@ function capabilityRefusal(key) {
 // panel, where the work actually happens, they did not exist: the owner asked
 // for a feature that had been shipped weeks earlier. Settings belong here.
 
+// FOUND BY THE LINTER: nothing reads this. loadCrawlSettings/saveCrawlSettings
+// name their keys inline instead, so this list can drift from the real ones and
+// nothing would say so. Left in place rather than deleted because "which keys
+// are the crawl settings" is worth having in one place -- WIRING it is the fix,
+// and that is a change to behaviour, not a lint tidy.
+// eslint-disable-next-line no-unused-vars
 const CRAWL_KEYS = ["crawl_honour_delay", "crawl_min_interval_s",
                     "crawl_parallel_sources", "crawl_timeout_s",
                     "crawl_user_agent"];
@@ -747,6 +764,12 @@ function financeRefreshIsOverdue(status) {
 }
 
 let financeCurrencySelectUi = null;
+// FOUND BY THE LINTER: assigned at setup and never read again, while its twin
+// `financeCurrencySelectUi` is re-synced every time the rates change. It may be
+// harmless -- the target list is not repopulated the way the source list is --
+// or it may be the sync nobody wrote. Answering that means knowing what the
+// target select is meant to show, which is the owner's call, not a linter's.
+// eslint-disable-next-line no-unused-vars
 let financeTargetSelectUi = null;
 
 function setupFinanceConverterSelect({selectId, triggerId, listId, labelPrefix}) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,3 +69,93 @@ markers = [
     # honest: a new file that reads extension/ and forgets the mark fails.
     "extension: guards the Chrome extension; runs on an extension-only change",
 ]
+
+[tool.ruff]
+# 100, not the default 88, because this repository already writes to it: the
+# 99th percentile line in scrapex/ is 91 characters and only 57 lines out of
+# 33,382 exceed 100. A limit the code already respects stops drift; one it does
+# not turns every future diff into a reformat argument.
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+# CHOSEN, not maximal. `--select ALL` reports 960 findings here and almost none
+# of them are defects -- see the ignore list for what was refused and why. A gate
+# that cries wolf 960 times is a gate people learn to skip.
+select = [
+    "F",      # pyflakes: undefined names, unused imports, shadowed imports
+    "E4", "E7", "E9", "E501",
+    "W",      # whitespace
+    "I",      # import order
+    "B",      # bugbear: mutable defaults, loop-variable closures, zip lengths
+    "C4",     # comprehensions
+    "DTZ",    # naive datetimes -- a price warehouse crosses timezones
+    "ISC",    # implicit string concatenation, i.e. the missing comma in a list
+    "PIE", "PLE", "PLW",
+    "SIM", "UP", "FURB", "RUF",
+]
+ignore = [
+    # THE ARABIC RULES. RUF001/2/3 flag ARABIC-INDIC DIGIT ONE and the ARABIC
+    # DECIMAL SEPARATOR as "ambiguous" and suggest `l` and `,` instead. Those
+    # characters are the DOMAIN: scrapex/contract.py parses them out of Egyptian
+    # and Saudi price pages. Enforcing this rule would push the next person to
+    # "fix" the exact characters the parser exists to read.
+    "RUF001", "RUF002", "RUF003",
+    # The CLI's whole job is to print. 81 findings, no defects.
+    "T201",
+    # `raise X from exc` inside except is good practice, but 42 call sites is a
+    # change to error messages the owner reads, not a lint fix. Its own task.
+    "B904",
+    # Every hit is an internal table name interpolated into SQL that never sees
+    # user input. Enabling it would train the reader to wave through S608.
+    "S608",
+    # The rule exists to catch a forgotten comma in a list. Every one of the 38
+    # hits here is instead a deliberately wrapped sentence -- this codebase says
+    # things in whole sentences and they do not fit on one line. The comma bug it
+    # guards against is caught by the tests that read those messages back.
+    "ISC004",
+    # Style, not defect: `except X: pass` written out is clearer to most readers
+    # here than contextlib.suppress, and a lambda that forwards is often named
+    # for what it means. Neither is worth 18 edits across working code.
+    "SIM105", "PLW0108",
+    # BOTH HITS ARE WRONG HERE. The handle is supposed to outlive the function:
+    # cli.py hands it to sys.stdout for the rest of the process, relaunch.py
+    # hands it to Popen. A context manager would close it immediately and break
+    # the feature -- this rule cannot see intent, so it is refused, not silenced
+    # at the call sites where it would read as an admission.
+    "SIM115",
+    # `_run` already implements `check` itself, and raises ScheduleTaskError with
+    # the exit code, what schtasks said, and the exact command line. Passing
+    # check=True would replace that with a bare CalledProcessError.
+    "PLW1510",
+    # One module-level SSL context, built once and shared. That is the point.
+    "PLW0603",
+    # Both strptime calls parse the SAME "...Z" format and only their DIFFERENCE
+    # is used, so the naive frame cancels. Adding %z would change nothing except
+    # to make the format string wrong for the stamps actually stored.
+    "DTZ007",
+    # Collapsing `if key in body:` / `if not setter(...): raise` into one `and`
+    # is semantically identical and strictly harder to read: it buries a call
+    # that MUTATES the database inside a boolean expression.
+    "SIM102",
+    # The three hits are GraphQL query bodies, which are full of `{` and `}`.
+    # Converting %-format to .format() there means escaping every brace in a
+    # query -- a live grenade for a zero-value change.
+    "UP031",
+    # Deferred, see the note below -- these are real changes, not lint tidies.
+    "DTZ011", "UP042", "UP046", "E501",
+]
+
+# NOT ignored -- DEFERRED, each with a task, because each is a real change to
+# behaviour or to a type that the whole codebase depends on, and none of them
+# belongs in a commit whose subject is "add a linter":
+#   DTZ011  date.today() x3 -- local-vs-UTC "as of" dates need a ruling first
+#   UP042   vocab.StrEnum  -- the base class every enum in the product inherits
+#   UP046   DomainDatabase -- PEP 695 generics, touched by every database caller
+#   E501    57 lines over 100 -- p99 is already 91, so this is a tidy, not a fix
+
+[tool.ruff.lint.per-file-ignores]
+# Tests build many small dicts and shadow names on purpose; they are also the
+# files another session edits most, and a gate that fights in-flight work is a
+# gate that gets turned off.
+"tests/*" = ["F401", "F811", "E501"]

--- a/scrapex/backupschedule.py
+++ b/scrapex/backupschedule.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import sqlite3
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 from . import settings
 
@@ -68,7 +68,7 @@ def _stamp(moment: datetime) -> str:
 
 def _read_stamp(text: str) -> datetime | None:
     try:
-        return datetime.strptime(text, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+        return datetime.strptime(text, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
     except (TypeError, ValueError):
         return None
 
@@ -81,7 +81,7 @@ def should_back_up(conn: sqlite3.Connection, *, changed: bool = False,
     `manual` is his own press and outranks everything except OFF: a person who
     just pressed Back up now is not asking to be told about a schedule.
     """
-    moment = (now or datetime.now(timezone.utc)).replace(microsecond=0)
+    moment = (now or datetime.now(UTC)).replace(microsecond=0)
     when = (settings.get(conn, "backup_when") or WHEN_AFTER_CHANGE).strip()
 
     if when == WHEN_OFF:
@@ -134,6 +134,6 @@ def record_upload(conn: sqlite3.Connection, now: datetime | None = None) -> str:
     failed upload postpone the next one, which is the opposite of what anyone
     would want from a backup.
     """
-    stamp = _stamp(now or datetime.now(timezone.utc))
+    stamp = _stamp(now or datetime.now(UTC))
     settings.save(conn, {"backup_last_uploaded_at": stamp})
     return stamp

--- a/scrapex/bundle.py
+++ b/scrapex/bundle.py
@@ -37,7 +37,6 @@ from __future__ import annotations
 import csv
 import gzip
 import hashlib
-import io
 import json
 import shutil
 import sqlite3
@@ -46,9 +45,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from .archive import backup_database
-from .reports import (export_details_table, export_history_table,
-                      export_source_table, list_sources)
 from .payload import utc_now_iso
+from .reports import export_details_table, export_history_table, export_source_table, list_sources
 from .version import VERSION
 
 #: The bundle's own shape, separate from the engine's version and from the
@@ -106,7 +104,7 @@ def _write_table(directory: Path, name: str, header: list[str],
     jsonl = directory / f"{name}.jsonl"
     with open(jsonl, "w", encoding="utf-8", newline="\n") as handle:
         for row in rows:
-            handle.write(json.dumps(dict(zip(header, row)), ensure_ascii=False))
+            handle.write(json.dumps(dict(zip(header, row, strict=True)), ensure_ascii=False))
             handle.write("\n")
 
     comma = directory / f"{name}.csv"

--- a/scrapex/capture.py
+++ b/scrapex/capture.py
@@ -7,9 +7,9 @@ it triggers this, which reuses the Python connectors + the one ingest pipeline.
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import Callable
 from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass, field
-from typing import Callable
 
 from . import settings
 from .config import SourceEntry
@@ -341,7 +341,7 @@ def capture_source(conn: sqlite3.Connection, entry: SourceEntry,
         # Said in the log as well as on the result because the result is a
         # return value and the log is what the owner actually reads.
         if journal_skips:
-            from .jobs import append_log, LogLevel
+            from .jobs import LogLevel, append_log
             for line in journal_skips:
                 append_log(conn, job_id, line, level=LogLevel.WARNING,
                            source_key=entry.source_key)

--- a/scrapex/catalog.py
+++ b/scrapex/catalog.py
@@ -12,8 +12,13 @@ import sqlite3
 from typing import Any
 
 from .catalog_models import (
-    DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, CatalogConflict, CatalogNotFound,
-    DatasetCreate, FieldCreate, SiteCreate,
+    DEFAULT_PAGE_SIZE,
+    MAX_PAGE_SIZE,
+    CatalogConflict,
+    CatalogNotFound,
+    DatasetCreate,
+    FieldCreate,
+    SiteCreate,
 )
 
 

--- a/scrapex/catalog_relations.py
+++ b/scrapex/catalog_relations.py
@@ -7,7 +7,10 @@ from typing import Any
 
 from .catalog import _dataset_row, _json, _page_limit, _site_row
 from .catalog_models import (
-    DEFAULT_PAGE_SIZE, CatalogConflict, RelationshipCreate, RelationshipReviewStatus,
+    DEFAULT_PAGE_SIZE,
+    CatalogConflict,
+    RelationshipCreate,
+    RelationshipReviewStatus,
 )
 
 

--- a/scrapex/changes.py
+++ b/scrapex/changes.py
@@ -166,7 +166,7 @@ def _display_unit(item: dict) -> str:
     raw columns are popped because they are query plumbing, not fields of a
     change event, and the feed's shape is part of its contract.
     """
-    from .reports import price_basis, price_unit      # display-only resolution
+    from .reports import price_basis, price_unit  # display-only resolution
     unit_code = item.pop("unit_code", None)
     basis = item.pop("basis_quantity", 1)
     weight = item.pop("weight", None)
@@ -206,7 +206,7 @@ def recent_changes(conn: sqlite3.Connection, source_key: str | None = None,
     sql += "ORDER BY c.change_event_id DESC LIMIT ?"
     params.append(max(1, min(limit, 500)))
 
-    from .reports import region_name          # display-only resolution
+    from .reports import region_name  # display-only resolution
     out = []
     for row in conn.execute(sql, params):
         item = dict(row)

--- a/scrapex/cli.py
+++ b/scrapex/cli.py
@@ -20,14 +20,13 @@ import sys
 from pathlib import Path
 
 from . import db as dbmod
-from . import localinbox
+from . import localinbox, version
 from .config import MANIFEST_FILE, load_manifest
 from .connectors.factory import build_connector
 from .databases import DatabaseRegistry
 from .databases.registry import REGISTRY_FILE
 from .funnel import FunnelClient
 from .ingest import ingest_payloads
-from .reports import recent_observations, source_summary
 from .payload import (
     PAYLOAD_COMPAT_VERSION,
     PAYLOAD_VERSION,
@@ -35,9 +34,9 @@ from .payload import (
     new_payload,
     utc_now_iso,
 )
+from .reports import recent_observations, source_summary
 from .rowspec import ALL_SPECS
 from .vocab import ExtractKind, PayloadClient
-from . import version
 
 ROOT_DIR = Path(__file__).resolve().parent.parent
 CONTRACTS_DIR = ROOT_DIR / "contracts"
@@ -539,7 +538,7 @@ def _cmd_peek(args: argparse.Namespace) -> int:
     print(f"  last run: {summary.last_run or 'never'} ({summary.last_status or '-'})")
     print("  SOURCE-LOCAL layer (raw, as scraped):")
     print(f"    products: {summary.products} | variants: {summary.variants} | observations: {summary.observations}")
-    print(f"    curation: " + ", ".join(f"{n} {status}" for status, n in sorted(summary.curation.items())))
+    print("    curation: " + ", ".join(f"{n} {status}" for status, n in sorted(summary.curation.items())))
     print("  UNIFIED layer (fills only after you curate — census/apply-decisions, Phase 2):")
     print(f"    matched variants: {summary.matched_variants} | published (in view): {summary.published_rows}")
     if sample:
@@ -713,7 +712,7 @@ def _upgrade_what_is_only_behind(registry, report: dict) -> dict:
         path = Path(state["path"])
         try:
             made = backup_database(path, tag="pre-upgrade")
-        except Exception as exc:           # noqa: BLE001 — no backup, no migration
+        except Exception as exc:
             print(f"error: the {state['kind']} database is behind but could not be "
                   f"backed up, so it was not upgraded ({exc})", file=sys.stderr)
             return report
@@ -738,6 +737,7 @@ def _cmd_ui(args: argparse.Namespace) -> int:
     _bind_log_streams()
     try:
         import uvicorn
+
         from .webui.app import create_app
     except ImportError:
         print("the UI needs the ui extra: pip install -e .[ui]", file=sys.stderr)
@@ -940,7 +940,7 @@ def _cmd_run_due(args) -> int:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    from .native import PROTOCOL_VERSION      # local, as everywhere else here
+    from .native import PROTOCOL_VERSION  # local, as everywhere else here
 
     parser = argparse.ArgumentParser(prog="scrapex", description=__doc__)
     # Answered without a subcommand, and it has to be: `--version` is what you
@@ -1114,7 +1114,7 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
         return args.func(args)
-    except Exception as exc:  # noqa: BLE001 — single explicit CLI error boundary (Q3)
+    except Exception as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 

--- a/scrapex/compaction.py
+++ b/scrapex/compaction.py
@@ -169,7 +169,7 @@ def _typed_class_for(path: Path):
     quietly build the legacy way AND switch off the check that would have caught
     it. An id of 0 is an answer and means legacy. Silence is not an answer.
     """
-    from .databases.domain import EngineDatabase   # local: databases/ imports down to here
+    from .databases.domain import EngineDatabase  # local: databases/ imports down to here
 
     app_id = _application_id(path)
     if app_id is None:
@@ -361,7 +361,7 @@ def _refused_by_the_product(source: Path, successor: Path) -> list[str]:
         return []          # a legacy unmarked warehouse has no typed door to try
     try:
         typed(successor).connect().close()
-    except Exception as exc:            # noqa: BLE001 — any refusal is a problem
+    except Exception as exc:
         return [f"the successor is not a {typed.kind} database this product can "
                 f"open ({type(exc).__name__}: {exc})"]
     return []
@@ -393,7 +393,7 @@ def verify_successor(src_path: Path | str, dst_path: Path | str) -> list[str]:
                 f"for example offer {next(iter(missing))[0]}")
 
         for check in ("integrity_check", "foreign_key_check"):
-            findings = [r for r in dst.execute(f"PRAGMA {check}")]
+            findings = list(dst.execute(f"PRAGMA {check}"))
             if check == "integrity_check":
                 findings = [f for f in findings if f[0] != "ok"]
             if findings:

--- a/scrapex/config.py
+++ b/scrapex/config.py
@@ -174,7 +174,7 @@ class TaxEvidence(BaseModel):
     verified_at: str | None = None
 
     @model_validator(mode="after")
-    def _evidence_must_be_evidenced(self) -> "TaxEvidence":
+    def _evidence_must_be_evidenced(self) -> TaxEvidence:
         # These mirror the CHECK constraints in migration 0018, so a bad manifest
         # is refused by validate-manifest instead of by SQLite mid-crawl.
         if self.evidence == "stated":
@@ -395,7 +395,7 @@ class SourceEntry(BaseModel):
         return v
 
     @model_validator(mode="after")
-    def _fallbacks_exclude_self(self) -> "SourceEntry":
+    def _fallbacks_exclude_self(self) -> SourceEntry:
         # A fallback chain that re-tries the family that just failed would loop
         # over the same failure instead of escalating.
         if self.family in self.fallback_families:
@@ -405,7 +405,7 @@ class SourceEntry(BaseModel):
         return self
 
     @model_validator(mode="after")
-    def _probe_placeholder_is_inactive(self) -> "SourceEntry":
+    def _probe_placeholder_is_inactive(self) -> SourceEntry:
         # A source that has not been probed cannot be active (A3: no family until proven).
         if self.family == ConnectorFamily.TBD_PROBE and self.active:
             raise ValueError(
@@ -421,7 +421,7 @@ class Manifest(BaseModel):
     sources: list[SourceEntry] = Field(min_length=1)
 
     @model_validator(mode="after")
-    def _unique_source_keys(self) -> "Manifest":
+    def _unique_source_keys(self) -> Manifest:
         seen: set[str] = set()
         for entry in self.sources:
             if entry.source_key in seen:

--- a/scrapex/connectors/aramco.py
+++ b/scrapex/connectors/aramco.py
@@ -14,7 +14,7 @@ the words are the contract.
 from __future__ import annotations
 
 import re
-from typing import Iterable
+from collections.abc import Iterable
 
 from ..config import SourceEntry
 from ..normalize import strip_markup
@@ -156,14 +156,14 @@ class AramcoFuelConnector:
             lines = page_lines(html)
             start = next(i for i, line in enumerate(lines) if _HEADING_EN in line)
             labels = {}
-            for price, label in parse_pairs(lines, start):
+            for _price, label in parse_pairs(lines, start):
                 material = _MATERIALS_EN.get(label.strip().lower())
                 if material:
                     labels[material] = label.strip()
             return labels
         except CrawlBlocked:
             raise
-        except Exception as exc:  # noqa: BLE001 — the Arabic prices are the point
+        except Exception as exc:
             warnings.append(f"english edition unavailable — labels stay "
                             f"Arabic-only this run: {exc}")
             return {}

--- a/scrapex/connectors/base.py
+++ b/scrapex/connectors/base.py
@@ -10,8 +10,9 @@ import random
 import ssl
 import threading
 import time
+from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Iterable, Protocol, runtime_checkable
+from typing import Protocol, runtime_checkable
 
 import httpx
 
@@ -192,7 +193,7 @@ def declare_frontier(fetcher, pages: int) -> None:
         return
     try:
         declare(pages)
-    except Exception:  # noqa: BLE001 — a progress figure may never break a crawl
+    except Exception:
         pass
 
 
@@ -302,7 +303,7 @@ class HttpFetcher:
 
     # ---- what this crawl expects to cost ------------------------------------
 
-    def expect_requests(self, pages: int) -> None:      # noqa: D401 — see declare_frontier
+    def expect_requests(self, pages: int) -> None:
         """A connector declaring "I now know I will fetch `pages` more pages".
 
         Counted FROM THE REQUESTS ALREADY MADE, because that is the only way the
@@ -338,12 +339,12 @@ class HttpFetcher:
                 # pages, which is the exact complaint being fixed.
                 try:
                     self.on_expectation(declared)
-                except Exception:  # noqa: BLE001 — progress display only
+                except Exception:
                     pass
 
     # ---- validators, so a repeat crawl can be answered with 304 -------------
 
-    def fresh_session(self) -> "HttpFetcher":
+    def fresh_session(self) -> HttpFetcher:
         """A SECOND fetcher with this one's settings and none of its state.
 
         For the rare case where a site's answer depends on the session itself
@@ -418,7 +419,7 @@ class HttpFetcher:
             if answer.status_code == 200:
                 parser = RobotFileParser()
                 parser.parse(answer.text.splitlines())
-        except Exception:  # noqa: BLE001 — no robots file is a normal state
+        except Exception:
             parser = None
         self._robots[host] = parser
         if parser is not None:
@@ -484,7 +485,7 @@ class HttpFetcher:
                     # (CrawlInterrupted). Swallowing THAT with the display
                     # errors would make the brakes decorative.
                     raise
-                except Exception:  # noqa: BLE001 — progress display only
+                except Exception:
                     pass
 
             if response.status_code == 304:
@@ -612,7 +613,7 @@ class BrowserFetcher:
                         return page.content()
                     finally:
                         browser.close()
-            except Exception as exc:  # noqa: BLE001 — recorded, retried, re-raised (Q3)
+            except Exception as exc:
                 last_error = exc
                 time.sleep(2**attempt)
         raise RuntimeError(f"browser fetch failed after {retries + 1} attempts: {url}") from last_error

--- a/scrapex/connectors/custom_json.py
+++ b/scrapex/connectors/custom_json.py
@@ -92,13 +92,13 @@ enrichment declaration to be complete.
 """
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from ..config import SourceEntry
 from ..normalize import brand_pair, selling_unit_from
 from ..rowspec import ENRICHMENT, PRODUCT_PRICES, RowBuilder
 from ..units import Charter, Resolution, charter_for
-from ..vocab import DetailGroup, group_for_code, Availability, ExtractKind
+from ..vocab import Availability, DetailGroup, ExtractKind, group_for_code
 from .base import CrawlBlocked, HttpFetcher, ScrapedTable
 
 # A page is 12 products; 8 pages today. This cap is a runaway guard, not a
@@ -456,7 +456,7 @@ class CustomJsonConnector:
                 body = self._fetcher.get(f"{endpoint}/{pid}").json()
             except CrawlBlocked:
                 raise
-            except Exception as exc:  # noqa: BLE001 — isolate per product
+            except Exception as exc:
                 body = None
                 notes.append(_skipped(product, f"the request failed: {exc}"))
             if body is not None:

--- a/scrapex/connectors/factory.py
+++ b/scrapex/connectors/factory.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 
 from ..config import SourceEntry
 from ..vocab import ConnectorFamily
+from .aramco import AramcoFuelConnector
 from .base import HttpFetcher, SiteConnector, resolve_fetcher
 from .custom_json import CustomJsonConnector
-from .aramco import AramcoFuelConnector
 from .gpp import GlobalPetrolPricesConnector
 from .heidelberg import HeidelbergPriceMatrixConnector
 from .hybris import HybrisOccConnector

--- a/scrapex/connectors/gpp.py
+++ b/scrapex/connectors/gpp.py
@@ -24,9 +24,9 @@ pairing spot-checked (Venezuela 0.004, Egypt 0.404, Saudi Arabia 0.476 USD/litre
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import date, timedelta
-from typing import Iterable
 
 from bs4 import BeautifulSoup
 
@@ -118,7 +118,7 @@ def parse_price_table(html: str, country_sel: str = _COUNTRY_SEL,
         raise ValueError(
             f"GPP layout drift: {len(names)} country labels vs {len(values)} price "
             "values (positional parse would misalign — refusing)")
-    return list(zip(names, values))
+    return list(zip(names, values, strict=True))
 
 
 def parse_rank_table(html: str, column: int) -> list[tuple[str, str]]:
@@ -251,7 +251,7 @@ class GlobalPetrolPricesConnector:
                 # stop signal under it would turn "stop" into hundreds more
                 # requests against a server that already objected.
                 raise
-            except Exception as exc:  # noqa: BLE001 — one page down never kills the crawl
+            except Exception as exc:
                 page_errors.append(f"{material_key}: {exc}")
                 failures += 1
                 continue
@@ -298,7 +298,7 @@ class GlobalPetrolPricesConnector:
                     detail = parse_country_page(self._fetcher.get(base + href).text)
                 except CrawlBlocked:
                     raise
-                except Exception as exc:  # noqa: BLE001 — isolate per country
+                except Exception as exc:
                     # Deliberately NOT tokenized: a page that FAILED must be
                     # retried on resume, unlike one that answered "nothing".
                     page_errors.append(f"{material_key}/{region}: {exc}")
@@ -357,7 +357,7 @@ class GlobalPetrolPricesConnector:
         yield from self._finish(source, base, builder, page_errors, unmapped)
 
     def _history_rows(self, builder: RowBuilder, material_key: str, region: str,
-                      detail: "CountryPrice", base: str, href: str,
+                      detail: CountryPrice, base: str, href: str,
                       currency: str, unit: str, vat: str,
                       page_errors: list[str]) -> list[list[str]]:
         """The full weekly series from the Arabic mirror, as reported rows.
@@ -374,7 +374,7 @@ class GlobalPetrolPricesConnector:
             points = parse_arabic_history(self._fetcher.get(ar_url).text)
         except CrawlBlocked:
             raise
-        except Exception as exc:  # noqa: BLE001 — history is additive, not vital
+        except Exception as exc:
             page_errors.append(f"{material_key}/{region}: history mirror: {exc}")
             return []
         if not points:
@@ -428,7 +428,7 @@ class GlobalPetrolPricesConnector:
 
 
 def _row(builder: RowBuilder, material_key: str, region: str, price: str,
-         currency: str, unit: str, vat: str, country: "CountryPrice | None" = None,
+         currency: str, unit: str, vat: str, country: CountryPrice | None = None,
          *, as_of: str = "", provenance: str = "observed", value: str = ""):
     """One commodity row. `country` carries what the country page published.
 
@@ -440,12 +440,12 @@ def _row(builder: RowBuilder, material_key: str, region: str, price: str,
     amount = value or price
     if not any(ch.isdigit() for ch in amount):
         return None  # '-' / 'N/A' cells — skip, don't feed the money parser garbage
-    fields = dict(
-        material_key=material_key, country_code_alpha2=region, currency=currency, unit=unit,
-        tax_included=vat, price=amount, observed_label="",
-        provenance=provenance, as_of_date=as_of,
-        price_basis="converted",
-    )
+    fields = {
+        "material_key": material_key, "country_code_alpha2": region, "currency": currency, "unit": unit,
+        "tax_included": vat, "price": amount, "observed_label": "",
+        "provenance": provenance, "as_of_date": as_of,
+        "price_basis": "converted",
+    }
     if country and country.price and country.currency:
         # The price becomes the one the SOURCE publishes, in the currency it
         # publishes it in. Carrying an EGP amount in a field labelled USD — which
@@ -474,7 +474,7 @@ def _row(builder: RowBuilder, material_key: str, region: str, price: str,
 
 
 def country_rows(builder: RowBuilder, material_key: str, region: str,
-                 country: "CountryPrice", currency: str, unit: str, vat: str,
+                 country: CountryPrice, currency: str, unit: str, vat: str,
                  today: date) -> list[list[str]]:
     """The current price plus whatever history the country page published.
 
@@ -542,7 +542,7 @@ _AGO_LABELS = {
     "six months ago": 182,
     "one year ago": 365,
 }
-_CURRENCY_UNIT = re.compile(r"Price\s*\(([A-Za-z]{3})\s*/\s*([^)]+)\)", re.I)
+_CURRENCY_UNIT = re.compile(r"Price\s*\(([A-Za-z]{3})\s*/\s*([^)]+)\)", re.IGNORECASE)
 
 # GPP has a SECOND country-page template — COMPACT — for Libya, Venezuela and
 # evidently much of the regulated cheap-fuel cohort. Verified live 2026-07-27
@@ -737,7 +737,7 @@ def parse_country_page(html: str) -> CountryPrice:
 # (date, local-currency price) back to 2016, readable by any visitor's browser.
 # In scope under the owner's licence rule (what the public page shows any
 # visitor); the paid API and data download remain untouched.
-_ADDROWS = re.compile(r"data\.addRows\(\[(.*?)\]\);", re.S)
+_ADDROWS = re.compile(r"data\.addRows\(\[(.*?)\]\);", re.DOTALL)
 _AR_POINT = re.compile(r"\[\s*'([^']*)'\s*,\s*([\d.]+)\s*\]")
 # The labels read 'يوم DD شهر MM سنة YYYY' — day, month, year, in words the
 # regex anchors on so a digit can never be read out of position.

--- a/scrapex/connectors/heidelberg.py
+++ b/scrapex/connectors/heidelberg.py
@@ -169,7 +169,7 @@ DISPLAY branches are correct. We record what is displayed.
 from __future__ import annotations
 
 import html
-from typing import Iterable
+from collections.abc import Iterable
 from urllib.parse import urljoin, urlsplit
 
 from bs4 import BeautifulSoup
@@ -349,7 +349,7 @@ def read_families(fetcher: HttpFetcher, taxonomy: TaxonomyConfig,
         url = f"{root}{path}"
         try:
             pages[lang] = _listing_labels(fetcher.get(url).text, url)
-        except Exception as exc:  # noqa: BLE001 — a second host is allowed to be down
+        except Exception as exc:
             pages[lang] = {}
             defects.append(
                 f"the {lang} cement-family listing ({url}) could not be read "

--- a/scrapex/connectors/hybris.py
+++ b/scrapex/connectors/hybris.py
@@ -19,10 +19,10 @@ on the manifest's word, because the payload cannot be wrong about itself.
 from __future__ import annotations
 
 import re
-from typing import Iterable
+from collections.abc import Iterable
 
-from ..normalize import brand_pair
 from ..config import SourceEntry
+from ..normalize import brand_pair
 from ..rowspec import ENRICHMENT, PRODUCT_PRICES, RowBuilder
 from ..vocab import Availability, ExtractKind, group_for_code
 from .base import CrawlBlocked, HttpFetcher, ScrapedTable
@@ -230,7 +230,6 @@ class HybrisOccConnector:
         display_base = source.base_url.rstrip("/")
         vat = "1" if source.vat_mode.value == "incl" else "0"
         currency = source.currency or "UNKNOWN"
-        rows: list[list[str]] = []
         notes: list[str] = []
         unpriced = 0
         # The pictures ride the SAME search response the prices come from, so
@@ -364,7 +363,7 @@ class HybrisOccConnector:
                     break
         except CrawlBlocked:
             raise
-        except Exception as exc:  # noqa: BLE001 — bilingual is additive, prices are vital
+        except Exception as exc:
             notes.append("english-names pass failed — names stay "
                          f"{PRIMARY_LANG}-only this run: {exc}")
             return {}
@@ -380,7 +379,7 @@ class HybrisOccConnector:
             body = self._fetcher.get(f"{_occ_root(source)}/languages").json() or {}
         except CrawlBlocked:
             raise
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             notes.append("could not read the store's language list — names "
                          f"stay {PRIMARY_LANG}-only this run: {exc}")
             return set()

--- a/scrapex/connectors/jsonld.py
+++ b/scrapex/connectors/jsonld.py
@@ -48,7 +48,7 @@ def sitemap_products(fetcher, sitemap_url: str, keep: Callable[[str], bool],
         locs = sitemap_locs(fetcher.get(sitemap_url).text)
     except CrawlBlocked:
         raise                                  # the owner's Stop, or the site's
-    except Exception as exc:  # noqa: BLE001 — reported, never turned into "empty"
+    except Exception as exc:
         raise SitemapUnreadable(
             f"the product index at {sitemap_url} could not be read ({exc}), so "
             "this run cannot tell an empty catalogue from an unreachable one"
@@ -60,7 +60,7 @@ def sitemap_products(fetcher, sitemap_url: str, keep: Callable[[str], bool],
             products += [url for url in sitemap_locs(fetcher.get(child).text) if keep(url)]
         except CrawlBlocked:
             raise
-        except Exception as exc:  # noqa: BLE001 — one child, counted and survived
+        except Exception as exc:
             if unreadable_children is not None:
                 unreadable_children.append(f"{child}: {exc}")
     return dedupe(products) if dedupe else list(dict.fromkeys(products))
@@ -179,7 +179,7 @@ def walk_product_pages(
             html = fetcher.get(url).text
         except CrawlBlocked:
             raise
-        except Exception:  # noqa: BLE001 — one dead page never kills the crawl (Q3)
+        except Exception:
             tally.unreachable += 1
             continue
         node = parse_product_jsonld(html)

--- a/scrapex/connectors/magento.py
+++ b/scrapex/connectors/magento.py
@@ -30,16 +30,13 @@ So a configurable row is stored at 50.4 with tax_included=0 and reads "Excl.
 from __future__ import annotations
 
 import re
-
-from typing import Iterable
+from collections.abc import Iterable
 
 from ..config import SourceEntry
-from ..units import charter_for
-from ..normalize import (option_axes_json, option_fingerprint, selling_unit_from,
-                         strip_markup)
+from ..normalize import option_axes_json, option_fingerprint, selling_unit_from, strip_markup
 from ..rowspec import ENRICHMENT, PRODUCT_PRICES, RowBuilder
-from ..vocab import (Availability, DetailGroup, DisplayMethod, ExtractKind,
-                     group_for_code)
+from ..units import charter_for
+from ..vocab import Availability, DisplayMethod, ExtractKind, group_for_code
 from .base import CrawlBlocked, HttpFetcher, ScrapedTable, declare_frontier
 
 PAGE_SIZE = 100
@@ -672,7 +669,7 @@ class MagentoGraphqlConnector:
                 )
 
     def _attribute_labels(self, endpoint: str, store: str | None,
-                          notes: list, codes: "set[str] | None" = None) -> dict:
+                          notes: list, codes: set[str] | None = None) -> dict:
         """attribute code -> the store's own human label, for EVERY attribute.
 
         The owner's report, with a screenshot: the site prints «المصنع»,
@@ -718,7 +715,7 @@ class MagentoGraphqlConnector:
             return found
         except CrawlBlocked:
             raise
-        except Exception as exc:  # noqa: BLE001 — labels are additive
+        except Exception as exc:
             notes.append(f"attribute labels unavailable for "
                          f"{store or 'the default store'} — codes stand in: {exc}")
             return {}
@@ -741,7 +738,7 @@ class MagentoGraphqlConnector:
                       .json() or {})
         except CrawlBlocked:
             raise
-        except Exception as exc:  # noqa: BLE001 — the crawl does not hang on this
+        except Exception as exc:
             notes.append(f"filters: aggregations unavailable ({exc}) — the site's "
                          "filterable attributes stay under More information")
             return {}
@@ -773,7 +770,7 @@ class MagentoGraphqlConnector:
                       .json() or {})
         except CrawlBlocked:
             raise
-        except Exception as exc:  # noqa: BLE001 — the crawl does not hang on this
+        except Exception as exc:
             notes.append(f"the store did not state the unit of its weights ({exc}) "
                          "— prices quoted against a weight show no basis this run")
             return ""
@@ -885,7 +882,7 @@ class MagentoGraphqlConnector:
                 page += 1
         except CrawlBlocked:
             raise
-        except Exception as exc:  # noqa: BLE001 — bilingual is additive, prices are vital
+        except Exception as exc:
             notes.append(f"english-names pass failed — names and variations stay "
                          f"Arabic-only this run: {exc}")
             return {"names": {}, "axis_labels": {}, "axis_values": {},
@@ -917,7 +914,7 @@ class MagentoGraphqlConnector:
                 walk(root, [])
         except CrawlBlocked:
             raise
-        except Exception as exc:  # noqa: BLE001 — the Arabic path still stands
+        except Exception as exc:
             notes.append(f"english category tree unavailable — classification "
                          f"stays Arabic-only this run: {exc}")
         return labels
@@ -991,7 +988,7 @@ class MagentoGraphqlConnector:
                 walk(root, [])
         except CrawlBlocked:
             raise
-        except Exception as exc:  # noqa: BLE001 — classification is additive, prices are vital
+        except Exception as exc:
             notes.append(f"category tree walk failed — rows carry no "
                          f"classification this run: {exc}")
             return {}

--- a/scrapex/connectors/salla.py
+++ b/scrapex/connectors/salla.py
@@ -38,27 +38,50 @@ than it works on.
 from __future__ import annotations
 
 import re
-from typing import Iterable
+from collections.abc import Iterable
 
 from bs4 import BeautifulSoup
 
-from ..localinbox import safe_token
-from ..normalize import brand_pair
 from ..config import SourceEntry
+from ..localinbox import safe_token
+
 # ENRICHMENT is imported eagerly: the enrichment branch below referenced it
 # without it ever being in scope, so a salla source that declared an
 # enrichment extract would have died on NameError after the whole crawl.
 from ..rowspec import ENRICHMENT, PRODUCT_PRICES, RowBuilder
 from ..vocab import ExtractKind
 from .base import HttpFetcher, ScrapedTable, declare_frontier
+
 # Shared SSR helpers (also re-exported for salla's tests). offer_price/parse are
 # generic; the /p{id} id scheme below is the salla-specific part. enrichment_rows
 # moved to jsonld when zid needed the same pictures-and-prose reading — it is
 # imported here rather than left behind so both families share one copy.
-from .jsonld import (Picture, WalkTally, brand_name, category_path,
-                     enrichment_rows, jsonld_pictures, merge_pictures,
-                     offer_price, parse_product_jsonld, product_row,
-                     sitemap_locs, sitemap_products, walk_product_pages)
+from .jsonld import (
+    Picture,
+    WalkTally,
+    brand_name,
+    category_path,
+    enrichment_rows,
+    jsonld_pictures,
+    merge_pictures,
+    offer_price,
+    parse_product_jsonld,
+    product_row,
+    sitemap_locs,
+    sitemap_products,
+    walk_product_pages,
+)
+
+# THE RE-EXPORTS, SAID OUT LOUD. The comment above has always claimed these are
+# re-exported for salla's tests; a comment could not stop `ruff --fix` deleting
+# four of them as unused, and it did -- tests/test_salla.py stopped importing.
+# __all__ is the same claim in a form the tooling reads.
+__all__ = [
+    "Picture", "SallaConnector", "WalkTally", "brand_name", "category_path",
+    "enrichment_rows", "jsonld_pictures", "merge_pictures", "offer_price",
+    "one_url_per_product", "page_pictures", "parse_product_jsonld",
+    "product_row", "sitemap_locs", "sitemap_products", "walk_product_pages",
+]
 
 _PRODUCT_ID = re.compile(r"/p(\d{5,})")
 

--- a/scrapex/connectors/shopify.py
+++ b/scrapex/connectors/shopify.py
@@ -6,7 +6,7 @@ against the canonical RowSpec (never hardcoded column order, Q2).
 """
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from ..config import SourceEntry
 from ..normalize import brand_pair, option_axes_json, option_fingerprint
@@ -127,7 +127,7 @@ class ShopifyConnector:
                 products = self._fetcher.get(url).json().get("products", [])
             except CrawlBlocked:
                 raise
-            except Exception as exc:  # noqa: BLE001 — bilingual is additive
+            except Exception as exc:
                 if page == 1:
                     notes.append(
                         f"{locale} locale unavailable — every name stays in the "

--- a/scrapex/connectors/woocommerce.py
+++ b/scrapex/connectors/woocommerce.py
@@ -14,13 +14,12 @@ request per variation buys the real numbers.
 from __future__ import annotations
 
 import re
-
-from typing import Iterable
+from collections.abc import Iterable
 
 from ..config import SourceEntry
 from ..normalize import brand_pair, option_axes_json, option_fingerprint, strip_markup
 from ..rowspec import ENRICHMENT, PRODUCT_PRICES, RowBuilder
-from ..vocab import DetailGroup, group_for_code, Availability, ExtractKind
+from ..vocab import Availability, DetailGroup, ExtractKind, group_for_code
 from .base import CrawlBlocked, HttpFetcher, ScrapedTable
 
 PER_PAGE = 100
@@ -207,7 +206,7 @@ class WooCommerceConnector:
                 child = self._fetcher.get(f"{endpoint}/{vid}").json()
             except CrawlBlocked:
                 raise    # the site said no — hundreds more requests is not the answer
-            except Exception as exc:  # noqa: BLE001 — isolate per variation
+            except Exception as exc:
                 notes.append(f"{product.get('name')}: variation {vid}: {exc}")
                 continue
             row = self._row(builder, child if isinstance(child, dict) else {},

--- a/scrapex/connectors/zid.py
+++ b/scrapex/connectors/zid.py
@@ -72,17 +72,25 @@ is the only way anyone can ever see it.
 from __future__ import annotations
 
 import re
-from typing import Iterable
+from collections.abc import Iterable
 from urllib.parse import urljoin
 
-from ..localinbox import safe_token
 from ..config import SourceEntry
+from ..localinbox import safe_token
 from ..rowspec import ENRICHMENT, PRODUCT_PRICES, RowBuilder
 from ..vocab import ExtractKind
 from .base import CrawlBlocked, HttpFetcher, ScrapedTable
-from .jsonld import (WalkTally, alternate_links, english_alternate,
-                     enrichment_rows, offer_price, parse_product_jsonld,
-                     product_row, sitemap_products, walk_product_pages)
+from .jsonld import (
+    WalkTally,
+    alternate_links,
+    english_alternate,
+    enrichment_rows,
+    offer_price,
+    parse_product_jsonld,
+    product_row,
+    sitemap_products,
+    walk_product_pages,
+)
 
 _PRODUCT_PATH = "/products/"
 
@@ -94,7 +102,7 @@ _STORE_RATE = re.compile(
     r'"code"\s*:\s*"([A-Za-z]{3})"'
     r'(?:(?!"code"\s*:).)*?'
     r'"exchange_rate"\s*:\s*"?([0-9]*\.?[0-9]+)"?',
-    re.S)
+    re.DOTALL)
 
 # 1 USD buying more than a million units is a parse gone wrong, not a rate.
 # Same ceiling rates.py applies to Google Finance, restated at this door
@@ -289,7 +297,7 @@ class ZidConnector:
                 found = _bootstrap_rates(probe.get(target).text)
             except CrawlBlocked:
                 raise                    # the site said stop — stop
-            except Exception as exc:  # noqa: BLE001 — one page never kills a crawl
+            except Exception as exc:
                 notes.append(f"{region.upper()}: the store's exchange rate was "
                              f"not read from {target} — {exc}")
                 continue
@@ -343,7 +351,7 @@ class ZidConnector:
             other = parse_product_jsonld(self._fetcher.get(alt).text)
         except CrawlBlocked:
             raise
-        except Exception:  # noqa: BLE001 — one dead page never kills the crawl (Q3)
+        except Exception:
             return {}, 1
         if not other:
             return {}, 1

--- a/scrapex/databases/domain.py
+++ b/scrapex/databases/domain.py
@@ -8,10 +8,11 @@ from __future__ import annotations
 import hashlib
 import os
 import sqlite3
+from collections.abc import Callable
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Callable, Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 from .. import db as legacy_db
 from ..database_ids import ENGINE_APPLICATION_ID, ENGINE_DATABASE_KIND
@@ -541,7 +542,7 @@ class DomainDatabase(Generic[T]):
 
 def _engine_plan() -> tuple[Migration, ...]:
     """One stream: the derived schema at v1, then the folder beside it."""
-    return tuple([Migration(1, ENGINE_SCHEMA), *_folder_migrations(ENGINE_MIGRATIONS)])
+    return (Migration(1, ENGINE_SCHEMA), *_folder_migrations(ENGINE_MIGRATIONS))
 
 
 class EngineDatabase(DomainDatabase[T]):

--- a/scrapex/databases/registry.py
+++ b/scrapex/databases/registry.py
@@ -52,14 +52,14 @@ class DatabaseRegistry:
                 "the database and the registry cannot be the same file")
 
     @classmethod
-    def defaults(cls, *, pointer_file: Path | str = REGISTRY_FILE) -> "DatabaseRegistry":
+    def defaults(cls, *, pointer_file: Path | str = REGISTRY_FILE) -> DatabaseRegistry:
         pointer = Path(pointer_file)
         if pointer.is_file():
             return cls.read(pointer)
         return cls(EngineDatabase(DEFAULT_ENGINE_PATH), pointer_file=pointer)
 
     @classmethod
-    def read(cls, pointer_file: Path | str = REGISTRY_FILE) -> "DatabaseRegistry":
+    def read(cls, pointer_file: Path | str = REGISTRY_FILE) -> DatabaseRegistry:
         pointer = Path(pointer_file)
         try:
             data = json.loads(pointer.read_text(encoding="utf-8"))

--- a/scrapex/db.py
+++ b/scrapex/db.py
@@ -18,7 +18,6 @@ import time
 from contextlib import contextmanager
 from pathlib import Path
 
-
 # db/ lives next to the package; schema.sql is the single DDL truth (Q1).
 DB_DIR = Path(__file__).resolve().parent.parent / "db"
 SCHEMA_FILE = DB_DIR / "schema.sql"

--- a/scrapex/drive.py
+++ b/scrapex/drive.py
@@ -165,8 +165,7 @@ def download(token: str, file_id: str, path: Path | str,
                 response.read()
                 _check(response, f"downloading {file_id}")
             with open(path, "wb") as handle:
-                for chunk in response.iter_bytes():
-                    handle.write(chunk)
+                handle.writelines(response.iter_bytes())
         return path
     finally:
         if client is None:

--- a/scrapex/extract/api.py
+++ b/scrapex/extract/api.py
@@ -6,7 +6,8 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Annotated, Any
 
-from fastapi import APIRouter, HTTPException, Path as ApiPath, Query, Request, status
+from fastapi import APIRouter, HTTPException, Query, Request, status
+from fastapi import Path as ApiPath
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
@@ -34,6 +35,7 @@ TEMPLATES = Jinja2Templates(
 # This second environment renders the SAME base.html, whose sidebar now comes
 # from the shared UI contract — a template global every environment must carry.
 from ..ui_manifest import workspace_navigation_groups  # noqa: E402
+
 TEMPLATES.env.globals["workspace_navigation_groups"] = workspace_navigation_groups
 
 

--- a/scrapex/extract/html_table.py
+++ b/scrapex/extract/html_table.py
@@ -11,7 +11,10 @@ from urllib.parse import urlparse
 from bs4 import BeautifulSoup, Tag
 
 from .models import (
-    MAX_PREVIEW_ROWS, MAX_TABLE_COLUMNS, MAX_TABLE_ROWS, MAX_TABLES,
+    MAX_PREVIEW_ROWS,
+    MAX_TABLE_COLUMNS,
+    MAX_TABLE_ROWS,
+    MAX_TABLES,
 )
 
 _INTEGER = re.compile(r"^[+-]?\d+$")
@@ -112,7 +115,7 @@ def _direct_rows(table: Tag) -> list[Tag]:
 
 
 def _cells(row: Tag) -> list[Tag]:
-    return [cell for cell in row.find_all(["th", "td"], recursive=False)]
+    return list(row.find_all(["th", "td"], recursive=False))
 
 
 def _infer_type(values: list[str | None]) -> tuple[str, float]:
@@ -147,7 +150,7 @@ def _is_datetime(value: str) -> bool:
     if "T" not in value and " " not in value:
         return False
     try:
-        datetime.fromisoformat(value.replace("Z", "+00:00"))
+        datetime.fromisoformat(value)
         return True
     except ValueError:
         return False

--- a/scrapex/extract/models.py
+++ b/scrapex/extract/models.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 from typing import Annotated
 
 from pydantic import (
-    AnyHttpUrl, BaseModel, ConfigDict, Field, field_validator, model_validator,
+    AnyHttpUrl,
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+    model_validator,
 )
 
 from ..catalog_models import CatalogKey, FieldType
@@ -53,7 +58,7 @@ class CandidateApproval(BaseModel):
         return fields
 
     @model_validator(mode="after")
-    def has_identity_field(self) -> "CandidateApproval":
+    def has_identity_field(self) -> CandidateApproval:
         if not any(field.identity for field in self.fields):
             raise ValueError(
                 "select at least one identity field before approving the dataset"

--- a/scrapex/extract/service.py
+++ b/scrapex/extract/service.py
@@ -121,7 +121,7 @@ def _convert(value: str | None, data_type: str, field_name: str) -> Any:
         if data_type == "date":
             return date.fromisoformat(value).isoformat()
         if data_type == "datetime":
-            return datetime.fromisoformat(value.replace("Z", "+00:00")).isoformat()
+            return datetime.fromisoformat(value).isoformat()
         if data_type == "url":
             parsed = urlparse(value)
             if parsed.scheme not in {"http", "https"} or not parsed.netloc:

--- a/scrapex/funnel.py
+++ b/scrapex/funnel.py
@@ -194,7 +194,7 @@ class FunnelClient:
                                   timeout=self._timeout_s, follow_redirects=True)
             response.raise_for_status()
             return response.json()
-        except Exception as exc:  # noqa: BLE001 — reported, not raised
+        except Exception as exc:
             return {"ok": False, "error": f"unreachable: {exc!r}"}
 
     def outbox_count(self) -> int:

--- a/scrapex/ingest.py
+++ b/scrapex/ingest.py
@@ -9,21 +9,26 @@ from __future__ import annotations
 
 import sqlite3
 from collections.abc import Sequence
-from functools import partial
 from dataclasses import dataclass, field
 from decimal import Decimal
+from functools import partial
 
+from . import db as _dbmod
+from . import pricekey, tax
 from .changes import (
-    ALIAS_FIELDS, TRACKED_PRODUCT_FIELDS, classify_availability, classify_price,
-    product_field_diffs, record_alias, record_change,
+    ALIAS_FIELDS,
+    TRACKED_PRODUCT_FIELDS,
+    classify_availability,
+    classify_price,
+    product_field_diffs,
+    record_alias,
+    record_change,
 )
 from .config import SourceEntry
-from . import db as _dbmod, pricekey, tax
 from .normalize import brand_pair, joined_brand, parse_money, record_hash
-from .payload import FunnelPayload, utc_now_iso
+from .payload import FunnelPayload
 from .rowspec import PRODUCT_PRICES, RowView, spec_for
-from .vocab import (Availability, ChangeType, CurationStatus, DetailGroup,
-                    ExtractKind, RunStatus)
+from .vocab import Availability, ChangeType, CurationStatus, DetailGroup, ExtractKind, RunStatus
 
 
 @dataclass
@@ -429,7 +434,7 @@ def _get_variant(conn, product_id: int, r: dict, run_id: int | None = None,
     }), True
 
 
-def _retire_product_level_stand_ins(conn, result: "IngestResult",
+def _retire_product_level_stand_ins(conn, result: IngestResult,
                                     run_id: int | None,
                                     job_id: int | None) -> None:
     """A product now publishing REAL variants retires its old stand-in.
@@ -1005,7 +1010,7 @@ def ingest_payloads(conn: sqlite3.Connection, entry: SourceEntry,
             try:
                 row_fn(conn, entry, source_id, run_id,
                        view.as_dict(raw), payload.scraped_at, result, job_id)
-            except Exception as exc:  # noqa: BLE001 — isolate one bad row (Q3)
+            except Exception as exc:
                 result.errors.append(f"row {i}: {exc}")
 
     # A detail whose VALUE changed arrived beside its old copy rather than
@@ -1035,7 +1040,7 @@ def ingest_payloads(conn: sqlite3.Connection, entry: SourceEntry,
     return result
 
 
-def _retire_superseded_attributes(conn, stated: dict, result: "IngestResult") -> None:
+def _retire_superseded_attributes(conn, stated: dict, result: IngestResult) -> None:
     """Drop the values a product no longer states, for the exact facts this run
     restated.
 
@@ -1156,7 +1161,7 @@ def _ingest_commodity_row(conn, entry, source_id, run_id, c, observed_at,
                  result, job_id)
 
 
-def _record_implied_rate(conn, entry, c: dict, result: "IngestResult") -> None:
+def _record_implied_rate(conn, entry, c: dict, result: IngestResult) -> None:
     """The exchange rate the PUBLISHER used, read off the row's own pair.
 
     A row carrying the local price and the site's printed USD conversion
@@ -1232,7 +1237,7 @@ def _commodity_to_product_row(c: dict) -> dict:
     Built from the spec's own column list, so a widened contract cannot leave
     the adapter silently behind it.
     """
-    row = {col: "" for col in PRODUCT_PRICES.columns}
+    row = dict.fromkeys(PRODUCT_PRICES.columns, "")
     row.update({
         "external_product_id": c["material_key"],
         # The site's own word for the material when it published one; the key

--- a/scrapex/jobs.py
+++ b/scrapex/jobs.py
@@ -21,22 +21,27 @@ import sys
 import threading
 import traceback
 import uuid
+from collections.abc import Callable, Iterable
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
-from typing import Callable, Iterable
+from datetime import UTC, datetime
 from urllib.parse import urlsplit
 
 from . import db as dbmod
-from .archive import archive_source, backup_database
+from .archive import backup_database
 from .capture import CaptureResult, capture_source
 from .connectors.base import CrawlInterrupted
 from .ingest import canary_breach, previous_rows_seen
 from .payload import utc_now_iso
 from .vocab import (
-    BLOCKING_JOB_STATUSES, TERMINAL_JOB_STATUSES, WORKER_HELD_STATUSES,
-    JobControl, JobStage, JobStatus, LogLevel, RunMode,
+    TERMINAL_JOB_STATUSES,
+    WORKER_HELD_STATUSES,
+    JobControl,
+    JobStage,
+    JobStatus,
+    LogLevel,
+    RunMode,
 )
 
 _COUNTER_FIELDS = ("observations", "duplicates", "products", "variants",
@@ -86,7 +91,7 @@ def list_jobs(conn: sqlite3.Connection, limit: int = 20, active_only: bool = Fal
         sql += f" WHERE status NOT IN ({marks})"
         params = tuple(s.value for s in TERMINAL_JOB_STATUSES)
     sql += " ORDER BY job_id DESC LIMIT ?"
-    return [_as_job(r) for r in conn.execute(sql, params + (limit,))]
+    return [_as_job(r) for r in conn.execute(sql, (*params, limit))]
 
 
 def set_control(conn: sqlite3.Connection, job_ref: str, control: JobControl | str) -> bool:
@@ -254,8 +259,8 @@ def record_source_fetch(conn: sqlite3.Connection, job_id: int, source_key: str,
     if row is None:
         return
     current = json.loads(row[0] or "{}") if row[0] else {}
-    slot = dict(((current.get(SOURCES_KEY) or {}).get(source_key) or {}))
-    slot.update({k: v for k, v in fields.items()})
+    slot = dict((current.get(SOURCES_KEY) or {}).get(source_key) or {})
+    slot.update(dict(fields.items()))
     conn.execute(
         "UPDATE crawl_job SET last_heartbeat_at = strftime('%Y-%m-%dT%H:%M:%SZ','now'), "
         f"counters_json = json_set(COALESCE(NULLIF(counters_json,''),'{{}}'), "
@@ -330,8 +335,8 @@ def _control_of(conn: sqlite3.Connection, job_id: int) -> str:
 
 
 def _merge_counters(counters: dict, result: CaptureResult) -> dict:
-    for field in _COUNTER_FIELDS:
-        counters[field] = counters.get(field, 0) + getattr(result.ingest, field)
+    for name in _COUNTER_FIELDS:
+        counters[name] = counters.get(name, 0) + getattr(result.ingest, name)
     counters["errors"] = (counters.get("errors", 0)
                           + len(result.ingest.errors) + len(result.ingest.contained))
     counters["requests"] = counters.get("requests", 0) + result.requests_count
@@ -384,7 +389,7 @@ def _host_of(manifest, key: str, fallback: str) -> str:
     """
     try:
         host = urlsplit(manifest.get(key).base_url).netloc.lower()
-    except Exception:  # noqa: BLE001 — resolved, and reported, per source
+    except Exception:
         return fallback
     return host.removeprefix("www.") or fallback
 
@@ -522,7 +527,7 @@ def _parallel_width(conn: sqlite3.Connection, connect, lanes: int) -> int:
 
 
 def _drive_lanes(run: _SourceRun, lanes: list[list[str]], width: int, connect,
-                 admission: "_CrawlAdmission | None" = None) -> None:
+                 admission: _CrawlAdmission | None = None) -> None:
     """Run each lane to completion; lanes concurrently when asked.
 
     `admission` (when present) is the cross-job gate every lane passes through —
@@ -545,7 +550,7 @@ def _drive_lanes(run: _SourceRun, lanes: list[list[str]], width: int, connect,
 
 
 def _run_lane(run: _SourceRun, lane: list[str], connect,
-              admission: "_CrawlAdmission | None" = None) -> None:
+              admission: _CrawlAdmission | None = None) -> None:
     """One host's sources, strictly in order, on a connection of this lane's own.
 
     The admission is acquired around the WHOLE lane, held across its sequential
@@ -729,7 +734,7 @@ def _run_source(run: _SourceRun, conn: sqlite3.Connection, source_key: str) -> b
                     last_heartbeat_at=utc_now_iso())
         conn.commit()
         return False
-    except Exception as exc:  # noqa: BLE001 — one bad source never kills the job (Q3)
+    except Exception as exc:
         run.errors.append(f"{source_key}: {exc}")
         append_log(conn, run.job_id, f"failed: {exc}", level=LogLevel.ERROR, source_key=source_key)
 
@@ -759,7 +764,7 @@ def run_job_once(conn: sqlite3.Connection, job_ref: str, manifest,
                  capture: Callable[[sqlite3.Connection, object], CaptureResult] = capture_source,
                  backup: Callable[[], object] | None = None,
                  connect: Callable[[], sqlite3.Connection] | None = None,
-                 admission: "_CrawlAdmission | None" = None) -> dict:
+                 admission: _CrawlAdmission | None = None) -> dict:
     """Execute one job to completion, or until a pause/cancel boundary.
 
     `connect` opens a database connection of the caller's choosing. It is the
@@ -816,7 +821,7 @@ def run_job_once(conn: sqlite3.Connection, job_ref: str, manifest,
     if rebuilding and not done and backup is not None:
         try:
             append_log(conn, job_id, f"backup created: {backup()}")
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             append_log(conn, job_id, f"backup failed: {exc}", level=LogLevel.ERROR)
             _finish(conn, job_id, JobStatus.FAILED, f"backup failed, rebuild aborted: {exc}")
             return get_job(conn, job_ref)
@@ -925,7 +930,7 @@ def record_worker_failure(conn: sqlite3.Connection, exc: BaseException,
             "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
             (WORKER_ERROR_KEY, payload))
         conn.commit()
-    except Exception:  # noqa: BLE001 — never let the reporter kill the worker
+    except Exception:
         traceback.print_exc(file=sys.stderr)
 
 
@@ -944,10 +949,10 @@ def _age_s(stamp: str | None) -> float | None:
     if not stamp:
         return None
     try:
-        then = datetime.strptime(stamp, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+        then = datetime.strptime(stamp, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
     except ValueError:
         return None
-    return (datetime.now(timezone.utc) - then).total_seconds()
+    return (datetime.now(UTC) - then).total_seconds()
 
 
 def worker_health(conn: sqlite3.Connection) -> dict:
@@ -1041,10 +1046,10 @@ def worker_is_alive(conn: sqlite3.Connection, max_age_s: float = HEARTBEAT_MAX_A
     if row is None or not row[0]:
         return False
     try:
-        beat = datetime.strptime(row[0], "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+        beat = datetime.strptime(row[0], "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
     except (ValueError, TypeError):
         return False
-    return (datetime.now(timezone.utc) - beat).total_seconds() <= max_age_s
+    return (datetime.now(UTC) - beat).total_seconds() <= max_age_s
 
 
 def reclaim_orphaned_jobs(conn: sqlite3.Connection) -> int:
@@ -1234,7 +1239,7 @@ class JobRunner:
         try:
             if not rates.refresh_is_due(conn):
                 return
-        except Exception as exc:  # noqa: BLE001 — never fatal to the loop
+        except Exception as exc:
             traceback.print_exc(file=sys.stderr)
             self._record_failure(conn, exc)
             return
@@ -1249,7 +1254,7 @@ class JobRunner:
             # while /api/jobs was trying to insert a row.
             with dbmod.write_lock(self._db_path):
                 batch = rates.refresh_if_due(conn, HttpFetcher())
-        except Exception as exc:  # noqa: BLE001 — never fatal to the loop
+        except Exception as exc:
             traceback.print_exc(file=sys.stderr)
             self._record_failure(conn, exc)
             return
@@ -1315,7 +1320,7 @@ class JobRunner:
                     fire_due(conn, manifest=self._manifest_provider())
                     self._refresh_rates(conn)
                     self._dispatch(conn)
-                except Exception as exc:  # noqa: BLE001 — survive any one pass...
+                except Exception as exc:
                     # ...but NEVER silently. Swallowing this used to leave a job
                     # 'running' forever (blocking its source's schedules) or spin
                     # the loop on it at poll speed with nothing written anywhere.
@@ -1323,7 +1328,7 @@ class JobRunner:
                     # this handler is for the loop's own scheduling work.
                     traceback.print_exc(file=sys.stderr)
                     self._record_failure(conn, exc)
-        except BaseException as exc:  # noqa: BLE001
+        except BaseException as exc:
             # The loop itself is gone — the connect, the orphan reclaim, or
             # anything the inner handler could not hold. This is the case
             # that produced a live port and a dead worker with nothing said
@@ -1331,7 +1336,7 @@ class JobRunner:
             traceback.print_exc(file=sys.stderr)
             try:
                 record_worker_failure(dbmod.connect(self._db_path), exc, fatal=True)
-            except Exception:  # noqa: BLE001
+            except Exception:
                 traceback.print_exc(file=sys.stderr)
             raise
         finally:
@@ -1410,7 +1415,7 @@ class JobRunner:
                              # only the worker can offer concurrency.
                              connect=lambda: dbmod.connect(str(self._db_path)),
                              admission=admission)
-            except Exception as exc:  # noqa: BLE001 — one job never takes the loop with it
+            except Exception as exc:
                 traceback.print_exc(file=sys.stderr)
                 self._record_failure(conn, exc)
                 if conn is not None:
@@ -1437,7 +1442,7 @@ class JobRunner:
             return
         try:
             spare = dbmod.connect(self._db_path)
-        except Exception:  # noqa: BLE001 — the database itself is what is unreachable
+        except Exception:
             traceback.print_exc(file=sys.stderr)
             return
         try:
@@ -1455,7 +1460,7 @@ class JobRunner:
                 return
             append_log(conn, job["job_id"], f"worker error: {exc}", level=LogLevel.ERROR)
             _finish(conn, job["job_id"], JobStatus.FAILED, f"worker error: {exc}")
-        except Exception:  # noqa: BLE001 — a failing failure-handler must not kill the worker
+        except Exception:
             conn.rollback()
             traceback.print_exc(file=sys.stderr)
 

--- a/scrapex/lease.py
+++ b/scrapex/lease.py
@@ -29,7 +29,7 @@ import platform
 import socket
 import uuid
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 #: How long a lease is good for without being renewed. Short enough that a
@@ -45,7 +45,7 @@ _ISO = "%Y-%m-%dT%H:%M:%SZ"
 
 
 def _now() -> datetime:
-    return datetime.now(timezone.utc).replace(microsecond=0)
+    return datetime.now(UTC).replace(microsecond=0)
 
 
 def _stamp(moment: datetime) -> str:
@@ -54,7 +54,7 @@ def _stamp(moment: datetime) -> str:
 
 def _read_stamp(text: str) -> datetime | None:
     try:
-        return datetime.strptime(text, _ISO).replace(tzinfo=timezone.utc)
+        return datetime.strptime(text, _ISO).replace(tzinfo=UTC)
     except (TypeError, ValueError):
         return None
 
@@ -123,7 +123,7 @@ class Lease:
         }, indent=2) + "\n"
 
     @classmethod
-    def from_json(cls, text: str) -> "Lease | None":
+    def from_json(cls, text: str) -> Lease | None:
         try:
             data = json.loads(text)
         except (ValueError, TypeError):
@@ -173,7 +173,7 @@ def claim(path: Path | str, device: str, label: str = "",
             0, int((remaining - moment).total_seconds() // 60)) if remaining else 0
         return Verdict(
             allowed=False, lease=held,
-            reason=(f"another device holds this warehouse"
+            reason=("another device holds this warehouse"
                     + (f" — {held.label}" if held.label else "")),
             action=(f"Stop ScrapeX there, or wait {minutes_left} minute"
                     f"{'' if minutes_left == 1 else 's'} for its lease to expire."))

--- a/scrapex/localinbox.py
+++ b/scrapex/localinbox.py
@@ -14,13 +14,13 @@ never touch those.
 """
 from __future__ import annotations
 
-import os
 import hashlib
 import json
+import os
 import re
 import uuid
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 from pydantic import ValidationError
@@ -128,7 +128,7 @@ def journal_state(base: Path | str, source_key: str) -> dict:
         newest[token] = max(newest.get(token, 0.0), mtime)
     if not newest:
         return {"pages": 0, "stopped_at": None}
-    stopped = datetime.fromtimestamp(max(newest.values()), timezone.utc)
+    stopped = datetime.fromtimestamp(max(newest.values()), UTC)
     return {"pages": len(newest),
             "stopped_at": stopped.strftime("%Y-%m-%dT%H:%M:%SZ")}
 

--- a/scrapex/localsheets.py
+++ b/scrapex/localsheets.py
@@ -88,7 +88,7 @@ def _write_sheet(book: Workbook, tab: str, header: list[str], rows: list[list],
     sheet.append(list(header))
     for row in rows:
         sheet.append(list(row))
-    if fresh and "Sheet" in book.sheetnames and "Sheet" != title:
+    if fresh and "Sheet" in book.sheetnames and title != "Sheet":
         del book["Sheet"]            # drop openpyxl's default empty sheet
 
 

--- a/scrapex/native.py
+++ b/scrapex/native.py
@@ -32,7 +32,8 @@ import sys
 from pathlib import Path
 from typing import BinaryIO
 
-from . import __version__, db as dbmod
+from . import __version__
+from . import db as dbmod
 
 # Bumped only on a BREAKING change to the contract between the extension and
 # this machine — BOTH paths, not just this one. /api/health publishes this same
@@ -197,7 +198,7 @@ def _database_report() -> tuple[dict[str, dict] | None, str | None]:
 
         registry = DatabaseRegistry.defaults()
         states = registry.health()
-    except Exception as exc:  # noqa: BLE001 - the UI needs the actual reason
+    except Exception as exc:
         return None, str(exc)
     return states, None
 
@@ -252,7 +253,7 @@ def upgrade_database() -> dict:
         )
         return {"ok": True, "applied": applied, "databases": states or {},
                 "message": message}
-    except Exception as exc:  # noqa: BLE001 - preserve the actionable database error
+    except Exception as exc:
         return _error("database_upgrade_failed", str(exc), action="check_storage")
 
 
@@ -364,7 +365,7 @@ def serve(db_path=None, stdin: BinaryIO | None = None, stdout: BinaryIO | None =
                             dbmod.migrate(conn)
                     if manifest is None:
                         manifest = load_manifest()
-            except Exception as exc:  # noqa: BLE001 — the warehouse is the fault, not us
+            except Exception as exc:
                 # Deliberately leaves conn/manifest None, so the NEXT command
                 # tries again: the owner repairs the database from the engine
                 # this host can still start, and the repair takes effect without
@@ -380,7 +381,7 @@ def serve(db_path=None, stdin: BinaryIO | None = None, stdout: BinaryIO | None =
                 response = handle(conn, message, manifest)
                 if conn is not None:
                     conn.commit()
-            except Exception as exc:  # noqa: BLE001 — one bad command never kills the host
+            except Exception as exc:
                 if conn is not None:
                     conn.rollback()
                 response = _error("internal", str(exc))

--- a/scrapex/osschedule.py
+++ b/scrapex/osschedule.py
@@ -45,7 +45,7 @@ def _schtasks() -> str:
     Naming the System32 copy keeps the command reproducible in the error
     message we print — "run this yourself" is only useful if `this` is exact.
     """
-    system_root = os.environ.get("SystemRoot") or os.environ.get("SYSTEMROOT")
+    system_root = os.environ.get("SYSTEMROOT") or os.environ.get("SYSTEMROOT")
     if system_root:
         candidate = Path(system_root) / "System32" / "schtasks.exe"
         if candidate.exists():

--- a/scrapex/outputs.py
+++ b/scrapex/outputs.py
@@ -26,8 +26,7 @@ from .fields import ORIGINAL_SCHEMA
 from .ingest import _canon_amount
 from .payload import new_payload, utc_now_iso
 from .publish import publish_source
-from .reports import export_source_table
-from .settings import RunResult          # the one shape every run reports in
+from .settings import RunResult  # the one shape every run reports in
 from .vocab import ExtractKind, PayloadClient
 
 EXCEL = "excel"

--- a/scrapex/pagesource.py
+++ b/scrapex/pagesource.py
@@ -20,9 +20,10 @@ one day differ for no reason anybody can name.
 """
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Iterable, Protocol, runtime_checkable
+from typing import Protocol, runtime_checkable
 
 
 class PageKind(StrEnum):
@@ -118,7 +119,7 @@ def supports_slices(source: PageSource, *, base_url: str = "") -> bool:
             0, "")
     except SliceNotSupported:
         return False
-    except Exception:                      # noqa: BLE001
+    except Exception:
         # Any other failure on an empty page says nothing about whether the
         # site can slice a real one. Only an explicit refusal counts.
         return True

--- a/scrapex/pagewalk.py
+++ b/scrapex/pagewalk.py
@@ -24,10 +24,11 @@ enforced rather than merely recorded.
 from __future__ import annotations
 
 import time
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
-from typing import Callable, Iterable
 
-from .crawlscope import CrawlScope, plan as plan_scope
+from .crawlscope import CrawlScope
+from .crawlscope import plan as plan_scope
 from .pagesource import FetchedPage, PageKind, PageSource, SliceNotSupported
 
 #: What the fetcher is: a url in, the page's text out. Anything that raises is
@@ -130,7 +131,7 @@ class PageWalker:
         self._fetched_any = True
         try:
             html = self._fetch(url)
-        except Exception as exc:                      # noqa: BLE001
+        except Exception as exc:
             # NOT RAISED. One dead page out of a hundred thousand must not
             # discard the rest, and a crawl that stops at the first 404 of a
             # thirty-four hour run is a crawl nobody can finish.

--- a/scrapex/payload.py
+++ b/scrapex/payload.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import json
 import math
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -250,10 +250,10 @@ class FunnelPayload(BaseModel):
     def _scraped_at_utc_iso(cls, v: str) -> str:
         # Explicit over clever (P5): require the exact wire format we emit.
         try:
-            parsed = datetime.fromisoformat(v.replace("Z", "+00:00"))
+            parsed = datetime.fromisoformat(v)
         except ValueError as exc:
             raise ValueError(f"scraped_at is not ISO8601: {v!r}") from exc
-        if parsed.tzinfo is None or parsed.utcoffset() != timezone.utc.utcoffset(None):
+        if parsed.tzinfo is None or parsed.utcoffset() != UTC.utcoffset(None):
             raise ValueError(f"scraped_at must be UTC ('Z' or +00:00): {v!r}")
         return v
 
@@ -291,7 +291,7 @@ def new_payload(**fields: object) -> FunnelPayload:
 
 def utc_now_iso() -> str:
     """The one blessed wire timestamp format (Q5)."""
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def split_into_chunks(

--- a/scrapex/probe.py
+++ b/scrapex/probe.py
@@ -54,7 +54,7 @@ def _try_json(fetcher, url: str, **kw):
     """GET and parse JSON, returning None on any failure (probe is best-effort)."""
     try:
         resp = fetcher.get(url, **kw)
-    except Exception:  # noqa: BLE001 — a missing endpoint is a negative signal, not an error
+    except Exception:
         return None
     try:
         return resp.json()
@@ -152,5 +152,5 @@ def probe(url: str, fetcher: HttpFetcher | None = None) -> ProbeResult:
 def _get_text(fetcher, url: str) -> str | None:
     try:
         return fetcher.get(url).text
-    except Exception:  # noqa: BLE001
+    except Exception:
         return None

--- a/scrapex/publish.py
+++ b/scrapex/publish.py
@@ -13,8 +13,7 @@ from typing import Protocol
 
 from .fields import ORIGINAL_SCHEMA, apply_schema
 from .payload import utc_now_iso
-from .reports import (export_details_table, export_history_table,
-                      export_source_table, source_summary)
+from .reports import export_details_table, export_history_table, export_source_table, source_summary
 
 
 class SheetSink(Protocol):

--- a/scrapex/rates.py
+++ b/scrapex/rates.py
@@ -61,9 +61,10 @@ import math
 import re
 import sqlite3
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
-from . import db as dbmod, settings
+from . import db as dbmod
+from . import settings
 from .connectors.base import CrawlBlocked
 from .payload import utc_now_iso
 
@@ -160,7 +161,7 @@ def _parse_quote_page(html: str, code: str, url: str) -> tuple[float, str, list[
         per_usd = _clean_rate_number(_attr(tag, "data-last-price") or "")
         stamp = _attr(tag, "data-last-normal-market-timestamp")
         if stamp and stamp.isdigit():
-            as_of = datetime.fromtimestamp(int(stamp), tz=timezone.utc).strftime(
+            as_of = datetime.fromtimestamp(int(stamp), tz=UTC).strftime(
                 "%Y-%m-%dT%H:%M:%SZ")
         else:
             as_of = utc_now_iso()
@@ -213,7 +214,7 @@ def fetch_rates(fetcher, currencies: list[str]) -> RateBatch:
             per_usd, as_of, shape_warnings = _parse_quote_page(html, code, url)
         except CrawlBlocked:
             raise                    # the site (or the owner) said stop — stop
-        except Exception as exc:  # noqa: BLE001 — recorded per currency, never silent
+        except Exception as exc:
             batch.warnings.append(f"{code}: no rate from {url} — {exc}")
             continue
         batch.warnings.extend(shape_warnings)

--- a/scrapex/reports.py
+++ b/scrapex/reports.py
@@ -7,12 +7,13 @@ owner curates). This directly answers "did anything actually land?".
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import Callable
 from dataclasses import dataclass, field
 
 from . import fields, rates, tax
 from .fields import AXIS_PREFIX
 from .normalize import option_axes_from
-from .vocab import BLOCK_ORDER, Block, DETAIL_GROUP_ORDER
+from .vocab import BLOCK_ORDER, DETAIL_GROUP_ORDER, Block
 
 
 @dataclass
@@ -1089,7 +1090,7 @@ _EXPORT_SELECT: dict[str, str] = {
 # `country`. The spreadsheet cannot notice that; the owner did, from a row of
 # copper cable. Pairing the name with its producer makes that class of defect
 # impossible rather than merely fixed once.
-EXPORT_COLUMNS: list[tuple[str, "Callable[[dict, object], object]"]] = [
+EXPORT_COLUMNS: list[tuple[str, Callable[[dict, object], object]]] = [
     # Identity. region/country sit right after the name: for a commodity source
     # they are what distinguishes one row from the next.
     ("product_name", lambda r, s: r["name_en"] or ""),
@@ -1231,7 +1232,7 @@ def export_source_table(conn: sqlite3.Connection, source_key: str,
     table = []
     parsed = []
     for raw in rows:
-        row = dict(zip(aliases, raw))
+        row = dict(zip(aliases, raw, strict=True))
         # ...and read for THIS row's figure, so tax_evidence never contradicts
         # the tax_included cell two columns to its left.
         state = (tax.resolve(tax_rules, row["country_code_alpha2"],
@@ -1312,9 +1313,9 @@ def _filter_groups(conn: sqlite3.Connection, source_key: str) -> dict[str, str]:
 
     rank = {name: position for position, name in enumerate(DETAIL_GROUP_ORDER)}
     best: dict[str, str] = {}
-    for label, group in rows:
-        label = str(label or "")
-        group = str(group or "")
+    for raw_label, raw_group in rows:
+        label = str(raw_label or "")
+        group = str(raw_group or "")
         if not label:
             continue
         current = best.get(label)
@@ -1384,7 +1385,7 @@ def _with_axis_columns(header: list[str], table: list[list],
     at = header.index("variant_ar") + 1
     widened = header[:at] + names + header[at:]
     rows = [row[:at] + [axes.get(name, "") for name in names] + row[at:]
-            for row, axes in zip(table, parsed)]
+            for row, axes in zip(table, parsed, strict=True)]
     return widened, rows
 
 
@@ -1629,7 +1630,7 @@ def price_extremes(conn: sqlite3.Connection, source_key: str, limit: int = 50) -
     for r in rows:
         item = dict(r)
         item["country"] = region_name(item["country_code_alpha2"])
-        first, current = item["first_price"], item["current_price"]
+        current = item["current_price"]
         # The Change column now answers the owner's question — the move from
         # the PREVIOUS price to the current one, not from the dawn of history.
         # First stays as context; with change-only storage, previous is the
@@ -1953,29 +1954,29 @@ def fold_variant_rows(rows: list[dict]) -> list[dict]:
             folded.append(members[0])
             continue
         merged = dict(members[0])
-        for field in members[0]:
-            if field in _FOLD_JOINED:
+        for column in members[0]:
+            if column in _FOLD_JOINED:
                 seen: list[str] = []
                 for member in members:
-                    value = str(member.get(field) or "").strip()
+                    value = str(member.get(column) or "").strip()
                     if value and value not in seen:
                         seen.append(value)
                 # An Arabic list reads with an Arabic comma; the rest with a
                 # plain one. Same rule the columns already follow.
-                separator = "، " if field.endswith("_ar") else ", "
-                merged[field] = separator.join(_shared_axis_once(seen))
+                separator = "، " if column.endswith("_ar") else ", "
+                merged[column] = separator.join(_shared_axis_once(seen))
                 continue
-            if field in _FOLD_KEPT:
+            if column in _FOLD_KEPT:
                 continue
-            values = [member.get(field) for member in members]
+            values = [member.get(column) for member in members]
             if all(value == values[0] for value in values):
                 continue
-            if field in (_FOLD_MIN, _FOLD_MAX):
+            if column in (_FOLD_MIN, _FOLD_MAX):
                 numbers = [v for v in values if isinstance(v, (int, float))]
                 if numbers:
-                    merged[field] = min(numbers) if field == _FOLD_MIN else max(numbers)
+                    merged[column] = min(numbers) if column == _FOLD_MIN else max(numbers)
                     continue
-            merged[field] = ""
+            merged[column] = ""
         merged["variants"] = len(members)
         merged["offer_ids"] = [m.get("offer_id") for m in members]
         folded.append(merged)

--- a/scrapex/scheduler.py
+++ b/scrapex/scheduler.py
@@ -11,29 +11,33 @@ while we are off is therefore a normal state, handled explicitly by
 from __future__ import annotations
 
 import sqlite3
-from datetime import datetime, timedelta, timezone as dt_timezone
+from datetime import UTC, datetime, timedelta
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from .jobs import create_job, list_jobs
 from .vocab import (
-    BLOCKING_JOB_STATUSES, MissedRunPolicy, OverlapPolicy, RunMode, ScheduleFrequency,
+    BLOCKING_JOB_STATUSES,
+    MissedRunPolicy,
+    OverlapPolicy,
+    RunMode,
+    ScheduleFrequency,
 )
 
 ISO = "%Y-%m-%dT%H:%M:%SZ"
 
 
 def utcnow() -> datetime:
-    return datetime.now(dt_timezone.utc)
+    return datetime.now(UTC)
 
 
 def _parse_iso(value: str | None) -> datetime | None:
     if not value:
         return None
-    return datetime.strptime(value, ISO).replace(tzinfo=dt_timezone.utc)
+    return datetime.strptime(value, ISO).replace(tzinfo=UTC)
 
 
 def _format_iso(value: datetime) -> str:
-    return value.astimezone(dt_timezone.utc).strftime(ISO)
+    return value.astimezone(UTC).strftime(ISO)
 
 
 def zone_exists(name: str) -> bool:
@@ -59,7 +63,7 @@ def _zone(name: str):
     try:
         return ZoneInfo(name)
     except (ZoneInfoNotFoundError, ValueError, KeyError):
-        return dt_timezone.utc
+        return UTC
 
 
 def compute_next_run(frequency: str, run_at: str, tz_name: str, weekday: int | None,
@@ -87,7 +91,7 @@ def compute_next_run(frequency: str, run_at: str, tz_name: str, weekday: int | N
     if frequency == ScheduleFrequency.DAILY.value:
         if candidate <= local:
             candidate += timedelta(days=1)
-        return candidate.astimezone(dt_timezone.utc)
+        return candidate.astimezone(UTC)
 
     if frequency == ScheduleFrequency.WEEKLY.value:
         target = 0 if weekday is None else int(weekday) % 7
@@ -95,7 +99,7 @@ def compute_next_run(frequency: str, run_at: str, tz_name: str, weekday: int | N
         candidate += timedelta(days=days_ahead)
         if candidate <= local:
             candidate += timedelta(days=7)
-        return candidate.astimezone(dt_timezone.utc)
+        return candidate.astimezone(UTC)
 
     return None
 

--- a/scrapex/settings.py
+++ b/scrapex/settings.py
@@ -24,7 +24,7 @@ import json
 import os
 import sqlite3
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 PREFIX = "setting:"
 
@@ -153,7 +153,7 @@ class RunResult:
 
 
 def utc_now() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def file_stamp() -> str:
@@ -163,7 +163,7 @@ def file_stamp() -> str:
     a form storage.base_stem could not match — so after a seal or a restore the
     owner's backups silently vanished from the Storage page.
     """
-    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
 
 
 class UnknownSettingError(KeyError):

--- a/scrapex/storage.py
+++ b/scrapex/storage.py
@@ -32,9 +32,10 @@ import re
 import shutil
 import sqlite3
 import sys
+from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import UTC
 from pathlib import Path
-from typing import Callable
 
 from . import db as dbmod
 from . import settings
@@ -153,7 +154,7 @@ def _point_registry_at(db_path: Path, previous: Path | None) -> None:
         return
     try:
         registry = DatabaseRegistry.read(REGISTRY_FILE)
-    except Exception:  # noqa: BLE001 — a registry we cannot read, we do not rewrite
+    except Exception:
         return
     if registry.engine.path.resolve() != previous.resolve():
         return                      # a different warehouse: not ours to move
@@ -469,7 +470,7 @@ def open_folder(folder: Path | str) -> RunResult:
         raise StorageRefused(f"There is no folder at {target} to open.")
     try:
         if os.name == "nt":
-            os.startfile(str(target))                     # noqa: S606 - a directory
+            os.startfile(str(target))
         elif sys.platform == "darwin":
             subprocess.run(["open", str(target)], check=True)
         else:
@@ -522,7 +523,7 @@ def undeclared_sources(conn) -> list[str]:
     from .config import MANIFEST_FILE, load_manifest
     try:
         declared = {entry.source_key for entry in load_manifest(MANIFEST_FILE).sources}
-    except Exception:  # noqa: BLE001 — a broken manifest is validate-manifest's job
+    except Exception:
         return []
     try:
         stored = {row[0] for row in conn.execute(
@@ -704,10 +705,10 @@ def prunable_backups(db_path: Path | str, folder: Path | None = None,
 
 
 def _mtime_iso(path: Path) -> str:
-    from datetime import datetime, timezone
+    from datetime import datetime
 
     try:
-        stamp = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+        stamp = datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
     except OSError:
         return ""
     return stamp.strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/scrapex/tax.py
+++ b/scrapex/tax.py
@@ -47,7 +47,7 @@ class TaxState:
     def verified(self) -> bool:
         return self.evidence != "unknown"
 
-    def for_row(self, tax_included: bool) -> "TaxState":
+    def for_row(self, tax_included: bool) -> TaxState:
         """The same evidence, read for ONE row's own figure.
 
         Two different facts had been collapsed into one. The RULE says what tax

--- a/scrapex/vocab.py
+++ b/scrapex/vocab.py
@@ -294,7 +294,7 @@ _DETAIL_GROUP_BY_PREFIX: tuple[tuple[str, DetailGroup], ...] = (
 )
 
 
-def group_for_code(code: str) -> "tuple[DetailGroup, bool]":
+def group_for_code(code: str) -> tuple[DetailGroup, bool]:
     """(group, recognised) for one attribute code.
 
     The language mark is stripped first: `coating` and `coating_ar` are ONE

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -16,80 +16,147 @@ import re
 import sqlite3
 import threading
 import time
-from urllib.parse import urlencode, urlsplit
+from datetime import UTC
 from pathlib import Path
+from urllib.parse import urlencode, urlsplit
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
-from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.middleware.trustedhost import TrustedHostMiddleware
 from fastapi.responses import HTMLResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.middleware.trustedhost import TrustedHostMiddleware
 
+from .. import compaction, localinbox, nativehost, pricehistory, rates, retention
 from .. import db as dbmod
-from .. import localinbox
-from .. import nativehost
 from ..capture import capture_source, crawl_settings
 from ..changes import change_summary, changes_for_offer, recent_changes
 from ..config import SourceEntry, load_manifest, resolve_manifest_path
 from ..connectors.base import CrawlBlocked, HttpFetcher
 from ..connectors.factory import _BUILDERS, supports_history
 from ..databases import (
-    DatabaseKindError, DatabaseMigrationError, DatabaseRegistry,
-    DatabaseUnavailableError, EngineDatabase,
+    DatabaseKindError,
+    DatabaseMigrationError,
+    DatabaseRegistry,
+    DatabaseUnavailableError,
+    EngineDatabase,
 )
-from ..jobs import (JobRunner, create_job, get_job, job_log_count, job_logs,
-                    list_jobs, set_control, worker_health)
-from ..fields import (
-    arranged, delete_view, ensure_fields, list_fields, list_views, promotable_attributes,
-    reorder, reset_view, save_view, set_display_name, set_promotion,
-    set_visibility, visible_columns,
-)
-from ..features import manifest as feature_manifest
 from ..extract.api import create_extraction_router
-from ..manifest_io import (DuplicateSourceError, add_source, remove_source,
-                           set_active, update_source)
-from ..sources_admin import SourceKeyInUse, rename_source, source_footprint
-from ..matching import (
-    ConflictError, Decision, decide, pending_reviews, suggest_for_source, undo_decision,
+from ..features import manifest as feature_manifest
+from ..fields import (
+    arranged,
+    delete_view,
+    ensure_fields,
+    list_fields,
+    list_views,
+    promotable_attributes,
+    reorder,
+    reset_view,
+    save_view,
+    set_display_name,
+    set_promotion,
+    set_visibility,
+    visible_columns,
 )
-from ..outputs import (
-    NotConfiguredError, all_destinations, apps_script_script_text, apps_script_send,
-    apps_script_status, apps_script_test, excel_export, excel_status, google_connect,
-    google_disconnect, google_push, google_status, rotate_funnel_token,
+from ..jobs import (
+    JobRunner,
+    create_job,
+    get_job,
+    job_log_count,
+    job_logs,
+    list_jobs,
+    set_control,
+    worker_health,
 )
 from ..localsheets import workbook_bytes
+from ..manifest_io import DuplicateSourceError, add_source, remove_source, set_active, update_source
+from ..matching import (
+    ConflictError,
+    Decision,
+    decide,
+    pending_reviews,
+    suggest_for_source,
+    undo_decision,
+)
+from ..outputs import (
+    NotConfiguredError,
+    all_destinations,
+    apps_script_script_text,
+    apps_script_send,
+    apps_script_status,
+    apps_script_test,
+    excel_export,
+    excel_status,
+    google_connect,
+    google_disconnect,
+    google_push,
+    google_status,
+    rotate_funnel_token,
+)
 from ..payload import utc_now_iso
+from ..probe import probe as probe_url
 from ..publish import workbook_tables
+from ..reports import (
+    BROWSE_COLUMNS,
+    FILTERABLE,
+    SORTABLE,
+    browse_columns,
+    browse_google_finance_rates,
+    browse_observations,
+    column_presence,
+    crawl_history,
+    data_model_report,
+    facet_options,
+    google_finance_status,
+    history_counts,
+    list_sources,
+    offer_identity,
+    offer_observations,
+    parse_filters,
+    price_extremes,
+    product_attributes,
+    schema_report,
+    table_payload,
+    watch,
+)
+from ..scheduler import list_schedules, upsert_schedule, zone_exists
 from ..settings import UnknownSettingError, get_state, public_settings
 from ..settings import get as settings_get
 from ..settings import save as save_settings
-from .. import compaction, pricehistory, rates, retention
+from ..sources_admin import SourceKeyInUse, rename_source, source_footprint
 from ..storage import (
-    StorageRefused, backup_folder, backup_now, check_move, export_database,
-    wipe_source,
-    migrate_location, open_folder, repair, resolve_db_path, restore, start_fresh,
+    StorageRefused,
+    backup_folder,
+    backup_now,
+    check_move,
+    export_database,
+    migrate_location,
+    open_folder,
+    repair,
+    resolve_db_path,
+    restore,
+    start_fresh,
     storage_status,
+    wipe_source,
 )
 from ..storage import compact as storage_compact
-from ..probe import probe as probe_url
 from ..ui_manifest import ui_manifest, workspace_navigation_groups
-from ..reports import (
-    BROWSE_COLUMNS, FILTERABLE, SORTABLE, browse_columns, browse_google_finance_rates,
-    browse_observations, column_presence,
-    crawl_history, facet_options, parse_filters, watch,
-    data_model_report, export_source_table, google_finance_status, history_counts,
-    list_sources, offer_identity,
-    schema_report,
-    offer_observations, price_extremes, product_attributes,
-    table_payload,
-)
-from ..scheduler import list_schedules, upsert_schedule, zone_exists
 from ..vocab import (
-    TERMINAL_JOB_STATUSES, Authority, Cadence, ConnectorFamily, ExtractKind,
-    ExtractScope, Fetcher, JobControl, JobStatus, MissedRunPolicy, OverlapPolicy,
-    RunMode, ScheduleFrequency, VatMode,
+    TERMINAL_JOB_STATUSES,
+    Authority,
+    Cadence,
+    ConnectorFamily,
+    ExtractKind,
+    ExtractScope,
+    Fetcher,
+    JobControl,
+    JobStatus,
+    MissedRunPolicy,
+    OverlapPolicy,
+    RunMode,
+    ScheduleFrequency,
+    VatMode,
 )
 from .catalog_api import create_catalog_router
 from .database_api import create_database_router, create_domain_health_router
@@ -133,7 +200,7 @@ def _google_finance_setting_values(body: dict) -> dict:
     if "google_finance_auto_refresh" in values:
         raw = values["google_finance_auto_refresh"]
         accepted = isinstance(raw, (bool, int, str)) and raw in {
-            True, False, 0, 1, "0", "1", "true", "false",
+            True, False, "0", "1", "true", "false",
         }
         if not accepted:
             raise HTTPException(
@@ -141,7 +208,7 @@ def _google_finance_setting_values(body: dict) -> dict:
                 detail="google_finance_auto_refresh must be true or false",
             )
         values["google_finance_auto_refresh"] = (
-            "1" if raw in {True, 1, "1", "true"} else "0"
+            "1" if raw in {True, "1", "true"} else "0"
         )
     if "google_finance_refresh_hours" in values:
         try:
@@ -202,7 +269,7 @@ def database_state(request: Request) -> dict:
     runner = getattr(request.app.state, "runner", None)
     try:
         engine_connected = bool(runner and runner.is_alive)
-    except Exception:  # noqa: BLE001 - runtime status must never break a page
+    except Exception:
         engine_connected = False
     runtime = {"engine_state": {"connected": engine_connected}}
 
@@ -211,7 +278,7 @@ def database_state(request: Request) -> dict:
         return {**runtime, "db_state": None}
     try:
         states = registry.health()
-    except Exception:  # noqa: BLE001 - a status widget must never break a page
+    except Exception:
         return {**runtime, "db_state": None}
     failed = {kind: item for kind, item in states.items() if not item["ok"]}
     return {
@@ -649,7 +716,7 @@ def create_app(
         """
         merged = dict(current)
         merged.update(overrides)
-        if any(k not in ("page",) for k in overrides):
+        if any(k != "page" for k in overrides):
             merged.pop("page", None)
         pairs = [(k, v) for k, v in merged.items() if v not in (None, "", [])]
         return "?" + urlencode(pairs, doseq=True) if pairs else ""
@@ -837,7 +904,7 @@ def create_app(
         port = int(request.url.port or 8000)
         try:
             helper = relaunch_module.spawn_helper(port)
-        except Exception as exc:  # noqa: BLE001 — never leave the owner without a route
+        except Exception as exc:
             raise HTTPException(
                 status_code=500,
                 detail=(f"could not start the helper that brings the engine back ({exc}). "
@@ -881,7 +948,7 @@ def create_app(
         before = allowed_extension_ids()
         try:
             written = install([extension_id])
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
         after = allowed_extension_ids()
         print(f"[native-host] {extension_id} asked to be recognised; "
@@ -1199,12 +1266,12 @@ def create_app(
                         for item in states.values() if not item["ok"]
                     ),
                 }
-            except Exception:  # noqa: BLE001 - health must not take health down
+            except Exception:
                 databases = {"ok": False, "detail": "status unavailable"}
         runner = getattr(app.state, "runner", None)
         try:
             thread_alive = bool(runner and runner.is_alive)
-        except Exception:  # noqa: BLE001 - health must survive worker state reads
+        except Exception:
             thread_alive = False
         # The THREAD being alive is not the same question as the worker
         # doing its work, and neither is the port answering. The heartbeat
@@ -1218,7 +1285,7 @@ def create_app(
                 worker = worker_health(conn)
             finally:
                 conn.close()
-        except Exception as exc:  # noqa: BLE001 - health must not take health down
+        except Exception as exc:
             # NOT `pass` onto a fallback seeded with thread_alive. That published
             # the thread flag AS the worker's liveness - the one conflation the
             # comment above forbids - and it did it on exactly the failure the
@@ -2174,9 +2241,7 @@ def create_app(
         from ..connectors.base import DEFAULT_USER_AGENT
         from ..contract import CONTRACT_VERSION
         from ..jobs import worker_is_alive
-
-        from ..version import (LATEST_SOURCE, MINIMUM_EXTENSION_VERSION,
-                               UPDATE_INSTRUCTIONS, VERSION)
+        from ..version import LATEST_SOURCE, MINIMUM_EXTENSION_VERSION, UPDATE_INSTRUCTIONS, VERSION
 
         worker = worker_health(conn)
         return {
@@ -2885,9 +2950,9 @@ def _today() -> str:
     A single function so a test can freeze it, rather than each caller reaching
     for the clock and drifting apart across a midnight boundary.
     """
-    from datetime import datetime, timezone
+    from datetime import datetime
 
-    return datetime.now(timezone.utc).date().isoformat()
+    return datetime.now(UTC).date().isoformat()
 
 
 def _source_keys(body: dict) -> list[str]:

--- a/scrapex/webui/static/grid.js
+++ b/scrapex/webui/static/grid.js
@@ -336,6 +336,14 @@
     return nested ? out : [];      // nothing to nest is not a tree
   }
 
+  // FOUND BY THE LINTER, LEFT IN ON PURPOSE. Nothing calls hide(), and once it
+  // is removed nothing calls remember() either -- the whole "hide a column on
+  // the server" chain is unreachable, while line 2922 still describes
+  // "Choose Columns -> hide" as a thing the owner can do. Deleting two working
+  // functions that implement a documented behaviour is a decision about the
+  // PRODUCT, not a lint fix, so the gate is told to allow it and the question
+  // is written down here where whoever answers it will be standing.
+  // eslint-disable-next-line no-unused-vars
   function hide(field) {
     // Server only. A local column.hide() would persist in the browser and then
     // outvote the server for ever.

--- a/scrapex/webui/static/pages/data-model.js
+++ b/scrapex/webui/static/pages/data-model.js
@@ -16,7 +16,6 @@
   const emptyState = document.getElementById("model-empty");
   const cards = [...stage.querySelectorAll(".model-table")];
 
-  const CARD_WIDTH = 304;
   const CARD_HEIGHT = 228;
   const LANE_WIDTH = 344;
   const LANE_HEAD = 54;

--- a/tests/test_the_lint_gate_cannot_be_quietly_widened.py
+++ b/tests/test_the_lint_gate_cannot_be_quietly_widened.py
@@ -1,0 +1,149 @@
+"""The two ways a linter stops being one, made into failures.
+
+A gate is only a gate while somebody cannot get round it cheaply. There are
+exactly two cheap ways round this one, and both are quiet:
+
+1. Add the failing rule to `ignore` and move on. The list grows, nobody rereads
+   it, and one day the gate passes because it checks nothing.
+2. Let `ruff --fix` delete something it thinks is unused. That is not
+   hypothetical here -- see the second test.
+
+Neither is caught by running ruff, because in both cases ruff is happy. They are
+caught here.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_every_ruff_ignore_says_why():
+    """An ignore with no reason is a rule someone turned off in a hurry.
+
+    The reason has to be a comment ABOVE the code in pyproject.toml, because
+    that is where the next person reads it -- not in a commit message they will
+    never go looking for.
+    """
+    raw = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    assert "ignore = [" in raw, "the ruff ignore list moved; this test must follow it"
+    block = raw.split("ignore = [", 1)[1].split("\n]", 1)[0]
+
+    undocumented, explained = [], False
+    for line in block.splitlines():
+        text = line.strip()
+        if not text:
+            continue
+        if text.startswith("#"):
+            explained = True
+            continue
+        if not explained:
+            undocumented.append(text)
+        explained = False
+
+    assert not undocumented, (
+        "these ruff ignores carry no comment saying why:\n  "
+        + "\n  ".join(undocumented)
+        + "\n\nAn ignore list nobody has to justify is how a gate becomes "
+          "decoration. Say what the rule gets wrong here, or fix the code.")
+
+
+def test_the_gate_actually_runs_on_the_code_that_ships():
+    """CI must lint `scrapex/`. A gate pointed at nothing passes forever."""
+    workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    assert "ruff check scrapex/" in workflow, (
+        "the CI lint step no longer runs ruff over scrapex/ — the gate is off")
+    assert "pip install ruff==" in workflow, (
+        "ruff is no longer pinned in CI: somebody else's release can now turn a "
+        "branch red without a line of this repository changing")
+
+
+def test_the_javascript_half_of_the_gate_runs_too():
+    workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    assert "eslint@9." in workflow, "the eslint step is gone, or is no longer pinned"
+    step = workflow.split("eslint@9.", 1)[1].splitlines()[0]
+    for area in ("extension", "scrapex/webui/static", "contract", "apps_script"):
+        assert area in step, (
+            f"eslint no longer covers {area} — a whole area went quietly unlinted")
+
+
+# MARKED ON THE TEST, not the module: only this one reads extension/ sources, so
+# only this one has to run when a change touches nothing but the extension. The
+# rest are about pyproject.toml and the workflow, and marking them too would put
+# ruff's configuration inside a gate named for the panel.
+@pytest.mark.extension
+def test_the_panel_defines_every_helper_it_calls():
+    """The regression test for the defect that paid for the whole JavaScript gate.
+
+    `el(...)` was called four times in renderSchemaLag and defined nowhere, from
+    c4ea06b (2026-07-30) until the gate found it. The early return above those
+    lines meant the normal case never reached them, so the panel looked fine —
+    it threw ReferenceError only when the database really was behind the engine,
+    which is the single situation that banner exists for.
+
+    eslint's `no-undef` is the mechanism; this is the plain-language reminder of
+    why, and it fails without needing node installed.
+    """
+    source = (ROOT / "extension" / "app.js").read_text(encoding="utf-8")
+    called = re.search(r"[^.\w]el\(", source) is not None
+    # ANCHORED TO COLUMN ZERO, and the first version of this test was not --
+    # it accepted `const el = $(id)`, a LOCAL inside an unrelated function 2600
+    # lines away, and so it passed with the helper deleted. Only a definition at
+    # module scope is in scope for renderSchemaLag.
+    defined = re.search(r"^(const|let|var|function)\s+el\b", source, re.M) is not None
+    assert not called or defined, (
+        "extension/app.js calls el(...) and does not define it. That is a "
+        "ReferenceError in renderSchemaLag, which runs from setStatus on every "
+        "status update — and it fires exactly when the owner's database is "
+        "behind the engine and he needs the banner most.")
+
+
+@pytest.mark.parametrize("name", [
+    "offer_price", "parse_product_jsonld", "sitemap_locs", "brand_name",
+    "category_path",
+])
+def test_sallas_re_exports_survive_a_linter(name):
+    """These five are imported by salla.py and used only OUTSIDE it.
+
+    THIS IS NOT A HYPOTHETICAL. Adding the ruff gate ran `--fix` over the tree,
+    F401 read four of these as unused imports, and deleted them -- straight
+    through a comment two lines above that said, in words, that they are
+    re-exported for salla's tests. tests/test_salla.py stopped importing at all.
+
+    A comment cannot stop a fixer. `__all__` can, because the tool reads it, and
+    this test fails if someone removes the name from either place.
+    """
+    from scrapex.connectors import salla
+
+    assert hasattr(salla, name), (
+        f"scrapex.connectors.salla.{name} is gone. It is re-exported on purpose: "
+        "the salla tests and the jsonld family both read it from here. If a "
+        "linter removed it, put it back and keep it in __all__.")
+    assert name in salla.__all__, (
+        f"{name} is importable but missing from salla.__all__, which is the only "
+        "thing standing between it and the next `ruff --fix`")
+
+
+def test_the_linter_is_actually_installed_and_clean_here():
+    """Runs the gate itself, so a local failure is found locally.
+
+    Skipped rather than failed when ruff is absent: a contributor who has not
+    installed it has not broken anything, and a test that fails for a missing
+    dev tool teaches people to ignore red.
+    """
+    try:
+        found = subprocess.run([sys.executable, "-m", "ruff", "check", "scrapex/"],
+                               cwd=str(ROOT), capture_output=True, text=True,
+                               encoding="utf-8", errors="replace", timeout=300)
+    except (OSError, subprocess.SubprocessError) as exc:      # pragma: no cover
+        pytest.skip(f"ruff is not installed here ({exc})")
+    if found.returncode == 1 and "No module named" in (found.stderr or ""):
+        pytest.skip("ruff is not installed here")
+    assert found.returncode == 0, (
+        "ruff is failing on scrapex/ right now:\n" + (found.stdout or found.stderr))


### PR DESCRIPTION
**OP-12**: no ruff, no eslint, no mypy anywhere. Every style and type rule in `ENGINEERING.md` was enforced by attention alone.

## The gate is chosen, not maximal

`--select ALL` reports **960 findings** on `scrapex/` and almost none are defects. Nineteen rules are switched off and **every one carries a comment saying what it gets wrong here** — plus a test that fails the build on an ignore with no reason, because a list nobody has to justify is how a gate becomes decoration.

The clearest example is `RUF001`. It flags **ARABIC-INDIC DIGIT ONE** and the **ARABIC DECIMAL SEPARATOR** as "ambiguous" and suggests `l` and `,` instead. Those characters are the *domain* — `scrapex/contract.py` parses them out of Egyptian and Saudi price pages. Enforcing that rule would push the next person to "fix" the exact characters the parser exists to read.

## Two live defects, neither visible to two thousand tests

**`el()` was called four times in `renderSchemaLag` and defined nowhere**, since `c4ea06b` (2026-07-30) — the commit that added the banner. The early return above those lines means the normal case never reaches them, so nothing looked broken. It threw `ReferenceError` only when the database really was behind the engine — the one situation the banner exists for. Its own comment says why it was written: *"the alternative he met was a raw SQLite error on a broken page."*

**`financeTargetSelectUi`** is assigned at setup and never read, while its twin `financeCurrencySelectUi` is re-synced every time the rates change. **Recorded, not changed** — whether the target list should also refresh is a question about what it is meant to show. Same for `hide()` in `grid.js`: nothing calls it, and once it goes nothing calls `remember()` either, so the whole "hide a column on the server" chain is unreachable while the code two thousand lines below still describes it as something the owner can do. Deleting working functions that implement a documented behaviour is a product decision, so the gate is told to allow them and the question is written where whoever answers it will be standing.

## Three times the tool, or I, nearly made it worse

- `ruff --fix` unquoted an annotation and left `Callable` **undefined** — and the full suite stayed **green**, because `from __future__ import annotations` means the name is never evaluated. Ruff caught what the tests could not.
- `ruff --fix` then deleted five names from `salla.py` that the comment two lines above called re-exports for its tests. `tests/test_salla.py` stopped importing. A comment cannot stop a fixer; `__all__` can, and a test now guards both.
- The regression test I wrote for `el` **did not bite** — it accepted `const el = $(id)`, a local inside an unrelated function 2,600 lines away. Anchored to column zero now, it fails with `6 != 0` when the helper goes.

## Scope

CI gates `scrapex/` and the four JavaScript areas. `tests/` and `tools/` carry 376 findings, nearly all import order, and are the files a second session edits most — gating them today means a conflict per commit for no defect prevented. The gate covers everything that **ships**; widening it is its own task.

## Verified

Full suite green. Both gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)