### PR TITLE
The store listing describes the manifest it is submitted with

### DIFF
--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -1,4 +1,4 @@
-# Chrome Web Store listing — ScrapeX 0.2.1
+# Chrome Web Store listing — ScrapeX 0.2.2
 
 Draft for the owner to review, edit and paste. Every claim here is checked
 against what the extension actually declares — the permissions and scopes below
@@ -158,9 +158,31 @@ connected, and a user could never sign in as somebody else.
 
 ### `https://www.googleapis.com/oauth2/v3/*`
 
-> Google's own endpoints, used only after the user signs in: the name and
-> picture of the signed-in account, Google Drive for backups the user asks for,
-> and Google Sheets for exports the user asks for.
+> The name, address and picture of the signed-in account, shown on the panel's
+> Profile page. One endpoint and no more. Nothing is sent to it but the token
+> Chrome already holds.
+
+### `https://www.googleapis.com/drive/v3/*`
+
+> Finding, listing and downloading the user's own backups. Narrowed to the Drive
+> API path rather than the whole of googleapis.com. The permission behind it is
+> Google's `drive.file`, which reaches only files this extension created and
+> files the user hands it — it is structurally unable to read anything else in
+> their Drive.
+
+### `https://www.googleapis.com/upload/drive/v3/*`
+
+> Sending a backup up. Drive's upload endpoint is a separate address from the
+> one above, and the upload is resumable so the panel can show real progress on
+> a file of tens of megabytes.
+
+### `https://sheets.googleapis.com/v4/*`
+
+> Writing the user's exported rows into a spreadsheet — one tab per source. The
+> same `drive.file` limit applies: a spreadsheet ScrapeX created, or one the
+> user chose for it, and no other. ScrapeX does **not** request Google's
+> `spreadsheets` permission, which is the one that would let an app read and
+> edit every spreadsheet the user owns.
 
 ---
 

--- a/tests/test_the_privacy_policy_is_true.py
+++ b/tests/test_the_privacy_policy_is_true.py
@@ -300,3 +300,73 @@ def test_the_policy_does_not_claim_the_accounts_list_is_unstored():
     assert "Nothing is stored" not in scopes_row[0], (
         "the policy says nothing is stored about the account details, and "
         "extension/accounts.js keeps a directory of them in chrome.storage.local")
+
+
+# ---- the listing is the manifest, in prose ----------------------------------
+
+LISTING = ROOT / "docs" / "store-listing.md"
+
+
+def test_the_listing_justifies_every_permission_the_manifest_asks_for():
+    """FOUND ON 2026-08-12, on the day the owner asked to upload the listing.
+
+    Three host permissions had been added that day — drive/v3, upload/drive/v3
+    and sheets.googleapis.com/v4 — and the listing justified none of them. The
+    store requires a justification per permission and rejects a submission
+    without one, so this would have been discovered by a rejection days later
+    rather than by a build.
+
+    Every other document in this repository that repeats the manifest is
+    guarded: the privacy policy names every host, the version ledger names every
+    capability. The listing was the one that was not, and it is the document
+    Google actually reads.
+    """
+    listing = LISTING.read_text(encoding="utf-8")
+
+    for permission in MANIFEST["permissions"]:
+        assert f"`{permission}`" in listing, (
+            f"the manifest asks for the {permission!r} permission and the store "
+            "listing does not justify it; the store rejects a submission that "
+            "leaves one unexplained")
+
+    for host in MANIFEST["host_permissions"]:
+        # Loopback is described as one entry covering both spellings, which is
+        # how the listing reads and how a reviewer thinks about it.
+        if host.startswith("http://127.0.0.1") or host.startswith("http://localhost"):
+            assert "127.0.0.1" in listing
+            continue
+        assert host in listing, (
+            f"the manifest may reach {host} and the store listing does not "
+            "justify it")
+
+
+def test_the_listing_claims_no_permission_the_manifest_dropped():
+    """The other direction, and the one that reads as a lie rather than an
+    omission: a listing describing access the extension gave up still declares
+    it on the store's data-usage form."""
+    listing = LISTING.read_text(encoding="utf-8")
+    asked = set(MANIFEST["permissions"])
+    hosts = " ".join(MANIFEST["host_permissions"])
+
+    section = listing.split("## Permission justifications", 1)[-1]
+    section = section.split("## OAuth scope justifications", 1)[0]
+
+    for heading in re.findall(r"^### `([^`]+)`", section, re.M):
+        if heading.startswith("http"):
+            stem = heading.rstrip("*").rstrip("/")
+            assert stem in hosts or "127.0.0.1" in heading, (
+                f"the listing justifies {heading}, which the manifest no longer "
+                "asks for")
+        else:
+            assert heading in asked, (
+                f"the listing justifies the {heading!r} permission and the "
+                "manifest does not ask for it")
+
+
+def test_the_listing_names_the_version_being_submitted():
+    """A listing headed with last month's version is the surest sign nobody
+    re-read it before pressing submit."""
+    listing = LISTING.read_text(encoding="utf-8")
+    assert MANIFEST["version"] in listing.splitlines()[0], (
+        f"the listing is headed {listing.splitlines()[0]!r} and the manifest is "
+        f"at {MANIFEST['version']}")


### PR DESCRIPTION
Asked to upload the listing, I read it against the manifest first.

## What was wrong

| | |
|---|---|
| `https://www.googleapis.com/drive/v3/*` | justified **nowhere** |
| `https://www.googleapis.com/upload/drive/v3/*` | justified **nowhere** |
| `https://sheets.googleapis.com/v4/*` | justified **nowhere** |
| Heading | still said **0.2.1**; the manifest says **0.2.2** |

All three hosts were added earlier today. The store requires a justification per permission and **rejects a submission without one** — so this would have come back as a rejection days later rather than as a build failure now.

## Why nothing caught it

Every other document here that repeats the manifest is already guarded: the privacy policy names every host, the version ledger names every capability. **The listing was the one that was not** — and it is the document Google actually reads.

## Three tests now hold it

1. Every permission and host in the manifest is justified in the listing.
2. **Nothing is justified that the manifest no longer asks for.** This matters as much as the first: a listing describing access the extension gave up still declares it on the store's data-usage form.
3. The heading names the version being submitted — a listing headed with last month's version is the surest sign nobody re-read it before pressing submit.

---

**Green locally:** the policy/listing suite · full extension suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)