### PR TITLE
Two places that were right by accident rather than by proof

### DIFF
--- a/scrapex/connectors/base.py
+++ b/scrapex/connectors/base.py
@@ -12,7 +12,14 @@ import threading
 import time
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    # Named here so the annotation on `_robots_reports` resolves for a reader
+    # and for a checker. The RUNTIME import stays inside `_request`, where the
+    # module is actually used — scrapex.robots imports nothing from here, but
+    # keeping the runtime edge where it is costs nothing and adds no cycle.
+    from ..robots import RobotsReport
 
 import httpx
 
@@ -298,8 +305,11 @@ class HttpFetcher:
         # tests/test_http_fetcher.py pins the two together.
         self._obey_disallow = obey_disallow
         #: host -> RobotsReport, so the file is read once and the report can be
-        #: shown to the owner afterwards without fetching it again.
-        self._robots_reports: dict[str, object] = {}
+        #: shown to the owner afterwards without fetching it again. Typed as the
+        #: real thing rather than `object`: it was the latter, so nothing checked
+        #: what went in, and `decide()` -- which needs a RobotsReport -- was
+        #: being handed something the type system knew nothing about.
+        self._robots_reports: dict[str, RobotsReport] = {}
         self.robots_warnings: list[str] = []
         # url -> {"ETag": ..., "Last-Modified": ...}, replayed on the next visit.
         self._validators: dict[str, dict[str, str]] = {}

--- a/scrapex/robots.py
+++ b/scrapex/robots.py
@@ -231,7 +231,13 @@ def decide(report: RobotsReport, choice: RobotsChoice, *,
     if choice is RobotsChoice.OBEY:
         enforce, delay = True, report.crawl_delay_s
         label = "set to obey this site's robots.txt"
-    elif choice is RobotsChoice.CUSTOM:
+    elif choice is RobotsChoice.CUSTOM and custom is not None:
+        # `and custom is not None` is redundant at runtime -- the guard at the
+        # top of this function already refused that combination. It is here
+        # because the safety was provable only by reading twenty lines up, and a
+        # branch added between the two would turn it into an AttributeError with
+        # nothing to catch it. mypy found it; the tests could not, because the
+        # impossible case is impossible until somebody makes it possible.
         enforce = custom.enforce_disallow
         delay = report.crawl_delay_s if custom.crawl_delay_s is None else custom.crawl_delay_s
         label = "a custom rule for this site"


### PR DESCRIPTION
`mypy --strict` over the price files, run for the first time on 2026-08-10: **72 findings**. Most are missing annotations. Fourteen were correctness-shaped, and after reading each — **ten are false, two are real, and both are mine from earlier today.**

## False, recorded so nobody re-opens them

`databases/domain.py` has four *"missing positional argument `migrations`"* on `self.__class__(incoming)`. But `EngineDatabase` overrides `__init__` to take a path alone, and `self.__class__` is the concrete subclass at runtime. mypy reads the base signature and cannot know that.

The seven `payload.py` findings are a `**dict[str, object]` splat — unprovable by construction rather than wrong.

## Real 1 — a None ruled out only by a distant raise

`robots.decide` used `custom.enforce_disallow` where custom is `RobotsCustom | None`. It is safe: the guard at the top refuses exactly that combination. But **the safety is provable only by reading twenty lines up**, and a branch added between the two turns it into an AttributeError with nothing to catch it.

No test could have found this — the impossible case is impossible until somebody makes it possible.

## Real 2 — a cache that did not say what it held

`HttpFetcher._robots_reports` was `dict[str, object]`, so the report handed to `decide()` — which needs a `RobotsReport` — was something the type system knew nothing about. Runtime was fine because the only writer put the right thing in. **Nothing enforced that.**

Fixing it cost a third finding, from ruff: the annotation referenced a name imported inside another function, so it resolved for nobody. `from __future__ import annotations` means it never ran, which is exactly why it would have sat there.

## The gate itself is not here

`--strict` on these files is 72 findings, ~60 of them annotations. Landing that churn while two sessions edit the same tree costs a rebase per commit for no defect prevented. The measurement is recorded; the gate follows when the tree is quiet, and it should be **chosen rather than maximal** — the rule the ruff gate already carries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)