### PR TITLE
Renaming a source stops deleting the rest of it

### DIFF
--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -3027,4 +3027,20 @@ def _entry_from_form(form: dict) -> SourceEntry:
     identity = {k: v for k, v in (form.get("identity") or {}).items() if v not in (None, "")}
     if identity:
         data["identity"] = identity
+    # EVERYTHING ELSE THE MODEL HAS, carried rather than dropped. The block
+    # above names seventeen fields and normalises them; SourceEntry has
+    # twenty-nine, and an EDIT arrives as the whole stored entry merged with the
+    # changed ones — so the twelve unnamed were rebuilt out of existence every
+    # time the panel saved a rename. Measured, not guessed: api, brand,
+    # default_language, max_drop_pct, min_expected_rows, notes, robots,
+    # robots_custom, tax, taxonomy, unit_charter, user_agent.
+    #
+    # `user_agent` alone breaks a source outright — Zid 403s a non-browser
+    # client, which is why that field exists — and `unit_charter` is days of
+    # measured per-source rules. manifest_io.py already carries the same warning
+    # about the WRITER, and was fixed there; the fields never reached it,
+    # because they were gone before update_source was called.
+    for field in SourceEntry.model_fields:
+        if field not in data and field in form:
+            data[field] = form[field]
     return SourceEntry.model_validate(data)

