### PR TITLE
Profile › Manage account

### DIFF
--- a/design/components.css
+++ b/design/components.css
@@ -1472,6 +1472,98 @@ code {
   font-size: var(--fs-2xs);
 }
 
+/* The destructive split button.
+ *
+ * Added 2026-08-12 for Profile › Manage account, where the primary action
+ * revokes a Google grant. The neutral primitive above reads as an ordinary tool;
+ * an action that cannot be undone should not.
+ *
+ * WHY LIGHT AND DARK DIFFER. Light fills the primary — a red block is the
+ * strongest thing on a white page and that is the point. Dark outlines it
+ * instead: a filled light-red button on a dark surface reads as an alert banner
+ * announcing a problem, not as a control waiting to be pressed.
+ *
+ * NOT COMPOSED WITH `button.danger`. That rule is (0,1,1) and would win some
+ * properties from `.split-button.danger .split-button-primary` (0,2,0) and lose
+ * others, giving a control that is half one variant and half the other. Every
+ * declaration this variant needs is written here.
+ */
+.split-button.danger {
+  border-color: var(--red);
+}
+.split-button.danger .split-button-primary {
+  background: var(--red);
+  color: var(--danger-contrast);
+}
+.split-button.danger .split-button-primary .sx-icon {
+  color: var(--danger-contrast);
+}
+.split-button.danger .split-button-primary:hover:not(:disabled) {
+  background: var(--red-hover);
+  color: var(--danger-contrast);
+}
+.split-button.danger .split-button-primary:active:not(:disabled) {
+  background: var(--red-hover);
+  color: var(--danger-contrast);
+}
+.split-button.danger .split-button-trigger {
+  border-inline-start-color: var(--danger-contrast);
+  color: var(--red);
+}
+.split-button.danger .split-button-trigger:hover,
+.split-button.danger .split-button-menu[open] .split-button-trigger {
+  background: var(--red-weak);
+  color: var(--red);
+}
+.split-button.danger .split-button-options {
+  border-color: var(--red);
+}
+.split-button.danger .split-button-option {
+  color: var(--red);
+}
+.split-button.danger .split-button-option:hover:not(:disabled) {
+  background: var(--red-weak);
+  border-color: var(--red);
+  color: var(--red);
+}
+.split-button.danger .split-button-option:active:not(:disabled) {
+  background: var(--red-weak);
+  border-color: var(--red);
+  color: var(--red);
+}
+
+/* Dark outlines rather than fills — see the note above. */
+:root[data-theme="dark"] .split-button.danger .split-button-primary,
+:root[data-theme="dark"] .split-button.danger .split-button-primary .sx-icon {
+  background: transparent;
+  color: var(--red);
+}
+:root[data-theme="dark"] .split-button.danger .split-button-primary:hover:not(:disabled),
+:root[data-theme="dark"] .split-button.danger .split-button-primary:active:not(:disabled) {
+  background: var(--red-weak);
+  color: var(--red-hover);
+}
+:root[data-theme="dark"] .split-button.danger .split-button-trigger {
+  border-inline-start-color: var(--red);
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .split-button.danger .split-button-primary,
+  :root:not([data-theme="light"]) .split-button.danger .split-button-primary .sx-icon {
+    background: transparent;
+    color: var(--red);
+  }
+  :root:not([data-theme="light"]) .split-button.danger
+    .split-button-primary:hover:not(:disabled),
+  :root:not([data-theme="light"]) .split-button.danger
+    .split-button-primary:active:not(:disabled) {
+    background: var(--red-weak);
+    color: var(--red-hover);
+  }
+  :root:not([data-theme="light"]) .split-button.danger .split-button-trigger {
+    border-inline-start-color: var(--red);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .split-button-options { animation: none; }
 }

--- a/design/gallery.html
+++ b/design/gallery.html
@@ -426,6 +426,42 @@
   &lt;/details&gt;
 &lt;/div&gt;</pre>
   </div>
+
+  <div class="g-item">
+    <h3>Split button — destructive</h3>
+    <p class="g-why">
+      Add <code class="code">danger</code> when the primary action cannot be undone.
+      Light <em>fills</em> the primary; dark <em>outlines</em> it — a filled light-red
+      button on a dark surface reads as an alert banner rather than a control.
+      Do not combine it with <code class="code">button.danger</code>: that rule wins
+      some properties from this one and loses others, giving half of each.
+    </p>
+    <div class="g-demo cluster">
+      <div class="split-button danger" role="group" aria-label="Disconnect">
+        <button type="button" class="split-button-primary">
+          <svg class="sx-icon" aria-hidden="true"><use href="#logout"></use></svg>
+          <span>Disconnect and sign out</span>
+        </button>
+        <details class="split-button-menu">
+          <summary class="split-button-trigger" aria-haspopup="menu"
+                   aria-expanded="false" aria-label="More disconnect options">
+            <svg class="sx-icon split-button-chevron" aria-hidden="true"><use href="#expand-more"></use></svg>
+          </summary>
+          <div class="split-button-options" role="menu" aria-label="Disconnect options">
+            <button type="button" class="split-button-option" role="menuitem">
+              <span class="split-button-option-icon">
+                <svg class="sx-icon" aria-hidden="true"><use href="#close"></use></svg>
+              </span>
+              <span class="split-button-option-copy">
+                <strong>Disconnect and erase everything</strong>
+              </span>
+            </button>
+          </div>
+        </details>
+      </div>
+    </div>
+    <pre>&lt;div class="split-button danger" role="group"&gt;…&lt;/div&gt;</pre>
+  </div>
 </section>
 
 <!-- ===================================================================== -->

--- a/extension/app.css
+++ b/extension/app.css
@@ -1783,6 +1783,267 @@
     color: var(--muted);
   }
 
