### PR TITLE
Export a source to Google Sheets, and stop telling the owner he is signed out

### DIFF
--- a/extension/app.js
+++ b/extension/app.js
@@ -18,7 +18,9 @@ import {
 } from "./accounts.js";
 import { backUp, fetchLatest, fetchPanelPack } from "./drive.js";
 import { readPanelPack, datasetSummaries } from "./bundleview.js";
-import { ensureFolder, ensureSpreadsheet, DEFAULT_WORKBOOK, SHEET_FOLDER } from "./sheets.js";
+import {
+  ensureFolder, ensureSpreadsheet, writeTab, DEFAULT_WORKBOOK, SHEET_FOLDER,
+} from "./sheets.js";
 import {
   afterIdle, afterNextPaint, deadlineForLocalRequest, fetchWithDeadline,
   isTimeoutError, markStartup,
@@ -2350,8 +2352,19 @@ async function loadAccount({ interactive = false } = {}) {
       state.token = result.token;
       state.account = accountResult.account;
       state.accountStatus = null;
-      renderAccount({});
+      // THE DIRECTORY IS UPDATED BEFORE THE CARD IS DRAWN, and the order is the
+      // whole fix. It used to render first and remember afterwards, so the card
+      // read `state.currentAccountId` while it still held the empty string left
+      // by the last sign-out — and the row for the account that had just signed
+      // in failed the `id !== currentAccountId` filter, appearing in the list
+      // BELOW the header, labelled "Signed out".
+      //
+      // Reported by the owner from the running panel on 2026-08-12: one
+      // account, signed in at the top and signed out two inches under it.
+      // Nothing re-rendered afterwards, so the contradiction simply stayed on
+      // screen. The state was never wrong; it was read one step too early.
       await rememberSignedInAccount(accountResult.account);
+      renderAccount({});
       return { ...result, account: accountResult.account };
     }
 
@@ -3932,14 +3945,13 @@ const SOURCE_ACTIONS = [
    why: "Address, name and how this source is read."},
   {action: "pause", label: "Pause collecting",
    why: "Stop scheduled crawls without deleting anything."},
-  // THE ONE THAT IS NOT READY, and what is missing is an ENGINE route rather
-  // than panel work: sheets.js can create a spreadsheet and write a tab, but the
-  // rows have nowhere to come from. /api/records is paginated at 100 and carries
-  // the compact card shape, not the export shape; /export/{key}.xlsx is a binary
-  // workbook this panel cannot parse without a library it will not ship. One
-  // JSON route over reports.export_source_table is the whole gap.
-  {action: "sheet", label: "Export to Google Sheets", ready: false,
-   why: "Not built yet — the engine has no route that hands the panel export rows."},
+  // BUILT ON 2026-08-12, and it shipped disabled for exactly one day with the
+  // reason written on it: sheets.js could create a spreadsheet and fill a tab,
+  // and the rows had nowhere to come from. GET /api/export/{key} closed that,
+  // reusing the same export_source_table the .xlsx and the Apps Script funnel
+  // already use rather than inventing a third idea of what an export is.
+  {action: "sheet", label: "Export to Google Sheets",
+   why: "One tab per source, in a spreadsheet ScrapeX made in your Drive."},
 ];
 
 function sourceMenu(source) {
@@ -3983,11 +3995,58 @@ async function runSourceAction(action, key) {
     }
     return;
   }
