### PR TITLE
OP-19: the chaos test now waits for the sweep instead of racing it

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -653,7 +653,7 @@ for three different readers, and compression hides it. If space ever becomes a
 problem, the 90 MB of `.jsonl`/`.csv` is the part regenerable from the `.db`;
 the zip is not the thing to reconsider.
 
-### OP-19 · The chaos test races the startup sweep it is checking
+### OP-19 · The chaos test races the startup sweep it is checking — FIXED 2026-08-12
 
 Found 2026-08-11 while removing the engine's Google surface. The suite went red
 on `test_a_killed_engine_does_not_leave_a_job_claiming_to_run`, and the first
@@ -671,10 +671,21 @@ runner and reliably loses on a loaded Windows machine — the worst arrangement,
 because it makes the flake look like "works in CI, broken locally" and invites
 exactly the wrong diagnosis.
 
-**The fix is not to add a sleep.** `start()` should wait for a signal the sweep
-has run — the engine already knows when it has finished; the test does not ask.
-Not fixed here: it is a real defect in a test that guards a real property, and it
-deserves its own change rather than a line in a removal.
+**The fix was not a sleep.** `reclaim_orphaned_jobs` now records when it
+finished, in `scrapex_meta` beside the heartbeat that was already there, and
+`Engine.start(swept=True)` waits for that value to change. The marker is written
+UNCONDITIONALLY — a marker that appears only when there were orphans would be
+absent on every healthy start, and anyone waiting for it would wait for ever on
+exactly the machines where nothing had gone wrong.
+
+**Four runs in four, green.** And an honest note on the check: removing the wait
+again passed three runs in three that afternoon, having failed three in four
+that morning. A race that depends on machine load cannot be reproduced on
+demand, so the mutation check proved nothing — which is precisely why "it passes
+now" was never evidence in the first place. The proof is structural and readable
+in the code: health is answered by the HTTP thread the moment the port binds,
+and the sweep runs on the worker thread after it connects. Two tests in
+`test_jobs.py` hold the marker's two properties deterministically.
 
 ## 6c. The extension/engine separation, audited — 2026-08-11
 

--- a/scrapex/jobs.py
+++ b/scrapex/jobs.py
@@ -887,6 +887,10 @@ def run_job_once(conn: sqlite3.Connection, job_ref: str, manifest,
 
 
 HEARTBEAT_KEY = "runtime_heartbeat"
+#: When this runtime last finished sweeping jobs left behind by a dead one. It
+#: is the answer to "has the engine tidied up yet?", which /api/health cannot
+#: give: health is the HTTP thread's answer and the sweep is the worker's.
+RECLAIM_KEY = "orphans_reclaimed_at"
 HEARTBEAT_MAX_AGE_S = 30.0
 
 # A JOB may go quiet for far longer than a loop pass and still be healthy:
@@ -1076,8 +1080,27 @@ def reclaim_orphaned_jobs(conn: sqlite3.Connection) -> int:
             "WHERE status = ?",
             (target.value, JobControl.NONE.value, target.value, utc_now_iso(), stuck.value))
         reclaimed += cur.rowcount