+  /* ---- Profile › Manage account ----------------------------------------
+     Its own view section rather than a child of #view-profile, and its own
+     layout rather than a place in the nine-id enumerations near the top of this
+     file: the header is pinned and only the body scrolls, which none of those
+     screens do. */
+  #view-manage-account {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+    overflow: hidden;
+    margin: calc(-1 * var(--sp-4));
+    background: var(--bg);
+  }
+  .manage-account-heading {
+    flex: none;
+    display: grid;
+    grid-template-columns: var(--control-height-sm) minmax(0, 1fr);
+    align-items: center;
+    gap: var(--sp-3);
+    padding: var(--sp-3) var(--sp-4);
+    border-bottom: 1px solid var(--line);
+    background: var(--surface);
+  }
+  button.manage-account-back {
+    width: var(--control-height-sm);
+    min-width: var(--control-height-sm);
+    padding: 0;
+    border-color: transparent;
+    border-radius: var(--radius-pill);
+    background: transparent;
+    color: var(--muted);
+  }
+  button.manage-account-back:hover:not(:disabled) {
+    border-color: transparent;
+    background: var(--control-hover);
+    color: var(--text);
+  }
+  #manage-account-title {
+    margin: 0;
+    font-size: var(--fs-lg);
+    font-weight: var(--fw-bold);
+    line-height: var(--lh-tight);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  /* The only scroller on this screen. */
+  .manage-account-body {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    padding: var(--sp-4);
+  }
+
+  .manage-account-identity {
+    display: grid;
+    grid-template-columns: 3.5rem minmax(0, 1fr);
+    align-items: center;
+    gap: var(--sp-3);
+    padding: var(--sp-4);
+    border-radius: var(--radius-xl);
+  }
+  .manage-account-face {
+    width: 3.5rem;
+    height: 3.5rem;
+    border-radius: 50%;
+    object-fit: cover;
+  }
+  .manage-account-face-fallback {
+    display: none;
+  }
+  /* Same one-owner rule the Profile card uses: the photo's `hidden` class is
+     the single answer to "is there a picture", and this reads it. */
+  #manage-account-photo.hidden ~ .manage-account-face-fallback {
+    display: grid;
+    place-items: center;
+    width: 3.5rem;
+    height: 3.5rem;
+    border-radius: 50%;
+    background: var(--accent-weak);
+    color: var(--accent-ink);
+  }
+  .manage-account-face-icon {
+    width: 2rem;
+    height: 2rem;
+  }
+  .manage-account-identity-text {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+  .manage-account-name,
+  .manage-account-email {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .manage-account-name {
+    font-size: var(--fs-md);
+    font-weight: var(--fw-bold);
+  }
+  .manage-account-email {
+    font-size: var(--fs-sm);
+    color: var(--muted);
+  }
+
+  .manage-account-section {
+    margin: var(--sp-5) 0 var(--sp-2);
+    font-size: var(--fs-xs);
+    font-weight: var(--fw-medium);
+    letter-spacing: .04em;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+
+  .manage-account-rows {
+    display: flex;
+    flex-direction: column;
+    padding: 0;
+    border-radius: var(--radius-xl);
+    overflow: hidden;
+  }
+  .manage-account-rows > * + * {
+    border-top: 1px solid var(--line);
+  }
+  .manage-account-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: var(--sp-3);
+    width: 100%;
+    padding: var(--sp-3) var(--sp-4);
+    text-align: start;
+  }
+  /* A leading icon is a column, not an extra child in the last one. */
+  .manage-account-row.has-lead {
+    grid-template-columns: 1.5rem minmax(0, 1fr) auto;
+  }
+  button.manage-account-row-button {
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    color: var(--text);
+    font-weight: var(--fw-regular);
+  }
+  button.manage-account-row-button:hover:not(:disabled) {
+    border-color: transparent;
+    background: var(--control-hover);
+    color: var(--text);
+  }
+  .manage-account-row-text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+  .manage-account-row-title {
+    font-weight: var(--fw-medium);
+  }
+  .manage-account-row-sub {
+    font-size: var(--fs-sm);
+    color: var(--muted);
+    /* Wraps: these lines are sentences, not labels, and truncating a promise
+       about what Google can read would be worse than two lines. */
+    white-space: normal;
+  }
+  .manage-account-row-icon {
+    color: var(--muted);
+  }
+  /* Sizes and counts read as data, not prose. */
+  .manage-account-figure {
+    font-family: var(--font-mono);
+  }
+
+  .manage-account-danger {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-2);
+    margin-top: var(--sp-5);
+    padding: var(--sp-4);
+    border-color: var(--red);
+    border-radius: var(--radius-xl);
+  }
+  .manage-account-danger-copy {
+    margin: 0;
+    font-size: var(--fs-sm);
+    color: var(--muted);
+  }
+  .manage-account-status {
+    margin: 0;
+    font-size: var(--fs-sm);
+    color: var(--muted);
+  }
+
+  /* ---- the confirmation ------------------------------------------------
+     ABOVE the rail, unlike the workspace drawer below it, because this one is
+     modal: it must not be possible to navigate away from a question about
+     revoking a grant.
+     The z-index is derived rather than taken: --z-modal is 30 and the side rail
+     is also 30 (see .side-rail above), so the token as it stands ties with the
+     thing this has to cover and the winner would be decided by source order.
+     Correcting the token is a design-system decision, not this screen's. */
+  .modal-veil {
+    position: fixed;
+    inset: 0;
+    z-index: calc(var(--z-modal) + 10);
+    display: grid;
+    place-items: center;
+    padding: var(--sp-5);
+    background: var(--overlay);
+  }
+  .modal-card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-3);
+    width: min(100%, 22rem);
+    max-height: 100%;
+    overflow-y: auto;
+    padding: var(--sp-5);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-xl);
+    background: var(--surface-raised);
+    box-shadow: var(--shadow-lg);
+  }
+  /* `text-transform` and `color` are RESETS, not decoration. A global `h2` rule
+     near the top of this file paints every h2 in the panel as a small uppercase
+     muted section label — which is right for a section heading and wrong for the
+     title of a question. Without these two the dialog asked "DISCONNECT DRIVE?"
+     in grey small-caps. */
+  .modal-title {
+    margin: 0;
+    font-size: var(--fs-md);
+    font-weight: var(--fw-bold);
+    line-height: var(--lh-tight);
+    text-transform: none;
+    letter-spacing: normal;
+    color: var(--text);
+  }
+  .modal-copy {
+    margin: 0;
+    font-size: var(--fs-sm);
+    color: var(--muted);
+  }
+  .modal-copy p {
+    margin: 0 0 var(--sp-2);
+  }
+  .modal-copy p:last-child {
+    margin-bottom: 0;
+  }
+  .modal-copy strong {
+    color: var(--text);
+  }
+  .modal-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: var(--sp-2);
+  }
+
   /* Appearance is a complete Android-style destination. It uses the same
      persistent page model as Source, Data and Settings; it is not a modal
      floating above whichever task happened to be open. */

--- a/extension/app.html
+++ b/extension/app.html
@@ -1187,11 +1187,7 @@
               <button class="ghost compact hidden" id="retry-account" type="button">
                 Retry
               </button>
-              <!-- Disabled until the Manage account screen exists. A control
-                   that looks live and answers nothing is worse than one that
-                   says plainly it is not ready yet. -->
-              <button class="ghost profile-manage" id="manage-account" type="button"
-                      disabled>
+              <button class="ghost profile-manage" id="manage-account" type="button">
                 Manage your account
               </button>
             </div>
@@ -1225,6 +1221,149 @@
           </div>
 
         </div>
