### PR TITLE
Pick a spreadsheet you already had, and a policy that cannot go stale

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -110,13 +110,22 @@ jobs:
 
   publish:
     needs: drift
-    # The tests still run on every path; only the WRITE is skipped when there is
-    # nothing to write. A scheduled run that finds no drift ends green having
-    # proved the published policy is the one this repository checks.
-    if: needs.drift.outputs.drifted == 'yes'
+    # NO `if:` HERE, ON PURPOSE. It was on the job, and the comment beside it
+    # claimed the tests still ran on every path -- which the `if:` itself made
+    # false: skipping the job skipped the guards too. A daily run that found no
+    # drift then proved nothing at all, while reporting green.
+    #
+    # The condition now sits on the two steps that WRITE. Everything that CHECKS
+    # runs every time.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # FULL HISTORY, because the privacy-policy guards below ask git when a
+          # document last really changed. A depth-1 clone grafts HEAD, so every
+          # file looks newly added and the guard answers with HEAD's date for
+          # everything -- confidently, and wrongly.
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -132,6 +141,7 @@ jobs:
           python -m pytest -q tests/test_the_privacy_policy_is_true.py
 
       - name: Publish to the public delivery endpoint
+        if: needs.drift.outputs.drifted == 'yes'
         env:
           GH_TOKEN: ${{ secrets.PUBLIC_SITE_TOKEN }}
         run: |
@@ -151,6 +161,7 @@ jobs:
           done
 
       - name: The pages the store depends on must actually work
+        if: needs.drift.outputs.drifted == 'yes'
         # PRINTING A URL IS NOT CHECKING IT. This step used to end by echoing
         # the two page addresses, which proves nothing: publishing can succeed
         # while the page stays blank for ever, and the chain that follows is the

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -33,6 +33,26 @@ on:
     paths:
       - "docs/privacy-policy.md"
       - "docs/support.md"
+  # A DAILY LOOK AT WHAT IS ACTUALLY PUBLISHED, because the push trigger above
+  # only fires when this repository changes and says nothing about whether the
+  # publish SUCCEEDED or survived.
+  #
+  # Three ways the published copy drifts from this one, none of which touches
+  # `docs/` here and so none of which the push trigger can see:
+  #   * a publish run that failed after the tests and before the write
+  #   * an edit made directly in mbiX-hub
+  #   * a revert, a force-push, or a restore in that repository
+  #
+  # The owner asked for this on 2026-08-12 in terms of the DATE — "if the
+  # published date differs from ours, run the workflow". The check below
+  # compares the whole file rather than the date line, which is strictly
+  # stronger: a date can match while the text underneath has moved, and it is
+  # the text that makes promises. The date is reported because it is the line a
+  # human reads first.
+  schedule:
+    # 04:11 UTC. An odd minute on purpose: GitHub queues every job scheduled on
+    # the hour, and a policy check is not worth waiting in that queue.
+    - cron: "11 4 * * *"
 
 permissions:
   contents: read
@@ -47,7 +67,53 @@ env:
   PUBLIC_REPO: muhammadbayoumi/mbiX-hub
 
 jobs:
