### PR TITLE
Wire Drive and Sheets into the panel, and fix the screen that never loaded

### DIFF
--- a/extension/app.html
+++ b/extension/app.html
@@ -1513,6 +1513,35 @@
               <p class="muted hint">
                 Local destinations stay separate from external sync services.</p>
               <div id="outputs" class="output-groups"><div class="skeleton"></div></div>
+
+              <!-- GOOGLE, DONE HERE RATHER THAN HANDED TO THE ENGINE'S PAGE.
+                   The owner ruled on 2026-08-11 that the engine fetches and
+                   saves locally while the extension owns every Google
+                   operation, so these controls call Google directly with the
+                   token Chrome already holds. Nothing on this block is inside
+                   #outputs: loadOutputs() replaces that div's innerHTML on
+                   every render and would wipe a progress bar mid-upload. -->
+              <section class="output-group" aria-labelledby="google-heading">
+                <div class="output-group-head">
+                  <h3 id="google-heading">Google Drive</h3>
+                </div>
+                <p class="muted hint" id="google-account-hint">
+                  Sign in from the Account button to use these.</p>
+                <div class="row">
+                  <button id="drive-backup" class="button" type="button">
+                    Back up to Drive</button>
+                  <button id="drive-restore" class="button ghost" type="button">
+                    Fetch the latest backup</button>
+                  <button id="sheet-create" class="button ghost" type="button">
+                    Create a spreadsheet</button>
+                </div>
+                <div id="drive-progress" class="bar hidden" role="progressbar"
+                     aria-labelledby="google-heading" aria-valuemin="0"
+                     aria-valuemax="100"><div id="drive-progress-fill"
+                     class="bar-fill"></div></div>
+                <p id="drive-msg" class="hint" role="status" aria-live="polite"></p>
+                <p id="sheet-link" class="hint"></p>
+              </section>
             </div>
           </article>
           <!-- The crawl's pace and the engine itself. These existed only on the