+      </div>
+    </section>
+
+    <!-- ====================== MANAGE ACCOUNT ======================
+         A SIBLING of #view-profile, not a child, and the reason is a test:
+         tests/test_panel_dom.py forbids [role="dialog"] anywhere INSIDE
+         #view-profile, and this screen's confirmation is a real modal. It also
+         has no rail button — it is reached from the Profile card and leaves by
+         its own back button, exactly as #view-source-edit does for Sources. -->
+    <section id="view-manage-account" class="hidden"
+             aria-labelledby="manage-account-title" tabindex="0">
+      <header class="manage-account-heading">
+        <button id="manage-account-back" type="button" class="ghost manage-account-back"
+                aria-label="Back to Profile" title="Back to Profile">
+          <svg class="sx-icon" aria-hidden="true">
+            <use href="icons/material-icons.svg#arrow-back"></use>
+          </svg>
+        </button>
+        <h1 id="manage-account-title">Manage account</h1>
+      </header>
+
+      <div class="manage-account-body">
+        <!-- The name and address appear ONLY here on this screen. -->
+        <section class="card manage-account-identity" aria-label="Signed in as">
+          <img class="manage-account-face hidden" id="manage-account-photo" alt=""
+               aria-hidden="true">
+          <span class="manage-account-face-fallback" aria-hidden="true">
+            <svg class="sx-icon manage-account-face-icon" aria-hidden="true">
+              <use href="icons/material-icons.svg#account-circle"></use>
+            </svg>
+          </span>
+          <span class="manage-account-identity-text">
+            <span class="manage-account-name" id="manage-account-name">Signed in</span>
+            <span class="manage-account-email" id="manage-account-email" dir="ltr"></span>
+          </span>
+        </section>
+
+        <h2 class="manage-account-section" id="manage-drive-title">Google Drive</h2>
+        <section class="card manage-account-rows" aria-labelledby="manage-drive-title">
+          <div class="manage-account-row">
+            <span class="manage-account-row-text">
+              <span class="manage-account-row-title">Drive features</span>
+              <!-- The handoff's line was "Nothing is uploaded while this is off",
+                   which describes a product this is not: there is no automatic
+                   upload to stop. Every Drive write in the extension is behind a
+                   button someone presses (Settings › Data output settings), and
+                   no preference gates them. So the switch ships disabled — the
+                   same ruling the owner gave for the erase action on 2026-08-12 —
+                   and the line says what is actually true. -->
+              <span class="manage-account-row-sub">Backups run only when you ask;
+                ScrapeX never uploads on its own. This switch is not wired up
+                yet.</span>
+            </span>
+            <!-- The shared switch, markup contract copied from the Appearance
+                 page: a label wrapping a real checkbox and a decorative span.
+                 The label is its own touch target, so it is NOT wrapped around
+                 the whole row. -->
+            <label class="appearance-switch">
+              <input type="checkbox" id="drive-enabled" aria-label="Drive features"
+                     disabled>
+              <span aria-hidden="true"></span>
+            </label>
+          </div>
+
+          <div class="manage-account-row">
+            <span class="manage-account-row-text">
+              <span class="manage-account-row-title">Granted access</span>
+              <!-- Literal, and deliberately not softened: identity.js asks for
+                   drive.file and nothing else. -->
+              <span class="manage-account-row-sub">Only files ScrapeX created in your
+                Drive. Nothing else is readable.</span>
+            </span>
+          </div>
+
+          <button class="manage-account-row manage-account-row-button" type="button"
+                  id="drive-review-permissions">
+            <span class="manage-account-row-text">
+              <span class="manage-account-row-title">Review permissions in Google</span>
+            </span>
+            <svg class="sx-icon lg manage-account-row-icon" aria-hidden="true">
+              <use href="icons/material-icons.svg#open-in-new"></use>
+            </svg>
+          </button>
+        </section>
+
+        <h2 class="manage-account-section" id="manage-backups-title">In your Drive</h2>
+        <section class="card manage-account-rows" aria-labelledby="manage-backups-title"
+                 id="drive-backups"></section>
+
+        <!-- The one destructive card. Its copy says what the code does, which is
+             not what the handoff drafted: revoking at Google ends the WHOLE
+             grant, identity scopes included, so this signs the account out. -->
+        <section class="card manage-account-danger" aria-labelledby="disconnect-title">
+          <strong id="disconnect-title">Disconnect Drive</strong>
+          <p class="manage-account-danger-copy">Stops backups and revokes ScrapeX's
+            access to your Drive. Because the same grant carries your name and
+            address, this signs you out of ScrapeX too. The backups already there
+            stay in your Drive — delete them yourself if you want them gone.
+            Nothing on this machine is touched.</p>
+
+          <div class="split-button danger" id="drive-disconnect" role="group"
+               aria-label="Disconnect Drive">
+            <button class="split-button-primary" type="button"
+                    data-split-action="disconnect-drive">
+              <svg class="sx-icon" aria-hidden="true">
+                <use href="icons/material-icons.svg#logout"></use>
+              </svg>
+              <span>Disconnect Drive and sign out</span>
+            </button>
+            <details class="split-button-menu">
+              <summary class="split-button-trigger" aria-haspopup="menu"
+                       aria-expanded="false" aria-label="More disconnect options">
+                <svg class="sx-icon split-button-chevron" aria-hidden="true">
+                  <use href="icons/material-icons.svg#expand-more"></use>
+                </svg>
+              </summary>
+              <div class="split-button-options" role="menu"
+                   aria-label="Disconnect options">
+                <!-- Disabled by the owner's ruling of 2026-08-12: the engine has
+                     no erase. /api/storage/start-fresh RENAMES the database
+                     aside and lists it under Restore (storage.py: "sealed aside,
+                     not erased"), and /api/storage/export writes to a path on
+                     the engine host rather than handing the browser a file.
+                     Shipping this live would put two false sentences in a
+                     confirmation dialog.
+                     It carries no icon slot: no symbol in the sprite means
+                     "erase", and adding one to the shared sprite for a control
+                     that cannot run yet would be inventing vocabulary ahead of
+                     the thing it names. The grid is adjusted for this instance
+                     in app.css. -->
+                <button class="split-button-option" type="button" role="menuitem"
+                        data-split-action="disconnect-and-erase" disabled>
+                  <span class="split-button-option-copy">
+                    <strong>Disconnect and erase everything</strong>
+                    Not available yet — the engine has no erase to call
+                  </span>
+                </button>
+              </div>
+            </details>
+          </div>
+          <p class="manage-account-status hidden" role="status" aria-live="polite"
+             id="disconnect-status"></p>
+        </section>
       </div>
     </section>
 
@@ -1921,6 +2060,30 @@
     <div id="workspace-links" class="workspace-menu-groups"
          aria-label="Workspace pages"></div>
   </aside>
+
+  <!-- The disconnect confirmation, at BODY level for two reasons a nested one
+       would meet. showView animates a view with a live `transform` for 180ms,
+       and a transformed ancestor becomes the containing block for
+       `position: fixed` — so a veil inside the view would be laid out against
+       the view instead of the panel, mid-navigation. And it keeps the dialog
+       out of #view-profile's subtree, which a test forbids outright.
+       Not a native <dialog>: a document-level keydown handler in app.js calls
+       preventDefault() on every Escape, which would stop the browser's own
+       close. This one is a plain element and owns its Escape. -->
+  <div id="disconnect-veil" class="modal-veil hidden">
+    <div class="modal-card" role="dialog" aria-modal="true"
+         aria-labelledby="disconnect-dialog-title" tabindex="-1"
+         id="disconnect-dialog">
+      <h2 class="modal-title" id="disconnect-dialog-title">Disconnect Drive?</h2>
+      <div class="modal-copy" id="disconnect-dialog-copy"></div>
+      <div class="modal-actions">
+        <button class="ghost" type="button" id="disconnect-cancel">Cancel</button>
+        <button class="danger" type="button" id="disconnect-confirm">
+          Disconnect and sign out
+        </button>
+      </div>
+    </div>
+  </div>
 
   <!-- app.js is appended by boot-app.js when `load` fires, NOT loaded here.
        Chrome reveals the Side Panel only after `load`, and a hidden document's

--- a/extension/app.js
+++ b/extension/app.js
@@ -16,7 +16,10 @@ import { getToken, accountFor, authorize, forgetToken, revokeToken } from "./ide
 import {
   clearCurrentAccount, forgetAccount, readAccounts, rememberAccount,
 } from "./accounts.js";
-import { backUp, fetchLatest, fetchPanelPack } from "./drive.js";
+import {
+  backUp, fetchLatest, fetchPanelPack,
+  FOLDER_NAME, KEEP, folderId, listing, readLatest,
+} from "./drive.js";
 import { readPanelPack, datasetSummaries } from "./bundleview.js";
 import {
   ensureFolder, ensureSpreadsheet, writeTab, DEFAULT_WORKBOOK, SHEET_FOLDER,
@@ -171,6 +174,11 @@ const VIEWS = [
   "profile", "engines",
   "source", "run", "data", "sources", "source-edit", "appearance", "finance",
   "console", "settings",
+  // A sub-view of Profile, like source-edit is of Sources: no rail button, and
+  // showView maps it back to the Profile rail entry below. A name here with no
+  // matching #view-<name> section takes down every navigation, so the two move
+  // together.
+  "manage-account",
 ];
 const PANEL_DESTINATIONS = new Set(["data", "settings"]);
 // The local fallback keeps every web page reachable even while the engine is
@@ -311,9 +319,21 @@ function setProfileAvatar(url) {
 
 function showView(name, animate = true) {
   const current = VIEWS.find((view) => !$(`view-${view}`).classList.contains("hidden"));
-  const navigationName = name === "source-edit" ? "sources" : name;
+  // Which RAIL entry stays lit. A sub-view has no button of its own, and
+  // without an entry here every rail button loses aria-current and tabIndex,
+  // leaving the rail with no keyboard entry point at all.
+  const SUB_VIEW_RAIL = {"source-edit": "sources", "manage-account": "profile"};
+  const navigationName = SUB_VIEW_RAIL[name] || name;
   runModeSelectUi?.close();
   closeWorkspaceMenu();
+  // BUG FIXED HERE, introduced with the accounts card and merged in PR 168.
+  // (Written without the number sign: the colour-literal guard reads a hash
+  // followed by three hex digits as a colour, and 168 qualifies.)
+  // state.openAccountMenu survived navigation, and while it was set the
+  // capture-phase Escape handler swallowed Escape on EVERY other view. Nothing
+  // was visibly open, so the only symptom was Escape quietly doing nothing
+  // somewhere else entirely.
+  closeAccountMenu();
   for (const v of VIEWS) $(`view-${v}`).classList.toggle("hidden", v !== name);
   const activeButton = document.querySelector(
     `nav.side-rail button[data-view="${navigationName}"]`);
@@ -360,6 +380,7 @@ function showView(name, animate = true) {
   }
   if (name === "source") loadCurrentPage();
   if (name === "engines") renderEngines();
+  if (name === "manage-account") loadManageAccount();
 }
 
 function currentViewName() {
@@ -2975,6 +2996,270 @@ async function signOutOfAllAccounts() {
   if (button) button.click();
 }
 
+// ---- Profile › Manage account ----------------------------------------------
+//
+// Everything on this screen is about the Drive side of the signed-in account.
+// Every number is READ LIVE — the folder id, the listing and the pointer — and
+// nothing is cached between visits: a count that is stale is a count that lies,
+// and this screen exists to be believed.
+//
+// It is a sibling section of #view-profile rather than a child, because its
+// confirmation is a real modal and tests/test_panel_dom.py forbids
+// [role="dialog"] anywhere inside #view-profile.
+
+const GOOGLE_PERMISSIONS_URL = "https://myaccount.google.com/permissions";
+let manageAccountGeneration = 0;
+
+function driveFolderUrl(id) {
+  return `https://drive.google.com/drive/folders/${encodeURIComponent(id)}`;
+}
+
+/** One row of a Manage-account card. `onClick` makes it a button instead. */
+function manageRow(title, {
+  sub = "", figure = "", lead = "", symbol = "", onClick = null,
+} = {}) {
+  const row = el(onClick ? "button" : "div",
+                 "manage-account-row"
+                 + (onClick ? " manage-account-row-button" : "")
+                 + (lead ? " has-lead" : ""));
+  if (onClick) {
+    row.type = "button";
+    row.addEventListener("click", onClick);
+  }
+  // The leading icon is a column of its own. Appending it after the figure put
+  // a third child in a two-column grid, which wrapped it onto its own line.
+  if (lead) row.insertAdjacentHTML("beforeend", icon(lead, "lg manage-account-row-icon"));
+  const text = el("span", "manage-account-row-text");
+  text.append(el("span", "manage-account-row-title", title));
+  if (sub) text.append(el("span", "manage-account-row-sub", sub));
+  row.append(text);
+  if (figure) row.append(el("span", "manage-account-figure", figure));
+  if (symbol) row.insertAdjacentHTML("beforeend", icon(symbol, "lg manage-account-row-icon"));
+  return row;
+}
+
+// The one sentence that says what a backup contains. Sourced from
+// scrapex/bundle.py, not from the design draft, so a change to what is packed
+// has one place to be corrected.
+const BUNDLE_CONTENTS =
+  "The database, a plain export of every dataset (JSON Lines and CSV), and a "
+  + "manifest with row counts and checksums.";
+
+function renderDriveFacts(
+  { state: phase, pointer = null, count = 0, folder = "", detail = "" } = {}) {
+  const card = $("drive-backups");
+  if (!card) return;
+  card.textContent = "";
+
+  if (phase === "loading") {
+    card.append(manageRow("Reading your Drive…"));
+    return;
+  }
+  if (phase === "signed-out") {
+    card.append(manageRow("Sign in to see what is in your Drive"));
+    return;
+  }
+  if (phase === "error") {
+    card.append(manageRow("Could not read your Drive", { sub: detail }));
+    return;
+  }
+
+  if (pointer) {
+    // financeDateTime despite the name: it is the panel's ONE instant formatter
+    // and routes through ScrapeXTime, so this screen cannot invent a second date
+    // format. fmtMegabytes is the same argument for sizes.
+    card.append(manageRow("Latest backup", {
+      sub: financeDateTime(pointer.created_at, "Time not recorded"),
+      figure: fmtMegabytes(pointer.bytes),
+      lead: "history",
+    }));
+    // The REAL count, not the policy. Pruning happens on the next backup, so a
+    // folder can briefly hold more than KEEP; `Math.min(count, KEEP)` was tried
+    // and it silently reported 3 while 4 were sitting there. The policy belongs
+    // in the sentence beside it, where it is a promise rather than a miscount.
+    card.append(manageRow("Backups kept", {
+      sub: `In the folder ScrapeX created, ${FOLDER_NAME}. The newest ${KEEP} are kept.`,
+      figure: String(count),
+      lead: "storage",
+    }));
+  } else {
+    // The card STAYS. Hiding it would leave the person with no way to learn
+    // what a backup will contain before making one.
+    card.append(manageRow("No backups in your Drive yet."));
+  }
+
+  card.append(manageRow("Each backup holds", { sub: BUNDLE_CONTENTS }));
+
+  if (folder) {
+    card.append(manageRow("Open the folder in Drive", {
+      symbol: "open-in-new",
+      onClick: () => window.open(driveFolderUrl(folder), "_blank", "noopener,noreferrer"),
+    }));
+  }
+}
+
+/** Say what went wrong in the words the person's next step depends on. */
+function driveFailureDetail(error) {
+  if (!error) return "Google did not say why.";
+  if (error.kind === "unauthorized") {
+    return "Google refused the token. Sign in again from the Profile page.";
+  }
+  if (error.kind === "forbidden") {
+    return "Google refused the request — usually a full Drive or a rate limit.";
+  }
+  if (error.kind === "network") return "Could not reach Google.";
+  if (error.kind === "malformed-pointer") {
+    return "The backup pointer in your Drive could not be read.";
+  }
+  return error.message || "Google did not say why.";
+}
+
+function renderManageAccountIdentity() {
+  const account = state.account;
+  $("manage-account-name").textContent = (account && account.name) || "Signed in";
+  const email = (account && account.email) || "";
+  $("manage-account-email").textContent = email;
+  $("manage-account-email").classList.toggle("hidden", !email);
+
+  const photo = $("manage-account-photo");
+  if (account && account.picture) {
+    photo.onerror = () => photo.classList.add("hidden");
+    photo.onload = () => photo.classList.remove("hidden");
+    photo.src = account.picture;
+  } else {
+    photo.removeAttribute("src");
+    photo.classList.add("hidden");
+  }
+}
+
+async function loadManageAccount() {
+  renderManageAccountIdentity();
+  setDisconnectStatus("");
+  if (!state.token) {
+    renderDriveFacts({ state: "signed-out" });
+    return;
+  }
+
+  // Generation guard, the same one loadAccount uses: leaving and returning
+  // starts a second read, and the slower answer must not paint over the newer.
+  const generation = ++manageAccountGeneration;
+  const current = () => generation === manageAccountGeneration
+    && !panelController.signal.aborted;
+  renderDriveFacts({ state: "loading" });
+  try {
+    const folder = await folderId(state.token);
+    if (!current()) return;
+    const files = await listing(state.token, folder);
+    if (!current()) return;
+    const pointer = await readLatest(state.token, folder);
+    if (!current()) return;
+    // The pointer file is not a backup. Counting it would say 4 of 3.
+    const bundles = files.filter((file) => file.name && file.name.endsWith(".zip"));
+    renderDriveFacts({ state: "ok", pointer, count: bundles.length, folder });
+  } catch (error) {
+    if (!current()) return;
+    renderDriveFacts({ state: "error", detail: driveFailureDetail(error) });
+  }
+}
+
+function setDisconnectStatus(detail) {
+  const status = $("disconnect-status");
+  if (!status) return;
+  status.textContent = detail || "";
+  status.classList.toggle("hidden", !detail);
+}
+
+// ---- the confirmation ------------------------------------------------------
+// A plain element, not <dialog>: the document keydown handler in this file
+// calls preventDefault() on every Escape, which would stop the browser's own
+// close and leave a dialog that only the mouse can dismiss.
+
+let disconnectReturnFocus = null;
+
+function disconnectDialogCopy() {
+  const email = (state.account && state.account.email) || "your account";
+  const veil = document.createDocumentFragment();
+  const first = el("p", "", `Backups stop, and ScrapeX loses access to the folder it `
+    + `created for ${email}. The backups already in your Drive stay where they are.`);
+  const second = el("p", "");
+  second.append(el("strong", "", "Nothing is deleted."),
+                document.createTextNode(" Not in your Drive, not on this machine. "
+                  + "Because the same Google grant carries your name and address, "
+                  + "this also signs you out of ScrapeX."));
+  veil.append(first, second);
+  return veil;
+}
+
+function openDisconnectDialog() {
+  const veil = $("disconnect-veil");
+  if (!veil) return;
+  disconnectReturnFocus = document.activeElement;
+  const copy = $("disconnect-dialog-copy");
+  copy.textContent = "";
+  copy.append(disconnectDialogCopy());
+  veil.classList.remove("hidden");
+  $("disconnect-dialog").focus({ preventScroll: true });
+}
+
+function closeDisconnectDialog({ restoreFocus = true } = {}) {
+  const veil = $("disconnect-veil");
+  if (!veil || veil.classList.contains("hidden")) return;
+  veil.classList.add("hidden");
+  if (restoreFocus && disconnectReturnFocus && disconnectReturnFocus.isConnected) {
+    disconnectReturnFocus.focus({ preventScroll: true });
+  }
+  disconnectReturnFocus = null;
+}
+
+function disconnectDialogIsOpen() {
+  const veil = $("disconnect-veil");
+  return Boolean(veil) && !veil.classList.contains("hidden");
+}
+
+/** Keep Tab inside the dialog while it is open. */
+function trapDisconnectFocus(event) {
+  if (event.key !== "Tab" || !disconnectDialogIsOpen()) return;
+  const dialog = $("disconnect-dialog");
+  const focusable = dialog.querySelectorAll("button:not(:disabled)");
+  if (!focusable.length) return;
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  const active = document.activeElement;
+  if (event.shiftKey && (active === first || active === dialog)) {
+    event.preventDefault();
+    last.focus({ preventScroll: true });
+  } else if (!event.shiftKey && active === last) {
+    event.preventDefault();
+    first.focus({ preventScroll: true });
+  }
+}
+
+/** Disconnect Drive — which is the same act as signing out.
+ *
+ * `revokeToken` ends the WHOLE grant at Google, identity scopes included; there
+ * is no Drive-only revoke. The button says so, and this reuses the sign-out path
+ * rather than writing a second one: it is the tested one, and its ordering
+ * (revoke while the token is still valid, then drop Chrome's copy) is
+ * load-bearing.
+ */
+async function disconnectDrive() {
+  const primary = $("drive-disconnect").querySelector(".split-button-primary");
+  const confirm = $("disconnect-confirm");
+  primary.disabled = true;
+  confirm.disabled = true;
+  setDisconnectStatus("Ending the grant at Google…");
+  try {
+    const signout = $("signout");
+    if (signout) signout.click();
+    setDisconnectStatus("");
+    closeDisconnectDialog({ restoreFocus: false });
+    showView("profile");
+  } finally {
+    primary.disabled = false;
+    confirm.disabled = false;
+  }
+}
+
 // ---- what is installed, and what is available -----------------------------
 // The Engines page is the one page that has to work with NO ENGINE INSTALLED —
 // that is its whole purpose, and it is the state every machine is in for its
@@ -5093,7 +5378,14 @@ function wireStartupShell() {
   // something to the workspace menu and the rail, and the innermost open thing
   // is the one that should answer it.
   document.addEventListener("keydown", (event) => {
-    if (event.key !== "Escape" || !state.openAccountMenu) return;
+    if (event.key !== "Escape") return;
+    // Innermost first. The dialog is modal, so nothing behind it may answer.
+    if (disconnectDialogIsOpen()) {
+      event.stopPropagation();
+      closeDisconnectDialog();
+      return;
+    }
+    if (!state.openAccountMenu) return;
     event.stopPropagation();
     closeAccountMenu({ restoreFocus: true });
   }, true);
@@ -5106,6 +5398,30 @@ function wireStartupShell() {
         && target.closest(".account-menu, .account-menu-button")) return;
     closeAccountMenu();
   });
+
+  // ---- Manage account -----------------------------------------------------
+  $("manage-account").addEventListener("click", () => showView("manage-account"));
+  $("manage-account-back").addEventListener("click", () => {
+    showView("profile");
+    focusAccountSummary();
+  });
+  $("drive-review-permissions").addEventListener("click", () => {
+    window.open(GOOGLE_PERMISSIONS_URL, "_blank", "noopener,noreferrer");
+  });
+  // The shared primitive owns open/close/aria/Escape/outside-click for the menu.
+  // Wired once, here, because wire() is once-per-node and a second call on a
+  // re-rendered node would leak a document listener.
+  window.ScrapeXSplitButton?.wire($("drive-disconnect"), (action) => {
+    if (action === "disconnect-drive") openDisconnectDialog();
+  });
+  $("disconnect-cancel").addEventListener("click", () => closeDisconnectDialog());
+  $("disconnect-confirm").addEventListener("click", () => { disconnectDrive(); });
+  // The veil itself, not the card: a click that lands on the card must not
+  // dismiss the question the card is asking.
+  $("disconnect-veil").addEventListener("click", (event) => {
+    if (event.target === $("disconnect-veil")) closeDisconnectDialog();
+  });
+  document.addEventListener("keydown", trapDisconnectFocus, true);
 
   setGoogleButtonScheme();
   window.addEventListener("scrapexappearancechange", () => {

--- a/extension/components.css
+++ b/extension/components.css
@@ -1472,6 +1472,98 @@ code {
   font-size: var(--fs-2xs);
 }
 
+/* The destructive split button.
+ *
+ * Added 2026-08-12 for Profile › Manage account, where the primary action
+ * revokes a Google grant. The neutral primitive above reads as an ordinary tool;
+ * an action that cannot be undone should not.
+ *
+ * WHY LIGHT AND DARK DIFFER. Light fills the primary — a red block is the
+ * strongest thing on a white page and that is the point. Dark outlines it
+ * instead: a filled light-red button on a dark surface reads as an alert banner
+ * announcing a problem, not as a control waiting to be pressed.
+ *
+ * NOT COMPOSED WITH `button.danger`. That rule is (0,1,1) and would win some
+ * properties from `.split-button.danger .split-button-primary` (0,2,0) and lose
+ * others, giving a control that is half one variant and half the other. Every
+ * declaration this variant needs is written here.
+ */
+.split-button.danger {
+  border-color: var(--red);
+}
+.split-button.danger .split-button-primary {
+  background: var(--red);
+  color: var(--danger-contrast);
+}
+.split-button.danger .split-button-primary .sx-icon {
+  color: var(--danger-contrast);
+}
+.split-button.danger .split-button-primary:hover:not(:disabled) {
+  background: var(--red-hover);
+  color: var(--danger-contrast);
+}
+.split-button.danger .split-button-primary:active:not(:disabled) {
+  background: var(--red-hover);
+  color: var(--danger-contrast);
+}
+.split-button.danger .split-button-trigger {
+  border-inline-start-color: var(--danger-contrast);
+  color: var(--red);
+}
+.split-button.danger .split-button-trigger:hover,
+.split-button.danger .split-button-menu[open] .split-button-trigger {
+  background: var(--red-weak);
+  color: var(--red);
+}
+.split-button.danger .split-button-options {
+  border-color: var(--red);
+}
+.split-button.danger .split-button-option {
+  color: var(--red);
+}
+.split-button.danger .split-button-option:hover:not(:disabled) {
+  background: var(--red-weak);
+  border-color: var(--red);
+  color: var(--red);
+}
+.split-button.danger .split-button-option:active:not(:disabled) {
+  background: var(--red-weak);
+  border-color: var(--red);
+  color: var(--red);
+}
+
+/* Dark outlines rather than fills — see the note above. */
+:root[data-theme="dark"] .split-button.danger .split-button-primary,
+:root[data-theme="dark"] .split-button.danger .split-button-primary .sx-icon {
+  background: transparent;
+  color: var(--red);
+}
+:root[data-theme="dark"] .split-button.danger .split-button-primary:hover:not(:disabled),
+:root[data-theme="dark"] .split-button.danger .split-button-primary:active:not(:disabled) {
+  background: var(--red-weak);
+  color: var(--red-hover);
+}
+:root[data-theme="dark"] .split-button.danger .split-button-trigger {
+  border-inline-start-color: var(--red);
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .split-button.danger .split-button-primary,
+  :root:not([data-theme="light"]) .split-button.danger .split-button-primary .sx-icon {
+    background: transparent;
+    color: var(--red);
+  }
+  :root:not([data-theme="light"]) .split-button.danger
+    .split-button-primary:hover:not(:disabled),
+  :root:not([data-theme="light"]) .split-button.danger
+    .split-button-primary:active:not(:disabled) {
+    background: var(--red-weak);
+    color: var(--red-hover);
+  }
+  :root:not([data-theme="light"]) .split-button.danger .split-button-trigger {
+    border-inline-start-color: var(--red);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .split-button-options { animation: none; }
 }

--- a/extension/tests/diagnostic-app-nomodule.html
+++ b/extension/tests/diagnostic-app-nomodule.html
@@ -1149,8 +1149,7 @@
               <button class="ghost compact hidden" id="retry-account" type="button">
                 Retry
               </button>
-              <button class="ghost profile-manage" id="manage-account" type="button"
-                      disabled>
+              <button class="ghost profile-manage" id="manage-account" type="button">
                 Manage your account
               </button>
             </div>
@@ -1168,6 +1167,117 @@
           </div>
 
         </div>
+      </div>
+    </section>
+
+    <!-- Manage account. A SIBLING of #view-profile, not a child: a test forbids
+         [role="dialog"] anywhere inside #view-profile and this screen has one.
+         Sprite hrefs carry the `../` this page needs and app.html does not. -->
+    <section id="view-manage-account" class="hidden"
+             aria-labelledby="manage-account-title" tabindex="0">
+      <header class="manage-account-heading">
+        <button id="manage-account-back" type="button" class="ghost manage-account-back"
+                aria-label="Back to Profile" title="Back to Profile">
+          <svg class="sx-icon" aria-hidden="true">
+            <use href="../icons/material-icons.svg#arrow-back"></use>
+          </svg>
+        </button>
+        <h1 id="manage-account-title">Manage account</h1>
+      </header>
+
+      <div class="manage-account-body">
+        <section class="card manage-account-identity" aria-label="Signed in as">
+          <img class="manage-account-face hidden" id="manage-account-photo" alt=""
+               aria-hidden="true">
+          <span class="manage-account-face-fallback" aria-hidden="true">
+            <svg class="sx-icon manage-account-face-icon" aria-hidden="true">
+              <use href="../icons/material-icons.svg#account-circle"></use>
+            </svg>
+          </span>
+          <span class="manage-account-identity-text">
+            <span class="manage-account-name" id="manage-account-name">Signed in</span>
+            <span class="manage-account-email" id="manage-account-email" dir="ltr"></span>
+          </span>
+        </section>
+
+        <h2 class="manage-account-section" id="manage-drive-title">Google Drive</h2>
+        <section class="card manage-account-rows" aria-labelledby="manage-drive-title">
+          <div class="manage-account-row">
+            <span class="manage-account-row-text">
+              <span class="manage-account-row-title">Drive features</span>
+              <span class="manage-account-row-sub">Backups run only when you ask;
+                ScrapeX never uploads on its own. This switch is not wired up
+                yet.</span>
+            </span>
+            <label class="appearance-switch">
+              <input type="checkbox" id="drive-enabled" aria-label="Drive features"
+                     disabled>
+              <span aria-hidden="true"></span>
+            </label>
+          </div>
+
+          <div class="manage-account-row">
+            <span class="manage-account-row-text">
+              <span class="manage-account-row-title">Granted access</span>
+              <span class="manage-account-row-sub">Only files ScrapeX created in your
+                Drive. Nothing else is readable.</span>
+            </span>
+          </div>
+
+          <button class="manage-account-row manage-account-row-button" type="button"
+                  id="drive-review-permissions">
+            <span class="manage-account-row-text">
+              <span class="manage-account-row-title">Review permissions in Google</span>
+            </span>
+            <svg class="sx-icon lg manage-account-row-icon" aria-hidden="true">
+              <use href="../icons/material-icons.svg#open-in-new"></use>
+            </svg>
+          </button>
+        </section>
+
+        <h2 class="manage-account-section" id="manage-backups-title">In your Drive</h2>
+        <section class="card manage-account-rows" aria-labelledby="manage-backups-title"
+                 id="drive-backups"></section>
+
+        <section class="card manage-account-danger" aria-labelledby="disconnect-title">
+          <strong id="disconnect-title">Disconnect Drive</strong>
+          <p class="manage-account-danger-copy">Stops backups and revokes ScrapeX's
+            access to your Drive. Because the same grant carries your name and
+            address, this signs you out of ScrapeX too. The backups already there
+            stay in your Drive — delete them yourself if you want them gone.
+            Nothing on this machine is touched.</p>
+
+          <div class="split-button danger" id="drive-disconnect" role="group"
+               aria-label="Disconnect Drive">
+            <button class="split-button-primary" type="button"
+                    data-split-action="disconnect-drive">
+              <svg class="sx-icon" aria-hidden="true">
+                <use href="../icons/material-icons.svg#logout"></use>
+              </svg>
+              <span>Disconnect Drive and sign out</span>
+            </button>
+            <details class="split-button-menu">
+              <summary class="split-button-trigger" aria-haspopup="menu"
+                       aria-expanded="false" aria-label="More disconnect options">
+                <svg class="sx-icon split-button-chevron" aria-hidden="true">
+                  <use href="../icons/material-icons.svg#expand-more"></use>
+                </svg>
+              </summary>
+              <div class="split-button-options" role="menu"
+                   aria-label="Disconnect options">
+                <button class="split-button-option" type="button" role="menuitem"
+                        data-split-action="disconnect-and-erase" disabled>
+                  <span class="split-button-option-copy">
+                    <strong>Disconnect and erase everything</strong>
+                    Not available yet — the engine has no erase to call
+                  </span>
+                </button>
+              </div>
+            </details>
+          </div>
+          <p class="manage-account-status hidden" role="status" aria-live="polite"
+             id="disconnect-status"></p>
+        </section>
       </div>
     </section>
 
@@ -1787,6 +1897,21 @@
     <div id="workspace-links" class="workspace-menu-groups"
          aria-label="Workspace pages"></div>
   </aside>
+
+  <div id="disconnect-veil" class="modal-veil hidden">
+    <div class="modal-card" role="dialog" aria-modal="true"
+         aria-labelledby="disconnect-dialog-title" tabindex="-1"
+         id="disconnect-dialog">
+      <h2 class="modal-title" id="disconnect-dialog-title">Disconnect Drive?</h2>
+      <div class="modal-copy" id="disconnect-dialog-copy"></div>
+      <div class="modal-actions">
+        <button class="ghost" type="button" id="disconnect-cancel">Cancel</button>
+        <button class="danger" type="button" id="disconnect-confirm">
+          Disconnect and sign out
+        </button>
+      </div>
+    </div>
+  </div>
 
   <!-- app.js REMOVED — this is what step 4 measures -->
 </body>

--- a/scrapex/webui/static/components.css
+++ b/scrapex/webui/static/components.css
@@ -1472,6 +1472,98 @@ code {
   font-size: var(--fs-2xs);
 }
 
+/* The destructive split button.
+ *
+ * Added 2026-08-12 for Profile › Manage account, where the primary action
+ * revokes a Google grant. The neutral primitive above reads as an ordinary tool;
+ * an action that cannot be undone should not.
+ *
+ * WHY LIGHT AND DARK DIFFER. Light fills the primary — a red block is the
+ * strongest thing on a white page and that is the point. Dark outlines it
+ * instead: a filled light-red button on a dark surface reads as an alert banner
+ * announcing a problem, not as a control waiting to be pressed.
+ *
+ * NOT COMPOSED WITH `button.danger`. That rule is (0,1,1) and would win some
+ * properties from `.split-button.danger .split-button-primary` (0,2,0) and lose
+ * others, giving a control that is half one variant and half the other. Every
+ * declaration this variant needs is written here.
+ */
+.split-button.danger {
+  border-color: var(--red);
+}
+.split-button.danger .split-button-primary {
+  background: var(--red);
+  color: var(--danger-contrast);
+}
+.split-button.danger .split-button-primary .sx-icon {
+  color: var(--danger-contrast);
+}
+.split-button.danger .split-button-primary:hover:not(:disabled) {
+  background: var(--red-hover);
+  color: var(--danger-contrast);
+}
+.split-button.danger .split-button-primary:active:not(:disabled) {
+  background: var(--red-hover);
+  color: var(--danger-contrast);
+}
+.split-button.danger .split-button-trigger {
+  border-inline-start-color: var(--danger-contrast);
+  color: var(--red);
+}
+.split-button.danger .split-button-trigger:hover,
+.split-button.danger .split-button-menu[open] .split-button-trigger {
+  background: var(--red-weak);
+  color: var(--red);
+}
+.split-button.danger .split-button-options {
+  border-color: var(--red);
+}
+.split-button.danger .split-button-option {
+  color: var(--red);
+}
+.split-button.danger .split-button-option:hover:not(:disabled) {
+  background: var(--red-weak);
+  border-color: var(--red);
+  color: var(--red);
+}
+.split-button.danger .split-button-option:active:not(:disabled) {
+  background: var(--red-weak);
+  border-color: var(--red);
+  color: var(--red);
+}
+
+/* Dark outlines rather than fills — see the note above. */
+:root[data-theme="dark"] .split-button.danger .split-button-primary,
+:root[data-theme="dark"] .split-button.danger .split-button-primary .sx-icon {
+  background: transparent;
+  color: var(--red);
+}
+:root[data-theme="dark"] .split-button.danger .split-button-primary:hover:not(:disabled),
+:root[data-theme="dark"] .split-button.danger .split-button-primary:active:not(:disabled) {
+  background: var(--red-weak);
+  color: var(--red-hover);
+}
+:root[data-theme="dark"] .split-button.danger .split-button-trigger {
+  border-inline-start-color: var(--red);
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .split-button.danger .split-button-primary,
+  :root:not([data-theme="light"]) .split-button.danger .split-button-primary .sx-icon {
+    background: transparent;
+    color: var(--red);
+  }
+  :root:not([data-theme="light"]) .split-button.danger
+    .split-button-primary:hover:not(:disabled),
+  :root:not([data-theme="light"]) .split-button.danger
+    .split-button-primary:active:not(:disabled) {
+    background: var(--red-weak);
+    color: var(--red-hover);
+  }
+  :root:not([data-theme="light"]) .split-button.danger .split-button-trigger {
+    border-inline-start-color: var(--red);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .split-button-options { animation: none; }
 }

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -4535,3 +4535,99 @@ def test_the_neutral_engine_hover_is_a_state_layer_not_an_opaque_fill(open_panel
         assert "color-mix" in declared and "--text" in declared, (
             f"{selector} hover is {declared!r}, not a translucent layer mixed "
             f"from the current text colour — so it cannot follow the scheme")
+
+
+# ---- Manage account: the screen #173 built, guarded ------------------------
+#
+# THE REVIEW FINDING, 2026-08-12. #173 added 1,221 lines — a whole sub-view, a
+# modal, a Drive stub in the harness — and changed `tests/` by nothing at all.
+# Its description reported measurements at 400px and 320px, light and dark, and
+# said the dialog "takes focus, traps Tab, and returns focus on close".
+#
+# Every one of those is true. Every one of them was measured ONCE, by hand, by
+# the person who wrote it, and nothing repeats any of it. That is section 6b of
+# the backlog exactly: a property that is DECLARED rather than checked.
+#
+# These are the four claims whose failure the owner would actually meet.
+
+
+def test_manage_account_is_reachable_and_is_not_a_dialog_inside_profile(open_panel):
+    """Two things at once, because they constrain each other.
+
+    The screen has a real modal, and `test_the_profile_states_live_in_one_
+    persistent_centered_card` forbids `[role=dialog]` INSIDE `#view-profile`.
+    That is a descendant combinator, so the fix was to make this a top-level
+    section — the shape `#view-source-edit` already had. If someone later moves
+    it back under Profile "to tidy up", the older test fails and this one says
+    why.
+    """
+    page = open_panel(signed_in=ACCOUNT)
+    page.wait_for_selector("#welcome-signed-in:visible")
+
+    page.click("#manage-account")
+    page.wait_for_selector("#view-manage-account:visible")
+
+    assert page.locator("#view-profile #view-manage-account").count() == 0, (
+        "the sub-view was nested inside #view-profile, where a [role=dialog] "
+        "is forbidden by an older test that would then fail for a reason no "
+        "one could see from here")
+    assert page.locator("#view-profile [role='dialog']").count() == 0
+
+    # The rail keeps showing Profile as current: a sub-view is not a tab.
+    assert page.get_attribute("#tab-profile", "aria-selected") == "true", (
+        "the rail lost its selected entry when the sub-view opened, so the "
+        "owner cannot tell where they are")
+
+
+def test_leaving_manage_account_returns_to_the_profile_it_came_from(open_panel):
+    """A back button that lands somewhere else is worse than none: the owner
+    loses the account they were looking at and has to find it again."""
+    page = open_panel(signed_in=ACCOUNT)
+    page.wait_for_selector("#welcome-signed-in:visible")
+    page.click("#manage-account")
+    page.wait_for_selector("#view-manage-account:visible")
+
+    page.click("#manage-account-back")
+
+    page.wait_for_selector("#view-profile:visible")
+    assert page.locator("#view-manage-account:visible").count() == 0
+    assert page.is_visible("#welcome-signed-in"), (
+        "back landed on Profile but not on the signed-in state it came from")
+
+
+def test_the_screen_names_the_account_it_is_managing(open_panel):
+    """"Manage account" with no account on it is a screen that could be about
+    anybody's. The address is the whole point of the header."""
+    page = open_panel(signed_in=ACCOUNT)
+    page.wait_for_selector("#welcome-signed-in:visible")
+    page.click("#manage-account")
+    page.wait_for_selector("#view-manage-account:visible")
+
+    assert ACCOUNT["email"] in (page.text_content("#manage-account-email") or ""), (
+        "the screen does not say which account it is managing")
+
+
+def test_every_control_that_cannot_run_yet_says_so_on_its_face(open_panel):
+    """THE OWNER'S RULE, given on 2026-08-12 for the Data page and applied here
+    by #173: a control that is not built is SHOWN, disabled, with the reason
+    where a person reads it — not hidden until it is finished.
+
+    Asserted so the words cannot be dropped later while the control stays dead,
+    which is the state that teaches someone the button is broken rather than
+    unbuilt.
+    """
+    page = open_panel(signed_in=ACCOUNT)
+    page.wait_for_selector("#welcome-signed-in:visible")
+    page.click("#manage-account")
+    page.wait_for_selector("#view-manage-account:visible")
+
+    view = page.locator("#view-manage-account")
+    dead = view.locator("button:disabled, input:disabled")
+    assert dead.count() > 0, (
+        "nothing is disabled here any more — if the erase and the Drive switch "
+        "were wired up, delete this test with the copy that explains them")
+
+    text = (page.text_content("#view-manage-account") or "").lower()
+    assert "not available yet" in text or "not wired up" in text, (
+        "a control on this screen is disabled and nothing on the screen says "
+        "why. The owner asked to see work in progress, not dead buttons.")

--- a/tools/panel_harness.py
+++ b/tools/panel_harness.py
@@ -77,7 +77,7 @@ def stub(backend: str = DEFAULT_BACKEND, *, engine_up=True, sources=None, jobs=N
          signed_in=None, signin_error=None, signin_delay_ms=0,
          signin_never_returns=False, route_delays=None, blackhole_routes=(),
          native_mode="absent", google_account_mode="ok",
-         remembered_accounts=None,
+         remembered_accounts=None, drive=None,
          worker_alive=True) -> str:
     """A chrome.* shim plus a fetch() interceptor.
 
@@ -304,6 +304,7 @@ const SIGNIN_DELAY_MS = {json.dumps(signin_delay_ms)};
 const SIGNIN_NEVER_RETURNS = {str(signin_never_returns).lower()};
 const NATIVE_MODE = {json.dumps(native_mode)};
 const GOOGLE_ACCOUNT_MODE = {json.dumps(google_account_mode)};
+const DRIVE = {json.dumps(drive)};
 const ROUTES = {json.dumps(routes)};
 const WRITE_ROUTES = {json.dumps(write_routes)};
 const LOG_PAYLOAD = {json.dumps(log_payload)};
@@ -345,6 +346,38 @@ window.fetch = async (url, options = {{}}) => {{
     let body = null;
     try {{ body = JSON.parse((options && options.body) || "null"); }} catch (_) {{}}
     window.__writes.push({{path, method, body}});
+  }}
+  // GOOGLE DRIVE. Without this every Drive read 404s and the Manage-account
+  // screen can only ever be seen in its failure state — which is how it was
+  // first shipped to review. `drive: None` keeps that behaviour deliberately,
+  // so the error path stays testable too.
+  //
+  // Three requests, told apart the way drive.js builds them: `alt=media` is a
+  // download, `orderBy` is only on the folder listing, and anything else is the
+  // search for the folder itself.
+  if (String(url).includes("googleapis.com/drive/v3/files")) {{
+    if (!DRIVE) {{
+      return {{ ok: false, status: 404, statusText: "Not Found",
+                headers: {{get: () => null}},
+                json: async () => ({{}}), text: async () => "" }};
+    }}
+    const target = String(url);
+    if (target.includes("alt=media")) {{
+      const id = decodeURIComponent(target.split("/files/")[1].split("?")[0]);
+      const pointer = (DRIVE.files || []).find(f => f.name === "latest.json");
+      const body = pointer && pointer.id === id
+        ? JSON.stringify(DRIVE.pointer || {{}}) : "";
+      return {{ ok: true, status: 200, headers: {{get: () => null}}, body: null,
+                blob: async () => new Blob([body]),
+                text: async () => body, json: async () => JSON.parse(body || "null") }};
+    }}
+    if (target.includes("orderBy")) {{
+      return {{ ok: true, status: 200, headers: {{get: () => null}},
+                json: async () => ({{files: DRIVE.files || []}}) }};
+    }}
+    return {{ ok: true, status: 200, headers: {{get: () => null}},
+              json: async () => ({{files: DRIVE.folder
+                ? [{{id: DRIVE.folder, name: "ScrapeX backups"}}] : []}}) }};
   }}
   if (String(url).includes("oauth2/v3/userinfo")) {{
     if (GOOGLE_ACCOUNT_MODE === "offline") throw new Error("network offline");


### PR DESCRIPTION
Implements the `design_handoff_manage_account` handoff (**rev0**): a new Profile sub-view for the Google Drive side of the signed-in account.

**Three of the handoff's sentences are false about this engine, and one of its premises does not exist.** That is the substance of this PR; the layout was the easy half. Each correction carries the owner's ruling of 2026-08-12.

## Where the view lives — decided by a test, not by taste

[test_panel_dom.py:2979](tests/test_panel_dom.py:2979) asserts `#view-profile [role='dialog']` counts zero, and this screen has a real modal. That is a **descendant** combinator, so it binds children of `#view-profile` and nothing else. The view is its own top-level section — the shape `#view-source-edit` already has for Sources — with no rail button, and `showView` maps it back to the Profile rail entry.

Two more constraints shaped the dialog:

- **Not a `<dialog>`** — a document keydown handler calls `preventDefault()` on *every* Escape, which would stop the browser's own close and leave a modal only the mouse could dismiss.
- **At `body` level** — `showView` animates a view with a live `transform` for 180ms, and a transformed ancestor becomes the containing block for `position: fixed`.

Its `z-index` is **derived, not taken**: `--z-modal` is 30 and the side rail is *also* 30, so the token ties with the thing a modal must cover. Correcting the token is a design-system decision, not this screen's — flagging it for you.

## Three sentences corrected

| Handoff copy | What the code does |
|---|---|
| `Disconnect Drive` | `revokeToken` ends the **whole** grant, identity scopes included. There is no Drive-only revoke — so the button reads **"Disconnect Drive and sign out"** and the copy says why. Reuses the tested `#signout` path. |
| `Nothing is uploaded while this is off` | There is **no Drive-features preference** in the repo. Every Drive write is behind a button on Settings. The switch ships **disabled**; the line now reads "Backups run only when you ask; ScrapeX never uploads on its own." |
| `Erases every database…` + `a copy is exported to your downloads folder first` | Both false. `/api/storage/start-fresh` **renames** the database aside — [storage.py:919](scrapex/storage.py:919): *"sealed aside, not erased"* — and lists it under Restore. `/api/storage/export` writes to a path on the **engine host**; nothing reaches the browser. |

Per your ruling, **`Disconnect and erase everything` ships disabled**, with the real behaviour left to you. Both disabled controls carry a code comment naming the file and line, so nobody has to guess why.

## Four defects, three of them mine

- **`#168` in a comment** failed the colour-literal guard — a hash plus three hex digits reads as a colour. False positive; the rule still stands.
- **The dialog asked "DISCONNECT DRIVE?"** in small grey caps: a global `h2` rule paints every h2 as a section label, and my class beat it only on the properties it declared.
- **The backup count read "3 of 3" while four bundles sat in the folder.** Pruning happens on the *next* backup, so `Math.min` was hiding a file to avoid the look of "4 of 3". The real number is shown; the policy moved into the sentence beside it.
- **Both row icons wrapped onto their own line** — appended after the figure, they were a third child in a two-column grid.

**Carried over from #168:** `state.openAccountMenu` survived navigation, so while set, the capture-phase Escape handler swallowed Escape on *every other view*. Invisible, because nothing was open to see. `showView` closes it now.

## The harness could only show this screen failing

Nothing stubbed Drive, so `folderId` 404'd and `In your Drive` was reviewable only in its error state. A `drive=` seed now answers the three requests `drive.js` makes, told apart the way it builds them (`alt=media`, `orderBy`, else the folder search). **`drive=None` keeps the old behaviour deliberately** — the error path has to stay testable too.

Both states measured:

- four bundles → `Latest backup [4.5 MB]` · `Backups kept [4]` with the newest-3 promise beside it
- empty Drive → the card **stays**, with `Each backup holds` still shown so someone can learn what a backup is before making one

## Verification

`pytest -m extension` green · `node --test` 163 green · `eslint` clean. Measured at 400px and 320px, light and dark: the panel never scrolls, the body does, the header stays pinned, the split menu is not clipped at any scroll position, and the dialog takes focus, traps Tab, and returns focus on close.

## For your decision

1. **`--z-modal` (30) collides with the side rail (30).** Worth fixing in `tokens.css`, outside this screen.
2. **The real erase and a real export** — the two paths the disabled control waits on.
3. **The Drive-features switch** — either wire a preference (touches Settings, which the handoff's scope box forbids) or drop the row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
