### PR TITLE
N7: the warehouse follows the manifest from every path, not one button

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -653,7 +653,7 @@ for three different readers, and compression hides it. If space ever becomes a
 problem, the 90 MB of `.jsonl`/`.csv` is the part regenerable from the `.db`;
 the zip is not the thing to reconsider.
 
-### OP-19 · The chaos test races the startup sweep it is checking — FIXED 2026-08-12
+### OP-19 · The chaos test races the startup sweep it is checking — MOSTLY fixed 2026-08-12
 
 Found 2026-08-11 while removing the engine's Google surface. The suite went red
 on `test_a_killed_engine_does_not_leave_a_job_claiming_to_run`, and the first
@@ -686,6 +686,17 @@ now" was never evidence in the first place. The proof is structural and readable
 in the code: health is answered by the HTTP thread the moment the port binds,
 and the sweep runs on the worker thread after it connects. Two tests in
 `test_jobs.py` hold the marker's two properties deterministically.
+
+**NOT FULLY CLOSED, and saying so is the point.** Later the same day it failed
+once more inside a FULL `-m "not extension"` run, then passed the next full run
+and every targeted one. So the sweep wait removed the race it was aimed at and
+something else in that test is still load-sensitive — the kill/restart cycle
+runs real subprocesses and a 90-second health wait, and the whole suite is a
+heavier neighbour than any subset.
+
+Recorded rather than declared fixed, because "it passed this time" is exactly
+the evidence this entry exists to reject. The next step is to find what ELSE in
+the cycle depends on timing, not to run it again until it is green.
 
 ## 6c. The extension/engine separation, audited — 2026-08-11
 

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -444,6 +444,41 @@ def create_app(
     # here, also means every later reload reads the same file this one did.
     app.state.manifest_path = str(resolve_manifest_path(manifest_path))
     app.state.manifest = load_manifest(app.state.manifest_path)
+
+    def _follow_the_manifest() -> list[str]:
+        """Write the manifest's `active` into the warehouse. Returns what moved.
+
+        THE MANIFEST IS THE DEFINITION; THE WAREHOUSE IS THE CONSEQUENCE. An
+        inactive source is never crawled, so its stored flag is never touched by
+        a crawl either — which is exactly how the database came to claim all
+        twelve sources were live while sources.yaml had five switched off.
+
+        CALLED FROM EVERY PATH THAT RELOADS THE MANIFEST, and that is the fix
+        rather than the reconciliation itself, which already existed. It had one
+        caller: the panel's active toggle. So the warehouse followed the manifest
+        only when the owner used that one control, and drifted silently whenever
+        sources.yaml changed any other way — an edit by hand, an add, a rename, a
+        remove, or a `git checkout`.
+
+        That last one is not hypothetical. BACKLOG OP-2 records a manifest edit
+        that existed on one machine, was reverted by a checkout, and went
+        unnoticed for eleven days.
+
+        Nothing reads the stored flag to decide a crawl — the scheduler reads the
+        manifest — so this repairs no behaviour. It repairs what the owner's own
+        database SAYS, which is what he queries, exports, and will read from the
+        Console.
+        """
+        conn = read_conn()
+        try:
+            return sorted(reconcile_active(conn))
+        except Exception:
+            # A warehouse that cannot be reconciled is a warehouse health
+            # already reports on. Refusing to start over it would be worse.
+            return []
+        finally:
+            conn.close()
+
     # The job worker owns ALL long-running crawls (spec 4). Tests drive the
     # synchronous seam instead, so the thread is opt-in.
     # The worker follows the warehouse: a move or a compaction changes
@@ -511,6 +546,16 @@ def create_app(
         if app.state.databases is not None:
             return app.state.databases.engine.connect()
         return dbmod.connect(app.state.db_path)
+
+    # AT STARTUP, and here rather than beside the manifest load thirty lines
+    # above: `_follow_the_manifest` closes over `read_conn`, which is defined on
+    # the line above this one. Calling it earlier raised
+    # "cannot access free variable 'read_conn'" — a closure reads its enclosing
+    # scope when it RUNS, and at that point the name was still unbound.
+    #
+    # This is the only path that notices a manifest changed outside the panel:
+    # an edit by hand, a restore, or a `git checkout` that reverts one.
+    _follow_the_manifest()
 
     def ensure_schema(conn) -> None:
         """Migrate ONLY a legacy single-file warehouse.
@@ -1458,17 +1503,7 @@ def create_app(
         except Exception as exc:  # pydantic refusals (e.g. a TBD-probe placeholder)
             raise HTTPException(status_code=400, detail=str(exc))
         app.state.manifest = load_manifest(app.state.manifest_path)
-        # THE WAREHOUSE FOLLOWS THE MANIFEST, here and not on the next crawl,
-        # because an inactive source is never crawled -- which is precisely why
-        # its stored flag stayed at 1 and the database claimed all twelve
-        # sources were live while five were switched off. Nothing reads the
-        # stored flag to decide a crawl (the scheduler reads the manifest), but
-        # the owner reads his own database, and so will the Console.
-        conn = read_conn()
-        try:
-            reconciled = reconcile_active(conn)
-        finally:
-            conn.close()
+        reconciled = _follow_the_manifest()
         return {"source_key": source_key, "active": wanted,
                 "warehouse_updated": sorted(reconciled)}
 
@@ -1483,6 +1518,7 @@ def create_app(
         except DuplicateSourceError as exc:
             raise HTTPException(status_code=409, detail=str(exc))
         app.state.manifest = load_manifest(app.state.manifest_path)  # reflect the new source
+        _follow_the_manifest()
         return {"ok": True, "source_key": entry.source_key,
                 "implemented": entry.family in _BUILDERS}
 
@@ -1637,6 +1673,7 @@ def create_app(
         except Exception as exc:  # pydantic refusals reach the panel as a message
             raise HTTPException(status_code=400, detail=str(exc))
         app.state.manifest = load_manifest(app.state.manifest_path)
+        _follow_the_manifest()
         return {"ok": True, "source_key": source_key}
 
     @app.post("/api/sources/{source_key}/rename")
@@ -1684,6 +1721,7 @@ def create_app(
                 detail=f"the rows moved to {new_key!r} but the manifest did not: "
                        f"{exc}. The warehouse is consistent; fix the manifest.")
         app.state.manifest = load_manifest(app.state.manifest_path)
+        _follow_the_manifest()
         return {"ok": True, "source_key": new_key, "moved": moved}
 
     @app.delete("/api/sources/{source_key}")
@@ -1699,6 +1737,7 @@ def create_app(
         if not remove_source(source_key, app.state.manifest_path):
             raise HTTPException(status_code=404, detail=f"unknown source {source_key!r}")
         app.state.manifest = load_manifest(app.state.manifest_path)
+        _follow_the_manifest()
         return {"ok": True, "source_key": source_key, "data_kept": True}
 
     @app.post("/api/sources/{source_key}/wipe")

--- a/tests/test_the_warehouse_follows_the_manifest.py
+++ b/tests/test_the_warehouse_follows_the_manifest.py
@@ -21,6 +21,8 @@ is undeclared whatever flag its rows carry.
 """
 from __future__ import annotations
 
+import pathlib
+
 import os
 import sqlite3
 import subprocess
@@ -29,6 +31,8 @@ import sys
 import pytest
 
 from scrapex.storage import reconcile_active, undeclared_sources
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
 
 TWO_SOURCES = """
 sources:
@@ -165,3 +169,67 @@ def test_reconciling_against_no_manifest_changes_nothing(tmp_path, monkeypatch):
         assert _stored(conn)["ANY"] == 1
     finally:
         conn.close()
+
+
+# ---- the warehouse follows the manifest, from every path -------------------
+
+def test_every_manifest_reload_reconciles_the_warehouse():
+    """N7 / OP-2, and the fix is the CALLERS rather than the reconciliation.
+
+    `reconcile_active` already existed and was already correct. It had exactly
+    one caller — the panel's active toggle — so the warehouse followed the
+    manifest only when the owner used that one control. Every other way the
+    manifest changes left the database claiming something else: an edit by hand,
+    an add, a rename, a remove, or a `git checkout`.
+
+    That last one is recorded rather than imagined. BACKLOG OP-2 measured a
+    manifest edit that lived on one machine, was reverted by a checkout, and
+    went unnoticed for eleven days.
+
+    Asserted over the SOURCE because the property is "no reload is missed", and
+    the way it gets broken is someone adding a sixth route that reloads the
+    manifest and forgets the line. A test that exercised the five known routes
+    would pass on the day the sixth arrives.
+    """
+    import re
+
+    source = (ROOT / "scrapex" / "webui" / "app.py").read_text(encoding="utf-8")
+    lines = source.splitlines()
+
+    reloads = [n for n, line in enumerate(lines)
+               if "app.state.manifest = load_manifest(" in line]
+    assert len(reloads) >= 5, (
+        f"only {len(reloads)} manifest reloads found; this test has lost track "
+        "of the thing it guards")
+
+    missing = []
+    for n in reloads:
+        # The definition line itself is the one inside create_app's body that
+        # precedes the helper; it is followed by the startup call a few lines
+        # down rather than immediately.
+        window = "\n".join(lines[n:n + 6])
+        if "_follow_the_manifest()" not in window:
+            missing.append(n + 1)
+
+    assert not missing, (
+        f"app.py reloads the manifest at line(s) {missing} without reconciling "
+        "the warehouse afterwards. The manifest is the definition and the "
+        "warehouse is the consequence — a reload that skips this leaves the "
+        "owner's own database saying something the manifest does not.")
+
+
+def test_the_reconciliation_is_not_reachable_only_through_one_button():
+    """The shape of the old defect, named so it cannot return quietly.
+
+    One caller is not a bug in itself; one caller for a rule that describes the
+    whole warehouse is. If this ever drops back to a single site, the rule has
+    silently become a feature of that one control again.
+    """
+    source = (ROOT / "scrapex" / "webui" / "app.py").read_text(encoding="utf-8")
+    calls = source.count("_follow_the_manifest()")
+
+    # One definition, one startup call, and one per reload path.
+    assert calls >= 6, (
+        f"the warehouse is reconciled from {calls} place(s). It needs to happen "
+        "wherever the manifest is reloaded, including at startup — that is the "
+        "only path that notices a manifest changed outside the panel.")


### PR DESCRIPTION
## Measured on the owner's own database, today

**Five of twelve rows disagree with `sources.yaml`:**

| source | manifest | warehouse |
|---|---|---|
| ELBUROJ | `False` | **True** |
| HEIDELBERG_EG | `False` | **True** |
| MADAR | `False` | **True** |
| SIKAEGSHOP | `False` | **True** |
| SPARK_ESHOP | `False` | **True** |

Exactly the five OP-2 recorded on 2026-08-10 — **still wrong two days later.**

## The reconciliation already existed and was already correct

`reconcile_active` was written for this and does the right thing. **It had one caller: the panel's active toggle.**

So the warehouse followed the manifest only when the owner used that one control, and drifted silently every other way the manifest changes — an edit by hand, an add, a rename, a remove, or a `git checkout`.

That last one is not hypothetical: OP-2 records a manifest edit that lived on one machine, was reverted by a checkout, and **went unnoticed for eleven days**.

## So the fix is the callers

One helper, called from **every** path that reloads the manifest and from **startup** — which is the only path that can notice a manifest changed outside the panel at all.

The owner's five stale rows correct themselves the next time the engine starts, with nothing for him to press.

Nothing reads the stored flag to decide a crawl; the scheduler reads the manifest. **This repairs no behaviour.** It repairs what the owner's own database *says* — what he queries, exports, and will read from the Console. A column called `active` that is always 1 is worse than no column, because it answers a question it does not know.

## Guarded over the source

Because the way this breaks is someone adding a **sixth** route that reloads the manifest and forgetting the line — and a test exercising the five known routes would pass on the day the sixth arrives. **Mutation-tested**: stripping one call fails it with the line number.

## One defect of my own on the way

The helper closes over `read_conn`, and calling it beside the manifest load raised `cannot access free variable` — a closure reads its enclosing scope when it **runs**, and the name was still unbound. Moved below the definition, with the reason written down.

## And OP-19 is downgraded, honestly

From **fixed** to **mostly fixed**. The chaos test failed once more inside a full engine run, then passed the next full run and every targeted one. The sweep wait removed the race it was aimed at; something else in that kill/restart cycle is still load-sensitive.

*"It passed this time"* is precisely the evidence that entry exists to reject — so it is recorded rather than re-declared green.

---

**Green:** full engine suite · `ruff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)