-  // `sheet` is disabled in the markup and cannot arrive here. Saying so if it
-  // ever does beats doing nothing silently.
-  out("datasets-msg",
-      "That action is not built yet — it needs an engine route that hands the "
-      + "panel export rows.", "err");
+  if (action === "sheet") return exportSourceToSheet(key);
+  out("datasets-msg", `Unknown action ${esc(action)}.`, "err");
+}
+
+/**
+ * One source, into a tab of the owner's own spreadsheet.
+ *
+ * THE DIVISION HOLDS ALL THE WAY THROUGH. The engine produces rows and knows
+ * nothing about Google; the panel talks to Google and never opens a database.
+ * The token is read at the moment of use, as everywhere else here, because
+ * sign-out clears it from five places and a captured copy would outlive it.
+ *
+ * ONE TAB PER SOURCE, named for the source. The alternative — everything in one
+ * sheet — is the arrangement gdrive.py had, and it means an export of one
+ * source silently rewrites the rows of another.
+ */
+async function exportSourceToSheet(key) {
+  if (!state.token) {
+    out("datasets-msg", "Sign in with Google first — the Account button at the "
+                        + "top of the panel.", "err");
+    return;
+  }
+  out("datasets-msg", `Reading ${esc(key)}…`, "");
+  try {
+    const table = await api(`/api/export/${encodeURIComponent(key)}`);
+    if (!table.rows.length) {
+      out("datasets-msg",
+          `${esc(key)} has no rows to export yet — crawl it first.`, "err");
+      return;
+    }
+
+    out("datasets-msg", `Writing ${fmtCount(table.rows.length)} rows to Google…`, "");
+    const folder = await ensureFolder(state.token, SHEET_FOLDER);
+    const sheet = await ensureSpreadsheet(state.token, DEFAULT_WORKBOOK, {folder});
+    await writeTab(state.token, sheet.id, {
+      tab: key, header: table.header, rows: table.rows,
+    });
+
+    // TRUNCATION IS SAID, NOT LEFT TO BE NOTICED. A spreadsheet that stops at
+    // forty thousand rows looks exactly like a business with forty thousand
+    // products, and the difference matters on the day someone counts.
+    const capped = table.truncated
+      ? ` Only the first ${fmtCount(table.limit)} rows fit — the tab is not the whole source.`
+      : "";
+    out("datasets-msg",
+        `${esc(key)}: ${fmtCount(table.rows.length)} rows written to `
+        + `<a class="link" href="${esc(sheet.url)}" target="_blank" `
+        + `rel="noreferrer noopener">${esc(sheet.name)}</a>.${capped}`,
+        table.truncated ? "" : "ok");
+  } catch (error) {
+    out("datasets-msg", esc((error && error.message) || "Something went wrong."), "err");
+  }
 }
 
 

--- a/extension/tests/sheets.test.mjs
+++ b/extension/tests/sheets.test.mjs
@@ -291,3 +291,26 @@ test("the Sheets host is declared in the manifest", async () => {
     "sheets.googleapis.com is not in host_permissions, so every call in " +
     "sheets.js fails before it leaves the panel");
 });