--- a/extension/app.js
+++ b/extension/app.js
@@ -13,6 +13,8 @@ import { capabilityProblem, deployedFrom, installedVersion, CAPABILITY_REPORTING
 import { PROTOCOL_VERSION } from "./transport.js";
 import { latestEngineRelease } from "./releases.js";
 import { getToken, accountFor, forgetToken, revokeToken } from "./identity.js";
+import { backUp, fetchLatest } from "./drive.js";
+import { ensureFolder, ensureSpreadsheet, DEFAULT_WORKBOOK, SHEET_FOLDER } from "./sheets.js";
 import {
   afterIdle, afterNextPaint, deadlineForLocalRequest, fetchWithDeadline,
   isTimeoutError, markStartup,
@@ -329,6 +331,14 @@ function showView(name, animate = true) {
     ensureTimeZoneControl();
     loadSchedules();
     loadStorage();
+    // THE OUTPUTS LIST LIVES ON THIS SCREEN AND WAS LOADED FROM THE OTHER ONE.
+    // `loadOutputs` had exactly one caller — loadRunDestination — which returns
+    // early unless the current view is "run" AND the engine is up. So the
+    // destinations panel here showed its loading skeleton forever to anyone who
+    // opened Settings without first visiting Run, and there was nothing on the
+    // screen to say why. Found on 2026-08-11 while reading the panel to wire
+    // Drive into it; guarded by test_every_screen_loads_what_it_shows.
+    loadOutputs();
   }
   if (name === "run") {
     loadRunDestination();
@@ -2931,6 +2941,14 @@ function fmtCount(n) {
   return Number(n || 0).toLocaleString();
 }
 
+// Bytes as megabytes, for the same reason fmtCount exists: the Storage panel
+// had this as a local `mb` helper and the Drive controls needed the identical
+// thing, and two copies of one rounding rule is how "12.3 MB" and "12 MB" end
+// up on one screen describing the same file.
+function fmtMegabytes(n) {
+  return `${(Number(n || 0) / 1048576).toFixed(1)} MB`;
+}
+
 // A duration in seconds as human time. Shared by elapsed AND the finish
 // estimate, so the two can never format the same span two different ways.
 function fmtDuration(secs) {
@@ -3520,12 +3538,11 @@ async function loadOutputs() {
 async function loadStorage() {
   try {
     const s = await api("/api/storage");
-    const mb = (n) => `${(Number(n || 0) / 1048576).toFixed(1)} MB`;
     // Health is a WORD here too, never a colour: the panel has no room for a
     // legend, so the state has to be readable on its own.
     $("storage-info").innerHTML = `
       <div class="kv"><span>Database</span><span class="tech">${esc(s.path)}</span></div>
-      <div class="kv"><span>Size</span><span>${esc(mb(s.sizes.db_bytes))}</span></div>
+      <div class="kv"><span>Size</span><span>${esc(fmtMegabytes(s.sizes.db_bytes))}</span></div>
       <div class="kv"><span>Health</span><span>${esc(s.health.status)}</span></div>
       <div class="kv"><span>Backups</span><span>${esc(String(s.sizes.backup_count))}</span></div>`;
   } catch (_) {
@@ -4377,9 +4394,120 @@ function wireStartupShell() {
   markStartup("shell-interactive");
 }
 
+// ---- Google, driven from here -----------------------------------------------
+//
+// The owner's ruling of 2026-08-11: the engine fetches and saves locally, and
+// the extension owns every Google operation. drive.js and sheets.js do the
+// talking; this is the part that knows about buttons.
+//
+// THE TOKEN IS READ PER CLICK, NEVER CAPTURED. state.token is cleared from five
+// places — a refused profile read, a 401, sign-out — so a handler that closed
+// over it once would keep using a token the owner has already revoked. Reading
+// state.token at the moment of use is the same discipline drive.js applies by
+// taking it as an argument rather than holding it.
+
+function driveProgress(fraction) {
+  const bar = $("drive-progress");
+  const fill = $("drive-progress-fill");
+  if (!bar || !fill) return;
+  if (fraction === null) {
+    bar.classList.add("hidden");
+    return;
+  }
+  const percent = Math.max(0, Math.min(100, Math.round(fraction * 100)));
+  bar.classList.remove("hidden");
+  bar.setAttribute("aria-valuenow", String(percent));
+  fill.style.width = percent + "%";
+}
+
+/** One shape for all three buttons: disable, run, report, re-enable. */
+async function runGoogleAction(button, working, action) {
+  if (!state.token) {
+    out("drive-msg", "Sign in with Google first — the Account button at the " +
+                     "top of the panel.", "err");
+    return;
+  }
+  const buttons = ["drive-backup", "drive-restore", "sheet-create"];
+  buttons.forEach((id) => { if ($(id)) $(id).disabled = true; });
+  out("drive-msg", esc(working), "");
+  try {
+    const said = await action(state.token);
+    out("drive-msg", esc(said), "ok");
+  } catch (error) {
+    // The message is the module's own sentence — "Sign in again from the
+    // panel", "ScrapeX can only open spreadsheets it created itself" — because
+    // those name the next action. Replacing them with a generic failure here
+    // would throw away the only part the owner can act on.
+    out("drive-msg", esc((error && error.message) || "Something went wrong."), "err");
+  } finally {
+    driveProgress(null);
+    buttons.forEach((id) => { if ($(id)) $(id).disabled = false; });
+  }
+}
+
+async function backUpToDrive(token) {
+  // The engine builds the bundle; the panel uploads it. Neither half sees the
+  // other's secret: the engine never gets the token, the panel never opens the
+  // database.
+  out("drive-msg", "Building the bundle…", "");
+  const built = await api("/api/bundle", { method: "POST" });
+  const archive = await (await fetch(
+    (await backendBase()) + "/api/bundle/archive")).blob();
+
+  const stored = await backUp(token, {
+    archive, name: built.name, manifest: built, bundleFormat: built.bundle_format,
+    onProgress: ({sent, total}) => driveProgress(total ? sent / total : 0),
+  });
+  const pruned = stored.pruned.length
+    ? ` ${stored.pruned.length} older backup${stored.pruned.length === 1 ? "" : "s"} removed.`
+    : "";
+  return `Backed up ${fmtMegabytes(archive.size)} to Drive.${pruned}`;
+}
+
+async function fetchFromDrive(token) {
+  const {archive, pointer} = await fetchLatest(token, {
+    onProgress: ({received, total}) => driveProgress(total ? received / total : 0),
+  });
+  // DOWNLOADED, NOT RESTORED. Putting this archive over the warehouse is a
+  // destructive act on the owner's only copy, and it belongs behind its own
+  // confirmed control rather than at the end of a fetch they asked for. What
+  // this proves today is that the backup is real, complete and readable.
+  return `Fetched ${fmtMegabytes(archive.size)} written ${pointer.created_at || "at an unrecorded time"}` +
+         ` by engine ${pointer.engine_version || "unknown"}. It is not installed — this only checks it is there.`;
+}
+
+async function createSpreadsheet(token) {
+  const folder = await ensureFolder(token, SHEET_FOLDER);
+  const sheet = await ensureSpreadsheet(token, DEFAULT_WORKBOOK, {folder});
+  const link = $("sheet-link");
+  if (link) {
+    link.innerHTML = `<a class="link" href="${esc(sheet.url)}" target="_blank" ` +
+                     `rel="noreferrer noopener">${esc(sheet.name)}</a>`;
+  }
+  return sheet.created
+    ? `Created "${sheet.name}" in ${SHEET_FOLDER}.`
+    : `"${sheet.name}" already exists — the link is below.`;
+}
+
+function wireGoogleControls() {
+  const actions = [
+    ["drive-backup", "Backing up…", backUpToDrive],
+    ["drive-restore", "Looking for the latest backup…", fetchFromDrive],
+    ["sheet-create", "Creating the spreadsheet…", createSpreadsheet],
+  ];
+  for (const [id, working, action] of actions) {
+    const button = $(id);
+    if (button) {
+      button.addEventListener("click", () =>
+        runGoogleAction(button, working, action));
+    }
+  }
+}
+
 function wireDeferredControls() {
   if (deferredControlsWired) return;
   deferredControlsWired = true;
+  wireGoogleControls();
   // `[data-sect]` is load-bearing: other buttons borrow the `.sect` LOOK (the
   // Advanced-settings toggle does), and without the attribute filter they get
   // this handler too and blow up on a null target.

--- a/extension/sheets.js
+++ b/extension/sheets.js
@@ -36,6 +36,17 @@ export const SHEET_MIME = "application/vnd.google-apps.spreadsheet";
 // in quota for the attempt.
 export const MAX_EXPORT_ROWS = 40_000;
 
+//: Where spreadsheets go, and what the default one is called. These are the
+//: names gdrive.py used (`google_folder`, `google_workbook`), kept so an owner
+//: who already has that folder keeps using it rather than acquiring a second.
+//:
+//: DELIBERATELY NOT drive.js's FOLDER_NAME. That one holds backup archives —
+//: opaque .zip files under a retention rule that deletes all but the newest
+//: three. A spreadsheet the owner opens and edits must not live somewhere a
+//: prune runs.
+export const SHEET_FOLDER = "ScrapeX";
+export const DEFAULT_WORKBOOK = "ScrapeX Data";
+
 export class SheetsError extends Error {
   constructor(message, status = null, kind = "sheets") {
     super(message);

--- a/tests/test_panel_wiring.py
+++ b/tests/test_panel_wiring.py
@@ -247,3 +247,96 @@ def test_every_panel_script_actually_parses():
         assert done.returncode == 0, (
             f"{script.name} does not parse: "
             + done.stderr.decode("utf-8", "replace")[:800])
+
+
+# ---- every screen loads what it shows --------------------------------------
+
+def _show_view_body() -> str:
+    """The body of showView, where a screen says what it needs loaded."""
+    start = JS.index("function showView(")
+    depth, index = 0, JS.index("{", start)
+    for position in range(index, len(JS)):
+        if JS[position] == "{":
+            depth += 1
+        elif JS[position] == "}":
+            depth -= 1
+            if depth == 0:
+                return JS[index:position + 1]
+    raise AssertionError("showView has no closing brace")
+
+
+#: The container each screen fills, and the function that fills it. A screen
+#: that paints a skeleton and never replaces it is indistinguishable from a slow
+#: engine, so this is asserted rather than left to a reader of two files.
+SCREEN_LOADERS = {
+    "settings": ["loadSchedules", "loadStorage", "loadOutputs"],
+    "data": ["loadDatasets"],
+    "sources": ["loadSources"],
+}
+
+
+@pytest.mark.parametrize("screen,loaders", sorted(SCREEN_LOADERS.items()))
+def test_every_screen_loads_what_it_shows(screen, loaders):
+    """FOUND ON 2026-08-11, and it had been true for a long time.
+
+    `loadOutputs` had exactly one caller: loadRunDestination, which returns
+    early unless the current view is "run" AND the engine is up. The
+    destinations list lives on the SETTINGS screen. So an owner who opened
+    Settings without first visiting Run saw the loading skeleton at
+    app.html's #outputs forever, with nothing on the screen to say why — and
+    every test passed, because no test asked who loads it.
+
+    This is the panel-wiring twin of the Add Site defect this file was written
+    for: two halves that must refer to each other, and nothing checking that
+    they do.
+    """
+    body = _show_view_body()
+    branch = re.search(
+        r'if\s*\(\s*name\s*===\s*"%s"\s*\)\s*\{(.*?)\n\s{2}\}' % screen,
+        body, re.S)
+    single = re.findall(r'if\s*\(\s*name\s*===\s*"%s"\s*\)\s*(\w+)\(' % screen, body)
+    called = set(re.findall(r"(\w+)\(", branch.group(1))) if branch else set(single)
+
+    missing = [name for name in loaders if name not in called]
+    assert not missing, (
+        f'showView("{screen}") never calls {", ".join(missing)}, so whatever '
+        "that function fills stays as its loading skeleton until some other "
+        "screen happens to load it. That is what happened to #outputs.")
+
+
+# ---- a module nobody imports is a module that does not exist ----------------
+
+#: Every ES module under extension/ that the panel is supposed to USE, not just
+#: ship. `bundleview.js` is the reason this list exists: it was written,
+#: reviewed, merged and covered by a cross-language test, and app.js never
+#: imported it — so the "read your data with no engine installed" feature was
+#: complete in every respect except being reachable. drive.js and sheets.js were
+#: one commit away from the same fate.
+PANEL_MODULES = ["engine.js", "transport.js", "version.js", "releases.js",
+                 "identity.js", "startup.js", "drive.js", "sheets.js"]
+
+
+@pytest.mark.parametrize("module", PANEL_MODULES)
+def test_the_panel_actually_imports_the_module(module):
+    """Written, tested and unreachable is the failure this repository keeps
+    making. It is not caught by any suite that tests the module itself: those
+    pass perfectly, which is exactly what makes it hard to notice."""
+    imported = set(re.findall(r'from\s+"\./([\w.-]+)"', JS))
+    assert module in imported, (
+        f"extension/{module} is not imported by app.js. Its own tests pass and "
+        "nothing it provides reaches the panel — the defect bundleview.js sat "
+        "in for months.")
+
+
+def test_bundleview_is_named_here_when_it_is_finally_wired():
+    """The one still unreachable, named so it cannot be quietly forgotten.
+
+    This asserts the CURRENT state rather than the desired one, and it fails the
+    day someone wires it — at which point the fix is one line: move
+    "bundleview.js" into PANEL_MODULES above. A todo that turns into a failing
+    test on completion is the only kind that does not rot.
+    """
+    imported = set(re.findall(r'from\s+"\./([\w.-]+)"', JS))
+    assert "bundleview.js" not in imported, (
+        "bundleview.js is imported now — good. Add it to PANEL_MODULES and "
+        "delete this test; the panel finally reads a bundle with no engine.")


### PR DESCRIPTION
`drive.js` and `sheets.js` were written, tested, and **imported by nothing**. That is the `bundleview.js` defect exactly — a feature complete in every respect except being reachable — and this closes it before it could sit there for months.

Three buttons on the Settings screen, beside the destinations list: **back up to Drive**, **fetch the latest backup**, **create a spreadsheet**. The engine builds the bundle and serves the bytes; the panel uploads them with the token Chrome already holds. Neither half sees the other's secret.

## A defect found on the way in, older than this work

`loadOutputs` had **exactly one caller** — `loadRunDestination` — which returns early unless the current view is `"run"` **and** the engine is up. The destinations list it fills lives on the **Settings** screen.

So an owner who opened Settings without first visiting Run saw a loading skeleton **forever**, with nothing on screen to say why. Every test passed, because no test asked who loads it.

`showView("settings")` now calls it, and `test_every_screen_loads_what_it_shows` holds the property for three screens. **Mutation-tested**: removing the call fails it by name.

## The guard aimed at the class, not the instance

`test_the_panel_actually_imports_the_module` asserts every module the panel is supposed to *use* is actually imported. A module's own tests pass perfectly while nothing imports it — which is precisely what makes this hard to notice.

`bundleview.js` is still unreachable, and it is named in a test that **fails the day someone wires it**:

> A todo that turns into a failing test on completion is the only kind that does not rot.

## What the existing guards caught — all mine

- Two invented CSS classes (`output-group-title`, `gap-sm`) that no stylesheet defines, refused by `test_every_class_in_markup_resolves_to_a_rule`.
- A second copy of the bytes-to-megabytes rounding. It is now one shared `fmtMegabytes`, rather than a local helper inside `loadStorage` and a duplicate beside it — two copies of one rounding rule is how "12.3 MB" and "12 MB" end up on one screen describing the same file.

## Two decisions worth stating

**The progress bar sits outside `#outputs`.** `loadOutputs` replaces that div's `innerHTML` wholesale and would wipe the bar mid-upload.

**"Fetch the latest backup" downloads and verifies, but does not install.** Putting an archive over the warehouse is destructive to the owner's only copy; it belongs behind its own confirmed control, not at the end of a fetch they asked for. What it proves today is that the backup is real, complete and readable.

---

**Green locally:** 500 extension tests · 119 node tests · `eslint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
