### PR TITLE
Carry the panel pack beside the archive, and let the Data page read it

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -623,6 +623,36 @@ opening strategy, a zero-width layout, the engine's absence. Three mechanisms
 were recorded WRONGLY on PR #152 and corrected. The conclusions converged only
 because nothing was accepted without a number.
 
+### Measured: what a backup bundle actually weighs — 2026-08-12
+
+Built from the owner's real warehouse (113.6 MB database, 22.4s to build) when
+he asked why the backup is zipped at all. The answer is a number, not a
+preference:
+
+| | files | size | share |
+|---|---:|---:|---:|
+| `warehouse.db` | 1 | 113.6 MB | 54.6% |
+| `.jsonl` | 34 | 62.0 MB | 29.8% |
+| `.csv` | 34 | 28.2 MB | 13.6% |
+| `panel.jsonl.gz` | 1 | 4.0 MB | 1.9% |
+| **total** | **73** | **207.9 MB** | |
+
+Zipped: **36.0 MB — 17.3%**, in 1.8 seconds. So 1.8 seconds of CPU saves 172 MB
+of upload, and with `KEEP = 3` Drive holds 108 MB instead of 624 MB. Uploading
+unzipped is not a trade-off, it is six times everything.
+
+**But the question was right about the part that mattered.** `panel.jsonl.gz` is
+already gzip, which browsers read natively, and it was locked inside a zip they
+cannot open at all. Lifting that one file out beside the archive costs 11% more
+upload and removes the need for a zip reader — which is what made the
+no-engine Data page reachable.
+
+**Worth recording for later:** the bundle carries the same data three times —
+in the `.db`, as `.jsonl` + `.csv`, and as `panel.jsonl.gz`. That is deliberate,
+for three different readers, and compression hides it. If space ever becomes a
+problem, the 90 MB of `.jsonl`/`.csv` is the part regenerable from the `.db`;
+the zip is not the thing to reconsider.
+
 ### OP-19 · The chaos test races the startup sweep it is checking
 
 Found 2026-08-11 while removing the engine's Google surface. The suite went red