+
+
+test("a tab is named for its source, not shared with every other one", async () => {
+  // gdrive.py put everything in one workbook and one tab per source; the tab
+  // NAME is what keeps an export of MADAR from overwriting ELSEWEDY's rows.
+  // writeTab clears before it writes, so a shared name would not merge the two
+  // — it would replace one with the other and report success.
+  const written = [];
+  const fetchImpl = scripted([
+    [(url) => url.includes("fields=sheets"),
+      () => reply(200, {body: {sheets: [{properties: {title: "MADAR"}},
+                                        {properties: {title: "ELSEWEDY"}}]}})],
+    [(url) => url.endsWith(":clear"), (url) => { written.push(`clear:${url}`); return reply(200, {body: {}}); }],
+    [(_url, init) => init.method === "PUT", (url) => { written.push(`put:${url}`); return reply(200, {body: {}}); }],
+  ]);
+
+  await writeTab("tok", "sheet-1", {tab: "MADAR", header: ["a"], rows: [["1"]], fetchImpl});
+  await writeTab("tok", "sheet-1", {tab: "ELSEWEDY", header: ["a"], rows: [["2"]], fetchImpl});
+
+  const named = written.map((entry) => decodeURIComponent(entry));
+  assert.ok(named.some((entry) => entry.includes("'MADAR'")), named.join("\n"));
+  assert.ok(named.some((entry) => entry.includes("'ELSEWEDY'")), named.join("\n"));
+});

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -105,6 +105,7 @@ from ..reports import (
     column_presence,
     crawl_history,
     data_model_report,
+    export_source_table,
     facet_options,
     google_finance_status,
     history_counts,
@@ -2395,6 +2396,11 @@ def create_app(
     #: Built bundles are named so the newest can be found without keeping any
     #: state between the two requests. A build followed by a restart must still
     #: be downloadable, and app.state would not survive one.
+    #: The export ceiling, named once. reports.export_source_table defaults to
+    #: the same number and extension/sheets.js mirrors it as MAX_EXPORT_ROWS —
+    #: three places that must agree, held together by the test beside this.
+    EXPORT_ROW_LIMIT = 40_000
+
     BUNDLE_PREFIX = "scrapex-bundle-"
 
     #: The panel pack lifted out of the bundle, named so the two files of one
@@ -2496,6 +2502,55 @@ def create_app(
                 "no bundle has been built yet — POST /api/bundle first"))
         return FileResponse(
             archive, media_type="application/zip", filename=archive.name)
+
+    @app.get("/api/export/{source_key}")
+    def api_export_rows(source_key: str):
+        """The rows the panel writes into a Google Sheet.
+
+        THE LAST GAP IN THE OWNER'S RULING OF 2026-08-11. The extension owns
+        every Google operation, and extension/sheets.js could already create a
+        spreadsheet and fill a tab — but the rows had nowhere to come from. The
+        panel's own /api/records is paginated at 100 and carries the COMPACT
+        card shape; /export/{key}.xlsx is a binary workbook the panel will not
+        ship a library to parse. So the menu entry sat disabled, saying so.
+
+        This is the same `export_source_table` the .xlsx and the Apps Script
+        funnel already use — one expression of what an export IS, rather than a
+        third. A separate query here would drift from those two, which is the
+        drift `fields.column_order` exists to prevent.
+
+        BOUNDED (A8) at the same 40,000 rows the function's own default sets and
+        the panel's MAX_EXPORT_ROWS mirrors. `truncated` is reported rather than
+        left to be inferred from a row count nobody compares — a spreadsheet
+        that quietly stops at forty thousand looks exactly like a business with
+        forty thousand products.
+        """
+        conn = read_conn()
+        try:
+            # THE MANIFEST, which is what /api/sources answers from and
+            # therefore what the panel's Data page offers. The first version of
+            # this checked `list_sources`, which reads `source_site` in the
+            # WAREHOUSE — a different set. On a database that has been
+            # initialised but not yet crawled the manifest names twelve sources
+            # and the warehouse none, so every export the panel offered was
+            # refused with "no source called MADAR" while the card for MADAR sat
+            # on the screen. Validating against a set the caller cannot see is
+            # worse than not validating.
+            known = {entry.source_key for entry in app.state.manifest.sources}
+            if source_key not in known:
+                raise HTTPException(status_code=404, detail=(
+                    f"no source called {source_key!r} — the panel asked for "
+                    "something the warehouse does not have"))
+            header, rows = export_source_table(conn, source_key)
+        finally:
+            conn.close()
+        return {
+            "source_key": source_key,
+            "header": header,
+            "rows": rows,
+            "truncated": len(rows) >= EXPORT_ROW_LIMIT,
+            "limit": EXPORT_ROW_LIMIT,
+        }
 
     @app.get("/api/bundle/panel-pack")
     def api_bundle_panel_pack():

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -808,10 +808,17 @@ def test_dataset_action_opens_the_workspace_directly(open_panel):
                   "Pause collecting", "Export to Google Sheets"):
         assert page.locator(f'.dataset-card [data-split-action]:has-text("{label}")'
                             ).count() == cards.count(), f"{label} is missing from the menu"
-    # The unbuilt one is PRESENT and DISABLED — the owner asked to watch the work
-    # in progress rather than have it hidden until it is finished.
-    assert page.locator('.dataset-card [data-split-action="sheet"][disabled]'
-                        ).count() == cards.count()
+    # EVERY ENTRY IS LIVE. Export shipped disabled for one day, with its reason
+    # written on it, because the engine had no route that could hand the panel
+    # export rows. GET /api/export/{key} closed that on 2026-08-12 and the
+    # entry was enabled in the same change.
+    #
+    # This asserted the DISABLED state until then, and the flip is the point: a
+    # menu that keeps saying "not built yet" after the thing is built is the
+    # same defect as one that hides it, pointing the other way.
+    assert page.locator(".dataset-card [data-split-action][disabled]").count() == 0, (
+        "a source action is disabled; if that is deliberate the reason belongs "
+        "in the entry, and this assertion belongs with it")
 
     page.click("#open-workbook")
     page.wait_for_timeout(200)