-    if reclaimed:
-        conn.commit()
+    # THE SWEEP SAYS WHEN IT RAN, and it says so even when it reclaimed nothing.
+    #
+    # OP-19. `Engine.start()` in the chaos test waited for /api/health and then
+    # read crawl_job.status immediately — but health is answered by the HTTP
+    # thread the moment the server binds, while this sweep runs on the WORKER
+    # thread after it connects. Which of the two won was a coin toss: the test
+    # failed three runs in four on a loaded Windows machine and passed reliably
+    # on the Linux runner, so it read as "works in CI, broken locally" and
+    # invited exactly the wrong diagnosis.
+    #
+    # Nothing here needed fixing — the reclaim was always correct. What was
+    # missing is that the engine knew it had finished and nobody could ask.
+    #
+    # Written UNCONDITIONALLY, before the `if reclaimed` above would have
+    # returned early: "no orphans found" is a completed sweep, and a marker that
+    # only appears when there was damage cannot be waited on by anyone.
+    conn.execute(
+        "INSERT INTO scrapex_meta (key, value) VALUES (?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (RECLAIM_KEY, utc_now_iso()))
+    conn.commit()
     return reclaimed
 
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1233,3 +1233,60 @@ def test_the_budget_bounds_how_many_sites_crawl_at_once(tmp_path):
     intervals = sorted(_intervals(events), key=lambda item: item[1])
     for (_, _prev_in, prev_out), (_, next_in, _next_out) in zip(intervals, intervals[1:]):
         assert prev_out <= next_in, f"budget 1 let two sites overlap: {events}"
+
+
+def test_the_sweep_records_that_it_ran_even_when_it_found_nothing(conn):
+    """OP-19's fix, guarded at its root rather than through the chaos test.
+
+    The chaos test above cannot prove this: it is a race whose outcome depends
+    on machine load, and removing the wait passed three runs in three on the
+    afternoon it was written while failing three in four that morning. A test
+    that cannot be made to fail on demand proves nothing when it passes.
+
+    So the property is asserted where it IS deterministic: the marker exists
+    after a sweep, and it exists even when the sweep found no orphans.
+
+    THE SECOND HALF IS THE LOAD-BEARING ONE. A marker written only when
+    something was reclaimed would be absent on every healthy start — and a
+    caller waiting for it would wait for ever on exactly the machines where
+    nothing had gone wrong.
+    """
+    from scrapex.jobs import RECLAIM_KEY, reclaim_orphaned_jobs
+
+    before = conn.execute(
+        "SELECT value FROM scrapex_meta WHERE key = ?", (RECLAIM_KEY,)).fetchone()
+    assert before is None, "the marker exists before any sweep has run"
+
+    reclaimed = reclaim_orphaned_jobs(conn)
+
+    after = conn.execute(
+        "SELECT value FROM scrapex_meta WHERE key = ?", (RECLAIM_KEY,)).fetchone()
+    assert reclaimed == 0, "the fixture warehouse had orphans to reclaim"
+    assert after is not None, (
+        "the sweep found nothing and recorded nothing, so anyone waiting "
+        "for it to finish waits for ever on a healthy engine")
+    assert after[0].endswith("Z")
+
+
+def test_a_second_sweep_moves_the_marker_forward(conn):
+    """A caller distinguishes "this runtime has swept" from "some runtime once
+    swept" by the value CHANGING. A marker written once and never updated would
+    let a restart look like a completed sweep it never performed."""
+    import sqlite3
+    import time
+
+    from scrapex.jobs import RECLAIM_KEY, reclaim_orphaned_jobs
+
+    reclaim_orphaned_jobs(conn)
+    first = conn.execute(
+        "SELECT value FROM scrapex_meta WHERE key = ?", (RECLAIM_KEY,)).fetchone()[0]
+    # The stamp is whole seconds, so a same-second second sweep is a
+    # real possibility and must not be mistaken for a stalled one.
+    time.sleep(1.1)
+    reclaim_orphaned_jobs(conn)
+    second = conn.execute(
+        "SELECT value FROM scrapex_meta WHERE key = ?", (RECLAIM_KEY,)).fetchone()[0]
+
+    assert second > first, (
+        f"the marker did not move: {first!r} then {second!r}. A caller "
+        "waiting for THIS runtime's sweep would accept a previous one's.")

--- a/tests/test_the_engine_survives_being_killed.py
+++ b/tests/test_the_engine_survives_being_killed.py
@@ -160,17 +160,62 @@ class Engine:
             encoding="utf-8", errors="replace", timeout=300)
         assert made.returncode == 0, f"init-db failed:\n{made.stdout}\n{made.stderr}"
 
