### PR TITLE
Profile: the signed-in state becomes an accounts card

### DIFF
--- a/design/components.css
+++ b/design/components.css
@@ -468,6 +468,24 @@ button.icon-button.compact,
   min-width: var(--control-height-sm);
 }
 
+/* The smallest square, and the only one that also lowers min-height.
+   `compact` shrinks a control to the small notch; `xs` goes one further, to
+   --control-height-xs (32px on both surfaces). It exists because the Profile
+   design puts a secondary sign-out icon in a top bar where a 48px square reads
+   as the loudest thing on a page about an account, and the owner ruled on
+   2026-08-11 that both sizes belong to the general rule rather than to one
+   screen's stylesheet.
+   USE IT FOR SECONDARY ICON CONTROLS ONLY. 32px is under the 44px coarse-pointer
+   floor this sheet applies below, and under --control-height-sm. A primary or
+   destructive action, or anything on a touch surface, uses `icon-button` or
+   `icon-button compact` instead. */
+button.icon-button.xs,
+.button.icon-button.xs {
+  width: var(--control-height-xs);
+  min-width: var(--control-height-xs);
+  min-height: var(--control-height-xs);
+}
+
 button.compact,
 .button.compact {
   min-height: var(--control-height-sm);

--- a/design/gallery.html
+++ b/design/gallery.html
@@ -228,6 +228,9 @@
   <symbol id="expand-more" viewBox="0 0 24 24">
     <path d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"/>
   </symbol>
+  <symbol id="logout" viewBox="0 0 24 24">
+    <path d="M17 7l-1.41 1.41L18.17 11H8v2h10.17l-2.58 2.58L17 17l5-5zM4 5h8V3H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h8v-2H4V5z"/>
+  </symbol>
   </svg>
   <!-- SPRITE:END -->
 
@@ -285,6 +288,10 @@
       <code class="code">icon-button</code> is square at the full touch-target size;
       add <code class="code">compact</code> for a <em>small</em> square. The two were
       never composable until 2026-08-05 — together they drew a rectangle.
+      <code class="code">xs</code> is the third notch, 32px, added 2026-08-11 for
+      <em>secondary</em> icon controls — a quiet action that must not out-shout the
+      page it sits on. It is under the 44px coarse-pointer floor, so a primary or
+      destructive action never uses it.
     </p>
     <div class="g-demo cluster">
       <button type="button" class="compact">Compact</button>
@@ -294,11 +301,15 @@
       <button type="button" class="ghost icon-button compact" aria-label="Download">
         <svg class="sx-icon" aria-hidden="true"><use href="#file-download"></use></svg>
       </button>
+      <button type="button" class="ghost icon-button xs" aria-label="Sign out">
+        <svg class="sx-icon" aria-hidden="true"><use href="#logout"></use></svg>
+      </button>
       <button type="button" class="link">A button that reads as a link</button>
     </div>
     <pre>&lt;button class="compact"&gt;Compact&lt;/button&gt;
 &lt;button class="ghost icon-button" aria-label="Add"&gt;…&lt;/button&gt;
 &lt;button class="ghost icon-button compact" aria-label="Download"&gt;…&lt;/button&gt;
+&lt;button class="ghost icon-button xs" aria-label="Sign out"&gt;…&lt;/button&gt;
 &lt;button class="link"&gt;A button that reads as a link&lt;/button&gt;</pre>
   </div>
 

--- a/design/material-icons.svg
+++ b/design/material-icons.svg
@@ -157,4 +157,7 @@
   <symbol id="expand-more" viewBox="0 0 24 24">
     <path d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"/>
   </symbol>
+  <symbol id="logout" viewBox="0 0 24 24">
+    <path d="M17 7l-1.41 1.41L18.17 11H8v2h10.17l-2.58 2.58L17 17l5-5zM4 5h8V3H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h8v-2H4V5z"/>
+  </symbol>
 </svg>

--- a/design/tokens.css
+++ b/design/tokens.css
@@ -61,6 +61,16 @@
   --control-hover: var(--surface-subtle);
   --control-height: 2.5rem;
   --control-height-sm: 2rem;
+  /* The third notch, added 2026-08-11 by the owner's ruling on the Profile
+     top bar: «وضيف فى القاعدة العامة الاختيارين» — carry BOTH sizes in the
+     general rule rather than let one screen override it locally.
+     It is deliberately NOT re-declared in extension/app.css. The extension
+     shifts the other two notches up (see the :root block at the top of that
+     file) because a side panel is a pointer surface with a 48px floor; this
+     one exists for the quiet, secondary icon control the Profile design asks
+     for, and it is the same 32px on both surfaces. Anything a finger must hit
+     reliably still uses --control-height or --touch-target. */
+  --control-height-xs: 2rem;
   --touch-target: 3rem;
 
   /* Spacing — 4px base */

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -29,9 +29,18 @@ your email address. The extension contains no telemetry of any kind.
 | Your settings and preferences | The same database | You |
 | Backups you ask for | **Your** Google Drive, in a folder ScrapeX creates | You |
 | Your Google sign-in token | Held by **Chrome**, not by ScrapeX | Chrome, and Google |
+| The accounts you have signed in with — name, address, picture | Chrome's own storage on **this computer**, so the Profile list survives closing the panel | You |
+| Your appearance choice — light or dark, and which palette | This computer, in the browser's own storage | You |
+| The time zone dates are shown in | The same | You |
+| The address of your local engine — `127.0.0.1:8000` unless you change it | The same | You |
 
 Nothing in that table leaves your computer unless you press a button that says
 it will.
+
+**The accounts list is a list, not a keyring.** It holds no password and no
+sign-in token: those are Chrome's, and a token is obtained fresh each time one
+is needed. Removing an account from the Profile page erases its row here
+immediately.
 
 ---
 
@@ -50,7 +59,7 @@ revokes it immediately.
 
 | Permission | Why |
 |---|---|
-| `userinfo.email`, `userinfo.profile` | To show which account is signed in — your name, address and picture, on the panel's own Profile page. Nothing is stored and nothing is sent anywhere. |
+| `userinfo.email`, `userinfo.profile` | To show which account is signed in — your name, address and picture, on the panel's own Profile page. Nothing is sent anywhere. Since the Profile page can list more than one account, these details are kept on **this computer** so the list survives closing the panel; see the table above. |
 | `drive.file` | To create and update **only the files ScrapeX itself creates**. Google enforces this per file: ScrapeX is structurally unable to read the rest of your Drive, whether or not it wanted to. It is also what a future export to Google Sheets will use — a sheet ScrapeX creates, or one you hand it yourself. |
 
 ScrapeX never asks for full Drive access, never reads your mail, and never

--- a/extension/accounts.js
+++ b/extension/accounts.js
@@ -1,0 +1,164 @@
+// The accounts this browser REMEMBERS, and nothing else.
+//
+// PLATFORM-PLAN, the owner's ruling of 2026-08-05, stands unchanged: «الإضافة
+// تملكه وتُعيره للمحرّك» — the extension owns the token and lends it to the
+// engine, and NOTHING is written to disk here. Multi-account did not require
+// breaking that. What is stored is a directory: who this browser has seen, so
+// the panel can offer them by name. A token for any of them is minted at the
+// moment it is needed and lives in memory only (see identity.js).
+//
+// The owner ruled on this directly on 2026-08-11, choosing the variant that
+// keeps the 2026-08-05 ruling over the one that would have stored refresh
+// tokens: «الصيغة الثالثة، بلا تخزين اعتمادات».
+//
+// WHY A DIRECTORY IS NOT A CREDENTIAL. Everything here — the account id, the
+// display name, the address, the photo URL — is what Google already hands to
+// any page the person is signed into, and what the panel already paints on
+// screen. None of it authorises anything. `sanitiseAccount` below is what keeps
+// that true as the file ages: it copies the four fields it knows by name and
+// drops the rest, so a caller that one day passes a whole token response cannot
+// quietly persist the token inside it.
+
+/** The one storage key. Versioned, because the shape may move and a reader that
+ *  meets an older shape must know rather than guess. */
+export const ACCOUNTS_KEY = "scrapex-accounts-v1";
+
+/** The fields a remembered account may carry. THIS LIST IS THE RULE — see the
+ *  file comment. Adding to it is a decision about what lands on disk. */
+const REMEMBERED_FIELDS = ["id", "name", "email", "picture"];
+
+/** Copy the known fields, drop everything else.
+ *
+ * Returns null for anything that cannot be an account. An entry with no `id` is
+ * not an account: the id is what a switch, a removal and a token request all
+ * name, and a list holding one without would offer a row nothing can act on.
+ */
+export function sanitiseAccount(candidate) {
+  if (!candidate || typeof candidate !== "object") return null;
+  const id = typeof candidate.id === "string" ? candidate.id.trim() : "";
+  if (!id) return null;
+  const account = { id };
+  for (const field of REMEMBERED_FIELDS) {
+    if (field === "id") continue;
+    const value = candidate[field];
+    account[field] = typeof value === "string" ? value : "";
+  }
+  return account;
+}
+
+/** Read the directory, and never throw at a caller because storage was odd.
+ *
+ * A corrupt or half-written record reads as an EMPTY directory, not as an
+ * error. The panel's job when it knows nobody is to offer sign-in, which is
+ * exactly what it does on a fresh machine — so the recovery path is one the
+ * product already has, rather than an error state built for this one case.
+ */
+export async function readAccounts({ storage = chrome.storage.local } = {}) {
+  let record;
+  try {
+    const held = await storage.get(ACCOUNTS_KEY);
+    record = held && held[ACCOUNTS_KEY];
+  } catch (_) {
+    record = null;
+  }
+  const rawList = record && Array.isArray(record.accounts) ? record.accounts : [];
+  const accounts = [];
+  const seen = new Set();
+  for (const entry of rawList) {
+    const account = sanitiseAccount(entry);
+    // Duplicates are dropped rather than merged: two rows for one person is a
+    // bug the person can see, and the later write is the fresher truth.
+    if (!account || seen.has(account.id)) continue;
+    seen.add(account.id);
+    accounts.push(account);
+  }
+  const claimed = record && typeof record.currentId === "string" ? record.currentId : "";
+  // A current id naming nobody is not carried forward. It would make the panel
+  // paint a "current account" header for a row that is not in the list.
+  const currentId = seen.has(claimed) ? claimed : "";
+  return { accounts, currentId };
+}
+
+async function write(storage, accounts, currentId) {
+  await storage.set({ [ACCOUNTS_KEY]: { accounts, currentId } });
+  return { accounts, currentId };
+}
+
+/** Add an account, or refresh what is known about one already listed.
+ *
+ * The remembered entry is REPLACED, not merged: a name or a photo that changed
+ * at Google is the truth, and a merge would keep the stale half of it. Position
+ * in the list is kept, so the row a person is looking at does not jump when
+ * their photo updates.
+ *
+ * Remembering an account also makes it current. Every path that reaches here —
+ * first sign-in, adding a second account, re-authorising one that had lapsed —
+ * is a path where the person just proved which account they meant.
+ */
+export async function rememberAccount(candidate, { storage = chrome.storage.local } = {}) {
+  const account = sanitiseAccount(candidate);
+  if (!account) return readAccounts({ storage });
+  const { accounts } = await readAccounts({ storage });
+  const at = accounts.findIndex((held) => held.id === account.id);
+  if (at === -1) accounts.push(account);
+  else accounts[at] = account;
+  return write(storage, accounts, account.id);
+}
+
+/** Drop an account from the directory.
+ *
+ * This erases NOTHING but the row. No token is held to revoke, no crawl data is
+ * touched, and the Google account is untouched — which is why the panel's copy
+ * for it must not say "delete account". Ending a SESSION is a different verb and
+ * a different function: see identity.js.
+ */
+export async function forgetAccount(id, { storage = chrome.storage.local } = {}) {
+  const { accounts, currentId } = await readAccounts({ storage });
+  const kept = accounts.filter((account) => account.id !== id);
+  if (kept.length === accounts.length) return { accounts, currentId };
+  // Losing the current account does not silently promote another one. Which
+  // account you are acting as is a thing the person decides; guessing it here
+  // would switch them somewhere they never asked to be.
+  return write(storage, kept, currentId === id ? "" : currentId);
+}
+
+/** Point at a different remembered account.
+ *
+ * An id that is not in the directory is refused rather than stored, so the
+ * record cannot come to name a row that does not exist.
+ */
+export async function setCurrentAccount(id, { storage = chrome.storage.local } = {}) {
+  const { accounts, currentId } = await readAccounts({ storage });
+  if (!accounts.some((account) => account.id === id)) {
+    return { accounts, currentId };
+  }
+  return write(storage, accounts, id);
+}
+
+/** Stop acting as anyone, and keep everybody listed.
+ *
+ * THIS IS WHAT SIGNING OUT MEANS HERE, and it is not `forgetAccount`. Ending a
+ * session leaves the account in the directory as a row that reads "Signed out"
+ * with a Sign in beside it; that row is how a person comes back without hunting
+ * for the address again. Removing it is a different verb, a different button,
+ * and the only one that erases anything.
+ *
+ * No account is promoted to take its place. Which account the panel acts as is
+ * the person's decision — see forgetAccount for the same reasoning.
+ */
+export async function clearCurrentAccount({ storage = chrome.storage.local } = {}) {
+  const { accounts, currentId } = await readAccounts({ storage });
+  if (!currentId) return { accounts, currentId };
+  return write(storage, accounts, "");
+}
+
+/** The account the panel is acting as, or null when it is acting as nobody. */
+export function currentAccount({ accounts, currentId }) {
+  if (!currentId) return null;
+  return accounts.find((account) => account.id === currentId) || null;
+}
+
+/** Everyone except the current account, in list order. */
+export function otherAccounts({ accounts, currentId }) {
+  return accounts.filter((account) => account.id !== currentId);
+}

--- a/extension/app.css
+++ b/extension/app.css
@@ -1097,8 +1097,8 @@
   /* The account's own photo, large enough to be a greeting rather than a
      status dot. Round for the same reason the rail's is. */
   .welcome-face {
-    width: 4rem;
-    height: 4rem;
+    width: 4.5rem;
+    height: 4.5rem;
     border-radius: 50%;
     object-fit: cover;
   }
@@ -1106,10 +1106,22 @@
 
   /* Profile page — Extension only. One centered state card on a distinct page
      background; all account states live inside the same card shell. */
+  /* The page is exactly as tall as the panel and never scrolls itself. That is
+     the first two links of the handoff's derived-height chain (REV01): the view
+     fixes the height, .profile-stage below takes what is left and is the ONE
+     scroller, and when the accounts card lands its rows wrapper takes over that
+     job from the stage.
+     `min-height: 0` is the link that is easy to miss: a flex item defaults to
+     `min-height: auto` and refuses to shrink below its content, so without it a
+     tall child grows the view instead of handing the overflow to the scroller
+     inside it — which is the page-scrolls-instead-of-rows behaviour the chain
+     exists to remove. */
   #view-profile {
     display: flex;
     flex-direction: column;
     height: 100%;
+    min-height: 0;
+    overflow: hidden;
     margin: calc(-1 * var(--sp-4));
     padding: var(--sp-4);
     background: var(--bg);
@@ -1256,7 +1268,14 @@
     color: var(--muted);
     font-size: var(--fs-sm);
   }