--- a/tests/test_panel_wiring.py
+++ b/tests/test_panel_wiring.py
@@ -409,3 +409,37 @@ def test_no_two_inlined_modules_declare_the_same_top_level_name():
     assert not clashes, (
         "two panel modules declare the same top-level name, and the DOM harness "
         "flattens them into one script: " + "; ".join(clashes))
+
+
+def test_every_source_action_the_menu_offers_is_handled():
+    """A menu entry with no branch does nothing and says nothing.
+
+    The Export entry shipped DISABLED on 2026-08-12 with its reason written on
+    it, and was enabled the next day when the engine route existed. The risk
+    either way is the same: the markup and the handler drift, and the owner
+    clicks something that silently is not there. Read from the one list that
+    builds the markup, so adding an entry without a branch fails here.
+    """
+    listed = set(re.findall(r'\{action: "(\w+)"', JS))
+    assert listed, "SOURCE_ACTIONS no longer declares any action"
+
+    body = JS[JS.index("async function runSourceAction("):]
+    body = body[:body.index("\n}\n")]
+    handled = set(re.findall(r'action === "(\w+)"', body))
+
+    missing = sorted(listed - handled)
+    assert not missing, (
+        f"the source menu offers {missing} and runSourceAction has no branch "
+        "for them, so the click does nothing at all")
+
+
+def test_the_export_action_is_no_longer_advertised_as_unbuilt():
+    """It was, deliberately, for one day. Leaving the words behind after the
+    thing exists is how a working feature keeps telling people it does not."""
+    assert 'action: "sheet"' in JS
+    entry = JS[JS.index('{action: "sheet"'):]
+    entry = entry[:entry.index("},")]
+    assert "ready: false" not in entry, (
+        "the export action is still marked unbuilt while the engine route and "
+        "the panel handler both exist")
+    assert "Not built yet" not in entry

