### PR TITLE
Issue 161: a reopened panel finds the crawl that is already running

### DIFF
--- a/extension/app.js
+++ b/extension/app.js
@@ -4066,8 +4066,43 @@ function handlePanelVisibility() {
   }
   // The shared appearance/timezone modules perform their own immediate refresh
   // on this event. Only the job poll is owned here, and the in-flight guard
-  // above prevents a second timer or request from being created.
-  if (state.engineUp && (state.job || state.jobRef)) pollJob();
+  // in pollJob prevents a second timer or request from being created.
+  //
+  // NO `state.job || state.jobRef` CONDITION. It used to require one, which
+  // meant the poll only resumed for a run this DOCUMENT already knew about —
+  // and a panel that was closed and reopened is a new document that knows about
+  // nothing. See reattachToRunningJob for the rest of that story.
+  if (state.engineUp) pollJob();
+}
+
+/**
+ * Find a crawl that was already running when this panel opened.
+ *
+ * ISSUE 161, and the half of it that was fragile. (Written without a
+ * leading hash: a hash and three hex digits is a colour literal to
+ * test_ui_colour_literals_live_only_in_the_canonical_colour_system, and a
+ * false positive there is still the guard doing its job.) app.js has promised since it
+ * was written that "closing this panel never stops a run and reopening
+ * reconnects to whatever is already in flight". The first half is the engine's
+ * doing and holds. The second was nobody's.
+ *
+ * `pollJob` had exactly one startup caller — loadRunDestination — which returns
+ * early unless the current view is "run". The panel opens on "profile" (line
+ * "The panel opens on Welcome"), so a reopened panel polled NOTHING until the
+ * owner happened to click Run. A crawl could be an hour into muqawil's 34 hours
+ * and the panel would show an idle screen.
+ *
+ * The failure is worse than a blank: the natural response to a run that has
+ * vanished is to start it again, and now two crawls of one source are writing
+ * at once.
+ *
+ * `pollJobOnce` already asks the engine for `active_only=true` and adopts
+ * whatever comes back, so reconnecting needs no new endpoint and no state
+ * carried across the close — only for the question to be asked.
+ */
+async function reattachToRunningJob() {
+  if (!state.engineUp) return null;
+  return pollJob();
 }
 
 async function controlJob(control) {
@@ -5818,6 +5853,11 @@ function scheduleNonCriticalStartup(backendPromise) {
         window.ScrapeXTime?.connect(backend),
         adoptUiContract(),
       ]);
+      // AFTER the shell is settled, never during it. A crawl that was already
+      // running has to be found (issue 161), and /api/jobs is destination data
+      // that the startup path is forbidden to touch — three tests hold that
+      // rule and they are right to. Idle time is where the two fit together.
+      await reattachToRunningJob();
     } catch (_) {}
   });
 }
@@ -5840,6 +5880,9 @@ async function init() {
     return backend;
   });
   const accountPromise = loadAccount();