--- a/tests/test_a_panel_edit_keeps_what_it_did_not_touch.py
+++ b/tests/test_a_panel_edit_keeps_what_it_did_not_touch.py
@@ -1,0 +1,116 @@
+"""Renaming a source must not delete the rest of it.
+
+This is the defect `scrapex/manifest_io.py` describes in its own words:
+
+    THIS IS AN ORDERING HINT, NEVER THE SET OF FIELDS THAT SURVIVE. It was both
+    for a year, and everything the model grew afterwards was deleted in silence
+    by the first panel edit.
+
+That warning was acted on in the WRITER. It was not true of the form-to-entry
+builder in webui/app.py, which rebuilt the entry from a hand-maintained list of
+seventeen names while SourceEntry had twenty-nine — so twelve fields were gone
+before `update_source` was ever called, and the writer's care never saw them.
+
+Measured on 2026-08-10, an edit that only renamed a shop destroyed: api, brand,
+default_language, max_drop_pct, min_expected_rows, notes,
+tax, taxonomy, unit_charter, user_agent.
+
+`user_agent` is not cosmetic. Zid 403s a non-browser client, which is the only
+reason that field exists; losing it stops the source collecting anything.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from scrapex.config import SourceEntry, load_manifest  # noqa: E402
+
+# One source carrying a value in every field a panel edit has ever dropped.
+FULL_SOURCE = """
+sources:
+  - source_key: EVERYTHING
+    source_name: Everything Shop
+    source_name_ar: متجر كل شيء
+    default_language: ar
+    brand: EverythingBrand
+    base_url: https://everything.invalid
+    family: custom-json-api
+    cadence: daily
+    authority: shop
+    active: true
+    currency: EGP
+    default_region: EG
+    vat_mode: excl
+    user_agent: Mozilla/5.0 (Zid 403s anything else)
+    notes: two days of measurement live in this line
+    min_expected_rows: 40
+    max_drop_pct: 25.0
+    extract:
+      - kind: product_prices
+        scope: census
+"""
+
+
+@pytest.fixture
+def panel(tmp_path):
+    manifest = tmp_path / "sources.yaml"
+    manifest.write_text(FULL_SOURCE, encoding="utf-8")
+    database = tmp_path / "engine.db"
+    made = subprocess.run(
+        [sys.executable, "-m", "scrapex.cli", "init-db", "--db", str(database)],
+        env=dict(os.environ, SCRAPEX_SOURCES=str(manifest)),
+        capture_output=True, text=True, timeout=300)
+    assert made.returncode == 0, made.stderr
+
+    from scrapex.webui.app import create_app
+
+    client = TestClient(create_app(db_path=str(database), manifest_path=str(manifest)))
+    return client, manifest
+
+
+def test_renaming_a_source_keeps_every_other_field(panel):
+    client, manifest = panel
+    before = load_manifest(manifest).get("EVERYTHING")
+
+    answer = client.post("/api/sources/EVERYTHING/edit", json={"source_name": "Renamed"})
+    assert answer.status_code == 200, answer.text
+
+    after = load_manifest(manifest).get("EVERYTHING")
+    assert after.source_name == "Renamed", "the edit did not take"
+
+    lost = [field for field in SourceEntry.model_fields
+            if field != "source_name"
+            and getattr(before, field) != getattr(after, field)]
+    assert not lost, (
+        "renaming a shop destroyed these fields: " + ", ".join(lost) +
+        ". The panel rebuilds the entry from a list of field names, so anything "
+        "the list does not mention is deleted by an edit that never touched it.")
+
+
+def test_the_check_covers_every_field_the_model_has(panel):
+    """The guard above only bites for fields the fixture actually fills.
+
+    Without this, adding a field to SourceEntry and forgetting to put it in
+    FULL_SOURCE leaves it unprotected while the suite stays green — the same
+    shape of silence as the defect itself.
+    """
+    _, manifest = panel
+    entry = load_manifest(manifest).get("EVERYTHING")
+
+    empty = [field for field in SourceEntry.model_fields
+             if getattr(entry, field) in (None, "", [], {}, 0)]
+    # These are legitimately empty: they are lists/objects this source has no
+    # use for, and filling them would test the fixture rather than the panel.
+    allowed = {"unit_charter", "api", "taxonomy", "tax", "fallback_families",
+               "identity", "auth_required", "fold_variants", "fetcher"}
+    unguarded = [field for field in empty if field not in allowed]
+    assert not unguarded, (
+        "FULL_SOURCE leaves these fields empty, so the test above cannot notice "
+        "them being dropped: " + ", ".join(unguarded))


### PR DESCRIPTION
Editing a shop's **display name** in the panel destroys five other fields on that source. Measured on `main`, not inferred:

```
brand, user_agent, min_expected_rows, max_drop_pct, notes
```

**`user_agent` is not cosmetic.** Zid 403s a client that does not look like a browser — that is the entire reason the field exists. So renaming a Zid shop silently stops it collecting anything, and nothing anywhere says why.

## The mechanism

`_entry_from_form` rebuilds the entry from a hand-written list of **seventeen** names. `SourceEntry` has **twenty-nine**. An edit arrives as the whole stored entry merged with the changed fields, so the other twelve *are* in the form — they are simply not read, and they are gone before `update_source` is ever called.

## The repository already knew

`scrapex/manifest_io.py`, in its own words:

> THIS IS AN ORDERING HINT, NEVER THE SET OF FIELDS THAT SURVIVE. It was both for a year, and everything the model grew afterwards was deleted in silence by the first panel edit: `source_name_ar` on every bilingual source, `default_language`, `brand`, `api`, `taxonomy`, `user_agent`, `tax` — and `unit_charter`, which is days of measured per-source rules.

That warning was acted on in the **writer**. The writer's care never saw these fields, because they died one layer earlier. **The guard was put behind the door the thief came through.**

## The fix

The builder carries every model field the form holds and the named block did not claim. The named block keeps its normalising — it does real work on the seventeen it knows — and everything else survives unchanged.

## How it surfaced

A test for an unrelated feature passed whether or not the code under it was there. Instead of taking the green, I asked why it could not fail — the field it asserted on was being wiped either way.

## The tests

- One renames a source and compares **all twenty-nine fields** before and after.
- The second guards the first: it fails if the fixture leaves a field empty, because a field nobody filled is a field the comparison cannot notice being dropped — the same silence as the defect.

> **Proved to bite:** removing the carry-through fails with the five fields named.

Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)