### PR TITLE
The engine stops calling itself dead while it crawls (OP-6 · ت2)

### DIFF
--- a/extension/tests/side-panel-startup.test.mjs
+++ b/extension/tests/side-panel-startup.test.mjs
@@ -18,6 +18,37 @@ const require = createRequire(import.meta.url);
 const DOCUMENT_KEY = "scrapexStartupTraceDocument";
 const HOST_KEY = "scrapexStartupTraceHost";
 
+/**
+ * Remove comments from a script BEFORE searching it for things it must not do.
+ *
+ * THE PREVIOUS VERSION WAS BLIND, AND BLIND IN THE DIRECTION THAT MATTERS.
+ * It was a single global regex meaning "a double slash, then everything up to
+ * the newline", replaced with nothing. The `//` in `https://` is a double
+ * slash, so everything after it went too, INCLUDING a real `fetch(` on the same
+ * line:
+ *
+ *     const u = "https://example.invalid/probe"; fetch(u);
+ *     -> "  const u = \"https:"          and the guard saw no fetch
+ *
+ * A guard cannot be trusted to find what it was written to find unless it fails
+ * when the thing is there. That is what `withoutComments is not blinded by a
+ * URL` below does, and it is the only reason this function is separate from its
+ * caller: a strip embedded in an assertion cannot be driven with a hostile
+ * input.
+ *
+ * WHOLE LINES ONLY. Every comment in diagnostic-panel.js occupies its own line,
+ * and the caller refuses a block comment outright. A trailing `// note` after
+ * code is therefore NOT stripped — which makes the guard stricter (a comment
+ * mentioning `fetch(` beside code would fail loudly) rather than blinder. That
+ * is the correct direction for the trade.
+ */
+function withoutComments(source) {
+  return source
+    .split("\n")
+    .filter((line) => !line.trimStart().startsWith("//"))
+    .join("\n");
+}
+
 function loadTraceFactory() {
   delete require.cache[require.resolve("../startup-trace.js")];
   return require("../startup-trace.js");
@@ -559,8 +590,19 @@ test("the minimal diagnostic page stays minimal", () => {
   assert.ok(!/\bhidden\b|display:\s*none|visibility:\s*hidden|opacity:\s*0/.test(markup),
     "the diagnostic page hides something");
 
-  const script = read("tests/diagnostic-panel.js")
-    .replace(/\/\/[^\n]*/g, "").replace(/\/\*[\s\S]*?\*\//g, "");
+  const source = read("tests/diagnostic-panel.js");
+
+  // A BLOCK COMMENT WOULD MAKE THIS STRIP WRONG, so it is refused rather than
+  // handled. `/* */` stripping has the same hazard the line strip had — a `/*`
+  // inside a string deletes forward to the next `*/` — and the file has never
+  // contained one. Refusing is cheaper than being clever, and it fails LOUDLY
+  // on the day someone adds one instead of quietly stripping too much.
+  assert.ok(!source.includes("/*"),
+    "diagnostic-panel.js grew a block comment; withoutComments() does not "
+    + "handle one, and stripping it with a regex would delete forward past a "
+    + "`*/` inside a string");
+
+  const script = withoutComments(source);
   assert.ok(!/\bfetch\s*\(/.test(script), "the diagnostic page makes a request");
   assert.ok(!/loadAccount|engine|appearance/i.test(script),
     "the diagnostic page runs product startup work");
@@ -843,3 +885,59 @@ test("choosing a file ends the handoff — picking is the last thing it is for",
     assert.deepEqual(calls.held.get("scrapexPickedSpreadsheet"),
       {fileId: "1Real", name: ""});
   });
+
+// ---------------------------------------------------------------------------
+// The guard that guards the guard.
+//
+// `the minimal diagnostic page stays minimal` is the only thing standing between
+// the diagnostic page and quietly regrowing the startup work it exists to
+// exclude. It searches the script for `fetch(` — and for eleven days it could
+// not see one, because its comment strip ate the rest of any line containing a
+// URL. Nothing failed. The suite was green for a page that plainly fetched.
+//
+// So the strip is now driven with the exact input that defeated it.
+// ---------------------------------------------------------------------------
+
+test("withoutComments is not blinded by a URL on the same line", () => {
+  const hostile = [
+    'const u = "https://example.invalid/probe"; fetch(u);',
+    'const v = "http://a/b"; fetch(v);',
+  ].join("\n");
+
+  const stripped = withoutComments(hostile);
+
+  assert.match(stripped, /\bfetch\s*\(/,
+    "a URL's `//` swallowed the rest of the line, so a real fetch( on that line "
+    + "is invisible to every assertion downstream — which is exactly the defect "
+    + "this function was rewritten to remove");
+  assert.equal(stripped.split("\n").length, 2, "lines were lost");
+});
+
+test("withoutComments still removes what it is for", () => {
+  const source = [
+    "// a whole-line comment mentioning fetch( and https://example.com",
+    "   // an indented one too",
+    "const kept = 1;",
+  ].join("\n");
+
+  const stripped = withoutComments(source);
+
+  assert.ok(!/\bfetch\s*\(/.test(stripped),
+    "a comment is being searched as if it were code, which produces the false "
+    + "failures that get a guard deleted");
+  assert.match(stripped, /const kept = 1;/);
+});
+
+test("the diagnostic page's own comments are all whole lines", () => {
+  // The strip's one assumption, checked against the real file rather than
+  // assumed. A trailing `// note` after code would not be stripped, and the
+  // guard would fail loudly on the word `fetch(` in a comment — recoverable,
+  // but the person hitting it deserves to find this test rather than guess.
+  const source = read("tests/diagnostic-panel.js");
+  const trailing = source.split("\n").filter((line) => {
+    const at = line.indexOf("//");
+    return at > 0 && line.slice(0, at).trim() !== "";
+  });
+  assert.deepEqual(trailing, [],
+    "diagnostic-panel.js grew a comment after code on the same line");
+});

--- a/scrapex/jobs.py
+++ b/scrapex/jobs.py
@@ -1045,6 +1045,14 @@ def worker_is_alive(conn: sqlite3.Connection, max_age_s: float = HEARTBEAT_MAX_A
     then hangs forever with a healthy-looking 'queued' status — the worst failure
     mode available. Callers that can only ENQUEUE (the native bridge) must check
     this first and refuse loudly instead.
+
+    IT HAS NO CALLERS. Measured 2026-08-12: `scrapex/native.py` — the caller this
+    docstring names — does not call it, and the last caller in the tree (`_about`
+    in webui/app.py) was moved to `worker_health` because THIS function reads
+    only the runtime heartbeat and therefore calls a busy worker dead. It is left
+    here rather than deleted because the refusal it describes is still missing
+    and still wanted; if the bridge is ever given that guard, it wants
+    `worker_health`'s two-heartbeat verdict, not this one.
     """
     row = conn.execute("SELECT value FROM scrapex_meta WHERE key = ?", (HEARTBEAT_KEY,)).fetchone()
     if row is None or not row[0]:

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -2342,7 +2342,6 @@ def create_app(
         from .. import __version__
         from ..connectors.base import DEFAULT_USER_AGENT
         from ..contract import CONTRACT_VERSION
-        from ..jobs import worker_is_alive
         from ..version import LATEST_SOURCE, MINIMUM_EXTENSION_VERSION, UPDATE_INSTRUCTIONS, VERSION
 
         worker = worker_health(conn)
@@ -2360,7 +2359,15 @@ def create_app(
             "update_instructions": UPDATE_INSTRUCTIONS,
             "contract_version": CONTRACT_VERSION,
             "schema_version": dbmod.schema_version(conn),
-            "worker_alive": worker_is_alive(conn),
+            # THE SAME VERDICT /api/health PUBLISHES, from the `worker` dict
+            # already computed above. It used to call worker_is_alive(), which
+            # reads ONLY the runtime heartbeat — the single-heartbeat answer
+            # worker_health() was written to supersede. So the Settings page
+            # this feeds declared "Not running", and advised the owner to check
+            # whether the engine had started at all, WHILE it was crawling. The
+            # panel read the corrected one and was right; the engine's own page
+            # read the old one and was wrong, which is the worse way round.
+            "worker_alive": worker.get("alive") is True,
             # Says WHY when the answer is no, instead of leaving the owner
             # to infer it from a port that answers regardless.
             "worker": worker,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -436,3 +436,86 @@ def test_the_version_report_without_a_caller_version_judges_nobody(client):
     assert body["installed_extension_version"] is None
     assert body["outdated"] is False and body["missing"] == []
     assert body["capabilities"], "the ledger is empty"
+
+
+def _a_crawl_is_running_but_the_loop_looks_quiet(db_path: Path) -> None:
+    """The exact shape that broke it: a job crawling, its OWN heartbeat fresh,
+    and the runtime heartbeat stale because the loop is busy.
+
+    This is not a contrived state — it is what a long crawl looks like from the
+    outside, and BACKLOG OP-6·ت2 records it costing the owner an afternoon.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    now = datetime.now(UTC)
+    stale = (now - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    fresh = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "INSERT OR REPLACE INTO scrapex_meta (key, value) VALUES ('runtime_heartbeat', ?)",
+            (stale,))
+        # BUILT FROM THE SHIPPED SCHEMA, not from memory, and not from PRAGMA
+        # either: `PRAGMA table_info` reports NOT NULL and defaults but shows no
+        # CHECK constraint at all. BACKLOG OP-17 records that exact trap costing
+        # three wrong fixtures, and the first version of this one repeated it —
+        # `run_mode='full'` is not in the allowed set, and only reading
+        # sqlite_master's CREATE TABLE says so.
+        conn.execute(
+            "INSERT INTO crawl_job (job_ref, run_mode, source_keys, status, "
+            "current_source_key, stage, last_heartbeat_at, started_at) "
+            "VALUES (?, 'update', ?, 'running', ?, ?, ?, ?)",
+            ("job_busy", "ELBUROJ", "ELBUROJ", "fetching", fresh, fresh))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_the_engine_does_not_call_itself_dead_on_its_own_settings_page(client, db_path):
+    """THE PANEL WAS RIGHT AND THE ENGINE'S OWN PAGE WAS WRONG, which is the
+    worse way round: the owner opens Settings precisely when something looks
+    broken.
+
+    There were TWO worker_alive computations. `/api/health` published the
+    two-heartbeat verdict from `worker_health`; `_about` — which renders the
+    Settings page — still called `worker_is_alive`, the single-heartbeat answer
+    that `worker_health` was written to supersede. So while a crawl ran, the
+    engine printed "Not running" beside advice to check whether it had started.
+    """
+    _a_crawl_is_running_but_the_loop_looks_quiet(db_path)
+
+    health = client.get("/api/health").json()
+    assert health["worker_alive"] is True, "the scenario under test did not arise"
+
+    # THE RENDERED PAGE, not the dict behind it. `_about` is a closure with no
+    # JSON route, and the badge is what the owner actually reads — a test on the
+    # dict would pass while the template said the opposite.
+    page = client.get("/settings").text
+    assert "Not running" not in page, (
+        "the engine's own Settings page says the worker is dead while a crawl "
+        "is running — the single-heartbeat verdict is back")
+    assert "Queued jobs wait until a worker is running" not in page, (
+        "the page advises the owner to check whether the engine started, while "
+        "it is crawling")
+    assert "Running" in page, "the badge says nothing at all"
+
+
+def test_the_two_liveness_answers_cannot_drift_apart_again(client, db_path):
+    """The point is not this one state, it is that there is ONE answer. Driven
+    across both directions rather than asserted about the source."""
+    def page_says_running() -> bool:
+        return "Not running" not in client.get("/settings").text
+
+    idle_health = client.get("/api/health").json()["worker_alive"]
+    assert page_says_running() is idle_health, (
+        "with nothing running, the page and /api/health already disagree")
+
+    _a_crawl_is_running_but_the_loop_looks_quiet(db_path)
+
+    busy_health = client.get("/api/health").json()["worker_alive"]
+    assert busy_health != idle_health, (
+        "the state did not actually change, so this test proves nothing")
+    assert page_says_running() is busy_health, (
+        "the page and /api/health drifted apart the moment a crawl started — "
+        "which is the only moment it matters")


### PR DESCRIPTION
Found by the 2026-08-12 backlog re-measurement, and it is a defect the owner can see today.

## Two `worker_alive` computations, and the fix reached one

| where | reads | verdict |
|---|---|---|
| `app.py:1366` — `/api/health` | `worker_health()` — **two** heartbeats | correct; the panel reads this one |
| `app.py:2363` — `_about` | `worker_is_alive()` — **one** heartbeat | the function `worker_health` was written to supersede |

`worker_health`'s own docstring records why the single-heartbeat answer was wrong, measured on 2026-07-28: *job 40 had been crawling ELBUROJ for three hours, 850 requests in, its own heartbeat 4 seconds old, and `/api/health` said `worker_alive false`.* **The harder the engine worked, the deader it looked.**

`_about` renders the engine's own Settings page. So while a crawl ran, that page printed:

> **Job worker** `Not running`
> Queued jobs wait until a worker is running. The worker starts with the engine, and the engine starts when you sign in to Windows.

The panel read the corrected verdict and was right; the engine's own page read the old one and was wrong — the worse way round, because Settings is the page an owner opens *precisely when something looks broken*.

`worker = worker_health(conn)` was already computed three lines above. The whole fix is to use it.

## Tested through the rendered page, not the dict behind it

`_about` is a closure with no JSON route, and the **badge is what the owner reads** — a test on the dict would pass while the template said the opposite.

Both tests drive the real shape: a job `running` with a **fresh** job heartbeat and a **stale** runtime heartbeat, which is simply what a long crawl looks like from outside.

| | |
|---|---|
| mutation — restore `worker_is_alive` | **2 failed** |
| restored | 2 passed |

The second test asserts the two answers move together in **both** directions, and refuses to pass if the state did not actually change — otherwise it would be green against a page that always says the same thing.

## The fixture was wrong twice, in the way this repo already documents

`PRAGMA table_info` reports NOT NULL and defaults but shows **no CHECK constraint at all**, so `run_mode='full'` passed every check I could see and failed against the database. BACKLOG **OP-17** records that exact trap costing three wrong fixtures. The row is now built from `sqlite_master`'s `CREATE TABLE`, and the comment says so.

## `worker_is_alive` now has no callers

Measured — including `native.py`, the caller its own docstring names. Left in place rather than deleted, because the refusal it describes (a bridge that can only enqueue must not enqueue into a database nothing is draining) is **still missing and still wanted**. The docstring now says both, and says that whoever adds that guard wants `worker_health`, not this.

## Verification

1832 engine tests pass (2 new) · ruff clean.