### PR TITLE
A dropdown under a small trigger, and a 403 that blamed the wrong thing

### DIFF
--- a/design/components.css
+++ b/design/components.css
@@ -1411,12 +1411,30 @@ code {
 .split-button-options {
   position: absolute;
   z-index: 120;
-  inset-inline: 0;
+  /* SIZED TO ITS CONTENT, not to whatever happens to be above it.
+     
+     `width: 100%; min-width: 0` was here, and it is only ever correct when the
+     trigger is already wide. The Activity log's split button IS wide, so it
+     looked right for a year. Two screens built on 2026-08-12 — the dataset
+     card's actions menu and Manage account's danger menu — both put this menu
+     under a ~32px icon, and both collapsed to ONE CHARACTER PER LINE:
+     "Dis / co / nn / ect / an / d ...".
+     
+     When two independent consumers break the same way, the shared rule is the
+     defect rather than the consumers.
+     
+     `min-width: 100%` keeps the wide case pixel-identical — a menu is still at
+     least as wide as the control it hangs from — while `max-content` fixes the
+     narrow one. The ceiling is what stops a long label overflowing a 320px
+     panel, which is the failure the old `min-width: 0` was reaching for and
+     achieving by breaking every label instead. */
+  inset-inline: auto 0;
   top: calc(100% + var(--sp-1));
   display: grid;
   gap: 2px;
-  width: 100%;
-  min-width: 0;
+  width: max-content;
+  min-width: 100%;
+  max-width: min(20rem, 88vw);
   padding: var(--sp-1);
   background: var(--surface);
   border: 1px solid var(--line-strong);
@@ -1430,8 +1448,22 @@ code {
   to { opacity: 1; transform: translateY(0) scale(1); }
 }
 .split-button-option {
+  /* THE ICON COLUMN SIZES TO ITS ICON, and to nothing when there is none.
+     
+     It was a fixed `1.25rem`, which silently required every option to carry an
+     icon child. An option that is only text puts that text in grid child ONE —
+     the icon slot — and 20px of column is the "Up / da / te / no / w" the owner
+     photographed on 2026-08-12.
+     
+     Two consumers hit it independently: the dataset card's actions menu, and
+     Manage account's erase option, which the PR that added it worked around
+     locally with a note that no sprite symbol means "erase". A template that
+     needs a workaround from every consumer without an icon is the defect.
+     
+     `auto` is 1.25rem when there IS an svg — the icons are that size — so every
+     existing menu is pixel-identical. */
   display: grid;
-  grid-template-columns: 1.25rem minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
   gap: var(--sp-2);
   width: 100%;

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -653,7 +653,7 @@ for three different readers, and compression hides it. If space ever becomes a
 problem, the 90 MB of `.jsonl`/`.csv` is the part regenerable from the `.db`;
 the zip is not the thing to reconsider.
 
-### OP-19 · The chaos test races the startup sweep it is checking
+### OP-19 · The chaos test races the startup sweep it is checking — FIXED 2026-08-12
 
 Found 2026-08-11 while removing the engine's Google surface. The suite went red
 on `test_a_killed_engine_does_not_leave_a_job_claiming_to_run`, and the first
@@ -671,10 +671,21 @@ runner and reliably loses on a loaded Windows machine — the worst arrangement,
 because it makes the flake look like "works in CI, broken locally" and invites
 exactly the wrong diagnosis.
 
-**The fix is not to add a sleep.** `start()` should wait for a signal the sweep
-has run — the engine already knows when it has finished; the test does not ask.
-Not fixed here: it is a real defect in a test that guards a real property, and it
-deserves its own change rather than a line in a removal.
+**The fix was not a sleep.** `reclaim_orphaned_jobs` now records when it
+finished, in `scrapex_meta` beside the heartbeat that was already there, and
+`Engine.start(swept=True)` waits for that value to change. The marker is written
+UNCONDITIONALLY — a marker that appears only when there were orphans would be
+absent on every healthy start, and anyone waiting for it would wait for ever on
+exactly the machines where nothing had gone wrong.
+
+**Four runs in four, green.** And an honest note on the check: removing the wait
+again passed three runs in three that afternoon, having failed three in four
+that morning. A race that depends on machine load cannot be reproduced on
+demand, so the mutation check proved nothing — which is precisely why "it passes
+now" was never evidence in the first place. The proof is structural and readable
+in the code: health is answered by the HTTP thread the moment the port binds,
+and the sweep runs on the worker thread after it connects. Two tests in
+`test_jobs.py` hold the marker's two properties deterministically.
 
 ## 6c. The extension/engine separation, audited — 2026-08-11
 

--- a/extension/app.css
+++ b/extension/app.css
@@ -352,6 +352,41 @@
                        inset-inline-end: var(--sp-3); color: var(--muted); }
   .dataset-card:hover .dataset-card-open { color: var(--accent-ink); }
   .dataset-card-open svg { width: 1rem; height: 1rem; fill: currentColor; }
+
+  /* THE ACTIONS MENU ON A DATASET CARD, and the two things it inherited that
+     were wrong for this place. Both were mine, from the menu that replaced the
+     chevron, and both were visible in one screenshot.
+
+     ONE: the chevron was `position: absolute` in the corner. Its replacement is
+     a real element, so it took the FIRST CELL of the card and pushed the whole
+     content sideways — a menu button sitting above the site name instead of
+     beside it. It goes back in the corner the chevron held.
+
+     TWO: `.split-button-options` is `width: 100%` of its container, which is
+     correct for the wide split button in the Activity log and absurd here: the
+     container is a 32px icon, so every label wrapped to one character per line
+     — "Up / da / te / no / w". Sized to its CONTENT here, with a floor so short
+     labels still line up and a ceiling so it cannot overflow the panel at
+     320px.
+
+     Local to this card on purpose. Changing the shared rule would move the
+     Activity log's menu, which is not broken. */
+  .dataset-card > .split-button {
+    position: absolute;
+    inset-block-start: var(--sp-2);
+    inset-inline-end: var(--sp-2);
+    z-index: 1;
+  }
+  /* Only the FLOOR is local now: the trigger is a 32px icon, so `min-width:
+     100%` from the shared rule would let a one-word label make a menu narrower
+     than it reads well at. The sizing itself is fixed where it was broken. */
+  /* MEASURED at 320px: the card is 184px, the menu's longest label
+     ("Export to Google Sheets · not built yet") wants 206px, and anchored to
+     the card's end edge that put its left side at -3px — three pixels off the
+     screen. Capped so it fits: the label wraps to two lines instead, which is
+     what a menu does on a narrow panel.
+     The floor keeps a one-word option from making a menu too narrow to read. */
+  .dataset-card .split-button-options { min-width: 11rem; max-width: 12rem; }
   .source-manager-panel { padding-bottom: var(--sp-2); }
   .source-manager-section-head {
     align-items: center;

--- a/extension/components.css
+++ b/extension/components.css
@@ -1411,12 +1411,30 @@ code {
 .split-button-options {
   position: absolute;
   z-index: 120;
-  inset-inline: 0;
+  /* SIZED TO ITS CONTENT, not to whatever happens to be above it.
+     
+     `width: 100%; min-width: 0` was here, and it is only ever correct when the
+     trigger is already wide. The Activity log's split button IS wide, so it
+     looked right for a year. Two screens built on 2026-08-12 — the dataset
+     card's actions menu and Manage account's danger menu — both put this menu
+     under a ~32px icon, and both collapsed to ONE CHARACTER PER LINE:
+     "Dis / co / nn / ect / an / d ...".
+     
+     When two independent consumers break the same way, the shared rule is the
+     defect rather than the consumers.
+     
+     `min-width: 100%` keeps the wide case pixel-identical — a menu is still at
+     least as wide as the control it hangs from — while `max-content` fixes the
+     narrow one. The ceiling is what stops a long label overflowing a 320px
+     panel, which is the failure the old `min-width: 0` was reaching for and
+     achieving by breaking every label instead. */
+  inset-inline: auto 0;
   top: calc(100% + var(--sp-1));
   display: grid;
   gap: 2px;
-  width: 100%;
-  min-width: 0;
+  width: max-content;
+  min-width: 100%;
+  max-width: min(20rem, 88vw);
   padding: var(--sp-1);
   background: var(--surface);
   border: 1px solid var(--line-strong);
@@ -1430,8 +1448,22 @@ code {
   to { opacity: 1; transform: translateY(0) scale(1); }
 }
 .split-button-option {
+  /* THE ICON COLUMN SIZES TO ITS ICON, and to nothing when there is none.
+     
+     It was a fixed `1.25rem`, which silently required every option to carry an
+     icon child. An option that is only text puts that text in grid child ONE —
+     the icon slot — and 20px of column is the "Up / da / te / no / w" the owner
+     photographed on 2026-08-12.
+     
+     Two consumers hit it independently: the dataset card's actions menu, and
+     Manage account's erase option, which the PR that added it worked around
+     locally with a note that no sprite symbol means "erase". A template that
+     needs a workaround from every consumer without an icon is the defect.
+     
+     `auto` is 1.25rem when there IS an svg — the icons are that size — so every
+     existing menu is pixel-identical. */
   display: grid;
-  grid-template-columns: 1.25rem minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
   gap: var(--sp-2);
   width: 100%;

--- a/extension/drive.js
+++ b/extension/drive.js
@@ -113,6 +113,28 @@ async function refuse(response, doing) {
     try { detail = (await response.text()).slice(0, 200); } catch (_) { /* nothing */ }
   }
   const tail = detail ? ` — ${detail}` : "";
+
+  // A DISABLED API IS A 403, AND IT IS NOT A PERMISSION PROBLEM.
+  //
+  // Found by the owner on 2026-08-12, creating his first spreadsheet: Google
+  // answered 403 with "Google Drive API has not been used in project ... before
+  // or it is disabled", and this function told him ScrapeX could only open
+  // files it created — the drive.file explanation, which is true in general and
+  // had nothing to do with what had just happened. He was sent to think about
+  // permissions while the fix was one click in a console.
+  //
+  // Blaming a component that is working sends the owner to fix the wrong thing;
+  // transport.js learned that and wrote it down, and this is the same lesson
+  // arriving through a different door. The console URL is Google's own and
+  // carries the project number, so it is repeated rather than summarised.
+  if (/has not been used in project|SERVICE_DISABLED|accessNotConfigured/i.test(detail)) {
+    return new DriveError(
+      "This Google project has not switched on the API ScrapeX needs. Open the " +
+      "link Google gives below, press Enable, wait a minute, and try again — " +
+      "nothing is wrong with your account or your files." + tail,
+      403, "api-disabled");
+  }
+
   if (response.status === 401) {
     return new DriveError(
       `Google refused the token while ${doing}. Sign in again from the panel.${tail}`,

--- a/extension/sheets.js
+++ b/extension/sheets.js
@@ -74,6 +74,28 @@ async function refuse(response, doing) {
     try { detail = (await response.text()).slice(0, 200); } catch (_) { /* nothing */ }
   }
   const tail = detail ? ` — ${detail}` : "";
+
+  // A DISABLED API IS A 403, AND IT IS NOT A PERMISSION PROBLEM.
+  //
+  // Found by the owner on 2026-08-12, creating his first spreadsheet: Google
+  // answered 403 with "Google Drive API has not been used in project ... before
+  // or it is disabled", and this function told him ScrapeX could only open
+  // files it created — the drive.file explanation, which is true in general and
+  // had nothing to do with what had just happened. He was sent to think about
+  // permissions while the fix was one click in a console.
+  //
+  // Blaming a component that is working sends the owner to fix the wrong thing;
+  // transport.js learned that and wrote it down, and this is the same lesson
+  // arriving through a different door. The console URL is Google's own and
+  // carries the project number, so it is repeated rather than summarised.
+  if (/has not been used in project|SERVICE_DISABLED|accessNotConfigured/i.test(detail)) {
+    return new SheetsError(
+      "This Google project has not switched on the API ScrapeX needs. Open the " +
+      "link Google gives below, press Enable, wait a minute, and try again — " +
+      "nothing is wrong with your account or your files." + tail,
+      403, "api-disabled");
+  }
+
   if (response.status === 401) {
     return new SheetsError(
       `Google refused the token while ${doing}. Sign in again from the panel.${tail}`,

--- a/extension/tests/sheets.test.mjs
+++ b/extension/tests/sheets.test.mjs
@@ -314,3 +314,43 @@ test("a tab is named for its source, not shared with every other one", async () 
   assert.ok(named.some((entry) => entry.includes("'MADAR'")), named.join("\n"));
   assert.ok(named.some((entry) => entry.includes("'ELSEWEDY'")), named.join("\n"));
 });
+
+
+test("a disabled API is named as that, not as a permission refusal", async () => {
+  // REPORTED BY THE OWNER, 2026-08-12, on his first spreadsheet. Google answers
+  // 403 for a project whose Drive API was never switched on, and this module
+  // told him ScrapeX could only open files it created — true in general, and
+  // nothing to do with what had just happened. He was sent to think about
+  // permissions while the fix was one click in a console.
+  //
+  // The truth reached him from Google's own detail after the em-dash, not from
+  // us. Blaming a component that is working sends the owner to fix the wrong
+  // thing; this is the same lesson transport.js wrote down, arriving through a
+  // different door.
+  const fetchImpl = scripted([[() => true, () => reply(403, {body: {error: {message:
+    "Google Drive API has not been used in project 668111083414 before or it is "
+    + "disabled. Enable it by visiting https://console.developers.google.com/apis/"
+    + "api/drive.googleapis.com/overview?project=668111083414 then retry."}}})]]);
+
+  await assert.rejects(() => ensureFolder("tok", "ScrapeX", {fetchImpl}), (error) => {
+    assert.equal(error.kind, "api-disabled",
+      "a disabled API was reported as a permission problem");
+    assert.match(error.message, /nothing is wrong with your account/);
+    assert.match(error.message, /console\.developers\.google\.com/,
+      "the link Google gave is not passed through, so the fix is unreachable");
+    return true;
+  });
+});
+
+
+test("a real permission refusal still says what it is", async () => {
+  // The branch above must not swallow the case it was carved out of.
+  const fetchImpl = scripted([[() => true,
+    () => reply(403, {body: {error: {message: "Insufficient permission"}}})]]);
+
+  await assert.rejects(() => openChosen("tok", "not-ours", {fetchImpl}), (error) => {
+    assert.equal(error.kind, "not-ours");
+    assert.match(error.message, /only open spreadsheets it created/);
+    return true;
+  });
+});

--- a/scrapex/jobs.py
+++ b/scrapex/jobs.py
@@ -887,6 +887,10 @@ def run_job_once(conn: sqlite3.Connection, job_ref: str, manifest,
 
 
 HEARTBEAT_KEY = "runtime_heartbeat"
+#: When this runtime last finished sweeping jobs left behind by a dead one. It
+#: is the answer to "has the engine tidied up yet?", which /api/health cannot
+#: give: health is the HTTP thread's answer and the sweep is the worker's.
+RECLAIM_KEY = "orphans_reclaimed_at"
 HEARTBEAT_MAX_AGE_S = 30.0
 
 # A JOB may go quiet for far longer than a loop pass and still be healthy:
@@ -1076,8 +1080,27 @@ def reclaim_orphaned_jobs(conn: sqlite3.Connection) -> int:
             "WHERE status = ?",
             (target.value, JobControl.NONE.value, target.value, utc_now_iso(), stuck.value))
         reclaimed += cur.rowcount
-    if reclaimed:
-        conn.commit()
+    # THE SWEEP SAYS WHEN IT RAN, and it says so even when it reclaimed nothing.
+    #
+    # OP-19. `Engine.start()` in the chaos test waited for /api/health and then
+    # read crawl_job.status immediately — but health is answered by the HTTP
+    # thread the moment the server binds, while this sweep runs on the WORKER
+    # thread after it connects. Which of the two won was a coin toss: the test
+    # failed three runs in four on a loaded Windows machine and passed reliably
+    # on the Linux runner, so it read as "works in CI, broken locally" and
+    # invited exactly the wrong diagnosis.
+    #
+    # Nothing here needed fixing — the reclaim was always correct. What was
+    # missing is that the engine knew it had finished and nobody could ask.
+    #
+    # Written UNCONDITIONALLY, before the `if reclaimed` above would have
+    # returned early: "no orphans found" is a completed sweep, and a marker that
+    # only appears when there was damage cannot be waited on by anyone.
+    conn.execute(
+        "INSERT INTO scrapex_meta (key, value) VALUES (?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (RECLAIM_KEY, utc_now_iso()))
+    conn.commit()
     return reclaimed
 
 

--- a/scrapex/webui/static/components.css
+++ b/scrapex/webui/static/components.css
@@ -1411,12 +1411,30 @@ code {
 .split-button-options {
   position: absolute;
   z-index: 120;
-  inset-inline: 0;
+  /* SIZED TO ITS CONTENT, not to whatever happens to be above it.
+     
+     `width: 100%; min-width: 0` was here, and it is only ever correct when the
+     trigger is already wide. The Activity log's split button IS wide, so it
+     looked right for a year. Two screens built on 2026-08-12 — the dataset
+     card's actions menu and Manage account's danger menu — both put this menu
+     under a ~32px icon, and both collapsed to ONE CHARACTER PER LINE:
+     "Dis / co / nn / ect / an / d ...".
+     
+     When two independent consumers break the same way, the shared rule is the
+     defect rather than the consumers.
+     
+     `min-width: 100%` keeps the wide case pixel-identical — a menu is still at
+     least as wide as the control it hangs from — while `max-content` fixes the
+     narrow one. The ceiling is what stops a long label overflowing a 320px
+     panel, which is the failure the old `min-width: 0` was reaching for and
+     achieving by breaking every label instead. */
+  inset-inline: auto 0;
   top: calc(100% + var(--sp-1));
   display: grid;
   gap: 2px;
-  width: 100%;
-  min-width: 0;
+  width: max-content;
+  min-width: 100%;
+  max-width: min(20rem, 88vw);
   padding: var(--sp-1);
   background: var(--surface);
   border: 1px solid var(--line-strong);
@@ -1430,8 +1448,22 @@ code {
   to { opacity: 1; transform: translateY(0) scale(1); }
 }
 .split-button-option {
+  /* THE ICON COLUMN SIZES TO ITS ICON, and to nothing when there is none.
+     
+     It was a fixed `1.25rem`, which silently required every option to carry an
+     icon child. An option that is only text puts that text in grid child ONE —
+     the icon slot — and 20px of column is the "Up / da / te / no / w" the owner
+     photographed on 2026-08-12.
+     
+     Two consumers hit it independently: the dataset card's actions menu, and
+     Manage account's erase option, which the PR that added it worked around
+     locally with a note that no sprite symbol means "erase". A template that
+     needs a workaround from every consumer without an icon is the defect.
+     
+     `auto` is 1.25rem when there IS an svg — the icons are that size — so every
+     existing menu is pixel-identical. */
   display: grid;
-  grid-template-columns: 1.25rem minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
   gap: var(--sp-2);
   width: 100%;

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1233,3 +1233,60 @@ def test_the_budget_bounds_how_many_sites_crawl_at_once(tmp_path):
     intervals = sorted(_intervals(events), key=lambda item: item[1])
     for (_, _prev_in, prev_out), (_, next_in, _next_out) in zip(intervals, intervals[1:]):
         assert prev_out <= next_in, f"budget 1 let two sites overlap: {events}"
+
+
+def test_the_sweep_records_that_it_ran_even_when_it_found_nothing(conn):
+    """OP-19's fix, guarded at its root rather than through the chaos test.
+
+    The chaos test above cannot prove this: it is a race whose outcome depends
+    on machine load, and removing the wait passed three runs in three on the
+    afternoon it was written while failing three in four that morning. A test
+    that cannot be made to fail on demand proves nothing when it passes.
+
+    So the property is asserted where it IS deterministic: the marker exists
+    after a sweep, and it exists even when the sweep found no orphans.
+
+    THE SECOND HALF IS THE LOAD-BEARING ONE. A marker written only when
+    something was reclaimed would be absent on every healthy start — and a
+    caller waiting for it would wait for ever on exactly the machines where
+    nothing had gone wrong.
+    """
+    from scrapex.jobs import RECLAIM_KEY, reclaim_orphaned_jobs
+
+    before = conn.execute(
+        "SELECT value FROM scrapex_meta WHERE key = ?", (RECLAIM_KEY,)).fetchone()
+    assert before is None, "the marker exists before any sweep has run"
+
+    reclaimed = reclaim_orphaned_jobs(conn)
+
+    after = conn.execute(
+        "SELECT value FROM scrapex_meta WHERE key = ?", (RECLAIM_KEY,)).fetchone()
+    assert reclaimed == 0, "the fixture warehouse had orphans to reclaim"
+    assert after is not None, (
+        "the sweep found nothing and recorded nothing, so anyone waiting "
+        "for it to finish waits for ever on a healthy engine")
+    assert after[0].endswith("Z")
+
+
+def test_a_second_sweep_moves_the_marker_forward(conn):
+    """A caller distinguishes "this runtime has swept" from "some runtime once
+    swept" by the value CHANGING. A marker written once and never updated would
+    let a restart look like a completed sweep it never performed."""
+    import sqlite3
+    import time
+
+    from scrapex.jobs import RECLAIM_KEY, reclaim_orphaned_jobs
+
+    reclaim_orphaned_jobs(conn)
+    first = conn.execute(
+        "SELECT value FROM scrapex_meta WHERE key = ?", (RECLAIM_KEY,)).fetchone()[0]
+    # The stamp is whole seconds, so a same-second second sweep is a
+    # real possibility and must not be mistaken for a stalled one.
+    time.sleep(1.1)
+    reclaim_orphaned_jobs(conn)
+    second = conn.execute(
+        "SELECT value FROM scrapex_meta WHERE key = ?", (RECLAIM_KEY,)).fetchone()[0]
+
+    assert second > first, (
+        f"the marker did not move: {first!r} then {second!r}. A caller "
+        "waiting for THIS runtime's sweep would accept a previous one's.")

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -4683,3 +4683,71 @@ def test_a_reopened_panel_with_nothing_running_says_nothing(open_panel):
 
     assert "hidden" in (page.get_attribute("#miniplayer", "class") or ""), (
         "the miniplayer is showing with no job to show")
+
+
+# ---- the dropdown that collapsed to one character per line -----------------
+
+@pytest.mark.parametrize("width", [320, 400])
+def test_a_menu_under_a_small_trigger_is_wide_enough_to_read(open_panel, width):
+    """FOUND IN A SCREENSHOT BY THE OWNER, 2026-08-12, on two screens at once.
+
+    `.split-button-options` was `width: 100%` of its container. That is only
+    ever right when the trigger is already wide — the Activity log's split
+    button is, so it looked correct for a year. The dataset card's actions menu
+    and Manage account's danger menu both hang from a ~32px icon, and both
+    rendered every label one character per line: "Up / da / te / no / w".
+
+    Measured rather than eyeballed, because "looks fine" is what it looked like
+    to whoever wrote the rule. A menu item narrower than about six characters
+    is not a label, it is a column of letters.
+    """
+    page = open_panel()
+    page.set_viewport_size({"width": width, "height": 800})
+    page.click(DATA_TAB)
+    page.wait_for_timeout(400)
+
+    trigger = page.locator(".dataset-card .split-button-trigger").first
+    trigger.click()
+    page.wait_for_timeout(250)
+
+    box = page.locator(".dataset-card .split-button-options").first.bounding_box()
+    assert box is not None, "the menu did not open"
+    assert box["width"] >= 140, (
+        f"the actions menu is {box['width']:.0f}px wide at {width}px — under a "
+        "32px trigger it inherits the trigger's width unless the shared rule "
+        "sizes it to its content")
+
+    # And it must stay inside the panel: a menu anchored to the card's right
+    # edge that is sized to content can run off a 320px screen if nothing caps
+    # it. That cap is the other half of the shared fix.
+    assert box["x"] >= -1, f"the menu starts off the left edge at {box['x']:.0f}px"
+    assert box["x"] + box["width"] <= width + 1, (
+        f"the menu ends at {box['x'] + box['width']:.0f}px on a {width}px panel")
+
+
+def test_no_menu_label_is_broken_into_a_column_of_letters(open_panel):
+    """The symptom itself, guarded where a width alone would not catch it: a
+    label can also be shredded by `white-space` or an inline-grid the box model
+    reports as wide. This measures the rendered LINE COUNT of a known label."""
+    page = open_panel()
+    page.set_viewport_size({"width": 320, "height": 800})
+    page.click(DATA_TAB)
+    page.wait_for_timeout(400)
+    page.locator(".dataset-card .split-button-trigger").first.click()
+    page.wait_for_timeout(250)
+
+    option = page.locator('.dataset-card [data-split-action="update"]').first
+
+    # THE TEXT'S OWN LINE BOXES, via a Range. The first version of this divided
+    # the BUTTON's height by its line-height and called the answer lines — which
+    # reported three for a label on one line, because `min-height` pins every
+    # option to the 48px touch target. It was measuring the touch target and
+    # blaming the typography.
+    lines = option.evaluate(
+        "el => { const r = document.createRange(); r.selectNodeContents(el);"
+        "  return r.getClientRects().length; }")
+
+    assert lines <= 2, (
+        f"'Update now' renders over {lines} line boxes — that is the "
+        "one-character-per-line collapse the owner photographed, not a wrapped "
+        "label")

--- a/tests/test_the_engine_survives_being_killed.py
+++ b/tests/test_the_engine_survives_being_killed.py
@@ -160,17 +160,62 @@ class Engine:
             encoding="utf-8", errors="replace", timeout=300)
         assert made.returncode == 0, f"init-db failed:\n{made.stdout}\n{made.stderr}"
 
-    def start(self) -> None:
+    def start(self, *, swept: bool = False) -> None:
+        """Start the engine. `swept` also waits for the orphan sweep to finish.
+
+        OP-19, AND THE REASON THIS ARGUMENT EXISTS. Waiting for /api/health
+        proves the HTTP thread is up and nothing else. The sweep that settles
+        jobs left by a dead runtime happens on the WORKER thread, after it
+        connects — so a test that read crawl_job.status straight after health
+        was racing two threads and calling the result a verdict.
+
+        Measured before the fix: three failures in four runs on a loaded Windows
+        machine, and green every time on the Linux runner. That combination is
+        the worst one available, because it reads as "works in CI, broken
+        locally" and sends the reader looking at their own machine.
+
+        NOT A SLEEP. The engine records when the sweep completed
+        (jobs.RECLAIM_KEY); this waits for a marker written after the work,
+        which cannot pass early on a fast machine or fail late on a slow one.
+        """
+        started = _reclaim_marker(self._db)
         self.process = subprocess.Popen(
             self._args, cwd=str(ROOT), env=self._env,
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
         _wait_for(lambda: _get(f"{self.url}/api/health"), 90, "the engine to answer")
+        if swept:
+            _wait_for(lambda: _reclaim_marker(self._db) not in (None, started),
+                      60, "the orphan sweep to finish")
 
     def kill(self) -> None:
         """No handler, no finally, no flush — TerminateProcess / SIGKILL."""
         if self.process and self.process.poll() is None:
             self.process.kill()
             self.process.wait(timeout=30)
+
+
+def _reclaim_marker(db: Path) -> str | None:
+    """When this database last had its orphaned jobs swept, or None.
+
+    Read straight from the database rather than through a new route: the engine
+    already writes it, the test already opens the file read-only, and an HTTP
+    endpoint would be a second thing to keep true.
+    """
+    if not Path(db).exists():
+        return None
+    try:
+        conn = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+    except sqlite3.Error:
+        return None
+    try:
+        row = conn.execute(
+            "SELECT value FROM scrapex_meta WHERE key = 'orphans_reclaimed_at'"
+        ).fetchone()
+        return row[0] if row else None
+    except sqlite3.Error:
+        return None
+    finally:
+        conn.close()
 
 
 def _job_status(db: Path, job_ref: str) -> str:
@@ -213,7 +258,9 @@ def test_a_killed_engine_does_not_leave_a_job_claiming_to_run(tmp_path, manifest
 
     # And now the part that matters: start again over the same database.
     survivor = Engine(manifest, db, _free_port())
-    survivor.start()
+    # The sweep is the thing under test here, so wait for IT rather than for
+    # the port. See Engine.start's docstring (OP-19).
+    survivor.start(swept=True)
     try:
         status = _job_status(db, job_ref)
         assert status not in IN_FLIGHT, (

--- a/tests/test_vendor.py
+++ b/tests/test_vendor.py
@@ -415,9 +415,22 @@ def test_export_actions_follow_the_grid_instead_of_sitting_above_it():
     assert ".split-button-primary:active:not(:disabled)" in shared_css
     assert ".split-button-options" in shared_css
     options_rule = shared_css.split(".split-button-options {", 1)[1].split("}", 1)[0]
-    assert "inset-inline: 0" in options_rule
+    # THE MENU HANGS FROM ITS CONTROL AND IS AT LEAST AS WIDE AS IT.
+    #
+    # These read `inset-inline: 0` and `width: 100%` until 2026-08-12 — the
+    # exact declarations rather than what they were for. `width: 100%` is only
+    # correct when the trigger is already wide, and the grid's export button is,
+    # so it looked right here while collapsing every label to one character per
+    # line under the 32px triggers on two other screens.
+    #
+    # What this test was guarding is unchanged and still asserted: anchored to
+    # the control, hung below it, never narrower than it. The sizing that was
+    # wrong is now `max-content` with `min-width: 100%` as the floor, so this
+    # grid's menu is pixel-identical.
+    assert "inset-inline: auto 0" in options_rule
     assert "top: calc(100% + var(--sp-1))" in options_rule
-    assert "width: 100%" in options_rule
+    assert "min-width: 100%" in options_rule
+    assert "width: max-content" in options_rule
     assert "bottom:" not in options_rule
     assert ".split-button-trigger:focus-visible" in shared_css
     focus_rule = shared_css.split(".split-button-trigger:focus-visible {", 1)[1].split("}", 1)[0]


### PR DESCRIPTION
Both found by the owner **using the panel**, in screenshots, within an hour.

## The menu collapsed to one character per line

`.split-button-options` was `width: 100%` of its container, and `.split-button-option` was a grid whose **first column was a fixed 1.25rem icon slot**. Both are only correct when the trigger is wide and every option carries an icon — true of the Activity log's split button, and of nothing built since.

**Two consumers hit it independently on the same day**: the dataset card's actions menu, and Manage account's erase option — whose own PR worked around the grid *locally*, with a note that no sprite symbol means "erase".

> When two independent consumers break the same way, the shared rule is the defect rather than the consumers.

So both are fixed there: `max-content` with `min-width: 100%` as the floor, and `auto` for the icon column. **Every existing menu is pixel-identical** — `auto` is 1.25rem when there *is* an svg.

The button also sat in the card's first grid cell, pushing the site name sideways, because the chevron it replaced was `position: absolute` and its replacement was not.

### The measuring corrected me twice

| | |
|---|---|
| At 320px | the card is 184px, the longest label wants 206px → the menu started at **-3px**, off the screen. Capped, it starts at 11px. |
| My first test | divided the option's **height** by its line-height and called the answer lines — reporting three for a label on one line. It was measuring the **48px touch target** and blaming the typography. |

It reads the text's own line boxes now.

## A 403 that was not a permission problem

Creating his first spreadsheet, the owner got *"ScrapeX can only open spreadsheets it created itself"* — while **Google's own detail**, appended after the em-dash, said the Drive API had never been switched on in the project.

A true sentence in the wrong situation. He was sent to think about permissions when the fix was one click in a console. **Blaming a component that is working sends the owner to fix the wrong thing** — which `transport.js` learned and wrote down; this is the same lesson through a different door.

A disabled API is now named as itself in both `drive.js` and `sheets.js`, with Google's own link passed through. A test holds the branch it was carved out of, so a real permission refusal still says what it is.

## One guard updated rather than weakened

`test_export_actions_follow_the_grid` asserted `inset-inline: 0` and `width: 100%` — **the declarations, not the property**. It now asserts what it was reaching for: anchored to the control, hung below it, never narrower than it.

---

**Green locally:** full extension suite · node tests · `eslint` · design sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)