--- a/extension/app.js
+++ b/extension/app.js
@@ -13,7 +13,8 @@ import { capabilityProblem, deployedFrom, installedVersion, CAPABILITY_REPORTING
 import { PROTOCOL_VERSION } from "./transport.js";
 import { latestEngineRelease } from "./releases.js";
 import { getToken, accountFor, forgetToken, revokeToken } from "./identity.js";
-import { backUp, fetchLatest } from "./drive.js";
+import { backUp, fetchLatest, fetchPanelPack } from "./drive.js";
+import { readPanelPack, datasetSummaries } from "./bundleview.js";
 import { ensureFolder, ensureSpreadsheet, DEFAULT_WORKBOOK, SHEET_FOLDER } from "./sheets.js";
 import {
   afterIdle, afterNextPaint, deadlineForLocalRequest, fetchWithDeadline,
@@ -3287,7 +3288,73 @@ async function loadDatasets() {
       });
     });
   } catch (_) {
-    box.innerHTML = `<div class="card"><span class="err">Couldn't reach the engine.</span></div>`;
+    // NOT A DEAD END ANY MORE. This is the machine with no engine on it — the
+    // case the whole bundle format was designed for — and until now the panel
+    // said "couldn't reach the engine" and stopped, while a complete copy of
+    // the owner's data sat in their Drive.
+    box.innerHTML = `<div class="card">
+      <span class="err">Couldn't reach the engine.</span>
+      <p class="hint">Your data is still in your Drive backup. It can be read
+        here without the engine — it will be a snapshot from the last backup,
+        not live.</p>
+      <button id="browse-offline" class="button" type="button">
+        Read my Drive backup</button>
+      <p id="offline-msg" class="hint" role="status" aria-live="polite"></p>
+    </div>`;
+    const button = $("browse-offline");
+    if (button) button.addEventListener("click", () => browseFromDrive(box));
+  }
+}
+
+/**
+ * The Data page, read from Drive, on a machine with no engine.
+ *
+ * 4 MB of gzip against a 36 MB archive only an engine can open, decompressed by
+ * the browser itself. bundleview.js has been able to do this since the day it
+ * was written and nothing ever called it; this is the call.
+ */
+async function browseFromDrive(box) {
+  if (!state.token) {
+    out("offline-msg", "Sign in with Google first — the Account button at the " +
+                       "top of the panel.", "err");
+    return;
+  }
+  const button = $("browse-offline");
+  if (button) button.disabled = true;
+  out("offline-msg", "Fetching the latest backup…", "");
+  try {
+    const {pack, pointer} = await fetchPanelPack(state.token, {
+      onProgress: ({received, total}) => {
+        if (total) {
+          out("offline-msg",
+              `Fetching… ${fmtMegabytes(received)} of ${fmtMegabytes(total)}`, "");
+        }
+      },
+    });
+    const datasets = await readPanelPack(pack);
+    const summaries = datasetSummaries(datasets);
+    if (!summaries.length) {
+      out("offline-msg", "That backup carries no datasets.", "err");
+      return;
+    }
+    // A SNAPSHOT, AND IT SAYS SO. Rows read here are as old as the last backup,
+    // and a screen that looked identical to the live one would be lying by
+    // omission on the day it matters.
+    box.innerHTML = `<div class="card">
+      <span class="muted">From your Drive backup${
+        pointer.created_at ? ` of ${esc(pointer.created_at)}` : ""
+      } — not live.</span></div>` +
+      summaries.map((d) => `
+      <article class="card dataset-card">
+        <div><div class="dataset-identity-line">${esc(d.source_key)}</div>
+          <div class="n">${fmtCount(d.rows)} rows</div>
+          <div class="n muted">${d.has_history
+            ? "with change history" : "current prices only"}</div></div>
+      </article>`).join("");
+  } catch (error) {
+    out("offline-msg", esc((error && error.message) || "Something went wrong."), "err");
+  } finally {
+    if ($("browse-offline")) $("browse-offline").disabled = false;
   }
 }
 