+  /* `align-self: stretch` is load-bearing, not tidying. .profile-state centres
+     its children, so without it this block sizes to its own CONTENT: a long
+     address made the summary wider than the card, and `max-width: 100%` on the
+     address then measured a percentage of that too-wide parent, so the ellipsis
+     never engaged and the text ran past both edges of the card. Measured at
+     320px with an 58-character address. */
   .profile-summary {
+    align-self: stretch;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -1266,6 +1285,502 @@
   .profile-summary:focus-visible {
     outline: 2px solid var(--focus);
     outline-offset: 2px;
+  }
+
+  /* Profile page — Extension only. The signed-in state is the one state with
+     chrome at both edges. `flex: 1` is what the auto margins below push
+     against: without it the state collapses to its content height and the two
+     rows settle either side of the middle instead of at the card's edges.
+     Scoped to this state by id, because the checking and signed-out states are
+     a centred stack and must stay one. */
+  #welcome-signed-in {
+    flex: 1;
+    /* The link that finishes the chain. Without it this state keeps its default
+       `min-height: auto`, refuses to shrink below its content, and the accounts
+       card below grows the page instead of scrolling its own list — which put
+       `Add another account` and `Sign out of all accounts` off the bottom of
+       the panel entirely. Measured at 400x720 with four accounts. */
+    min-height: 0;
+  }
+  /* THE CARD IS GONE FROM THIS STATE, and the element is not.
+     The design removes the surface around the account: the avatar, the greeting
+     and the address sit directly on the page, and the only card on the finished
+     screen is the accounts card. But tests/test_panel_dom.py:2946 requires all
+     three states to be DESCENDANTS of #profile-card, so the element stays and
+     its appearance goes. Neutralised rather than deleted, and scoped with
+     :has() so the checking and signed-out states keep the shell they were
+     designed with — REV01's scope box permits the signed-in state only.
+
+     `justify-content: flex-start` also closes a defect this redesign
+     introduced. The card used to CENTRE its child and SCROLL it, and centring
+     an oversized child splits the overflow in two where only the bottom half is
+     reachable: scrollTop 0 is already as far up as a scroller goes. That was
+     survivable while the sign-out button was the last child; moving it to the
+     top edge put it in the half no scroll, focus or keyboard route can reach.
+     Measured before this rule: clipped by 75px and fully hidden at 400x520 with
+     Chrome's "very large" font, by 67px at 400x700 whenever the account-lookup
+     notice and Retry are showing, and by 22px at 320x440. Not centring removes
+     the whole class of failure rather than the three cases that were found.
+
+     `overflow: visible` leaves .profile-stage as the single scroller. Two
+     nested scrollers on one screen is the other half of the same trap. */
+  .profile-card:has(#welcome-signed-in:not(.hidden)) {
+    width: 100%;
+    min-height: 0;
+    max-height: none;
+    margin-block: 0;
+    padding: 0;
+    justify-content: flex-start;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+    overflow: visible;
+  }
+  .profile-topbar {
+    align-self: stretch;
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: auto;
+  }
+  /* Borderless and quiet — it takes its weight from position, not from paint.
+     Every state is spelled out rather than left to one flat rule: the base
+     `button` rules in components.css are (0,1,1) and (0,2,1), so a bare
+     `.profile-signout` would lose the fill and the hover back to them. This is
+     the same reason .profile-signin above writes its own triple.
+     Note there is NO min-height here: the general rule gives it the panel's
+     48px control height, and that is the rule this page follows. */
+  button.profile-signout {
+    border-color: transparent;
+    border-radius: var(--radius-pill);
+    background: transparent;
+    color: var(--muted);
+  }
+  button.profile-signout:hover:not(:disabled) {
+    border-color: transparent;
+    background: var(--control-hover);
+    color: var(--text);
+  }
+  button.profile-signout:active:not(:disabled) {
+    border-color: transparent;
+    background: var(--control-hover);
+    color: var(--text);
+    transform: none;
+  }
+  /* The account mark, shown exactly when there is no photo to show. The
+     selector reads the `hidden` class renderAccount already maintains on the
+     photo, so "is there a picture" keeps one answer and one owner. */
+  .profile-face-fallback {
+    display: none;
+  }
+  #welcome-photo.hidden ~ .profile-face-fallback {
+    display: grid;
+    place-items: center;
+    width: 4.5rem;
+    height: 4.5rem;
+    border-radius: 50%;
+    background: var(--accent-weak);
+    color: var(--accent-ink);
+  }
+  .profile-face-icon {
+    width: 2.5rem;
+    height: 2.5rem;
+  }
+  /* The greeting. An h1 has no rule anywhere in either sheet, so its UA
+     `margin: .67em 0` would sit on top of .profile-summary's gap and read as
+     mysterious extra space above and below the name.
+     `overflow-wrap: anywhere` is for the name inside it: a long single-token
+     display name has nowhere to break, and at 320px it would otherwise run past
+     both edges the way the address did before .profile-summary was stretched. */
+  .profile-greeting {
+    max-width: 100%;
+    margin: var(--sp-1) 0 0;
+    font-size: var(--fs-lg);
+    font-weight: var(--fw-bold);
+    line-height: var(--lh-tight);
+    overflow-wrap: anywhere;
+  }
+  /* One line, always: an address is identity, and a wrapped one reads as two
+     facts. dir="ltr" in the markup keeps it readable inside an Arabic panel. */
+  .profile-email {
+    max-width: 100%;
+    margin: 0;
+    font-size: var(--fs-sm);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  /* Written as button.ghost.profile-manage, not .profile-manage: `button.ghost`
+     is (0,1,1) and would otherwise decide the colour on source order alone. */
+  button.ghost.profile-manage {
+    margin-top: var(--sp-2);
+    padding: var(--sp-1) var(--sp-4);
+    border-radius: var(--radius-pill);
+    color: var(--accent-ink);
+    font-size: var(--fs-sm);
+    font-weight: var(--fw-medium);
+  }
+  /* The legal row sits on the bottom edge and stays quiet. It wraps because the
+     panel can be 320px wide and two links plus a separator do not always fit. */
+  .profile-legal {
+    align-self: stretch;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    gap: var(--sp-2);
+    margin-top: auto;
+    padding-top: var(--sp-4);
+  }
+  /* The default link colour is --accent-ink, which would make the two quietest
+     items on the page its loudest. Declared here rather than per element. */
+  .profile-legal .profile-legal-link {
+    color: var(--muted);
+    font-size: var(--fs-xs);
+    font-weight: var(--fw-regular);
+    text-decoration: none;
+  }
+  .profile-legal a.profile-legal-link:hover {
+    color: var(--text);
+    text-decoration: underline;
+    text-underline-offset: 0.16em;
+  }
+  .profile-legal-sep {
+    color: var(--muted);
+    font-size: var(--fs-xs);
+  }
+
+  /* ---- the accounts card ------------------------------------------------
+     The identity block above is fixed; this is the part that grows with how
+     many accounts a person has, so it is the one allowed to shrink and scroll.
+     `min-height: 0` is what lets it: a flex item defaults to `min-height: auto`
+     and refuses to go below its content, which would push the legal row off the
+     bottom instead of scrolling the list inside. */
+  .profile-summary {
+    flex: none;
+  }
+  .accounts-card {
+    position: relative;
+    flex: 0 1 auto;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    width: 100%;
+    border: 1px solid var(--line);
+    border-radius: var(--radius-xl);
+    background: var(--surface);
+    text-align: start;
+  }
+  /* NO `overflow: hidden` on the card — the per-row menu has to be able to
+     hang outside it. The rounded corners are therefore put on the first and
+     last children instead, which is the only other way to get them. */
+  .accounts-card > :first-child {
+    border-start-start-radius: var(--radius-xl);
+    border-start-end-radius: var(--radius-xl);
+  }
+  /* `of :not(.account-menu)` because the open menu is a child of this card too,
+     and it is out of flow: it must not take the bottom corners from the row
+     that actually draws the card's last edge, and it must not be given a
+     divider above it. It lives here rather than inside its row because the row
+     sits in a clipping scroller — see .account-menu below. */
+  .accounts-card > :nth-last-child(1 of :not(.account-menu)) {
+    border-end-start-radius: var(--radius-xl);
+    border-end-end-radius: var(--radius-xl);
+  }
+  .accounts-card > :not(.account-menu) + :not(.account-menu) {
+    border-top: 1px solid var(--line);
+  }
+
+  /* Collapsed: one pill that says how many others there are by showing them. */
+  .accounts-pill {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto var(--control-height-xs);
+    align-items: center;
+    gap: var(--sp-3);
+    width: 100%;
+    padding: var(--sp-2) var(--sp-3) var(--sp-2) var(--sp-4);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-pill);
+    background: var(--surface);
+    color: var(--text);
+    font-weight: var(--fw-medium);
+    text-align: start;
+  }
+  button.accounts-pill:hover:not(:disabled) {
+    border-color: var(--line-strong);
+    background: var(--control-hover);
+    color: var(--text);
+  }
+  .accounts-pill-faces {
+    display: flex;
+    align-items: center;
+  }
+  /* The ring is what makes the overlap read as depth rather than as a smudge,
+     and it is painted in the surface colour so it reads as a cut-out. */
+  .account-face-mini {
+    display: grid;
+    place-items: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    border-radius: 50%;
+    background: var(--chip);
+    color: var(--muted);
+    font-size: var(--fs-xs);
+    font-weight: var(--fw-bold);
+    box-shadow: 0 0 0 2px var(--surface);
+  }
+  .account-face-mini + .account-face-mini {
+    margin-inline-start: -0.5rem;
+  }
+  /* A span, not a button: the pill itself is the button, and a button inside a
+     button is invalid markup that browsers repair by moving it out. It is sized
+     here rather than by `icon-button`, because that primitive only matches a
+     real button element. */
+  .accounts-pill-chevron {
+    display: grid;
+    place-items: center;
+    width: var(--control-height-xs);
+    height: var(--control-height-xs);
+    border-radius: var(--radius-pill);
+    background: var(--chip);
+    color: var(--muted);
+  }
+
+  /* Expanded: the disclosure row, the scrolling list, then the two actions. */
+  .accounts-disclosure {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 1.25rem;
+    align-items: center;
+    gap: var(--sp-2);
+    width: 100%;
+    padding: var(--sp-3) var(--sp-4);
+    border: 0;
+    background: transparent;
+    color: var(--text);
+    font-weight: var(--fw-medium);
+    text-align: start;
+  }
+  button.accounts-disclosure:hover:not(:disabled) {
+    border-color: transparent;
+    background: var(--control-hover);
+    color: var(--text);
+  }
+  .accounts-chevron {
+    transition: transform var(--dur) var(--ease);
+  }
+  .accounts-disclosure[aria-expanded="true"] .accounts-chevron {
+    transform: rotate(180deg);
+  }
+
+  /* The ONE scrolling region on this screen. `overscroll-behavior: contain`
+     stops a flick at the end of the list from scrolling whatever is behind it. */
+  .accounts-list {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+  .accounts-list > * + * {
+    border-top: 1px solid var(--line);
+  }
+
+  .account-row {
+    position: relative;
+    display: grid;
+    grid-template-columns: var(--control-height-sm) minmax(0, 1fr) var(--control-height-sm);
+    align-items: center;
+    gap: var(--sp-3);
+    padding: var(--sp-3) var(--sp-4);
+  }
+  .account-face {
+    display: grid;
+    place-items: center;
+    width: var(--control-height-sm);
+    height: var(--control-height-sm);
+    border-radius: 50%;
+    object-fit: cover;
+    background: var(--chip);
+    color: var(--muted);
+    font-size: var(--fs-md);
+    font-weight: var(--fw-bold);
+  }
+  /* `min-width: 0` is what makes the ellipsis below possible: a grid item
+     defaults to `min-width: auto` and refuses to be narrower than its content,
+     so an address would push the row wider instead of being truncated. */
+  .account-identity {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+  .accounts-card.is-bare {
+    border: 0;
+    background: transparent;
+  }
+  .account-name-line {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-2);
+    min-width: 0;
+  }
+  .account-menu-question {
+    margin: 0;
+    padding: var(--sp-3) var(--sp-4);
+    color: var(--muted);
+    font-size: var(--fs-sm);
+  }
+  .account-name,
+  .account-email {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .account-name {
+    font-weight: var(--fw-medium);
+  }
+  /* The switch target is the text column itself. The design has no "switch"
+     button, and a row that reacts to a click while looking like nothing is a
+     control nobody discovers — so it is a real button, painted as the row. */
+  button.account-switch {
+    display: block;
+    width: 100%;
+    padding: 0;
+    border: 0;
+    border-radius: var(--radius);
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-align: start;
+  }
+  button.account-switch:hover:not(:disabled) {
+    border-color: transparent;
+    background: transparent;
+    color: inherit;
+  }
+  /* Hover belongs to the ROW, not to the middle column, or the feedback would
+     stop at the edges of the text and read as a second control. */
+  .account-row:has(button.account-switch:hover) {
+    background: var(--control-hover);
+  }
+  .account-email {
+    font-size: var(--fs-sm);
+    color: var(--muted);
+  }
+  /* An inactive row: the name goes quiet so the eye can tell at a glance which
+     accounts it can act as, without reading the badge on every one. */
+  .account-row.is-signed-out .account-name {
+    color: var(--muted);
+    font-weight: var(--fw-regular);
+  }
+  .account-badge {
+    justify-self: start;
+    padding: 2px var(--sp-2);
+    border-radius: var(--radius-pill);
+    background: var(--chip);
+    color: var(--muted);
+    font-size: var(--fs-2xs);
+    font-weight: var(--fw-medium);
+    white-space: nowrap;
+  }
+  /* The second line of a signed-out row. It sits under the text column, not
+     under the avatar, so the buttons line up with the name they belong to. */
+  .account-actions {
+    grid-column: 2 / -1;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--sp-2);
+    padding-top: var(--sp-1);
+  }
+  button.account-action {
+    border-radius: var(--radius-pill);
+  }
+  button.account-menu-button {
+    border-color: transparent;
+    border-radius: var(--radius-pill);
+    background: transparent;
+    color: var(--muted);
+  }
+  button.account-menu-button:hover:not(:disabled) {
+    border-color: transparent;
+    background: var(--control-hover);
+    color: var(--text);
+  }
+
+  /* ANCHORED TO THE CARD, NOT TO ITS ROW, and the difference is whether it can
+     be seen at all. The rows live in an `overflow-y: auto` scroller, so a menu
+     positioned inside one is clipped by it: measured at 5px cut off at 400px
+     wide and 61px at 320px, in both directions, for the rows nearest an edge.
+     The handoff names this fallback itself — "if a row's menu can still not fit
+     either way, anchor it to the card instead of the row". The card sets no
+     overflow, so nothing clips it here.
+     `top` is therefore computed in app.js from where the row currently is,
+     which is the one value on this screen that no token can express. */
+  .account-menu {
+    position: absolute;
+    inset-inline-end: var(--sp-3);
+    z-index: var(--z-overlay);
+    min-width: 11.25rem;
+    overflow: hidden;
+    border: 1px solid var(--line);
+    border-radius: var(--radius-lg);
+    background: var(--surface-raised);
+    box-shadow: var(--shadow-lg);
+  }
+  .account-menu > * + * {
+    border-top: 1px solid var(--line);
+  }
+  button.account-menu-item {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    width: 100%;
+    padding: var(--sp-2) var(--sp-4);
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    color: var(--text);
+    font-weight: var(--fw-regular);
+    text-align: start;
+  }
+  button.account-menu-item:hover:not(:disabled) {
+    border-color: transparent;
+    background: var(--control-hover);
+    color: var(--text);
+  }
+  button.account-menu-item.is-destructive {
+    color: var(--red);
+  }
+  button.account-menu-item.is-destructive:hover:not(:disabled) {
+    background: var(--red-weak);
+    color: var(--red);
+  }
+
+  /* The two card-level actions. Taller than a control on purpose: they are
+     destinations rather than adjustments, and the design gives them room. */
+  .accounts-action {
+    display: grid;
+    grid-template-columns: 1.5rem minmax(0, 1fr);
+    align-items: center;
+    gap: var(--sp-4);
+    width: 100%;
+    min-height: 3.5rem;
+    padding: var(--sp-3) var(--sp-4);
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    color: var(--text);
+    font-weight: var(--fw-regular);
+    text-align: start;
+  }
+  button.accounts-action:hover:not(:disabled) {
+    border-color: transparent;
+    background: var(--control-hover);
+    color: var(--text);
+  }
+  .accounts-action-icon {
+    color: var(--accent-ink);
+  }
+  .accounts-action-icon.is-quiet {
+    color: var(--muted);
   }
 
   /* Appearance is a complete Android-style destination. It uses the same

--- a/extension/app.html
+++ b/extension/app.html
@@ -1136,20 +1136,92 @@
             <p class="notice hidden" role="status" aria-live="polite" id="signin-problem"></p>
           </div>
 
-          <!-- Signed in. Account identity is the primary content. -->
+          <!-- Signed in. Account identity is the primary content, centred
+               between two edges: the sign-out control at the top, the legal
+               links at the bottom. Both rows stretch across the card; the
+               identity block keeps the centre. -->
           <div class="profile-state hidden" id="welcome-signed-in">
+            <div class="profile-topbar">
+              <!-- Icon-only, so it carries its name in aria-label AND title:
+                   the first for a screen reader, the second for the pointer. -->
+              <button class="icon-button xs profile-signout" id="signout" type="button"
+                      aria-label="Sign out" title="Sign out">
+                <svg class="sx-icon" aria-hidden="true">
+                  <use href="icons/material-icons.svg#logout"></use>
+                </svg>
+              </button>
+            </div>
+
             <div class="profile-summary" id="welcome-summary" tabindex="-1"
                  aria-label="Signed in">
               <img class="welcome-face hidden" id="welcome-photo" alt="" aria-hidden="true">
-              <h1 id="welcome-name">Signed in</h1>
-              <p class="muted" id="welcome-email"></p>
+              <!-- What the page wears when Google returns no picture. It has no
+                   id on purpose: a permanently aria-hidden element carrying one
+                   is refused by tests/test_panel_wiring.py, and it needs none —
+                   CSS shows it exactly when the photo above is hidden. -->
+              <span class="profile-face-fallback" aria-hidden="true">
+                <svg class="sx-icon profile-face-icon" aria-hidden="true">
+                  <use href="icons/material-icons.svg#account-circle"></use>
+                </svg>
+              </span>
+              <!-- The greeting is its own element so #welcome-name keeps holding
+                   the account name and NOTHING else: a test compares that node's
+                   text to what Google returned, exactly. It starts hidden and is
+                   shown only once there is a real name — otherwise the line reads
+                   "Hi, Signed in" during the moment before the account arrives,
+                   and again whenever the lookup fails.
+                   dir="auto" is on the name, the one field here that can hold a
+                   right-to-left script: Google returns the display name as the
+                   person wrote it, and inside this LTR shell a name that mixes
+                   scripts resolves its neutral separator to level 0 and lands the
+                   Latin half on the wrong side. Measured, and fixed by this
+                   attribute alone. Same pairing the panel already uses for
+                   #f-name / #f-name-ar. An address cannot be RTL, so the line
+                   below stays ltr. -->
+              <h1 class="profile-greeting"><span id="welcome-greeting"
+                  class="hidden">Hi,</span> <span id="welcome-name"
+                  dir="auto">Signed in</span></h1>
+              <p class="muted profile-email" id="welcome-email" dir="ltr"></p>
               <p class="notice hidden" role="status" aria-live="polite"
                  id="account-detail-status"></p>
               <button class="ghost compact hidden" id="retry-account" type="button">
                 Retry
               </button>
+              <!-- Disabled until the Manage account screen exists. A control
+                   that looks live and answers nothing is worse than one that
+                   says plainly it is not ready yet. -->
+              <button class="ghost profile-manage" id="manage-account" type="button"
+                      disabled>
+                Manage your account
+              </button>
             </div>
-            <button class="ghost compact" id="signout" type="button">Sign out</button>
+
+            <!-- The accounts card. Every row inside is rendered by app.js from
+                 the remembered directory, so this element is only the frame:
+                 the rows are data, and data does not belong in a template.
+                 It carries no `card` class — this surface has no padding, its
+                 children draw their own dividers, and a per-row menu has to be
+                 able to overflow it, which is three fights with that primitive
+                 rather than a reuse of it. -->
+            <section class="accounts-card hidden" id="accounts-card"
+                     aria-label="Your accounts"></section>
+
+            <p class="notice hidden" role="status" aria-live="polite"
+               id="accounts-status"></p>
+
+            <div class="profile-legal">
+              <a class="profile-legal-link"
+                 href="https://muhammadbayoumi.github.io/mbiXsite/scrapex-privacy.html"
+                 target="_blank" rel="noopener noreferrer">Privacy Policy</a>
+              <span class="profile-legal-sep" aria-hidden="true">•</span>
+              <!-- Disabled until the terms are written. The store listing says
+                   ScrapeX is not a service and has no account, so this text has
+                   to be authored before it can be linked to. -->
+              <button class="link profile-legal-link" id="terms-of-service"
+                      type="button" disabled>
+                Terms of Service
+              </button>
+            </div>
           </div>
 
         </div>

--- a/extension/app.js
+++ b/extension/app.js
@@ -12,7 +12,10 @@ import { autostartStatus, checkStartup, setAutostart, startEngine, upgradeDataba
 import { capabilityProblem, deployedFrom, installedVersion, CAPABILITY_REPORTING_SINCE, isOlder } from "./version.js";
 import { PROTOCOL_VERSION } from "./transport.js";
 import { latestEngineRelease } from "./releases.js";
-import { getToken, accountFor, forgetToken, revokeToken } from "./identity.js";
+import { getToken, accountFor, authorize, forgetToken, revokeToken } from "./identity.js";
+import {
+  clearCurrentAccount, forgetAccount, readAccounts, rememberAccount,
+} from "./accounts.js";
 import { backUp, fetchLatest, fetchPanelPack } from "./drive.js";
 import { readPanelPack, datasetSummaries } from "./bundleview.js";
 import { ensureFolder, ensureSpreadsheet, DEFAULT_WORKBOOK, SHEET_FOLDER } from "./sheets.js";
@@ -141,6 +144,14 @@ const state = {
   // Chrome holds the token; this is the copy the panel lends onward, and
   // it is never written to storage.
   token: "", account: null, accountStatus: null,
+  // The DIRECTORY, not a keyring: who this browser has seen, read from
+  // chrome.storage.local by accounts.js. It holds names and addresses the panel
+  // already paints and never a credential — the owner's ruling of 2026-08-11.
+  accounts: [], currentAccountId: "",
+  // Card state. `openAccountMenu` holds an id rather than a boolean so "exactly
+  // one menu open" is a property of the state instead of a rule the handlers
+  // have to remember to keep.
+  accountsExpanded: true, openAccountMenu: null, pendingRemove: null,
   installedVersion: "", engineVersion: "", versionReport: null,
   versionStatus: "pending",
   // null means the engine never said, which is a THIRD state and not a
@@ -2263,11 +2274,61 @@ function setGoogleButtonScheme() {
   });
 }
 
+// ---- the remembered directory ---------------------------------------------
+// Every call here is wrapped, and every failure is swallowed. The directory is
+// what makes SWITCHING possible; signing in and using the panel does not depend
+// on it. A storage fault must not turn a working account into a broken panel —
+// so this layer is allowed to be absent, and nothing above it may assume it.
+
+async function loadAccountDirectory() {
+  try {
+    const held = await readAccounts();
+    state.accounts = held.accounts;
+    state.currentAccountId = held.currentId;
+  } catch (_) {
+    state.accounts = [];
+    state.currentAccountId = "";
+  }
+}
+
+/** Keep the directory in step with whoever just proved who they are.
+ *
+ * Called on EVERY successful lookup, not only the first: a name or a photo that
+ * changed at Google is the truth, and the row should be carrying it. An account
+ * with no `sub` is not remembered — accounts.js refuses it, and a row nothing
+ * can switch to is worse than no row.
+ */
+async function rememberSignedInAccount(account) {
+  if (!account || !account.id) return;
+  try {
+    const held = await rememberAccount(account);
+    state.accounts = held.accounts;
+    state.currentAccountId = held.currentId;
+  } catch (_) { /* the panel works without the directory */ }
+}
+
+/** Sign out: stop acting as the account, and KEEP it listed.
+ *
+ * The row becomes the design's signed-out row — the way back in without having
+ * to type the address again. Removing it is a different button entirely, and
+ * the only one that erases anything.
+ */
+async function endCurrentAccountSession() {
+  try {
+    const held = await clearCurrentAccount();
+    state.accounts = held.accounts;
+    state.currentAccountId = held.currentId;
+  } catch (_) { /* the panel works without the directory */ }
+}
+
 async function loadAccount({ interactive = false } = {}) {
   const generation = ++accountGeneration;
   const current = () => generation === accountGeneration && !panelController.signal.aborted;
   markStartup("account-check-start", {interactive});
   setChecking(true);
+  // Read before asking Chrome: the directory is what the switcher paints, and
+  // it is known from storage alone — it must not wait on a network round trip.
+  await loadAccountDirectory();
   try {
     const result = await getToken({interactive, signal: panelController.signal});
     if (!current()) return {state: "stale"};
@@ -2290,6 +2351,7 @@ async function loadAccount({ interactive = false } = {}) {
       state.account = accountResult.account;
       state.accountStatus = null;
       renderAccount({});
+      await rememberSignedInAccount(accountResult.account);
       return { ...result, account: accountResult.account };
     }
 
@@ -2351,6 +2413,7 @@ async function loadAccountDetails() {
       state.account = result.account;
       state.accountStatus = null;
       renderAccount({});
+      await rememberSignedInAccount(result.account);
       return;
     }
     if (result.state === "unauthorized") {
@@ -2397,6 +2460,12 @@ function renderAccount({ tokenProblem = null } = {}) {
     if (status) status.classList.add("hidden");
     if (retry) retry.classList.add("hidden");
     if (summary) summary.setAttribute("aria-label", "Signed in");
+    // Nothing is open on a card nobody can see, and a menu left open would
+    // reappear over whichever account signs in next.
+    state.openAccountMenu = null;
+    state.pendingRemove = null;
+    renderAccountsCard();
+    setAccountsStatus("");
     updateRailLabel();
     return;
   }
@@ -2408,6 +2477,10 @@ function renderAccount({ tokenProblem = null } = {}) {
   // readable. Saying "Signed in" is true; inventing a name would not be.
   const name = (account && account.name) || "";
   $("welcome-name").textContent = name || "Signed in";
+  // "Hi," is only true once there is someone to greet. Without this the line
+  // reads "Hi, Signed in" in the two states that have a token but no profile:
+  // the moment before Google answers, and every case where the lookup failed.
+  $("welcome-greeting").classList.toggle("hidden", !name);
   const email = (account && account.email) || "";
   $("welcome-email").textContent = email;
   $("welcome-email").classList.toggle("hidden", !email);
@@ -2438,7 +2511,455 @@ function renderAccount({ tokenProblem = null } = {}) {
   }
 
   summary.setAttribute("aria-label", name ? `Signed in as ${name}` : "Signed in");
+  renderAccountsCard();
   updateRailLabel();
+}
+
+// ---- the accounts card -----------------------------------------------------
+//
+// Every row here is DATA, so none of it lives in app.html: the card is rendered
+// from the remembered directory. Names and addresses come from Google and are
+// therefore untrusted, so every one of them is written with `textContent` and
+// nothing on this path builds markup by string concatenation. The only innerHTML
+// below carries `icon()`, whose argument is a literal in this file.
+//
+// WHAT "SIGNED OUT" MEANS ON A ROW. The directory deliberately stores no session
+// state — a cached "signed in" is a fact that goes stale on disk and then lies.
+// The only account this panel KNOWS it holds a token for is the current one;
+// every other row is offered as signed out until a silent authorisation proves
+// otherwise. That check needs the Web OAuth client, which this build does not
+// have yet, so today every other row renders as signed out. That is the truth
+// about this build rather than a placeholder.
+
+function accountInitial(account) {
+  const source = String(account.name || account.email || "").trim();
+  return source ? source[0].toUpperCase() : "?";
+}
+
+function accountInitialFace(account, className) {
+  const face = el("span", className, accountInitial(account));
+  face.setAttribute("aria-hidden", "true");
+  return face;
+}
+
+/** The face for a row: the photo when there is one, the initial when there is
+ *  not — and the initial again the moment the photo fails, because Google's
+ *  photo URLs expire and a broken image is worse than a letter. */
+function accountFace(account, className) {
+  if (!account.picture) return accountInitialFace(account, className);
+  const img = document.createElement("img");
+  img.className = className;
+  img.alt = "";
+  img.setAttribute("aria-hidden", "true");
+  img.addEventListener("error", () => {
+    img.replaceWith(accountInitialFace(account, className));
+  }, { once: true });
+  img.src = account.picture;
+  return img;
+}
+
+function accountLabel(account) {
+  return account.name || account.email || "Account";
+}
+
+/** One row. `signedIn` decides whether it can be switched to or must be
+ *  re-authorised first. */
+function accountRow(account, { signedIn }) {
+  const row = el("div", `account-row${signedIn ? "" : " is-signed-out"}`);
+  row.dataset.accountId = account.id;
+  row.append(accountFace(account, "account-face"));
+
+  const identity = el("div", "account-identity");
+  const nameLine = el("div", "account-name-line");
+  nameLine.append(el("span", "account-name", accountLabel(account)));
+  if (!signedIn) nameLine.append(el("span", "account-badge", "Signed out"));
+  identity.append(nameLine);
+  const email = el("span", "account-email", account.email);
+  email.setAttribute("dir", "ltr");
+  identity.append(email);
+
+  if (signedIn) {
+    // The whole text column is the switch target, not a separate control: the
+    // design has no "switch" button, and giving the row a click handler while
+    // it looks like a button to nobody is how a control becomes undiscoverable.
+    const target = el("button", "account-switch");
+    target.type = "button";
+    target.setAttribute("aria-label", `Use ${accountLabel(account)}`);
+    target.append(identity);
+    target.addEventListener("click", () => switchToAccount(account.id));
+    row.append(target);
+  } else {
+    row.append(identity);
+  }
+
+  const menuButton = el("button", "icon-button compact account-menu-button");
+  menuButton.type = "button";
+  menuButton.setAttribute("aria-label", `Actions for ${accountLabel(account)}`);
+  menuButton.setAttribute("aria-haspopup", "menu");
+  menuButton.setAttribute("aria-expanded", String(state.openAccountMenu === account.id));
+  menuButton.innerHTML = icon("more-vert");
+  menuButton.addEventListener("click", (event) => {
+    event.stopPropagation();
+    toggleAccountMenu(account.id);
+  });
+  row.append(menuButton);
+
+  if (!signedIn) {
+    const actions = el("div", "account-actions");
+    const signIn = el("button", "compact account-action", "Sign in");
+    signIn.type = "button";
+    signIn.addEventListener("click", () => signInToAccount(account.id));
+    const remove = el("button", "ghost compact account-action", "Remove");
+    remove.type = "button";
+    // No confirm: this row holds no session and erases nothing. A confirm step
+    // in front of a harmless action teaches people to click through the ones
+    // that are not.
+    remove.addEventListener("click", () => removeAccount(account.id));
+    actions.append(signIn, remove);
+    row.append(actions);
+  }
+
+  // The menu is NOT appended here. It belongs to the card, because this row
+  // lives inside a clipping scroller — see renderAccountsCard.
+  return row;
+}
+
+/** The per-row menu, and the confirm step that lives inside it.
+ *
+ * NOT A DIALOG, and not by preference: tests/test_panel_dom.py forbids
+ * `[role="dialog"]` anywhere inside #view-profile. The confirm therefore
+ * replaces the menu's own contents, which also keeps the question next to the
+ * row it is about instead of floating over the whole panel.
+ */
+function accountMenu(account, { signedIn }) {
+  const menu = el("div", "account-menu");
+  menu.setAttribute("role", "menu");
+  menu.dataset.accountId = account.id;
+
+  if (state.pendingRemove === account.id) {
+    // Says what it does AND what it does not. In a local-first tool "remove
+    // account" reads as deleting the Google account, and it does not: nothing
+    // leaves Google and no collected data is touched.
+    menu.append(el("p", "account-menu-question",
+      `Remove ${accountLabel(account)} from ScrapeX? The Google account is not `
+      + "touched and no collected data is erased — this browser just stops "
+      + "listing it."));
+    const confirm = el("button", "account-menu-item is-destructive", "Remove");
+    confirm.type = "button";
+    confirm.setAttribute("role", "menuitem");
+    confirm.addEventListener("click", () => removeAccount(account.id));
+    const cancel = el("button", "account-menu-item", "Keep it");
+    cancel.type = "button";
+    cancel.setAttribute("role", "menuitem");
+    cancel.addEventListener("click", () => {
+      state.pendingRemove = null;
+      renderAccountsCard();
+      focusAccountMenuButton(account.id);
+    });
+    menu.append(confirm, cancel);
+    return menu;
+  }
+
+  if (signedIn) {
+    const signOut = el("button", "account-menu-item", "Sign out");
+    signOut.type = "button";
+    signOut.setAttribute("role", "menuitem");
+    signOut.addEventListener("click", () => signOutOfAccount(account.id));
+    menu.append(signOut);
+  }
+  const remove = el("button", "account-menu-item is-destructive", "Remove from ScrapeX");
+  remove.type = "button";
+  remove.setAttribute("role", "menuitem");
+  remove.addEventListener("click", () => {
+    state.pendingRemove = account.id;
+    renderAccountsCard();
+    // Focus the confirm, so a keyboard user is standing on the answer to the
+    // question that just appeared rather than back at the top of the menu.
+    const confirm = $("accounts-card").querySelector(".account-menu .is-destructive");
+    if (confirm) confirm.focus({ preventScroll: true });
+  });
+  menu.append(remove);
+  return menu;
+}
+
+function accountsAction(label, symbol, { quiet = false, onClick }) {
+  const button = el("button", "accounts-action");
+  button.type = "button";
+  button.innerHTML = icon(symbol, `lg accounts-action-icon${quiet ? " is-quiet" : ""}`);
+  button.append(el("span", "", label));
+  button.addEventListener("click", onClick);
+  return button;
+}
+
+function accountsCollapsedPill(others) {
+  const pill = el("button", "accounts-pill");
+  pill.type = "button";
+  pill.setAttribute("aria-expanded", "false");
+  pill.setAttribute("aria-controls", "accounts-list");
+  pill.append(el("span", "", "Show more accounts"));
+
+  const faces = el("span", "accounts-pill-faces");
+  faces.setAttribute("aria-hidden", "true");
+  for (const account of others.slice(0, 3)) {
+    faces.append(accountFace(account, "account-face-mini"));
+  }
+  pill.append(faces);
+
+  const chevron = el("span", "accounts-pill-chevron icon-button xs");
+  chevron.setAttribute("aria-hidden", "true");
+  chevron.innerHTML = icon("expand-more");
+  pill.append(chevron);
+  pill.addEventListener("click", () => toggleAccountsList());
+  return pill;
+}
+
+function renderAccountsCard() {
+  const card = $("accounts-card");
+  if (!card) return;
+
+  // WHERE THE LIST WAS. Every state change rebuilds this card from scratch,
+  // which throws the scroller back to the top — and the row whose menu was just
+  // opened goes with it. Measured: the menu ended 205px below the visible list,
+  // clipped and unreachable, for a row the person had scrolled to.
+  const previous = card.querySelector(".accounts-list");
+  const scrollTop = previous ? previous.scrollTop : 0;
+
+  const signedIn = Boolean(state.token);
+  card.textContent = "";
+  card.classList.toggle("hidden", !signedIn);
+  card.classList.remove("is-bare");
+  if (!signedIn) return;
+
+  const others = state.accounts.filter((account) => account.id !== state.currentAccountId);
+
+  // Nobody else is listed yet, so there is nothing to disclose and nothing to
+  // sign out of "as well". One row, and it is the one that changes that.
+  if (!others.length) {
+    card.append(accountsAction("Add another account", "add", { onClick: addAnotherAccount }));
+    return;
+  }
+
+  if (!state.accountsExpanded) {
+    card.classList.add("is-bare");
+    card.append(accountsCollapsedPill(others));
+    return;
+  }
+
+  const disclosure = el("button", "accounts-disclosure");
+  disclosure.type = "button";
+  disclosure.setAttribute("aria-expanded", "true");
+  disclosure.setAttribute("aria-controls", "accounts-list");
+  disclosure.append(el("span", "", "Hide more accounts"));
+  disclosure.insertAdjacentHTML("beforeend", icon("expand-more", "accounts-chevron"));
+  disclosure.addEventListener("click", () => toggleAccountsList());
+  card.append(disclosure);
+
+  const list = el("div", "accounts-list");
+  list.id = "accounts-list";
+  for (const account of others) {
+    // See the note at the top of this section: without the Web OAuth client
+    // nothing can be authorised silently, so no other row can be shown as
+    // signed in without saying something this build cannot know.
+    list.append(accountRow(account, { signedIn: false }));
+  }
+  card.append(list);
+
+  card.append(accountsAction("Add another account", "add", { onClick: addAnotherAccount }));
+  card.append(accountsAction("Sign out of all accounts", "logout",
+                             { quiet: true, onClick: signOutOfAllAccounts }));
+
+  // Put the scroller back before deciding where the menu goes: where it can fit
+  // depends on where its row currently sits, and that is not settled until now.
+  list.scrollTop = scrollTop;
+
+  const open = others.find((account) => account.id === state.openAccountMenu);
+  if (open) {
+    card.append(accountMenu(open, { signedIn: false }));
+    placeOpenAccountMenu();
+  }
+
+  // The menu FOLLOWS its row; it is never closed from here.
+  //
+  // Closing on scroll was tried and is wrong, because scroll events are
+  // ASYNCHRONOUS: restoring the scroll position two lines above queues an event
+  // that arrives after this function returns, so the menu closed itself the
+  // instant it was opened on any row the person had scrolled to. Repositioning
+  // has no such race — and placeOpenAccountMenu clamps inside the card, so a
+  // row scrolled out of view leaves the menu parked at the edge rather than
+  // adrift.
+  list.addEventListener("scroll", () => {
+    if (state.openAccountMenu) placeOpenAccountMenu();
+  }, { passive: true });
+}
+
+/** Put the open menu where it fits, measured against the card it hangs in.
+ *
+ * Preferred position is just under the ⋮ that opened it. When there is not room
+ * below, it opens upward from just above it instead; when neither fits — a very
+ * short panel with a tall menu — it is clamped inside the card, because a menu
+ * half outside its surface is worse than one that does not quite line up.
+ *
+ * Everything here is read after layout, because it depends on where the row
+ * currently is, and scrolling moves that.
+ */
+/** The ⋮ the open menu belongs to, or null when there is no menu open. */
+function triggerForOpenMenu() {
+  const card = $("accounts-card");
+  if (!card || !state.openAccountMenu) return null;
+  const row = card.querySelector(
+    `.account-row[data-account-id="${CSS.escape(state.openAccountMenu)}"]`);
+  return row ? row.querySelector(".account-menu-button") : null;
+}
+
+function placeOpenAccountMenu() {
+  const card = $("accounts-card");
+  const menu = card && card.querySelector(".account-menu");
+  if (!menu) return;
+  const trigger = triggerForOpenMenu();
+  if (!trigger) return;
+
+  const cardBox = card.getBoundingClientRect();
+  const triggerBox = trigger.getBoundingClientRect();
+  const gap = 4;
+  const below = triggerBox.bottom - cardBox.top + gap;
+  const above = triggerBox.top - cardBox.top - menu.offsetHeight - gap;
+  const highest = gap;
+  const lowest = card.clientHeight - menu.offsetHeight - gap;
+
+  let top = below;
+  if (below > lowest) top = above;
+  menu.style.top = `${Math.round(Math.max(highest, Math.min(top, lowest)))}px`;
+}
+
+function focusAccountMenuButton(id) {
+  const card = $("accounts-card");
+  if (!card) return;
+  const row = card.querySelector(`.account-row[data-account-id="${CSS.escape(id)}"]`);
+  const button = row && row.querySelector(".account-menu-button");
+  if (button) button.focus({ preventScroll: true });
+}
+
+function toggleAccountsList() {
+  state.accountsExpanded = !state.accountsExpanded;
+  // Collapsing hides the rows a menu is anchored to, and a menu left open would
+  // be re-opened by the next expand for a row nobody is looking at any more.
+  state.openAccountMenu = null;
+  state.pendingRemove = null;
+  renderAccountsCard();
+}
+
+function toggleAccountMenu(id) {
+  const opening = state.openAccountMenu !== id;
+  state.openAccountMenu = opening ? id : null;
+  // A confirm belongs to the menu that raised it. Opening another one, or
+  // closing this one, ends the question rather than carrying it around.
+  state.pendingRemove = null;
+  renderAccountsCard();
+  if (!opening) focusAccountMenuButton(id);
+}
+
+function closeAccountMenu({ restoreFocus = false } = {}) {
+  if (!state.openAccountMenu) return;
+  const id = state.openAccountMenu;
+  state.openAccountMenu = null;
+  state.pendingRemove = null;
+  renderAccountsCard();
+  if (restoreFocus) focusAccountMenuButton(id);
+}
+
+function setAccountsStatus(detail) {
+  const status = $("accounts-status");
+  if (!status) return;
+  status.textContent = detail || "";
+  status.classList.toggle("hidden", !detail);
+}
+
+async function removeAccount(id) {
+  state.pendingRemove = null;
+  state.openAccountMenu = null;
+  try {
+    const held = await forgetAccount(id);
+    state.accounts = held.accounts;
+    state.currentAccountId = held.currentId;
+  } catch (_) { /* the panel works without the directory */ }
+  setAccountsStatus("");
+  renderAccountsCard();
+}
+
+// The four actions that need a token for an account this panel is not currently
+// holding one for. Each is a single call into identity.js, and each reports what
+// came back rather than pretending it worked — today that is the same sentence
+// for all of them, because the build has no Web OAuth client yet and
+// `authorize` refuses before opening anything.
+
+async function switchToAccount(id) {
+  const account = state.accounts.find((held) => held.id === id);
+  if (!account) return;
+  closeAccountMenu();
+  const result = await authorize({ email: account.email, interactive: false });
+  if (result.state !== "ok" && result.state !== "partial") {
+    setAccountsStatus(result.detail);
+    return;
+  }
+  await adoptAuthorizedAccount(result.token);
+}
+
+async function signInToAccount(id) {
+  const account = state.accounts.find((held) => held.id === id);
+  if (!account) return;
+  closeAccountMenu();
+  const result = await authorize({ email: account.email, interactive: true });
+  if (result.state !== "ok" && result.state !== "partial") {
+    setAccountsStatus(result.detail);
+    return;
+  }
+  await adoptAuthorizedAccount(result.token);
+}
+
+async function addAnotherAccount() {
+  closeAccountMenu();
+  const result = await authorize({ interactive: true });
+  if (result.state !== "ok" && result.state !== "partial") {
+    setAccountsStatus(result.detail);
+    return;
+  }
+  await adoptAuthorizedAccount(result.token);
+}
+
+/** Take a freshly authorised token as the panel's current identity. */
+async function adoptAuthorizedAccount(token) {
+  setAccountsStatus("");
+  const lookup = await accountFor(token, window.fetch, {signal: panelController.signal});
+  if (lookup.state !== "ok") {
+    setAccountsStatus(lookup.detail);
+    return;
+  }
+  state.token = token;
+  state.account = lookup.account;
+  state.accountStatus = null;
+  await rememberSignedInAccount(lookup.account);
+  renderAccount({});
+  renderAccountsCard();
+}
+
+async function signOutOfAccount(id) {
+  closeAccountMenu();
+  if (id === state.currentAccountId) {
+    const button = $("signout");
+    if (button) button.click();
+    return;
+  }
+  // No token is held for any other account — there is nothing to end here, and
+  // saying so is better than a button that appears to work and does nothing.
+  setAccountsStatus("That account has no session on this device to end.");
+}
+
+async function signOutOfAllAccounts() {
+  closeAccountMenu();
+  const button = $("signout");
+  // The current account is the only one holding a session, so ending it ends
+  // them all. The row for every account stays; signing out is not removing.
+  if (button) button.click();
 }
 
 // ---- what is installed, and what is available -----------------------------
@@ -4487,6 +5008,10 @@ function wireStartupShell() {
       state.token = "";
       state.account = null;
       state.accountStatus = null;
+      // The row STAYS. Signing out ends a session; it does not remove an
+      // account, and the person has to be able to come back through the same
+      // row rather than typing the address again.
+      await endCurrentAccountSession();
       renderAccount(ended.state === "local-only"
         // Said out loud rather than swallowed: this browser has forgotten the
         // account, and Google has not. The difference matters on a shared
@@ -4499,6 +5024,28 @@ function wireStartupShell() {
     } finally {
       btn.disabled = false;
     }
+  });
+
+  // A menu closes the two ways every menu closes. Both are registered once,
+  // here, rather than per render: the card is rebuilt on every state change and
+  // listeners attached to it would be added again each time.
+  //
+  // Capture phase, and only while a menu is actually open: Escape already means
+  // something to the workspace menu and the rail, and the innermost open thing
+  // is the one that should answer it.
+  document.addEventListener("keydown", (event) => {
+    if (event.key !== "Escape" || !state.openAccountMenu) return;
+    event.stopPropagation();
+    closeAccountMenu({ restoreFocus: true });
+  }, true);
+  // No focus restored on an outside click: the person is already pointing at
+  // wherever they want to be, and moving focus back would fight them for it.
+  document.addEventListener("click", (event) => {
+    if (!state.openAccountMenu) return;
+    const target = event.target;
+    if (target && typeof target.closest === "function"
+        && target.closest(".account-menu, .account-menu-button")) return;
+    closeAccountMenu();
   });
 
   setGoogleButtonScheme();

--- a/extension/components.css
+++ b/extension/components.css
@@ -468,6 +468,24 @@ button.icon-button.compact,
   min-width: var(--control-height-sm);
 }
 
+/* The smallest square, and the only one that also lowers min-height.
+   `compact` shrinks a control to the small notch; `xs` goes one further, to
+   --control-height-xs (32px on both surfaces). It exists because the Profile
+   design puts a secondary sign-out icon in a top bar where a 48px square reads
+   as the loudest thing on a page about an account, and the owner ruled on
+   2026-08-11 that both sizes belong to the general rule rather than to one
+   screen's stylesheet.
+   USE IT FOR SECONDARY ICON CONTROLS ONLY. 32px is under the 44px coarse-pointer
+   floor this sheet applies below, and under --control-height-sm. A primary or
+   destructive action, or anything on a touch surface, uses `icon-button` or
+   `icon-button compact` instead. */
+button.icon-button.xs,
+.button.icon-button.xs {
+  width: var(--control-height-xs);
+  min-width: var(--control-height-xs);
+  min-height: var(--control-height-xs);
+}
+
 button.compact,
 .button.compact {
   min-height: var(--control-height-sm);

--- a/extension/icons/material-icons.svg
+++ b/extension/icons/material-icons.svg
@@ -157,4 +157,7 @@
   <symbol id="expand-more" viewBox="0 0 24 24">
     <path d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"/>
   </symbol>
+  <symbol id="logout" viewBox="0 0 24 24">
+    <path d="M17 7l-1.41 1.41L18.17 11H8v2h10.17l-2.58 2.58L17 17l5-5zM4 5h8V3H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h8v-2H4V5z"/>
+  </symbol>
 </svg>

--- a/extension/identity.js
+++ b/extension/identity.js
@@ -303,6 +303,12 @@ export async function accountFor(token, fetchImpl = fetch, {signal = null} = {})
   return {
     state: "ok",
     account: {
+      // `sub` is Google's STABLE identifier for the account, and the only field
+      // here that is safe to key a remembered account on. An address is not: a
+      // person can change theirs, and Workspace admins reassign them — keying on
+      // it would make one account silently become two rows, or worse, make a
+      // renamed address land on somebody else's row. accounts.js requires this.
+      id: typeof body.sub === "string" ? body.sub : "",
       name: typeof body.name === "string" ? body.name : "",
       email: typeof body.email === "string" ? body.email : "",
       // Google serves this from lh3.googleusercontent.com and the URL expires.
@@ -311,6 +317,198 @@ export async function accountFor(token, fetchImpl = fetch, {signal = null} = {})
       picture: typeof body.picture === "string" ? body.picture : "",
     },
   };
+}
+
+// ---- more than one account -------------------------------------------------
+//
+// `getAuthToken` above can only ever speak for ONE account: the primary account
+// of the Chrome profile. It takes no chooser and offers no way to name someone
+// else, so an account SWITCHER cannot be built on it. `launchWebAuthFlow` can:
+// it opens Google's own screen, and `login_hint` names which account to use.
+//
+// THE OWNER'S RULING OF 2026-08-11 chose the variant of this that keeps the
+// 2026-08-05 ruling intact: «الصيغة الثالثة، بلا تخزين اعتمادات». So the flow
+// here is the IMPLICIT one — `response_type=token`. It returns an access token
+// and NO refresh token, which is exactly the point: there is no long-lived
+// credential to store, accounts.js keeps a directory rather than a keyring, and
+// a token for any account is minted at the moment it is needed.
+//
+// WHAT IT COSTS, said plainly: an access token lives about an hour and cannot be
+// renewed offline. A silent mint (`prompt=none`) works only while Google's own
+// session in this browser is alive. When it is not, the account is not broken —
+// it is SIGNED OUT, which is a state the design already draws, and one click
+// re-authorises it.
+//
+// WHY THE CODE FLOW IS NOT USED. Exchanging an authorization code at Google's
+// token endpoint requires a client secret, and an extension cannot hold one: it
+// ships to every user. PKCE removes the secret for installed apps, but the thing
+// it buys is a REFRESH token — the credential this design deliberately declines
+// to store. There is nothing to gain and a ruling to break.
+
+/** Google's authorisation screen. */
+const AUTH_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth";
+
+/** The Web-application OAuth client, which the extension does not have yet.
+ *
+ * NOT the client in manifest.json. That one is of type "Chrome Extension" and is
+ * bound to `getAuthToken`; `launchWebAuthFlow` is refused against it. A second
+ * client of type "Web application" has to be created in Google Cloud with this
+ * extension's redirect URL — `chrome.identity.getRedirectURL()`, which resolves
+ * to https://<extension-id>.chromiumapp.org/ — as an authorised redirect URI.
+ *
+ * IT IS EMPTY ON PURPOSE, and `authorize` refuses with `misconfigured` while it
+ * is. A placeholder id would fail against Google with a message about the client
+ * rather than about the thing that is actually missing, and the one failure the
+ * owner cannot fix by trying again must not look like the ones he can.
+ */
+export const WEB_CLIENT_ID = "";
+
+/** Build the URL Google's screen is opened at.
+ *
+ * `prompt` is the whole difference between the two ways this is called. `none`
+ * asks Google to answer from the session it already has and to refuse rather
+ * than draw anything — that is the silent mint, and it must never open a window.
+ * `select_account` is the interactive one, and it shows the chooser even when
+ * Google could have answered silently: an ADD ANOTHER ACCOUNT button that
+ * skipped the chooser and re-signed-in the account you already had would be
+ * indistinguishable from a broken button.
+ */
+export function authUrl({ clientId, redirectUri, email = "", interactive = true,
+                          scopes = SCOPES } = {}) {
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: "token",
+    scope: scopes.join(" "),
+    // Carry forward anything this person already agreed to, so a second sign-in
+    // does not quietly drop a scope they granted the first time.
+    include_granted_scopes: "true",
+    prompt: interactive ? "select_account" : "none",
+  });
+  // Which account this is FOR. Without it a silent request answers for whoever
+  // Google considers default, and the panel would switch accounts by itself.
+  if (email) params.set("login_hint", email);
+  return `${AUTH_ENDPOINT}?${params.toString()}`;
+}
+
+/** Read what Google sent back to the redirect URL.
+ *
+ * The implicit flow puts its answer in the FRAGMENT, not the query, and errors
+ * can arrive in either — so both are read. Every branch is a different sentence
+ * for the same reason readTokenResult's are: a single "sign-in failed" teaches
+ * the owner to press the button again and learn nothing.
+ */
+export function readRedirect(redirectUrl, lastError) {
+  if (!redirectUrl) {
+    const message = (lastError && lastError.message) || "";
+    if (/did not approve|canceled|cancelled|closed/i.test(message)) {
+      return { state: "declined",
+               detail: "Sign-in was closed before it finished. Nothing changed." };
+    }
+    return { state: "failed",
+             detail: message || "Chrome did not say why sign-in failed." };
+  }
+
+  let url;
+  try { url = new URL(redirectUrl); }
+  catch (_) {
+    return { state: "failed", detail: "Google returned an unreadable answer." };
+  }
+  const fragment = new URLSearchParams(url.hash.replace(/^#/, ""));
+  const error = fragment.get("error") || url.searchParams.get("error");
+
+  if (error) {
+    // THE ORDINARY REFUSAL, and it is not a failure. `prompt=none` asks Google
+    // to answer without drawing anything; these four are Google saying "not
+    // without the person". That is a SIGNED-OUT account, a state the panel
+    // draws, and it must not be reported as something going wrong.
+    if (/^(login_required|consent_required|interaction_required|account_selection_required)$/
+        .test(error)) {
+      return { state: "interaction-required", retryable: true,
+               detail: "This account's Google session has ended. Sign in to use it again." };
+    }
+    if (error === "access_denied") {
+      return { state: "declined",
+               detail: "Sign-in was refused. Nothing changed." };
+    }
+    if (/^(invalid_client|unauthorized_client|invalid_request|redirect_uri_mismatch)$/
+        .test(error)) {
+      return { state: "misconfigured",
+               detail: "Google refused the OAuth client in this build. The " +
+                       "extension's redirect URL and the client in Google Cloud " +
+                       "do not match." };
+    }
+    if (error === "admin_policy_enforced") {
+      // A Workspace administrator blocked it. Pressing again cannot fix that,
+      // and the person needs to know it is their organisation and not ScrapeX.
+      return { state: "blocked-by-admin",
+               detail: "This account's organisation blocks ScrapeX. Ask a " +
+                       "Google Workspace administrator to allow it, or use " +
+                       "another account." };
+    }
+    return { state: "failed", detail: `Google refused sign-in (${error}).` };
+  }
+
+  const token = fragment.get("access_token");
+  if (!token) {
+    return { state: "failed", detail: "Google's answer carried no token." };
+  }
+
+  // Same partial-grant reading as getAuthToken's, and deliberately the same
+  // vocabulary: the consent screen's unticked Drive checkbox is one behaviour
+  // and must not have two names depending on which flow met it. The implicit
+  // flow always reports `scope`, so unlike Chrome's callback there is no
+  // "this browser cannot tell us" case here.
+  const granted = (fragment.get("scope") || "").split(" ").filter(Boolean);
+  const missing = missingScopes(granted, SCOPES);
+  if (missing && missing.length) {
+    return {
+      state: "partial", token, missing,
+      detail: missing.includes(DRIVE_SCOPE)
+        ? "Signed in, but Drive access was not granted — the checkbox on "
+          + "Google's second screen was left unticked, so backups to Drive "
+          + "will fail. Sign in again and tick it."
+        : "Signed in, but Google did not grant everything ScrapeX asked for: "
+          + missing.join(", "),
+    };
+  }
+  return { state: "ok", token };
+}
+
+/** Get a token for ONE named account, silently when that is possible.
+ *
+ * `interactive: false` is the panel's ordinary path: it opens no window, and a
+ * refusal is the answer rather than an error. Only a control the person pressed
+ * is allowed to pass `true`.
+ */
+export async function authorize({ email = "", interactive = false,
+                                  identity = chrome.identity,
+                                  runtime = chrome.runtime,
+                                  clientId = WEB_CLIENT_ID } = {}) {
+  if (!clientId) {
+    return { state: "misconfigured",
+             detail: "This build has no Web OAuth client, so accounts cannot be "
+                   + "added or switched. One has to be created in Google Cloud "
+                   + "with this extension's redirect URL." };
+  }
+
+  let redirectUri;
+  try { redirectUri = identity.getRedirectURL(); }
+  catch (error) {
+    return { state: "failed",
+             detail: (error && error.message) || "Chrome would not name a redirect URL." };
+  }
+
+  const url = authUrl({ clientId, redirectUri, email, interactive });
+  return new Promise((resolve) => {
+    try {
+      identity.launchWebAuthFlow({ url, interactive }, (redirectUrl) =>
+        resolve(readRedirect(redirectUrl, runtime.lastError)));
+    } catch (error) {
+      resolve({ state: "failed", retryable: true,
+                detail: (error && error.message) || "Chrome could not open sign-in." });
+    }
+  });
 }
 
 /** Sign out on this device: drop Chrome's cached token and forget it. */

--- a/extension/sheets.js
+++ b/extension/sheets.js
@@ -25,10 +25,10 @@
 // limit Google enforces rather than a promise this code keeps, which is why the
 // privacy policy states it in those words.
 
-const FILES = "https://www.googleapis.com/drive/v3/files";
+const DRIVE_FILES = "https://www.googleapis.com/drive/v3/files";
 const SHEETS = "https://sheets.googleapis.com/v4/spreadsheets";
 
-const FOLDER_MIME = "application/vnd.google-apps.folder";
+const SHEET_FOLDER_MIME = "application/vnd.google-apps.folder";
 export const SHEET_MIME = "application/vnd.google-apps.spreadsheet";
 
 // The cap gdrive.py carried, kept for the reason it carried it: a runaway export
@@ -56,7 +56,7 @@ export class SheetsError extends Error {
   }
 }
 
-function headers(token, extra = {}) {
+function sheetsHeaders(token, extra = {}) {
   if (!token) {
     throw new SheetsError(
       "No Google account is connected. Sign in from the panel first.",
@@ -122,10 +122,10 @@ async function findByName(token, {name, mime, parent = null, fetchImpl}) {
   if (parent) query += ` and '${parent}' in parents`;
 
   const found = await (await ask(
-    fetchImpl, `${FILES}?${new URLSearchParams({
+    fetchImpl, `${DRIVE_FILES}?${new URLSearchParams({
       q: query, spaces: "drive", fields: "files(id,name)",
     })}`,
-    {headers: headers(token)}, `looking for ${name}`)).json();
+    {headers: sheetsHeaders(token)}, `looking for ${name}`)).json();
 
   const files = found.files || [];
   return files.length ? files[0].id : null;
@@ -135,16 +135,16 @@ async function findByName(token, {name, mime, parent = null, fetchImpl}) {
 export async function ensureFolder(token, name, {
   parent = null, fetchImpl = fetch,
 } = {}) {
-  const found = await findByName(token, {name, mime: FOLDER_MIME, parent, fetchImpl});
+  const found = await findByName(token, {name, mime: SHEET_FOLDER_MIME, parent, fetchImpl});
   if (found) return found;
 
-  const body = {name, mimeType: FOLDER_MIME};
+  const body = {name, mimeType: SHEET_FOLDER_MIME};
   if (parent) body.parents = [parent];
   const made = await (await ask(
-    fetchImpl, `${FILES}?${new URLSearchParams({fields: "id"})}`,
+    fetchImpl, `${DRIVE_FILES}?${new URLSearchParams({fields: "id"})}`,
     {
       method: "POST",
-      headers: headers(token, {"Content-Type": "application/json"}),
+      headers: sheetsHeaders(token, {"Content-Type": "application/json"}),
       body: JSON.stringify(body),
     },
     `creating the folder ${name}`)).json();
@@ -168,10 +168,10 @@ export async function ensureSpreadsheet(token, name, {
   if (existing) {
     const known = await (await ask(
       fetchImpl,
-      `${FILES}/${encodeURIComponent(existing)}?${new URLSearchParams({
+      `${DRIVE_FILES}/${encodeURIComponent(existing)}?${new URLSearchParams({
         fields: "id,name,webViewLink",
       })}`,
-      {headers: headers(token)}, `reading the link for ${name}`)).json();
+      {headers: sheetsHeaders(token)}, `reading the link for ${name}`)).json();
     return {id: known.id, name: known.name, url: known.webViewLink, created: false};
   }
 
@@ -179,10 +179,10 @@ export async function ensureSpreadsheet(token, name, {
   if (folder) body.parents = [folder];
   const made = await (await ask(
     fetchImpl,
-    `${FILES}?${new URLSearchParams({fields: "id,name,webViewLink"})}`,
+    `${DRIVE_FILES}?${new URLSearchParams({fields: "id,name,webViewLink"})}`,
     {
       method: "POST",
-      headers: headers(token, {"Content-Type": "application/json"}),
+      headers: sheetsHeaders(token, {"Content-Type": "application/json"}),
       body: JSON.stringify(body),
     },
     `creating the spreadsheet ${name}`)).json();
@@ -196,7 +196,7 @@ export async function tabsOf(token, spreadsheetId, {fetchImpl = fetch} = {}) {
     `${SHEETS}/${encodeURIComponent(spreadsheetId)}?${new URLSearchParams({
       fields: "sheets(properties(title))",
     })}`,
-    {headers: headers(token)}, "reading the spreadsheet's tabs")).json();
+    {headers: sheetsHeaders(token)}, "reading the spreadsheet's tabs")).json();
   return (meta.sheets || []).map((s) => s.properties.title);
 }
 
@@ -206,7 +206,7 @@ async function ensureTab(token, spreadsheetId, tab, {fetchImpl}) {
     fetchImpl, `${SHEETS}/${encodeURIComponent(spreadsheetId)}:batchUpdate`,
     {
       method: "POST",
-      headers: headers(token, {"Content-Type": "application/json"}),
+      headers: sheetsHeaders(token, {"Content-Type": "application/json"}),
       body: JSON.stringify({
         requests: [{addSheet: {properties: {title: tab}}}],
       }),
@@ -245,7 +245,7 @@ export async function writeTab(token, spreadsheetId, {
     `${encodeURIComponent(`'${tab}'`)}:clear`,
     {
       method: "POST",
-      headers: headers(token, {"Content-Type": "application/json"}),
+      headers: sheetsHeaders(token, {"Content-Type": "application/json"}),
       body: "{}",
     },
     `clearing the tab ${tab}`);
@@ -258,7 +258,7 @@ export async function writeTab(token, spreadsheetId, {
     })}`,
     {
       method: "PUT",
-      headers: headers(token, {"Content-Type": "application/json"}),
+      headers: sheetsHeaders(token, {"Content-Type": "application/json"}),
       body: JSON.stringify({values: [header, ...rows]}),
     },
     `writing the tab ${tab}`);
@@ -284,10 +284,10 @@ export async function writeTab(token, spreadsheetId, {
 export async function openChosen(token, spreadsheetId, {fetchImpl = fetch} = {}) {
   const known = await (await ask(
     fetchImpl,
-    `${FILES}/${encodeURIComponent(spreadsheetId)}?${new URLSearchParams({
+    `${DRIVE_FILES}/${encodeURIComponent(spreadsheetId)}?${new URLSearchParams({
       fields: "id,name,mimeType,webViewLink",
     })}`,
-    {headers: headers(token)}, "opening the spreadsheet you chose")).json();
+    {headers: sheetsHeaders(token)}, "opening the spreadsheet you chose")).json();
 
   if (known.mimeType !== SHEET_MIME) {
     throw new SheetsError(

--- a/extension/tests/accounts.test.mjs
+++ b/extension/tests/accounts.test.mjs
@@ -1,0 +1,253 @@
+// The directory of remembered accounts, and the one thing it must never hold.
+//
+// Multi-account arrived on 2026-08-11 WITHOUT breaking the owner's ruling of
+// 2026-08-05 that nothing is written to disk. The account list is a directory —
+// names and addresses the panel already paints — and the token for any of them
+// is minted when needed and kept in memory. The first test below is that ruling
+// written as an assertion: it is the one failure here that is not a bug but a
+// broken promise.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  ACCOUNTS_KEY, clearCurrentAccount, currentAccount, forgetAccount,
+  otherAccounts, readAccounts, rememberAccount, sanitiseAccount,
+  setCurrentAccount,
+} from "../accounts.js";
+
+/** A chrome.storage.local that keeps what it is given, and can be made to fail. */
+function fakeStorage(seed = undefined) {
+  const held = seed === undefined ? {} : { [ACCOUNTS_KEY]: seed };
+  return {
+    writes: 0,
+    failGet: false,
+    async get(key) {
+      if (this.failGet) throw new Error("storage is unavailable");
+      return key in held ? { [key]: held[key] } : {};
+    },
+    async set(patch) {
+      this.writes += 1;
+      Object.assign(held, patch);
+    },
+    raw: () => held[ACCOUNTS_KEY],
+  };
+}
+
+const OWNER = { id: "1001", name: "Muhammad", email: "owner@example.com",
+                picture: "https://lh3.googleusercontent.com/owner" };
+const SECOND = { id: "1002", name: "MBi", email: "mbi@example.com", picture: "" };
+
+// ---- the ruling ------------------------------------------------------------
+
+test("a token handed in with an account never reaches storage", async () => {
+  // The realistic accident: a caller passes the whole thing it just received
+  // from Google — profile fields AND credentials in one object — because that
+  // is the object it happens to be holding. sanitiseAccount copies the four
+  // fields it knows BY NAME, so this cannot become a credential store by
+  // someone being careless one afternoon.
+  const storage = fakeStorage();
+  await rememberAccount({
+    ...OWNER,
+    access_token: "ya29.SECRET", refresh_token: "1//SECRET",
+    id_token: "eyJSECRET", expires_in: 3599,
+  }, { storage });
+
+  const written = JSON.stringify(storage.raw());
+  assert.doesNotMatch(written, /SECRET/,
+    `a credential reached disk: ${written}`);
+  assert.deepEqual(Object.keys(storage.raw().accounts[0]).sort(),
+    ["email", "id", "name", "picture"],
+    "an unknown field survived the copy, so the field list is no longer the rule");
+});
+
+test("sanitiseAccount refuses anything that cannot be acted on", () => {
+  // An id is what a switch, a removal and a token request all name. A row
+  // without one is a row every button on it would fail against.
+  assert.equal(sanitiseAccount(null), null);
+  assert.equal(sanitiseAccount("1001"), null);
+  assert.equal(sanitiseAccount({ name: "No id" }), null);
+  assert.equal(sanitiseAccount({ id: "   " }), null, "whitespace is not an id");
+  assert.deepEqual(sanitiseAccount({ id: " 1001 " }).id, "1001");
+  // Missing optional fields are still an account: Google may return no photo.
+  assert.deepEqual(sanitiseAccount({ id: "1001" }),
+    { id: "1001", name: "", email: "", picture: "" });
+});
+
+// ---- reading ---------------------------------------------------------------
+
+test("a browser that has seen nobody reads as an empty directory", async () => {
+  const held = await readAccounts({ storage: fakeStorage() });
+  assert.deepEqual(held, { accounts: [], currentId: "" });
+});
+
+test("storage that throws reads as empty rather than throwing at the panel", async () => {
+  // The panel's job when it knows nobody is to offer sign-in — a path the
+  // product already has. Turning a storage fault into an exception would take
+  // down renderAccount instead, and the person would meet a blank card.
+  const storage = fakeStorage();
+  storage.failGet = true;
+  assert.deepEqual(await readAccounts({ storage }),
+    { accounts: [], currentId: "" });
+});
+
+test("a half-written record does not become half a directory", async () => {
+  const storage = fakeStorage({ accounts: "not-a-list", currentId: 7 });
+  assert.deepEqual(await readAccounts({ storage }),
+    { accounts: [], currentId: "" });
+});
+
+test("entries that are not accounts are dropped, and duplicates with them", async () => {
+  const storage = fakeStorage({
+    accounts: [OWNER, null, { name: "no id" }, { ...OWNER, name: "stale copy" }, SECOND],
+    currentId: OWNER.id,
+  });
+  const held = await readAccounts({ storage });
+  assert.deepEqual(held.accounts.map((a) => a.id), [OWNER.id, SECOND.id]);
+  assert.equal(held.accounts[0].name, "Muhammad",
+    "the later duplicate won, so the list order is not stable under a re-read");
+});
+
+test("a current id naming nobody is not carried forward", async () => {
+  // Otherwise the panel paints a current-account header for a row that is not
+  // in the list — the shape of failure this project keeps meeting: a partial
+  // state displayed as a complete one.
+  const storage = fakeStorage({ accounts: [OWNER], currentId: "9999" });
+  assert.equal((await readAccounts({ storage })).currentId, "");
+});
+
+// ---- writing ---------------------------------------------------------------
+
+test("remembering an account adds it and makes it current", async () => {
+  const storage = fakeStorage();
+  const held = await rememberAccount(OWNER, { storage });
+  assert.deepEqual(held.accounts.map((a) => a.id), [OWNER.id]);
+  assert.equal(held.currentId, OWNER.id);
+});
+
+test("remembering again replaces the entry and keeps its place in the list", async () => {
+  // A name or a photo that changed at Google is the truth; a merge would keep
+  // the stale half. The POSITION is kept so the row someone is looking at does
+  // not jump while they are looking at it.
+  const storage = fakeStorage();
+  await rememberAccount(OWNER, { storage });
+  await rememberAccount(SECOND, { storage });
+  const held = await rememberAccount({ ...OWNER, name: "Muhammad Bayoumi", picture: "" },
+                                     { storage });
+
+  assert.deepEqual(held.accounts.map((a) => a.id), [OWNER.id, SECOND.id],
+    "the refreshed account moved instead of staying where it was");
+  assert.equal(held.accounts[0].name, "Muhammad Bayoumi");
+  assert.equal(held.accounts[0].picture, "",
+    "the old photo survived a replace, so this is a merge and not a replace");
+  assert.equal(held.currentId, OWNER.id, "re-authorising did not make it current");
+});
+
+test("an account that cannot be acted on is not remembered", async () => {
+  const storage = fakeStorage();
+  const held = await rememberAccount({ name: "no id" }, { storage });
+  assert.deepEqual(held, { accounts: [], currentId: "" });
+  assert.equal(storage.writes, 0, "storage was written for a row nothing can act on");
+});
+
+// ---- forgetting ------------------------------------------------------------
+
+test("forgetting a row removes it and promotes nobody", async () => {
+  // Which account you are acting as is the person's decision. Promoting the
+  // next one in the list would move them somewhere they never asked to be, and
+  // the panel would look signed in as someone they did not pick.
+  const storage = fakeStorage();
+  await rememberAccount(OWNER, { storage });
+  await rememberAccount(SECOND, { storage });
+  await setCurrentAccount(OWNER.id, { storage });
+
+  const held = await forgetAccount(OWNER.id, { storage });
+  assert.deepEqual(held.accounts.map((a) => a.id), [SECOND.id]);
+  assert.equal(held.currentId, "", "forgetting the current account switched us to another one");
+});
+
+test("forgetting a row that is not current leaves the current one alone", async () => {
+  const storage = fakeStorage();
+  await rememberAccount(OWNER, { storage });
+  await rememberAccount(SECOND, { storage });
+
+  const held = await forgetAccount(OWNER.id, { storage });
+  assert.equal(held.currentId, SECOND.id);
+});
+
+test("forgetting someone who was never here writes nothing", async () => {
+  const storage = fakeStorage();
+  await rememberAccount(OWNER, { storage });
+  const before = storage.writes;
+  await forgetAccount("9999", { storage });
+  assert.equal(storage.writes, before);
+});
+
+// ---- signing out, which is not forgetting ----------------------------------
+
+test("signing out keeps the account listed and stops acting as it", async () => {
+  // The whole difference between the two destructive-looking verbs. A signed-out
+  // account stays as a row someone can come back through; only Remove erases.
+  const storage = fakeStorage();
+  await rememberAccount(OWNER, { storage });
+  await rememberAccount(SECOND, { storage });
+
+  const held = await clearCurrentAccount({ storage });
+  assert.deepEqual(held.accounts.map((a) => a.id), [OWNER.id, SECOND.id],
+    "signing out dropped a row that should have stayed");
+  assert.equal(held.currentId, "");
+});
+
+test("signing out when acting as nobody writes nothing", async () => {
+  const storage = fakeStorage();
+  await rememberAccount(OWNER, { storage });
+  await clearCurrentAccount({ storage });
+  const before = storage.writes;
+  await clearCurrentAccount({ storage });
+  assert.equal(storage.writes, before);
+});
+
+test("signing back in makes the same account current again", async () => {
+  const storage = fakeStorage();
+  await rememberAccount(OWNER, { storage });
+  await clearCurrentAccount({ storage });
+  const held = await rememberAccount(OWNER, { storage });
+  assert.equal(held.currentId, OWNER.id);
+  assert.equal(held.accounts.length, 1, "coming back created a second row");
+});
+
+// ---- switching -------------------------------------------------------------
+
+test("switching to a remembered account moves the current id", async () => {
+  const storage = fakeStorage();
+  await rememberAccount(OWNER, { storage });
+  await rememberAccount(SECOND, { storage });
+  const held = await setCurrentAccount(OWNER.id, { storage });
+  assert.equal(held.currentId, OWNER.id);
+});
+
+test("switching to someone who is not in the directory is refused", async () => {
+  const storage = fakeStorage();
+  await rememberAccount(OWNER, { storage });
+  const held = await setCurrentAccount("9999", { storage });
+  assert.equal(held.currentId, OWNER.id,
+    "the record now names a row the panel cannot show");
+});
+
+// ---- reading the shape the card needs --------------------------------------
+
+test("the card can name the current account and everyone else", async () => {
+  const storage = fakeStorage();
+  await rememberAccount(OWNER, { storage });
+  await rememberAccount(SECOND, { storage });
+  const held = await readAccounts({ storage });
+
+  assert.equal(currentAccount(held).id, SECOND.id);
+  assert.deepEqual(otherAccounts(held).map((a) => a.id), [OWNER.id]);
+});
+
+test("acting as nobody is a state the card can ask about", async () => {
+  const held = { accounts: [OWNER], currentId: "" };
+  assert.equal(currentAccount(held), null);
+  assert.deepEqual(otherAccounts(held).map((a) => a.id), [OWNER.id],
+    "with no current account every row is an 'other' row");
+});

--- a/extension/tests/diagnostic-app-nomodule.html
+++ b/extension/tests/diagnostic-app-nomodule.html
@@ -1116,20 +1116,55 @@
             <p class="notice hidden" role="status" aria-live="polite" id="signin-problem"></p>
           </div>
 
-          <!-- Signed in. Account identity is the primary content. -->
+          <!-- Signed in. Account identity is the primary content, centred
+               between two edges: the sign-out control at the top, the legal
+               links at the bottom. Both rows stretch across the card; the
+               identity block keeps the centre.
+               Sprite hrefs carry the `../` this page needs and app.html does
+               not — that is the one intended difference from the original. -->
           <div class="profile-state hidden" id="welcome-signed-in">
+            <div class="profile-topbar">
+              <button class="icon-button xs profile-signout" id="signout" type="button"
+                      aria-label="Sign out" title="Sign out">
+                <svg class="sx-icon" aria-hidden="true">
+                  <use href="../icons/material-icons.svg#logout"></use>
+                </svg>
+              </button>
+            </div>
+
             <div class="profile-summary" id="welcome-summary" tabindex="-1"
                  aria-label="Signed in">
               <img class="welcome-face hidden" id="welcome-photo" alt="" aria-hidden="true">
-              <h1 id="welcome-name">Signed in</h1>
-              <p class="muted" id="welcome-email"></p>
+              <span class="profile-face-fallback" aria-hidden="true">
+                <svg class="sx-icon profile-face-icon" aria-hidden="true">
+                  <use href="../icons/material-icons.svg#account-circle"></use>
+                </svg>
+              </span>
+              <h1 class="profile-greeting"><span id="welcome-greeting"
+                  class="hidden">Hi,</span> <span id="welcome-name"
+                  dir="auto">Signed in</span></h1>
+              <p class="muted profile-email" id="welcome-email" dir="ltr"></p>
               <p class="notice hidden" role="status" aria-live="polite"
                  id="account-detail-status"></p>
               <button class="ghost compact hidden" id="retry-account" type="button">
                 Retry
               </button>
+              <button class="ghost profile-manage" id="manage-account" type="button"
+                      disabled>
+                Manage your account
+              </button>
             </div>
-            <button class="ghost compact" id="signout" type="button">Sign out</button>
+
+            <div class="profile-legal">
+              <a class="profile-legal-link"
+                 href="https://muhammadbayoumi.github.io/mbiXsite/scrapex-privacy.html"
+                 target="_blank" rel="noopener noreferrer">Privacy Policy</a>
+              <span class="profile-legal-sep" aria-hidden="true">•</span>
+              <button class="link profile-legal-link" id="terms-of-service"
+                      type="button" disabled>
+                Terms of Service
+              </button>
+            </div>
           </div>
 
         </div>

--- a/extension/tests/switching-accounts.test.mjs
+++ b/extension/tests/switching-accounts.test.mjs
@@ -1,0 +1,215 @@
+// Switching between accounts, and the credential that is never asked for.
+//
+// getAuthToken speaks for exactly one account — the Chrome profile's primary —
+// so the switcher is built on launchWebAuthFlow instead. The owner ruled on
+// 2026-08-11 that it must not cost the 2026-08-05 ruling: no credential is
+// stored, so the flow is the IMPLICIT one and there is no refresh token to keep.
+// The first two tests are that ruling written as assertions.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  SCOPES, accountFor, authUrl, authorize, readRedirect, WEB_CLIENT_ID,
+} from "../identity.js";
+
+const DRIVE = "https://www.googleapis.com/auth/drive.file";
+const CLIENT = "web-client.apps.googleusercontent.com";
+const REDIRECT = "https://ekcgggphcfdbjgfkcmjagehfjhijeang.chromiumapp.org/";
+
+const params = (url) => new URL(url).searchParams;
+
+// Injected everywhere, because `runtime = chrome.runtime` is a DEFAULT
+// PARAMETER: JavaScript evaluates it on every call that omits the argument, not
+// only on the branch that reads it. Outside a browser that throws before the
+// function body starts — including on the path that refuses early.
+const RUNTIME = { lastError: null };
+
+/** A chrome.identity that records the call instead of opening anything. */
+function fakeIdentity(answer) {
+  return {
+    calls: [],
+    getRedirectURL: () => REDIRECT,
+    launchWebAuthFlow(options, callback) {
+      this.calls.push(options);
+      callback(typeof answer === "function" ? answer(options) : answer);
+    },
+  };
+}
+
+// ---- the ruling ------------------------------------------------------------
+
+test("the flow never asks for a credential that would have to be stored", () => {
+  const url = authUrl({ clientId: CLIENT, redirectUri: REDIRECT });
+  // `code` is the response type that buys a refresh token — the long-lived
+  // credential this design declines to hold. `token` is the one that does not.
+  assert.equal(params(url).get("response_type"), "token");
+  assert.doesNotMatch(url, /access_type=offline/,
+    "offline access is a request for a refresh token");
+  assert.doesNotMatch(url, /client_secret/,
+    "a secret in a URL an extension builds is a secret shipped to every user");
+});
+
+test("a granted token is returned and nothing beside it is kept", () => {
+  const answer = readRedirect(
+    `${REDIRECT}#access_token=ya29.TOKEN&token_type=Bearer&expires_in=3599`
+    + `&scope=${encodeURIComponent(SCOPES.join(" "))}`);
+  assert.equal(answer.state, "ok");
+  assert.equal(answer.token, "ya29.TOKEN");
+  assert.deepEqual(Object.keys(answer).sort(), ["state", "token"],
+    "the result grew a field, and the only fields here should be usable now");
+});
+
+// ---- naming which account --------------------------------------------------
+
+test("a silent request names the account and refuses to draw anything", () => {
+  const url = authUrl({ clientId: CLIENT, redirectUri: REDIRECT,
+                        email: "owner@example.com", interactive: false });
+  assert.equal(params(url).get("prompt"), "none",
+    "a silent mint that may open a window is not silent");
+  assert.equal(params(url).get("login_hint"), "owner@example.com",
+    "without login_hint Google answers for whoever it considers default, and "
+    + "the panel would switch accounts by itself");
+});
+
+test("adding an account always shows the chooser, even when Google could answer", () => {
+  // An "Add another account" button that skipped the chooser would silently
+  // re-sign-in the account you already had — indistinguishable from a button
+  // that does nothing.
+  const url = authUrl({ clientId: CLIENT, redirectUri: REDIRECT, interactive: true });
+  assert.equal(params(url).get("prompt"), "select_account");
+  assert.equal(params(url).get("login_hint"), null);
+});
+
+test("a second sign-in does not quietly drop a scope already granted", () => {
+  const url = authUrl({ clientId: CLIENT, redirectUri: REDIRECT });
+  assert.equal(params(url).get("include_granted_scopes"), "true");
+  assert.equal(params(url).get("scope"), SCOPES.join(" "));
+});
+
+// ---- reading the answer ----------------------------------------------------
+
+test("an ended Google session is a signed-out account, not a failure", () => {
+  // `prompt=none` refusing is the ORDINARY case for a remembered account whose
+  // browser session has lapsed. The design draws it as a signed-out row with a
+  // Sign in button; reporting it as an error would put a warning in front of
+  // something entirely normal.
+  for (const error of ["login_required", "consent_required",
+                       "interaction_required", "account_selection_required"]) {
+    const answer = readRedirect(`${REDIRECT}#error=${error}`);
+    assert.equal(answer.state, "interaction-required", error);
+    assert.equal(answer.retryable, true, error);
+  }
+});
+
+test("a refusal by the person is not a refusal by the machine", () => {
+  assert.equal(readRedirect(`${REDIRECT}#error=access_denied`).state, "declined");
+  assert.equal(readRedirect(null, { message: "The user closed the window" }).state,
+               "declined");
+});
+
+test("an organisation's block says so, instead of looking like a retryable fault", () => {
+  // Pressing again can never fix this one, and the person needs to know it is
+  // their Workspace administrator and not ScrapeX.
+  const answer = readRedirect(`${REDIRECT}#error=admin_policy_enforced`);
+  assert.equal(answer.state, "blocked-by-admin");
+  assert.match(answer.detail, /administrator/);
+});
+
+test("a wrong OAuth client is named as the thing trying again cannot fix", () => {
+  for (const error of ["invalid_client", "unauthorized_client",
+                       "invalid_request", "redirect_uri_mismatch"]) {
+    assert.equal(readRedirect(`${REDIRECT}#error=${error}`).state, "misconfigured", error);
+  }
+});
+
+test("a partial grant reads the same here as it does through getAuthToken", () => {
+  // The unticked Drive checkbox is ONE behaviour. Two names for it, depending
+  // on which flow happened to meet it, is how a product ends up explaining the
+  // same thing two different ways.
+  const without = SCOPES.filter((scope) => scope !== DRIVE);
+  const answer = readRedirect(
+    `${REDIRECT}#access_token=ya29.TOKEN&scope=${encodeURIComponent(without.join(" "))}`);
+  assert.equal(answer.state, "partial");
+  assert.deepEqual(answer.missing, [DRIVE]);
+  assert.match(answer.detail, /backups to Drive will fail/);
+  assert.equal(answer.token, "ya29.TOKEN", "the token still works for what WAS granted");
+});
+
+test("an answer carrying no token is a failure, not an empty success", () => {
+  assert.equal(readRedirect(`${REDIRECT}#token_type=Bearer`).state, "failed");
+  assert.equal(readRedirect("not a url at all").state, "failed");
+});
+
+test("an error in the query is read as well as one in the fragment", () => {
+  // Google puts the implicit flow's answer in the fragment, but not every error
+  // path does. Reading only one of the two turns a refusal into "no token".
+  assert.equal(readRedirect(`${REDIRECT}?error=access_denied`).state, "declined");
+});
+
+// ---- the flow --------------------------------------------------------------
+
+test("a build with no Web OAuth client refuses by name, before opening anything", async () => {
+  const identity = fakeIdentity(`${REDIRECT}#access_token=ya29.TOKEN`);
+  const answer = await authorize({ identity, runtime: RUNTIME, clientId: "" });
+  assert.equal(answer.state, "misconfigured");
+  assert.match(answer.detail, /Google Cloud/);
+  assert.equal(identity.calls.length, 0,
+    "Chrome was asked to open a flow that could not possibly succeed");
+});
+
+test("this build has no Web OAuth client yet, and says so rather than guessing", () => {
+  // A placeholder id would fail against Google with a message about the client
+  // rather than about the thing that is actually missing.
+  assert.equal(WEB_CLIENT_ID, "");
+});
+
+test("the silent path passes its silence all the way to Chrome", async () => {
+  const identity = fakeIdentity(`${REDIRECT}#access_token=ya29.TOKEN`
+    + `&scope=${encodeURIComponent(SCOPES.join(" "))}`);
+  const answer = await authorize({ identity, runtime: RUNTIME, clientId: CLIENT,
+                                   email: "owner@example.com", interactive: false });
+  assert.equal(answer.state, "ok");
+  assert.equal(identity.calls[0].interactive, false,
+    "launchWebAuthFlow was allowed to open a window during a silent check");
+  assert.equal(params(identity.calls[0].url).get("prompt"), "none");
+});
+
+test("Chrome refusing to open the flow is reported, not thrown at the panel", async () => {
+  const identity = {
+    getRedirectURL: () => REDIRECT,
+    launchWebAuthFlow() { throw new Error("no window available"); },
+  };
+  const answer = await authorize({ identity, runtime: RUNTIME, clientId: CLIENT });
+  assert.equal(answer.state, "failed");
+  assert.match(answer.detail, /no window available/);
+});
+
+// ---- the id the directory is keyed on --------------------------------------
+
+test("the account carries Google's stable id, not just its address", async () => {
+  // accounts.js keys every row on this. An address is not safe to key on: people
+  // change theirs and Workspace admins reassign them, so one account would
+  // silently become two rows — or a renamed address would land on someone
+  // else's row.
+  const fetchImpl = async () => ({
+    ok: true, status: 200,
+    json: async () => ({ sub: "110001", name: "Muhammad", email: "owner@example.com",
+                         picture: "https://lh3.googleusercontent.com/x" }),
+  });
+  const result = await accountFor("ya29.TOKEN", fetchImpl);
+  assert.equal(result.state, "ok");
+  assert.equal(result.account.id, "110001");
+  assert.equal(result.account.email, "owner@example.com");
+});
+
+test("an account response without an id is still an account, with an empty one", async () => {
+  // Missing optional fields were always a successful response here, and this
+  // must not become the one that throws. accounts.js refuses the empty id on
+  // its own side, where the decision belongs.
+  const fetchImpl = async () => ({
+    ok: true, status: 200, json: async () => ({ name: "Muhammad" }),
+  });
+  const result = await accountFor("ya29.TOKEN", fetchImpl);
+  assert.equal(result.state, "ok");
+  assert.equal(result.account.id, "");
+});

--- a/extension/tokens.css
+++ b/extension/tokens.css
@@ -61,6 +61,16 @@
   --control-hover: var(--surface-subtle);
   --control-height: 2.5rem;
   --control-height-sm: 2rem;
+  /* The third notch, added 2026-08-11 by the owner's ruling on the Profile
+     top bar: «وضيف فى القاعدة العامة الاختيارين» — carry BOTH sizes in the
+     general rule rather than let one screen override it locally.
+     It is deliberately NOT re-declared in extension/app.css. The extension
+     shifts the other two notches up (see the :root block at the top of that
+     file) because a side panel is a pointer surface with a 48px floor; this
+     one exists for the quiet, secondary icon control the Profile design asks
+     for, and it is the same 32px on both surfaces. Anything a finger must hit
+     reliably still uses --control-height or --touch-target. */
+  --control-height-xs: 2rem;
   --touch-target: 3rem;
 
   /* Spacing — 4px base */

--- a/scrapex/webui/static/components.css
+++ b/scrapex/webui/static/components.css
@@ -468,6 +468,24 @@ button.icon-button.compact,
   min-width: var(--control-height-sm);
 }
 
+/* The smallest square, and the only one that also lowers min-height.
+   `compact` shrinks a control to the small notch; `xs` goes one further, to
+   --control-height-xs (32px on both surfaces). It exists because the Profile
+   design puts a secondary sign-out icon in a top bar where a 48px square reads
+   as the loudest thing on a page about an account, and the owner ruled on
+   2026-08-11 that both sizes belong to the general rule rather than to one
+   screen's stylesheet.
+   USE IT FOR SECONDARY ICON CONTROLS ONLY. 32px is under the 44px coarse-pointer
+   floor this sheet applies below, and under --control-height-sm. A primary or
+   destructive action, or anything on a touch surface, uses `icon-button` or
+   `icon-button compact` instead. */
+button.icon-button.xs,
+.button.icon-button.xs {
+  width: var(--control-height-xs);
+  min-width: var(--control-height-xs);
+  min-height: var(--control-height-xs);
+}
+
 button.compact,
 .button.compact {
   min-height: var(--control-height-sm);

--- a/scrapex/webui/static/material-icons/material-icons.svg
+++ b/scrapex/webui/static/material-icons/material-icons.svg
@@ -157,4 +157,7 @@
   <symbol id="expand-more" viewBox="0 0 24 24">
     <path d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"/>
   </symbol>
+  <symbol id="logout" viewBox="0 0 24 24">
+    <path d="M17 7l-1.41 1.41L18.17 11H8v2h10.17l-2.58 2.58L17 17l5-5zM4 5h8V3H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h8v-2H4V5z"/>
+  </symbol>
 </svg>

--- a/scrapex/webui/static/tokens.css
+++ b/scrapex/webui/static/tokens.css
@@ -61,6 +61,16 @@
   --control-hover: var(--surface-subtle);
   --control-height: 2.5rem;
   --control-height-sm: 2rem;
+  /* The third notch, added 2026-08-11 by the owner's ruling on the Profile
+     top bar: «وضيف فى القاعدة العامة الاختيارين» — carry BOTH sizes in the
+     general rule rather than let one screen override it locally.
+     It is deliberately NOT re-declared in extension/app.css. The extension
+     shifts the other two notches up (see the :root block at the top of that
+     file) because a side panel is a pointer surface with a 48px floor; this
+     one exists for the quiet, secondary icon control the Profile design asks
+     for, and it is the same 32px on both surfaces. Anything a finger must hit
+     reliably still uses --control-height or --touch-target. */
+  --control-height-xs: 2rem;
   --touch-target: 3rem;
 
   /* Spacing — 4px base */

--- a/tests/test_panel_wiring.py
+++ b/tests/test_panel_wiring.py
@@ -369,3 +369,43 @@ def test_the_offline_reader_is_reachable_from_the_data_page():
         "the Drive fallback is not offered where the engine request fails, so "
         "a machine with no engine still reaches a dead end — which is the whole "
         "case the bundle format exists for")
+
+
+def test_no_two_inlined_modules_declare_the_same_top_level_name():
+    """The DOM harness concatenates the panel's modules into ONE classic script,
+    and two modules declaring the same `const` is a SyntaxError that kills the
+    whole page.
+
+    FOUND ON 2026-08-12 the expensive way. drive.js and sheets.js both declared
+    `FILES`, `FOLDER_MIME` and `headers`. The harness produced a page that threw
+    before anything ran, four account tests timed out after thirty seconds each
+    waiting for an element that could never appear, and not one of the messages
+    said "SyntaxError" — Playwright reports what it was waiting for, not why the
+    page is dead.
+
+    `headers` is the worse half of the pair. Function declarations may be
+    redeclared, so it would NOT have thrown: sheets.js's version would silently
+    replace drive.js's, and the harness would test error messages that the real
+    panel never produces.
+
+    Checked here rather than left to the harness because the failure this
+    produces is unreadable at the point it happens, and one name is enough.
+    """
+    modules = ["startup.js", "transport.js", "version.js", "releases.js",
+               "identity.js", "accounts.js", "drive.js", "sheets.js",
+               "bundleview.js", "engine.js"]
+    seen: dict[str, str] = {}
+    clashes: list[str] = []
+    for name in modules:
+        body = (EXT / name).read_text(encoding="utf-8")
+        body = re.sub(r"^import[\s\S]*?;\s*$", "", body, flags=re.M)
+        body = re.sub(r"\bexport\s+", "", body)
+        for declared in re.findall(
+                r"^(?:const|let|var|function|class)\s+([A-Za-z_$][\w$]*)", body, re.M):
+            if declared in seen and seen[declared] != name:
+                clashes.append(f"{declared} in both {seen[declared]} and {name}")
+            seen.setdefault(declared, name)
+
+    assert not clashes, (
+        "two panel modules declare the same top-level name, and the DOM harness "
+        "flattens them into one script: " + "; ".join(clashes))

--- a/tests/test_panel_wiring.py
+++ b/tests/test_panel_wiring.py
@@ -43,6 +43,32 @@ def test_every_element_the_script_reaches_for_exists():
     assert not missing, f"app.js reaches for ids that app.html does not define: {missing}"
 
 
+def test_the_dom_harness_inlines_every_module_the_panel_imports():
+    """tools/panel_harness.py flattens the module graph by hand, and a module
+    left off that list does not fail loudly.
+
+    MET ON 2026-08-11. extension/accounts.js was added and wired into app.js but
+    not into the harness, so the harness stripped app.js's imports and every
+    call into it raised ReferenceError at the call site. Those calls are wrapped
+    in try/catch on purpose — the panel has to survive a storage fault — so the
+    remembered-accounts directory was silently never written while every visible
+    part of the panel, and every existing test, kept passing.
+
+    A missing module can break a feature outright or, worse, half of one. This
+    check is static and cheap, and it is the only thing standing between the two.
+    """
+    harness = (Path(__file__).resolve().parent.parent
+               / "tools" / "panel_harness.py").read_text(encoding="utf-8")
+    imported = set(re.findall(r'^import[\s\S]*?from "\./([\w.-]+\.js)";', JS, flags=re.M))
+    assert imported, "app.js appears to import nothing, so this guard reads the wrong file"
+
+    inlined = set(re.findall(r'EXT / "([\w.-]+\.js)"', harness))
+    missing = sorted(imported - inlined)
+    assert not missing, (
+        "tools/panel_harness.py does not inline modules app.js imports, so every "
+        f"call into them is a ReferenceError inside the harness: {missing}")
+
+
 def _pages_and_what_their_scripts_reach_for():
     """Every page in the extension, paired with the ids it defines and the ids
     the scripts IT loads reach for. Ids a script renders itself count as defined,

--- a/tests/test_the_panel_remembers_who_signed_in.py
+++ b/tests/test_the_panel_remembers_who_signed_in.py
@@ -1,0 +1,154 @@
+"""The directory of accounts the panel remembers, and what it must never hold.
+
+Multi-account switching arrived on 2026-08-11 WITHOUT breaking the owner's
+ruling of 2026-08-05 that nothing is written to disk. What is stored is a
+DIRECTORY — the names and addresses the panel already paints on screen — and a
+token for any of them is minted at the moment it is needed and kept in memory.
+
+extension/tests/accounts.test.mjs pins that store in isolation. This file pins
+the WIRING: that signing in actually reaches it, that signing out leaves the row
+behind instead of erasing it, and that nothing on the way in carries a
+credential into storage. A store that is correct and never called would pass
+every assertion in the other file.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.extension
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "tools"))
+
+pytest.importorskip("playwright")
+
+from playwright.sync_api import sync_playwright  # noqa: E402
+
+import panel_harness as harness  # noqa: E402
+
+# The key accounts.js versions its record under.
+ACCOUNTS_KEY = "scrapex-accounts-v1"
+
+# `sub` is Google's stable identifier, and the field the directory keys on. The
+# harness returns this dict verbatim as the userinfo response.
+ACCOUNT = {"sub": "110001", "name": "Muhammad Bayoumi",
+           "email": "madastore1899@gmail.com",
+           "picture": "https://lh3.googleusercontent.com/x"}
+
+
+@pytest.fixture(scope="module")
+def browser():
+    with sync_playwright() as pw:
+        instance = pw.chromium.launch()
+        try:
+            yield instance
+        finally:
+            instance.close()
+
+
+@pytest.fixture()
+def open_panel(browser, tmp_path):
+    pages = []
+
+    def opener(**stub_kwargs):
+        page_file = harness.build_page(tmp_path, harness.stub(**stub_kwargs),
+                                       name=f"directory{len(pages)}.html")
+        page = browser.new_page(viewport={"width": 400, "height": 900})
+        page.goto(page_file.as_uri())
+        pages.append(page)
+        return page
+
+    try:
+        yield opener
+    finally:
+        for page in pages:
+            page.close()
+
+
+def _directory(page):
+    """What is actually in chrome.storage.local, read from the page itself."""
+    return page.evaluate(
+        "async (key) => (await window.chrome.storage.local.get(key))[key] || null",
+        ACCOUNTS_KEY)
+
+
+def test_signing_in_puts_the_account_in_the_directory(open_panel):
+    """Without this the switcher has nobody to switch to: the store can be
+    perfect and never called, and every unit test still passes."""
+    page = open_panel(signed_in=ACCOUNT)
+    page.wait_for_selector("#welcome-signed-in:visible")
+    page.wait_for_function(
+        "async () => (await window.chrome.storage.local.get('scrapex-accounts-v1'))"
+        "['scrapex-accounts-v1'] != null",
+        timeout=10000)
+
+    held = _directory(page)
+    assert [row["id"] for row in held["accounts"]] == ["110001"], (
+        "the account that just signed in is not in the directory")
+    assert held["currentId"] == "110001", (
+        "the panel does not record which account it is acting as")
+    assert held["accounts"][0]["email"] == ACCOUNT["email"]
+
+
+def test_the_directory_carries_no_credential(open_panel):
+    """The owner's ruling of 2026-08-05, checked where it can actually be
+    broken. accounts.js copies four fields by name; this proves the caller
+    hands it an account and not the whole token response it is holding."""
+    page = open_panel(signed_in=ACCOUNT)
+    page.wait_for_selector("#welcome-signed-in:visible")
+    page.wait_for_function(
+        "async () => (await window.chrome.storage.local.get('scrapex-accounts-v1'))"
+        "['scrapex-accounts-v1'] != null",
+        timeout=10000)
+
+    held = _directory(page)
+    assert sorted(held["accounts"][0]) == ["email", "id", "name", "picture"], (
+        f"an unexpected field reached storage: {held['accounts'][0]}")
+
+    written = page.evaluate(
+        "async () => JSON.stringify(await window.chrome.storage.local.get(null))")
+    # The harness hands the panel this token; none of it may land on disk.
+    assert "granted-token" not in written, f"a token reached storage: {written}"
+
+
+def test_signing_out_keeps_the_row_and_stops_acting_as_it(open_panel):
+    """Ending a session is not removing an account. The row is the way back in
+    without typing the address again — the design draws it as a signed-out row
+    with a Sign in beside it. Erasing it here would make Sign out and Remove the
+    same button with two names."""
+    page = open_panel(signed_in=ACCOUNT)
+    page.wait_for_selector("#welcome-signed-in:visible")
+    page.wait_for_function(
+        "async () => (await window.chrome.storage.local.get('scrapex-accounts-v1'))"
+        "['scrapex-accounts-v1'] != null",
+        timeout=10000)
+
+    page.click("#signout")
+    page.wait_for_selector("#welcome-signed-out:visible")
+    page.wait_for_function(
+        "async () => (await window.chrome.storage.local.get('scrapex-accounts-v1'))"
+        "['scrapex-accounts-v1'].currentId === ''",
+        timeout=10000)
+
+    held = _directory(page)
+    assert [row["id"] for row in held["accounts"]] == ["110001"], (
+        "signing out erased the account instead of ending its session")
+    assert held["currentId"] == ""
+
+
+def test_an_account_without_a_stable_id_is_not_remembered(open_panel):
+    """Google should always return `sub`, and the panel must not fall apart on
+    the day it does not. An address is not a safe key — people change theirs and
+    Workspace admins reassign them — so a row without an id is not written at
+    all, and the panel goes on working without a directory entry."""
+    page = open_panel(signed_in={k: v for k, v in ACCOUNT.items() if k != "sub"})
+    page.wait_for_selector("#welcome-signed-in:visible")
+    page.wait_for_timeout(700)
+
+    assert _directory(page) is None, (
+        "a row nothing can switch to was written into the directory")
+    assert page.text_content("#welcome-name").strip() == ACCOUNT["name"], (
+        "the panel stopped painting the account because the directory refused it")

--- a/tests/test_the_privacy_policy_is_true.py
+++ b/tests/test_the_privacy_policy_is_true.py
@@ -217,3 +217,86 @@ def test_the_support_and_policy_name_the_same_public_home():
     for path in (ROOT / "docs" / "support.md", ROOT / "docs" / "privacy-policy.md"):
         assert PUBLIC_REPO in path.read_text(encoding="utf-8"), (
             f"{path.name} does not name the public home")
+
+
+# ---- what the extension writes to disk, against what the policy admits ------
+
+def test_every_place_the_extension_persists_data_is_in_the_policy():
+    """THE GAP THIS FILE HAD, found while reviewing #168 on 2026-08-12.
+
+    Every test above checks what the extension REACHES — scopes, hosts, remote
+    calls. Nothing checked what it KEEPS. So when accounts.js began writing a
+    directory of names, addresses and pictures into chrome.storage.local, the
+    published policy still said of exactly those fields "Nothing is stored and
+    nothing is sent anywhere", and the whole suite stayed green.
+
+    That sentence was not a small inaccuracy. It is the answer to the question a
+    reader of a privacy policy is actually asking, and it was false about the one
+    kind of data — a person's name and email address — that a policy exists for.
+
+    The check is deliberately crude: any module that touches a persistent store
+    must be named in the policy's storage table. Crude and loud beats precise
+    and absent, and the failure message says what to write rather than only that
+    something is wrong.
+    """
+    policy = POLICY.read_text(encoding="utf-8")
+    # Split on a horizontal RULE — a line that is only dashes — not on "---",
+    # because a markdown table's own header separator (`|---|---|`) contains it
+    # and the first version of this cut the section off above every data row.
+    # It then reported all three modules as missing, including one whose row was
+    # right there. A check that is wrong about its own input is worse than none.
+    after = policy.split("## What is stored, and where", 1)[-1]
+    storage_table = re.split(r"^-{3,}\s*$", after, maxsplit=1, flags=re.M)[0]
+
+    # A CALL, not a mention. The first version matched the bare API name and
+    # reported app.js, which names chrome.storage.local only in a comment
+    # explaining that accounts.js is the module that uses it. A test that cannot
+    # tell writing from talking about writing produces exactly the noise that
+    # gets a test disabled.
+    persistent = (r"chrome\.storage\.(?:local|sync)\.(?:set|get|remove|clear)\s*\(",
+                  r"\blocalStorage\.(?:setItem|getItem|removeItem)\s*\(",
+                  r"\bindexedDB\.open\s*\(")
+    writers: dict[str, set[str]] = {}
+    for module in sorted((ROOT / "extension").glob("*.js")):
+        body = module.read_text(encoding="utf-8")
+        found = {pattern for pattern in persistent if re.search(pattern, body)}
+        if found:
+            writers[module.name] = found
+
+    # The panel keeps three things on this machine and the policy must own all
+    # three: the appearance choice, the display time zone, and — since #168 —
+    # the accounts directory.
+    described = {
+        "appearance.js": "appearance",
+        "timezone.js": "time zone",
+        "accounts.js": "accounts",
+        "engine.js": "engine",
+    }
+    missing = [name for name in writers
+               if name in described and described[name].lower() not in storage_table.lower()]
+    assert not missing, (
+        "these modules write to a store that survives closing the panel, and the "
+        f"policy's storage table does not mention what they keep: {missing}. Add "
+        "a row saying WHAT is kept, WHERE, and WHO can read it — a reader of a "
+        "privacy policy is asking exactly that.")
+
+    unknown = sorted(set(writers) - set(described))
+    assert not unknown, (
+        f"{unknown} began persisting data and nobody decided what the policy "
+        "should say about it. Add it to `described` above WITH its policy row, "
+        "or stop persisting.")
+
+
+def test_the_policy_does_not_claim_the_accounts_list_is_unstored():
+    """The exact sentence that went false, guarded by its own test.
+
+    A general rule would let this be reintroduced in different words; the
+    specific claim is worth naming because it was published and wrong.
+    """
+    policy = POLICY.read_text(encoding="utf-8")
+    scopes_row = [line for line in policy.splitlines()
+                  if "userinfo.email" in line and "|" in line]
+    assert scopes_row, "the policy no longer describes the userinfo scopes"
+    assert "Nothing is stored" not in scopes_row[0], (
+        "the policy says nothing is stored about the account details, and "
+        "extension/accounts.js keeps a directory of them in chrome.storage.local")

--- a/tools/panel_harness.py
+++ b/tools/panel_harness.py
@@ -77,6 +77,7 @@ def stub(backend: str = DEFAULT_BACKEND, *, engine_up=True, sources=None, jobs=N
          signed_in=None, signin_error=None, signin_delay_ms=0,
          signin_never_returns=False, route_delays=None, blackhole_routes=(),
          native_mode="absent", google_account_mode="ok",
+         remembered_accounts=None,
          worker_alive=True) -> str:
     """A chrome.* shim plus a fetch() interceptor.
 
@@ -201,6 +202,14 @@ def stub(backend: str = DEFAULT_BACKEND, *, engine_up=True, sources=None, jobs=N
     # an empty log. Carries `total` so the "all shown" caption has its number.
     entries = logs if logs is not None else []
     log_payload = {"entries": entries, "total": len(entries), "truncated": False}
+    # What chrome.storage.local already holds when the panel opens. `backend` is
+    # what engine.js reads; `remembered_accounts` seeds the account directory so
+    # a card with more than one row can be driven at all — the panel can only
+    # ever write ONE account into it by signing in.
+    local_seed = {"backend": backend}
+    if remembered_accounts is not None:
+        local_seed["scrapex-accounts-v1"] = remembered_accounts
+    local_seed = json.dumps(local_seed)
     return f"""
 if (typeof AbortSignal !== 'undefined' && !AbortSignal.timeout) {{
   AbortSignal.timeout = (ms) => {{
@@ -227,7 +236,20 @@ window.chrome = {{
               }} }},
   tabs: {{ query: async () => [{json.dumps(tab if tab is not None else ACTIVE_TAB)}],
            create: () => {{}} }},
-  storage: {{ local: {{ get: async () => ({{backend: {backend!r}}}), set: async () => {{}} }} }},
+  // A REAL store, not a fixed answer. accounts.js writes the remembered account
+  // directory through here and reads it back; a `set` that threw everything away
+  // would let a broken write pass every test driven by this harness, which is
+  // the shape of failure this file exists to prevent.
+  storage: {{ local: (() => {{
+    const held = {local_seed};
+    return {{
+      get: async (keys) => {{
+        if (typeof keys === "string") return keys in held ? {{[keys]: held[keys]}} : {{}};
+        return {{...held}};
+      }},
+      set: async (patch) => {{ Object.assign(held, patch); }},
+    }};
+  }})() }},
   // chrome.identity reports failure by leaving the token undefined and setting
   // runtime.lastError, so the shim must be able to do BOTH — a stub that only
   // ever returned a token could not test a single refusal branch.
@@ -433,6 +455,13 @@ def build_page(tmp: Path, stub_js: str, name: str = "panel.html") -> Path:
     version_js = (EXT / "version.js").read_text(encoding="utf-8")
     releases_js = (EXT / "releases.js").read_text(encoding="utf-8")
     identity_js = (EXT / "identity.js").read_text(encoding="utf-8")
+    # THE LIST BELOW IS HAND-MAINTAINED, and a module missing from it does not
+    # fail loudly: app.js's imports are stripped, so a call into an un-inlined
+    # module is a ReferenceError at the call site. accounts.js is wrapped in
+    # try/catch by design — the panel must survive a storage fault — so leaving
+    # it out made the directory silently never written while every visible part
+    # of the panel kept working.
+    accounts_js = (EXT / "accounts.js").read_text(encoding="utf-8")
 
     # Flatten the ES-module graph. engine.js imports the protocol version from
     # transport.js, while app.js imports both modules; leaving even that
@@ -440,11 +469,20 @@ def build_page(tmp: Path, stub_js: str, name: str = "panel.html") -> Path:
     # before DOMContentLoaded. Keep the harness on the extension's real module
     # graph instead of re-declaring any of its functions in a test-only stub.
     app_js = re.sub(r"^import[\s\S]*?;\s*$", "", app_js, flags=re.M)
+    # The <use> rewrite above only touches app.html's TEXT, so every icon app.js
+    # renders at runtime kept the real path and 404'd here — 71 of them, all
+    # invisible, in a harness whose whole point is that the picture and the
+    # assertions describe the same page. Pointing the sprite constant at the
+    # inlined symbols fixes them the same way the markup was fixed.
+    app_js = app_js.replace('const ICON_SPRITE = "icons/material-icons.svg";',
+                            'const ICON_SPRITE = "";')
     engine_js = re.sub(r"^import .*?;$", "", engine_js, flags=re.M)
     transport_js = re.sub(r"^import .*?;$", "", transport_js, flags=re.M)
     version_js = re.sub(r"^import .*?;$", "", version_js, flags=re.M)
     releases_js = re.sub(r"^import .*?;$", "", releases_js, flags=re.M)
     identity_js = re.sub(r"^import .*?;$", "", identity_js, flags=re.M)
+    accounts_js = re.sub(r"^import .*?;$", "", accounts_js, flags=re.M)
+    accounts_js = re.sub(r"\bexport\s+", "", accounts_js)
     startup_js = re.sub(r"\bexport\s+", "", startup_js)
     engine_js = re.sub(r"\bexport\s+", "", engine_js)
     transport_js = re.sub(r"\bexport\s+", "", transport_js)
@@ -488,6 +526,6 @@ def build_page(tmp: Path, stub_js: str, name: str = "panel.html") -> Path:
         # would run init() twice and double-bind every listener — a click would
         # then toggle twice and appear to do nothing at all.
         f"<script>{startup_js}\n{transport_js}\n{version_js}\n{releases_js}\n{identity_js}\n"
-        f"{engine_js}\n{app_js}</script></body></html>",
+        f"{accounts_js}\n{engine_js}\n{app_js}</script></body></html>",
         encoding="utf-8")
     return page

--- a/tools/panel_harness.py
+++ b/tools/panel_harness.py
@@ -476,19 +476,28 @@ def build_page(tmp: Path, stub_js: str, name: str = "panel.html") -> Path:
     # inlined symbols fixes them the same way the markup was fixed.
     app_js = app_js.replace('const ICON_SPRITE = "icons/material-icons.svg";',
                             'const ICON_SPRITE = "";')
-    engine_js = re.sub(r"^import .*?;$", "", engine_js, flags=re.M)
-    transport_js = re.sub(r"^import .*?;$", "", transport_js, flags=re.M)
-    version_js = re.sub(r"^import .*?;$", "", version_js, flags=re.M)
-    releases_js = re.sub(r"^import .*?;$", "", releases_js, flags=re.M)
-    identity_js = re.sub(r"^import .*?;$", "", identity_js, flags=re.M)
-    accounts_js = re.sub(r"^import .*?;$", "", accounts_js, flags=re.M)
-    accounts_js = re.sub(r"\bexport\s+", "", accounts_js)
-    startup_js = re.sub(r"\bexport\s+", "", startup_js)
-    engine_js = re.sub(r"\bexport\s+", "", engine_js)
-    transport_js = re.sub(r"\bexport\s+", "", transport_js)
-    version_js = re.sub(r"\bexport\s+", "", version_js)
-    releases_js = re.sub(r"\bexport\s+", "", releases_js)
-    identity_js = re.sub(r"\bexport\s+", "", identity_js)
+    # ONE FLATTENING RULE, APPLIED TO EVERY MODULE, rather than three lines per
+    # module repeated down the file. The comment above says this list is
+    # hand-maintained; it still is, but adding a module is now one name instead
+    # of three near-identical substitutions to copy correctly.
+    #
+    # drive.js, bundleview.js and sheets.js arrived on 2026-08-12 when the Drive
+    # work landed on main, and the test below caught their absence during the
+    # rebase — which is what it was written for.
+    def flatten(source: str) -> str:
+        source = re.sub(r"^import[\s\S]*?;\s*$", "", source, flags=re.M)
+        return re.sub(r"\bexport\s+", "", source)
+
+    startup_js = flatten(startup_js)
+    engine_js = flatten(engine_js)
+    transport_js = flatten(transport_js)
+    version_js = flatten(version_js)
+    releases_js = flatten(releases_js)
+    identity_js = flatten(identity_js)
+    accounts_js = flatten(accounts_js)
+    drive_js = flatten((EXT / "drive.js").read_text(encoding="utf-8"))
+    sheets_js = flatten((EXT / "sheets.js").read_text(encoding="utf-8"))
+    bundleview_js = flatten((EXT / "bundleview.js").read_text(encoding="utf-8"))
 
     tmp.mkdir(parents=True, exist_ok=True)
     page = tmp / name
@@ -526,6 +535,7 @@ def build_page(tmp: Path, stub_js: str, name: str = "panel.html") -> Path:
         # would run init() twice and double-bind every listener — a click would
         # then toggle twice and appear to do nothing at all.
         f"<script>{startup_js}\n{transport_js}\n{version_js}\n{releases_js}\n{identity_js}\n"
-        f"{accounts_js}\n{engine_js}\n{app_js}</script></body></html>",
+        f"{accounts_js}\n{drive_js}\n{sheets_js}\n{bundleview_js}\n"
+        f"{engine_js}\n{app_js}</script></body></html>",
         encoding="utf-8")
     return page


### PR DESCRIPTION
Implements the `design_handoff_profile_accounts` handoff (**REV01**) for the extension side panel's signed-in Profile state, plus the account directory underneath it.

**Please review the two rulings first — they are the decisions, the rest is consequence.**

## 1. Multi-account without storing credentials

`getAuthToken` speaks for exactly one account (the Chrome profile's primary) and takes no chooser, so the switcher cannot be built on it. The obvious alternative — `launchWebAuthFlow` + stored refresh tokens — breaks the ruling of 2026-08-05 recorded in `extension/identity.js` that nothing is written to disk.

It was not necessary. The **implicit flow** (`response_type=token`) returns an access token and no refresh token, so what is stored is a *directory* (names and addresses the panel already paints) and a token is minted per account when needed. The owner chose this on 2026-08-11.

The ruling is enforced as assertions, not comments:
- `switching-accounts.test.mjs` — the auth URL may not request a `code`, `access_type=offline`, or carry a `client_secret`
- `accounts.test.mjs` — a token handed in alongside an account never reaches storage
- `test_the_panel_remembers_who_signed_in.py` — the same, checked through the real wiring

## 2. Control sizes belong to the general rule

The handoff asks for a 32×32 top-bar button. Rather than a local `min-height` override, this adds a third notch to the shared system: `--control-height-xs` + `button.icon-button.xs`, with a live example in `design/gallery.html` (required by `test_ui_kit`). The gallery text states it is for **secondary controls only** — it is below the 44px coarse-pointer floor.

## Three defects the screenshots called fine

| Defect | Measured |
|---|---|
| Sign-out landed in the unreachable half of a centred scroller | 75px clipped and fully hidden at 400×520; 67px with the lookup notice showing; 22px at 320×440 |
| The card grew the page instead of scrolling its list, pushing the two action rows off the bottom | the derived-height chain was one link short — `#welcome-signed-in` kept `min-height: auto` |
| The per-row menu never opened on a scrolled row | scroll events are **asynchronous**; restoring `scrollTop` queued an event that closed the menu just opened. Worked on row 1, failed on the rest |

The menu is anchored to the **card**, not the row — the rows sit in an `overflow-y: auto` box that clipped it by 5px at 400px and 61px at 320px. The handoff names this fallback itself. Its confirm step lives inside the menu because `test_panel_dom.py:2946` forbids `role="dialog"` in `#view-profile`.

## Two holes in the test harness

- **`accounts.js` was not in `panel_harness.py`'s hand-written module list.** `app.js`'s imports are stripped, so every call raised `ReferenceError` — inside the `try/catch` that exists so a storage fault cannot break the panel. The directory was silently never written while every test stayed green. `test_panel_wiring.py` now fails the build for any un-inlined import, and the guard was verified against the defect it was written for.
- **71 runtime-rendered icons 404'd** in every harness test and screenshot: the sprite-path rewrite touched `app.html`'s text only. Down to 12.

`chrome.storage.local` is now a real store; previously `set()` discarded everything, so a broken write would have passed.

## What does not work yet, and why it is not a placeholder

Switching, `Sign in` and `Add another account` reach `authorize()` and are refused with `misconfigured` **before Chrome is asked to open anything**. `launchWebAuthFlow` needs a **Web-application OAuth client**; `manifest.json` carries a Chrome-Extension client. `WEB_CLIENT_ID` is empty deliberately — a placeholder would fail at Google with a message about the client rather than about what is missing.

**Blocked on the owner:** create that client in Google Cloud with redirect URI `https://ekcgggphcfdbjgfkcmjagehfjhijeang.chromiumapp.org/`.

Every non-current account renders as signed out for the same reason: the directory stores no session state on purpose (a cached "signed in" goes stale and then lies), and the silent check needs the same client.

`Manage your account` and `Terms of Service` ship **disabled**, pending a screen and pending written terms.

## Also fixed

An adversarial review of the diff found `#welcome-name` had no `dir="auto"` — the only field in the block that can hold a right-to-left script, and the one the redesign's direction reasoning skipped while giving the ASCII-only address a `dir` it does not need.

## Open questions for you

1. **Version** — this is user-visible, but a release with no new Capability produces a CHANGELOG section that vanishes on the next bump (`scrapex/cli.py:401`). Bump `manifest.json` or not?
2. **Scope box vs. `#view-profile`** — REV01 forbids touching the checking/signed-out states but requires changing the element all three share. Applied directly, then measured: both states render **byte-identically** with and without the change (3 and 8 boxes compared).
3. **Copy** — the destructive action reads `Remove from ScrapeX`, not `Delete account`, per the handoff's own note.

## Verification

`pytest -m extension` green · `node --test extension/tests/*.test.mjs` 128 green · `eslint` clean · light/dark × 320/400 measured for overflow, ellipsis, menu placement and touch-target geometry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
