### PR TITLE
The warehouse stops claiming every source is active

### DIFF
--- a/scrapex/storage.py
+++ b/scrapex/storage.py
@@ -526,11 +526,62 @@ def undeclared_sources(conn) -> list[str]:
     except Exception:
         return []
     try:
-        stored = {row[0] for row in conn.execute(
-            "SELECT source_key FROM source_site WHERE active = 1")}
+        # NO `WHERE active = 1`. That filter was here and did nothing: the column
+        # is written once on insert and never set to 0, so every row matched it
+        # and the clause only suggested a maintenance that was not happening.
+        # It is also the wrong question — a source deleted from the manifest is
+        # undeclared whatever flag its rows carry.
+        stored = {row[0] for row in conn.execute("SELECT source_key FROM source_site")}
     except sqlite3.DatabaseError:
         return []                      # not a warehouse; health says so already
     return sorted(stored - declared)
+
+
+def reconcile_active(conn) -> dict[str, bool]:
+    """Write the manifest's `active` into the warehouse that describes it.
+
+    THE WAREHOUSE WAS LYING, and measured on the owner's own database on
+    2026-08-10 it claimed all twelve sources were active while sources.yaml had
+    five of them switched off: ELBUROJ, HEIDELBERG_EG, MADAR, SIKAEGSHOP and
+    SPARK_ESHOP.
+
+    Nothing was broken by it — the scheduler reads `entry.active` from the
+    manifest, so the right sources were crawled. The damage is to anyone who
+    reads the DATABASE: the owner with a query, an export, a future page, or the
+    Console when it arrives. A column called `active` that is always 1 is worse
+    than no column, because it answers a question it does not know.
+
+    `undeclared_sources` above states the rule this enforces: "The manifest is
+    the definition; the warehouse is the consequence."
+
+    Returns only what CHANGED, so a caller can say so rather than reporting a
+    reconciliation nobody needed.
+    """
+    from .config import MANIFEST_FILE, load_manifest
+
+    try:
+        wanted = {entry.source_key: bool(entry.active)
+                  for entry in load_manifest(MANIFEST_FILE).sources}
+    except Exception:
+        return {}                                # no manifest to obey
+
+    changed: dict[str, bool] = {}
+    try:
+        stored = dict(conn.execute("SELECT source_key, active FROM source_site"))
+        for key, is_active in stored.items():
+            # A source the manifest no longer names is left ALONE, deliberately.
+            # Its rows are `undeclared_sources`' business, and silently marking
+            # them inactive would hide the very thing that function exists to
+            # surface.
+            if key in wanted and bool(is_active) != wanted[key]:
+                conn.execute("UPDATE source_site SET active = ? WHERE source_key = ?",
+                             (1 if wanted[key] else 0, key))
+                changed[key] = wanted[key]
+        if changed:
+            conn.commit()
+    except sqlite3.DatabaseError:
+        return {}
+    return changed
 
 
 def health(db_path: Path | str) -> dict:

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -133,6 +133,7 @@ from ..storage import (
     export_database,
     migrate_location,
     open_folder,
+    reconcile_active,
     repair,
     resolve_db_path,
     restore,
@@ -1459,7 +1460,19 @@ def create_app(
         except Exception as exc:  # pydantic refusals (e.g. a TBD-probe placeholder)
             raise HTTPException(status_code=400, detail=str(exc))
         app.state.manifest = load_manifest(app.state.manifest_path)
-        return {"source_key": source_key, "active": wanted}
+        # THE WAREHOUSE FOLLOWS THE MANIFEST, here and not on the next crawl,
+        # because an inactive source is never crawled -- which is precisely why
+        # its stored flag stayed at 1 and the database claimed all twelve
+        # sources were live while five were switched off. Nothing reads the
+        # stored flag to decide a crawl (the scheduler reads the manifest), but
+        # the owner reads his own database, and so will the Console.
+        conn = read_conn()
+        try:
+            reconciled = reconcile_active(conn)
+        finally:
+            conn.close()
+        return {"source_key": source_key, "active": wanted,
+                "warehouse_updated": sorted(reconciled)}
 
     @app.post("/api/sources")
     def api_add_source(body: dict):

--- a/tests/test_the_warehouse_follows_the_manifest.py
+++ b/tests/test_the_warehouse_follows_the_manifest.py
@@ -1,0 +1,167 @@
+"""A column called `active` that is always 1 answers a question it does not know.
+
+MEASURED ON THE OWNER'S OWN DATABASE, 2026-08-10. `source_site.active` said all
+twelve sources were live. `sources.yaml` had five of them switched off —
+ELBUROJ, HEIDELBERG_EG, MADAR, SIKAEGSHOP, SPARK_ESHOP.
+
+Nothing was broken by it: the scheduler reads `entry.active` from the manifest,
+so the right sources were crawled. The damage is to anyone who reads the
+DATABASE — the owner with a query, an export, a future page, the Console when it
+arrives. And the flag could never have been right, because it is written on
+insert and nothing ever set it to 0: an inactive source is never crawled, so the
+only code that touches its row never runs.
+
+`storage.undeclared_sources` already states the rule this enforces, in its own
+words: "The manifest is the definition; the warehouse is the consequence."
+
+That same function filtered on `WHERE active = 1`, which matched every row and
+so meant nothing — a clause that looked like maintenance and was not. It is
+gone, and it was the wrong question anyway: a source deleted from the manifest
+is undeclared whatever flag its rows carry.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import sys
+
+import pytest
+
+from scrapex.storage import reconcile_active, undeclared_sources
+
+TWO_SOURCES = """
+sources:
+  - source_key: LIVEONE
+    source_name: Live One
+    base_url: https://live.invalid
+    family: custom-json-api
+    cadence: daily
+    authority: shop
+    active: true
+    currency: EGP
+    default_region: EG
+    vat_mode: excl
+    extract:
+      - kind: product_prices
+        scope: census
+  - source_key: SWITCHEDOFF
+    source_name: Switched Off
+    base_url: https://off.invalid
+    family: custom-json-api
+    cadence: daily
+    authority: shop
+    active: false
+    currency: EGP
+    default_region: EG
+    vat_mode: excl
+    extract:
+      - kind: product_prices
+        scope: census
+"""
+
+
+@pytest.fixture
+def warehouse(tmp_path, monkeypatch):
+    """A real database with both sources stored as the ingest would leave them:
+    present, and marked active, because that is the only value ever written."""
+    manifest = tmp_path / "sources.yaml"
+    manifest.write_text(TWO_SOURCES, encoding="utf-8")
+    database = tmp_path / "engine.db"
+    made = subprocess.run(
+        [sys.executable, "-m", "scrapex.cli", "init-db", "--db", str(database)],
+        env=dict(os.environ, SCRAPEX_SOURCES=str(manifest)),
+        capture_output=True, text=True, timeout=300)
+    assert made.returncode == 0, made.stderr
+
+    monkeypatch.setenv("SCRAPEX_SOURCES", str(manifest))
+    import scrapex.config as config
+    monkeypatch.setattr(config, "MANIFEST_FILE", manifest)
+    import scrapex.storage as storage
+    monkeypatch.setattr(storage, "MANIFEST_FILE", manifest, raising=False)
+
+    conn = sqlite3.connect(database)
+    for key, name in (("LIVEONE", "Live One"), ("SWITCHEDOFF", "Switched Off"),
+                      ("DELETEDFROMMANIFEST", "Gone")):
+        conn.execute(
+            "INSERT INTO source_site (source_key, source_name, source_name_ar, "
+            "base_url, active) VALUES (?, ?, ?, ?, 1)",
+            (key, name, name, f"https://{key.lower()}.invalid"))
+    conn.commit()
+    try:
+        yield conn, manifest
+    finally:
+        conn.close()
+
+
+def _stored(conn) -> dict[str, int]:
+    return dict(conn.execute("SELECT source_key, active FROM source_site"))
+
+
+def test_a_source_switched_off_in_the_manifest_stops_claiming_to_be_active(warehouse):
+    conn, _ = warehouse
+    assert _stored(conn)["SWITCHEDOFF"] == 1, "fixture is wrong: it starts as the bug"
+
+    changed = reconcile_active(conn)
+
+    assert _stored(conn)["SWITCHEDOFF"] == 0, (
+        "the warehouse still says this source is active while sources.yaml has "
+        "it switched off — anyone reading the database gets the wrong answer")
+    assert changed == {"SWITCHEDOFF": False}, (
+        f"only the source that actually changed should be reported: {changed}")
+
+
+def test_an_active_source_is_left_alone_and_reported_as_unchanged(warehouse):
+    conn, _ = warehouse
+    reconcile_active(conn)
+
+    assert _stored(conn)["LIVEONE"] == 1
+    assert reconcile_active(conn) == {}, (
+        "a second run reports changes it did not make, so a caller cannot tell "
+        "a real reconciliation from a no-op")
+
+
+def test_a_source_the_manifest_no_longer_names_is_not_quietly_switched_off(warehouse):
+    """Marking it inactive would HIDE it. Its rows are `undeclared_sources`'
+    business — 22% of every offer in this warehouse once belonged to a source
+    deleted from the manifest, and it was found by hand two days later."""
+    conn, _ = warehouse
+    reconcile_active(conn)
+
+    assert _stored(conn)["DELETEDFROMMANIFEST"] == 1, (
+        "reconciliation switched off a source the manifest does not name, which "
+        "buries the orphan instead of surfacing it")
+    assert "DELETEDFROMMANIFEST" in undeclared_sources(conn)
+
+
+def test_the_orphan_query_no_longer_depends_on_a_flag_nobody_maintains(warehouse):
+    """It filtered on `active = 1`, which matched everything. After
+    reconciliation a switched-off source has active = 0 — and it must STILL not
+    appear as undeclared, because the manifest names it."""
+    conn, _ = warehouse
+    reconcile_active(conn)
+
+    orphans = undeclared_sources(conn)
+    assert "SWITCHEDOFF" not in orphans, (
+        "a source the manifest names is being reported as undeclared because "
+        "its active flag is 0 — the flag and the declaration are different "
+        "questions")
+    assert orphans == ["DELETEDFROMMANIFEST"]
+
+
+def test_reconciling_against_no_manifest_changes_nothing(tmp_path, monkeypatch):
+    """An unreadable manifest must not be read as "every source is off". The
+    warehouse keeps what it has and something else reports the real problem."""
+    import scrapex.config as config
+    monkeypatch.setattr(config, "MANIFEST_FILE", tmp_path / "absent.yaml")
+    monkeypatch.delenv("SCRAPEX_SOURCES", raising=False)
+
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE source_site (source_key TEXT, active INTEGER)")
+    conn.execute("INSERT INTO source_site VALUES ('ANY', 1)")
+    conn.commit()
+    try:
+        assert reconcile_active(conn) == {}
+        assert _stored(conn)["ANY"] == 1
+    finally:
+        conn.close()


### PR DESCRIPTION
Measured on the owner's own database, 2026-08-10:

| | |
|---|---|
| `source_site.active` says | all **twelve** sources are live |
| `sources.yaml` says | **five are switched off** — ELBUROJ, HEIDELBERG_EG, MADAR, SIKAEGSHOP, SPARK_ESHOP |

## It is not two competing answers

The column is written once on insert and **never set to 0** — because an inactive source is never crawled, so the only code that touches its row never runs. Its single reader filtered on `WHERE active = 1`, which matched every row and therefore meant nothing: a clause that looked like maintenance and was not.

**Nothing was broken by it.** The scheduler reads `entry.active` from the manifest, so the right sources were crawled. The damage is to anyone who reads the **database** — the owner with a query, an export, a future page, the Console when it arrives. A column called `active` that is always 1 is worse than no column, because it answers a question it does not know.

## The rule was already written down

`storage.undeclared_sources`, in its own words:

> The manifest is the definition; the warehouse is the consequence.

`reconcile_active` enforces it — the manifest's intent is written into the warehouse **on every flip from the panel**, because waiting for the next crawl is exactly the gap that let the flag rot.

## One decision inside it, deliberate

A source the manifest no longer names is **left alone**. Marking it inactive would bury it, and `undeclared_sources` exists to surface it: 22% of every offer in this warehouse once belonged to a source deleted from the manifest, found by hand-censusing two days later. The flag and the declaration are different questions.

The no-op filter goes with it — also the wrong question, since a deleted source is undeclared whatever flag its rows carry.

## Verified

Five tests. **Both directions proved to bite:** removing the reconciliation leaves the warehouse lying, and letting it touch orphans buries the one thing that finds them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)