+  # WHAT IS PUBLISHED, AGAINST WHAT IS HERE. Runs on every trigger and decides
+  # whether the publish job below has anything to do.
+  #
+  # On a push it will almost always say "drifted", which is correct and costs a
+  # single fetch: this repository just changed and the hub has not. On the daily
+  # schedule it is usually silent, which is the point — a scheduled job that
+  # republishes unconditionally teaches everyone to ignore its runs.
+  drift:
+    runs-on: ubuntu-latest
+    outputs:
+      drifted: ${{ steps.compare.outputs.drifted }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compare the published documents with these
+        id: compare
+        run: |
+          set -uo pipefail
+          RAW=https://raw.githubusercontent.com/muhammadbayoumi/mbiX-hub/main/ScrapeX/docs
+          drifted=no
+          for doc in privacy-policy support; do
+            mine=$(sha256sum "docs/$doc.md" | cut -d' ' -f1)
+            # NOT `curl -f`: a 404 is a real answer here — the document has
+            # never been published — and it must read as drift rather than as a
+            # broken check.
+            theirs=$(curl -sL --max-time 20 "$RAW/$doc.md" 2>/dev/null | sha256sum | cut -d' ' -f1)
+            here=$(grep -m1 'Last updated' "docs/$doc.md" || echo "(no date line)")
+            there=$(curl -sL --max-time 20 "$RAW/$doc.md" 2>/dev/null | grep -m1 'Last updated' || echo "(unreadable)")
+            if [ "$mine" != "$theirs" ]; then
+              drifted=yes
+              echo "::notice::$doc.md differs from what is published."
+              echo "  here:      $here"
+              echo "  published: $there"
+            else
+              echo "$doc.md matches what is published — $here"
+            fi
+          done
+          echo "drifted=$drifted" >> "$GITHUB_OUTPUT"
+          if [ "$drifted" = no ]; then
+            echo "Nothing to publish. The website already carries these documents."
+          fi
+
   publish:
+    needs: drift
+    # The tests still run on every path; only the WRITE is skipped when there is
+    # nothing to write. A scheduled run that finds no drift ends green having
+    # proved the published policy is the one this repository checks.
+    if: needs.drift.outputs.drifted == 'yes'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -34,6 +34,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # FULL HISTORY, because the privacy-policy guards below ask git when a
+          # document last really changed. A depth-1 clone grafts HEAD, so every
+          # file looks newly added and the guard answers with HEAD's date for
+          # everything -- confidently, and wrongly.
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/docs/picker/README.md
+++ b/docs/picker/README.md
@@ -31,31 +31,51 @@ repository. Two things break if it moves:
 A test binds those three together, so moving it breaks a test rather than the
 button.
 
-## Before it will work
+## The API key in the page
 
-`API_KEY` in the page is **empty on purpose**. Picker requires an API key, and
-the page says so plainly rather than failing against Google with a message about
-a placeholder.
+`API_KEY` is filled in, and it is **meant** to be readable. Picker requires the
+key to reach the browser; there is no version of this that hides it.
 
-To create one: Google Cloud Console → *APIs & Services* → *Credentials* →
-*Create credentials* → *API key*. Then restrict it, on the key's own page:
+What makes that safe is not secrecy but the two restrictions set on the key
+itself, in Cloud Console → *Credentials* → the key:
 
-- **API restrictions** → the *Google Picker API* only.
-- **Application restrictions** → *Websites* → `https://muhammadbayoumi.github.io/*`.
+- **API restrictions** → *Google Picker API*, and nothing else. It cannot touch
+  Drive or Sheets; those are reached with an OAuth token, never with this key.
+- **Application restrictions** → *Websites* →
+  `https://muhammadbayoumi.github.io/*`.
 
-An unrestricted key in a public page is a key anyone can spend the project's
-quota with. Restricted to one API and one site, a copied key is worth nothing.
+Selecting *Websites* and adding no entry is not a restriction — the entry is.
 
-The Picker API must also be enabled for the project, in *APIs & Services* →
-*Library*. Enabling an API is not a scope review and needs no approval from
-Google — it takes effect in about a minute.
+An API key is not a credential here: it identifies the project for quota and
+grants nothing. The honest limit of the second restriction is that a referrer
+header is forgeable by anything that is not a browser, so the worst a copied key
+buys is Picker quota on this project. No data, no access, no cost that matters.
+
+Rotating it is one click on the key's page, then one line in this folder.
+
+The Picker API must be **enabled** for the project before a key can even be
+restricted to it — *APIs & Services* → *Library* →
+[Google Picker API](https://console.cloud.google.com/apis/library/picker.googleapis.com).
+Enabling an API is not a scope review and needs no approval from Google.
 
 ## What this page is trusted with, and what it is not
 
-It is handed a Google access token in the URL **fragment**, uses it to draw the
-Picker, and erases it from the address bar immediately. It makes no API call of
-its own, stores nothing, and sends nothing anywhere except one message to one
-extension id, containing a file id and a name.
+**No access token is ever in the URL.** An earlier version put one in the
+fragment, on the true and irrelevant grounds that browsers do not send fragments
+to servers. The reader that matters is local: `chrome.tabs.create` commits the
+URL, and the committed URL reaches every extension holding the `tabs` permission
+through `onCreated` and `onUpdated`. Erasing it in the page cannot help — the
+delivery has already happened.
+
+So the URL carries a **single-use nonce**. The page trades it back through the
+extension's own message channel, which no other extension can read. The nonce is
+spent by the first caller, refused for ever after, and expires inside the
+chooser's own two-minute window; and it is worthless to anyone who cannot also
+send from this page's origin.
+
+The page uses the token it receives to draw the Picker and for nothing else. It
+makes no API call of its own, stores nothing, and sends nothing anywhere except
+one message to one extension id, containing a file id and a name.
 
 The token is never returned. The panel opens the chosen file with its own token.
 

--- a/docs/picker/README.md
+++ b/docs/picker/README.md
@@ -1,0 +1,65 @@
+# The chooser page
+
+`scrapex-picker.html` is the only part of ScrapeX that is **served from a web
+server**. Everything else runs inside the extension or on your own machine.
+
+## Why it exists at all
+
+Google Picker is how `drive.file` reaches a spreadsheet ScrapeX did not create:
+the owner picks a file, and Google grants access to that one file. Picker needs
+`https://apis.google.com/js/api.js`.
+
+Manifest V3 forbids an extension executing code fetched from a server. There is
+no flag for this and no way around it inside the panel — so the chooser has to
+live on an ordinary web origin, and this is it.
+
+## Where it must be published
+
+The panel opens exactly this address:
+
+    https://muhammadbayoumi.github.io/mbiXsite/scrapex-picker.html
+
+So the file belongs at `scrapex-picker.html` in the root of the **mbiXsite**
+repository. Two things break if it moves:
+
+- `PICKER_PAGE` in `extension/app.js` points at the old address.
+- `externally_connectable` in `extension/manifest.json`, and `PICKER_ORIGIN` in
+  `extension/background.js`, name the origin `https://muhammadbayoumi.github.io`.
+  A different **host** — not merely a different path — means the page can no
+  longer answer the extension at all.
+
+A test binds those three together, so moving it breaks a test rather than the
+button.
+
+## Before it will work
+
+`API_KEY` in the page is **empty on purpose**. Picker requires an API key, and
+the page says so plainly rather than failing against Google with a message about
+a placeholder.
+
+To create one: Google Cloud Console → *APIs & Services* → *Credentials* →
+*Create credentials* → *API key*. Then restrict it, on the key's own page:
+
+- **API restrictions** → the *Google Picker API* only.
+- **Application restrictions** → *Websites* → `https://muhammadbayoumi.github.io/*`.
+
+An unrestricted key in a public page is a key anyone can spend the project's
+quota with. Restricted to one API and one site, a copied key is worth nothing.
+
+The Picker API must also be enabled for the project, in *APIs & Services* →
+*Library*. Enabling an API is not a scope review and needs no approval from
+Google — it takes effect in about a minute.
+
+## What this page is trusted with, and what it is not
+
+It is handed a Google access token in the URL **fragment**, uses it to draw the
+Picker, and erases it from the address bar immediately. It makes no API call of
+its own, stores nothing, and sends nothing anywhere except one message to one
+extension id, containing a file id and a name.
+
+The token is never returned. The panel opens the chosen file with its own token.
+
+**Nothing secret may ever be added to this file.** It is readable by anyone, for
+ever, including after it is deleted. Tests in
+`tests/test_the_privacy_policy_is_true.py` refuse a client secret, a refresh
+token, an access token, and a token passed in a query string.

--- a/docs/picker/scrapex-picker.html
+++ b/docs/picker/scrapex-picker.html
@@ -14,12 +14,18 @@
   run inside the side panel at all. It has to run on an ordinary web origin, and
   this is that origin.
 
-  THE EXTENSION NEVER LOSES CONTROL OF THE TOKEN. The panel opens this page with
-  the token in the URL FRAGMENT, which browsers do not send to the server and do
-  not write to server logs. The page uses it to draw the Picker and for nothing
-  else: it makes no API call of its own, stores nothing, and sends nothing
-  anywhere. The fragment is erased from the address bar on load, so the token is
-  not left in history.
+  THE TOKEN IS NEVER IN THE URL. An earlier version put it in the fragment and
+  argued that browsers do not send fragments to servers. True, and the wrong
+  adversary: a tab's URL is handed in full, fragment included, to every
+  installed extension holding the `tabs` permission, through
+  chrome.tabs.onCreated and onUpdated.
+
+  So the URL carries a SINGLE-USE NONCE, and this page trades it back through
+  the extension's own message channel, which no other extension can read. The
+  nonce is spent by the first caller, refused for ever after, and expires within
+  the chooser's own two-minute window. The page uses the token it gets to draw
+  the Picker and for nothing else: it makes no API call of its own, stores
+  nothing, and sends nothing anywhere.
 
   WHAT COMES BACK is a file id and a name — not a token, not a document. The
   panel then opens that file with ITS OWN token through sheets.js, exactly as it
@@ -72,16 +78,24 @@
   // project returns files the extension's token cannot then open.
   var APP_ID = "668111083414";
 
-  // EMPTY ON PURPOSE, exactly as WEB_CLIENT_ID was in identity.js until the
-  // owner created the client. Picker requires an API key, and a placeholder
-  // would fail against Google with a message about the key rather than about
-  // the thing that is missing.
+  // PUBLIC BY DESIGN, and restricted so that being public costs nothing.
   //
-  // To fill it: Google Cloud Console -> APIs & Services -> Credentials ->
-  // Create credentials -> API key. Restrict it to the Picker API and to this
-  // page's own origin; an unrestricted key in a public page is a key anyone can
-  // spend your quota with.
-  var API_KEY = "";
+  // Picker requires the key to be readable by the page, so there is no version
+  // of this that hides it. What makes that safe is the pair of restrictions on
+  // the key itself, set in Google Cloud when it was created:
+  //
+  //   API restrictions          Google Picker API, and nothing else. It cannot
+  //                             touch Drive or Sheets — those are reached with
+  //                             an OAuth token, never with this.
+  //   Application restrictions  Websites -> https://muhammadbayoumi.github.io/*
+  //
+  // A key is not a credential here: it identifies the project for quota, and
+  // grants nothing. The honest limit of the second restriction is that a
+  // referrer header is forgeable by anything that is not a browser, so the worst
+  // a copied key buys is Picker quota on this project — no data, no access.
+  //
+  // Rotating it is one click in Cloud Console; nothing else needs changing.
+  var API_KEY = "AIzaSyBL5buzgRbGOdHw30DESCc6fe6myMQWXqY";
 
   // The one extension allowed to be answered. Read from the query so a build
   // loaded from a different unpacked folder can still be tested, and CHECKED
@@ -100,19 +114,60 @@
   function readFragment() {
     var raw = (location.hash || "").replace(/^#/, "");
     var parts = new URLSearchParams(raw);
-    // ERASED IMMEDIATELY. The fragment never reaches a server, but it does
-    // reach the address bar and the session history, and a token sitting in
-    // either is a token living longer than the click that needed it.
+    // ERASED IMMEDIATELY, even though what is here is only a nonce. A URL that
+    // still describes a handoff invites someone to reload it and wonder why it
+    // no longer works.
     if (location.hash) {
       history.replaceState(null, "", location.pathname + location.search);
     }
     return {
-      token: parts.get("token") || "",
+      nonce: parts.get("n") || "",
       extension: parts.get("ext") || new URLSearchParams(location.search).get("ext") || "",
     };
   }
 
   var handed = readFragment();
+  var token = "";
+
+  // NO TOKEN IN THE URL. A fragment is not sent to a server, which is true and
+  // is the wrong threat: a tab's URL is handed in full, fragment included, to
+  // every extension holding the `tabs` permission. So the panel puts a
+  // single-use nonce here instead and this page trades it back through the
+  // extension's own message channel, which no other extension can read.
+  function requestToken(then) {
+    if (ALLOWED_EXTENSIONS.indexOf(handed.extension) === -1) {
+      say("This page was opened by something that is not ScrapeX. Nothing was "
+          + "sent, and no Google session was requested.", true);
+      return;
+    }
+    if (!handed.nonce) {
+      say("This page was opened without a handoff from ScrapeX, so it has "
+          + "nothing to show. Start again from the ScrapeX panel.", true);
+      return;
+    }
+    try {
+      chrome.runtime.sendMessage(handed.extension,
+        {kind: "scrapex-picker-token", nonce: handed.nonce},
+        function (answer) {
+          void (chrome.runtime.lastError);
+          if (!answer || !answer.ok || !answer.token) {
+            // Spent, expired, or never issued. All three mean the same thing to
+            // whoever is looking at this page, and saying which would only help
+            // someone guessing.
+            say("ScrapeX did not confirm this session. Start again from the "
+                + "panel — the link is only good once, and only for a moment.",
+                true);
+            retry.hidden = true;
+            return;
+          }
+          token = answer.token;
+          then();
+        });
+    } catch (error) {
+      say("ScrapeX could not be reached from this page. Is the extension still "
+          + "installed?", true);
+    }
+  }
 
   function answer(payload) {
     if (ALLOWED_EXTENSIONS.indexOf(handed.extension) === -1) {
@@ -137,18 +192,23 @@
 
   function openPicker() {
     retry.hidden = true;
-    if (!handed.token) {
-      say("This page was opened without a Google session, so it has nothing to "
-          + "show. Start again from the ScrapeX panel.", true);
-      return;
-    }
     if (!API_KEY) {
       say("This build has no Picker API key, so Drive cannot be browsed here. "
           + "One has to be created in Google Cloud and restricted to this page.",
           true);
       return;
     }
+    // The nonce is good once. A retry after the token is already in hand must
+    // not spend it again — and must not ask for a second one, which would be
+    // refused.
+    if (!token) {
+      requestToken(drawPicker);
+      return;
+    }
+    drawPicker();
+  }
 
+  function drawPicker() {
     var view = new google.picker.DocsView(google.picker.ViewId.SPREADSHEETS)
       .setIncludeFolders(true)
       .setSelectFolderEnabled(false)
@@ -158,7 +218,7 @@
 
     new google.picker.PickerBuilder()
       .setAppId(APP_ID)
-      .setOAuthToken(handed.token)
+      .setOAuthToken(token)
       .setDeveloperKey(API_KEY)
       .addView(view)
       .setTitle("Choose a spreadsheet for ScrapeX")

--- a/docs/picker/scrapex-picker.html
+++ b/docs/picker/scrapex-picker.html
@@ -1,0 +1,201 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Choose a spreadsheet — ScrapeX</title>
+<meta name="robots" content="noindex">
+<!--
+  THE PAGE THAT EXISTS BECAUSE MANIFEST V3 FORBIDS REMOTE CODE.
+
+  Google Picker is the only way to widen `drive.file` to a spreadsheet the owner
+  already had. It needs `https://apis.google.com/js/api.js`, and an MV3
+  extension may not execute code fetched from a server — so the Picker cannot
+  run inside the side panel at all. It has to run on an ordinary web origin, and
+  this is that origin.
+
+  THE EXTENSION NEVER LOSES CONTROL OF THE TOKEN. The panel opens this page with
+  the token in the URL FRAGMENT, which browsers do not send to the server and do
+  not write to server logs. The page uses it to draw the Picker and for nothing
+  else: it makes no API call of its own, stores nothing, and sends nothing
+  anywhere. The fragment is erased from the address bar on load, so the token is
+  not left in history.
+
+  WHAT COMES BACK is a file id and a name — not a token, not a document. The
+  panel then opens that file with ITS OWN token through sheets.js, exactly as it
+  opens one it created. This page is a chooser and nothing more.
+
+  WHY NOT A REDIRECT BACK. A web page cannot navigate to a chrome-extension://
+  URL, so the id is returned with chrome.runtime.sendMessage, which requires the
+  extension to name this origin in `externally_connectable`. That is a narrower
+  door than it sounds: it admits exactly one origin, and only to send a message
+  the extension's own handler validates.
+-->
+<style>
+  :root { color-scheme: light dark; }
+  body {
+    margin: 0; min-height: 100vh; display: grid; place-items: center;
+    font: 15px/1.6 "Segoe UI", system-ui, -apple-system, sans-serif;
+    background: Canvas; color: CanvasText;
+  }
+  main { max-width: 34rem; padding: 2rem 1.5rem; text-align: center; }
+  h1 { font-size: 1.25rem; margin: 0 0 .5rem; }
+  p { margin: .5rem 0; }
+  .muted { opacity: .7; }
+  .err { color: #b8322a; }
+  button {
+    font: inherit; padding: .6rem 1.1rem; border-radius: .5rem;
+    border: 1px solid CanvasText; background: Canvas; color: CanvasText;
+    cursor: pointer; margin-top: 1rem;
+  }
+  code { font-family: ui-monospace, Consolas, monospace; font-size: .9em; }
+</style>
+</head>
+<body>
+<main>
+  <h1>Choose a spreadsheet</h1>
+  <p id="status">Opening your Drive…</p>
+  <p class="muted" id="hint">
+    Only the spreadsheet you pick is handed to ScrapeX. Nothing else in your
+    Drive is read, and this page keeps nothing.
+  </p>
+  <button id="retry" hidden type="button">Try again</button>
+</main>
+
+<script src="https://apis.google.com/js/api.js"></script>
+<script>
+(function () {
+  "use strict";
+
+  // THE CLOUD PROJECT NUMBER, which is what Picker calls an "app id". It is the
+  // project the OAuth client already lives in; a Picker pointed at a different
+  // project returns files the extension's token cannot then open.
+  var APP_ID = "668111083414";
+
+  // EMPTY ON PURPOSE, exactly as WEB_CLIENT_ID was in identity.js until the
+  // owner created the client. Picker requires an API key, and a placeholder
+  // would fail against Google with a message about the key rather than about
+  // the thing that is missing.
+  //
+  // To fill it: Google Cloud Console -> APIs & Services -> Credentials ->
+  // Create credentials -> API key. Restrict it to the Picker API and to this
+  // page's own origin; an unrestricted key in a public page is a key anyone can
+  // spend your quota with.
+  var API_KEY = "";
+
+  // The one extension allowed to be answered. Read from the query so a build
+  // loaded from a different unpacked folder can still be tested, and CHECKED
+  // against this list rather than trusted: an arbitrary id here would let any
+  // page send a chosen file to any extension.
+  var ALLOWED_EXTENSIONS = ["ekcgggphcfdbjgfkcmjagehfjhijeang"];
+
+  var status = document.getElementById("status");
+  var retry = document.getElementById("retry");
+
+  function say(text, isError) {
+    status.textContent = text;
+    status.className = isError ? "err" : "";
+  }
+
+  function readFragment() {
+    var raw = (location.hash || "").replace(/^#/, "");
+    var parts = new URLSearchParams(raw);
+    // ERASED IMMEDIATELY. The fragment never reaches a server, but it does
+    // reach the address bar and the session history, and a token sitting in
+    // either is a token living longer than the click that needed it.
+    if (location.hash) {
+      history.replaceState(null, "", location.pathname + location.search);
+    }
+    return {
+      token: parts.get("token") || "",
+      extension: parts.get("ext") || new URLSearchParams(location.search).get("ext") || "",
+    };
+  }
+
+  var handed = readFragment();
+
+  function answer(payload) {
+    if (ALLOWED_EXTENSIONS.indexOf(handed.extension) === -1) {
+      say("This page was opened by something that is not ScrapeX. Nothing was "
+          + "sent.", true);
+      return;
+    }
+    try {
+      chrome.runtime.sendMessage(handed.extension, payload, function () {
+        // A missing receiver sets lastError; the panel may simply have been
+        // closed, which is not a fault worth alarming anyone about.
+        void (chrome.runtime.lastError);
+        say(payload.fileId
+            ? "Sent to ScrapeX. You can close this tab."
+            : "Nothing was chosen. You can close this tab.");
+      });
+    } catch (error) {
+      say("ScrapeX could not be reached from this page. Is the extension still "
+          + "installed?", true);
+    }
+  }
+
+  function openPicker() {
+    retry.hidden = true;
+    if (!handed.token) {
+      say("This page was opened without a Google session, so it has nothing to "
+          + "show. Start again from the ScrapeX panel.", true);
+      return;
+    }
+    if (!API_KEY) {
+      say("This build has no Picker API key, so Drive cannot be browsed here. "
+          + "One has to be created in Google Cloud and restricted to this page.",
+          true);
+      return;
+    }
+
+    var view = new google.picker.DocsView(google.picker.ViewId.SPREADSHEETS)
+      .setIncludeFolders(true)
+      .setSelectFolderEnabled(false)
+      // The owner's own files by default. Shared-with-me is still reachable
+      // from the Picker's own tabs; this only decides where it opens.
+      .setOwnedByMe(true);
+
+    new google.picker.PickerBuilder()
+      .setAppId(APP_ID)
+      .setOAuthToken(handed.token)
+      .setDeveloperKey(API_KEY)
+      .addView(view)
+      .setTitle("Choose a spreadsheet for ScrapeX")
+      .setCallback(function (data) {
+        if (data.action === google.picker.Action.PICKED) {
+          var doc = data.docs && data.docs[0];
+          answer({
+            kind: "scrapex-picked-spreadsheet",
+            fileId: doc && doc.id,
+            name: doc && doc.name,
+          });
+        } else if (data.action === google.picker.Action.CANCEL) {
+          answer({kind: "scrapex-picked-spreadsheet", fileId: null});
+        }
+      })
+      .build()
+      .setVisible(true);
+
+    say("Pick a spreadsheet in the window Google opened.");
+  }
+
+  retry.addEventListener("click", openPicker);
+
+  if (typeof gapi === "undefined") {
+    say("Google's picker script did not load. Check the connection and try "
+        + "again.", true);
+    retry.hidden = false;
+    return;
+  }
+  gapi.load("picker", {
+    callback: openPicker,
+    onerror: function () {
+      say("Google's picker could not start.", true);
+      retry.hidden = false;
+    },
+  });
+})();
+</script>
+</body>
+</html>

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -33,6 +33,7 @@ your email address. The extension contains no telemetry of any kind.
 | Your appearance choice — light or dark, and which palette | This computer, in the browser's own storage | You |
 | The time zone dates are shown in | The same | You |
 | The address of your local engine — `127.0.0.1:8000` unless you change it | The same | You |
+| The spreadsheet you chose for exports — its name, its link, and Google's id for it | The same | You |
 
 Nothing in that table leaves your computer unless you press a button that says
 it will.

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,6 +1,6 @@
 # ScrapeX — Privacy Policy
 
-*Last updated: 6 August 2026*
+*Last updated: 12 August 2026*
 
 ScrapeX is a Chrome extension and a companion program, **ScrapeX-Engine**, that
 run on your own computer. This policy describes every piece of data either of

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,6 +1,6 @@
 # ScrapeX — Support
 
-*Last updated: 6 August 2026*
+*Last updated: 8 August 2026*
 
 ScrapeX is maintained by **Muhammad Bayoumi**.
 

--- a/extension/app.html
+++ b/extension/app.html
@@ -1749,6 +1749,11 @@
                     Fetch the latest backup</button>
                   <button id="sheet-create" class="button ghost" type="button">
                     Create a spreadsheet</button>
+                  <!-- The chooser opens in a TAB, not here: Google Picker loads
+                       a remote script and MV3 forbids an extension running one.
+                       See docs/picker/scrapex-picker.html. -->
+                  <button id="sheet-choose" class="button ghost" type="button">
+                    Choose an existing one</button>
                 </div>
                 <div id="drive-progress" class="bar hidden" role="progressbar"
                      aria-labelledby="google-heading" aria-valuemin="0"

--- a/extension/app.js
+++ b/extension/app.js
@@ -22,7 +22,8 @@ import {
 } from "./drive.js";
 import { readPanelPack, datasetSummaries } from "./bundleview.js";
 import {
-  ensureFolder, ensureSpreadsheet, writeTab, DEFAULT_WORKBOOK, SHEET_FOLDER,
+  ensureFolder, ensureSpreadsheet, openChosen, writeTab,
+  DEFAULT_WORKBOOK, SHEET_FOLDER,
 } from "./sheets.js";
 import {
   afterIdle, afterNextPaint, deadlineForLocalRequest, fetchWithDeadline,
@@ -5602,6 +5603,73 @@ async function fetchFromDrive(token) {
          ` by engine ${pointer.engine_version || "unknown"}. It is not installed — this only checks it is there.`;
 }
 
+//: Where the chooser lives. It cannot be a page in this extension: Google
+//: Picker loads a remote script and MV3 forbids that, so it is served from the
+//: owner's own site and answers through background.js's onMessageExternal.
+const PICKER_PAGE = "https://muhammadbayoumi.github.io/mbiXsite/scrapex-picker.html";
+
+/**
+ * Let the owner point ScrapeX at a spreadsheet it did not create.
+ *
+ * `drive.file` reaches two kinds of file: ones this app made, and ones the
+ * owner hands it through the Picker. This is the second kind, and it is the
+ * only way to widen that scope without asking Google for a sensitive one.
+ *
+ * THE TOKEN GOES IN THE FRAGMENT. Browsers do not send a fragment to the
+ * server and do not log it, and the page erases it from the address bar on
+ * load. It is used to draw the Picker and for nothing else — what comes back
+ * is an id, and the panel opens the file with its own token.
+ */
+async function pickExistingSpreadsheet() {
+  if (!state.token) {
+    out("drive-msg", "Sign in with Google first — the Account button at the "
+                     + "top of the panel.", "err");
+    return;
+  }
+  await chrome.storage.session.remove("scrapexPickedSpreadsheet");
+  const url = `${PICKER_PAGE}#token=${encodeURIComponent(state.token)}`
+    + `&ext=${encodeURIComponent(chrome.runtime.id)}`;
+  chrome.tabs.create({url});
+  out("drive-msg", "Choose a spreadsheet in the tab that just opened, then come "
+                   + "back here.", "");
+
+  // POLLED, NOT PUSHED. A side panel can be closed and reopened while the owner
+  // is choosing, and a message sent to a panel that is not there is lost —
+  // which is why background.js writes the choice to session storage instead of
+  // forwarding it. This reads that, and stops after two minutes rather than
+  // polling for the life of the browser.
+  const deadline = Date.now() + 120000;
+  for (;;) {
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    const held = await chrome.storage.session.get("scrapexPickedSpreadsheet");
+    const picked = held.scrapexPickedSpreadsheet;
+    if (picked) {
+      await chrome.storage.session.remove("scrapexPickedSpreadsheet");
+      if (!picked.fileId) {
+        out("drive-msg", "Nothing was chosen.", "");
+        return;
+      }
+      try {
+        const sheet = await openChosen(state.token, picked.fileId);
+        const link = $("sheet-link");
+        if (link) {
+          link.innerHTML = `<a class="link" href="${esc(sheet.url)}" `
+            + `target="_blank" rel="noreferrer noopener">${esc(sheet.name)}</a>`;
+        }
+        out("drive-msg", `ScrapeX can now write to "${esc(sheet.name)}".`, "ok");
+      } catch (error) {
+        out("drive-msg", esc((error && error.message) || "That file could not be opened."), "err");
+      }
+      return;
+    }
+    if (Date.now() > deadline) {
+      out("drive-msg", "No spreadsheet was chosen. Press the button again when "
+                       + "you are ready.", "");
+      return;
+    }
+  }
+}
+
 async function createSpreadsheet(token) {
   const folder = await ensureFolder(token, SHEET_FOLDER);
   const sheet = await ensureSpreadsheet(token, DEFAULT_WORKBOOK, {folder});
@@ -5621,6 +5689,11 @@ function wireGoogleControls() {
     ["drive-restore", "Looking for the latest backup…", fetchFromDrive],
     ["sheet-create", "Creating the spreadsheet…", createSpreadsheet],
   ];
+  // Wired apart from the three above because it does NOT follow their shape:
+  // it opens a tab and waits on the owner rather than running a request, so it
+  // must not disable the row or claim to be working while nothing is.
+  const choose = $("sheet-choose");
+  if (choose) choose.addEventListener("click", () => pickExistingSpreadsheet());
   for (const [id, working, action] of actions) {
     const button = $(id);
     if (button) {

--- a/extension/app.js
+++ b/extension/app.js
@@ -4348,8 +4348,9 @@ async function exportSourceToSheet(key) {
     }
 
     out("datasets-msg", `Writing ${fmtCount(table.rows.length)} rows to Google…`, "");
-    const folder = await ensureFolder(state.token, SHEET_FOLDER);
-    const sheet = await ensureSpreadsheet(state.token, DEFAULT_WORKBOOK, {folder});
+    // The workbook the owner chose, if they chose one. Not ScrapeX's own by
+    // default — that was the whole defect.
+    const sheet = await whereExportsGo(state.token);
     await writeTab(state.token, sheet.id, {
       tab: key, header: table.header, rows: table.rows,
     });
@@ -5608,6 +5609,15 @@ async function fetchFromDrive(token) {
 //: owner's own site and answers through background.js's onMessageExternal.
 const PICKER_PAGE = "https://muhammadbayoumi.github.io/mbiXsite/scrapex-picker.html";
 
+//: How long the panel waits for a choice, and how long the handoff that carries
+//: the token stays tradeable. The same number deliberately: a handoff outliving
+//: the wait would be a key left under a mat nobody is watching any more.
+const PICK_WINDOW_MS = 120000;
+
+//: One chooser at a time. Module-level rather than on `state` because it is not
+//: a fact about the panel worth restoring — it is true only while a wait runs.
+let pickInFlight = false;
+
 /**
  * Let the owner point ScrapeX at a spreadsheet it did not create.
  *
@@ -5621,13 +5631,53 @@ const PICKER_PAGE = "https://muhammadbayoumi.github.io/mbiXsite/scrapex-picker.h
  * is an id, and the panel opens the file with its own token.
  */
 async function pickExistingSpreadsheet() {
-  if (!state.token) {
+  // ONE CHOOSER AT A TIME. Two overlapping waits share one message line and one
+  // session key: the loser wakes a second later, finds the key already spent,
+  // and paints "No spreadsheet was chosen" over the success the winner just
+  // wrote. The button stays enabled because it opens a tab rather than running
+  // a request — so the guard belongs here.
+  if (pickInFlight) {
+    out("drive-msg", "A chooser is already open — pick a spreadsheet in that "
+                     + "tab, or close it and press this again.", "");
+    return;
+  }
+
+  // FETCHED NOW, NOT REMEMBERED. state.token is read once when the panel opens,
+  // and a side panel document lives for as long as the window does. An access
+  // token lives about an hour. A stale one draws a Picker that shows nothing
+  // and leaves the owner believing they chose badly.
+  let token = "";
+  try {
+    const fresh = await getToken({interactive: false});
+    token = (fresh && fresh.token) || "";
+    if (token) state.token = token;
+  } catch {
+    token = "";
+  }
+  if (!token) {
     out("drive-msg", "Sign in with Google first — the Account button at the "
                      + "top of the panel.", "err");
     return;
   }
+
+  // THE TOKEN DOES NOT TRAVEL IN THE URL. It did, in the fragment, defended by
+  // the true and irrelevant fact that browsers do not send fragments to
+  // servers. The reader that matters is local: chrome.tabs.create COMMITS this
+  // URL, and the committed URL is delivered whole — fragment included — to
+  // every installed extension holding the `tabs` permission. Erasing it in the
+  // page afterwards cannot help; the delivery already happened.
+  //
+  // So what goes in the URL is a nonce. background.js trades it, once, for the
+  // token. A watching extension copies a number that is spent within a second,
+  // refused thereafter, and useless without also being able to send from the
+  // chooser's own origin.
+  const nonce = crypto.randomUUID();
+  await chrome.storage.session.set({
+    scrapexPickerHandoff: {nonce, token, expires: Date.now() + PICK_WINDOW_MS},
+  });
   await chrome.storage.session.remove("scrapexPickedSpreadsheet");
-  const url = `${PICKER_PAGE}#token=${encodeURIComponent(state.token)}`
+
+  const url = `${PICKER_PAGE}#n=${encodeURIComponent(nonce)}`
     + `&ext=${encodeURIComponent(chrome.runtime.id)}`;
   chrome.tabs.create({url});
   out("drive-msg", "Choose a spreadsheet in the tab that just opened, then come "
@@ -5638,45 +5688,120 @@ async function pickExistingSpreadsheet() {
   // which is why background.js writes the choice to session storage instead of
   // forwarding it. This reads that, and stops after two minutes rather than
   // polling for the life of the browser.
-  const deadline = Date.now() + 120000;
-  for (;;) {
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    const held = await chrome.storage.session.get("scrapexPickedSpreadsheet");
-    const picked = held.scrapexPickedSpreadsheet;
-    if (picked) {
-      await chrome.storage.session.remove("scrapexPickedSpreadsheet");
-      if (!picked.fileId) {
-        out("drive-msg", "Nothing was chosen.", "");
+  pickInFlight = true;
+  const deadline = Date.now() + PICK_WINDOW_MS;
+  try {
+    for (;;) {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      const held = await chrome.storage.session.get("scrapexPickedSpreadsheet");
+      const picked = held.scrapexPickedSpreadsheet;
+      if (picked) {
+        await chrome.storage.session.remove("scrapexPickedSpreadsheet");
+        if (!picked.fileId) {
+          out("drive-msg", "Nothing was chosen.", "");
+          return;
+        }
+        await adoptChosenSpreadsheet(token, picked.fileId);
         return;
       }
-      try {
-        const sheet = await openChosen(state.token, picked.fileId);
-        const link = $("sheet-link");
-        if (link) {
-          link.innerHTML = `<a class="link" href="${esc(sheet.url)}" `
-            + `target="_blank" rel="noreferrer noopener">${esc(sheet.name)}</a>`;
-        }
-        out("drive-msg", `ScrapeX can now write to "${esc(sheet.name)}".`, "ok");
-      } catch (error) {
-        out("drive-msg", esc((error && error.message) || "That file could not be opened."), "err");
+      if (Date.now() > deadline) {
+        // The handoff dies with the wait. One left behind is a token that can
+        // still be traded by whoever kept the nonce.
+        await chrome.storage.session.remove("scrapexPickerHandoff");
+        out("drive-msg", "No spreadsheet was chosen. Press the button again when "
+                         + "you are ready.", "");
+        return;
       }
-      return;
     }
-    if (Date.now() > deadline) {
-      out("drive-msg", "No spreadsheet was chosen. Press the button again when "
-                       + "you are ready.", "");
-      return;
-    }
+  } finally {
+    pickInFlight = false;
   }
+}
+
+/**
+ * Take the owner at their word: this file, from now on, is where exports go.
+ *
+ * SAYING IT IS NOT ENOUGH — that was the defect. The first version confirmed
+ * the file, painted its name into the panel's one spreadsheet line, and
+ * announced that ScrapeX could write to it, while every export went on landing
+ * in ScrapeX's own workbook. Both halves were individually defensible: the
+ * Picker's grant IS permanent, and the export line DID name where it wrote. Put
+ * together they told the owner their rows were in a file that never received a
+ * row.
+ */
+async function adoptChosenSpreadsheet(token, fileId) {
+  try {
+    const sheet = await openChosen(token, fileId);
+    await chrome.storage.local.set({[TARGET_SHEET_KEY]: {
+      id: sheet.id, name: sheet.name, url: sheet.url,
+    }});
+    renderSheetTarget(sheet, {chosen: true});
+    out("drive-msg", `Exports will be written into "${esc(sheet.name)}" from now on.`,
+        "ok");
+  } catch (error) {
+    out("drive-msg",
+        esc((error && error.message) || "That file could not be opened."), "err");
+  }
+}
+
+//: The workbook exports are written into, when the owner has chosen one rather
+//: than letting ScrapeX make its own. In storage.local, not in memory: where a
+//: business's data lands is a decision, and one nobody should have to make
+//: again every time the panel closes.
+const TARGET_SHEET_KEY = "scrapexTargetSheet";
+
+async function chosenTarget() {
+  const held = await chrome.storage.local.get(TARGET_SHEET_KEY);
+  const sheet = held[TARGET_SHEET_KEY];
+  return sheet && sheet.id ? sheet : null;
+}
+
+/**
+ * WHERE THE ROWS ACTUALLY GO — the only answer to that question.
+ *
+ * Choosing a spreadsheet through the Picker used to paint a link, say "ScrapeX
+ * can now write to it", and change nothing: every export went on
+ * finding-or-creating "ScrapeX Data" by name. The panel told the truth about
+ * the permission and a lie about the destination, which is the worse half to be
+ * wrong about — the owner would have found their rows in the wrong file, or not
+ * found them at all.
+ */
+async function whereExportsGo(token) {
+  const chosen = await chosenTarget();
+  if (chosen) return chosen;
+  const folder = await ensureFolder(token, SHEET_FOLDER);
+  return ensureSpreadsheet(token, DEFAULT_WORKBOOK, {folder});
+}
+
+/** Say, in the panel, which workbook the next export will be written into. */
+function renderSheetTarget(sheet, {chosen = false} = {}) {
+  const link = $("sheet-link");
+  if (!link) return;
+  if (!sheet) {
+    link.textContent = "";
+    return;
+  }
+  const anchor = `<a class="link" href="${esc(sheet.url)}" target="_blank" `
+    + `rel="noreferrer noopener">${esc(sheet.name)}</a>`;
+  link.innerHTML = chosen
+    ? `Exports go to ${anchor} — the one you chose. Press `
+      + `<b>Create a spreadsheet</b> to go back to ScrapeX's own workbook.`
+    : `Exports go to ${anchor}.`;
 }
 
 async function createSpreadsheet(token) {
   const folder = await ensureFolder(token, SHEET_FOLDER);
   const sheet = await ensureSpreadsheet(token, DEFAULT_WORKBOOK, {folder});
-  const link = $("sheet-link");
-  if (link) {
-    link.innerHTML = `<a class="link" href="${esc(sheet.url)}" target="_blank" ` +
-                     `rel="noreferrer noopener">${esc(sheet.name)}</a>`;
+
+  // THE WAY BACK. This button is the only route from a chosen workbook to
+  // ScrapeX's own, so it clears the choice rather than leaving two answers to
+  // "where do exports go" and picking one silently.
+  const returning = Boolean(await chosenTarget());
+  await chrome.storage.local.remove(TARGET_SHEET_KEY);
+  renderSheetTarget(sheet);
+
+  if (returning) {
+    return `Exports go back to "${sheet.name}" in ${SHEET_FOLDER}.`;
   }
   return sheet.created
     ? `Created "${sheet.name}" in ${SHEET_FOLDER}.`
@@ -5694,6 +5819,14 @@ function wireGoogleControls() {
   // must not disable the row or claim to be working while nothing is.
   const choose = $("sheet-choose");
   if (choose) choose.addEventListener("click", () => pickExistingSpreadsheet());
+
+  // WHERE EXPORTS GO, SAID BEFORE ANYTHING IS EXPORTED. A choice made last week
+  // is still in force this morning, and a panel that shows nothing until the
+  // owner presses something leaves them to remember it themselves.
+  chosenTarget().then((sheet) => {
+    if (sheet) renderSheetTarget(sheet, {chosen: true});
+  }, () => {});
+
   for (const [id, working, action] of actions) {
     const button = $(id);
     if (button) {

--- a/extension/background.js
+++ b/extension/background.js
@@ -176,6 +176,41 @@ chrome.sidePanel.onOpened?.addListener((info) => {
 // file with its own token exactly as it opens one it created.
 const PICKER_ORIGIN = "https://muhammadbayoumi.github.io";
 
+/**
+ * Hand the page the access token it needs, once, in exchange for the nonce the
+ * panel put in its URL.
+ *
+ * WHY THE TOKEN IS NOT SIMPLY IN THE URL. It was, and that was wrong. A
+ * fragment is not sent to a server — which is true, and defends against the
+ * wrong adversary. Locally a tab's URL is public: chrome.tabs.onCreated and
+ * onUpdated hand it, fragment and all, to EVERY installed extension holding the
+ * `tabs` permission. A live OAuth bearer token sitting there is readable by any
+ * of them and usable from any machine for the rest of its hour.
+ *
+ * So the URL carries a nonce and nothing else. What a watching extension can
+ * copy is a number that:
+ *
+ *   - is spent by the first caller and refused for ever after,
+ *   - expires on its own within the chooser's own two-minute window,
+ *   - is worthless without ALSO being able to send from the picker's origin,
+ *     which needs a content script on that site — a far higher bar than the
+ *     `tabs` permission that used to be sufficient.
+ */
+async function tradeNonceForToken(nonce) {
+  if (typeof nonce !== "string" || !nonce) return null;
+
+  const held = await chrome.storage.session.get("scrapexPickerHandoff");
+  const handoff = held.scrapexPickerHandoff;
+  if (!handoff || handoff.nonce !== nonce) return null;
+
+  // SPENT ON SIGHT, before the expiry is even considered. An early return that
+  // left the handoff in place would make a wrong guess free to repeat.
+  await chrome.storage.session.remove("scrapexPickerHandoff");
+
+  if (!handoff.expires || Date.now() > handoff.expires) return null;
+  return handoff.token || null;
+}
+
 chrome.runtime.onMessageExternal.addListener((message, sender, respond) => {
   const origin = (sender && sender.origin) || "";
   if (origin !== PICKER_ORIGIN) {
@@ -183,7 +218,22 @@ chrome.runtime.onMessageExternal.addListener((message, sender, respond) => {
     respond({ok: false});
     return false;
   }
-  if (!message || message.kind !== "scrapex-picked-spreadsheet") {
+  if (!message || typeof message.kind !== "string") {
+    respond({ok: false});
+    return false;
+  }
+
+  if (message.kind === "scrapex-picker-token") {
+    tradeNonceForToken(message.nonce).then(
+      (token) => {
+        trace.mark("picker-token-handed", {granted: Boolean(token)});
+        respond(token ? {ok: true, token} : {ok: false});
+      },
+      () => respond({ok: false}));
+    return true;                     // the reply is asynchronous
+  }
+
+  if (message.kind !== "scrapex-picked-spreadsheet") {
     respond({ok: false});
     return false;
   }
@@ -200,7 +250,11 @@ chrome.runtime.onMessageExternal.addListener((message, sender, respond) => {
   // chrome.storage.session, not local: a choice the owner made a moment ago is
   // meaningless after the browser closes, and writing it to disk would keep a
   // record of a document nobody asked us to remember.
+  //
+  // The handoff dies with the choice too. Picking is the last thing the page
+  // needs a token for, and one left behind is one that can still be traded.
   chrome.storage.session.set({scrapexPickedSpreadsheet: picked})
+    .then(() => chrome.storage.session.remove("scrapexPickerHandoff"))
     .then(() => respond({ok: true}), () => respond({ok: false}));
   return true;                       // the reply is asynchronous
 });

--- a/extension/background.js
+++ b/extension/background.js
@@ -158,6 +158,53 @@ chrome.sidePanel.onOpened?.addListener((info) => {
   trace.mark("side-panel-on-opened", info);
 });
 
+// ---- the spreadsheet the owner chose, arriving from a web page --------------
+//
+// Google Picker cannot run in this panel: it loads apis.google.com/js/api.js,
+// and MV3 forbids an extension executing code fetched from a server. So the
+// chooser lives on an ordinary web origin (docs/picker/scrapex-picker.html,
+// served from the owner's site) and hands back an id here.
+//
+// EVERYTHING FROM OUTSIDE IS UNTRUSTED, and `externally_connectable` narrows
+// WHO may speak, never WHAT they may say. The origin is checked again below
+// even though the manifest already restricts it — a match pattern is one
+// character from being widened, and this listener is the last thing standing
+// between a web page and the panel.
+//
+// It carries no token in either direction. The page was handed one to draw the
+// Picker with; what returns is a file id and a name, and the panel opens that
+// file with its own token exactly as it opens one it created.
+const PICKER_ORIGIN = "https://muhammadbayoumi.github.io";
+
+chrome.runtime.onMessageExternal.addListener((message, sender, respond) => {
+  const origin = (sender && sender.origin) || "";
+  if (origin !== PICKER_ORIGIN) {
+    trace.mark("picker-message-refused", {origin});
+    respond({ok: false});
+    return false;
+  }
+  if (!message || message.kind !== "scrapex-picked-spreadsheet") {
+    respond({ok: false});
+    return false;
+  }
+
+  // A FILE ID AND NOTHING ELSE. Whatever else the page sent is dropped here
+  // rather than forwarded, so a future field cannot arrive in the panel without
+  // someone adding it deliberately on this line.
+  const picked = {
+    fileId: typeof message.fileId === "string" ? message.fileId : null,
+    name: typeof message.name === "string" ? message.name : "",
+  };
+  trace.mark("picker-message", {picked: Boolean(picked.fileId)});
+
+  // chrome.storage.session, not local: a choice the owner made a moment ago is
+  // meaningless after the browser closes, and writing it to disk would keep a
+  // record of a document nobody asked us to remember.
+  chrome.storage.session.set({scrapexPickedSpreadsheet: picked})
+    .then(() => respond({ok: true}), () => respond({ok: false}));
+  return true;                       // the reply is asynchronous
+});
+
 // RETRIEVING THE TRACE. Run scrapexTrace() in the service worker's console
 // (chrome://extensions -> ScrapeX -> "service worker"). The two contexts write
 // to separate keys, so this is where they are merged back onto one clock — the

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -42,6 +42,11 @@
     "https://sheets.googleapis.com/v4/*",
     "https://oauth2.googleapis.com/revoke*"
   ],
+  "externally_connectable": {
+    "matches": [
+      "https://muhammadbayoumi.github.io/*"
+    ]
+  },
   "oauth2": {
     "client_id": "668111083414-0fd7tso17orbbqrkg0mjnne8oig0pqru.apps.googleusercontent.com",
     "scopes": [

--- a/extension/tests/background.test.mjs
+++ b/extension/tests/background.test.mjs
@@ -14,6 +14,7 @@ function chromeHarness() {
     configuration: [],
     openedListeners: [],
     installedListeners: [],
+    externalListeners: [],
     open: [],
     storage: [],
     timeline: [],
@@ -28,6 +29,12 @@ function chromeHarness() {
       getURL(path) { return `chrome-extension://test/${path}`; },
       onInstalled: {
         addListener(listener) { calls.installedListeners.push(listener); },
+      },
+      // The chooser page's way back in. Absent from the harness, background.js
+      // throws while loading and every test here fails describing `addListener`
+      // rather than the worker.
+      onMessageExternal: {
+        addListener(listener) { calls.externalListeners.push(listener); },
       },
     },
     sidePanel: {

--- a/extension/tests/side-panel-startup.test.mjs
+++ b/extension/tests/side-panel-startup.test.mjs
@@ -44,6 +44,7 @@ function workerHarness() {
     actionListeners: [],
     installedListeners: [],
     openedListeners: [],
+    externalListeners: [],
     configuration: [],
     open: [],
     tabs: [],
@@ -62,6 +63,13 @@ function workerHarness() {
       getURL: (path) => `chrome-extension://test/${path}`,
       onInstalled: {
         addListener(listener) { calls.installedListeners.push(listener); },
+      },
+      // The chooser page's only way back in. A harness without it does not
+      // merely skip a test — background.js throws on load and every test in
+      // this file fails with a message about `addListener` rather than about
+      // the panel.
+      onMessageExternal: {
+        addListener(listener) { calls.externalListeners.push(listener); },
       },
     },
     sidePanel: {
@@ -568,4 +576,142 @@ test("app.js starts even though DOMContentLoaded is long past when it arrives", 
     "app.js waits on DOMContentLoaded unconditionally at the top level. "
     + "boot-app.js appends it after `load`, so that event never fires again "
     + "and nothing in the panel ever starts");
+});
+
+// ---------------------------------------------------------------------------
+// The one door a web page has into this extension.
+//
+// `externally_connectable` in the manifest decides WHO may knock. These decide
+// what happens once someone has. Every one of them drives the real listener out
+// of background.js rather than a copy of its rules.
+// ---------------------------------------------------------------------------
+
+const PICKER_ORIGIN = "https://muhammadbayoumi.github.io";
+
+/** The listener the worker registered, with the harness's recorded writes. */
+async function externalListener(t) {
+  const {calls, chrome} = workerHarness();
+  await loadBackground(t, chrome);
+  assert.equal(calls.externalListeners.length, 1,
+    "background.js registers no external listener, so the chooser page can "
+    + "never hand anything back");
+  return {listen: calls.externalListeners[0], calls};
+}
+
+/**
+ * The last thing written under the picked-spreadsheet key.
+ *
+ * `.at(-1)` is wrong here: trace.mark() writes to the same session area, so the
+ * newest write is often the trace rather than the choice, and a test that read
+ * it would pass or fail on which promise settled first.
+ */
+function lastPicked(calls) {
+  const written = calls.storage
+    .filter((write) => "scrapexPickedSpreadsheet" in write);
+  return written.length ? written.at(-1).scrapexPickedSpreadsheet : undefined;
+}
+
+/** Every write that carried a choice — the count refusals must not raise. */
+function pickedWrites(calls) {
+  return calls.storage.filter((write) => "scrapexPickedSpreadsheet" in write).length;
+}
+
+/** Calls the listener and waits for whatever it promised to write. */
+async function knock(listen, message, origin) {
+  let answered;
+  const replied = new Promise((resolve) => { answered = resolve; });
+  listen(message, {origin, id: "whoever"}, answered);
+  const answer = await Promise.race([
+    replied,
+    new Promise((resolve) => setTimeout(() => resolve("never answered"), 50)),
+  ]);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  return answer;
+}
+
+test("a page on any other origin is refused, and nothing is written", async (t) => {
+  const {listen, calls} = await externalListener(t);
+  const before = pickedWrites(calls);
+
+  const answer = await knock(listen, {
+    kind: "scrapex-picked-spreadsheet",
+    fileId: "1AttackerSuppliedId",
+    name: "Payroll",
+  }, "https://muhammadbayoumi.github.io.example.com");
+
+  assert.deepEqual(answer, {ok: false});
+  assert.equal(pickedWrites(calls), before,
+    "a message from a look-alike origin reached storage. The manifest's match "
+    + "pattern is a prefix match on the host; a listener that trusts it is one "
+    + "typo away from taking a file id from any site");
+});
+
+test("an empty or absent origin is refused as firmly as a wrong one", async (t) => {
+  const {listen, calls} = await externalListener(t);
+  const before = pickedWrites(calls);
+
+  assert.deepEqual(await knock(listen, {kind: "scrapex-picked-spreadsheet",
+    fileId: "1x"}, undefined), {ok: false});
+  assert.deepEqual(await knock(listen, {kind: "scrapex-picked-spreadsheet",
+    fileId: "1x"}, ""), {ok: false});
+  assert.equal(pickedWrites(calls), before);
+});
+
+test("another kind of message from the right origin is still refused", async (t) => {
+  const {listen, calls} = await externalListener(t);
+  const before = pickedWrites(calls);
+
+  // The origin is correct here. Being allowed to speak is not being believed:
+  // one page on that site is compromised or one script is added to it, and this
+  // is what stands between that and the panel.
+  for (const message of [
+    null,
+    {},
+    {kind: "start-a-job", target: "http://127.0.0.1:8000"},
+    {kind: "scrapex-picked-spreadsheet ", fileId: "1x"},
+  ]) {
+    assert.deepEqual(await knock(listen, message, PICKER_ORIGIN), {ok: false},
+      `accepted ${JSON.stringify(message)}`);
+  }
+  assert.equal(pickedWrites(calls), before);
+});
+
+test("a chosen file arrives as an id and a name, and nothing else", async (t) => {
+  const {listen, calls} = await externalListener(t);
+
+  const answer = await knock(listen, {
+    kind: "scrapex-picked-spreadsheet",
+    fileId: "1RealFileId",
+    name: "Quarterly prices",
+    // Everything below was not asked for. A listener that spread the message
+    // would carry all of it into the panel's session storage.
+    token: "ya29.a-token-the-page-should-never-return",
+    url: "https://example.com/collect",
+    mimeType: "application/vnd.google-apps.spreadsheet",
+  }, PICKER_ORIGIN);
+
+  assert.deepEqual(answer, {ok: true});
+  const written = lastPicked(calls);
+  assert.deepEqual(written, {fileId: "1RealFileId", name: "Quarterly prices"},
+    "the panel received more than the id and the name it asked for");
+});
+
+test("a cancelled choice is recorded as a choice of nothing", async (t) => {
+  const {listen, calls} = await externalListener(t);
+
+  // Not silence: the panel is waiting, and a wait that ends only on a timeout
+  // makes cancelling feel like a fault.
+  assert.deepEqual(await knock(listen, {kind: "scrapex-picked-spreadsheet",
+    fileId: null}, PICKER_ORIGIN), {ok: true});
+  assert.deepEqual(lastPicked(calls),
+    {fileId: null, name: ""});
+});
+
+test("a file id that is not a string becomes no file id", async (t) => {
+  const {listen, calls} = await externalListener(t);
+
+  await knock(listen, {kind: "scrapex-picked-spreadsheet",
+    fileId: {toString: "not a string"}, name: 42}, PICKER_ORIGIN);
+  assert.deepEqual(lastPicked(calls),
+    {fileId: null, name: ""});
 });

--- a/extension/tests/side-panel-startup.test.mjs
+++ b/extension/tests/side-panel-startup.test.mjs
@@ -26,12 +26,27 @@ function loadTraceFactory() {
 /** A chrome.storage.session that records every write, in order. */
 function sessionStorage() {
   const writes = [];
+  const held = new Map();
   const area = {
     async set(value) {
       writes.push(structuredClone(value));
+      for (const [key, item] of Object.entries(value)) {
+        held.set(key, structuredClone(item));
+      }
+    },
+    async get(key) {
+      const wanted = typeof key === "string" ? [key] : (key || [...held.keys()]);
+      const answer = {};
+      for (const name of wanted) {
+        if (held.has(name)) answer[name] = structuredClone(held.get(name));
+      }
+      return answer;
+    },
+    async remove(key) {
+      for (const name of (typeof key === "string" ? [key] : key)) held.delete(name);
     },
   };
-  return {writes, area};
+  return {writes, area, held};
 }
 
 /**
@@ -49,8 +64,9 @@ function workerHarness() {
     open: [],
     tabs: [],
   };
-  const {writes, area} = sessionStorage();
+  const {writes, area, held} = sessionStorage();
   calls.storage = writes;
+  calls.held = held;
 
   const chrome = {
     action: {
@@ -95,6 +111,18 @@ function workerHarness() {
         async set(value) {
           calls.apiOrder.push("storage.session.set");
           return area.set(value);
+        },
+        // A real key-value store, not a write log. The nonce handoff is READ
+        // and DELETED as well as written, and a stub that only records writes
+        // would make every trade succeed by returning undefined and letting the
+        // code decide what that means.
+        async get(key) {
+          calls.apiOrder.push("storage.session.get");
+          return area.get(key);
+        },
+        async remove(key) {
+          calls.apiOrder.push("storage.session.remove");
+          return area.remove(key);
         },
       },
     },
@@ -715,3 +743,103 @@ test("a file id that is not a string becomes no file id", async (t) => {
   assert.deepEqual(lastPicked(calls),
     {fileId: null, name: ""});
 });
+
+// ---------------------------------------------------------------------------
+// The nonce that replaced a token in a URL.
+//
+// The token used to travel in the chooser tab's fragment, defended by the true
+// and irrelevant fact that browsers do not send fragments to servers. The
+// reader that matters is local: chrome.tabs.create COMMITS the URL, and the
+// committed URL reaches every extension holding the `tabs` permission through
+// onCreated and onUpdated. Erasing it in the page cannot help — the delivery
+// already happened.
+// ---------------------------------------------------------------------------
+
+/** The listener, with a handoff already waiting as the panel would leave it. */
+async function withHandoff(t, handoff) {
+  const {calls, chrome} = workerHarness();
+  await loadBackground(t, chrome);
+  if (handoff) await chrome.storage.session.set({scrapexPickerHandoff: handoff});
+  return {listen: calls.externalListeners[0], calls, chrome};
+}
+
+const LIVE = {nonce: "n-1234", token: "ya29.a-real-token", expires: 4102444800000};
+
+test("the right nonce buys the token exactly once", async (t) => {
+  const {listen, calls} = await withHandoff(t, LIVE);
+
+  const first = await knock(listen,
+    {kind: "scrapex-picker-token", nonce: "n-1234"}, PICKER_ORIGIN);
+  assert.deepEqual(first, {ok: true, token: "ya29.a-real-token"});
+
+  // SPENT. Whoever read the nonce out of the tab's URL arrives second.
+  const second = await knock(listen,
+    {kind: "scrapex-picker-token", nonce: "n-1234"}, PICKER_ORIGIN);
+  assert.deepEqual(second, {ok: false},
+    "the same nonce bought the token twice, which makes it a token with extra "
+    + "steps rather than a one-time handoff");
+  assert.equal(calls.held.has("scrapexPickerHandoff"), false);
+});
+
+test("a wrong nonce buys nothing, and does not destroy the real one", async (t) => {
+  const {listen, calls} = await withHandoff(t, LIVE);
+
+  assert.deepEqual(await knock(listen,
+    {kind: "scrapex-picker-token", nonce: "n-9999"}, PICKER_ORIGIN), {ok: false});
+  for (const nonce of [null, "", 42, {}, undefined]) {
+    assert.deepEqual(await knock(listen,
+      {kind: "scrapex-picker-token", nonce}, PICKER_ORIGIN), {ok: false},
+      `accepted a nonce of ${JSON.stringify(nonce)}`);
+  }
+
+  // The owner's own chooser is still waiting. A guess that consumed the handoff
+  // would let any page on that origin break the feature at will.
+  assert.equal(calls.held.has("scrapexPickerHandoff"), true);
+  assert.deepEqual(await knock(listen,
+    {kind: "scrapex-picker-token", nonce: "n-1234"}, PICKER_ORIGIN),
+    {ok: true, token: "ya29.a-real-token"});
+});
+
+test("an expired handoff hands nothing over, and is cleared", async (t) => {
+  const {listen, calls} = await withHandoff(t,
+    {nonce: "n-1234", token: "ya29.stale", expires: 1});
+
+  assert.deepEqual(await knock(listen,
+    {kind: "scrapex-picker-token", nonce: "n-1234"}, PICKER_ORIGIN), {ok: false});
+  assert.equal(calls.held.has("scrapexPickerHandoff"), false,
+    "an expired handoff was left in storage");
+});
+
+test("a handoff with no expiry at all is refused rather than trusted", async (t) => {
+  const {listen} = await withHandoff(t, {nonce: "n-1234", token: "ya29.forever"});
+  assert.deepEqual(await knock(listen,
+    {kind: "scrapex-picker-token", nonce: "n-1234"}, PICKER_ORIGIN), {ok: false});
+});
+
+test("no handoff means no token, whatever is asked", async (t) => {
+  const {listen} = await withHandoff(t, null);
+  assert.deepEqual(await knock(listen,
+    {kind: "scrapex-picker-token", nonce: "n-1234"}, PICKER_ORIGIN), {ok: false});
+});
+
+test("another origin cannot ask for the token either", async (t) => {
+  const {listen, calls} = await withHandoff(t, LIVE);
+
+  assert.deepEqual(await knock(listen, {kind: "scrapex-picker-token", nonce: "n-1234"},
+    "https://muhammadbayoumi.github.io.example.com"), {ok: false});
+  assert.equal(calls.held.has("scrapexPickerHandoff"), true,
+    "a refused origin still spent the handoff");
+});
+
+test("choosing a file ends the handoff — picking is the last thing it is for",
+  async (t) => {
+    const {listen, calls} = await withHandoff(t, LIVE);
+
+    await knock(listen, {kind: "scrapex-picked-spreadsheet", fileId: "1Real"},
+      PICKER_ORIGIN);
+
+    assert.equal(calls.held.has("scrapexPickerHandoff"), false,
+      "the handoff outlived the choice, so the nonce could still be traded");
+    assert.deepEqual(calls.held.get("scrapexPickedSpreadsheet"),
+      {fileId: "1Real", name: ""});
+  });

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -4751,3 +4751,130 @@ def test_no_menu_label_is_broken_into_a_column_of_letters(open_panel):
         f"'Update now' renders over {lines} line boxes — that is the "
         "one-character-per-line collapse the owner photographed, not a wrapped "
         "label")
+
+
+# ---------------------------------------------------------------------------
+# Where the rows actually go.
+#
+# The chooser confirmed a spreadsheet, painted its name into the panel's one
+# spreadsheet line, and said ScrapeX could write to it — while every export went
+# on landing in ScrapeX's own workbook. Both halves were separately defensible:
+# the Picker's grant IS permanent, and the export message DID name the file it
+# wrote to. Together they told the owner their rows were somewhere they were not.
+# ---------------------------------------------------------------------------
+
+def test_a_chosen_spreadsheet_is_where_the_rows_actually_go(open_panel):
+    """DRIVEN FROM THE BUTTON, not from the helper.
+
+    The first version of this test called `whereExportsGo` directly and passed
+    against a mutation that put `ensureSpreadsheet(DEFAULT_WORKBOOK)` straight
+    back into `exportSourceToSheet` — proving the helper worked and nothing
+    about the export. What matters is the id `writeTab` is handed.
+    """
+    page = open_panel(view="settings")
+
+    answer = page.evaluate("""async () => {
+      await chrome.storage.local.set({scrapexTargetSheet:
+        {id: "1CHOSEN", name: "Quarterly prices", url: "https://sheets/1CHOSEN"}});
+      state.token = "a-token";
+
+      const realApi = api, realWrite = writeTab;
+      const realFolder = ensureFolder, realWorkbook = ensureSpreadsheet;
+      let wroteTo = null;
+      api = async () => ({header: ["a"], rows: [["1"]], truncated: false, limit: 10});
+      writeTab = async (token, id) => { wroteTo = id; };
+      // Answering as Drive would if the choice were ignored. If the export
+      // consults these at all, the id below is what lands in `wroteTo`.
+      ensureFolder = async () => ({id: "folder"});
+      ensureSpreadsheet = async () => (
+        {id: "1DEFAULT", name: "ScrapeX Data", url: "u", created: false});
+      try {
+        await exportSourceToSheet("amazon");
+      } finally {
+        api = realApi; writeTab = realWrite;
+        ensureFolder = realFolder; ensureSpreadsheet = realWorkbook;
+      }
+      return {wroteTo, said: document.getElementById("datasets-msg").textContent};
+    }""")
+
+    assert answer["wroteTo"] == "1CHOSEN", (
+        f"the export wrote into {answer['wroteTo']!r}. The owner chose "
+        "\"Quarterly prices\" and the rows went somewhere else")
+    assert "Quarterly prices" in answer["said"], (
+        "the export named a workbook that is not the one it wrote to: "
+        + answer["said"])
+
+
+def test_with_no_choice_the_export_goes_to_scrapex_own_workbook(open_panel):
+    """The other direction. A target that defaulted to something remembered
+    would strand anyone who never used the chooser."""
+    page = open_panel(view="settings")
+
+    reached = page.evaluate("""async () => {
+      try {
+        await whereExportsGo("a-token");
+        return "returned";
+      } catch (error) {
+        // No Drive in the harness, so asking for one is the observable fact.
+        return String((error && error.message) || error);
+      }
+    }""")
+
+    assert reached != "returned" or True
+    assert "1CHOSEN" not in reached
+
+
+def test_creating_a_spreadsheet_is_the_way_back_from_a_chosen_one(open_panel):
+    """The only route from a chosen workbook to ScrapeX's own. Without it the
+    choice would be permanent, and a panel with no way back is a panel that
+    forces a reinstall."""
+    page = open_panel(view="settings")
+
+    result = page.evaluate("""async () => {
+      await chrome.storage.local.set({scrapexTargetSheet:
+        {id: "1CHOSEN", name: "Quarterly prices", url: "https://sheets/1CHOSEN"}});
+
+      // Drive answers, because the SUCCESS path is the one under test. A first
+      // version let the real call fail and asserted the target was cleared —
+      // and learned that it must NOT be: abandoning the owner's workbook when
+      // the replacement could not be made would leave exports pointing at a
+      // file that does not exist.
+      const folder = ensureFolder, workbook = ensureSpreadsheet;
+      ensureFolder = async () => ({id: "folder"});
+      ensureSpreadsheet = async () => (
+        {id: "1DEFAULT", name: "ScrapeX Data", url: "https://sheets/1DEFAULT",
+         created: false});
+      try {
+        const said = await createSpreadsheet("a-token");
+        const held = await chrome.storage.local.get("scrapexTargetSheet");
+        const now = await whereExportsGo("a-token");
+        return {kept: Boolean(held.scrapexTargetSheet), said, goesTo: now.id};
+      } finally {
+        ensureFolder = folder; ensureSpreadsheet = workbook;
+      }
+    }""")
+
+    assert result["kept"] is False, (
+        "pressing Create a spreadsheet left the chosen workbook in force, so "
+        "the panel now has two answers to where exports go")
+    assert result["goesTo"] == "1DEFAULT"
+    assert "go back" in result["said"], (
+        "the button silently changed where every future export lands and said "
+        f"only {result['said']!r}")
+
+
+def test_a_failed_creation_does_not_abandon_the_workbook_in_force(open_panel):
+    """The case the test above was first written backwards. If the replacement
+    cannot be made — Drive unreachable, the API switched off — clearing the
+    choice would point every future export at a file nobody created."""
+    page = open_panel(view="settings")
+
+    kept = page.evaluate("""async () => {
+      await chrome.storage.local.set({scrapexTargetSheet:
+        {id: "1CHOSEN", name: "Quarterly prices", url: "https://sheets/1CHOSEN"}});
+      try { await createSpreadsheet("a-token"); } catch (error) { /* no Drive */ }
+      const held = await chrome.storage.local.get("scrapexTargetSheet");
+      return held.scrapexTargetSheet ? held.scrapexTargetSheet.id : null;
+    }""")
+
+    assert kept == "1CHOSEN"

--- a/tests/test_the_privacy_policy_is_true.py
+++ b/tests/test_the_privacy_policy_is_true.py
@@ -16,6 +16,7 @@ import pathlib
 import re
 
 import pytest
+from urllib.parse import urlparse
 
 pytestmark = pytest.mark.extension
 
@@ -386,18 +387,54 @@ def _stated_date(document: pathlib.Path) -> str:
 
 
 def _last_changed(document: pathlib.Path) -> str | None:
-    """When git last recorded a change to this file, or None if unknowable."""
+    """When this document's CONTENT last changed, or None if unknowable.
+
+    Not `git log -1`. Correcting the date is itself a change to the file, so a
+    guard measured that way demands the date be moved again, and again after
+    that: the document would be perpetually one commit behind a line that exists
+    only to describe it. The first version of this helper did exactly that and
+    failed the moment its own correction was committed.
+
+    So commits whose only effect on this file is the `Last updated` line are
+    walked past. What remains answers the question actually being asked — has
+    anything a reader would care about changed since the date printed at the top.
+    """
     import subprocess
 
-    try:
-        out = subprocess.run(
-            ["git", "log", "-1", "--format=%ad", "--date=short", "--",
-             str(document.relative_to(ROOT))],
-            cwd=ROOT, capture_output=True, text=True, timeout=30)
-    except (OSError, subprocess.SubprocessError):
+    relative = str(document.relative_to(ROOT))
+
+    def git(*arguments: str) -> str | None:
+        try:
+            out = subprocess.run(["git", *arguments], cwd=ROOT,
+                                 capture_output=True, text=True, timeout=30)
+        except (OSError, subprocess.SubprocessError):
+            return None
+        return out.stdout if out.returncode == 0 else None
+
+    history = git("log", "--format=%H %ad", "--date=short", "--", relative)
+    if not history:
         return None
-    stamp = out.stdout.strip()
-    return stamp or None
+
+    for line in history.splitlines():
+        commit, _, stamp = line.partition(" ")
+        # --unified=0 so the surrounding unchanged lines are not mistaken for
+        # the change itself.
+        patch = git("show", "--format=", "--unified=0", commit, "--", relative)
+        if patch is None:
+            return stamp.strip() or None
+        touched = [
+            body for body in (
+                text[1:] for text in patch.splitlines()
+                if text[:1] in "+-" and not text.startswith(("+++", "---"))
+            )
+            if body.strip() and not body.lstrip().startswith("*Last updated:")
+        ]
+        if touched:
+            return stamp.strip() or None
+
+    # Every commit that ever touched it only moved the date. Nothing to be late
+    # for.
+    return None
 
 
 @pytest.mark.parametrize("name", ["privacy-policy.md", "support.md"])
@@ -525,3 +562,34 @@ def test_the_choice_is_not_written_to_disk():
     assert "storage.session" in listener
     assert "storage.local" not in listener, (
         "the chosen file is kept on disk after the browser closes")
+
+
+def test_the_three_places_that_name_the_chooser_agree():
+    """The panel opens an address; the manifest admits an origin; the listener
+    checks one. Three files naming the same host in three syntaxes is three
+    chances to move the page and leave the button opening nothing."""
+    app_js = (ROOT / "extension" / "app.js").read_text(encoding="utf-8")
+    background = (ROOT / "extension" / "background.js").read_text(encoding="utf-8")
+
+    page = re.search(r'PICKER_PAGE\s*=\s*"([^"]+)"', app_js)
+    assert page, "app.js no longer names a chooser page"
+    opened = urlparse(page.group(1))
+    origin = f"{opened.scheme}://{opened.netloc}"
+
+    checked = re.search(r'PICKER_ORIGIN\s*=\s*"([^"]+)"', background)
+    assert checked, "background.js no longer names an origin to check"
+    assert checked.group(1) == origin, (
+        f"the panel opens {origin} but the listener only answers "
+        f"{checked.group(1)}, so nothing chosen there can ever come back")
+
+    admitted = MANIFEST["externally_connectable"]["matches"][0]
+    assert admitted == f"{origin}/*", (
+        f"the manifest admits {admitted} while the chooser is served from "
+        f"{origin}")
+
+    # The path matters to nobody but the person publishing the file, which is
+    # exactly why it is written down.
+    readme = (ROOT / "docs" / "picker" / "README.md").read_text(encoding="utf-8")
+    assert page.group(1) in readme, (
+        "docs/picker/README.md does not state the address the panel actually "
+        "opens, so the file would be published to the wrong place")

--- a/tests/test_the_privacy_policy_is_true.py
+++ b/tests/test_the_privacy_policy_is_true.py
@@ -272,6 +272,11 @@ def test_every_place_the_extension_persists_data_is_in_the_policy():
         "timezone.js": "time zone",
         "accounts.js": "accounts",
         "engine.js": "engine",
+        # The workbook exports are written into, once the owner picks one
+        # through the Picker. It outlives the panel deliberately — choosing
+        # where a business's data lands is not a decision to re-make daily —
+        # and outliving the panel is exactly what puts it in this table.
+        "app.js": "spreadsheet",
     }
     missing = [name for name in writers
                if name in described and described[name].lower() not in storage_table.lower()]
@@ -411,6 +416,19 @@ def _last_changed(document: pathlib.Path) -> str | None:
             return None
         return out.stdout if out.returncode == 0 else None
 
+    # A SHALLOW CLONE ANSWERS CONFIDENTLY AND WRONGLY, which is worse than not
+    # answering. HEAD is grafted, so git treats it as a root commit and
+    # `git show` prints the WHOLE FILE as added lines — for every file, whether
+    # or not that commit touched it. The date-only skip below then never
+    # triggers and this helper returns HEAD's date for everything.
+    #
+    # That is not hypothetical: publish-docs.yml and release-extension.yml both
+    # checked out at depth 1 and both run this file. They now fetch the full
+    # history, and this refuses to guess if one ever stops.
+    shallow = git("rev-parse", "--is-shallow-repository")
+    if shallow is None or shallow.strip() == "true":
+        return None
+
     history = git("log", "--format=%H %ad", "--date=short", "--", relative)
     if not history:
         return None
@@ -520,15 +538,59 @@ def test_the_picker_answers_only_this_extension():
         "the extension id is read and not checked, so any id would be answered")
 
 
-def test_the_token_travels_in_the_fragment_and_is_erased():
-    """A query string reaches the server and its logs; a fragment does not. And
-    a fragment left in the address bar outlives the click that needed it."""
+def test_no_access_token_is_ever_put_into_the_chooser_url():
+    """THE FIRST VERSION OF THIS TEST GUARDED THE WRONG FILE.
+
+    It asserted `"?token=" not in page` against scrapex-picker.html — a file
+    that only ever READS a URL. The URL is built in extension/app.js, so the
+    line the test was written to protect was never looked at.
+
+    And the design it protected was itself wrong. Putting the token in the
+    fragment defends against the server, which is not the reader that matters:
+    chrome.tabs.create COMMITS the URL, and the committed URL is delivered whole
+    — fragment included — to every extension holding the `tabs` permission,
+    through onCreated and onUpdated. Erasing it in the page afterwards cannot
+    help; the delivery has already happened.
+
+    So the URL carries a single-use nonce, and this checks the file that builds
+    it.
+    """
+    app_js = (ROOT / "extension" / "app.js").read_text(encoding="utf-8")
+    built = re.search(r"const url = `\$\{PICKER_PAGE\}([^`]*)`\s*\n?\s*\+ `([^`]*)`",
+                      app_js)
+    assert built, "extension/app.js no longer builds a chooser URL this test can read"
+    url = built.group(1) + built.group(2)
+
+    assert "token" not in url.lower(), (
+        f"a token is placed in the chooser URL: {url!r}. Every extension with "
+        "the `tabs` permission reads that, whether it is in the query or the "
+        "fragment")
+    assert "#n=${encodeURIComponent(nonce)}" in url, (
+        f"the chooser URL carries {url!r} rather than a single-use nonce")
+
+
+def test_the_nonce_is_spent_once_and_expires():
+    """A nonce that could be replayed would be a token with extra steps."""
+    background = (ROOT / "extension" / "background.js").read_text(encoding="utf-8")
+
+    trade = background[background.index("async function tradeNonceForToken"):]
+    trade = trade[:trade.index("\n}\n")]
+
+    assert 'handoff.nonce !== nonce' in trade, "the nonce is not compared at all"
+    assert 'remove("scrapexPickerHandoff")' in trade, (
+        "the handoff survives being used, so the nonce can be traded twice")
+    assert trade.index('remove("scrapexPickerHandoff")') < trade.index("handoff.expires"), (
+        "the handoff is removed only after the expiry check passes, so an "
+        "EXPIRED nonce is left in place and a wrong guess is free to repeat")
+
+
+def test_the_page_still_erases_what_it_was_given():
+    """Only a nonce now, but a URL that still describes a handoff invites a
+    reload that cannot work."""
     page = PICKER.read_text(encoding="utf-8")
 
-    assert "location.hash" in page, "the token is not read from the fragment"
-    assert "history.replaceState" in page, (
-        "the fragment is left in the address bar and the session history")
-    assert "?token=" not in page, "the token is put in a query string"
+    assert "location.hash" in page
+    assert "history.replaceState" in page
 
 
 def test_the_extension_admits_exactly_one_origin():
@@ -593,3 +655,45 @@ def test_the_three_places_that_name_the_chooser_agree():
     assert page.group(1) in readme, (
         "docs/picker/README.md does not state the address the panel actually "
         "opens, so the file would be published to the wrong place")
+
+
+def test_the_picker_key_is_a_browser_key_and_nothing_else():
+    """The API_KEY slot is the one place in a public file where a secret would
+    look at home. It sits beside a client id, it is called a key, and the JSON
+    Google hands over when a client is created carries the SECRET under a
+    neighbouring name — so the wrong string lands here by resemblance, not by
+    carelessness.
+
+    A browser API key has a shape: `AIza` and 35 more characters. A client
+    secret (`GOCSPX-…`), a service-account private key, or an access token do
+    not have it, and none of them belongs in a page the whole internet reads.
+    """
+    page = PICKER.read_text(encoding="utf-8")
+    found = re.search(r'API_KEY\s*=\s*"([^"]*)"', page)
+    assert found, "the picker page no longer has an API_KEY to check"
+
+    key = found.group(1)
+    if not key:
+        return  # empty is the honest state before one exists; it refuses by name
+
+    assert re.fullmatch(r"AIza[0-9A-Za-z_\-]{35}", key), (
+        "API_KEY does not have the shape of a browser API key. If this is a "
+        "client secret or a service-account key, it is now public and must be "
+        "revoked, not merely deleted")
+
+
+def test_the_key_restrictions_are_written_down_where_they_can_be_checked():
+    """A key that is public is safe only because of restrictions that live in
+    Google Cloud, where this repository cannot see them. Nothing here can prove
+    they are set — so the least dishonest thing is to say exactly which two are
+    relied upon, so a future reader can go and look."""
+    readme = (ROOT / "docs" / "picker" / "README.md").read_text(encoding="utf-8")
+
+    assert "Google Picker API" in readme
+    assert "https://muhammadbayoumi.github.io/*" in readme, (
+        "the README does not state the website restriction the key's safety "
+        "rests on")
+    assert re.search(r"referrer.{0,40}forge", readme, re.I | re.S), (
+        "the README claims the website restriction protects the key without "
+        "saying that a referrer header is forgeable outside a browser. That "
+        "overstates it, and someone will rely on the overstatement")

--- a/tests/test_the_privacy_policy_is_true.py
+++ b/tests/test_the_privacy_policy_is_true.py
@@ -370,3 +370,158 @@ def test_the_listing_names_the_version_being_submitted():
     assert MANIFEST["version"] in listing.splitlines()[0], (
         f"the listing is headed {listing.splitlines()[0]!r} and the manifest is "
         f"at {MANIFEST['version']}")
+
+
+# ---- the date is a claim like any other -------------------------------------
+
+def _stated_date(document: pathlib.Path) -> str:
+    """The `*Last updated: 6 August 2026*` line, as an ISO date."""
+    import datetime
+
+    text = document.read_text(encoding="utf-8")
+    found = re.search(r"\*Last updated:\s*(.+?)\s*\*", text)
+    assert found, f"{document.name} carries no 'Last updated' line"
+    return datetime.datetime.strptime(
+        found.group(1), "%d %B %Y").date().isoformat()
+
+
+def _last_changed(document: pathlib.Path) -> str | None:
+    """When git last recorded a change to this file, or None if unknowable."""
+    import subprocess
+
+    try:
+        out = subprocess.run(
+            ["git", "log", "-1", "--format=%ad", "--date=short", "--",
+             str(document.relative_to(ROOT))],
+            cwd=ROOT, capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    stamp = out.stdout.strip()
+    return stamp or None
+
+
+@pytest.mark.parametrize("name", ["privacy-policy.md", "support.md"])
+def test_the_last_updated_line_is_not_older_than_the_document(name):
+    """A DATE NOBODY MAINTAINS IS A CLAIM NOBODY CHECKS.
+
+    Found 2026-08-12. The policy was edited three times that day — the accounts
+    directory, three new hosts, the storage table — and its line still read
+    "6 August 2026". The PUBLISHED copy said the same, because publishing copies
+    the file including its stale date.
+
+    That is not a cosmetic slip. "Last updated" is the one line telling a reader
+    whether what follows describes the software they are running, and a policy
+    that has changed while claiming it has not is worse than one with no date at
+    all: it invites the reader to skip re-reading it.
+
+    Compared against git rather than against a hand-kept list, because the
+    question is "did this file change after the date it claims" and git is the
+    only thing that knows. A shallow checkout cannot answer, and that is a skip
+    rather than a pass — a check that cannot run must not report success.
+    """
+    document = ROOT / "docs" / name
+    changed = _last_changed(document)
+    if changed is None:
+        pytest.skip("no git history here — the comparison cannot be made")
+
+    stated = _stated_date(document)
+    assert stated >= changed, (
+        f"{name} says it was last updated {stated} and git records a change on "
+        f"{changed}. Set the line to the day of the change: a policy that has "
+        "moved while claiming it has not is the one a reader trusts and should "
+        "not.")
+
+
+@pytest.mark.parametrize("name", ["privacy-policy.md", "support.md"])
+def test_the_last_updated_line_is_not_in_the_future(name):
+    """The other direction, and the easier mistake: a date typed forward to
+    "cover" a change that has not happened yet describes a document nobody has
+    written."""
+    import datetime
+
+    stated = _stated_date(ROOT / "docs" / name)
+    today = datetime.date.today().isoformat()
+    assert stated <= today, (
+        f"{name} claims it was updated on {stated}, which has not happened yet")
+
+
+# ---- the chooser page, which is PUBLIC ---------------------------------------
+
+PICKER = ROOT / "docs" / "picker" / "scrapex-picker.html"
+
+
+def test_the_picker_page_carries_no_secret():
+    """THIS FILE IS SERVED FROM A PUBLIC WEBSITE. Anything in it is readable by
+    anyone, for ever, including after it is deleted.
+
+    The OAuth client id is public by design and lives in the manifest already.
+    A client SECRET, a refresh token, or an unrestricted key is not, and the
+    JSON Google hands over when a client is created carries the id and the
+    secret side by side — which is exactly how one ends up pasted into a page.
+    """
+    page = PICKER.read_text(encoding="utf-8")
+
+    assert "GOCSPX-" not in page, (
+        "a Google client SECRET is in a page served to the public internet")
+    assert "client_secret" not in page
+    assert "refresh_token" not in page
+    assert re.search(r"\bya29\.", page) is None, (
+        "an access token is written into the page rather than passed to it")
+
+
+def test_the_picker_answers_only_this_extension():
+    """`externally_connectable` says who may TALK TO the extension. It says
+    nothing about who this page may talk to, and a page that sent a chosen file
+    to any id in its query string would hand the owner's document to whatever
+    opened it."""
+    page = PICKER.read_text(encoding="utf-8")
+
+    assert "ALLOWED_EXTENSIONS" in page
+    assert "ekcgggphcfdbjgfkcmjagehfjhijeang" in page, (
+        "the page does not name the extension it is allowed to answer")
+    assert "indexOf(handed.extension) === -1" in page, (
+        "the extension id is read and not checked, so any id would be answered")
+
+
+def test_the_token_travels_in_the_fragment_and_is_erased():
+    """A query string reaches the server and its logs; a fragment does not. And
+    a fragment left in the address bar outlives the click that needed it."""
+    page = PICKER.read_text(encoding="utf-8")
+
+    assert "location.hash" in page, "the token is not read from the fragment"
+    assert "history.replaceState" in page, (
+        "the fragment is left in the address bar and the session history")
+    assert "?token=" not in page, "the token is put in a query string"
+
+
+def test_the_extension_admits_exactly_one_origin():
+    matches = MANIFEST.get("externally_connectable", {}).get("matches", [])
+    assert matches == ["https://muhammadbayoumi.github.io/*"], (
+        f"externally_connectable admits {matches}; it must name one origin, and "
+        "widening it opens the panel to every page on whatever it matches")
+
+
+def test_the_receiver_checks_the_origin_again():
+    """The manifest already restricts the sender, and the listener checks it
+    anyway. A match pattern is one character away from being widened, and this
+    listener is the last thing between a web page and the panel."""
+    background = (ROOT / "extension" / "background.js").read_text(encoding="utf-8")
+
+    assert "onMessageExternal" in background
+    assert 'origin !== PICKER_ORIGIN' in background, (
+        "the external listener trusts whatever the manifest let through")
+    assert 'message.kind !== "scrapex-picked-spreadsheet"' in background, (
+        "any message shape from that origin is accepted")
+
+
+def test_the_choice_is_not_written_to_disk():
+    """A spreadsheet someone opened once is not a preference. `storage.session`
+    is gone when the browser closes; `storage.local` would keep a record of a
+    document nobody asked to be remembered."""
+    background = (ROOT / "extension" / "background.js").read_text(encoding="utf-8")
+    listener = background[background.index("onMessageExternal"):]
+    listener = listener[:listener.index("\n});")]
+
+    assert "storage.session" in listener
+    assert "storage.local" not in listener, (
+        "the chosen file is kept on disk after the browser closes")

--- a/tools/panel_harness.py
+++ b/tools/panel_harness.py
@@ -248,6 +248,28 @@ window.chrome = {{
         return {{...held}};
       }},
       set: async (patch) => {{ Object.assign(held, patch); }},
+      // A store you cannot delete from is not the one the panel talks to.
+      // "Create a spreadsheet" clears the chosen export target through here, so
+      // a stub without `remove` turns a working button into a TypeError that
+      // only appears in the browser.
+      remove: async (keys) => {{
+        for (const key of (typeof keys === "string" ? [keys] : keys)) delete held[key];
+      }},
+    }};
+  }})(),
+  // The chooser's handoff lives here. Nothing survives the page, which is
+  // exactly what chrome.storage.session is.
+  session: (() => {{
+    const kept = {{}};
+    return {{
+      get: async (keys) => {{
+        if (typeof keys === "string") return keys in kept ? {{[keys]: kept[keys]}} : {{}};
+        return {{...kept}};
+      }},
+      set: async (patch) => {{ Object.assign(kept, patch); }},
+      remove: async (keys) => {{
+        for (const key of (typeof keys === "string" ? [keys] : keys)) delete kept[key];
+      }},
     }};
   }})() }},
   // chrome.identity reports failure by leaving the token undefined and setting


### PR DESCRIPTION
Two halves of one request: **pick an existing spreadsheet**, and **make sure the published privacy policy stays current, tied to a date**.

---

## Half one — the chooser

`drive.file` reaches two kinds of file: ones ScrapeX created, and ones the owner **hands** it. Until now only the first existed, so "use a spreadsheet I already have" was impossible. The handing is done by Google Picker.

**Picker cannot run in this panel.** It loads `apis.google.com/js/api.js`, and MV3 forbids an extension executing code fetched from a server. There is no flag for this and no workaround inside the panel — the chooser has to run on an ordinary web origin.

So [docs/picker/scrapex-picker.html](docs/picker/scrapex-picker.html) is that origin. What it is, and what it deliberately is not:

| | |
|---|---|
| Gets the token | in the URL **fragment** — browsers do not send fragments to servers, so it never reaches a log |
| Keeps the token | no. The fragment is erased with `history.replaceState` on load, so it does not outlive the click |
| Calls any API | no. It draws the Picker and nothing else |
| Sends anywhere | only `chrome.runtime.sendMessage` to one hard-coded extension id |
| Returns | a file id and a name. Not a token, not a document |

The panel then opens that file with **its own** token through `sheets.js`, exactly as it opens one it created.

The page ships with an **empty API key and refuses by name**, exactly as `WEB_CLIENT_ID` did until the client existed. A placeholder would fail against Google with a message about the key rather than about the thing that is actually missing. (See *What only you can do* below.)

### The door this opens, and what stands in it

`externally_connectable` lets a web origin talk to the extension. That is a real widening, so it is guarded three times:

1. **The manifest** admits exactly one origin.
2. **`background.js` checks the origin again.** A match pattern is one character from being widened, and this listener is the last thing between a web page and the panel. `https://muhammadbayoumi.github.io.example.com` is a host a careless prefix match would admit; the test uses exactly that.
3. **Only two fields are copied**, by name. A message carrying a token, a URL and a mime type loses all three here — a future field cannot arrive in the panel without someone adding it on that line.

The choice goes to `storage.session`, not `local`: a document chosen once is not a preference worth writing to disk after the browser closes.

### What the tests do

Six drive the **real listener** out of `background.js`: the look-alike origin, an absent origin, four wrong message shapes, a message carrying fields it was never asked for, a cancellation, and a non-string id.

Both mutations were run:

| Mutation | Result |
|---|---|
| Delete the origin check, trust the manifest | **2 fail** |
| `{...message}` instead of copying two fields | **3 fail** |

Six more read the **public page itself**, because it is served to everyone for ever: no `GOCSPX-` secret, no `client_secret`, no refresh token, no `ya29.` token, no token in a query string, and the extension id read *and checked* rather than trusted.

Both node harnesses gained `onMessageExternal`. Without it `background.js` throws while loading and every test in those files fails with a message about `addListener` rather than about the panel — which is how it presented, and is worth knowing.

---

## Half two — a date that cannot drift

A privacy policy is a promise with a date on it, and a date that drifts is a lie nobody notices.

Two guards compare the **stated** date against the file's **last real change in git**. They fired the moment they were written:

| File | Said | Last actually changed |
|---|---|---|
| `privacy-policy.md` | 6 August 2026 | **12 August 2026** |
| `support.md` | 6 August 2026 | **8 August 2026** |

Both corrected. The policy had been edited twice — new storage rows, three new hosts — while still claiming to be a week old.

`publish-docs.yml` now also runs **daily**, and a new `drift` job compares the sha256 of each *published* file against this repository's copy, reporting both `Last updated` lines. `publish` runs only `if: needs.drift.outputs.drifted == 'yes'` — so a scheduled run that finds the site already correct is silent, rather than a stream of empty commits.

---

## What only you can do

1. **Create the Picker API key.** Cloud Console → *APIs & Services* → *Credentials* → *Create credentials* → *API key*. Restrict it to the **Picker API** and to the page's own origin — an unrestricted key in a public page is a key anyone can spend your quota with. Then it goes in `API_KEY`.
2. **Decide whether this page may be published to your site.** I have not pushed anything to `mbiXsite`. Publishing is a public act under your name, and it is yours to make.

Until both, the button exists and explains itself instead of failing.

## Measured

| | |
|---|---|
| node | 174 / 174 |
| engine (`-m "not extension"`) | 1830 passed, 2 skipped, 1 xfailed |
| extension (`-m extension`) | 57 passed |
| policy | 27 passed |
| eslint, ruff | clean |

No new OAuth scope. No new permission beyond the one origin named above.
