### PR TITLE
A command that carries the two databases over, and a message that stops sending people to one that does not

### DIFF
--- a/scrapex/cli.py
+++ b/scrapex/cli.py
@@ -72,6 +72,38 @@ def _cmd_init_db(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_carry_over(args: argparse.Namespace) -> int:
+    """Copy a two-database installation into the single file that replaced it."""
+    from .databases.carry_over import carry_over, read_split_pointer
+
+    plan = read_split_pointer(Path(args.registry) if args.registry else REGISTRY_FILE)
+    print(f"carrying {', '.join(p.name for p in plan.sources)} -> {plan.destination}")
+    report = carry_over(plan, dry_run=args.dry_run)
+
+    for table, counts in sorted(report["tables"].items()):
+        mark = " " if counts["written"] >= counts["read"] else "!"
+        print(f"  {mark} {table:<34} read {counts['read']:>8}  "
+              f"now holds {counts['written']:>8}")
+    for skip in report["skipped"]:
+        print(f"  - {skip['table']:<34} {skip['rows']:>8} rows LEFT BEHIND — "
+              f"{skip['why']}")
+
+    if args.dry_run:
+        print()
+        print("nothing was written and the pointer was not moved (--dry-run).")
+        return 0
+    if report["short"]:
+        print()
+        print("REFUSED to move the pointer: some tables hold fewer rows than "
+              "were read.")
+        print("The old files are untouched. Nothing now uses the new database.")
+        return 1
+    print()
+    print(f"the pointer now names {report['pointer_moved_to']}.")
+    print("The old files were opened read-only and are still where they were.")
+    return 0
+
+
 def _cmd_database_status(args: argparse.Namespace) -> int:
     registry = DatabaseRegistry.read(Path(args.registry) if args.registry else REGISTRY_FILE)
     health = registry.health()
@@ -983,6 +1015,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="legacy unified database path (only for migration or rollback)",
     )
     p.set_defaults(func=_cmd_init_db)
+
+    p = sub.add_parser(
+        "carry-over",
+        help="copy a two-database installation into the single database")
+    p.add_argument("--registry", help="pointer file (default: ~/.scrapex/databases.json)")
+    p.add_argument("--dry-run", action="store_true",
+                   help="report what would be carried and write nothing")
+    p.set_defaults(func=_cmd_carry_over)
 
     p = sub.add_parser("database-status", help="show the database's health")
     p.add_argument("--registry", help="database registry path")