-    def start(self) -> None:
+    def start(self, *, swept: bool = False) -> None:
+        """Start the engine. `swept` also waits for the orphan sweep to finish.
+
+        OP-19, AND THE REASON THIS ARGUMENT EXISTS. Waiting for /api/health
+        proves the HTTP thread is up and nothing else. The sweep that settles
+        jobs left by a dead runtime happens on the WORKER thread, after it
+        connects — so a test that read crawl_job.status straight after health
+        was racing two threads and calling the result a verdict.
+
+        Measured before the fix: three failures in four runs on a loaded Windows
+        machine, and green every time on the Linux runner. That combination is
+        the worst one available, because it reads as "works in CI, broken
+        locally" and sends the reader looking at their own machine.
+
+        NOT A SLEEP. The engine records when the sweep completed
+        (jobs.RECLAIM_KEY); this waits for a marker written after the work,
+        which cannot pass early on a fast machine or fail late on a slow one.
+        """
+        started = _reclaim_marker(self._db)
         self.process = subprocess.Popen(
             self._args, cwd=str(ROOT), env=self._env,
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
         _wait_for(lambda: _get(f"{self.url}/api/health"), 90, "the engine to answer")
+        if swept:
+            _wait_for(lambda: _reclaim_marker(self._db) not in (None, started),
+                      60, "the orphan sweep to finish")
 
     def kill(self) -> None:
         """No handler, no finally, no flush — TerminateProcess / SIGKILL."""
         if self.process and self.process.poll() is None:
             self.process.kill()
             self.process.wait(timeout=30)
+
+
+def _reclaim_marker(db: Path) -> str | None:
+    """When this database last had its orphaned jobs swept, or None.
+
+    Read straight from the database rather than through a new route: the engine
+    already writes it, the test already opens the file read-only, and an HTTP
+    endpoint would be a second thing to keep true.
+    """
+    if not Path(db).exists():
+        return None
+    try:
+        conn = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+    except sqlite3.Error:
+        return None
+    try:
+        row = conn.execute(
+            "SELECT value FROM scrapex_meta WHERE key = 'orphans_reclaimed_at'"
+        ).fetchone()
+        return row[0] if row else None
+    except sqlite3.Error:
+        return None
+    finally:
+        conn.close()
 
 
 def _job_status(db: Path, job_ref: str) -> str:
@@ -213,7 +258,9 @@ def test_a_killed_engine_does_not_leave_a_job_claiming_to_run(tmp_path, manifest
 
     # And now the part that matters: start again over the same database.
     survivor = Engine(manifest, db, _free_port())
-    survivor.start()
+    # The sweep is the thing under test here, so wait for IT rather than for
+    # the port. See Engine.start's docstring (OP-19).
+    survivor.start(swept=True)
     try:
         status = _job_status(db, job_ref)
         assert status not in IN_FLIGHT, (


### PR DESCRIPTION
`test_a_killed_engine_does_not_leave_a_job_claiming_to_run` failed **three runs in four** on a loaded Windows machine and passed **every time** on the Linux runner.

That is the worst arrangement available: it reads as *"works in CI, broken locally"* and sends the reader to look at their own machine.

## Nothing was wrong with the engine

`Engine.start()` waited for `/api/health`, and the test then read `crawl_job.status` immediately. But:

| | thread |
|---|---|
| `/api/health` answers | the **HTTP** thread, the moment the port binds |
| the orphan sweep runs | the **worker** thread, after it connects |

Which of the two won was decided by load. **The engine already knew it had finished sweeping. Nobody could ask.**

## The fix is not a sleep

`reclaim_orphaned_jobs` now records when it completed, in `scrapex_meta` beside the heartbeat that was already there. `start(swept=True)` waits for that value to change — a marker written **after** the work, so it cannot pass early on a fast machine or fail late on a slow one.

**Written unconditionally, and that is the load-bearing half.** A marker that appeared only when orphans were *found* would be absent on every healthy start — and a caller waiting for it would wait for ever on exactly the machines where nothing had gone wrong.

Two deterministic tests in `test_jobs.py` hold both properties, including that a second sweep **moves** the value, so "this runtime has swept" cannot be satisfied by a previous runtime's stamp.

## An honest note on the mutation check

Removing the wait again passed **three runs in three** this afternoon, having failed **three in four** this morning.

A race that depends on machine load cannot be reproduced on demand, so that check **proved nothing** — which is exactly why *"it passes now"* was never evidence in the first place.

The proof is structural and readable in the code, and it is written into the docstring so the next reader does not have to rediscover which thread does what.

---

**Four runs in four, green.** Full engine suite green · `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)