@@ -4451,11 +4518,19 @@ async function backUpToDrive(token) {
   // database.
   out("drive-msg", "Building the bundle…", "");
   const built = await api("/api/bundle", { method: "POST" });
-  const archive = await (await fetch(
-    (await backendBase()) + "/api/bundle/archive")).blob();
+  const base = await backendBase();
+  const archive = await (await fetch(base + "/api/bundle/archive")).blob();
+  // The 4 MB a browser can read on its own, carried beside the 36 MB archive
+  // only an engine can open. Fetched here rather than inside drive.js: that
+  // module talks to Google and nothing else, and giving it a second opinion
+  // about the engine's address is how one boundary becomes two.
+  const panelPack = built.panel_pack
+    ? await (await fetch(base + "/api/bundle/panel-pack")).blob()
+    : null;
 
   const stored = await backUp(token, {
-    archive, name: built.name, manifest: built, bundleFormat: built.bundle_format,
+    archive, name: built.name, panelPack,
+    manifest: built, bundleFormat: built.bundle_format,
     onProgress: ({sent, total}) => driveProgress(total ? sent / total : 0),
   });
   const pruned = stored.pruned.length

--- a/extension/drive.js
+++ b/extension/drive.js
@@ -45,6 +45,21 @@ const FOLDER_MIME = "application/vnd.google-apps.folder";
 /** The pointer that says which upload is the current one. */
 export const LATEST = "latest.json";
 
+/**
+ * The one file in a backup a browser can read on its own.
+ *
+ * A FIXED NAME, REPLACED EACH TIME, exactly like the pointer beside it — not a
+ * stamped file per backup. Two reasons, and the second is the load-bearing one:
+ *
+ *   * it always describes the CURRENT data, which is the only thing a panel
+ *     with no engine is asking for; nobody browses last week's backup.
+ *   * `prunable` only ever proposes `.zip` files, so a stamped pack would be
+ *     skipped by retention forever and accumulate one 4 MB file per backup
+ *     until the owner noticed. Making it a replaced singleton removes that
+ *     failure rather than adding a second rule to remember.
+ */
+export const PANEL_PACK = "panel.jsonl.gz";
+
 /** How many bundles survive a prune. Three is a fortnight of daily backups
  * without asking the owner to think about it, and Drive quota is the owner's. */
 export const KEEP = 3;
@@ -355,7 +370,7 @@ export async function readLatest(token, parent, {fetchImpl = fetch} = {}) {
  * doing it twice is how two readers of one format drift.
  */
 export async function backUp(token, {
-  archive, name, manifest = {}, bundleFormat = 1,
+  archive, name, panelPack = null, manifest = {}, bundleFormat = 1,
   onProgress = null, fetchImpl = fetch,
 } = {}) {
   const parent = await folderId(token, {fetchImpl});
@@ -363,6 +378,23 @@ export async function backUp(token, {
   const stored = await upload(token, {
     blob: archive, name, parent, onProgress, fetchImpl,
   });
+
+  // THE PANEL PACK, BEFORE THE POINTER AND AFTER THE ARCHIVE. Its place in the
+  // order follows the same rule as everything else here: the pointer is written
+  // last, so it can only ever name files that have already arrived. A pointer
+  // promising a pack that failed to upload would send a bare panel to fetch
+  // something that is not there — with no engine on that machine to explain it.
+  let packed = null;
+  if (panelPack) {
+    const existing = await listing(token, parent, {fetchImpl});
+    for (const file of existing.filter((f) => f.name === PANEL_PACK)) {
+      await remove(token, file.id, {fetchImpl});
+    }
+    packed = await upload(token, {
+      blob: panelPack, name: PANEL_PACK, parent,
+      mime: "application/gzip", fetchImpl,
+    });
+  }
 
   const pointer = {
     file_id: stored.id,
@@ -372,6 +404,9 @@ export async function backUp(token, {
     created_at: manifest.created_at || "",
     engine_version: manifest.engine_version || "",
     bundle_format: bundleFormat,
+    panel_pack: packed
+      ? {file_id: packed.id, name: PANEL_PACK, bytes: panelPack.size}
+      : null,
   };
 
   // Replace, never append. The old pointer is deleted before the new one is
@@ -434,4 +469,46 @@ export async function fetchLatest(token, {
       "Nothing was restored.", null, "truncated");
   }
   return {archive, pointer};
+}
+
+/**
+ * The 4 MB a bare panel actually needs — no engine, no zip reader, no archive.
+ *
+ * THIS IS THE FUNCTION THE WHOLE ARRANGEMENT EXISTS FOR. The archive above is
+ * 36 MB of zip that only an engine can open; this is one gzip file the browser
+ * decompresses natively, and it carries every row the Data page shows.
+ *
+ * It reads the pointer FIRST rather than fetching `panel.jsonl.gz` by name.
+ * Fetching by name would work and would also happily return a pack left behind
+ * by a backup that never finished — the pointer is what says a pack belongs to
+ * a complete one, which is the same reason nothing else here trusts a filename.
+ */
+export async function fetchPanelPack(token, {
+  onProgress = null, fetchImpl = fetch,
+} = {}) {
+  const parent = await folderId(token, {fetchImpl});
+  const pointer = await readLatest(token, parent, {fetchImpl});
+  if (!pointer) {
+    throw new DriveError(
+      "No backup has been uploaded from any device yet.", null, "no-backup");
+  }
+  if (!pointer.panel_pack || !pointer.panel_pack.file_id) {
+    // An OLD backup, made before the pack was carried separately. Saying that
+    // is better than "no data": the owner's warehouse is safe, it is this one
+    // screen that cannot open it, and the fix is one more backup.
+    throw new DriveError(
+      "That backup was made before ScrapeX could show data without the " +
+      "engine. Back up once more from a machine that has the engine, and this " +
+      "screen will work everywhere.", null, "no-panel-pack");
+  }
+
+  const pack = await download(token, pointer.panel_pack.file_id,
+                              {onProgress, fetchImpl});
+  const promised = pointer.panel_pack.bytes;
+  if (promised && pack.size !== promised) {
+    throw new DriveError(
+      `The download stopped at ${pack.size} of ${promised} bytes, so the rows ` +
+      "would be incomplete. Nothing is shown.", null, "truncated");
+  }
+  return {pack, pointer};
 }

--- a/extension/tests/drive.test.mjs
+++ b/extension/tests/drive.test.mjs
@@ -10,7 +10,8 @@ import assert from "node:assert/strict";
 
 import {
   backUp, download, fetchLatest, folderId, listing, prunable, upload,
-  BUNDLE_FORMAT, DriveError, KEEP, LATEST,
+  fetchPanelPack,
+  BUNDLE_FORMAT, DriveError, KEEP, LATEST, PANEL_PACK,
 } from "../drive.js";
 import {readFileSync} from "node:fs";
 
@@ -398,4 +399,146 @@ test("download reports progress and returns the bytes", async () => {
   assert.equal(blob.size, 5);
   assert.deepEqual(seen.map((p) => p.received), [0, 3, 5]);
   assert.equal(seen.at(-1).total, 5);
+});
+
+
+test("the panel pack goes up after the archive and before the pointer", async () => {
+  // Same rule as everything else here: the pointer is written last, so it can
+  // only ever name files that have already arrived. A pointer promising a pack
+  // that failed would send a bare panel to fetch something that is not there,
+  // with no engine on that machine to explain it.
+  const order = [];
+  const fetchImpl = scripted([
+    [isSearch, (url) => (url.includes("mimeType")
+      ? reply(200, {body: {files: [{id: "folder-1"}]}})
+      : reply(200, {body: {files: []}}))],
+    [isStart, (_url, init) => {
+      order.push(JSON.parse(init.body).name);
+      return reply(200, {headers: {Location: SESSION}});
+    }],
+    [isPut, () => reply(200, {body: {id: "up", name: "x"}})],
+  ]);
+
+  await backUp("tok", {
+    archive: new Blob(["archive"]), name: "bundle.zip",
+    panelPack: new Blob(["pack"]), fetchImpl,
+  });
+
+  assert.deepEqual(order, ["bundle.zip", PANEL_PACK, LATEST],
+    "the three uploads did not happen in the one order that is safe");
+});
+
+
+test("the pointer records the pack, so a reader never guesses a filename", async () => {
+  let written = null;
+  const fetchImpl = scripted([
+    [isSearch, (url) => (url.includes("mimeType")
+      ? reply(200, {body: {files: [{id: "folder-1"}]}})
+      : reply(200, {body: {files: []}}))],
+    [isStart, (_url, init) => {
+      written = JSON.parse(init.body).name;
+      return reply(200, {headers: {Location: SESSION}});
+    }],
+    [isPut, (_url, init) => {
+      if (written === LATEST) {
+        // The pointer's own bytes, which is the only place its shape is real.
+        return init.body.text().then((text) =>
+          reply(200, {body: {id: "ptr", name: LATEST, _wrote: text}}));
+      }
+      return reply(200, {body: {id: `id-${written}`, name: written}});
+    }],
+  ]);
+
+  const result = await backUp("tok", {
+    archive: new Blob(["a"]), name: "bundle.zip",
+    panelPack: new Blob(["12345"]), fetchImpl,
+  });
+
+  assert.equal(result.panel_pack.name, PANEL_PACK);
+  assert.equal(result.panel_pack.bytes, 5);
+  assert.ok(result.panel_pack.file_id, "the pack's id was not recorded");
+});
+
+
+test("a backup with no pack still works and says so in the pointer", async () => {
+  const fetchImpl = scripted([
+    [isSearch, (url) => (url.includes("mimeType")
+      ? reply(200, {body: {files: [{id: "folder-1"}]}})
+      : reply(200, {body: {files: []}}))],
+    [isStart, () => reply(200, {headers: {Location: SESSION}})],
+    [isPut, () => reply(200, {body: {id: "up", name: "x"}})],
+  ]);
+
+  const result = await backUp("tok", {
+    archive: new Blob(["a"]), name: "bundle.zip", fetchImpl,
+  });
+
+  assert.equal(result.panel_pack, null,
+    "an absent pack must be null, not missing — a reader has to tell the two "
+    + "apart to give the owner the right sentence");
+});
+
+
+test("only one panel pack ever exists, however many were there before", async () => {
+  const deleted = [];
+  const fetchImpl = scripted([
+    [isSearch, (url) => (url.includes("mimeType")
+      ? reply(200, {body: {files: [{id: "folder-1"}]}})
+      : reply(200, {body: {files: [
+        {id: "old-pack", name: PANEL_PACK, createdTime: "2026-08-01T00:00:00Z"},
+      ]}}))],
+    [isStart, () => reply(200, {headers: {Location: SESSION}})],
+    [isPut, () => reply(200, {body: {id: "new", name: "x"}})],
+    [(_url, init) => init.method === "DELETE",
+      (url) => { deleted.push(url); return reply(204); }],
+  ]);
+
+  await backUp("tok", {
+    archive: new Blob(["a"]), name: "bundle.zip",
+    panelPack: new Blob(["p"]), fetchImpl,
+  });
+
+  assert.equal(deleted.filter((u) => u.includes("old-pack")).length, 1,
+    "the previous pack survived; retention only proposes .zip files, so it "
+    + "would sit there forever growing one 4 MB file per backup");
+});
+
+
+test("an old backup with no pack is named, not reported as no data", async () => {
+  // The owner's warehouse is safe; it is this one screen that cannot open it,
+  // and the fix is one more backup. "No data" would say the opposite.
+  const fetchImpl = scripted([
+    [isSearch, (url) => (url.includes("mimeType")
+      ? reply(200, {body: {files: [{id: "folder-1"}]}})
+      : reply(200, {body: {files: [{id: "ptr", name: LATEST}]}}))],
+    [(url) => url.includes("alt=media"),
+      () => reply(200, {body: JSON.stringify({file_id: "a", bytes: 1})})],
+  ]);
+
+  await assert.rejects(() => fetchPanelPack("tok", {fetchImpl}), (error) => {
+    assert.equal(error.kind, "no-panel-pack");
+    assert.match(error.message, /Back up once more/);
+    return true;
+  });
+});
+
+
+test("a truncated pack shows nothing rather than half the rows", async () => {
+  const fetchImpl = scripted([
+    [isSearch, (url) => (url.includes("mimeType")
+      ? reply(200, {body: {files: [{id: "folder-1"}]}})
+      : reply(200, {body: {files: [{id: "ptr", name: LATEST}]}}))],
+    [(url) => url.includes("alt=media"), (url) => (url.includes("ptr")
+      ? reply(200, {body: JSON.stringify({
+          file_id: "a", bytes: 1,
+          panel_pack: {file_id: "pack", name: PANEL_PACK, bytes: 4096},
+        })})
+      : reply(200, {body: "short"}))],
+  ]);
+
+  await assert.rejects(() => fetchPanelPack("tok", {fetchImpl}), (error) => {
+    assert.equal(error.kind, "truncated");
+    assert.match(error.message, /Nothing is shown/);
+    return true;
+  });
 });

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -2397,11 +2397,15 @@ def create_app(
     #: be downloadable, and app.state would not survive one.
     BUNDLE_PREFIX = "scrapex-bundle-"
 
+    #: The panel pack lifted out of the bundle, named so the two files of one
+    #: backup share a stamp and sort together.
+    PANEL_SUFFIX = "-panel.jsonl.gz"
+
     def _bundle_folder(conn) -> Path:
         return backup_folder(conn, app.state.db_path)
 
-    def _newest_bundle(folder: Path) -> Path | None:
-        made = sorted(folder.glob(f"{BUNDLE_PREFIX}*.zip"),
+    def _newest(folder: Path, suffix: str) -> Path | None:
+        made = sorted(folder.glob(f"{BUNDLE_PREFIX}*{suffix}"),
                       key=lambda p: p.stat().st_mtime, reverse=True)
         return made[0] if made else None
 
@@ -2430,6 +2434,25 @@ def create_app(
                     "the bundle did not verify, so nothing was packed: "
                     + "; ".join(f"{f.path}: {f.problem}" for f in report.faults[:3])))
             described = bundle.pack(staging, archive)
+            # THE PANEL PACK IS LIFTED OUT OF THE BUNDLE BEFORE THE STAGING
+            # DIRECTORY GOES, and this is the whole reason this block exists.
+            #
+            # A browser has DecompressionStream for gzip and no zip reader at
+            # all, and this repository ships no npm dependency on purpose. So
+            # `panel.jsonl.gz` inside the archive is unreachable to the very
+            # reader it was written for: extension/bundleview.js.
+            #
+            # MEASURED on the owner's warehouse, 2026-08-12: the bundle is
+            # 207.9 MB raw and 36.0 MB zipped — the zip earns its 1.8 seconds
+            # many times over and is not going anywhere. But panel.jsonl.gz is
+            # 4.0 MB and ALREADY gzipped, so copying it out beside the archive
+            # costs 11% more upload and removes the need for a zip reader
+            # entirely. Compressing it again would be the mistake; carrying it
+            # separately is the fix.
+            pack_source = staging / bundle.PANEL_PACK
+            panel_pack = folder / f"{BUNDLE_PREFIX}{stamp}{PANEL_SUFFIX}"
+            if pack_source.is_file():
+                shutil.copy2(pack_source, panel_pack)
         except ValueError as error:
             raise HTTPException(status_code=400, detail=str(error)) from error
         finally:
@@ -2446,6 +2469,11 @@ def create_app(
             "bundle_format": bundle.BUNDLE_FORMAT,
             "engine_version": engine_version.VERSION,
             "created_at": utc_now_iso(),
+            "panel_pack": {
+                "name": panel_pack.name,
+                "bytes": panel_pack.stat().st_size,
+                "sha256": bundle.sha256_of(panel_pack),
+            } if panel_pack.is_file() else None,
         }
 
     @app.get("/api/bundle/archive")
@@ -2462,12 +2490,39 @@ def create_app(
         finally:
             conn.close()
 
-        archive = _newest_bundle(folder)
+        archive = _newest(folder, ".zip")
         if archive is None:
             raise HTTPException(status_code=404, detail=(
                 "no bundle has been built yet — POST /api/bundle first"))
         return FileResponse(
             archive, media_type="application/zip", filename=archive.name)
+
+    @app.get("/api/bundle/panel-pack")
+    def api_bundle_panel_pack():
+        """Stream the newest panel pack — the one file a browser can read.
+
+        Separate from the archive above rather than a parameter on it, for the
+        same reason that route takes no arguments at all: two fixed routes
+        cannot be pointed anywhere, and a `?which=` would be the first place a
+        path would eventually arrive from the caller.
+        """
+        conn = read_conn()
+        try:
+            folder = _bundle_folder(conn)
+        finally:
+            conn.close()
+
+        pack = _newest(folder, PANEL_SUFFIX)
+        if pack is None:
+            raise HTTPException(status_code=404, detail=(
+                "no panel pack has been built yet — POST /api/bundle first"))
+        # `application/gzip`, and the encoding is NOT declared as a Content-
+        # Encoding: this is a gzip FILE being transferred, not a response the
+        # browser should transparently inflate. Getting that wrong would hand
+        # bundleview.js already-decompressed bytes it would then try to
+        # decompress again.
+        return FileResponse(
+            pack, media_type="application/gzip", filename=pack.name)
 
     @app.post("/api/storage/restore")
     def api_storage_restore(body: dict):

--- a/tests/test_panel_wiring.py
+++ b/tests/test_panel_wiring.py
@@ -313,7 +313,8 @@ def test_every_screen_loads_what_it_shows(screen, loaders):
 #: complete in every respect except being reachable. drive.js and sheets.js were
 #: one commit away from the same fate.
 PANEL_MODULES = ["engine.js", "transport.js", "version.js", "releases.js",
-                 "identity.js", "startup.js", "drive.js", "sheets.js"]
+                 "identity.js", "startup.js", "drive.js", "sheets.js",
+                 "bundleview.js"]
 
 
 @pytest.mark.parametrize("module", PANEL_MODULES)
@@ -328,15 +329,17 @@ def test_the_panel_actually_imports_the_module(module):
         "in for months.")
 
 
-def test_bundleview_is_named_here_when_it_is_finally_wired():
-    """The one still unreachable, named so it cannot be quietly forgotten.
+def test_the_offline_reader_is_reachable_from_the_data_page():
+    """bundleview.js was written, tested across two languages, and imported by
+    nothing for months. The sentinel that used to live here — a test asserting
+    it was NOT imported, which would fail the day someone wired it — has done
+    its job and is gone.
 
-    This asserts the CURRENT state rather than the desired one, and it fails the
-    day someone wires it — at which point the fix is one line: move
-    "bundleview.js" into PANEL_MODULES above. A todo that turns into a failing
-    test on completion is the only kind that does not rot.
-    """
-    imported = set(re.findall(r'from\s+"\./([\w.-]+)"', JS))
-    assert "bundleview.js" not in imported, (
-        "bundleview.js is imported now — good. Add it to PANEL_MODULES and "
-        "delete this test; the panel finally reads a bundle with no engine.")
+    What replaces it is narrower and worth more: being imported is not the same
+    as being reachable. The offline path has to be OFFERED, and the only place
+    it can be is where the engine has just failed."""
+    assert "browseFromDrive" in JS, "the offline reader has no entry point"
+    assert re.search(r'catch[^}]*?browse-offline', JS, re.S), (
+        "the Drive fallback is not offered where the engine request fails, so "
+        "a machine with no engine still reaches a dead end — which is the whole "
+        "case the bundle format exists for")

--- a/tests/test_the_engine_hands_the_bundle_over.py
+++ b/tests/test_the_engine_hands_the_bundle_over.py
@@ -171,3 +171,70 @@ def test_the_manifest_inside_names_the_format_the_panel_checks(client):
         manifest = json.loads(opened.read("manifest.json"))
 
     assert manifest["bundle_format"] == described["bundle_format"]
+
+
+def test_the_panel_pack_is_lifted_out_of_the_archive(client):
+    """THE FILE THE BROWSER CAN ACTUALLY READ.
+
+    A browser has DecompressionStream for gzip and no zip reader at all, and
+    this repository ships no npm dependency on purpose. So `panel.jsonl.gz`
+    inside the archive is unreachable to the one reader it was written for.
+
+    MEASURED on the owner's warehouse, 2026-08-12: the bundle is 207.9 MB raw
+    and 36.0 MB zipped, so the zip stays. The pack is 4.0 MB and already
+    gzipped, so carrying it separately costs 11% more upload and removes the
+    need for a zip reader entirely.
+    """
+    connected, backups = client
+
+    described = connected.post("/api/bundle").json()
+
+    assert described["panel_pack"], "no panel pack was reported"
+    pack = backups / described["panel_pack"]["name"]
+    assert pack.is_file(), f"the pack was reported but not written: {pack}"
+    assert described["panel_pack"]["bytes"] == pack.stat().st_size
+    assert described["panel_pack"]["sha256"] == bundle.sha256_of(pack)
+    assert pack.name.endswith(".jsonl.gz")
+
+
+def test_the_pack_is_readable_gzip_and_not_re_compressed(client):
+    """Served as a gzip FILE, not as a response the browser inflates on the way
+    in. Getting that wrong hands bundleview.js already-decompressed bytes that
+    it then tries to decompress again."""
+    import gzip
+
+    connected, _ = client
+    connected.post("/api/bundle")
+
+    got = connected.get("/api/bundle/panel-pack")
+
+    assert got.status_code == 200
+    assert got.headers["content-type"] == "application/gzip"
+    assert "content-encoding" not in {k.lower() for k in got.headers}, (
+        "the pack is declared as an encoding rather than a file, so the "
+        "browser would inflate it before bundleview.js ever sees it")
+    # It really is gzip, and it really is JSON Lines.
+    text = gzip.decompress(got.content).decode("utf-8")
+    for line in [line for line in text.splitlines() if line.strip()][:5]:
+        entry = json.loads(line)
+        assert "dataset" in entry, f"a pack line carries no dataset key: {entry}"
+
+
+def test_asking_for_a_pack_before_one_is_built_says_which_step_is_missing(client):
+    connected, _ = client
+
+    refused = connected.get("/api/bundle/panel-pack")
+
+    assert refused.status_code == 404
+    assert "POST /api/bundle" in refused.json()["detail"]
+
+
+def test_the_pack_route_cannot_be_pointed_anywhere_either(client):
+    connected, _ = client
+    connected.post("/api/bundle")
+
+    for attempt in ("?name=../../../etc/passwd", "?which=archive"):
+        got = connected.get(f"/api/bundle/panel-pack{attempt}")
+        assert got.status_code == 200
+        assert got.headers["content-disposition"].endswith('.jsonl.gz"'), (
+            f"the query string {attempt} changed which file was served")


### PR DESCRIPTION
You asked why the backup is zipped at all. **Measured on the real warehouse rather than answered.**

## The numbers

Built from the owner's own database — 113.6 MB, 22.4s to build:

| | files | size | share |
|---|---:|---:|---:|
| `warehouse.db` | 1 | 113.6 MB | 54.6% |
| `.jsonl` | 34 | 62.0 MB | 29.8% |
| `.csv` | 34 | 28.2 MB | 13.6% |
| **`panel.jsonl.gz`** | **1** | **4.0 MB** | **1.9%** |
| **total** | **73** | **207.9 MB** | |

Zipped: **36.0 MB — 17.3%, in 1.8 seconds.**

So 1.8 seconds of CPU saves **172 MB** of upload, and with `KEEP = 3` Drive holds 108 MB instead of 624 MB. Uploading unzipped is not a trade-off; it is six times everything. **The zip stays.**

## But the question was right about the part that mattered

`panel.jsonl.gz` is 4.0 MB and **already gzip**, which browsers decompress natively — and it was locked inside a zip they cannot open at all. The engine now lifts that one file out beside the archive: **11% more upload, and no zip reader needed anywhere.**

## What that unlocked

`bundleview.js` has been able to read a pack since the day it was written, and nothing ever called it — the defect this repository keeps making, and the one a guard was added for two commits ago.

The Data page's `catch` used to say *"Couldn't reach the engine"* and stop — **on the exact machine the bundle format was designed for**, while a complete copy of the data sat in Drive. It now offers to read it, says plainly that what it shows is a **snapshot rather than live**, and names the backup's date.

## Two design decisions

**A fixed name, replaced each time**, exactly like the pointer. Not a stamped file per backup: `prunable` only ever proposes `.zip`, so a stamped pack would be skipped by retention **forever** and accumulate 4 MB per backup until someone noticed. A replaced singleton removes that failure instead of adding a second rule to remember.

**Order: archive → pack → pointer.** The pointer is written last so it can only name files that have already arrived. A pointer promising a pack that failed would send a bare panel to fetch something that is not there — with no engine on that machine to explain it.

A backup made before today has no pack, and that case is **named** rather than reported as "no data": the warehouse is safe, it is this one screen that cannot open it, and the fix is one more backup.

---

**Green locally:** full engine suite · 500 extension tests · 125 node tests (6 new) · `ruff` · `eslint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)