--- a/tests/test_the_engine_hands_the_bundle_over.py
+++ b/tests/test_the_engine_hands_the_bundle_over.py
@@ -12,6 +12,7 @@ backup folder.
 """
 from __future__ import annotations
 
+import inspect
 import io
 import json
 import zipfile
@@ -238,3 +239,69 @@ def test_the_pack_route_cannot_be_pointed_anywhere_either(client):
         assert got.status_code == 200
         assert got.headers["content-disposition"].endswith('.jsonl.gz"'), (
             f"the query string {attempt} changed which file was served")
+
+
+# ---- the rows the panel writes into a spreadsheet ---------------------------
+
+def test_the_export_route_hands_over_the_same_table_the_xlsx_carries(client):
+    """ONE EXPRESSION OF WHAT AN EXPORT IS, not a third.
+
+    `export_source_table` already feeds the .xlsx download and the Apps Script
+    funnel. A separate query for the panel would drift from those two, which is
+    the drift `fields.column_order` exists to prevent — and the drift would show
+    as two spreadsheets of the same source with different columns.
+    """
+    from scrapex.reports import EXPORT_HEADER
+
+    connected, _ = client
+    # An empty warehouse still has to answer with the right SHAPE: the panel
+    # decides whether to write a tab from `rows`, and a 500 here would read to
+    # the owner as "Google refused" when Google was never asked.
+    known = connected.get("/api/sources").json()["sources"]
+    if not known:
+        pytest.skip("no sources in the fixture warehouse")
+    key = known[0]["source_key"]
+
+    table = connected.get(f"/api/export/{key}").json()
+
+    assert table["header"] == EXPORT_HEADER
+    assert table["source_key"] == key
+    assert isinstance(table["rows"], list)
+    assert table["truncated"] is False
+
+
+def test_a_source_that_does_not_exist_is_named_rather_than_empty(client):
+    """An unknown key answering with zero rows would have the panel write an
+    empty tab over a real one and report success."""
+    connected, _ = client
+
+    refused = connected.get("/api/export/NO_SUCH_SOURCE")
+
+    assert refused.status_code == 404
+    assert "NO_SUCH_SOURCE" in refused.json()["detail"]
+
+
+def test_the_row_ceiling_is_the_same_number_in_all_three_places():
+    """The engine's route, the function it calls, and the panel that writes the
+    result each carry this limit. Two of them agreeing is not enough: the panel
+    refuses at its own number BEFORE calling Google, so a lower ceiling there
+    would reject rows the engine was willing to send, and a higher one would
+    hand Google more than the engine ever produces.
+    """
+    import re
+
+    from scrapex.reports import export_source_table
+    from scrapex.webui import app as webui
+
+    engine_default = inspect.signature(export_source_table).parameters["limit"].default
+    route_limit = re.search(r"EXPORT_ROW_LIMIT = ([\d_]+)",
+                            Path(webui.__file__).read_text(encoding="utf-8"))
+    panel_limit = re.search(
+        r"MAX_EXPORT_ROWS = ([\d_]+)",
+        (Path(__file__).resolve().parent.parent / "extension" / "sheets.js")
+        .read_text(encoding="utf-8"))
+
+    assert route_limit, "EXPORT_ROW_LIMIT is gone from the web layer"
+    assert panel_limit, "MAX_EXPORT_ROWS is gone from extension/sheets.js"
+    assert int(route_limit.group(1).replace("_", "")) == engine_default
+    assert int(panel_limit.group(1).replace("_", "")) == engine_default

--- a/tests/test_the_panel_remembers_who_signed_in.py
+++ b/tests/test_the_panel_remembers_who_signed_in.py
@@ -152,3 +152,69 @@ def test_an_account_without_a_stable_id_is_not_remembered(open_panel):
         "a row nothing can switch to was written into the directory")
     assert page.text_content("#welcome-name").strip() == ACCOUNT["name"], (
         "the panel stopped painting the account because the directory refused it")
+
+
+def test_signing_in_again_does_not_list_you_as_signed_out(open_panel):
+    """REPORTED BY THE OWNER FROM THE RUNNING PANEL, 2026-08-12.
+
+    Sign in, sign out, sign in again — and the account appeared TWICE: as the
+    signed-in header at the top, and in the list below it, labelled "Signed
+    out", with Sign in and Remove beside it. One account, two contradictory
+    truths, two inches apart.
+
+    The state was never wrong. It was READ ONE STEP TOO EARLY: `loadAccount`
+    called `renderAccount()` and only then awaited `rememberSignedInAccount()`,
+    so the card was drawn while `state.currentAccountId` still held the empty
+    string left by the sign-out. The row therefore passed the
+    `id !== currentAccountId` filter that exists to exclude the current account,
+    and nothing re-rendered afterwards, so it simply stayed there.
+
+    `adoptAuthorizedAccount` — the other path to the same place — already
+    remembered before rendering. The correct order was sitting ten lines away.
+
+    This is the panel-state twin of a pattern this project keeps meeting: a
+    partial state displayed as a complete one. Guarded here through the real
+    wiring rather than by asserting the order of two statements, because the
+    property is "the screen never contradicts itself", not "these lines are in
+    this sequence".
+    """
+    page = open_panel(signed_in=ACCOUNT)
+    page.wait_for_selector("#welcome-signed-in:visible")
+    page.wait_for_function(
+        "async () => (await window.chrome.storage.local.get('scrapex-accounts-v1'))"
+        "['scrapex-accounts-v1'] != null",
+        timeout=10000)
+
+    page.click("#signout")
+    page.wait_for_selector("#welcome-signed-out:visible")
+    page.wait_for_function(
+        "async () => (await window.chrome.storage.local.get('scrapex-accounts-v1'))"
+        "['scrapex-accounts-v1'].currentId === ''",
+        timeout=10000)
+
+    # In again, through the same button the owner used. Chrome is told the
+    # account is grantable once more, because signing out really does clear its
+    # cache — the harness models that faithfully and the owner's next click is
+    # what puts it back.
+    page.evaluate("(account) => window.__sx_grant_again(account)", ACCOUNT)
+    page.click("#signin")
+    page.wait_for_selector("#welcome-signed-in:visible")
+    page.wait_for_function(
+        "async () => (await window.chrome.storage.local.get('scrapex-accounts-v1'))"
+        "['scrapex-accounts-v1'].currentId === '110001'",
+        timeout=10000)
+
+    # THE ASSERTION. The account that is signed in must not also be offered as a
+    # signed-out row to sign in to.
+    rows = page.locator(".accounts-list [data-account-id]")
+    listed = [rows.nth(n).get_attribute("data-account-id")
+              for n in range(rows.count())]
+    assert "110001" not in listed, (
+        "the signed-in account is also listed below as another account; that is "
+        "the row the owner saw labelled 'Signed out' while the header above it "
+        f"said signed in. Listed: {listed}")
+
+    card = page.text_content("#accounts-card") or ""
+    assert "Signed out" not in card, (
+        "the accounts card says 'Signed out' while the panel is signed in: "
+        + card.strip()[:200])

--- a/tools/panel_harness.py
+++ b/tools/panel_harness.py
@@ -286,6 +286,18 @@ window.chrome = {{
     }},
   }},
 }};
+
+// SIGNING IN A SECOND TIME, which this harness could not model at all.
+//
+// `removeCachedAuthToken` sets SIGNED_IN to null, correctly: Chrome really has
+// forgotten the token. But a person who signs out and presses Sign in again
+// gets a working sign-in, and until this existed no test could reach that
+// state — which is exactly where the owner found the panel listing him as
+// signed out while the header said he was signed in (2026-08-12).
+//
+// A test-only door, and a narrow one: it restores what Chrome would answer and
+// nothing else. The panel is driven through its own button either way.
+window.__sx_grant_again = (account) => {{ SIGNED_IN = account; }};
 let SIGNED_IN = {json.dumps(signed_in)};
 const SIGNIN_ERROR = {json.dumps(signin_error)};
 const SIGNIN_DELAY_MS = {json.dumps(signin_delay_ms)};


### PR DESCRIPTION
Two things: the last export connection, and a defect you found by using the panel while it was being built.

## The export

`sheets.js` could create a spreadsheet and fill a tab since yesterday, and **the rows had nowhere to come from**. `/api/records` is paginated at 100 and carries the compact card shape; `/export/{key}.xlsx` is a binary workbook this panel will not ship a library to parse. So the menu entry shipped **disabled with that written on it**.

`GET /api/export/{source_key}` closes it, over the same `export_source_table` the .xlsx download and the Apps Script funnel already use — **one expression of what an export is**, rather than a third that would drift from both.

**One tab per source, named for the source.** `writeTab` clears before it writes, so a shared tab would not merge two sources — it would replace one with the other and report success.

**Truncation is said, not left to be noticed.** A spreadsheet that stops at 40,000 rows looks exactly like a business with 40,000 products.

### The validation I got wrong first

The route validates against the **manifest**. My first version checked `list_sources`, which reads `source_site` in the **warehouse** — a different set. On a database initialised but not yet crawled, the manifest names twelve sources and the warehouse none, so **every export the panel offered was refused** with *"no source called MADAR"* while MADAR's card sat on the screen.

Validating against a set the caller cannot see is worse than not validating.

## The defect you found

Sign in → sign out → sign in again, and the account appeared **twice**: signed in at the top, and listed below as *"Signed out"* with Sign in beside it. One account, two contradictory truths, two inches apart.

**The state was never wrong. It was read one step too early.**

```js
renderAccount({});                                    // drew the card
await rememberSignedInAccount(accountResult.account); // set currentAccountId after
```

The card was drawn while `currentAccountId` still held the empty string left by the sign-out, so the row passed the `id !== currentAccountId` filter that exists precisely to exclude the current account — and nothing re-rendered afterwards.

`adoptAuthorizedAccount`, the other path to the same place, **already remembered before rendering**. The correct order was ten lines away.

### Why four existing tests missed it

Guarded now through the real wiring, and **mutation-tested**: restoring the old order fails the new test with your own screen in the message.

Writing it needed a harness change. `removeCachedAuthToken` sets `SIGNED_IN = null` — correct, Chrome really does forget the token — which meant **no test could reach a second sign-in at all**. That gap is why this survived a suite that already had four tests about the directory.

---

**Green locally:** full extension suite · node tests · `ruff` on `scrapex/` · `eslint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)