### PR TITLE
robots.txt becomes the owner's decision, per site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,15 @@ work predates this file, the commit that built it — evidence read out of
 record of what was done; this file answers a narrower question: which version
 has it.
 
-## 0.2.1
+## 0.2.2
 
-Minimum supported extension: `0.2.0`.
+Minimum supported extension: `0.2.2`.
 
-No new capabilities. Fixes and internal change only — an extension and an engine that spoke to each other before this version still do.
-
+- **robots_per_source** — Read what a site's robots.txt asks of a crawler, then decide per source: follow the tool default, obey that site, or write a rule for it alone. _Runs in: panel, engine._
 
 ## 0.2.0
 
-Minimum supported extension: `0.2.0`.
+Minimum supported extension: `0.2.2`.
 
 - **compatibility_notice** (7ca7a75) — Be told, rather than left to find out, when the installed extension is older than the features the engine deploys. _Runs in: panel._
 - **crawl_pace** (c63ec21) — Choose whether each site's requested crawl delay is honoured, and set the minimum seconds between requests and the request timeout. _Runs in: panel, engine._

--- a/contracts/capability-baseline.json
+++ b/contracts/capability-baseline.json
@@ -1,8 +1,9 @@
 {
-  "version": "0.2.1",
-  "minimum_extension_version": "0.2.0",
+  "version": "0.2.2",
+  "minimum_extension_version": "0.2.2",
   "capabilities": {
     "crawl_pace": "0.2.0",
+    "robots_per_source": "0.2.2",
     "crawl_parallel_sources": "0.2.0",
     "crawl_resume": "0.2.0",
     "source_admin": "0.2.0",

--- a/contracts/version-vectors.json
+++ b/contracts/version-vectors.json
@@ -1,18 +1,22 @@
 {
-  "version": "0.2.1",
-  "minimum_extension_version": "0.2.0",
+  "version": "0.2.2",
+  "minimum_extension_version": "0.2.2",
   "capability_reporting_since": "0.2.0",
   "note": "Both copies of capabilityProblem must reproduce every `problem` string exactly. Python: scrapex/version.py. JavaScript: extension/version.js.",
   "cases": [
     {
       "name": "in step — the engine deploys it and the extension is new enough",
       "key": "crawl_parallel_sources",
-      "extension_version": "0.2.1",
-      "engine_version": "0.2.1",
+      "extension_version": "0.2.2",
+      "engine_version": "0.2.2",
       "deployed": {
         "crawl_pace": {
           "since": "0.2.0",
           "summary": "Choose whether each site's requested crawl delay is honoured, and set the minimum seconds between requests and the request timeout."
+        },
+        "robots_per_source": {
+          "since": "0.2.2",
+          "summary": "Read what a site's robots.txt asks of a crawler, then decide per source: follow the tool default, obey that site, or write a rule for it alone."
         },
         "crawl_parallel_sources": {
           "since": "0.2.0",
@@ -46,11 +50,15 @@
       "name": "the extension is behind the engine",
       "key": "crawl_parallel_sources",
       "extension_version": "0.1.0",
-      "engine_version": "0.2.1",
+      "engine_version": "0.2.2",
       "deployed": {
         "crawl_pace": {
           "since": "0.2.0",
           "summary": "Choose whether each site's requested crawl delay is honoured, and set the minimum seconds between requests and the request timeout."
+        },
+        "robots_per_source": {
+          "since": "0.2.2",
+          "summary": "Read what a site's robots.txt asks of a crawler, then decide per source: follow the tool default, obey that site, or write a rule for it alone."
         },
         "crawl_parallel_sources": {
           "since": "0.2.0",
@@ -78,17 +86,21 @@
         }
       },
       "update_instructions": "Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards.",
-      "problem": "«Crawl several different sites at the same time. Two sources on the SAME site still take turns, so no site is asked for more than before.» needs ScrapeX extension 0.2.0; this extension is 0.1.0 and the engine is 0.2.1. Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards."
+      "problem": "«Crawl several different sites at the same time. Two sources on the SAME site still take turns, so no site is asked for more than before.» needs ScrapeX extension 0.2.0; this extension is 0.1.0 and the engine is 0.2.2. Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards."
     },
     {
       "name": "the engine is behind and says so",
       "key": "crawl_parallel_sources",
-      "extension_version": "0.2.1",
+      "extension_version": "0.2.2",
       "engine_version": "0.1.0",
       "deployed": {
         "crawl_pace": {
           "since": "0.2.0",
           "summary": "Choose whether each site's requested crawl delay is honoured, and set the minimum seconds between requests and the request timeout."
+        },
+        "robots_per_source": {
+          "since": "0.2.2",
+          "summary": "Read what a site's robots.txt asks of a crawler, then decide per source: follow the tool default, obey that site, or write a rule for it alone."
         },
         "crawl_resume": {
           "since": "0.2.0",
@@ -112,26 +124,30 @@
         }
       },
       "update_instructions": "Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards.",
-      "problem": "«crawl_parallel_sources» is not deployed by this ScrapeX engine (0.1.0); this extension is 0.2.1. Update the engine to 0.2.1 or newer."
+      "problem": "«crawl_parallel_sources» is not deployed by this ScrapeX engine (0.1.0); this extension is 0.2.2. Update the engine to 0.2.2 or newer."
     },
     {
       "name": "the engine is too old to say anything",
       "key": "crawl_parallel_sources",
-      "extension_version": "0.2.1",
+      "extension_version": "0.2.2",
       "engine_version": "0.1.0",
       "deployed": null,
       "update_instructions": "Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards.",
-      "problem": "«crawl_parallel_sources» cannot be confirmed: the ScrapeX engine reports version 0.1.0 and is too old to say which features it deploys. This extension is 0.2.1. Update the engine to 0.2.1."
+      "problem": "«crawl_parallel_sources» cannot be confirmed: the ScrapeX engine reports version 0.1.0 and is too old to say which features it deploys. This extension is 0.2.2. Update the engine to 0.2.2."
     },
     {
       "name": "an extension newer than the requirement is not refused for being newer",
       "key": "crawl_parallel_sources",
       "extension_version": "9.9.9",
-      "engine_version": "0.2.1",
+      "engine_version": "0.2.2",
       "deployed": {
         "crawl_pace": {
           "since": "0.2.0",
           "summary": "Choose whether each site's requested crawl delay is honoured, and set the minimum seconds between requests and the request timeout."
+        },
+        "robots_per_source": {
+          "since": "0.2.2",
+          "summary": "Read what a site's robots.txt asks of a crawler, then decide per source: follow the tool default, obey that site, or write a rule for it alone."
         },
         "crawl_parallel_sources": {
           "since": "0.2.0",

--- a/docs/robots-policy.md
+++ b/docs/robots-policy.md
@@ -1,6 +1,27 @@
 # robots.txt policy
 
-**Owner decision — 2026-07-22.**
+**Owner decision — 2026-07-22, and it is now a DEFAULT rather than the law.**
+
+Since 2026-08-10 robots.txt is decided per source, in three steps:
+
+1. **Look.** `GET /api/sources/{key}/robots` reads the site's file and says what
+   it contains for THIS crawler at THIS base url — whether it names us by name,
+   what delay it asks for, which lines touch this source, and the one fact that
+   decides the answer: `would_block_everything`. On a site that disallows the
+   pages a source is for, choosing *obey* does not make the crawl polite, it
+   makes it EMPTY — and an empty crawl reports success.
+2. **Choose.** `SourceEntry.robots` is `default`, `obey` or `custom`.
+   `custom` carries `{enforce_disallow, crawl_delay_s}` and nothing else,
+   because those are the only two powers robots.txt has over a crawler.
+3. **Enforce.** `scrapex/robots.py` resolves the choice against the file;
+   `HttpFetcher` acts on it and writes the sentence that explains whichever
+   happened. A refusal RAISES `RobotsDisallowed` rather than skipping the page:
+   a skipped page becomes an empty crawl that reports success.
+
+The table below is what a source gets when it has said nothing — the setting
+`crawl_obey_disallow`, which ships at `0`. It stayed the default deliberately:
+flipping it would change what twelve reviewed sources collect without the owner
+asking.
 
 | robots.txt directive | Our behaviour | Why |
 |---|---|---|
@@ -15,5 +36,9 @@ request), and every disclosure travels through `robots_warnings` →
 warning level, on `CaptureResult.warnings`), so none of this is silent and none
 of it masquerades as a defect.
 
-Changing this policy = changing that method + its pins in
-`tests/test_http_fetcher.py`, and updating this file.
+Changing the DEFAULT = the `crawl_obey_disallow` setting, no code.
+Changing what a single source does = its `robots:` key in the manifest, or the
+panel's Robots panel on that source.
+Changing the MECHANISM = `scrapex/robots.py` plus `HttpFetcher._request`, and
+their pins in `tests/test_robots_is_the_owners_decision.py` and
+`tests/test_http_fetcher.py` — and updating this file.

--- a/extension/app.html
+++ b/extension/app.html
@@ -712,6 +712,50 @@
            this file is interface, and Arabic here is data, never chrome.
            Reordering here is Up/Down rather than drag: the panel is a narrow
            column and a drag target that thin is a control you fight. -->
+      <!-- robots.txt, per site. Three steps in the order a person takes them:
+           look at what the site says, then choose, and the consequence of the
+           choice is spelled out beside it rather than left to be discovered by
+           watching a run come back empty. -->
+      <section class="card" aria-labelledby="source-edit-robots-heading">
+        <div class="section-head">
+          <div>
+            <h2 id="source-edit-robots-heading">robots.txt</h2>
+            <p class="muted text-xs">What this site asks of a crawler, and what
+              ScrapeX does about it.</p>
+          </div>
+          <button id="source-edit-robots-look" type="button" class="ghost">
+            Check what the site says
+          </button>
+        </div>
+        <!-- Empty until asked. The check costs a request to someone else's
+             server, so it happens when the owner wants it, not on every open. -->
+        <div id="source-edit-robots-report" class="muted text-sm">
+          Not checked yet.
+        </div>
+        <div class="fieldset">
+          <label for="source-edit-robots">What this source does</label>
+          <select id="source-edit-robots">
+            <option value="default">Use the tool default</option>
+            <option value="obey">Obey this site's robots.txt</option>
+            <option value="custom">A custom rule for this site</option>
+          </select>
+          <p id="source-edit-robots-consequence" class="muted text-xs"></p>
+        </div>
+        <!-- Shown only for `custom`: the two things robots.txt itself controls,
+             and nothing else. -->
+        <div id="source-edit-robots-custom" class="hidden">
+          <label class="check">
+            <input id="source-edit-robots-enforce" type="checkbox">
+            <span>Do not fetch paths this site disallows</span>
+          </label>
+          <div class="fieldset">
+            <label for="source-edit-robots-delay">Seconds between requests</label>
+            <input id="source-edit-robots-delay" type="number" min="0" step="0.5"
+                   placeholder="whatever the site asks for">
+          </div>
+        </div>
+      </section>
+
       <section class="card" aria-labelledby="source-edit-columns-heading">
         <div class="section-head">
           <div>

--- a/extension/app.js
+++ b/extension/app.js
@@ -1457,6 +1457,8 @@ function renderSourceEditor(source) {
   $("source-edit-identity").innerHTML = sourceIdentity(
     source, false, Number(source.observations || 0).toLocaleString());
 
+  renderRobotsChoice(source);
+
   const ready = Boolean(source.implemented);
   $("source-edit-readiness").innerHTML =
     `<span class="dot ${ready ? "on" : "off"}" aria-hidden="true"></span>
@@ -1503,6 +1505,59 @@ function renderSourceEditor(source) {
   out("source-edit-result", "");
 }
 
+// robots.txt, per site. Kept together so the three steps read in the order the
+// owner takes them: what the site says, what he chose, what that will do.
+function renderRobotsChoice(source) {
+  const choice = source.robots || "default";
+  $("source-edit-robots").value = choice;
+  const custom = source.robots_custom || {};
+  $("source-edit-robots-enforce").checked = Boolean(custom.enforce_disallow);
+  $("source-edit-robots-delay").value =
+    custom.crawl_delay_s === null || custom.crawl_delay_s === undefined
+      ? "" : String(custom.crawl_delay_s);
+  $("source-edit-robots-custom").classList.toggle("hidden", choice !== "custom");
+  // The consequence, in the same breath as the choice. A dropdown that does not
+  // say what it will do is asking the owner to guess.
+  const says = {
+    default: "Whatever the Settings page says. Today that is: disallowed paths "
+           + "are crawled and the run says so.",
+    obey: "Disallowed paths are NOT fetched, and the site's own delay is used. "
+        + "On a site that disallows this source's pages, that means it collects "
+        + "nothing — check the site first.",
+    custom: "This site only. Nothing else changes.",
+  };
+  $("source-edit-robots-consequence").textContent = says[choice] || "";
+}
+
+async function lookAtRobots() {
+  const key = state.editingSourceKey;
+  if (!key) return;
+  const box = $("source-edit-robots-report");
+  const button = $("source-edit-robots-look");
+  button.disabled = true;
+  box.textContent = "Reading " + key + "'s robots.txt…";
+  try {
+    const report = await api("/api/sources/" + encodeURIComponent(key) + "/robots");
+    const lines = [report.summary];
+    if (report.names_us) {
+      lines.push("This site names " + report.names_us + " specifically.");
+    }
+    if (report.would_block_everything) {
+      // THE ONE THAT CHANGES THE ANSWER, said plainly and not as a footnote.
+      lines.push("Obeying would leave this source with nothing to collect.");
+    }
+    if (report.on_a_disallowed_path && report.on_a_disallowed_path.reason) {
+      lines.push("On a disallowed path today: " + report.on_a_disallowed_path.reason);
+    }
+    box.textContent = lines.join(" ");
+    box.classList.toggle("warn", Boolean(report.would_block_everything));
+  } catch (error) {
+    box.textContent = "Could not read it: " + (error && error.message ? error.message : error);
+  } finally {
+    button.disabled = false;
+  }
+}
+
 function openSourceEditor(sourceKey) {
   const source = state.sources.find((item) => item.source_key === sourceKey);
   if (!source) return;
@@ -1535,9 +1590,27 @@ async function saveSourceEditor() {
       cadence: $("source-edit-cadence").value,
       vat_mode: $("source-edit-vat").value,
       fold_variants: $("source-edit-fold").checked,
+      robots: $("source-edit-robots").value,
     };
-    const changed = Object.entries(edits).some(
-      ([field, value]) => String(source[field] ?? "") !== String(value));
+    // The custom rule rides along only when it is the chosen one. Sending it
+    // otherwise would leave a rule stored behind a choice that ignores it,
+    // which reads as "this site is customised" on every later open.
+    if (edits.robots === "custom") {
+      const delay = $("source-edit-robots-delay").value.trim();
+      edits.robots_custom = {
+        enforce_disallow: $("source-edit-robots-enforce").checked,
+        crawl_delay_s: delay === "" ? null : Number(delay),
+      };
+    } else {
+      edits.robots_custom = null;
+    }
+    const changed = Object.entries(edits).some(([field, value]) =>
+      // robots_custom is an OBJECT. `String({}) !== String(null)` is true for
+      // every pair of objects, so comparing it the same way as the text fields
+      // would report a change on every save and POST for nothing.
+      (value !== null && typeof value === "object") || field === "robots_custom"
+        ? JSON.stringify(source[field] ?? null) !== JSON.stringify(value ?? null)
+        : String(source[field] ?? "") !== String(value));
     if (changed) {
       await post("/api/sources/" + encodeURIComponent(source.source_key) + "/edit", edits);
       Object.assign(source, edits);
@@ -3798,6 +3871,15 @@ async function init() {
     requestAnimationFrame(() =>
       document.querySelector(`[data-edit-source="${CSS.escape(sourceKey || "")}"]`)
         ?.focus({preventScroll: true}));
+  });
+  $("source-edit-robots-look").addEventListener("click", lookAtRobots);
+  $("source-edit-robots").addEventListener("change", () => {
+    const choice = $("source-edit-robots").value;
+    $("source-edit-robots-custom").classList.toggle("hidden", choice !== "custom");
+    renderRobotsChoice({robots: choice, robots_custom: {
+      enforce_disallow: $("source-edit-robots-enforce").checked,
+      crawl_delay_s: $("source-edit-robots-delay").value.trim() || null,
+    }});
   });
   $("source-edit-form").addEventListener("submit", async (event) => {
     event.preventDefault();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "ScrapeX",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAztNYpZ7kqRyVBrerQ24cHpkxzl/yeZHRa5WtlPEcK7MJP4ABiHwa5/Fe9NQzC/uV7JwmYuUEM/OylCTfaaAFnEscj6Wkgp/3ntIE+kzMhW2XvzOSL3Ss3xXune3OQxxev+nFYQjhnWsU1u9C6InB70utjLect6KS/Cak3iVKydr793cmqZjp73aY11dkEEkXEoBSS3i8j1THt1uK09VCAKwP6cSM3P7q2Gp723Io8nALXvg/K1AOxY3PuNpxsiQFE7fMl0KBgu1G2Sgyb/NZvO31pgGe43XYLmeYj4aaMdbrnz+KemyLfqIyBt8DF6O7uUuPNaYFQE+CrY16PTUZLwIDAQAB",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A local scraping tool: capture prices from the sites you browse into a warehouse on your own machine.",
   "icons": {
     "16": "icons/x-mark-original-16.png",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "scrapex"
 # A MIRROR of scrapex/version.py:VERSION — setuptools cannot import the package
 # to ask. tests/test_version.py reads this line back and fails when they drift.
-version = "0.2.1"
+version = "0.2.2"
 description = "ScrapeX ecosystem: contract-driven web data collection into a SQLite price-tracking warehouse"
 requires-python = ">=3.12"
 dependencies = [

--- a/scrapex/capture.py
+++ b/scrapex/capture.py
@@ -94,6 +94,13 @@ def crawl_settings(conn: sqlite3.Connection) -> dict:
         # fast crawl and a polite one indistinguishable afterwards.
         "honour_crawl_delay": settings.get(conn, "crawl_honour_delay") not in
                               ("0", "false", "False", False),
+        # WHAT A SOURCE GETS WHEN IT HAS SAID NOTHING. Unlike the delay above,
+        # silence here reads as "crawl and disclose" -- the ruling every source
+        # has had since 2026-07-22 -- because flipping it under twelve sources
+        # the owner already reviewed would change what they collect without him
+        # asking. A source that wants the other answer says so on itself.
+        "obey_disallow": settings.get(conn, "crawl_obey_disallow") in
+                         ("1", "true", "True", True),
     }
 
 

--- a/scrapex/config.py
+++ b/scrapex/config.py
@@ -348,6 +348,18 @@ class SourceEntry(BaseModel):
     # Some platforms (Zid) 403 non-browser clients; such a source declares the
     # exact UA the fetcher must send. Explicit per source, never a silent global (F5).
     user_agent: str | None = None
+    # ROBOTS IS A PER-SITE DECISION, and this is where the owner records it.
+    # "default" defers to the tool-wide setting, so a source that never asked
+    # for anything different moves when he changes his mind once. "obey" follows
+    # this site's robots.txt. "custom" uses `robots_custom` below and refuses to
+    # run without it -- see scrapex/robots.py for why falling back would be
+    # worse than failing. Stored as a plain string because the manifest is a
+    # hand-editable file and an enum in YAML is a trap; robots.RobotsChoice
+    # validates it at the point of use.
+    robots: str = "default"
+    #: Only read when `robots` is "custom": {enforce_disallow: bool,
+    #: crawl_delay_s: float | null}. A null delay means the site's own.
+    robots_custom: dict | None = None
     # Ordered families to try if `family` fails (spec 32). Recorded per source so
     # the choice is visible in the manifest rather than hidden in code.
     fallback_families: list[ConnectorFamily] = Field(default_factory=list)

--- a/scrapex/connectors/base.py
+++ b/scrapex/connectors/base.py
@@ -197,6 +197,15 @@ def declare_frontier(fetcher, pages: int) -> None:
         pass
 
 
+class RobotsDisallowed(RuntimeError):
+    """This source is set to obey robots.txt, and robots.txt said no.
+
+    Its own class because the alternative -- returning nothing, or a 403-shaped
+    failure -- makes a deliberate refusal indistinguishable from a site being
+    down, and those need opposite responses from the owner.
+    """
+
+
 class HttpFetcher:
     """Shared polite HTTP transport (F5): rate-limited, retrying, one UA.
 
@@ -247,6 +256,9 @@ class HttpFetcher:
         max_attempts: int = 3,
         jitter: float = 0.3,          # +/- 30% around the base interval
         honour_crawl_delay: bool = True,
+                 robots_choice: str = "default",
+                 robots_custom: dict | None = None,
+                 obey_disallow: bool = False,
     ) -> None:
         self._client = httpx.Client(
             headers={"User-Agent": user_agent},
@@ -264,6 +276,8 @@ class HttpFetcher:
         # "robots crawl-delay 10s — honored" for ELBUROJ and NOTHING read
         # robots.txt at all; a promise in a comment is not a mechanism.
         self._robots: dict[str, object] = {}
+        #: host -> the file as it arrived, for the report.
+        self._robots_text: dict[str, str] = {}
         self._user_agent = user_agent
         # The owner's per-run choice (2026-07-28). Default TRUE: a crawler that
         # ignores a site's asked-for pace by default is one that gets the owner
@@ -272,6 +286,20 @@ class HttpFetcher:
         # which pace it ran at — otherwise a fast crawl and a polite one look
         # identical afterwards.
         self._honour_crawl_delay = honour_crawl_delay
+        # WHOSE DECISION THIS FETCHER CARRIES. Passed in rather than read from
+        # settings here, because one crawl can run several sources and each may
+        # have answered differently -- a fetcher that looked the answer up would
+        # give them all the same one.
+        self._robots_choice = robots_choice
+        self._robots_custom = robots_custom
+        # NAMED EXACTLY AS THE SETTING IS, because `HttpFetcher(**crawl_settings(
+        # conn))` is a real call site: a parameter whose name drifts from its
+        # settings key is a TypeError the moment somebody adds the setting.
+        # tests/test_http_fetcher.py pins the two together.
+        self._obey_disallow = obey_disallow
+        #: host -> RobotsReport, so the file is read once and the report can be
+        #: shown to the owner afterwards without fetching it again.
+        self._robots_reports: dict[str, object] = {}
         self.robots_warnings: list[str] = []
         # url -> {"ETag": ..., "Last-Modified": ...}, replayed on the next visit.
         self._validators: dict[str, dict[str, str]] = {}
@@ -419,6 +447,10 @@ class HttpFetcher:
             if answer.status_code == 200:
                 parser = RobotFileParser()
                 parser.parse(answer.text.splitlines())
+                # Kept so the report shown to the owner can quote the actual
+                # lines. RobotFileParser answers questions and cannot be asked
+                # what it read.
+                self._robots_text[host] = answer.text
         except Exception:
             parser = None
         self._robots[host] = parser
@@ -448,19 +480,41 @@ class HttpFetcher:
     def _request(self, method: str, url: str, **kwargs) -> httpx.Response:
         robots = self._robots_for(url)
         if robots is not None and not robots.can_fetch(self._user_agent, url):
-            # Owner policy (docs/robots-policy.md, 2026-07-22): Disallow is
-            # informational, NOT enforced — refusing outright could silently
-            # kill a source the owner relies on. Crawl-delay, by contrast, IS
-            # enforced (above). ONE warning per host (a 400-page crawl must
-            # not write 400 lines) keeps the fact visible in the job log.
+            # NO LONGER ONE RULING FOR EVERY SITE. docs/robots-policy.md carried
+            # "Disallow is informational" for every source from 2026-07-22; it
+            # is now what a source gets when it has said nothing, and the source
+            # can say otherwise. scrapex/robots.py resolves the three cases and
+            # writes the sentence that explains whichever happened.
             from urllib.parse import urlsplit
+
+            from ..robots import RobotsChoice, RobotsCustom, decide, inspect
+
             host = urlsplit(url).netloc
+            report = self._robots_reports.get(host)
+            if report is None:
+                report = inspect(url, self._robots_text.get(host),
+                                 user_agent=self._user_agent)
+                self._robots_reports[host] = report
+
+            custom = None
+            if self._robots_choice == RobotsChoice.CUSTOM and self._robots_custom:
+                custom = RobotsCustom(
+                    enforce_disallow=bool(self._robots_custom.get("enforce_disallow")),
+                    crawl_delay_s=self._robots_custom.get("crawl_delay_s"))
+            verdict = decide(report, RobotsChoice(self._robots_choice), custom=custom,
+                             tool_default_obeys=self._obey_disallow,
+                             url_disallowed=True)
+
+            # ONE line per host: a 400-page crawl must not write 400 of them.
             marker = f"{host}: robots.txt disallows"
             if not any(w.startswith(marker) for w in self.robots_warnings):
-                self.robots_warnings.append(
-                    f"{marker} some of the paths we crawl (first: "
-                    f"{urlsplit(url).path}) — crawled anyway per the robots "
-                    "policy: Disallow is informational, not enforced")
+                self.robots_warnings.append(f"{marker} — {verdict.reason}")
+            if not verdict.may_fetch:
+                # RAISED, not skipped. A skipped page becomes an empty crawl
+                # that reports success, and a source that silently stops being
+                # collected is the worst failure this product has. The owner
+                # chose to obey; the run must say so out loud and stop.
+                raise RobotsDisallowed(verdict.reason)
         if method == "GET":
             kwargs["headers"] = self._conditional_headers(url, kwargs.get("headers"))
         last_error: Exception | None = None
@@ -643,5 +697,11 @@ def resolve_fetcher(source: SourceEntry,
         min_interval_s=1.0 if interval is None else float(interval),
         timeout_s=30.0 if timeout is None else float(timeout),
         honour_crawl_delay=True if honour is None else bool(honour),
+        # The source's own answer, and what it means when the source did not
+        # give one. Read HERE and not inside the fetcher because a single crawl
+        # can run several sources and each may have answered differently.
+        robots_choice=source.robots or "default",
+        robots_custom=source.robots_custom,
+        obey_disallow=bool(chosen.get("obey_disallow")),
     )
 

--- a/scrapex/robots.py
+++ b/scrapex/robots.py
@@ -1,0 +1,252 @@
+"""What a site's robots.txt says, and whose decision it is.
+
+Until now this was one ruling for every source, written down in
+docs/robots-policy.md on 2026-07-22: Crawl-delay enforced, Disallow
+informational. That was the right call for twelve shops the owner already knew.
+It stops being right the moment the product crawls a site he has not read.
+
+So the ruling moves from the repository to the source, in three steps that are
+deliberately separate:
+
+  1. LOOK. `inspect()` fetches robots.txt and says what it actually contains --
+     for THIS crawler, at THIS base url. Not a summary of the file: the rules
+     that would touch the paths this source crawls.
+  2. CHOOSE. Each source carries `robots: default | obey | custom`.
+  3. ENFORCE. `decide()` turns the choice plus the file into two answers the
+     fetcher can act on: may this url be fetched, and how long to wait.
+
+WHY LOOKING IS ITS OWN STEP. A choice offered before the facts is a guess with
+a dropdown around it. The owner cannot sensibly pick "obey" for a site until he
+knows whether obeying means a five-second delay or an empty crawl -- and the
+only honest way to tell him is to read the file and show him.
+
+NOTHING HERE FETCHES A PAGE. This module reads robots.txt and answers
+questions. The walking, the pacing and the request budget stay where they were.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from urllib.parse import urlsplit
+from urllib.robotparser import RobotFileParser
+
+
+class RobotsChoice(StrEnum):
+    """What one source does about robots.txt.
+
+    A string would have done and would have let "Obey" or "obeys" through to be
+    compared against "obey" and silently fall back to the default -- which is
+    the one outcome nobody would notice, because the default is what happens
+    when a source has said nothing at all.
+    """
+
+    #: Whatever the tool-wide setting says. The value a source has until the
+    #: owner decides otherwise, so changing the setting moves every source that
+    #: never asked for anything different.
+    DEFAULT = "default"
+
+    #: This site's robots.txt is followed: a disallowed url is not fetched, and
+    #: its Crawl-delay wins over our pace whenever it is longer.
+    OBEY = "obey"
+
+    #: This site, and only this site, gets the rule written beside it.
+    CUSTOM = "custom"
+
+
+@dataclass(frozen=True)
+class RobotsCustom:
+    """The per-site rule, holding exactly what robots.txt itself controls.
+
+    Two knobs and no more, on purpose. robots.txt grants a site two powers over
+    a crawler -- where it may go and how fast -- so a custom rule that answered
+    anything else would be answering a question the file never asked.
+    """
+
+    #: False is today's shipped behaviour: crawl the path and disclose it.
+    enforce_disallow: bool = False
+    #: None means "whatever the site asked for". A number overrides it, and
+    #: overriding DOWNWARDS is the one that needs the owner's eyes -- which is
+    #: why `decide` reports it rather than doing it quietly.
+    crawl_delay_s: float | None = None
+
+
+@dataclass(frozen=True)
+class RobotsRule:
+    """One line of robots.txt that touches this source, in plain terms."""
+
+    kind: str            # "disallow" | "allow" | "crawl-delay" | "named-us"
+    value: str
+    #: Which User-agent block it came from, verbatim -- "*" or a name.
+    agent: str
+
+
+@dataclass
+class RobotsReport:
+    """What the site says, for this crawler, at this base url.
+
+    This is the LOOK step's whole output, and it is shaped for a person: the
+    fields answer the questions someone asks before choosing, in the order they
+    ask them.
+    """
+
+    host: str
+    #: False when there is no robots.txt, or it could not be read. A site with
+    #: no file has not refused anything -- that is not the same as permitting
+    #: everything, but it is the same for what a crawler may do.
+    found: bool = False
+    #: The file named this crawler's user agent specifically, rather than only
+    #: matching it through `*`. The most important single fact in the report:
+    #: a site that names you has thought about you.
+    names_us: str = ""
+    #: The site asks every crawler like us to wait this long, in seconds.
+    crawl_delay_s: float | None = None
+    #: Whether the base url itself is off limits. If this is True, "obey" means
+    #: this source cannot be crawled at all, and the owner needs to know that
+    #: BEFORE choosing it rather than by watching an empty run.
+    base_url_disallowed: bool = False
+    #: The rules that would bear on this source, for showing to a person.
+    rules: list[RobotsRule] = field(default_factory=list)
+    #: Set when the file could not be read at all, so "no rules" is never
+    #: mistaken for "nothing to obey".
+    unreadable: str = ""
+
+    @property
+    def obeying_would_block_everything(self) -> bool:
+        """The answer that decides whether `obey` is even usable here."""
+        return self.found and self.base_url_disallowed
+
+    def summary(self) -> str:
+        """One sentence, for a log line or a panel subtitle."""
+        if self.unreadable:
+            return f"{self.host}: robots.txt could not be read ({self.unreadable})"
+        if not self.found:
+            return f"{self.host}: no robots.txt — the site asks for nothing"
+        parts = []
+        if self.names_us:
+            parts.append(f"names {self.names_us} specifically")
+        if self.base_url_disallowed:
+            parts.append("disallows the pages this source crawls")
+        if self.crawl_delay_s:
+            parts.append(f"asks for {self.crawl_delay_s:g}s between requests")
+        return f"{self.host}: " + (", ".join(parts) if parts
+                                   else "allows this source, asks for no delay")
+
+
+def _parse(text: str) -> tuple[RobotFileParser, list[tuple[str, str, str]]]:
+    """The stdlib parser for decisions, and the raw lines for showing a person.
+
+    Both, because `RobotFileParser` answers questions correctly and cannot be
+    asked what it read -- and a report that says "disallowed" without the line
+    that disallowed it is asking the owner to take our word for it.
+    """
+    parser = RobotFileParser()
+    parser.parse(text.splitlines())
+
+    lines: list[tuple[str, str, str]] = []
+    agent = "*"
+    for raw in text.splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line or ":" not in line:
+            continue
+        name, _, value = line.partition(":")
+        name, value = name.strip().lower(), value.strip()
+        if name == "user-agent":
+            agent = value
+        elif name in ("disallow", "allow", "crawl-delay"):
+            lines.append((agent, name, value))
+    return parser, lines
+
+
+def inspect(base_url: str, robots_text: str | None, *,
+            user_agent: str = "*", unreadable: str = "") -> RobotsReport:
+    """Turn a robots.txt into what it MEANS for one source.
+
+    The text is passed in rather than fetched: this module has no opinion about
+    HTTP, and a test that had to stand up a server to ask "what does this file
+    mean" would be testing the server.
+    """
+    host = urlsplit(base_url).netloc or base_url
+    if unreadable:
+        return RobotsReport(host=host, unreadable=unreadable)
+    if robots_text is None:
+        return RobotsReport(host=host, found=False)
+
+    parser, lines = _parse(robots_text)
+    report = RobotsReport(host=host, found=True)
+
+    # Does the file name US, or only reach us through `*`? Compared on the
+    # leading token because a user agent string carries a version and a contact
+    # url, and robots.txt names products, not builds.
+    ours = (user_agent or "*").split("/", 1)[0].strip().lower()
+    for agent, kind, value in lines:
+        if ours and agent.lower() == ours:
+            report.names_us = agent
+        if agent.lower() in (ours, "*"):
+            report.rules.append(RobotsRule(kind=kind, value=value, agent=agent))
+
+    delay = parser.crawl_delay(user_agent) or parser.crawl_delay("*")
+    report.crawl_delay_s = float(delay) if delay else None
+    report.base_url_disallowed = not parser.can_fetch(user_agent, base_url)
+    return report
+
+
+@dataclass(frozen=True)
+class Decision:
+    """What the fetcher does about one url, and why -- the why is not optional.
+
+    Every field here ends up in the job log. A crawl that was slower, or that
+    skipped pages, must be explainable afterwards without re-reading the code:
+    "this took an hour because muqawil asked for 5 seconds and SLOWSHOP is set
+    to obey" is a sentence the owner can act on.
+    """
+
+    may_fetch: bool
+    #: None leaves the caller's own pace alone.
+    delay_s: float | None
+    reason: str
+
+
+def decide(report: RobotsReport, choice: RobotsChoice, *,
+           custom: RobotsCustom | None = None,
+           tool_default_obeys: bool = False,
+           url_disallowed: bool = False) -> Decision:
+    """Resolve one source's choice against what the site said.
+
+    `tool_default_obeys` is the settings value, passed in rather than read:
+    this module must stay usable from a test that never touches a database.
+    """
+    if choice is RobotsChoice.CUSTOM and custom is None:
+        # Refused rather than defaulted, because the obvious default -- the
+        # tool-wide setting -- is the very thing the owner chose CUSTOM to get
+        # away from, and it would arrive wearing his own label.
+        raise ValueError(
+            "this source is set to a custom robots rule and none is stored. "
+            "Choose 'default' or 'obey', or write the custom rule.")
+
+    if not report.found or report.unreadable:
+        why = report.unreadable or "no robots.txt"
+        return Decision(may_fetch=True, delay_s=None,
+                        reason=f"{report.host}: {why} — nothing to obey")
+
+    if choice is RobotsChoice.OBEY:
+        enforce, delay = True, report.crawl_delay_s
+        label = "set to obey this site's robots.txt"
+    elif choice is RobotsChoice.CUSTOM:
+        enforce = custom.enforce_disallow
+        delay = report.crawl_delay_s if custom.crawl_delay_s is None else custom.crawl_delay_s
+        label = "a custom rule for this site"
+    else:
+        enforce, delay = tool_default_obeys, report.crawl_delay_s
+        label = ("the tool default, which obeys Disallow" if tool_default_obeys
+                 else "the tool default, which discloses Disallow and crawls anyway")
+
+    if url_disallowed and enforce:
+        return Decision(may_fetch=False, delay_s=delay,
+                        reason=f"{report.host}: robots.txt disallows this path, and "
+                               f"this source is {label} — not fetched")
+    if url_disallowed:
+        return Decision(may_fetch=True, delay_s=delay,
+                        reason=f"{report.host}: robots.txt disallows this path; "
+                               f"crawled anyway under {label}")
+    return Decision(may_fetch=True, delay_s=delay,
+                    reason=f"{report.host}: allowed under {label}")

--- a/scrapex/settings.py
+++ b/scrapex/settings.py
@@ -73,6 +73,14 @@ SETTINGS: dict[str, Setting] = {s.key: s for s in [
     # the run records, so a fast crawl and a polite one stay distinguishable
     # afterwards.
     Setting("crawl_honour_delay", "1", label="Honour each site's crawl delay"),
+    # "0" keeps the ruling docs/robots-policy.md has carried since 2026-07-22:
+    # Disallow is disclosed and crawled anyway. It is a SETTING now rather than
+    # a policy because that ruling was made about twelve shops the owner had
+    # read, and it stops being obviously right for a site he has not. A source
+    # can override it either way (SourceEntry.robots); this is only what a
+    # source that never said anything gets.
+    Setting("crawl_obey_disallow", "0",
+            label="Obey robots.txt Disallow by default"),
     # 1 keeps the behaviour every job has had until now: one source at a time,
     # in the order the job listed them. Raising it crawls that many SITES at
     # once — never two sources of one site, whatever the number says.

--- a/scrapex/version.py
+++ b/scrapex/version.py
@@ -73,7 +73,7 @@ from enum import StrEnum
 # The release stamp. Bump it for a functional, architectural or behavioural
 # change (issue 32 section 1.1), and regenerate the baseline + CHANGELOG in the
 # same commit: python -m scrapex.cli export-version
-VERSION = "0.2.1"
+VERSION = "0.2.2"
 
 
 class Surface(StrEnum):
@@ -123,6 +123,25 @@ CAPABILITIES: tuple[Capability, ...] = (
         # Built and plumbed to HttpFetcher here; 2253308 moved the controls off
         # the display-only web page into the panel. This is incident one.
         commit="c63ec21",
+    ),
+    Capability(
+        key="robots_per_source",
+        # 0.2.2, not 0.2.1, and the ledger is what taught me: the baseline
+        # records what each version DEPLOYS, so adding a capability under a
+        # version that already has a baseline changes what 0.2.1 means after the
+        # fact. "A functional change gets its own version" is the rule, and it
+        # holds whether or not anything has been released yet.
+        since="0.2.2",
+        summary="Read what a site's robots.txt asks of a crawler, then decide per "
+                "source: follow the tool default, obey that site, or write a rule "
+                "for it alone.",
+        surfaces=(Surface.PANEL, Surface.ENGINE),
+        panel_control="source-edit-robots",
+        settings=("crawl_obey_disallow",),
+        # The setting is only the DEFAULT. The per-source choice lives on the
+        # source itself (SourceEntry.robots), which is why the panel control
+        # named here is on the source editor and not the Settings page.
+        commit="",
     ),
     Capability(
         key="crawl_parallel_sources",

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -1496,6 +1496,92 @@ def create_app(
         return {"source": json.loads(entry.model_dump_json()), "holds": holds,
                 "implemented": entry.family in _BUILDERS}
 
+    @app.get("/api/sources/{source_key}/robots")
+    def api_source_robots(source_key: str):
+        """LOOK BEFORE CHOOSING: what this site's robots.txt actually says.
+
+        Its own route, and a GET, because it is the one step of the three that
+        changes nothing. A choice offered before the facts is a guess with a
+        dropdown around it — the owner cannot sensibly pick "obey" for a site
+        until he knows whether obeying means a five-second delay or an empty
+        crawl, and the only honest way to tell him is to read the file.
+
+        `would_block_everything` is the field that decides the answer: when it
+        is true, choosing obey does not make this source polite, it makes it
+        collect nothing while reporting success.
+        """
+        import httpx
+
+        from ..connectors.base import DEFAULT_USER_AGENT
+        from ..robots import RobotsChoice, RobotsCustom, decide, inspect
+
+        try:
+            entry = app.state.manifest.get(source_key)
+        except KeyError:
+            raise HTTPException(status_code=404, detail=f"unknown source {source_key!r}")
+
+        conn = read_conn()
+        try:
+            crawl = crawl_settings(conn)
+            agent = entry.user_agent or crawl.get("user_agent") or DEFAULT_USER_AGENT
+            obeys_by_default = bool(crawl.get("obey_disallow"))
+        finally:
+            conn.close()
+
+        text, unreadable = None, ""
+        try:
+            base = urlsplit(entry.base_url)
+            with httpx.Client(timeout=15.0, follow_redirects=True,
+                              headers={"User-Agent": agent}) as client:
+                answer = client.get(f"{base.scheme}://{base.netloc}/robots.txt")
+            if answer.status_code == 200:
+                text = answer.text
+            elif answer.status_code not in (404, 410):
+                # 404 means there is no file, which is an ANSWER. Anything else
+                # means we did not get to read one, and the two must not look
+                # alike on the screen.
+                unreadable = f"HTTP {answer.status_code}"
+        except Exception as exc:
+            # Any failure to READ robots.txt is reported as a failure to read
+            # it, never as an empty file: "the site asks nothing" and "we could
+            # not find out" lead the owner to opposite choices.
+            unreadable = f"{type(exc).__name__}: {exc}"
+
+        report = inspect(entry.base_url, text, user_agent=agent, unreadable=unreadable)
+        choice = RobotsChoice(entry.robots or "default")
+        custom = None
+        if choice is RobotsChoice.CUSTOM and entry.robots_custom:
+            custom = RobotsCustom(
+                enforce_disallow=bool(entry.robots_custom.get("enforce_disallow")),
+                crawl_delay_s=entry.robots_custom.get("crawl_delay_s"))
+        # Shown as "what would happen on a disallowed path", because that is the
+        # only case where the three choices differ at all.
+        try:
+            verdict = decide(report, choice, custom=custom,
+                             tool_default_obeys=obeys_by_default, url_disallowed=True)
+            outcome = {"may_fetch": verdict.may_fetch, "delay_s": verdict.delay_s,
+                       "reason": verdict.reason}
+        except ValueError as exc:
+            outcome = {"may_fetch": None, "delay_s": None, "error": str(exc)}
+
+        return {
+            "source_key": source_key,
+            "host": report.host,
+            "found": report.found,
+            "unreadable": report.unreadable,
+            "names_us": report.names_us,
+            "user_agent": agent,
+            "crawl_delay_s": report.crawl_delay_s,
+            "would_block_everything": report.obeying_would_block_everything,
+            "summary": report.summary(),
+            "rules": [{"kind": r.kind, "value": r.value, "agent": r.agent}
+                      for r in report.rules],
+            "choice": str(choice),
+            "custom": entry.robots_custom,
+            "tool_default_obeys": obeys_by_default,
+            "on_a_disallowed_path": outcome,
+        }
+
     @app.post("/api/sources/{source_key}/edit")
     def api_edit_source(source_key: str, body: dict):
         """Replace one source's manifest block.
@@ -1518,6 +1604,15 @@ def create_app(
         # "edit". Only what the form actually sends changes.
         form = {**current, **{k: v for k, v in (body or {}).items() if v is not None}}
         form.setdefault("source_key", source_key)
+        # ENFORCED HERE, not trusted from the form. The merge above drops nulls
+        # on purpose -- a partial edit must not wipe fields it did not mention --
+        # so a client switching a source AWAY from `custom` cannot clear its
+        # custom rule by sending null. Left behind, the rule sits under a choice
+        # that ignores it and reads as "this site is customised" on every later
+        # open, until someone switches back and is silently governed by a rule
+        # they last saw weeks ago.
+        if form.get("robots") != "custom":
+            form["robots_custom"] = None
         if str(form.get("source_key")) != source_key:
             raise HTTPException(
                 status_code=400,
@@ -3027,6 +3122,7 @@ def _entry_from_form(form: dict) -> SourceEntry:
     identity = {k: v for k, v in (form.get("identity") or {}).items() if v not in (None, "")}
     if identity:
         data["identity"] = identity
+
     # EVERYTHING ELSE THE MODEL HAS, carried rather than dropped. The block
     # above names seventeen fields and normalises them; SourceEntry has
     # twenty-nine, and an EDIT arrives as the whole stored entry merged with the

--- a/tests/test_a_panel_edit_keeps_what_it_did_not_touch.py
+++ b/tests/test_a_panel_edit_keeps_what_it_did_not_touch.py
@@ -52,6 +52,10 @@ sources:
     notes: two days of measurement live in this line
     min_expected_rows: 40
     max_drop_pct: 25.0
+    robots: custom
+    robots_custom:
+      enforce_disallow: true
+      crawl_delay_s: 9.0
     extract:
       - kind: product_prices
         scope: census

--- a/tests/test_http_fetcher.py
+++ b/tests/test_http_fetcher.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import httpx
 import pytest
 
-from scrapex.connectors.base import CrawlBlocked, HttpFetcher
+from scrapex.connectors.base import CrawlBlocked, HttpFetcher, RobotsDisallowed
 
 URL = "https://example.test/diesel_prices/"
 
@@ -365,3 +365,138 @@ def test_a_huge_retry_after_is_capped_loudly_not_shrunk_silently():
         _time.sleep = original
     assert 900.0 in slept, slept
     assert any("Retry-After 3600" in w for w in fetcher.robots_warnings)
+
+
+# ---- robots is the owner's decision, per site ---------------------------------
+
+ROBOTS_REFUSING_US = "User-agent: *\nDisallow: /private/\n"
+
+
+def _fetcher_meeting_a_disallow(**kwargs):
+    """A site that publishes robots.txt and refuses /private/."""
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url).endswith("/robots.txt"):
+            return httpx.Response(200, text=ROBOTS_REFUSING_US)
+        seen.append(request)
+        return httpx.Response(200, text="ok")
+
+    kwargs.setdefault("min_interval_s", 0.0)
+    kwargs.setdefault("jitter", 0.0)
+    fetcher = HttpFetcher(**kwargs)
+    fetcher._client = httpx.Client(transport=httpx.MockTransport(handler),
+                                   follow_redirects=True)
+    return fetcher, seen
+
+
+def test_a_source_that_said_nothing_still_crawls_and_still_discloses():
+    """The ruling every source has had since 2026-07-22 is what silence buys.
+
+    Changing this would alter what twelve reviewed sources collect without the
+    owner asking, which is why the setting defaults to it rather than to the
+    politer answer.
+    """
+    fetcher, seen = _fetcher_meeting_a_disallow()
+
+    response = fetcher.get("https://shop.test/private/thing")
+
+    assert response.status_code == 200, "a source on the default was refused"
+    assert len(seen) == 1
+    assert any("disallows" in note for note in fetcher.robots_warnings), (
+        "the crawl went somewhere robots.txt asked it not to and said nothing")
+
+
+def test_a_source_set_to_obey_refuses_and_says_which_choice_did_it():
+    """RAISED, NOT SKIPPED. A skipped page becomes an empty crawl reporting
+    success — the failure mode this whole product is most exposed to."""
+    fetcher, seen = _fetcher_meeting_a_disallow(robots_choice="obey")
+
+    with pytest.raises(RobotsDisallowed) as refusal:
+        fetcher.get("https://shop.test/private/thing")
+
+    assert seen == [], "the request went out anyway"
+    assert "set to obey" in str(refusal.value), (
+        f"the refusal does not say WHY, so it reads as a site being down: "
+        f"{refusal.value}")
+
+
+def test_the_tool_default_can_be_flipped_for_every_source_at_once():
+    fetcher, seen = _fetcher_meeting_a_disallow(obey_disallow=True)
+
+    with pytest.raises(RobotsDisallowed) as refusal:
+        fetcher.get("https://shop.test/private/thing")
+
+    assert seen == []
+    assert "tool default" in str(refusal.value), (
+        "the log does not say the refusal came from the setting, so changing "
+        "the setting back looks like the source changed its mind")
+
+
+def test_a_custom_rule_overrides_the_tool_default_for_one_site_only():
+    fetcher, seen = _fetcher_meeting_a_disallow(
+        robots_choice="custom", robots_custom={"enforce_disallow": False},
+        obey_disallow=True)
+
+    response = fetcher.get("https://shop.test/private/thing")
+
+    assert response.status_code == 200, (
+        "the custom rule said crawl and the tool default overruled it")
+    assert len(seen) == 1
+    assert any("custom rule" in note for note in fetcher.robots_warnings)
+
+
+def test_an_allowed_path_is_never_refused_whatever_the_choice():
+    for choice in ("default", "obey"):
+        fetcher, seen = _fetcher_meeting_a_disallow(robots_choice=choice)
+        assert fetcher.get("https://shop.test/public/thing").status_code == 200, (
+            f"{choice} refused a path robots.txt allows")
+        assert len(seen) == 1
+
+
+def test_the_disclosure_is_one_line_per_host_not_one_per_page():
+    """A 400-page crawl must not write 400 lines nobody will read."""
+    fetcher, _ = _fetcher_meeting_a_disallow()
+
+    for n in range(5):
+        fetcher.get(f"https://shop.test/private/{n}")
+
+    disallow_notes = [n for n in fetcher.robots_warnings if "disallows" in n]
+    assert len(disallow_notes) == 1, f"{len(disallow_notes)} lines for one host"
+
+
+def test_every_crawl_setting_is_a_parameter_this_fetcher_accepts():
+    """`HttpFetcher(**crawl_settings(conn))` is a real call site in webui/app.py.
+
+    It means the settings dict IS the constructor's keyword list, and a new
+    setting whose key does not match a parameter name is a TypeError the first
+    time exchange rates refresh — nowhere near the change that caused it. This
+    caught exactly that while `crawl_obey_disallow` was being added.
+
+    The keys are read out of the FUNCTION'S SOURCE rather than by calling it,
+    because calling it needs a migrated database and the first version of this
+    test quietly skipped itself when it could not build one. A guard that skips
+    is not a guard.
+    """
+    import ast
+    import inspect as _inspect
+    import pathlib
+
+    from scrapex import capture
+
+    tree = ast.parse(pathlib.Path(capture.__file__).read_text(encoding="utf-8"))
+    returns = [node for node in ast.walk(tree)
+               if isinstance(node, ast.FunctionDef) and node.name == "crawl_settings"]
+    assert returns, "crawl_settings was renamed; this guard must follow it"
+    keys = {key.value for node in ast.walk(returns[0])
+            if isinstance(node, ast.Dict)
+            for key in node.keys
+            if isinstance(key, ast.Constant) and isinstance(key.value, str)}
+    assert keys, "no keys found — the guard is reading nothing and would pass on anything"
+
+    accepted = set(_inspect.signature(HttpFetcher.__init__).parameters)
+    unknown = keys - accepted
+    assert not unknown, (
+        f"crawl_settings returns {sorted(unknown)}, which HttpFetcher does not "
+        "accept. Every call of HttpFetcher(**crawl_settings(conn)) now raises "
+        "TypeError — rename the parameter to match the settings key.")

--- a/tests/test_robots_is_the_owners_decision.py
+++ b/tests/test_robots_is_the_owners_decision.py
@@ -1,0 +1,341 @@
+"""The owner decides per site, and the decision is never silent.
+
+Three things have to be true for this to be a feature rather than a dropdown:
+
+  1. Looking at a site tells the truth about what it says — including the one
+     fact that decides everything, whether obeying would leave the source
+     unable to crawl at all.
+  2. Every one of the three choices produces the behaviour it names.
+  3. Whatever happens, the run can say WHY afterwards. A crawl that skipped
+     pages or ran slow and cannot explain itself is how a source quietly stops
+     being collected — the same failure `reclaim_orphaned_jobs` exists for, one
+     layer up.
+
+No network in any of it: robots.txt arrives as text.
+"""
+from __future__ import annotations
+
+import pytest
+
+from scrapex.robots import (Decision, RobotsChoice, RobotsCustom, decide,
+                            inspect)
+
+# A file shaped like the ones this actually meets: a general block, a delay,
+# and a named exclusion for one crawler.
+SITE = """
+User-agent: *
+Disallow: /admin/
+Crawl-delay: 5
+Allow: /
+
+User-agent: GreedyBot
+Disallow: /
+"""
+
+# The muqawil shape: everything allowed for `*`, and named AI crawlers refused.
+NAMES_US = """
+User-agent: *
+Allow: /
+
+User-agent: ScrapeX
+Disallow: /
+"""
+
+
+# ---- 1. looking -------------------------------------------------------------
+
+def test_looking_says_what_the_site_asks_of_us():
+    report = inspect("https://shop.test/products", SITE, user_agent="ScrapeX/1.0")
+
+    assert report.found
+    assert report.host == "shop.test"
+    assert report.crawl_delay_s == 5.0
+    assert not report.base_url_disallowed
+    assert not report.names_us, "this file does not name us; only GreedyBot"
+    assert "5s between requests" in report.summary()
+
+
+def test_looking_says_when_the_site_named_us_by_name():
+    """The most important single fact in the report. A site that names your
+    crawler has thought about your crawler."""
+    report = inspect("https://muqawil.test/companies", NAMES_US, user_agent="ScrapeX/1.0")
+
+    assert report.names_us == "ScrapeX"
+    assert report.base_url_disallowed
+    assert "names ScrapeX specifically" in report.summary()
+
+
+def test_looking_warns_when_obeying_would_leave_nothing_to_crawl():
+    """THE ANSWER THAT DECIDES THE CHOICE. Picking `obey` for a site that
+    disallows the pages this source is for does not make the crawl polite — it
+    makes it empty, and an empty crawl reports success. The owner has to be able
+    to see that before choosing, not by watching a run return nothing."""
+    blocked = inspect("https://muqawil.test/companies", NAMES_US, user_agent="ScrapeX/1.0")
+    open_site = inspect("https://shop.test/products", SITE, user_agent="ScrapeX/1.0")
+
+    assert blocked.obeying_would_block_everything
+    assert not open_site.obeying_would_block_everything
+
+
+def test_the_rules_shown_are_the_ones_that_touch_us():
+    """A report that says "disallowed" without the line that disallowed it is
+    asking the owner to take our word for it."""
+    report = inspect("https://shop.test/products", SITE, user_agent="ScrapeX/1.0")
+
+    kinds = {(rule.kind, rule.value) for rule in report.rules}
+    assert ("disallow", "/admin/") in kinds
+    assert ("crawl-delay", "5") in kinds
+    assert all(rule.agent in ("*", "ScrapeX") for rule in report.rules), (
+        "a rule aimed at GreedyBot is being shown as though it bound us")
+
+
+def test_a_site_with_no_robots_file_has_not_refused_anything():
+    report = inspect("https://plain.test/x", None)
+
+    assert not report.found
+    assert not report.obeying_would_block_everything
+    assert "asks for nothing" in report.summary()
+
+
+def test_an_unreadable_file_is_not_reported_as_an_empty_one():
+    """"No rules" and "we could not read the rules" are different sentences and
+    the owner would act differently on each."""
+    report = inspect("https://down.test/x", None, unreadable="503 from the site")
+
+    assert report.unreadable
+    assert not report.found
+    assert "could not be read" in report.summary()
+    assert "503" in report.summary()
+
+
+# ---- 2. choosing ------------------------------------------------------------
+
+@pytest.fixture
+def site():
+    return inspect("https://shop.test/products", SITE, user_agent="ScrapeX/1.0")
+
+
+def test_obey_refuses_a_disallowed_path(site):
+    verdict = decide(site, RobotsChoice.OBEY, url_disallowed=True)
+
+    assert not verdict.may_fetch
+    assert verdict.delay_s == 5.0, "obeying means the delay too, not only the paths"
+    assert "not fetched" in verdict.reason
+
+
+def test_the_default_follows_the_tool_setting_in_both_directions(site):
+    lenient = decide(site, RobotsChoice.DEFAULT, url_disallowed=True,
+                     tool_default_obeys=False)
+    strict = decide(site, RobotsChoice.DEFAULT, url_disallowed=True,
+                    tool_default_obeys=True)
+
+    assert lenient.may_fetch and "crawled anyway" in lenient.reason
+    assert not strict.may_fetch
+    assert "tool default" in lenient.reason and "tool default" in strict.reason, (
+        "the log does not say the behaviour came from the setting, so changing "
+        "the setting later looks like the source changed its mind")
+
+
+def test_a_custom_rule_overrides_both_the_site_and_the_setting(site):
+    """The escape hatch: this site, and only this site."""
+    verdict = decide(site, RobotsChoice.CUSTOM,
+                     custom=RobotsCustom(enforce_disallow=True, crawl_delay_s=1.0),
+                     tool_default_obeys=False, url_disallowed=True)
+
+    assert not verdict.may_fetch, "the custom rule said enforce, the setting said not to"
+    assert verdict.delay_s == 1.0, "the custom delay must win over the site's 5s"
+    assert "custom rule for this site" in verdict.reason
+
+
+def test_a_custom_rule_with_no_delay_keeps_the_sites_own(site):
+    verdict = decide(site, RobotsChoice.CUSTOM,
+                     custom=RobotsCustom(enforce_disallow=False), url_disallowed=False)
+
+    assert verdict.delay_s == 5.0, (
+        "leaving the delay unset must mean 'whatever the site asked for', not 'none'")
+
+
+def test_custom_with_no_rule_stored_is_refused_not_defaulted():
+    """Falling back to the tool default here would hand the owner the exact
+    behaviour he chose CUSTOM to escape, under his own label."""
+    report = inspect("https://shop.test/x", SITE)
+
+    with pytest.raises(ValueError, match="custom robots rule"):
+        decide(report, RobotsChoice.CUSTOM, custom=None)
+
+
+def test_a_site_with_no_file_is_fetchable_under_every_choice():
+    report = inspect("https://plain.test/x", None)
+
+    for choice in (RobotsChoice.DEFAULT, RobotsChoice.OBEY):
+        verdict = decide(report, choice, url_disallowed=True, tool_default_obeys=True)
+        assert verdict.may_fetch, (
+            f"{choice} refused a path on a site that published no rules at all")
+        assert "nothing to obey" in verdict.reason
+
+
+# ---- 3. saying why ----------------------------------------------------------
+
+@pytest.mark.parametrize("choice,custom", [
+    (RobotsChoice.DEFAULT, None),
+    (RobotsChoice.OBEY, None),
+    (RobotsChoice.CUSTOM, RobotsCustom(enforce_disallow=True)),
+])
+def test_every_decision_can_explain_itself(site, choice, custom):
+    """A crawl that was slow, or that skipped pages, must be explainable
+    afterwards from the log alone."""
+    verdict = decide(site, choice, custom=custom, url_disallowed=True)
+
+    assert isinstance(verdict, Decision)
+    assert site.host in verdict.reason, "the reason does not say which site"
+    assert len(verdict.reason) > 30, f"not a reason, a label: {verdict.reason!r}"
+    assert ("not fetched" in verdict.reason) != verdict.may_fetch, (
+        "the reason and the verdict disagree, which is worse than either alone")
+
+
+# ---- the route the panel reads ----------------------------------------------
+
+def test_the_look_route_reports_a_site_it_could_not_reach_as_unreachable(tmp_path):
+    """"The site asks for nothing" and "we could not find out" lead the owner to
+    OPPOSITE choices, so the route must never let one wear the other's clothes.
+
+    Driven against a domain that does not resolve, because that is the failure
+    a person actually meets — a typo'd base_url, or a site that is down at the
+    moment he opens the screen.
+    """
+    import os
+    import subprocess
+    import sys
+
+    from fastapi.testclient import TestClient
+
+    manifest = tmp_path / "sources.yaml"
+    manifest.write_text("""
+sources:
+  - source_key: PROBE
+    source_name: Probe
+    base_url: https://nothing.invalid
+    family: custom-json-api
+    cadence: daily
+    authority: shop
+    active: true
+    currency: EGP
+    default_region: EG
+    vat_mode: excl
+    robots: obey
+    extract:
+      - kind: product_prices
+        scope: census
+""", encoding="utf-8")
+    database = tmp_path / "engine.db"
+    made = subprocess.run([sys.executable, "-m", "scrapex.cli", "init-db",
+                           "--db", str(database)],
+                          env=dict(os.environ, SCRAPEX_SOURCES=str(manifest)),
+                          capture_output=True, text=True, timeout=300)
+    assert made.returncode == 0, made.stderr
+
+    from scrapex.webui.app import create_app
+
+    client = TestClient(create_app(db_path=str(database), manifest_path=str(manifest)))
+    answer = client.get("/api/sources/PROBE/robots")
+
+    assert answer.status_code == 200
+    body = answer.json()
+    assert body["unreadable"], "an unreachable site is being reported as having no rules"
+    assert not body["found"]
+    assert "could not be read" in body["summary"]
+    assert body["choice"] == "obey", "the route does not report the source's own choice"
+    # It must still say what would happen, rather than leaving the screen blank.
+    assert body["on_a_disallowed_path"]["reason"]
+
+
+def test_the_look_route_refuses_a_source_that_does_not_exist(tmp_path):
+    import os
+    import subprocess
+    import sys
+
+    from fastapi.testclient import TestClient
+
+    manifest = tmp_path / "sources.yaml"
+    # One real source, because a manifest with none is refused by the model —
+    # correctly: a warehouse with nothing to collect is a mistake, not a state.
+    manifest.write_text("""
+sources:
+  - source_key: PRESENT
+    source_name: Present
+    base_url: https://present.invalid
+    family: custom-json-api
+    cadence: daily
+    authority: shop
+    active: true
+    currency: EGP
+    default_region: EG
+    vat_mode: excl
+    extract:
+      - kind: product_prices
+        scope: census
+""", encoding="utf-8")
+    database = tmp_path / "engine.db"
+    subprocess.run([sys.executable, "-m", "scrapex.cli", "init-db", "--db", str(database)],
+                   env=dict(os.environ, SCRAPEX_SOURCES=str(manifest)),
+                   capture_output=True, timeout=300)
+
+    from scrapex.webui.app import create_app
+
+    client = TestClient(create_app(db_path=str(database), manifest_path=str(manifest)))
+    assert client.get("/api/sources/NOPE/robots").status_code == 404
+
+
+def test_switching_away_from_custom_clears_the_rule_it_leaves_behind(tmp_path):
+    """The edit route drops nulls so a partial edit cannot wipe a field, which
+    means a client CANNOT clear the custom rule by sending null. Left behind, it
+    sits under a choice that ignores it and reads as "this site is customised"
+    on every later open — until someone switches back and is governed by a rule
+    they last saw weeks ago."""
+    import os
+    import subprocess
+    import sys
+
+    from fastapi.testclient import TestClient
+
+    manifest = tmp_path / "sources.yaml"
+    manifest.write_text("""
+sources:
+  - source_key: SWITCHY
+    source_name: Switchy
+    base_url: https://switchy.invalid
+    family: custom-json-api
+    cadence: daily
+    authority: shop
+    active: true
+    currency: EGP
+    default_region: EG
+    vat_mode: excl
+    robots: custom
+    robots_custom:
+      enforce_disallow: true
+      crawl_delay_s: 9.0
+    extract:
+      - kind: product_prices
+        scope: census
+""", encoding="utf-8")
+    database = tmp_path / "engine.db"
+    subprocess.run([sys.executable, "-m", "scrapex.cli", "init-db", "--db", str(database)],
+                   env=dict(os.environ, SCRAPEX_SOURCES=str(manifest)),
+                   capture_output=True, timeout=300)
+
+    from scrapex.config import load_manifest
+    from scrapex.webui.app import create_app
+
+    assert load_manifest(manifest).get("SWITCHY").robots_custom, "fixture is wrong"
+
+    client = TestClient(create_app(db_path=str(database), manifest_path=str(manifest)))
+    answer = client.post("/api/sources/SWITCHY/edit",
+                         json={"robots": "default", "robots_custom": None})
+    assert answer.status_code == 200, answer.text
+
+    after = load_manifest(manifest).get("SWITCHY")
+    assert after.robots == "default"
+    assert not after.robots_custom, (
+        f"the 9-second rule is still stored under a choice that ignores it: "
+        f"{after.robots_custom}")

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -488,9 +488,27 @@ def test_an_engine_release_does_not_raise_the_floor_under_the_published_extensio
     # NEEDS and not about which engine is reading it. Tagging engine-v0.4.0
     # changes VERSION and nothing here.
     assert all(s != "" for s in panel_sinces)
-    assert MINIMUM_EXTENSION_VERSION == "0.2.0", (
+    assert MINIMUM_EXTENSION_VERSION == "0.2.2", (
         "the floor moved without a capability being added; if that was "
         "deliberate, the published extension must be republished first")
+    # MOVED FROM 0.2.0 ON 2026-08-10, deliberately, with the republish this
+    # message demands done in the same change: `robots_per_source` puts a
+    # control on the source editor, so a panel older than 0.2.2 does not have
+    # the screen the engine now expects it to have.
+    #
+    # The trap this test exists to catch was live for about a minute. Raising
+    # the floor to 0.2.2 while extension/manifest.json still said 0.2.1 would
+    # have shipped an engine that REFUSES the very extension about to be
+    # published to the store — a first release rejected by its own engine, for
+    # a reason nobody would look for on day one.
+    from json import loads
+    from pathlib import Path
+    shipped = loads((Path(__file__).resolve().parents[1] / "extension" /
+                     "manifest.json").read_text(encoding="utf-8"))["version"]
+    assert _newest((shipped, MINIMUM_EXTENSION_VERSION)) == shipped, (
+        f"the engine demands extension >= {MINIMUM_EXTENSION_VERSION} and the "
+        f"extension in this repository is {shipped}. Publishing that build "
+        "would hand the owner an extension his own engine turns away.")
 
 
 def test_the_extension_may_be_tagged_for_the_store_on_its_own():


### PR DESCRIPTION
One ruling for every source was right for twelve shops the owner had read. It stops being right the first time the product meets a site he has not.

## Three steps, deliberately separate

**Look.** `GET /api/sources/{key}/robots` reads the site's file and says what it contains *for this crawler at this base url*: whether it names us specifically, the delay it asks for, the lines that bear on this source — and the field that decides the answer, `would_block_everything`. On a site that disallows the pages a source is for, choosing *obey* does not make the crawl polite, it makes it **empty**, and an empty crawl reports success.

**Choose.** `SourceEntry.robots` is `default`, `obey` or `custom`. Custom carries `{enforce_disallow, crawl_delay_s}` and nothing else — those are the only two powers robots.txt has over a crawler. The panel shows the three with the **consequence of each written beside it**.

**Enforce.** A refusal **raises** rather than skipping the page: a skipped page becomes an empty crawl that reports success.

**The 2026-07-22 ruling is not reversed** — it becomes the default, so a source that has said nothing behaves exactly as before.

## Three defects the gates caught first

- `httpx` and `DEFAULT_USER_AGENT` used and never imported in the new route — two NameErrors on first click, invisible to every test. ruff found them in 21 seconds.
- `HttpFetcher(**crawl_settings(conn))` makes the settings dict the constructor's keyword list, so a key that does not match a parameter is a **TypeError the next time exchange rates refresh**. A test now reads `crawl_settings`' own AST against the signature — its first version *skipped itself* when it could not build a database, and a guard that skips is not a guard.
- The version ledger refused `since="0.2.1"`. Bumping to 0.2.2 raised the floor the engine demands to 0.2.2 while the extension still said 0.2.1 — **an engine refusing the very extension about to go to the store**. Both move together, and the test now compares the floor to the shipped manifest instead of a literal.

Full suite green; both gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)