### PR TITLE
Profile › Checking: the opening frame

### DIFF
--- a/extension/app.css
+++ b/extension/app.css
@@ -1190,6 +1190,86 @@
   @media (max-height: 500px) {
     .profile-card { min-height: auto; }
   }
+
+  /* ---- Profile › Checking -----------------------------------------------
+     The opening frame. No card: this is the one state with nothing to read,
+     and a border around emptiness reads as an error rather than as a wait.
+     The element stays — a test requires all three states inside #profile-card —
+     and only its paint goes, scoped by :has() so the other two states keep the
+     shell they were designed with. */
+  .profile-card:has(#welcome-checking:not(.hidden)) {
+    width: 100%;
+    min-height: 0;
+    max-height: none;
+    margin-block: 0;
+    padding: var(--sp-5);
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+    overflow: visible;
+  }
+  #welcome-checking {
+    flex: 1;
+    justify-content: center;
+  }
+  /* The mark is the same masked box the signed-out state uses; only its size
+     differs here, so the size is all that is restated. */
+  #welcome-checking .welcome-mark {
+    width: 6rem;
+    height: 6rem;
+    background: var(--accent);
+    color: var(--accent);
+  }
+  .checking-copy {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--sp-4);
+  }
+  .checking-name {
+    font-size: var(--fs-2xl);
+    font-weight: var(--fw-bold);
+    letter-spacing: .01em;
+    color: var(--text);
+  }
+  .checking-tagline {
+    max-width: 15rem;
+    font-size: var(--fs-sm);
+    color: var(--muted);
+  }
+
+  /* The bar. Its geometry is TWO custom properties and nothing else: the
+     keyframe below is written in terms of them, so the travel cannot drift out
+     of step with the track the way two hand-repeated pixel values would. */
+  .checking-bar {
+    --checking-track: 10rem;
+    --checking-thumb: 2.5rem;
+    position: relative;
+    width: var(--checking-track);
+    max-width: 100%;
+    height: 3px;
+    overflow: hidden;
+    border-radius: var(--radius-pill);
+    background: var(--line);
+  }
+  .checking-bar-thumb {
+    position: absolute;
+    inset-block: 0;
+    inline-size: var(--checking-thumb);
+    border-radius: var(--radius-pill);
+    background: var(--accent);
+    animation: sx-checking-sweep 1.4s linear infinite;
+  }
+  /* One direction, no bounce: in from the start edge, across, out at the end
+     edge, then again from the start.
+     `inset-inline-start` rather than `translateX`, because a transform is
+     physical and would run backwards under dir="rtl" — the panel is LTR today,
+     and a rule that only works because of that is a trap for the day it is not. */
+  @keyframes sx-checking-sweep {
+    from { inset-inline-start: calc(-1 * var(--checking-thumb)); }
+    to { inset-inline-start: var(--checking-track); }
+  }
   .profile-state {
     display: flex;
     flex-direction: column;
@@ -2999,6 +3079,13 @@
     .m3-switch-track,
     .m3-switch-handle-container,
     .m3-switch-handle { transition: none; }
+    /* Parked at the start edge, not stopped wherever it happened to be. A thumb
+       frozen mid-track reads as stalled — as if the wait had failed — which is
+       the opposite of what this screen is for. */
+    .checking-bar-thumb {
+      animation: none;
+      inset-inline-start: 0;
+    }
   }
 
 /* The install steps, folded. `summary` is a control, so it says so on hover and

--- a/extension/app.html
+++ b/extension/app.html
@@ -1101,10 +1101,33 @@
 
           <!-- Checking: the mark and welcome stay stable; only the status line
                changes. The Google action is hidden until Chrome answers. -->
+          <!-- The panel's opening frame. It is the one screen with nothing to
+               read, and a card frame around emptiness reads as an error — so
+               there is no card here, and no status sentence on screen. -->
           <div class="profile-state" id="welcome-checking">
             <div class="welcome-mark" aria-hidden="true"></div>
-            <h1>Welcome to ScrapeX</h1>
-            <p class="profile-status" role="status" aria-live="polite">
+            <div class="checking-copy">
+              <!-- Not an <h1>: the signed-in greeting owns the panel's heading,
+                   and this state is gone in a second. -->
+              <span class="checking-name">ScrapeX</span>
+              <span class="checking-tagline">where everything begins</span>
+              <div class="checking-bar" aria-hidden="true">
+                <span class="checking-bar-thumb"></span>
+              </div>
+            </div>
+            <!-- KEPT, AND HIDDEN, both halves on purpose.
+                 The design deletes these from the screen, not from the page. A
+                 state with nothing to read is still a state that has to be
+                 ANNOUNCED, and the handoff's own checklist says it is "conveyed
+                 by the existing live region" — this is that region. Deleting it
+                 would leave a screen-reader user in silence while the panel
+                 decides who they are.
+                 Both strings are also read by tests, by exact text:
+                 tests/test_panel_dom.py:3007-3008 and
+                 extension/tests/side-panel-startup.test.mjs:384-385, the second
+                 of which reads the raw file before any script runs. -->
+            <h1 class="visually-hidden">Welcome to ScrapeX</h1>
+            <p class="profile-status visually-hidden" role="status" aria-live="polite">
               Checking your account…
             </p>
           </div>

--- a/extension/tests/diagnostic-app-nomodule.html
+++ b/extension/tests/diagnostic-app-nomodule.html
@@ -1083,8 +1083,15 @@
                changes. The Google action is hidden until Chrome answers. -->
           <div class="profile-state" id="welcome-checking">
             <div class="welcome-mark" aria-hidden="true"></div>
-            <h1>Welcome to ScrapeX</h1>
-            <p class="profile-status" role="status" aria-live="polite">
+            <div class="checking-copy">
+              <span class="checking-name">ScrapeX</span>
+              <span class="checking-tagline">where everything begins</span>
+              <div class="checking-bar" aria-hidden="true">
+                <span class="checking-bar-thumb"></span>
+              </div>
+            </div>
+            <h1 class="visually-hidden">Welcome to ScrapeX</h1>
+            <p class="profile-status visually-hidden" role="status" aria-live="polite">
               Checking your account…
             </p>
           </div>


### PR DESCRIPTION
Implements `design_handoff_checking` (**rev00**), Option C — brand splash — for `#welcome-checking`.

Presentation only: **no JavaScript changed**, `identity.js` untouched, nothing added to the sprite. Three files: `app.html`, `app.css`, and the diagnostic twin.

## The one decision worth your review

The handoff deletes `Checking your account…` and rules out an `<h1>`. **Two tests read both strings by exact text:**

- [test_panel_dom.py:3007-3008](tests/test_panel_dom.py:3007)
- [side-panel-startup.test.mjs:384-385](extension/tests/side-panel-startup.test.mjs:384) — which reads the **raw file, before any script runs**

I kept both and hid them visually — and not to satisfy the tests. This is the one state with nothing to read, which makes it the one state with nothing to **announce**. The handoff's own checklist says the state is "conveyed by the existing live region"; `.profile-status` *is* that region. Deleting it would leave a screen-reader user in silence while the panel decides who they are, in service of a visual change they cannot see.

Measured after the change:

| | |
|---|---|
| `h1` / `.profile-status` rendered box | `1x1` / `1x1` |
| still in the accessibility tree | `checkVisibility()` **true** — clip-based hiding, not `display:none` |
| live region | `aria-live="polite"` |

**If you would rather delete them outright, say so** — it means editing those two tests, which is a call about what the panel owes a screen reader, not a detail.

## The keyframe is not the handoff's — on the handoff's own advice

It proposes `translateX` with positive pixel values, then warns the values must be negated under RTL or the bar runs backwards. `transform` is physical; `inset-inline-start` is not, so **there is nothing to negate and no second rule to keep in step with the first**. Geometry is two custom properties the keyframe is written in terms of, so travel cannot drift out of step with the track.

Reduced motion **parks the thumb at the start edge** rather than stopping it where it happened to be — a bar frozen mid-track reads as stalled, the opposite of what this screen is for. It extends the existing `@media` block rather than adding a competing one.

## Verification

`pytest -m extension` green · `node --test` 181 green.

Measured at 400px and 320px, light and dark:

| | |
|---|---|
| card | `border: 0` · `box-shadow: none` · transparent background |
| brand mark | 96×96, inside the frame at both widths |
| bar | 160×3 |
| thumb travel (4 samples) | 142 → 176 → 209 → 242 — one direction, no bounce |
| `prefers-reduced-motion` | `animation: none`, thumb at offset **0** |
| horizontal overflow | 0 |
| short panel (320×420) | group still centred, nothing overflows |

The `#profile-card` element stays and only its paint goes, scoped with `:has()` — a test requires all three account states to live inside it, and the other two keep the shell they were designed with.

## Correction

An earlier probe of mine for the hidden pair was written `!x > 1`, which JavaScript reads as `(!x) > 1` — always false. It verified nothing. The numbers above come from the replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
