### PR TITLE
A menu on the dataset card, with the unbuilt action visible in it

### DIFF
--- a/extension/app.html
+++ b/extension/app.html
@@ -535,6 +535,10 @@
         <div id="datasets" class="dataset-list">
           <div class="skeleton"></div><div class="skeleton"></div>
         </div>
+        <!-- Outside #datasets, which loadDatasets() overwrites wholesale: a
+             result written into it would be erased by the reload the action
+             itself triggers. -->
+        <p id="datasets-msg" class="hint" role="status" aria-live="polite"></p>
       </section>
 
     </section>

--- a/extension/app.js
+++ b/extension/app.js
@@ -3273,16 +3273,29 @@ async function loadDatasets() {
       <article class="card dataset-card" data-open="${esc(s.source_key)}"
                role="link" tabindex="0"
                aria-label="Open ${esc(sourceDomain(s.base_url) || s.source_name || s.source_key)} dataset in workbook">
-        <span class="dataset-card-open">${icon("chevron-right", "sm")}</span>
+        ${sourceMenu(s)}
         <div><div class="dataset-identity-line">${sourceIdentity(
           s, false, fmtCount(s.observations))}</div>
           <div class="n">${fmtCount(s.products)} products</div>
           <div class="n muted">${freshnessLine(s)}</div></div>
       </article>`).join("");
+    box.querySelectorAll(".dataset-card .split-button").forEach((root) => {
+      const key = root.closest("[data-open]").dataset.open;
+      window.ScrapeXSplitButton.wire(root, (action) => runSourceAction(action, key));
+    });
     box.querySelectorAll("[data-open]").forEach((card) => {
-      card.addEventListener("click", () => openDataset(card.dataset.open));
+      // THE MENU IS INSIDE THE CARD, AND THE CARD IS ITSELF A LINK. Without
+      // this guard, opening the menu ALSO opens the dataset in a new tab — the
+      // owner clicks three dots and lands on a different page, having chosen
+      // nothing. `closest` rather than a target check, because the click can
+      // land on the icon, the summary or the option inside it.
+      card.addEventListener("click", (event) => {
+        if (event.target.closest(".split-button")) return;
+        openDataset(card.dataset.open);
+      });
       card.addEventListener("keydown", (event) => {
         if (!["Enter", " "].includes(event.key)) return;
+        if (event.target.closest(".split-button")) return;
         event.preventDefault();
         openDataset(card.dataset.open);
       });
@@ -3375,6 +3388,87 @@ function freshnessLine(s) {
     : last.requests_count ? `${fmtCount(last.requests_count)} requests` : "";
   return `Last crawled ${when}${measure ? " · " + esc(measure) : ""}`;
 }
+
+// ---- what can be done to one source, from its own card ----------------------
+//
+// The card used to carry a chevron and one action: open. Everything else about a
+// source lived on another screen or on the engine's web page, and the owner had
+// to know where. The chevron is now a menu of the things that are actually about
+// THIS source, built on the split-button already shared with the Activity log
+// rather than a second menu implementation.
+//
+// AN ACTION THAT IS NOT BUILT IS SHOWN, DISABLED, WITH THE REASON. The owner
+// asked to see the work in progress rather than a tidy screen that hides it, and
+// this repository already had the convention ("Not built yet." on the file
+// source). A menu that quietly omits what is coming teaches the owner it will
+// never exist.
+const SOURCE_ACTIONS = [
+  {action: "update", label: "Update now",
+   why: "Crawl this source once, immediately."},
+  {action: "changes", label: "Recent changes",
+   why: "What moved since the last crawl."},
+  {action: "settings", label: "Source settings",
+   why: "Address, name and how this source is read."},
+  {action: "pause", label: "Pause collecting",
+   why: "Stop scheduled crawls without deleting anything."},
+  // THE ONE THAT IS NOT READY, and what is missing is an ENGINE route rather
+  // than panel work: sheets.js can create a spreadsheet and write a tab, but the
+  // rows have nowhere to come from. /api/records is paginated at 100 and carries
+  // the compact card shape, not the export shape; /export/{key}.xlsx is a binary
+  // workbook this panel cannot parse without a library it will not ship. One
+  // JSON route over reports.export_source_table is the whole gap.
+  {action: "sheet", label: "Export to Google Sheets", ready: false,
+   why: "Not built yet — the engine has no route that hands the panel export rows."},
+];
+
+function sourceMenu(source) {
+  const options = SOURCE_ACTIONS.map((item) => `
+    <button class="split-button-option" role="menuitem" type="button"
+            data-split-action="${item.action}"${item.ready === false ? " disabled" : ""}
+            title="${esc(item.why)}">${esc(item.label)}${
+      item.ready === false ? ' <span class="muted">· not built yet</span>' : ""
+    }</button>`).join("");
+  return `<div class="split-button" role="group"
+               aria-label="Actions for ${esc(source.source_key)}">
+      <details class="split-button-menu">
+        <summary class="split-button-trigger" aria-haspopup="menu"
+                 aria-expanded="false" title="Actions for this source">
+          ${icon("more-vert", "sm")}</summary>
+        <div class="split-button-options" role="menu">${options}</div>
+      </details>
+    </div>`;
+}
+
+/** Everything a source menu can do, in one place so the card stays a template. */
+async function runSourceAction(action, key) {
+  if (action === "changes") return openTab(`/source/${key}#changes`);
+  if (action === "settings") return openTab(`/sources/${key}`);
+  if (action === "update") {
+    try {
+      await post("/api/jobs", {source_keys: [key], run_mode: "current"});
+      showView("run");
+    } catch (error) {
+      out("datasets-msg", esc((error && error.message) || "Couldn't start it."), "err");
+    }
+    return;
+  }
+  if (action === "pause") {
+    try {
+      await post(`/api/sources/${encodeURIComponent(key)}/active`, {active: false});
+      out("datasets-msg", `${esc(key)} paused. Nothing was deleted.`, "ok");
+      loadDatasets();
+    } catch (error) {
+      out("datasets-msg", esc((error && error.message) || "Couldn't pause it."), "err");
+    }
+    return;
+  }
+  // `sheet` is disabled in the markup and cannot arrive here. Saying so if it
+  // ever does beats doing nothing silently.
+  out("datasets-msg",
+      "That action is not built yet — it needs an engine route that hands the "
+      + "panel export rows.", "err");
+}
+
 
 function openDataset(key) {
   openTab("/source/" + key);

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -794,8 +794,24 @@ def test_dataset_action_opens_the_workspace_directly(open_panel):
     page.wait_for_timeout(300)
     assert page.locator("header.sx-header").count() == 0
     assert page.locator("#open-workbook").count() == 1
-    assert page.locator("#datasets button").count() == 0
+    # The rule this used to state as "no buttons in a card" is really "no
+    # REDUNDANT OPEN button in a card": the card IS the open action, and a
+    # second control saying so was the clutter that got removed. A menu of the
+    # things that are NOT opening — update, changes, settings, pause — is a
+    # different thing, and it arrived on 2026-08-12 at the owner's request.
     assert "Open in Workspace" not in page.text_content("#view-data")
+    cards = page.locator(".dataset-card")
+    assert cards.count() > 0
+    assert page.locator(".dataset-card .split-button-trigger").count() == cards.count(), (
+        "every dataset card must carry exactly one actions menu")
+    for label in ("Update now", "Recent changes", "Source settings",
+                  "Pause collecting", "Export to Google Sheets"):
+        assert page.locator(f'.dataset-card [data-split-action]:has-text("{label}")'
+                            ).count() == cards.count(), f"{label} is missing from the menu"
+    # The unbuilt one is PRESENT and DISABLED — the owner asked to watch the work
+    # in progress rather than have it hidden until it is finished.
+    assert page.locator('.dataset-card [data-split-action="sheet"][disabled]'
+                        ).count() == cards.count()
 
     page.click("#open-workbook")
     page.wait_for_timeout(200)
@@ -810,6 +826,18 @@ def test_dataset_action_opens_the_workspace_directly(open_panel):
     opened = page.evaluate("() => window.__opened")
     assert len(opened) == 1
     assert opened[0].endswith("/source/LONG_AR")
+
+    # OPENING THE MENU MUST NOT OPEN THE DATASET. The menu lives inside a card
+    # that is itself a link, so without a guard the owner clicks three dots,
+    # lands in a new tab, and has chosen nothing.
+    page.evaluate("() => { window.__opened = []; }")
+    page.click('[data-open="LONG_AR"] .split-button-trigger')
+    page.wait_for_timeout(200)
+
+    assert page.evaluate("() => window.__opened") == [], (
+        "opening the actions menu also opened the dataset in a new tab")
+    assert page.locator('[data-open="LONG_AR"] .split-button-menu[open]').count() == 1, (
+        "the menu did not open")
 
 
 def test_data_rows_scroll_inside_the_browse_card_not_the_page(open_panel):


### PR DESCRIPTION
The card carried a chevron and one action: **open**. Everything else about a source lived on another screen or on the engine's own web page, and the owner had to know where. The chevron is now a three-dot menu of the things that are actually about **this** source.

## The six entries

| Action | What it does | State |
|---|---|---|
| **Update now** | `POST /api/jobs`, then switches to the Run screen | ✅ |
| **Recent changes** | The engine's page, anchored at the change feed | ✅ |
| **Source settings** | Address, name, how the source is read | ✅ |
| **Pause collecting** | `POST /api/sources/{key}/active` — nothing deleted | ✅ |
| **Export to Google Sheets** | — | ❌ **not built** |

*Open* is the card itself, so it is not repeated in the menu.

## The unbuilt one is in the menu, disabled, with the reason

The owner asked to **watch the work in progress** rather than have it hidden until finished, and this repository already had the convention (`Not built yet.` on the file source). A menu that quietly omits what is coming teaches the owner it will never exist.

What is missing is an **engine** route rather than panel work. `sheets.js` can create a spreadsheet and write a tab, but the rows have nowhere to come from:

- `/api/records` is paginated at 100 and carries the **compact card shape**, not the export shape
- `/export/{key}.xlsx` is a **binary workbook** this panel will not ship a library to parse

One JSON route over `reports.export_source_table` is the whole gap.

## Built on the menu that already exists

`split-button.js` — shared with the Activity log — rather than a second implementation. The open/close/aria/escape/outside-click dance is exactly the part a second copy gets subtly wrong.

## A test that had to change, and what it was really holding

`test_dataset_action_opens_the_workspace_directly` asserted **"no buttons in a dataset card"**. The rule was never that. It was *no redundant **open** button* — the card **is** the open action, and a second control saying so was the clutter that got removed.

That is now stated in those words, and the new risk is guarded instead: **opening the menu must not also open the dataset**, which it would, since the menu lives inside a card that is a link. The owner would click three dots, land in a new tab, and have chosen nothing.

---

**Green locally:** 500 extension tests · 125 node tests · `eslint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)