--- a/scrapex/databases/carry_over.py
+++ b/scrapex/databases/carry_over.py
@@ -138,6 +138,12 @@ def carry_over(
     target = sqlite3.connect(plan.destination)
     try:
         target_tables = _tables(target)
+        # WHAT THE DESTINATION ALREADY HOLDS. `initialize()` writes its own rows
+        # -- schema version, migration ledger -- and counting those as carried
+        # would make a short carry look complete. Comparing "rows read" against
+        # "rows now in the table" was the first version of this check and it was
+        # simply the wrong comparison; the baseline is what makes it right.
+        baseline = {table: _row_count(target, table) for table in target_tables}
         for source_path in plan.sources:
             source = sqlite3.connect(f"file:{source_path}?mode=ro", uri=True)
             try:
@@ -161,13 +167,19 @@ def carry_over(
                     quoted = ", ".join(f'"{c}"' for c in shared)
                     payload = source.execute(
                         f'SELECT {quoted} FROM "{table}"').fetchall()
+                    # DISTINCT, because the two old files can legitimately hold
+                    # the same row -- both carried `scrapex_meta`, for instance.
+                    # `INSERT OR IGNORE` drops the second copy, and counting it
+                    # as missing would fail every real carry-over.
+                    distinct = len({tuple(row) for row in payload})
                     if not dry_run:
                         target.executemany(
                             f'INSERT OR IGNORE INTO "{table}" ({quoted}) '
                             f'VALUES ({", ".join("?" * len(shared))})', payload)
                     entry = report["tables"].setdefault(
-                        table, {"read": 0, "written": 0, "source": []})
+                        table, {"read": 0, "distinct": 0, "written": 0, "source": []})
                     entry["read"] += rows
+                    entry["distinct"] += distinct
                     entry["source"].append(source_path.name)
                 for table in sorted(_tables(source) - target_tables):
                     report["skipped"].append(
@@ -178,23 +190,28 @@ def carry_over(
 
         if not dry_run:
             target.commit()
-        for table in report["tables"]:
-            report["tables"][table]["written"] = _row_count(target, table)
+        for table, counts in report["tables"].items():
+            counts["written"] = _row_count(target, table) - baseline.get(table, 0)
     finally:
         target.close()
 
     short = [
         {"table": name, **counts}
         for name, counts in report["tables"].items()
-        if counts["written"] < counts["read"]
+        if counts["written"] < counts["distinct"]
     ]
     report["short"] = short
     report["ok"] = not short and not dry_run
 
     if short:
-        # INSERT OR IGNORE drops a row whose key already exists, which is right
-        # when a carry-over is re-run and wrong if it hides a real loss. Either
-        # way the pointer does not move: a human decides.
+        # Fewer rows arrived than the sources hold DISTINCTLY, so something was
+        # genuinely dropped rather than deduplicated. The pointer does not move
+        # and a human decides.
+        #
+        # WHAT THIS STILL CANNOT SEE: a row that arrived with a different value
+        # under the same key. The counts would agree and the content would not.
+        # Proving that needs a per-row comparison this command does not do, and
+        # saying so here is better than implying a guarantee it has not earned.
         return report
 
     if not dry_run:

--- a/scrapex/databases/carry_over.py
+++ b/scrapex/databases/carry_over.py
@@ -1,0 +1,206 @@
+"""Carry a two-database installation into the single file that replaced it.
+
+THE DEFECT THIS EXISTS FOR, found on the owner's own machine on 2026-08-11.
+`~/.scrapex/databases.json` still said `"mode": "split"`, so every engine command
+refused to start with:
+
+    ... points at the two-database layout that ScrapeX used before it kept
+    everything in one file. Nothing has been changed and nothing has been lost:
+    the old files are still where they were. Run 'scrapex init-db' to create the
+    single database, then 'scrapex database-status'.
+
+Both sentences are true and together they are a trap. `init-db` creates a NEW
+database and applies migrations to it; it does not read `marketlens.db` and never
+has. Following that instruction on this installation would have produced an empty
+warehouse beside 110 MB of prices that nothing would ever open again.
+
+Nobody noticed because the engine had simply stopped starting, and a side panel
+whose engine never answers looks like a side panel problem. It cost most of a day
+before anyone read the pointer file.
+
+WHAT THIS DOES, and the order matters. It copies every row of every shared table
+from the old files into the new one, verifies the counts match, and only then
+rewrites the pointer. If anything disagrees the pointer is left alone, so a
+failed carry-over leaves an installation that still refuses to start rather than
+one that starts on top of half its data.
+
+The old files are never deleted or altered. They are opened read-only.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+from .domain import EngineDatabase
+from .registry import DEFAULT_ENGINE_PATH, REGISTRY_FILE, DatabasePointerError
+
+
+@dataclass(frozen=True)
+class CarryOverPlan:
+    """What was found, before anything is written."""
+
+    marketlens: Path | None
+    general: Path | None
+    destination: Path
+    pointer: Path
+
+    @property
+    def sources(self) -> list[Path]:
+        return [path for path in (self.marketlens, self.general) if path is not None]
+
+
+def read_split_pointer(pointer_file: Path | str = REGISTRY_FILE) -> CarryOverPlan:
+    """Read a `split` pointer, or say why this installation is not one.
+
+    Refusing early and by name matters more than usual here: the command that
+    follows writes a database, and "there was nothing to carry" and "the carry
+    silently found no rows" must never look the same to a caller.
+    """
+    pointer = Path(pointer_file)
+    if not pointer.is_file():
+        raise DatabasePointerError(
+            f"there is no {pointer}, so there is no two-database installation "
+            "to carry over. Run 'scrapex init-db' to create the single database.")
+    try:
+        data = json.loads(pointer.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise DatabasePointerError(
+            f"{pointer} could not be read, so what it points at is unknown. "
+            "Restore it from a backup rather than guessing.") from exc
+
+    mode = data.get("mode")
+    if mode == "single":
+        raise DatabasePointerError(
+            f"{pointer} already points at a single database "
+            f"({data.get('engine_path')}). There is nothing to carry over.")
+    if mode not in ("split", "legacy"):
+        raise DatabasePointerError(
+            f"{pointer} does not describe a two-database installation "
+            f"(mode={mode!r}), so this command cannot tell what to carry.")
+
+    def named(key: str) -> Path | None:
+        raw = str(data.get(key) or "").strip()
+        if not raw:
+            return None
+        path = Path(raw)
+        if not path.is_file():
+            raise DatabasePointerError(
+                f"{pointer} names {path} as its {key}, and that file is not "
+                "there. Restore it before carrying anything over: a carry-over "
+                "that skipped it would look like a success.")
+        return path
+
+    return CarryOverPlan(
+        marketlens=named("marketlens_path"),
+        general=named("general_path"),
+        destination=DEFAULT_ENGINE_PATH,
+        pointer=pointer,
+    )
+
+
+def _tables(conn: sqlite3.Connection) -> set[str]:
+    return {
+        row[0] for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name NOT LIKE 'sqlite_%'")
+    }
+
+
+def _row_count(conn: sqlite3.Connection, table: str) -> int:
+    return conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+
+
+def carry_over(
+    plan: CarryOverPlan,
+    *,
+    migrations: tuple = (),
+    dry_run: bool = False,
+) -> dict:
+    """Copy every shared table across, count both sides, then move the pointer.
+
+    THE POINTER MOVES LAST, and only if every table agrees. A carry-over that
+    wrote the pointer first and then failed would leave an installation that
+    starts and serves an incomplete warehouse -- which is worse than one that
+    refuses to start, because nothing would say so.
+    """
+    # `initialize`, not `connect`: the destination does not exist yet on the
+    # installation this command is for. The registry's own initialize() would
+    # also WRITE the pointer, and the pointer must not move until every row is
+    # accounted for — so the database is created directly and the pointer is
+    # left to the end of this function.
+    plan.destination.parent.mkdir(parents=True, exist_ok=True)
+    EngineDatabase(plan.destination).initialize()
+
+    report: dict = {"destination": str(plan.destination), "tables": {}, "skipped": []}
+
+    target = sqlite3.connect(plan.destination)
+    try:
+        target_tables = _tables(target)
+        for source_path in plan.sources:
+            source = sqlite3.connect(f"file:{source_path}?mode=ro", uri=True)
+            try:
+                for table in sorted(_tables(source) & target_tables):
+                    rows = _row_count(source, table)
+                    if rows == 0:
+                        continue
+                    columns = [r[1] for r in source.execute(f'PRAGMA table_info("{table}")')]
+                    target_columns = [
+                        r[1] for r in target.execute(f'PRAGMA table_info("{table}")')]
+                    shared = [c for c in columns if c in target_columns]
+                    if not shared:
+                        # A table whose columns no longer overlap is not a table
+                        # this version knows how to carry. Named, never skipped
+                        # in silence -- an unreported skip is how a migration
+                        # loses a year of prices and reports success.
+                        report["skipped"].append(
+                            {"table": table, "rows": rows,
+                             "why": "no column in common with the new schema"})
+                        continue
+                    quoted = ", ".join(f'"{c}"' for c in shared)
+                    payload = source.execute(
+                        f'SELECT {quoted} FROM "{table}"').fetchall()
+                    if not dry_run:
+                        target.executemany(
+                            f'INSERT OR IGNORE INTO "{table}" ({quoted}) '
+                            f'VALUES ({", ".join("?" * len(shared))})', payload)
+                    entry = report["tables"].setdefault(
+                        table, {"read": 0, "written": 0, "source": []})
+                    entry["read"] += rows
+                    entry["source"].append(source_path.name)
+                for table in sorted(_tables(source) - target_tables):
+                    report["skipped"].append(
+                        {"table": table, "rows": _row_count(source, table),
+                         "why": "the new schema has no such table"})
+            finally:
+                source.close()
+
+        if not dry_run:
+            target.commit()
+        for table in report["tables"]:
+            report["tables"][table]["written"] = _row_count(target, table)
+    finally:
+        target.close()
+
+    short = [
+        {"table": name, **counts}
+        for name, counts in report["tables"].items()
+        if counts["written"] < counts["read"]
+    ]
+    report["short"] = short
+    report["ok"] = not short and not dry_run
+
+    if short:
+        # INSERT OR IGNORE drops a row whose key already exists, which is right
+        # when a carry-over is re-run and wrong if it hides a real loss. Either
+        # way the pointer does not move: a human decides.
+        return report
+
+    if not dry_run:
+        plan.pointer.write_text(
+            json.dumps({"format_version": 2, "mode": "single",
+                        "engine_path": str(plan.destination)}, indent=2),
+            encoding="utf-8")
+        report["pointer_moved_to"] = str(plan.destination)
+    return report

--- a/scrapex/databases/carry_over.py
+++ b/scrapex/databases/carry_over.py
@@ -100,6 +100,32 @@ def read_split_pointer(pointer_file: Path | str = REGISTRY_FILE) -> CarryOverPla
     )
 
 
+#: Tables the DESTINATION owns, with the reason each is here.
+#:
+#: Measured on the owner's real databases on 2026-08-11: every table of DATA
+#: carried across exactly -- 88,286 price observations, 122,509 change events,
+#: 37,452 product attributes, not one row short. These two came up short and
+#: stopped the whole carry-over:
+#:
+#:     database_migration   62 -> 56
+#:     scrapex_meta         26 -> 21
+#:
+#: Neither is data. `EngineDatabase.initialize()` writes its own schema version
+#: and its own migration record when it creates the database, so some of the old
+#: rows are duplicates and INSERT OR IGNORE drops them -- correctly. A new schema
+#: must not inherit its predecessor's ledger; that is what makes it a new schema.
+#:
+#: They are still COPIED and still REPORTED. What changes is only that a
+#: shortfall in one of them does not block the pointer, because a shortfall there
+#: is expected rather than a loss. Written as a named set with this note rather
+#: than as two names quietly dropped from a comparison: a guard that is narrowed
+#: without saying why is a guard nobody can audit later.
+LEDGER_TABLES = {
+    "database_migration": "the destination writes its own migration record",
+    "scrapex_meta": "the destination writes its own schema version",
+}
+
+
 def _tables(conn: sqlite3.Connection) -> set[str]:
     return {
         row[0] for row in conn.execute(
@@ -198,7 +224,12 @@ def carry_over(
     short = [
         {"table": name, **counts}
         for name, counts in report["tables"].items()
-        if counts["written"] < counts["distinct"]
+        if counts["written"] < counts["distinct"] and name not in LEDGER_TABLES
+    ]
+    report["ledgers"] = [
+        {"table": name, "why": LEDGER_TABLES[name], **counts}
+        for name, counts in report["tables"].items()
+        if name in LEDGER_TABLES and counts["written"] < counts["distinct"]
     ]
     report["short"] = short
     report["ok"] = not short and not dry_run

--- a/scrapex/databases/registry.py
+++ b/scrapex/databases/registry.py
@@ -80,8 +80,13 @@ class DatabaseRegistry:
                 f"{pointer} points at the two-database layout that ScrapeX used "
                 "before it kept everything in one file. Nothing has been changed "
                 "and nothing has been lost: the old files are still where they "
-                "were. Run 'scrapex init-db' to create the single database, then "
-                "'scrapex database-status'.")
+                "were. Run 'scrapex carry-over' to copy them into the single "
+                "database, then 'scrapex database-status'. "
+                "NOT 'init-db': that is what this message used to say and it "
+                "was a trap, because init-db creates a NEW database and applies "
+                "migrations to it and never reads the old files. On an "
+                "installation with data in them it produces an empty warehouse "
+                "beside a full one that nothing will open again.")
         if mode != "single":
             raise DatabasePointerError(
                 f"{pointer} does not say which database is live (mode={mode!r}); "

--- a/tests/test_the_split_databases_are_carried_not_replaced.py
+++ b/tests/test_the_split_databases_are_carried_not_replaced.py
@@ -36,6 +36,23 @@ def _make_source(path: Path, rows: int, *, extra_table: bool = False,
     conn.execute("CREATE TABLE scrapex_meta (key TEXT PRIMARY KEY, value TEXT)")
     conn.executemany("INSERT INTO scrapex_meta VALUES (?, ?)",
                      [(f"{prefix}-{n}", f"value-{n}") for n in range(rows)])
+    # A real DATA table beside the ledger, because the guard under test must be
+    # exercised on something the destination does not own. Its columns match the
+    # shipped schema: the first version of this fixture invented two of them and
+    # every row was dropped by INSERT OR IGNORE on a NOT NULL it did not supply.
+    # The guard caught that (45 read, 0 written) -- which is the guard working,
+    # and a reminder that OR IGNORE swallows constraint failures as quietly as
+    # it swallows duplicates.
+    conn.execute("""CREATE TABLE currency_rate (
+        currency_rate_id INTEGER PRIMARY KEY, currency TEXT NOT NULL,
+        per_usd REAL NOT NULL, as_of TEXT NOT NULL, source_key TEXT,
+        source_kind TEXT, recorded_at TEXT)""")
+    conn.executemany(
+        "INSERT INTO currency_rate (currency_rate_id, currency, per_usd, as_of, "
+        "source_key, source_kind, recorded_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        [(hash(prefix) % 1000 * 100 + n, f"{prefix[:2].upper()}{n}", 1.0 + n,
+          "2026-08-11", "TEST", "manual", "2026-08-11T00:00:00Z")
+         for n in range(rows)])
     if extra_table:
         conn.execute("CREATE TABLE forgotten_domain (id INTEGER PRIMARY KEY, note TEXT)")
         conn.executemany("INSERT INTO forgotten_domain (note) VALUES (?)",
@@ -176,9 +193,12 @@ def test_a_short_count_refuses_and_leaves_the_pointer_where_it_was(split, monkey
     real_count = module._row_count
 
     def short(conn, table):
-        # Report the destination as holding one row fewer than it does.
+        # `currency_rate`, NOT `scrapex_meta`. The latter is a LEDGER the
+        # destination owns, so a shortfall there is expected and excused by
+        # design; using it here would have made this test pass for a reason
+        # that has nothing to do with what it guards.
         value = real_count(conn, table)
-        return value - 1 if table == "scrapex_meta" and value > 10 else value
+        return value - 1 if table == "currency_rate" and value > 3 else value
 
     monkeypatch.setattr(module, "_row_count", short)
     report = carry_over(plan)

--- a/tests/test_the_split_databases_are_carried_not_replaced.py
+++ b/tests/test_the_split_databases_are_carried_not_replaced.py
@@ -75,7 +75,7 @@ def _rows(path: Path, table: str = "scrapex_meta") -> int:
 
 
 def test_every_row_arrives_and_only_then_does_the_pointer_move(split):
-    pointer, destination, marketlens, general = split
+    pointer, destination, _, _ = split
 
     report = carry_over(read_split_pointer(pointer))
 
@@ -104,7 +104,7 @@ def test_the_old_files_are_never_touched(split):
 
 
 def test_a_dry_run_writes_nothing_and_leaves_the_pointer_alone(split):
-    pointer, destination, _, _ = split
+    pointer, _, _, _ = split
 
     report = carry_over(read_split_pointer(pointer), dry_run=True)
 
@@ -147,7 +147,7 @@ def test_running_it_twice_is_safe_and_does_not_double_the_rows(split):
 
 
 def test_a_pointer_that_already_says_single_is_refused_by_name(split):
-    pointer, destination, _, _ = split
+    pointer, _, _, _ = split
     carry_over(read_split_pointer(pointer))
 
     with pytest.raises(DatabasePointerError, match="already points at a single"):
@@ -169,7 +169,7 @@ def test_a_missing_old_file_stops_everything_before_a_single_row_moves(split):
 def test_a_short_count_refuses_and_leaves_the_pointer_where_it_was(split, monkeypatch):
     """THE ONE THAT MATTERS. If rows do not arrive, the installation must keep
     refusing to start rather than start on top of an incomplete warehouse."""
-    pointer, destination, _, _ = split
+    pointer, _, _, _ = split
     plan = read_split_pointer(pointer)
 
     import scrapex.databases.carry_over as module

--- a/tests/test_the_split_databases_are_carried_not_replaced.py
+++ b/tests/test_the_split_databases_are_carried_not_replaced.py
@@ -1,0 +1,190 @@
+"""A migration that loses rows and says nothing is worse than one that refuses.
+
+FOUND ON THE OWNER'S MACHINE, 2026-08-11. `~/.scrapex/databases.json` still said
+`"mode": "split"`, so every engine command refused to start — which is why
+nothing was listening on 127.0.0.1:8000 all day and why the side panel's engine
+check returned ERR_CONNECTION_REFUSED in a loop.
+
+The refusal message told the reader to run `init-db`. That command creates a NEW
+database and applies migrations to it; it has never read `marketlens.db`.
+Following it on that installation would have produced an empty warehouse beside
+110 MB of prices — 88,286 price observations, 122,509 change events — that
+nothing would ever open again. The files would all still be there, exactly as the
+message promised, and the data would be gone from the product's point of view.
+
+So the property under test is not "the carry-over works". It is that the pointer
+NEVER moves unless every row arrived, because the pointer moving is what makes
+the new database the real one.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scrapex.databases.carry_over import carry_over, read_split_pointer
+from scrapex.databases.registry import DatabasePointerError
+
+
+def _make_source(path: Path, rows: int, *, extra_table: bool = False,
+                 prefix: str = "key") -> None:
+    """An old-layout database with a table the new schema also has."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE scrapex_meta (key TEXT PRIMARY KEY, value TEXT)")
+    conn.executemany("INSERT INTO scrapex_meta VALUES (?, ?)",
+                     [(f"{prefix}-{n}", f"value-{n}") for n in range(rows)])
+    if extra_table:
+        conn.execute("CREATE TABLE forgotten_domain (id INTEGER PRIMARY KEY, note TEXT)")
+        conn.executemany("INSERT INTO forgotten_domain (note) VALUES (?)",
+                         [(f"row {n}",) for n in range(7)])
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def split(tmp_path, monkeypatch):
+    """A pointer that names two real old files, and a destination that does not
+    exist yet — which is the state every affected installation is in."""
+    marketlens = tmp_path / "marketlens" / "marketlens.db"
+    general = tmp_path / "general" / "general.db"
+    _make_source(marketlens, 40, extra_table=True)
+    _make_source(general, 5, prefix="general")
+
+    pointer = tmp_path / "databases.json"
+    pointer.write_text(json.dumps({
+        "format_version": 1, "mode": "split",
+        "marketlens_path": str(marketlens), "general_path": str(general),
+        "legacy_path": None,
+    }), encoding="utf-8")
+
+    destination = tmp_path / "engine" / "scrapex-engine.db"
+    import scrapex.databases.carry_over as module
+    monkeypatch.setattr(module, "DEFAULT_ENGINE_PATH", destination)
+    return pointer, destination, marketlens, general
+
+
+def _rows(path: Path, table: str = "scrapex_meta") -> int:
+    conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    try:
+        return conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+    finally:
+        conn.close()
+
+
+def test_every_row_arrives_and_only_then_does_the_pointer_move(split):
+    pointer, destination, marketlens, general = split
+
+    report = carry_over(read_split_pointer(pointer))
+
+    assert report["ok"], report
+    # The report's own figure, not a raw row count: the destination carries its
+    # own schema rows from initialize(), and counting those as carried is
+    # exactly the mistake the baseline in carry_over() was added to fix.
+    carried = report["tables"]["scrapex_meta"]
+    assert carried["written"] == carried["distinct"] == 45, (
+        "rows went missing between the old files and the new database, and the "
+        f"carry-over reported success anyway: {carried}")
+    moved = json.loads(pointer.read_text(encoding="utf-8"))
+    assert moved["mode"] == "single"
+    assert moved["engine_path"] == str(destination)
+
+
+def test_the_old_files_are_never_touched(split):
+    """They are the only copy until the new database is proved complete."""
+    pointer, _, marketlens, general = split
+    before = (marketlens.read_bytes(), general.read_bytes())
+
+    carry_over(read_split_pointer(pointer))
+
+    assert (marketlens.read_bytes(), general.read_bytes()) == before, (
+        "an old database was modified; it was supposed to be opened read-only")
+
+
+def test_a_dry_run_writes_nothing_and_leaves_the_pointer_alone(split):
+    pointer, destination, _, _ = split
+
+    report = carry_over(read_split_pointer(pointer), dry_run=True)
+
+    assert report["ok"] is False, "a dry run must never report itself as done"
+    # The file exists — the destination has to be created to be inspected — but
+    # not one carried row is in it.
+    assert report["tables"]["scrapex_meta"]["written"] == 0
+    assert json.loads(pointer.read_text(encoding="utf-8"))["mode"] == "split"
+
+
+def test_a_table_the_new_schema_lost_is_named_rather_than_dropped_in_silence(split):
+    """`forgotten_domain` exists only in the old file. Carrying nothing is the
+    right behaviour; carrying nothing QUIETLY is how a year of prices disappears
+    behind a success message."""
+    pointer, _, _, _ = split
+
+    report = carry_over(read_split_pointer(pointer))
+
+    left = {entry["table"]: entry for entry in report["skipped"]}
+    assert "forgotten_domain" in left, (
+        "a table full of rows was left behind and never mentioned")
+    assert left["forgotten_domain"]["rows"] == 7
+    assert left["forgotten_domain"]["why"]
+
+
+def test_running_it_twice_is_safe_and_does_not_double_the_rows(split):
+    """An owner who is unsure whether the first run finished will run it again."""
+    pointer, destination, _, _ = split
+    carry_over(read_split_pointer(pointer))
+    first = _rows(destination)
+
+    # The pointer now says "single", so the plan has to be rebuilt by hand —
+    # which is itself the guard in the next test.
+    from scrapex.databases.carry_over import CarryOverPlan
+    plan = CarryOverPlan(marketlens=None, general=None,
+                         destination=destination, pointer=pointer)
+    carry_over(plan)
+
+    assert _rows(destination) == first, "a second run duplicated rows"
+
+
+def test_a_pointer_that_already_says_single_is_refused_by_name(split):
+    pointer, destination, _, _ = split
+    carry_over(read_split_pointer(pointer))
+
+    with pytest.raises(DatabasePointerError, match="already points at a single"):
+        read_split_pointer(pointer)
+
+
+def test_a_missing_old_file_stops_everything_before_a_single_row_moves(split):
+    """Half a carry-over that reports success is the failure this whole module
+    exists to prevent."""
+    pointer, destination, marketlens, _ = split
+    marketlens.unlink()
+
+    with pytest.raises(DatabasePointerError, match="not there"):
+        read_split_pointer(pointer)
+    assert not destination.exists(), "a database was created despite the refusal"
+    assert json.loads(pointer.read_text(encoding="utf-8"))["mode"] == "split"
+
+
+def test_a_short_count_refuses_and_leaves_the_pointer_where_it_was(split, monkeypatch):
+    """THE ONE THAT MATTERS. If rows do not arrive, the installation must keep
+    refusing to start rather than start on top of an incomplete warehouse."""
+    pointer, destination, _, _ = split
+    plan = read_split_pointer(pointer)
+
+    import scrapex.databases.carry_over as module
+    real_count = module._row_count
+
+    def short(conn, table):
+        # Report the destination as holding one row fewer than it does.
+        value = real_count(conn, table)
+        return value - 1 if table == "scrapex_meta" and value > 10 else value
+
+    monkeypatch.setattr(module, "_row_count", short)
+    report = carry_over(plan)
+
+    assert report["short"], "a short table was not detected"
+    assert report["ok"] is False
+    assert json.loads(pointer.read_text(encoding="utf-8"))["mode"] == "split", (
+        "the pointer moved even though rows were missing — the installation "
+        "would now start and serve an incomplete warehouse with nothing saying so")

--- a/tests/test_the_split_databases_are_carried_not_replaced.py
+++ b/tests/test_the_split_databases_are_carried_not_replaced.py
@@ -36,23 +36,46 @@ def _make_source(path: Path, rows: int, *, extra_table: bool = False,
     conn.execute("CREATE TABLE scrapex_meta (key TEXT PRIMARY KEY, value TEXT)")
     conn.executemany("INSERT INTO scrapex_meta VALUES (?, ?)",
                      [(f"{prefix}-{n}", f"value-{n}") for n in range(rows)])
-    # A real DATA table beside the ledger, because the guard under test must be
-    # exercised on something the destination does not own. Its columns match the
-    # shipped schema: the first version of this fixture invented two of them and
-    # every row was dropped by INSERT OR IGNORE on a NOT NULL it did not supply.
-    # The guard caught that (45 read, 0 written) -- which is the guard working,
-    # and a reminder that OR IGNORE swallows constraint failures as quietly as
-    # it swallows duplicates.
+    # A REAL DATA TABLE beside the ledger, because the guard under test must be
+    # exercised on something the destination does NOT own.
+    #
+    # Its columns and constraints are copied from the shipped schema, read out of
+    # the owner's own database rather than retyped from memory. The first two
+    # attempts were retyped and both were wrong: `source_key`, `source_kind` and
+    # `recorded_at` are all NOT NULL, and `(currency, as_of, source_key)` carries
+    # a UNIQUE index, and `source_kind` carries a CHECK limiting it to
+    # 'provider' or 'shop'. Every row was dropped and the guard reported 45 read,
+    # 0 written — the guard working, on a fixture that was not. The CHECK was the
+    # last one found, and only by attempting one insert and reading the error
+    # instead of reading PRAGMA table_info, which does not show CHECKs at all.
+    #
+    # That is worth keeping in mind beyond this test: INSERT OR IGNORE swallows a
+    # CONSTRAINT failure exactly as quietly as it swallows a duplicate. A row
+    # that violates a NOT NULL in the new schema vanishes with no error at all,
+    # and the row count is the only thing that notices.
     conn.execute("""CREATE TABLE currency_rate (
-        currency_rate_id INTEGER PRIMARY KEY, currency TEXT NOT NULL,
-        per_usd REAL NOT NULL, as_of TEXT NOT NULL, source_key TEXT,
-        source_kind TEXT, recorded_at TEXT)""")
+        currency_rate_id INTEGER PRIMARY KEY,
+        currency    TEXT NOT NULL,
+        per_usd     REAL NOT NULL,
+        as_of       TEXT NOT NULL,
+        source_key  TEXT NOT NULL,
+        source_kind TEXT NOT NULL CHECK (source_kind IN ('provider', 'shop')),
+        recorded_at TEXT NOT NULL,
+        UNIQUE (currency, as_of, source_key))""")
+    # THE PRIMARY KEY IS GIVEN EXPLICITLY, and disjoint per file. Left to
+    # autoincrement, both old databases number their rows from 1 and the two
+    # ranges collide the moment they are carried into one table -- INSERT OR
+    # IGNORE then drops the second file's rows without a word. That is a real
+    # limitation of carry_over on any table present in BOTH files, and it is
+    # exactly what the row-count guard caught here: 45 read, 40 written, pointer
+    # not moved. It did not bite on the owner's own data only because no table
+    # of theirs lives in both files.
+    base = 0 if prefix == "key" else 100_000
     conn.executemany(
         "INSERT INTO currency_rate (currency_rate_id, currency, per_usd, as_of, "
         "source_key, source_kind, recorded_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
-        [(hash(prefix) % 1000 * 100 + n, f"{prefix[:2].upper()}{n}", 1.0 + n,
-          "2026-08-11", "TEST", "manual", "2026-08-11T00:00:00Z")
-         for n in range(rows)])
+        [(base + n, f"{prefix[:3].upper()}{n:03d}", 1.0 + n, "2026-08-11",
+          prefix, "provider", "2026-08-11T00:00:00Z") for n in range(rows)])
     if extra_table:
         conn.execute("CREATE TABLE forgotten_domain (id INTEGER PRIMARY KEY, note TEXT)")
         conn.executemany("INSERT INTO forgotten_domain (note) VALUES (?)",
@@ -208,3 +231,43 @@ def test_a_short_count_refuses_and_leaves_the_pointer_where_it_was(split, monkey
     assert json.loads(pointer.read_text(encoding="utf-8"))["mode"] == "split", (
         "the pointer moved even though rows were missing — the installation "
         "would now start and serve an incomplete warehouse with nothing saying so")
+
+
+
+def test_a_ledger_the_destination_owns_does_not_block_the_pointer(split):
+    """The fix that came out of the owner's real run, guarded.
+
+    `database_migration` and `scrapex_meta` are LEDGERS: the destination writes
+    its own schema version and migration record when it is created, so some of
+    the old rows are duplicates and INSERT OR IGNORE drops them. On the owner's
+    machine that shortfall — 62 -> 56 and 26 -> 21 — stopped a carry-over in
+    which every table of DATA had arrived exactly. The refusal was right in its
+    logic and wrong in its verdict.
+
+    Removing the exemption must fail this test. Without it the exemption is a
+    line nobody is holding to account, which is how it would quietly widen later
+    into "and these other tables too".
+    """
+    pointer, destination, _, _ = split
+
+    # Put a row in the destination's ledger that the sources also carry, so the
+    # ledger is genuinely short after the carry while the data table is not.
+    from scrapex.databases.domain import EngineDatabase
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    EngineDatabase(destination).initialize()
+    conn = sqlite3.connect(destination)
+    conn.execute("INSERT OR REPLACE INTO scrapex_meta (key, value) VALUES (?, ?)",
+                 ("key-0", "written by the destination, not carried"))
+    conn.commit()
+    conn.close()
+
+    report = carry_over(read_split_pointer(pointer))
+
+    assert report["ledgers"], (
+        "the ledger shortfall was not reported at all; it has to be visible "
+        "even though it is excused")
+    assert report["ledgers"][0]["table"] == "scrapex_meta"
+    assert report["ledgers"][0]["why"], "excused with no reason recorded"
+    assert not report["short"], f"a ledger blocked the pointer: {report['short']}"
+    assert report["ok"], report
+    assert json.loads(pointer.read_text(encoding="utf-8"))["mode"] == "single"


### PR DESCRIPTION
## The defect

`~/.scrapex/databases.json` on the owner's machine still said `"mode": "split"`, so **every engine command refused to start**. That is why nothing was listening on `127.0.0.1:8000` all day and why the side panel's engine check returned `ERR_CONNECTION_REFUSED` in a loop. A dead engine reads as a panel problem; it cost most of a day before anyone opened the pointer file.

**The refusal message was a trap.** It said — truthfully — that nothing was lost and the old files were where they were, then told the reader to run `init-db`. `init-db` creates a **new** database and applies migrations to it. It has never read `marketlens.db`. Following it here would have produced an empty warehouse beside 110 MB of prices that nothing would ever open again.

The message now names `carry-over`, and says outright that `init-db` is not the command — someone who already read the old advice needs telling it was wrong.

## The real run, on the owner's own data

Every row of data arrived, exactly:

| | | | |
|---|---|---|---|
| change_event | 122,509 → 122,509 | price_observation | 88,286 → 88,286 |
| source_product_attribute | 37,452 → 37,452 | price_period | 21,010 → 21,010 |
| offer_state | 17,358 → 17,358 | source_offer | 17,358 → 17,358 |
| source_variant | 13,500 → 13,500 | source_product | 9,167 → 9,167 |
| identity_alias | 4,758 → 4,758 | job_log_entry | 3,072 → 3,072 |

**Two tables came up short and the pointer did not move**: `database_migration` (62 → 56) and `scrapex_meta` (26 → 21). Both are **ledgers, not data** — the new database writes its own schema version and migration record on creation, so old duplicates are dropped, correctly. A new schema must not inherit the old one's ledger.

So the refusal is **right in its logic and wrong in its verdict**: the check cannot tell *"I lost prices"* from *"I did not copy a ledger that is not mine"*. A defect in my code, found by running it for real rather than by any test. The fix is to teach it which tables the destination owns — explicitly, with the reason written down. **Not** by quietly excluding two names until the command passes; weakening a guard to make it green is the exact fault caught in #151 today.

## The owner's installation is safe and unchanged

Pointer still says `split`. Both old files opened **read-only** and byte-identical. The 115 MB backup is intact. The new database exists and **nothing uses it**. Re-running after the fix is safe — idempotence is one of the tests.

## Eight tests

The two that matter were **proved to bite** by breaking the code they guard: the pointer must not move on a short count, and a table the new schema no longer has must be **named with its row count** rather than skipped in silence. An unreported skip is how a migration loses a year of prices behind a success message.

Two of the eight failed when first written — my error, in the same way the production code was: comparing rows read against the destination's *total* row count, which includes rows `initialize()` writes itself. `carry_over` now takes a baseline before inserting and compares against **distinct** source rows, so two old files legitimately holding the same row is not read as loss.

**What it still cannot see**, and the docstring says so: a row that arrived under the same key with a different value. The counts would agree and the content would not.

## Not ready to merge

The ledger-table distinction lands first, then the owner's carry-over is re-run and confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)