+  // `render()` is what settles state.engineUp, so the reattach hangs off it
+  // rather than racing it. A crawl that was already running is adopted here,
+  // on whatever view the panel opened — see reattachToRunningJob (issue 161).
   const enginePromise = backendPromise.then(() => render());
   Promise.allSettled([accountPromise, enginePromise]).then(() => {
     markStartup("fully-settled", {

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -1937,12 +1937,19 @@ def test_the_active_crawl_minimizes_to_a_statusbar_and_opens_again(open_panel):
     page = open_panel(jobs=[job])
     bar = page.locator("#miniplayer")
 
-    # Job state is destination-specific startup work: Profile opens without it,
-    # and entering Run performs the first active-job read.
-    assert not bar.is_visible()
-    page.click(RUN_TAB)
+    # THE PANEL FINDS A RUNNING CRAWL WHEREVER IT OPENS (owner's ruling,
+    # 2026-08-12, issue 161). This used to assert the opposite — "Profile opens
+    # without it, and entering Run performs the first active-job read" — which
+    # was a real decision and is now a reversed one: a run that looks vanished
+    # gets started a second time, and two crawls then write one source.
+    #
+    # What the miniplayer IS remains the subject of this test, and is unchanged
+    # below: a <details> that rests minimised.
     page.wait_for_function(
         "() => !document.getElementById('miniplayer').classList.contains('hidden')")
+    assert bar.is_visible(), "a running crawl is invisible until Run is opened"
+    page.click(RUN_TAB)
+    page.wait_for_timeout(300)
     assert bar.is_visible()
     assert bar.evaluate("el => el.tagName") == "DETAILS"
     assert not bar.evaluate("el => el.open"), "a running crawl should rest minimized"
@@ -4631,3 +4638,48 @@ def test_every_control_that_cannot_run_yet_says_so_on_its_face(open_panel):
     assert "not available yet" in text or "not wired up" in text, (
         "a control on this screen is disabled and nothing on the screen says "
         "why. The owner asked to see work in progress, not dead buttons.")
+# ---- issue #161: reopening reconnects to whatever is already in flight -----
+
+def test_a_reopened_panel_finds_a_crawl_that_was_already_running(open_panel):
+    """THE PROMISE IN app.js's FIRST PARAGRAPH, checked at last.
+
+        "closing this panel never stops a run and reopening reconnects to
+         whatever is already in flight"
+
+    The first half is the engine's doing and holds: it owns execution. The
+    second was nobody's. `pollJob` had one startup caller — loadRunDestination
+    — which returns early unless the current view is "run", and the panel opens
+    on Welcome. So a reopened panel polled nothing until the owner happened to
+    click Run, and a crawl an hour into muqawil's thirty-four hours showed as an
+    idle screen.
+
+    THE FAILURE IS WORSE THAN A BLANK. The natural response to a run that has
+    vanished is to start it again, and then two crawls of one source are writing
+    at once.
+
+    WHY EVERY EXISTING JOB TEST MISSED IT: they all go through `_open_on_run`,
+    which clicks the Run tab first. Not one asked whether the panel finds a job
+    WITHOUT being taken there. This test deliberately does not click anything —
+    a reopened side panel is a fresh document that has been clicked nowhere.
+    """
+    page = open_panel(jobs=[_running_job()])
+
+    # No navigation. This is exactly what Chrome hands back when the owner
+    # reopens the side panel while a crawl is running.
+    page.wait_for_selector("#miniplayer:not(.hidden)", timeout=10000)
+
+    title = text_of(page, "#mini-title")
+    assert "SALLA_SHOP" in title, (
+        f"the panel reopened onto a running crawl and does not name it: {title!r}")
+    assert "running" in title
+
+
+def test_a_reopened_panel_with_nothing_running_says_nothing(open_panel):
+    """The other half of the same reattach: asking the engine on every open must
+    not put an empty player on a panel with no crawl behind it. A miniplayer
+    that appears for nothing is a control that means nothing."""
+    page = open_panel(jobs=[])
+    page.wait_for_timeout(600)
+
+    assert "hidden" in (page.get_attribute("#miniplayer", "class") or ""), (
+        "the miniplayer is showing with no job to show")

--- a/tests/test_panel_startup.py
+++ b/tests/test_panel_startup.py
@@ -256,7 +256,22 @@ def test_profile_startup_handles_healthy_and_stopped_engines_without_run_data(
     _wait_for_mark(page, "fully-settled")
 
     assert page.locator("#estat-text").inner_text().startswith(expected)
-    assert not any(call.startswith(DESTINATION_ROUTES) for call in _calls(page))
+
+    # THE RULE, NARROWED BY A DECISION RATHER THAN BY CONVENIENCE (2026-08-12).
+    #
+    # This forbade EVERY destination route on startup. The owner ruled that a
+    # crawl already running must be visible the moment the panel opens, on
+    # whatever screen it opens — issue 161, where a reopened panel showed an
+    # idle screen over a live run and the natural response was to start it
+    # again, putting two crawls on one source.
+    #
+    # Reattaching costs exactly one loopback request, and it happens AFTER the
+    # shell has settled. What the rule was protecting — a shell that paints
+    # before remote work — is untouched, and is still asserted: /api/health is
+    # called once, and the heavy reads are still forbidden.
+    heavy = tuple(route for route in DESTINATION_ROUTES if route != "/api/jobs")
+    assert not any(call.startswith(heavy) for call in _calls(page)), (
+        "startup read destination data it does not need to paint the shell")
     assert _calls(page).count("/api/health") == 1
     assert not page.js_errors
 
@@ -553,10 +568,22 @@ def test_startup_instrumentation_spans_shell_checks_and_first_destination(
     assert before["paint-opportunity-resolved"] <= before["shell-post-opportunity"]
     assert before["shell-post-opportunity"] <= before["account-check-start"]
     assert before["shell-post-opportunity"] <= before["engine-check-start"]
-    assert "first-destination-data-request" not in before
-
-    page.click(RUN_TAB)
+    # THE PROPERTY, STATED DIRECTLY. This used to assert that no destination
+    # request had happened by `fully-settled`, which was a proxy for "the shell
+    # is interactive first" and stopped being true on 2026-08-12: the owner
+    # ruled that a running crawl must be found the moment the panel opens
+    # (issue 161), so one loopback read now lands shortly after settle.
+    #
+    # The ordering is what the rule was ever about, and asserting it is stronger
+    # than asserting an absence at one instant — an absence that a slower
+    # machine could satisfy for the wrong reason.
     _wait_for_mark(page, "first-destination-data-request")
     after = _marks(page)
-    assert after["first-destination-data-request"] >= before["shell-interactive"]
+    assert after["first-destination-data-request"] >= after["shell-interactive"], (
+        "destination data was requested before the shell was interactive")
+    assert after["first-destination-data-request"] >= after["paint-opportunity-resolved"], (
+        "a remote read beat the renderer's paint opportunity")
+
+    page.click(RUN_TAB)
+    page.wait_for_timeout(300)
     assert not page.js_errors


### PR DESCRIPTION
`app.js` has promised since it was written:

> closing this panel never stops a run and **reopening reconnects to whatever is already in flight**

The first half is the engine's doing and holds. **The second was nobody's.**

## Measured, not assumed

`pollJob` had exactly one startup caller — `loadRunDestination` — which returns early unless the current view is `"run"`. The panel opens on Welcome.

So a reopened panel polled **nothing** until the owner happened to click Run: a crawl an hour into muqawil's thirty-four hours showed as an idle screen.

**The failure is worse than a blank.** The natural response to a run that has vanished is to start it again — and then two crawls of one source are writing at once.

`handlePanelVisibility` had the same shape from the other direction: it resumed the poll only `if (state.job || state.jobRef)`, for a run *this document* already knew about. A reopened panel is a new document that knows about nothing.

## Why it survived: the repository held two contradictory decisions

| | says |
|---|---|
| `app.js` header | reopening **reconnects** |
| `test_the_active_crawl_minimizes` | *"Profile opens without it, and entering Run performs the first active-job read"* |
| `test_profile_startup` | **every** destination route is forbidden at startup |

Three guards on one side, a paragraph on the other, and issue 161 sitting between them. **The owner ruled on 2026-08-12: found immediately, on whatever screen.**

## The three guards are amended to say that — and not weakened

1. **The startup rule** now forbids the *heavy* destination reads and permits the one active-job probe. `/api/health` is still asserted to be called exactly once.
2. **The instrumentation test** asserted an *absence at one instant* as a proxy for ordering. It now asserts **the ordering itself** — which a slow machine cannot satisfy for the wrong reason.
3. **The miniplayer test** keeps its whole subject (what the miniplayer *is*) and reverses only the clause the ruling reversed.

Reattaching happens **after the shell has settled**, in idle time, so what the startup rule protects is untouched. It costs one loopback request and needs no new endpoint — `pollJobOnce` already asks for `active_only=true`.

## Mutation-tested both ways

Removing the reattach fails the new test by timing out on a miniplayer that never appears — **which is exactly the screen the owner would have seen.**

Also fixed: my own comment wrote the issue as `#161`, and a hash with three hex digits is a colour literal to `test_ui_colour_literals`. A false positive, and the guard was still right to fire.

---

**Green locally:** full extension suite · node tests · `eslint`.

Closes #161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)