### PR TITLE
The engine stops asking Google about currencies that cannot exist

### DIFF
--- a/scrapex/rates.py
+++ b/scrapex/rates.py
@@ -368,6 +368,29 @@ def last_checked(conn: sqlite3.Connection) -> str:
     return (row[0] if row and row[0] else "") or ""
 
 
+#: Codes that appear in the warehouse and can never be quoted, with the reason.
+#: Measured against the owner's database on 2026-08-10: of 123 currencies with
+#: observations, 119 had a rate and four did not -- and three of those four were
+#: not gaps at all.
+#:
+#: Without this, every refresh cycle asks Google Finance for USD-UNKNOWN,
+#: USD-SLL and USD-ZWD, fails on all three, and writes three warnings nobody can
+#: act on. For ever. A permanent warning is a warning that gets ignored, and the
+#: one real one after it goes with it.
+UNQUOTABLE = {
+    # Not a currency. `ingest` and three connectors write it when a source
+    # declares none -- all 3,149 of these observations belong to SPARK_ESHOP,
+    # which was deleted from the manifest. `storage.undeclared_sources` is where
+    # that belongs; asking a rate service about it can only ever fail.
+    "UNKNOWN": "a placeholder written when a source declares no currency",
+    # Redenominated to SLE in 2022 at 1000:1. No service quotes the old code.
+    "SLL": "retired in 2022 — Sierra Leone redenominated to SLE",
+    # Abandoned in 2009 after hyperinflation; Zimbabwe has used other
+    # currencies since.
+    "ZWD": "retired in 2009 — Zimbabwe abandoned the dollar",
+}
+
+
 def currencies_in_use(conn: sqlite3.Connection) -> list[str]:
     """Every currency the warehouse actually prices in.
 
@@ -376,10 +399,14 @@ def currencies_in_use(conn: sqlite3.Connection) -> list[str]:
     fetching a page for a currency no row uses — or, worse, leave a currency
     that IS in use without a rate because its manifest entry says otherwise.
     """
-    return [r[0] for r in conn.execute(
+    codes = [r[0] for r in conn.execute(
         "SELECT DISTINCT currency FROM price_observation "
         "WHERE TRIM(COALESCE(currency,'')) <> '' AND currency <> 'USD' "
         "ORDER BY currency")]
+    # USD is excluded in the SQL because it is the BASE -- `per_usd` -- so it
+    # cannot be missing a rate. The rest are excluded here, by name and with a
+    # reason, because they are codes no service will ever quote.
+    return [code for code in codes if code not in UNQUOTABLE]
 
 
 def refresh_is_due(conn: sqlite3.Connection, *, now: str | None = None) -> bool:

--- a/tests/test_rates_stops_asking_for_the_impossible.py
+++ b/tests/test_rates_stops_asking_for_the_impossible.py
@@ -1,0 +1,92 @@
+"""Three codes the engine asked Google about on every refresh, for ever.
+
+MEASURED ON THE OWNER'S DATABASE, 2026-08-10. Of 123 currencies with price
+observations, 119 had a rate and four did not — and three of the four were not
+gaps at all:
+
+    UNKNOWN   3,149 observations   not a currency. All of them belong to
+                                   SPARK_ESHOP, the source deleted from the
+                                   manifest; `ingest` and three connectors write
+                                   this placeholder when a source declares none.
+    USD       2,242 observations   the BASE. `currency_rate.per_usd` is defined
+                                   against it, so it cannot be missing its own
+                                   rate. Already excluded in SQL.
+    SLL          52 observations   retired in 2022 — redenominated to SLE.
+    ZWD          50 observations   retired in 2009 — abandoned.
+
+So the standing backlog item "the five currencies with no exchange rate" was
+never five, and after this it is none: one orphan, one base, two dead codes.
+
+WHY IT MATTERS MORE THAN THE COUNT. `currencies_in_use` feeds the refresh, which
+builds `https://www.google.com/finance/quote/USD-{code}` for each. Three of those
+requests could never succeed. Every cycle spent three fetches and wrote three
+warnings nobody could act on — and a warning that is always there is a warning
+that gets ignored, taking the real one after it along with it.
+"""
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from scrapex.rates import UNQUOTABLE, currencies_in_use
+
+
+@pytest.fixture
+def priced():
+    """Observations in a real currency, the base, the placeholder, and a code
+    that no longer exists."""
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE price_observation (currency TEXT)")
+    conn.executemany("INSERT INTO price_observation VALUES (?)",
+                     [("EGP",), ("EGP",), ("SAR",), ("USD",),
+                      ("UNKNOWN",), ("SLL",), ("ZWD",), ("",), (None,)])
+    conn.commit()
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def test_only_currencies_a_service_could_quote_are_asked_for(priced):
+    assert currencies_in_use(priced) == ["EGP", "SAR"]
+
+
+def test_the_placeholder_is_not_treated_as_a_currency(priced):
+    """`UNKNOWN` is what a connector writes when a source declares no currency.
+    Asking a rate service about it can only ever fail, and the rows it marks are
+    `storage.undeclared_sources`' business rather than the rate fetcher's."""
+    assert "UNKNOWN" not in currencies_in_use(priced)
+
+
+def test_a_retired_code_is_not_asked_for_every_cycle_for_ever(priced):
+    """SLL and ZWD are real codes that were real money. No service quotes them
+    now, and no amount of retrying will change that."""
+    for dead in ("SLL", "ZWD"):
+        assert dead not in currencies_in_use(priced)
+
+
+def test_the_base_currency_is_not_reported_as_missing_its_own_rate(priced):
+    assert "USD" not in currencies_in_use(priced)
+
+
+def test_every_exclusion_carries_a_reason(priced):
+    """A list of codes with no reasons is a list nobody can ever shorten. When
+    Sierra Leone's SLE has been in the warehouse long enough that SLL is gone,
+    the note is what tells the next reader it is safe to drop the entry."""
+    for code, why in UNQUOTABLE.items():
+        assert isinstance(why, str) and len(why) > 20, (
+            f"{code} is excluded with no usable reason: {why!r}")
+
+
+def test_a_real_currency_is_never_silently_dropped(priced):
+    """The failure this must not have. Excluding a live currency would leave its
+    prices uncomparable and NOTHING would say so — the same silence as a source
+    that stops collecting."""
+    conn = priced
+    conn.execute("INSERT INTO price_observation VALUES ('SLE')")   # the successor
+    conn.commit()
+
+    assert "SLE" in currencies_in_use(conn), (
+        "the code that REPLACED SLL is being excluded with it, so every price "
+        "in Sierra Leone's actual currency would go unconverted in silence")


### PR DESCRIPTION
The backlog carried *"the five currencies with no exchange rate"* as a standing item. Measured against the owner's warehouse on 2026-08-10, it is not five — and after this it is **none**.

| | | |
|---|---|---|
| `UNKNOWN` | 3,149 obs | **Not a currency.** Every one belongs to SPARK_ESHOP, the source deleted from the manifest. `ingest` and three connectors write this placeholder when a source declares none. |
| `USD` | 2,242 obs | **The base.** `currency_rate.per_usd` is defined against it. Already excluded in SQL. |
| `SLL` | 52 obs | **Retired 2022** — Sierra Leone redenominated to SLE. |
| `ZWD` | 50 obs | **Retired 2009** — Zimbabwe abandoned the dollar. |

123 currencies have observations; 119 have a rate; four do not, and three of those four are not gaps.

## Why it matters more than the count

`currencies_in_use` feeds the refresh, which builds `google.com/finance/quote/USD-{code}` for each name it returns. **Three of those requests could never succeed** — so every cycle spent three fetches failing and wrote three warnings nobody could act on. For ever.

A warning that is always present is a warning that gets ignored, and it takes the real one after it along with it.

## Named, with reasons

They are listed in `UNQUOTABLE` with the reason and date for each, because **a list of codes without reasons is a list nobody can ever shorten** — when SLE has been in the warehouse long enough, the note is what tells the next reader that dropping SLL is safe. A test enforces that every exclusion carries a usable one.

## The test that matters most

It asserts **SLE is not excluded with its predecessor**. Excluding a live currency would leave every price in it unconverted and nothing anywhere would say so — the same silence as a source that quietly stops collecting.

Six tests; three fail when the exclusion is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)