### PR TITLE
The Console opens, and refuses any workbook but the right one (A3)

### DIFF
--- a/contract/addin-contract.json
+++ b/contract/addin-contract.json
@@ -139,6 +139,18 @@
   "constants": {
     "TRANSFORM_SEPARATOR": "|",
     "TRANSFORM_ARGUMENT_SEPARATOR": ":",
-    "BLOCKS_SYNC_FROM": "Error"
+    "BLOCKS_SYNC_FROM": "Error",
+
+    "_comment_uri": [
+      "The three literals SourceUriValidator searches for inside the WHOLE",
+      "address, case-insensitively (SourceUriValidator.cs:80-118). They are",
+      "contract facts exactly like the transform separator above: change one in",
+      "the add-in and every Console warning about an address becomes wrong.",
+      "They live here rather than inline for the same reason the boolean",
+      "spellings do — so a change to the add-in has one place to land."
+    ],
+    "URI_GOOGLE_SHEETS_MARKER": "docs.google.com",
+    "URI_TSV_MARKERS": ["output=tsv", "format=tsv"],
+    "URI_TAB_MARKER": "gid="
   }
 }

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -34,6 +34,7 @@ your email address. The extension contains no telemetry of any kind.
 | The time zone dates are shown in | The same | You |
 | The address of your local engine — `127.0.0.1:8000` unless you change it | The same | You |
 | The spreadsheet you chose for exports — its name, its link, and Google's id for it | The same | You |
+| The spreadsheet holding your Excel add-in's configuration, if you open the Console — its name and id | The same | You |
 
 Nothing in that table leaves your computer unless you press a button that says
 it will.

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,6 +1,6 @@
 # ScrapeX — Privacy Policy
 
-*Last updated: 12 August 2026*
+*Last updated: 13 August 2026*
 
 ScrapeX is a Chrome extension and a companion program, **ScrapeX-Engine**, that
 run on your own computer. This policy describes every piece of data either of

--- a/extension/addin-contract.js
+++ b/extension/addin-contract.js
@@ -31,6 +31,7 @@ import {
   BEHAVIOUR_VERSION, TRUE_SPELLINGS, FALSE_SPELLINGS, CLICKABLE_ACTIONS,
   MENU_ACTIONS, ENTITY_TYPES, STORAGE_STRATEGIES, LICENSE_TIERS, SEMANTIC_ROLES,
   DATA_TYPES, SOURCE_TYPES, MATCH_MODES, SHEETS as CONTRACT_SHEETS,
+  URI_GOOGLE_SHEETS_MARKER,
 } from "./addin-vocabulary.js";
 
 /**
@@ -66,6 +67,34 @@ export function readBoolean(cell, whenUnreadable) {
   if (TRUE_SPELLINGS.includes(value)) return true;
   if (FALSE_SPELLINGS.includes(value)) return false;
   return whenUnreadable;                       // blank AND unrecognised alike
+}
+
+/**
+ * What the add-in makes of an ADDRESS — `SourceUriValidator`'s own test, and a
+ * companion to `readBoolean` above in every sense: a quirk of the add-in
+ * reproduced here so the Console can report it, with the literals read from the
+ * contract rather than written into this line.
+ *
+ * IT IS A SUBSTRING OF THE WHOLE ADDRESS, and that is a defect. The host is
+ * never parsed, so
+ *
+ *     https://attacker.example/?x=docs.google.com&output=tsv
+ *
+ * is "a Google Sheet" as far as the add-in is concerned. It then fetches it
+ * over plain HTTP with NO AUTHENTICATION, following up to five redirects, and
+ * parses whatever returns as the table's rows.
+ *
+ * THIS FUNCTION IS NOT A SECURITY CHECK AND MUST NEVER BE USED AS ONE. It
+ * answers exactly one question — "what will the add-in conclude?" — so the
+ * Console's advice about a TSV format and a gid lands in precisely the cases
+ * the add-in's does. Whether an address IS Google's is decided by parsing the
+ * host, in `checkSourceUri`, which is also where the impostor above is reported.
+ *
+ * The real repair belongs in the add-in's C#; until it lands, the Console is
+ * the only surface that says this out loud.
+ */
+export function readsUriAsGoogleSheets(uri) {
+  return String(uri ?? "").toLowerCase().includes(URI_GOOGLE_SHEETS_MARKER);
 }
 
 /**

--- a/extension/addin-vocabulary.js
+++ b/extension/addin-vocabulary.js
@@ -92,3 +92,13 @@ export const SHEETS = {
 export const TRANSFORM_SEPARATOR = "|";
 export const TRANSFORM_ARGUMENT_SEPARATOR = ":";
 export const BLOCKS_SYNC_FROM = "Error";
+
+// The three literals SourceUriValidator searches for inside the WHOLE
+// address, case-insensitively (SourceUriValidator.cs:80-118). They are
+// contract facts exactly like the transform separator above: change one in
+// the add-in and every Console warning about an address becomes wrong.
+// They live here rather than inline for the same reason the boolean
+// spellings do — so a change to the add-in has one place to land.
+export const URI_GOOGLE_SHEETS_MARKER = "docs.google.com";
+export const URI_TSV_MARKERS = ["output=tsv", "format=tsv"];
+export const URI_TAB_MARKER = "gid=";

--- a/extension/app.html
+++ b/extension/app.html
@@ -1529,13 +1529,35 @@
       </header>
 
       <div class="view-scroll">
-        <p class="planned-note" data-planned="M7">
-          Not built yet, and not part of the published build — this page exists in
-          the owner build only.
-        </p>
+        <!-- THE PANEL IS THE LAUNCHER, NOT THE CONSOLE. Six sheets of
+             configuration are a table editor, and this column is 360px. The
+             Console is an extension page in a tab — same extension, same token,
+             same account, and room to read a row. -->
+        <section class="card" aria-labelledby="console-open-title">
+          <h2 id="console-open-title">The add-in's configuration</h2>
+          <p>
+            Six sheets describe the Excel add-in: its tables, their fields, where
+            each one's data comes from, and how a source column becomes a field.
+            The Console reads them, says what the add-in would make of them, and
+            refuses any workbook that is not the one it actually reads.
+          </p>
+          <div class="row">
+            <button id="console-open" class="button" type="button">
+              Open the Console</button>
+          </div>
+        </section>
 
         <section class="card" aria-labelledby="console-datasets-title">
           <h2 id="console-datasets-title">Datasets</h2>
+          <!-- INSIDE the card it governs, not floating beside three of them.
+               The Console page above reads the add-in's configuration today;
+               publishing a collected dataset OUT to it is not built, and a page
+               where half is real needs the note attached to the half that is
+               not. -->
+          <p class="planned-note" data-planned="M7">
+            Not built yet — this card is a shape. The Console reads the add-in's
+            configuration and reports on it; nothing here writes a dataset out.
+          </p>
           <p>Everything collected, and whether Excel already knows about it.</p>
           <div class="kv"><span>Registered</span><span class="tech">—</span></div>
           <div class="kv"><span>Not registered</span><span class="tech">—</span></div>

--- a/extension/app.js
+++ b/extension/app.js
@@ -5997,6 +5997,11 @@ function wireDeferredControls() {
   });
   $("how").addEventListener("click", () =>
     chrome.tabs.create({ url: chrome.runtime.getURL("onboarding.html") }));
+  // chrome.runtime.getURL, not openTab: openTab prefixes the ENGINE's address,
+  // and the Console has nothing to do with the engine. This one opens a page
+  // that ships inside the extension, so it works with the engine stopped.
+  $("console-open").addEventListener("click", () =>
+    chrome.tabs.create({ url: chrome.runtime.getURL("console.html") }));
   $("open-browse").addEventListener("click", () => openTab("/"));
   // The workspace opens with the Storage section already expanded, so the link
   // lands on what it promised rather than on a wall of closed rows.

--- a/extension/console.css
+++ b/extension/console.css
@@ -141,3 +141,100 @@ body {
   .finding { grid-template-columns: 1fr; }
   .finding-where { white-space: normal; }
 }
+
+/* ---- the source list --------------------------------------------------------
+   Buttons, not rows with a click handler: this is a list you navigate with a
+   keyboard as much as with a mouse, and a div that listens for clicks is
+   reachable by neither Tab nor Enter. */
+
+.source-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  margin-block-start: var(--sp-3);
+}
+
+.source-row {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr) auto;
+  gap: var(--sp-3);
+  align-items: center;
+  width: 100%;
+  padding: var(--sp-2) var(--sp-3);
+  border: 0;
+  border-inline-start: 3px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: start;
+  cursor: pointer;
+}
+
+.source-row:hover,
+.source-row:focus-visible { background: var(--surface-subtle); }
+
+/* The same two colours the findings list uses, and for the same two meanings —
+   a third vocabulary for the same distinction would have to be learned twice. */
+.source-stopped { border-inline-start-color: var(--red); }
+.source-noted { border-inline-start-color: var(--amber); }
+
+.source-key {
+  overflow: hidden;
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.source-into,
+.source-verdict {
+  font-size: var(--fs-xs);
+  color: var(--muted);
+}
+
+.source-verdict { justify-self: end; }
+
+/* ---- the editor ------------------------------------------------------------ */
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+  margin-block-start: var(--sp-3);
+}
+
+.field label {
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-medium);
+}
+
+.field input,
+.field select {
+  padding: var(--sp-2) var(--sp-3);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--control-bg);
+  color: var(--text);
+  font: inherit;
+  font-size: var(--fs-sm);
+}
+
+.field input:focus-visible,
+.field select:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 1px;
+}
+
+/* The note sits UNDER its own control, not in a summary at the bottom. A list
+   of faults away from the fields they belong to is a list you read once and
+   then hunt through. */
+.field-note {
+  margin: 0;
+  font-size: var(--fs-xs);
+  color: var(--muted);
+}
+
+.field-note:empty { display: none; }
+.note-error { color: var(--red); }
+.note-warn { color: var(--amber); }

--- a/extension/console.css
+++ b/extension/console.css
@@ -1,0 +1,143 @@
+/* The Console's own page.
+ *
+ * NOT app.css. That file makes `body` a two-column grid with a column reserved
+ * for the side rail — "Nothing may widen the panel", in its own words. A
+ * full-width tab page that loaded it would inherit a rail that is not there.
+ * tokens.css and components.css carry everything shared; this carries only what
+ * a wide page needs and the panel does not. */
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-sans);
+  font-size: var(--fs-md);
+  line-height: 1.55;
+}
+
+/* A reading measure, not the whole window. A findings list stretched across a
+   27-inch monitor is a list nobody finishes a line of. */
+.console-head,
+.console-body {
+  max-width: 60rem;
+  margin-inline: auto;
+  padding-inline: var(--sp-5);
+}
+
+.console-head {
+  padding-block: var(--sp-6) var(--sp-4);
+}
+
+.console-title {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+}
+
+.console-title h1 {
+  margin: 0;
+  font-size: var(--fs-xl);
+  font-weight: var(--fw-bold);
+}
+
+.console-title .sx-icon {
+  width: 1.5rem;
+  height: 1.5rem;
+  color: var(--accent);
+}
+
+.console-lede {
+  margin: var(--sp-2) 0 0;
+  color: var(--muted);
+}
+
+.console-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-4);
+  padding-block-end: var(--sp-6);
+}
+
+/* ---- findings -------------------------------------------------------------
+   The severity is carried by a border rather than a background, so a long list
+   stays readable: fifteen tinted blocks in a column is a wall, and the eye
+   stops separating them. */
+
+.findings {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  margin-block-start: var(--sp-3);
+}
+
+.finding {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--sp-1) var(--sp-3);
+  padding: var(--sp-3);
+  border-inline-start: 3px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface-subtle);
+}
+
+.finding-broken { border-inline-start-color: var(--red); }
+.finding-unused { border-inline-start-color: var(--amber); }
+
+.finding-where {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.finding-kind {
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-medium);
+  text-transform: lowercase;
+}
+
+.finding-detail {
+  grid-column: 1 / -1;
+  margin: 0;
+  font-size: var(--fs-sm);
+}
+
+/* ---- the six sheets -------------------------------------------------------- */
+
+.sheet-rows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+  margin-block-start: var(--sp-3);
+}
+
+.sheet-row {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  padding-block: var(--sp-2);
+  border-block-end: 1px solid var(--line);
+}
+
+.sheet-row:last-of-type { border-block-end: 0; }
+
+.sheet-name {
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+}
+
+.sheet-count {
+  font-size: var(--fs-sm);
+  color: var(--muted);
+}
+
+/* A narrow window is a real case here — the owner may keep this tab beside the
+   panel rather than full width. */
+@media (max-width: 40rem) {
+  .console-head,
+  .console-body { padding-inline: var(--sp-3); }
+
+  .finding { grid-template-columns: 1fr; }
+  .finding-where { white-space: normal; }
+}

--- a/extension/console.css
+++ b/extension/console.css
@@ -9,6 +9,11 @@
 body {
   margin: 0;
   min-height: 100vh;
+  /* THE SHELL: a fixed rail and one scrolling screen. The rail does not scroll
+     with the content, because a navigation you have to scroll back to find is
+     a navigation you stop using. */
+  display: grid;
+  grid-template-columns: 15rem minmax(0, 1fr);
   background: var(--bg);
   color: var(--text);
   font-family: var(--font-sans);
@@ -16,47 +21,177 @@ body {
   line-height: 1.55;
 }
 
-/* A reading measure, not the whole window. A findings list stretched across a
-   27-inch monitor is a list nobody finishes a line of. */
-.console-head,
-.console-body {
-  max-width: 60rem;
-  margin-inline: auto;
-  padding-inline: var(--sp-5);
+.console-rail {
+  display: flex;
+  position: sticky;
+  top: 0;
+  flex-direction: column;
+  gap: var(--sp-4);
+  height: 100vh;
+  padding: var(--sp-4) var(--sp-3);
+  border-inline-end: 1px solid var(--line);
+  background: var(--surface);
 }
 
-.console-head {
-  padding-block: var(--sp-6) var(--sp-4);
-}
-
-.console-title {
+.rail-brand {
   display: flex;
   align-items: center;
-  gap: var(--sp-3);
+  gap: var(--sp-2);
+  padding-inline: var(--sp-2);
+  font-size: var(--fs-lg);
+  font-weight: var(--fw-bold);
 }
 
-.console-title h1 {
+.rail-brand .sx-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  color: var(--accent);
+}
+
+.rail-group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.rail-link {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: var(--sp-2);
+  align-items: center;
+  padding: var(--sp-2) var(--sp-2);
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: var(--fs-sm);
+  text-align: start;
+  cursor: pointer;
+}
+
+.rail-link .sx-icon { width: 1.125rem; height: 1.125rem; }
+.rail-link:hover { background: var(--surface-subtle); color: var(--text); }
+
+/* Selected state on the ARIA attribute, not on a class the script has to
+   remember to keep in step with it. One source, and screen readers read the
+   same thing the eye does. */
+.rail-link[aria-selected="true"] {
+  background: var(--accent-weak);
+  color: var(--accent-ink);
+  font-weight: var(--fw-medium);
+}
+
+.rail-count {
+  font-size: var(--fs-2xs);
+  font-variant-numeric: tabular-nums;
+  opacity: .8;
+}
+
+.rail-foot {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  margin-block-start: auto;
+  padding-inline: var(--sp-2);
+}
+
+.rail-book {
+  margin: 0;
+  overflow: hidden;
+  font-size: var(--fs-xs);
+  color: var(--muted);
+  text-overflow: ellipsis;
+}
+
+.console-main {
+  height: 100vh;
+  padding: var(--sp-5) var(--sp-5) var(--sp-6);
+  overflow-y: auto;
+}
+
+/* Every screen shares one reading measure. A findings list stretched across a
+   27-inch monitor is a list nobody finishes a line of. */
+.cv {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-4);
+  max-width: 58rem;
+}
+
+.cv-head h1 {
   margin: 0;
   font-size: var(--fs-xl);
   font-weight: var(--fw-bold);
 }
 
-.console-title .sx-icon {
-  width: 1.5rem;
-  height: 1.5rem;
-  color: var(--accent);
-}
-
-.console-lede {
-  margin: var(--sp-2) 0 0;
+.cv-head p {
+  margin: var(--sp-1) 0 0;
   color: var(--muted);
 }
 
-.console-body {
+.link-back {
+  margin-block-end: var(--sp-2);
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--accent-ink);
+  font: inherit;
+  font-size: var(--fs-sm);
+  cursor: pointer;
+}
+
+.inspect-body {
   display: flex;
   flex-direction: column;
   gap: var(--sp-4);
-  padding-block-end: var(--sp-6);
+}
+
+/* ---- two-column lists, shared by ScrapeX, Tables and Inspect --------------- */
+
+.pair-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  margin-block-start: var(--sp-3);
+}
+
+.pair-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(0, 1.4fr) auto;
+  gap: var(--sp-3);
+  align-items: baseline;
+  width: 100%;
+  padding: var(--sp-2) var(--sp-3);
+  border: 0;
+  border-inline-start: 3px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: start;
+}
+
+button.pair-row { cursor: pointer; }
+button.pair-row:hover,
+button.pair-row:focus-visible { background: var(--surface-subtle); }
+
+.pair-missing { border-inline-start-color: var(--red); }
+.pair-off { opacity: .65; }
+
+.pair-key {
+  overflow: hidden;
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  text-overflow: ellipsis;
+}
+
+.pair-into { font-size: var(--fs-sm); }
+
+.pair-note {
+  justify-self: end;
+  font-size: var(--fs-xs);
+  color: var(--muted);
 }
 
 /* ---- findings -------------------------------------------------------------
@@ -134,12 +269,18 @@ body {
 
 /* A narrow window is a real case here — the owner may keep this tab beside the
    panel rather than full width. */
-@media (max-width: 40rem) {
-  .console-head,
-  .console-body { padding-inline: var(--sp-3); }
-
+/* A narrow window is a real case: the owner may keep this tab beside the panel
+   rather than full width. The rail loses its labels before it loses itself. */
+@media (max-width: 56rem) {
+  body { grid-template-columns: 3.25rem minmax(0, 1fr); }
+  .rail-link { grid-template-columns: auto; justify-items: center; }
+  .rail-link span:not(.rail-count) { display: none; }
+  .rail-brand span,
+  .rail-foot { display: none; }
+  .console-main { padding-inline: var(--sp-3); }
   .finding { grid-template-columns: 1fr; }
   .finding-where { white-space: normal; }
+  .pair-row { grid-template-columns: 1fr; }
 }
 
 /* ---- the source list --------------------------------------------------------

--- a/extension/console.html
+++ b/extension/console.html
@@ -67,12 +67,108 @@
       <div id="findings-list" class="findings"></div>
     </section>
 
+    <!-- THE FIRST SHEET THAT CAN BE EDITED. Data sources first because it is
+         where a new source is added and where the commonest mistake lives — an
+         address with no TSV format, which the add-in reports as a problem with
+         the DATA rather than with the address. -->
+    <section class="card hidden" id="sources-card" aria-labelledby="sources-title">
+      <h2 id="sources-title">Data sources</h2>
+      <p class="hint" id="sources-summary" role="status" aria-live="polite"></p>
+      <div id="sources-list" class="source-rows"></div>
+      <div class="row">
+        <button id="source-add" class="button ghost" type="button">
+          Add a source</button>
+      </div>
+    </section>
+
+    <!-- The editor. One row at a time: a grid of every source at once would be
+         the Google Sheets this page exists to replace. -->
+    <section class="card hidden" id="editor-card" aria-labelledby="editor-title">
+      <h2 id="editor-title">Editing</h2>
+      <p class="hint" id="editor-where"></p>
+
+      <div class="field">
+        <label for="f-SOURCE_KEY">Source key</label>
+        <input id="f-SOURCE_KEY" type="text" autocomplete="off">
+        <p class="field-note" id="n-SOURCE_KEY"></p>
+      </div>
+
+      <div class="field">
+        <label for="f-TARGET_ENTITY_KEY">Table it loads into</label>
+        <select id="f-TARGET_ENTITY_KEY"></select>
+        <p class="field-note" id="n-TARGET_ENTITY_KEY"></p>
+      </div>
+
+      <div class="field">
+        <label for="f-PROFILE_KEY">Mapping profile</label>
+        <select id="f-PROFILE_KEY"></select>
+        <p class="field-note" id="n-PROFILE_KEY"></p>
+      </div>
+
+      <div class="field">
+        <label for="f-SOURCE_URI">Address</label>
+        <input id="f-SOURCE_URI" type="text" autocomplete="off" spellcheck="false">
+        <p class="field-note" id="n-SOURCE_URI"></p>
+      </div>
+
+      <div class="field">
+        <label for="f-DISPLAY_LABEL">Label</label>
+        <input id="f-DISPLAY_LABEL" type="text" autocomplete="off">
+        <p class="field-note" id="n-DISPLAY_LABEL"></p>
+      </div>
+
+      <div class="field">
+        <label for="f-SOURCE_REGION">Region</label>
+        <select id="f-SOURCE_REGION"></select>
+        <p class="field-note" id="n-SOURCE_REGION"></p>
+      </div>
+
+      <div class="field">
+        <label for="f-IS_ACTIVE">Active</label>
+        <!-- A CLOSED LIST, and this is the one field where that matters most:
+             the add-in accepts sixteen spellings and treats a seventeenth as
+             TRUE without recording anything. A typo here switches a table on. -->
+        <select id="f-IS_ACTIVE">
+          <option value="TRUE">TRUE</option>
+          <option value="FALSE">FALSE</option>
+        </select>
+        <p class="field-note" id="n-IS_ACTIVE"></p>
+      </div>
+
+      <div class="field">
+        <label for="f-MIN_LICENSE_REQ">Minimum licence</label>
+        <select id="f-MIN_LICENSE_REQ"></select>
+        <p class="field-note" id="n-MIN_LICENSE_REQ"></p>
+      </div>
+
+      <div class="field">
+        <label for="f-VERSION_TAG">Version tag</label>
+        <input id="f-VERSION_TAG" type="text" autocomplete="off">
+        <p class="field-note">
+          Nothing validates this. It is one input to the add-in's own
+          change-detection hash, so moving it forces a re-download.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="f-CONTEXT_PROPS">Context properties (JSON)</label>
+        <input id="f-CONTEXT_PROPS" type="text" autocomplete="off" spellcheck="false">
+        <p class="field-note" id="n-CONTEXT_PROPS"></p>
+      </div>
+
+      <p id="editor-verdict" class="hint" role="status" aria-live="polite"></p>
+      <div class="row">
+        <button id="editor-save" class="button" type="button">Save to the sheet</button>
+        <button id="editor-cancel" class="button ghost" type="button">Cancel</button>
+      </div>
+    </section>
+
     <section class="card hidden" id="sheets-card" aria-labelledby="sheets-title">
       <h2 id="sheets-title">The six sheets</h2>
       <div id="sheets-list" class="sheet-rows"></div>
       <p class="hint">
-        Editing arrives one sheet at a time, beginning with Data sources. Until
-        then this page reads and checks; it writes nothing.
+        Data sources can be edited above. The other five are read and checked
+        here; editing them arrives one sheet at a time.
       </p>
     </section>
 

--- a/extension/console.html
+++ b/extension/console.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Console — ScrapeX</title>
+<!--
+  THE CONSOLE. An extension page, opened in a TAB from the side rail.
+
+  Not a page on a website, and not a view in the panel. Not a website because
+  the token would then have to leave the extension, and the widening in
+  `externally_connectable` that the Picker needs is not something to repeat for
+  a surface that does not need it — the Sheets API is a plain fetch that
+  `host_permissions` already covers. Not a panel view because this is a table
+  editor and the panel is 360px wide.
+
+  It edits the mbiXaddin CONFIGURATION WORKBOOK: six tabs that describe an Excel
+  add-in entirely. Editing them by hand in Google Sheets is editing a database
+  through a text box, and a mistake surfaces as a table that fails to load in
+  front of whoever is using Excel that morning.
+
+  THE ENGINE IS NOT INVOLVED. No route, no Python, no 127.0.0.1 anywhere in this
+  page's path. The owner's ruling, restated 2026-08-12.
+-->
+<link rel="stylesheet" href="tokens.css">
+<link rel="stylesheet" href="components.css">
+<link rel="stylesheet" href="console.css">
+</head>
+<body>
+  <header class="console-head">
+    <div class="console-title">
+      <svg class="sx-icon" aria-hidden="true">
+        <use href="icons/material-icons.svg#file-upload"></use>
+      </svg>
+      <h1>Console</h1>
+    </div>
+    <p class="console-lede">
+      The configuration the Excel add-in reads — checked before it is changed.
+    </p>
+  </header>
+
+  <main class="console-body">
+
+    <!-- STEP ONE, AND IT IS A REAL STEP. The add-in reads one specific
+         spreadsheet, identified by six tab ids compiled into its own build. A
+         Console pointed at a different file would check it happily and report
+         that everything is fine about a workbook nobody reads. -->
+    <section class="card" aria-labelledby="workbook-title">
+      <h2 id="workbook-title">The workbook</h2>
+      <p id="workbook-state" class="hint" role="status" aria-live="polite">
+        Checking your Google account…
+      </p>
+      <div class="row">
+        <button id="workbook-choose" class="button" type="button" hidden>
+          Choose the configuration workbook</button>
+        <button id="workbook-recheck" class="button ghost" type="button" hidden>
+          Check it again</button>
+      </div>
+      <p id="workbook-identity" class="hint"></p>
+    </section>
+
+    <!-- WHAT IS WRONG, BEFORE ANYTHING IS EDITED. The order is deliberate: a
+         Console that opened on an editor would invite a change while the file
+         already had faults nobody had been shown. -->
+    <section class="card hidden" id="findings-card" aria-labelledby="findings-title">
+      <h2 id="findings-title">What the add-in would make of this</h2>
+      <p id="findings-summary" class="hint" role="status" aria-live="polite"></p>
+      <div id="findings-list" class="findings"></div>
+    </section>
+
+    <section class="card hidden" id="sheets-card" aria-labelledby="sheets-title">
+      <h2 id="sheets-title">The six sheets</h2>
+      <div id="sheets-list" class="sheet-rows"></div>
+      <p class="hint">
+        Editing arrives one sheet at a time, beginning with Data sources. Until
+        then this page reads and checks; it writes nothing.
+      </p>
+    </section>
+
+  </main>
+
+  <!-- appearance.js FIRST, and as a classic script. It is what puts
+       `data-theme` on the document, and a module would run after first paint —
+       the onboarding page shipped that way once and ignored the owner's palette
+       entirely. -->
+  <script src="appearance.js"></script>
+  <script type="module" src="console.js"></script>
+</body>
+</html>

--- a/extension/console.html
+++ b/extension/console.html
@@ -6,17 +6,15 @@
 <!--
   THE CONSOLE. An extension page, opened in a TAB from the side rail.
 
-  Not a page on a website, and not a view in the panel. Not a website because
-  the token would then have to leave the extension, and the widening in
-  `externally_connectable` that the Picker needs is not something to repeat for
-  a surface that does not need it — the Sheets API is a plain fetch that
-  `host_permissions` already covers. Not a panel view because this is a table
-  editor and the panel is 360px wide.
+  Not a page on a website, because the token would then have to leave the
+  extension. Not a view in the panel, because six sheets of configuration are a
+  table editor and the panel is 360px.
 
-  It edits the mbiXaddin CONFIGURATION WORKBOOK: six tabs that describe an Excel
-  add-in entirely. Editing them by hand in Google Sheets is editing a database
-  through a text box, and a mistake surfaces as a table that fails to load in
-  front of whoever is using Excel that morning.
+  IT IS AN APPLICATION, NOT A PAGE. A rail on the left, one screen at a time,
+  and the workbook read ONCE and shared between them. The shape is deliberately
+  the panel's own — `showView`, a registry of screen names, a rail whose buttons
+  carry `data-view` — because a second navigation idiom in the same product is a
+  second thing to learn for no gain.
 
   THE ENGINE IS NOT INVOLVED. No route, no Python, no 127.0.0.1 anywhere in this
   page's path. The owner's ruling, restated 2026-08-12.
@@ -26,24 +24,73 @@
 <link rel="stylesheet" href="console.css">
 </head>
 <body>
-  <header class="console-head">
-    <div class="console-title">
+
+<nav class="console-rail" aria-label="Console sections">
+  <div class="rail-brand">
+    <svg class="sx-icon" aria-hidden="true">
+      <use href="icons/material-icons.svg#file-upload"></use>
+    </svg>
+    <span>Console</span>
+  </div>
+
+  <div class="rail-group" role="tablist" aria-label="Sections">
+    <button class="rail-link" id="cv-tab-overview" role="tab" data-view="overview"
+            aria-controls="cv-overview" aria-selected="true">
       <svg class="sx-icon" aria-hidden="true">
-        <use href="icons/material-icons.svg#file-upload"></use>
+        <use href="icons/material-icons.svg#dashboard"></use>
       </svg>
-      <h1>Console</h1>
-    </div>
-    <p class="console-lede">
-      The configuration the Excel add-in reads — checked before it is changed.
-    </p>
-  </header>
+      <span>Overview</span>
+    </button>
+    <button class="rail-link" id="cv-tab-scrapex" role="tab" data-view="scrapex"
+            aria-controls="cv-scrapex" aria-selected="false" tabindex="-1">
+      <svg class="sx-icon" aria-hidden="true">
+        <use href="icons/material-icons.svg#storage"></use>
+      </svg>
+      <span>ScrapeX</span>
+      <span class="rail-count" id="count-scrapex"></span>
+    </button>
+    <button class="rail-link" id="cv-tab-tables" role="tab" data-view="tables"
+            aria-controls="cv-tables" aria-selected="false" tabindex="-1">
+      <svg class="sx-icon" aria-hidden="true">
+        <use href="icons/material-icons.svg#view-column"></use>
+      </svg>
+      <span>Tables</span>
+      <span class="rail-count" id="count-tables"></span>
+    </button>
+    <button class="rail-link" id="cv-tab-sources" role="tab" data-view="sources"
+            aria-controls="cv-sources" aria-selected="false" tabindex="-1">
+      <svg class="sx-icon" aria-hidden="true">
+        <use href="icons/material-icons.svg#link"></use>
+      </svg>
+      <span>Sources</span>
+      <span class="rail-count" id="count-sources"></span>
+    </button>
+    <button class="rail-link" id="cv-tab-problems" role="tab" data-view="problems"
+            aria-controls="cv-problems" aria-selected="false" tabindex="-1">
+      <svg class="sx-icon" aria-hidden="true">
+        <use href="icons/material-icons.svg#info"></use>
+      </svg>
+      <span>Problems</span>
+      <span class="rail-count" id="count-problems"></span>
+    </button>
+  </div>
 
-  <main class="console-body">
+  <div class="rail-foot">
+    <p class="rail-book" id="rail-book"></p>
+    <button class="button ghost" id="workbook-recheck" type="button" hidden>
+      Re-read</button>
+  </div>
+</nav>
 
-    <!-- STEP ONE, AND IT IS A REAL STEP. The add-in reads one specific
-         spreadsheet, identified by six tab ids compiled into its own build. A
-         Console pointed at a different file would check it happily and report
-         that everything is fine about a workbook nobody reads. -->
+<main class="console-main">
+
+  <!-- ── Overview ─────────────────────────────────────────────────────────── -->
+  <section id="cv-overview" class="cv" role="tabpanel" aria-labelledby="cv-tab-overview">
+    <header class="cv-head">
+      <h1>Overview</h1>
+      <p>The configuration the Excel add-in reads — checked before it is changed.</p>
+    </header>
+
     <section class="card" aria-labelledby="workbook-title">
       <h2 id="workbook-title">The workbook</h2>
       <p id="workbook-state" class="hint" role="status" aria-live="polite">
@@ -52,37 +99,67 @@
       <div class="row">
         <button id="workbook-choose" class="button" type="button" hidden>
           Choose the configuration workbook</button>
-        <button id="workbook-recheck" class="button ghost" type="button" hidden>
-          Check it again</button>
       </div>
       <p id="workbook-identity" class="hint"></p>
     </section>
 
-    <!-- WHAT IS WRONG, BEFORE ANYTHING IS EDITED. The order is deliberate: a
-         Console that opened on an editor would invite a change while the file
-         already had faults nobody had been shown. -->
-    <section class="card hidden" id="findings-card" aria-labelledby="findings-title">
-      <h2 id="findings-title">What the add-in would make of this</h2>
-      <p id="findings-summary" class="hint" role="status" aria-live="polite"></p>
-      <div id="findings-list" class="findings"></div>
+    <section class="card hidden" id="sheets-card" aria-labelledby="sheets-title">
+      <h2 id="sheets-title">The six sheets</h2>
+      <div id="sheets-list" class="sheet-rows"></div>
     </section>
+  </section>
 
-    <!-- THE FIRST SHEET THAT CAN BE EDITED. Data sources first because it is
-         where a new source is added and where the commonest mistake lives — an
-         address with no TSV format, which the add-in reports as a problem with
-         the DATA rather than with the address. -->
-    <section class="card hidden" id="sources-card" aria-labelledby="sources-title">
+  <!-- ── ScrapeX ──────────────────────────────────────────────────────────── -->
+  <section id="cv-scrapex" class="cv hidden" role="tabpanel" aria-labelledby="cv-tab-scrapex">
+    <header class="cv-head">
+      <h1>ScrapeX</h1>
+      <p>What this tool collects, and whether the add-in knows about it.</p>
+    </header>
+    <section class="card" aria-labelledby="scrapex-title">
+      <h2 id="scrapex-title">Collected sources</h2>
+      <p class="hint" id="scrapex-summary" role="status" aria-live="polite"></p>
+      <div id="scrapex-list" class="pair-rows"></div>
+    </section>
+  </section>
+
+  <!-- ── Tables ───────────────────────────────────────────────────────────── -->
+  <section id="cv-tables" class="cv hidden" role="tabpanel" aria-labelledby="cv-tab-tables">
+    <header class="cv-head">
+      <h1>Tables</h1>
+      <p>Every table the add-in defines. Choose one to see it across all six sheets.</p>
+    </header>
+    <section class="card" aria-labelledby="tables-title">
+      <h2 id="tables-title">Defined</h2>
+      <div id="tables-list" class="pair-rows"></div>
+    </section>
+  </section>
+
+  <!-- ── One table, across every sheet ────────────────────────────────────── -->
+  <section id="cv-inspect" class="cv hidden" role="tabpanel" aria-labelledby="cv-tab-tables">
+    <header class="cv-head">
+      <button class="link-back" id="inspect-back" type="button">← Tables</button>
+      <h1 id="inspect-name">—</h1>
+      <p id="inspect-lede"></p>
+    </header>
+    <div id="inspect-body" class="inspect-body"></div>
+  </section>
+
+  <!-- ── Sources ──────────────────────────────────────────────────────────── -->
+  <section id="cv-sources" class="cv hidden" role="tabpanel" aria-labelledby="cv-tab-sources">
+    <header class="cv-head">
+      <h1>Sources</h1>
+      <p>Where each table's rows come from. This is the sheet that can be edited.</p>
+    </header>
+
+    <section class="card" aria-labelledby="sources-title">
       <h2 id="sources-title">Data sources</h2>
       <p class="hint" id="sources-summary" role="status" aria-live="polite"></p>
       <div id="sources-list" class="source-rows"></div>
       <div class="row">
-        <button id="source-add" class="button ghost" type="button">
-          Add a source</button>
+        <button id="source-add" class="button ghost" type="button">Add a source</button>
       </div>
     </section>
 
-    <!-- The editor. One row at a time: a grid of every source at once would be
-         the Google Sheets this page exists to replace. -->
     <section class="card hidden" id="editor-card" aria-labelledby="editor-title">
       <h2 id="editor-title">Editing</h2>
       <p class="hint" id="editor-where"></p>
@@ -92,37 +169,31 @@
         <input id="f-SOURCE_KEY" type="text" autocomplete="off">
         <p class="field-note" id="n-SOURCE_KEY"></p>
       </div>
-
       <div class="field">
         <label for="f-TARGET_ENTITY_KEY">Table it loads into</label>
         <select id="f-TARGET_ENTITY_KEY"></select>
         <p class="field-note" id="n-TARGET_ENTITY_KEY"></p>
       </div>
-
       <div class="field">
         <label for="f-PROFILE_KEY">Mapping profile</label>
         <select id="f-PROFILE_KEY"></select>
         <p class="field-note" id="n-PROFILE_KEY"></p>
       </div>
-
       <div class="field">
         <label for="f-SOURCE_URI">Address</label>
         <input id="f-SOURCE_URI" type="text" autocomplete="off" spellcheck="false">
         <p class="field-note" id="n-SOURCE_URI"></p>
       </div>
-
       <div class="field">
         <label for="f-DISPLAY_LABEL">Label</label>
         <input id="f-DISPLAY_LABEL" type="text" autocomplete="off">
         <p class="field-note" id="n-DISPLAY_LABEL"></p>
       </div>
-
       <div class="field">
         <label for="f-SOURCE_REGION">Region</label>
         <select id="f-SOURCE_REGION"></select>
         <p class="field-note" id="n-SOURCE_REGION"></p>
       </div>
-
       <div class="field">
         <label for="f-IS_ACTIVE">Active</label>
         <!-- A CLOSED LIST, and this is the one field where that matters most:
@@ -134,13 +205,11 @@
         </select>
         <p class="field-note" id="n-IS_ACTIVE"></p>
       </div>
-
       <div class="field">
         <label for="f-MIN_LICENSE_REQ">Minimum licence</label>
         <select id="f-MIN_LICENSE_REQ"></select>
         <p class="field-note" id="n-MIN_LICENSE_REQ"></p>
       </div>
-
       <div class="field">
         <label for="f-VERSION_TAG">Version tag</label>
         <input id="f-VERSION_TAG" type="text" autocomplete="off">
@@ -149,7 +218,6 @@
           change-detection hash, so moving it forces a re-download.
         </p>
       </div>
-
       <div class="field">
         <label for="f-CONTEXT_PROPS">Context properties (JSON)</label>
         <input id="f-CONTEXT_PROPS" type="text" autocomplete="off" spellcheck="false">
@@ -162,23 +230,27 @@
         <button id="editor-cancel" class="button ghost" type="button">Cancel</button>
       </div>
     </section>
+  </section>
 
-    <section class="card hidden" id="sheets-card" aria-labelledby="sheets-title">
-      <h2 id="sheets-title">The six sheets</h2>
-      <div id="sheets-list" class="sheet-rows"></div>
-      <p class="hint">
-        Data sources can be edited above. The other five are read and checked
-        here; editing them arrives one sheet at a time.
-      </p>
+  <!-- ── Problems ─────────────────────────────────────────────────────────── -->
+  <section id="cv-problems" class="cv hidden" role="tabpanel" aria-labelledby="cv-tab-problems">
+    <header class="cv-head">
+      <h1>Problems</h1>
+      <p>What the add-in would make of this workbook, in the order it matters.</p>
+    </header>
+    <section class="card" aria-labelledby="findings-title">
+      <h2 id="findings-title">Findings</h2>
+      <p id="findings-summary" class="hint" role="status" aria-live="polite"></p>
+      <div id="findings-list" class="findings"></div>
     </section>
+  </section>
 
-  </main>
+</main>
 
-  <!-- appearance.js FIRST, and as a classic script. It is what puts
-       `data-theme` on the document, and a module would run after first paint —
-       the onboarding page shipped that way once and ignored the owner's palette
-       entirely. -->
-  <script src="appearance.js"></script>
-  <script type="module" src="console.js"></script>
+<!-- appearance.js FIRST, and as a classic script. It is what puts `data-theme`
+     on the document, and a module would run after first paint — the onboarding
+     page shipped that way once and ignored the owner's palette entirely. -->
+<script src="appearance.js"></script>
+<script type="module" src="console.js"></script>
 </body>
 </html>

--- a/extension/console.js
+++ b/extension/console.js
@@ -1,0 +1,276 @@
+// The Console — reads the add-in's configuration workbook, and says what is
+// wrong with it before offering to change anything.
+//
+// THE ENGINE IS NOT INVOLVED. No fetch to 127.0.0.1, no import from anything
+// that talks to it. The owner's ruling, restated 2026-08-12: «الكونسول يخص
+// extension بنسبة 100%، المحرك غير مسؤول عنه اطلاقا».
+
+import { getToken } from "./identity.js";
+import { chooseSpreadsheet } from "./picker.js";
+import { TAB_NAMES, parseWorkbook, inspect, vocabularies } from "./workbook.js";
+import { KNOWN_VOCABULARIES, SHEET_GIDS } from "./addin-contract.js";
+
+const $ = (id) => document.getElementById(id);
+const SHEETS_API = "https://sheets.googleapis.com/v4/spreadsheets";
+
+//: Where the chosen workbook is remembered. storage.local, not session: this is
+//: a decision about which file the add-in reads, not a passing choice, and
+//: making the owner find it again every morning would be its own defect.
+const REMEMBERED = "scrapexConfigWorkbook";
+
+const state = {token: "", fileId: "", name: ""};
+
+function say(id, text, tone = "") {
+  const node = $(id);
+  if (!node) return;
+  node.textContent = text;
+  node.className = tone ? `hint ${tone}` : "hint";
+}
+
+// ---- Google -----------------------------------------------------------------
+
+async function ask(path, token) {
+  const answer = await fetch(`${SHEETS_API}/${path}`, {
+    headers: {Authorization: `Bearer ${token}`},
+  });
+  if (!answer.ok) {
+    let detail = `${answer.status}`;
+    try {
+      const body = await answer.json();
+      detail = body?.error?.message || detail;
+    } catch { /* a body that is not JSON tells us nothing extra */ }
+    throw new Error(detail);
+  }
+  return answer.json();
+}
+
+/**
+ * The tab ids of a spreadsheet, by tab name.
+ *
+ * `spreadsheets.get` with a fields mask, because the whole document would be
+ * megabytes of cell data to answer a question about six names.
+ */
+async function tabsOf(fileId, token) {
+  const book = await ask(
+    `${encodeURIComponent(fileId)}?fields=properties.title,sheets.properties`,
+    token);
+  const tabs = {};
+  for (const sheet of book.sheets || []) {
+    const properties = sheet.properties || {};
+    tabs[properties.title] = String(properties.sheetId);
+  }
+  return {title: book.properties?.title || "", tabs};
+}
+
+/** All six tabs in one call. */
+async function readWorkbook(fileId, token) {
+  const ranges = TAB_NAMES
+    .map((tab) => `ranges=${encodeURIComponent(`'${tab}'!A1:CA2000`)}`)
+    .join("&");
+  const answer = await ask(
+    `${encodeURIComponent(fileId)}/values:batchGet?${ranges}`, token);
+  return parseWorkbook(answer.valueRanges || []);
+}
+
+// ---- is this even the right file --------------------------------------------
+
+/**
+ * THE CHECK THAT COMES BEFORE EVERY OTHER CHECK.
+ *
+ * The add-in does not find its configuration by name. `EndpointCatalog` carries
+ * six tab ids compiled into the build, and fetches each one directly. So a
+ * workbook can have all six tab NAMES, look perfect, and be a copy the add-in
+ * has never read — and a Console that checked it would report that everything
+ * is fine about a file nobody opens. That is a worse outcome than refusing.
+ */
+function identify(tabs) {
+  const wrong = [];
+  const absent = [];
+  for (const [tab, gid] of Object.entries(SHEET_GIDS)) {
+    if (!(tab in tabs)) absent.push(tab);
+    else if (tabs[tab] !== gid) wrong.push({tab, found: tabs[tab], wanted: gid});
+  }
+  return {ok: !wrong.length && !absent.length, wrong, absent};
+}
+
+// ---- what it says -----------------------------------------------------------
+
+function renderFindings(found) {
+  const list = $("findings-list");
+  list.textContent = "";
+
+  const broken = found.filter((f) => f.severity === "broken");
+  const unused = found.filter((f) => f.severity === "unused");
+
+  if (!found.length) {
+    say("findings-summary",
+        "Nothing to report. Every reference resolves and every source has an "
+        + "address the add-in can read.", "ok");
+    return;
+  }
+
+  say("findings-summary",
+      `${broken.length} ${broken.length === 1 ? "problem" : "problems"} that `
+      + `would change what the add-in loads, and ${unused.length} that would `
+      + "not.");
+
+  for (const finding of found) {
+    const row = document.createElement("div");
+    row.className = `finding finding-${finding.severity}`;
+
+    const where = document.createElement("span");
+    where.className = "finding-where";
+    where.textContent = finding.row
+      ? `${finding.tab} · row ${finding.row}`
+      : finding.tab;
+
+    const kind = document.createElement("span");
+    kind.className = "finding-kind";
+    kind.textContent = finding.kind;
+
+    const detail = document.createElement("p");
+    detail.className = "finding-detail";
+    detail.textContent = finding.detail;
+
+    row.append(where, kind, detail);
+    list.append(row);
+  }
+}
+
+function renderSheets(workbook) {
+  const list = $("sheets-list");
+  list.textContent = "";
+  const lists = vocabularies(workbook, KNOWN_VOCABULARIES);
+
+  for (const tab of TAB_NAMES) {
+    const sheet = workbook.sheets[tab];
+    const row = document.createElement("div");
+    row.className = "sheet-row";
+
+    const name = document.createElement("span");
+    name.className = "sheet-name";
+    name.textContent = tab;
+
+    const count = document.createElement("span");
+    count.className = "sheet-count";
+    count.textContent = sheet ? `${sheet.rows.length} rows` : "not found";
+
+    row.append(name, count);
+    list.append(row);
+  }
+
+  const note = document.createElement("p");
+  note.className = "hint";
+  note.textContent =
+    `${lists.entityKeys.length} tables, ${lists.profileKeys.length} mapping `
+    + `profiles, ${lists.sourceKeys.length} sources.`;
+  list.append(note);
+}
+
+// ---- the flow ---------------------------------------------------------------
+
+async function show(fileId) {
+  say("workbook-state", "Reading the workbook…");
+  $("findings-card").classList.add("hidden");
+  $("sheets-card").classList.add("hidden");
+
+  let identity;
+  try {
+    identity = await tabsOf(fileId, state.token);
+  } catch (error) {
+    say("workbook-state",
+        `That workbook could not be opened: ${error.message}`, "err");
+    return;
+  }
+
+  state.name = identity.title;
+  const verdict = identify(identity.tabs);
+  $("workbook-identity").textContent = identity.title;
+
+  if (!verdict.ok) {
+    // REFUSED, and told exactly why. "Something is wrong" would send the owner
+    // looking at the data; the tab ids are the thing that is wrong.
+    const parts = [];
+    if (verdict.absent.length) {
+      parts.push(`it has no ${verdict.absent.join(", ")}`);
+    }
+    for (const {tab, found, wanted} of verdict.wrong) {
+      parts.push(`${tab} is tab ${found} here and the add-in reads tab ${wanted}`);
+    }
+    say("workbook-state",
+        "This is not the workbook the add-in reads — " + parts.join("; ")
+        + ". Nothing is shown, because checking the wrong file and reporting it "
+        + "correct is worse than saying nothing.", "err");
+    $("workbook-choose").hidden = false;
+    return;
+  }
+
+  let workbook;
+  try {
+    workbook = await readWorkbook(fileId, state.token);
+  } catch (error) {
+    say("workbook-state", `The sheets could not be read: ${error.message}`, "err");
+    return;
+  }
+
+  await chrome.storage.local.set({[REMEMBERED]: {fileId, name: identity.title}});
+  say("workbook-state",
+      "This is the workbook the add-in reads — all six tabs match.", "ok");
+  $("workbook-choose").hidden = false;
+  $("workbook-recheck").hidden = false;
+
+  renderFindings(inspect(workbook));
+  renderSheets(workbook);
+  $("findings-card").classList.remove("hidden");
+  $("sheets-card").classList.remove("hidden");
+}
+
+async function pick() {
+  $("workbook-choose").disabled = true;
+  say("workbook-state",
+      "Choose the workbook in the tab that just opened, then come back here.");
+  try {
+    const picked = await chooseSpreadsheet({token: state.token, surface: "console"});
+    if (!picked) {
+      say("workbook-state", "Nothing was chosen.");
+      return;
+    }
+    state.fileId = picked.fileId;
+    await show(picked.fileId);
+  } catch (error) {
+    say("workbook-state", error.message || "The chooser could not be opened.", "err");
+  } finally {
+    $("workbook-choose").disabled = false;
+  }
+}
+
+async function start() {
+  const result = await getToken({interactive: false});
+  if (result.state !== "ok" || !result.token) {
+    say("workbook-state",
+        "Sign in with Google from the ScrapeX panel first — this page reads a "
+        + "spreadsheet with your account, and asks for nothing else.", "err");
+    return;
+  }
+  state.token = result.token;
+
+  const held = await chrome.storage.local.get(REMEMBERED);
+  const remembered = held[REMEMBERED];
+  $("workbook-choose").hidden = false;
+
+  if (remembered?.fileId) {
+    state.fileId = remembered.fileId;
+    await show(remembered.fileId);
+    return;
+  }
+  say("workbook-state",
+      "Choose the workbook the Excel add-in reads. This page will refuse any "
+      + "other file rather than check the wrong one.");
+}
+
+$("workbook-choose").addEventListener("click", () => pick());
+$("workbook-recheck").addEventListener("click", () => {
+  if (state.fileId) show(state.fileId);
+});
+
+start();

--- a/extension/console.js
+++ b/extension/console.js
@@ -7,8 +7,11 @@
 
 import { getToken } from "./identity.js";
 import { chooseSpreadsheet } from "./picker.js";
-import { TAB_NAMES, parseWorkbook, inspect, vocabularies } from "./workbook.js";
-import { KNOWN_VOCABULARIES, SHEET_GIDS } from "./addin-contract.js";
+import { TAB_NAMES, parseWorkbook, inspect, vocabularies, SHEETS } from "./workbook.js";
+import { KNOWN_VOCABULARIES, SHEET_GIDS, LICENSE_TIERS, readBoolean,
+         BOOLEAN_DEFAULTS } from "./addin-contract.js";
+import { checkDataSourceRow, stopsThisSource, switchedOff, suggestedKey }
+  from "./datasource-rules.js";
 
 const $ = (id) => document.getElementById(id);
 const SHEETS_API = "https://sheets.googleapis.com/v4/spreadsheets";
@@ -18,7 +21,8 @@ const SHEETS_API = "https://sheets.googleapis.com/v4/spreadsheets";
 //: making the owner find it again every morning would be its own defect.
 const REMEMBERED = "scrapexConfigWorkbook";
 
-const state = {token: "", fileId: "", name: ""};
+const SOURCES = "3.DataSource";
+const state = {token: "", fileId: "", name: "", workbook: null, editing: null};
 
 function say(id, text, tone = "") {
   const node = $(id);
@@ -167,12 +171,226 @@ function renderSheets(workbook) {
   list.append(note);
 }
 
+// ---- the source list and its editor ------------------------------------------
+
+/** The world a row is judged against, rebuilt from whatever is loaded now. */
+function worldFor(workbook, exceptRow = null) {
+  const rows = (tab) => (workbook.sheets[tab]?.rows) || [];
+  const tables = rows("1.TableDefinition");
+  return {
+    entities: tables.map((r) => r.ENTITY_KEY).filter(Boolean),
+    activeEntities: tables
+      .filter((r) => readBoolean(r.IS_ACTIVE,
+                                 BOOLEAN_DEFAULTS["1.TableDefinition"].IS_ACTIVE))
+      .map((r) => r.ENTITY_KEY).filter(Boolean),
+    profilesDefined: [...new Set(rows("4.DataMap")
+      .map((r) => r.PROFILE_KEY).filter(Boolean))],
+    others: rows(SOURCES).filter((r) => r !== exceptRow),
+  };
+}
+
+function renderSources(workbook) {
+  const list = $("sources-list");
+  list.textContent = "";
+  const rows = workbook.sheets[SOURCES]?.rows || [];
+
+  let dead = 0;
+  let noted = 0;
+  for (const row of rows) {
+    const found = checkDataSourceRow(row, worldFor(workbook, row));
+    const stops = stopsThisSource(found);
+    const off = switchedOff(found);
+    if (stops) dead += 1;
+    if (found.length && !stops) noted += 1;
+
+    const item = document.createElement("button");
+    item.type = "button";
+    item.className = "source-row"
+      + (stops ? " source-stopped" : found.length ? " source-noted" : "");
+    item.addEventListener("click", () => edit(row));
+
+    const key = document.createElement("span");
+    key.className = "source-key";
+    key.textContent = row.SOURCE_KEY || "(no key)";
+
+    const into = document.createElement("span");
+    into.className = "source-into";
+    into.textContent = row.TARGET_ENTITY_KEY || "—";
+
+    const verdict = document.createElement("span");
+    verdict.className = "source-verdict";
+    // THREE DIFFERENT THINGS, said differently. "Nothing comes out" is a
+    // failure; "switched off" is a decision; a note is neither.
+    verdict.textContent = stops ? "produces nothing"
+      : off ? "switched off"
+      : found.length ? `${found.length} note${found.length === 1 ? "" : "s"}`
+      : "";
+
+    item.append(key, into, verdict);
+    list.append(item);
+  }
+
+  say("sources-summary",
+      `${rows.length} sources. ${dead} produce nothing; ${noted} have something `
+      + "worth reading. Choose one to edit.",
+      dead ? "err" : "");
+}
+
+/** Fill a `<select>`, keeping a value the sheet already holds even if unlisted. */
+function options(id, values, current, {blank = ""} = {}) {
+  const select = $(id);
+  select.textContent = "";
+  const all = [...values];
+  if (current && !all.some((v) => String(v).toLowerCase() === current.toLowerCase())) {
+    // NEVER SILENTLY REPLACE WHAT IS IN THE SHEET. An unknown value is a fact
+    // about the workbook, and a drop-down that quietly dropped it would change
+    // the row the moment it was opened.
+    all.unshift(current);
+  }
+  if (blank !== null) {
+    const empty = document.createElement("option");
+    empty.value = "";
+    empty.textContent = blank;
+    select.append(empty);
+  }
+  for (const value of all) {
+    const option = document.createElement("option");
+    option.value = value;
+    option.textContent = value;
+    select.append(option);
+  }
+  select.value = current ?? "";
+}
+
+const FIELDS = ["SOURCE_KEY", "TARGET_ENTITY_KEY", "PROFILE_KEY", "SOURCE_URI",
+                "DISPLAY_LABEL", "SOURCE_REGION", "IS_ACTIVE", "MIN_LICENSE_REQ",
+                "VERSION_TAG", "CONTEXT_PROPS"];
+
+function readForm() {
+  const row = {};
+  for (const name of FIELDS) row[name] = $(`f-${name}`).value.trim();
+  if (state.editing?._row) row._row = state.editing._row;
+  return row;
+}
+
+/** Re-judge the form as it stands and put each finding beside its own field. */
+function judge() {
+  const row = readForm();
+  const found = checkDataSourceRow(row, worldFor(state.workbook, state.editing));
+
+  for (const name of FIELDS) {
+    const note = $(`n-${name}`);
+    if (!note) continue;
+    const mine = found.filter((f) => f.field === name);
+    note.textContent = mine
+      .map((f) => f.fix ? `${f.detail} ${f.fix}` : f.detail).join(" ");
+    note.className = "field-note"
+      + (mine.some((f) => f.severity === "Critical" || f.severity === "Error")
+         ? " note-error"
+         : mine.length ? " note-warn" : "");
+  }
+
+  const stops = stopsThisSource(found);
+  const blocking = found.filter(
+    (f) => f.severity === "Critical" || f.severity === "Error");
+
+  // SAVING IS REFUSED ONLY WHEN THE ROW WOULD PRODUCE NOTHING. A row the add-in
+  // merely complains about is a row the add-in still runs, and a Console that
+  // refused it would be stricter than the thing it configures — which teaches
+  // an owner to edit the sheet directly and never come back.
+  $("editor-save").disabled = stops;
+  say("editor-verdict",
+      stops
+        ? "As it stands this source produces nothing. Saving is refused."
+        : blocking.length
+          ? `Saveable. The add-in will record ${blocking.length} `
+            + `${blocking.length === 1 ? "complaint" : "complaints"} about it and sync it anyway.`
+          : "Nothing to report.",
+      stops ? "err" : blocking.length ? "" : "ok");
+  return found;
+}
+
+function edit(row) {
+  state.editing = row;
+  const workbook = state.workbook;
+  const lists = vocabularies(workbook, KNOWN_VOCABULARIES);
+  const profiles = [...new Set([...lists.profileKeys, "DEFAULT"])].sort();
+
+  $("editor-where").textContent = row._row
+    ? `${SOURCES}, row ${row._row}`
+    : `${SOURCES}, a new row at the end`;
+
+  $("f-SOURCE_KEY").value = row.SOURCE_KEY || "";
+  options("f-TARGET_ENTITY_KEY", lists.entityKeys, row.TARGET_ENTITY_KEY || "",
+          {blank: "— choose a table —"});
+  options("f-PROFILE_KEY", profiles, row.PROFILE_KEY || "",
+          {blank: "— blank: use the table's own key —"});
+  $("f-SOURCE_URI").value = row.SOURCE_URI || "";
+  $("f-DISPLAY_LABEL").value = row.DISPLAY_LABEL || "";
+  options("f-SOURCE_REGION", ["GLOBAL", ...lists.regions], row.SOURCE_REGION || "",
+          {blank: "— none —"});
+  $("f-IS_ACTIVE").value =
+    readBoolean(row.IS_ACTIVE, BOOLEAN_DEFAULTS[SOURCES].IS_ACTIVE) ? "TRUE" : "FALSE";
+  options("f-MIN_LICENSE_REQ", LICENSE_TIERS, row.MIN_LICENSE_REQ || "",
+          {blank: "— none —"});
+  $("f-VERSION_TAG").value = row.VERSION_TAG || "";
+  $("f-CONTEXT_PROPS").value = row.CONTEXT_PROPS || "";
+
+  $("editor-card").classList.remove("hidden");
+  judge();
+  $("editor-card").scrollIntoView({behavior: "smooth", block: "start"});
+}
+
+/** Write the row back, and only that row. */
+async function save() {
+  const row = readForm();
+  const columns = SHEETS.find((s) => s.tab === SOURCES).columns;
+  const values = [columns.map((name) => row[name] ?? "")];
+
+  // A1 for the row's OWN span, so a save cannot touch a neighbour. A new row
+  // goes to the first line after the last one read.
+  const last = state.workbook.sheets[SOURCES].rows.at(-1);
+  const line = row._row || ((last?._row || 1) + 1);
+  const end = String.fromCharCode("A".charCodeAt(0) + columns.length - 1);
+  const range = `'${SOURCES}'!A${line}:${end}${line}`;
+
+  $("editor-save").disabled = true;
+  say("editor-verdict", "Saving…");
+  try {
+    const answer = await fetch(
+      `${SHEETS_API}/${encodeURIComponent(state.fileId)}/values/`
+      + `${encodeURIComponent(range)}?valueInputOption=RAW`,
+      {method: "PUT",
+       headers: {Authorization: `Bearer ${state.token}`,
+                 "Content-Type": "application/json"},
+       body: JSON.stringify({values})});
+    if (!answer.ok) {
+      let detail = `${answer.status}`;
+      try { detail = (await answer.json())?.error?.message || detail; } catch { /* */ }
+      throw new Error(detail);
+    }
+  } catch (error) {
+    say("editor-verdict", `Not saved: ${error.message}`, "err");
+    $("editor-save").disabled = false;
+    return;
+  }
+
+  // RE-READ RATHER THAN PATCH IN MEMORY. The sheet is the truth, another editor
+  // may have moved something, and a Console showing its own optimistic copy is
+  // the beginning of the drift this page exists to prevent.
+  $("editor-card").classList.add("hidden");
+  state.editing = null;
+  await show(state.fileId);
+}
+
 // ---- the flow ---------------------------------------------------------------
 
 async function show(fileId) {
   say("workbook-state", "Reading the workbook…");
   $("findings-card").classList.add("hidden");
+  $("sources-card").classList.add("hidden");
   $("sheets-card").classList.add("hidden");
+  $("editor-card").classList.add("hidden");
 
   let identity;
   try {
@@ -214,14 +432,17 @@ async function show(fileId) {
   }
 
   await chrome.storage.local.set({[REMEMBERED]: {fileId, name: identity.title}});
+  state.workbook = workbook;
   say("workbook-state",
       "This is the workbook the add-in reads — all six tabs match.", "ok");
   $("workbook-choose").hidden = false;
   $("workbook-recheck").hidden = false;
 
   renderFindings(inspect(workbook));
+  renderSources(workbook);
   renderSheets(workbook);
   $("findings-card").classList.remove("hidden");
+  $("sources-card").classList.remove("hidden");
   $("sheets-card").classList.remove("hidden");
 }
 
@@ -269,6 +490,29 @@ async function start() {
 }
 
 $("workbook-choose").addEventListener("click", () => pick());
+$("source-add").addEventListener("click", () => edit({}));
+$("editor-cancel").addEventListener("click", () => {
+  state.editing = null;
+  $("editor-card").classList.add("hidden");
+});
+$("editor-save").addEventListener("click", () => save());
+// Judged on every keystroke and every choice, because a rule the owner meets
+// only when he presses Save is a rule that arrives after the work.
+for (const name of FIELDS) {
+  const control = $(`f-${name}`);
+  control.addEventListener("input", () => judge());
+  control.addEventListener("change", () => judge());
+}
+// The key has a stated convention; offer it rather than making him retype it.
+for (const name of ["TARGET_ENTITY_KEY", "PROFILE_KEY"]) {
+  $(`f-${name}`).addEventListener("change", () => {
+    const key = $("f-SOURCE_KEY");
+    if (!key.value.trim()) {
+      key.value = suggestedKey(readForm());
+      judge();
+    }
+  });
+}
 $("workbook-recheck").addEventListener("click", () => {
   if (state.fileId) show(state.fileId);
 });

--- a/extension/console.js
+++ b/extension/console.js
@@ -171,6 +171,33 @@ function renderSheets(workbook) {
   list.append(note);
 }
 
+
+// ---- navigation --------------------------------------------------------------
+//
+// THE PANEL'S OWN SHAPE, deliberately: a registry of screen names, sections
+// called `cv-<name>`, and rail buttons carrying `data-view`. A second navigation
+// idiom in the same product is a second thing to learn for no gain.
+//
+// `inspect` is in the registry and NOT in the rail: it is reached by choosing a
+// table, and a rail button for it would be a button with nothing to show.
+
+const VIEWS = ["overview", "scrapex", "tables", "inspect", "sources", "problems"];
+
+function showView(name) {
+  for (const view of VIEWS) {
+    $(`cv-${view}`)?.classList.toggle("hidden", view !== name);
+  }
+  // Inspect belongs to Tables, so the rail keeps Tables lit rather than going
+  // blank on a screen that is plainly still about a table.
+  const lit = name === "inspect" ? "tables" : name;
+  for (const button of document.querySelectorAll(".rail-link[data-view]")) {
+    const on = button.dataset.view === lit;
+    button.setAttribute("aria-selected", String(on));
+    button.tabIndex = on ? 0 : -1;
+  }
+  document.querySelector(".console-main")?.scrollTo({top: 0});
+}
+
 // ---- the source list and its editor ------------------------------------------
 
 /** The world a row is judged against, rebuilt from whatever is loaded now. */
@@ -234,6 +261,7 @@ function renderSources(workbook) {
       `${rows.length} sources. ${dead} produce nothing; ${noted} have something `
       + "worth reading. Choose one to edit.",
       dead ? "err" : "");
+  $("count-sources").textContent = rows.length || "";
 }
 
 /** Fill a `<select>`, keeping a value the sheet already holds even if unlisted. */
@@ -336,6 +364,7 @@ function edit(row) {
   $("f-VERSION_TAG").value = row.VERSION_TAG || "";
   $("f-CONTEXT_PROPS").value = row.CONTEXT_PROPS || "";
 
+  showView("sources");
   $("editor-card").classList.remove("hidden");
   judge();
   $("editor-card").scrollIntoView({behavior: "smooth", block: "start"});
@@ -383,12 +412,224 @@ async function save() {
   await show(state.fileId);
 }
 
+
+// ---- what this tool collects, and whether the add-in knows ------------------
+
+//: ScrapeX's own sources, as the add-in would have to name them. Read from the
+//: workbook rather than typed here: the three that exist are already named
+//: ScrapeX_*, and the convention is the only thing that ties the two products
+//: together. A hard-coded list would be wrong the first time a source is added.
+const SCRAPEX_MARK = /^(ScrapeX|Agent)_/i;
+
+function renderScrapeX(workbook) {
+  const list = $("scrapex-list");
+  list.textContent = "";
+  const sources = workbook.sheets[SOURCES]?.rows || [];
+  const mine = sources.filter((r) => SCRAPEX_MARK.test(r.SOURCE_KEY || ""));
+  const entities = new Set((workbook.sheets["1.TableDefinition"]?.rows || [])
+    .map((r) => r.ENTITY_KEY).filter(Boolean));
+
+  for (const row of mine) {
+    const table = row.TARGET_ENTITY_KEY || "";
+    const known = entities.has(table);
+    list.append(pairRow(row.SOURCE_KEY, table || "—",
+                        known ? "registered" : "no such table",
+                        known ? "" : "pair-missing",
+                        known ? () => showTable(table) : null));
+  }
+
+  if (!mine.length) {
+    const empty = document.createElement("p");
+    empty.className = "hint";
+    empty.textContent =
+      "No source in this workbook is named ScrapeX_… or Agent_…, so nothing "
+      + "here is recognisably this tool's.";
+    list.append(empty);
+  }
+
+  say("scrapex-summary",
+      `${mine.length} of this workbook's ${sources.length} sources come from `
+      + "ScrapeX. Choosing one opens the table it feeds.");
+  $("count-scrapex").textContent = mine.length || "";
+}
+
+/** One row of a two-column list, optionally a button. */
+function pairRow(left, right, note, extra = "", onClick = null) {
+  const row = document.createElement(onClick ? "button" : "div");
+  if (onClick) { row.type = "button"; row.addEventListener("click", onClick); }
+  row.className = `pair-row ${extra}`.trim();
+
+  const a = document.createElement("span");
+  a.className = "pair-key";
+  a.textContent = left;
+  const b = document.createElement("span");
+  b.className = "pair-into";
+  b.textContent = right;
+  const c = document.createElement("span");
+  c.className = "pair-note";
+  c.textContent = note;
+
+  row.append(a, b, c);
+  return row;
+}
+
+// ---- every table, and one table across every sheet --------------------------
+
+function renderTables(workbook) {
+  const list = $("tables-list");
+  list.textContent = "";
+  const tables = workbook.sheets["1.TableDefinition"]?.rows || [];
+
+  for (const row of tables) {
+    const key = row.ENTITY_KEY;
+    if (!key) continue;
+    const active = readBoolean(row.IS_ACTIVE,
+                               BOOLEAN_DEFAULTS["1.TableDefinition"].IS_ACTIVE);
+    const fields = (workbook.sheets["2.SchemaRule"]?.rows || [])
+      .filter((r) => (r.ENTITY_KEY || "").toLowerCase() === key.toLowerCase()).length;
+    list.append(pairRow(key, row.DISPLAY_NAME || "—",
+                        `${fields} field${fields === 1 ? "" : "s"}`
+                        + (active ? "" : " · off"),
+                        active ? "" : "pair-off",
+                        () => showTable(key)));
+  }
+  $("count-tables").textContent = tables.length || "";
+}
+
+/** A titled block of rows inside the inspect screen. */
+function block(title, rows, empty) {
+  const card = document.createElement("section");
+  card.className = "card";
+  const heading = document.createElement("h2");
+  heading.textContent = title;
+  card.append(heading);
+
+  if (!rows.length) {
+    const none = document.createElement("p");
+    none.className = "hint";
+    none.textContent = empty;
+    card.append(none);
+    return card;
+  }
+  const holder = document.createElement("div");
+  holder.className = "pair-rows";
+  for (const row of rows) holder.append(row);
+  card.append(holder);
+  return card;
+}
+
+/**
+ * ONE TABLE, EVERYWHERE IT APPEARS.
+ *
+ * The reason this screen exists: the six sheets are a database whose foreign
+ * keys are strings, and answering "what is T_BITUMEN made of" by hand means
+ * filtering five sheets by the same word and holding the answers in your head.
+ */
+function showTable(key) {
+  const workbook = state.workbook;
+  const same = (a) => (a || "").toLowerCase() === key.toLowerCase();
+  const rows = (tab) => workbook.sheets[tab]?.rows || [];
+
+  const definition = rows("1.TableDefinition").find((r) => same(r.ENTITY_KEY));
+  const fields = rows("2.SchemaRule").filter((r) => same(r.ENTITY_KEY));
+  const sources = rows(SOURCES).filter((r) => same(r.TARGET_ENTITY_KEY));
+  const profiles = new Set(sources.map((r) => {
+    const named = (r.PROFILE_KEY || "").trim();
+    return (!named || named.toUpperCase() === "DEFAULT") ? key : named;
+  }));
+  const maps = rows("4.DataMap").filter((r) => profiles.has(r.PROFILE_KEY));
+  const views = rows("5.ExportViews").filter((r) => same(r.ENTITY_KEY));
+
+  $("inspect-name").textContent = key;
+  $("inspect-lede").textContent = definition
+    ? `${definition.DISPLAY_NAME || "no display name"} · `
+      + `${definition.ENTITY_TYPE || "no type"} · `
+      + `${definition.STORAGE_STRATEGY || "no storage strategy"}`
+    : "This name is used elsewhere in the workbook and no table defines it.";
+
+  const body = $("inspect-body");
+  body.textContent = "";
+
+  body.append(block("Fields", fields.map((r) => pairRow(
+    r.ATTRIBUTE_KEY, r.DATA_TYPE || "TEXT",
+    [r.SEMANTIC_ROLE, readBoolean(r.IS_PK, false) ? "key" : "",
+     readBoolean(r.IS_MANDATORY, false) ? "required" : ""].filter(Boolean).join(" · "))),
+    "No fields, so this table has no columns — the add-in refuses to sync it."));
+
+  body.append(block("Sources", sources.map((r) => pairRow(
+    r.SOURCE_KEY, r.PROFILE_KEY || "(the table's own key)",
+    r.SOURCE_REGION || "")),
+    "Nothing loads this table."));
+
+  body.append(block("Mappings", maps.map((r) => pairRow(
+    r.SOURCE_EXPRESSION || "(no expression)", `→ ${r.TARGET_ATTRIBUTE_KEY}`,
+    [r.SOURCE_TYPE, r.TRANSFORM_CHAIN].filter(Boolean).join(" · "))),
+    "No mapping tells the add-in how to read this table's source."));
+
+  body.append(block("Export views", views.map((r) => pairRow(
+    r.VIEW_KEY, r.LABEL || "—", r.COLUMNS ? `${r.COLUMNS.split(",").length} columns` : "")),
+    "No export view offers this table."));
+
+  // THE RIBBON, WHICH NEITHER OF THE ADD-IN'S OWN SURFACES SHOWS. Its Console
+  // never reads 6.RibbonControls, and its Info tab's "RIBBON_CONFIG" section is
+  // a different thing — the JSON bag on the definition, not these rows. So the
+  // buttons a person actually presses are invisible in the tool built to
+  // explain the configuration.
+  //
+  // ACTION_TAG carries the entity, sometimes with a region after a pipe
+  // (`T_BITUMEN|EG`), which is why this matches on the part before it.
+  const ribbon = rows("6.RibbonControls").filter((r) => {
+    const tag = (r.ACTION_TAG || "").split("|")[0].trim();
+    return same(tag);
+  });
+  body.append(block("Ribbon", ribbon.map((r) => pairRow(
+    r.LABEL || r.ITEM_KEY, r.ACTION_TAG || "—",
+    [r.ACTION_CLASS, r.REGION].filter(Boolean).join(" · "))),
+    "No ribbon entry points at this table, so nothing in Excel opens it."));
+
+  // ---- the two warnings the add-in's Info panel gets right --------------------
+  const notes = [];
+  const strategy = (definition?.STORAGE_STRATEGY || "").toLowerCase();
+  if (strategy === "replaceall") {
+    notes.push(["ReplaceAll", "Every sync DELETES all rows in this table before "
+      + "writing. Nothing accumulates, and nothing survives a source that comes "
+      + "back empty."]);
+  }
+  const keys = fields.filter((r) => readBoolean(r.IS_PK, false));
+  if (strategy === "mergeupsert" && !keys.length) {
+    notes.push(["MergeUpsert with no key", "There is no IS_PK column to match "
+      + "on, so every sync APPENDS the same rows again. The table grows a "
+      + "duplicate set each time."]);
+  }
+  if (keys.length > 1) {
+    notes.push(["Composite key", `${keys.length} columns are marked IS_PK and the `
+      + `add-in uses only the first (${keys[0].ATTRIBUTE_KEY}). Composite keys are `
+      + "not supported."]);
+  }
+  if (notes.length) {
+    const card = document.createElement("section");
+    card.className = "card";
+    const heading = document.createElement("h2");
+    heading.textContent = "How this table is written";
+    card.append(heading);
+    for (const [title, detail] of notes) {
+      const line = document.createElement("p");
+      line.className = "hint err";
+      const strong = document.createElement("b");
+      strong.textContent = `${title}. `;
+      line.append(strong, document.createTextNode(detail));
+      card.append(line);
+    }
+    body.append(card);
+  }
+
+  showView("inspect");
+}
+
 // ---- the flow ---------------------------------------------------------------
 
 async function show(fileId) {
   say("workbook-state", "Reading the workbook…");
-  $("findings-card").classList.add("hidden");
-  $("sources-card").classList.add("hidden");
   $("sheets-card").classList.add("hidden");
   $("editor-card").classList.add("hidden");
 
@@ -438,12 +679,15 @@ async function show(fileId) {
   $("workbook-choose").hidden = false;
   $("workbook-recheck").hidden = false;
 
-  renderFindings(inspect(workbook));
+  const found = inspect(workbook);
+  renderFindings(found);
   renderSources(workbook);
+  renderScrapeX(workbook);
+  renderTables(workbook);
   renderSheets(workbook);
-  $("findings-card").classList.remove("hidden");
-  $("sources-card").classList.remove("hidden");
   $("sheets-card").classList.remove("hidden");
+  $("count-problems").textContent = found.length || "";
+  $("rail-book").textContent = identity.title;
 }
 
 async function pick() {
@@ -489,6 +733,13 @@ async function start() {
       + "other file rather than check the wrong one.");
 }
 
+for (const button of document.querySelectorAll(".rail-link[data-view]")) {
+  button.addEventListener("click", () => showView(button.dataset.view));
+}
+$("inspect-back").addEventListener("click", () => showView("tables"));
+$("workbook-recheck").addEventListener("click", () => {
+  if (state.fileId) show(state.fileId);
+});
 $("workbook-choose").addEventListener("click", () => pick());
 $("source-add").addEventListener("click", () => edit({}));
 $("editor-cancel").addEventListener("click", () => {

--- a/extension/datasource-rules.js
+++ b/extension/datasource-rules.js
@@ -11,7 +11,23 @@
 // the rest of that row being checked — so the Console stops with it, or it
 // would print a cascade of complaints about a row the add-in never reaches.
 
-import { readBoolean, BOOLEAN_DEFAULTS, ERROR_CODE } from "./addin-contract.js";
+import { readBoolean, BOOLEAN_DEFAULTS, ERROR_CODE, CONTEXT_PROPS_KEYS }
+  from "./addin-contract.js";
+
+/**
+ * Settings the add-in ACCEPTS, DOCUMENTS, and then does not apply.
+ *
+ * Read from its own Info panel, which marks each one "NOT APPLIED" with a note
+ * explaining that presenting them as live settings "sent operators chasing a
+ * value that does nothing". That note is correct and it is in the wrong place:
+ * it is visible only to someone who already went looking. Here it arrives while
+ * the value is being typed.
+ */
+const IGNORED_CONTEXT_KEYS = {
+  Encoding: "the parser always reads UTF-8, with the BOM detected automatically.",
+  Delimiter: "the parser always splits on a tab, whatever this says.",
+  TimeoutSeconds: "the HTTP client uses its own timeout and never reads this.",
+};
 
 /** Severities in the order the add-in ranks them. */
 const RANK = {Info: 0, Warning: 1, Error: 2, Critical: 3};
@@ -54,15 +70,54 @@ export function checkSourceUri(uri) {
       + "bare filenames are not supported.")];
   }
 
+  //: The host, PARSED. Everything below that reasons about who is being talked
+  //: to uses this rather than a substring of the whole address.
+  let host = "";
   if (isHttp) {
-    const authority = value.slice(value.indexOf("//") + 2).split("/")[0];
-    if (!authority.includes(".")) {
+    try {
+      host = new URL(value).hostname.toLowerCase();
+    } catch {
+      return [finding("Error", "SOURCE_URI", ERROR_CODE.badValue,
+        "This is not a well-formed web address.")];
+    }
+    if (!host.includes(".")) {
       found.push(finding("Warning", "SOURCE_URI", ERROR_CODE.badValue,
-        `"${authority}" has no dot in it, so it is probably not a real host.`));
+        `"${host}" has no dot in it, so it is probably not a real host.`));
     }
   }
 
-  // Case-insensitive substring, exactly as the add-in matches.
+  //: Is the address really Google's, rather than merely SAYING so?
+  const reallyGoogle = host === "docs.google.com" || host.endsWith(".google.com");
+
+  // A DEFECT IN THE ADD-IN, FOUND BY A SCANNER POINTED AT THIS FILE.
+  //
+  // `SourceUriValidator` decides "is this Google Sheets" with a case-insensitive
+  // SUBSTRING of the whole address, and this module mirrored it because the rule
+  // here is to mirror rather than invent. CodeQL flagged the mirror as
+  // js/incomplete-url-substring-sanitization, and it was right about the
+  // consequence even though the Console is not the thing at risk:
+  //
+  //     https://attacker.example/?x=docs.google.com&output=tsv
+  //
+  // satisfies every check the add-in makes, and the add-in then downloads it
+  // with NO AUTHENTICATION of any kind. Whatever comes back is parsed as the
+  // table's rows.
+  //
+  // The mirror stays, because a Console that warned differently from the add-in
+  // would be wrong about what the add-in does. What is added is the thing the
+  // add-in cannot tell you.
+  if (isHttp && lower.includes("docs.google.com") && !reallyGoogle) {
+    found.push(finding("Error", "SOURCE_URI", ERROR_CODE.badValue,
+      `This address MENTIONS docs.google.com but is served by "${host}". The `
+      + "add-in decides an address is Google's by searching the whole string, "
+      + "so it accepts this one and downloads it with no authentication — and "
+      + "whatever comes back becomes the table's rows.",
+      "If this is meant to be a Google Sheet, the host itself must be "
+      + "docs.google.com."));
+  }
+
+  // Case-insensitive substring, exactly as the add-in matches — so the Console
+  // asks for output=tsv in precisely the cases the add-in does.
   if (lower.includes("docs.google.com")) {
     if (!lower.includes("output=tsv") && !lower.includes("format=tsv")) {
       found.push(finding("Error", "SOURCE_URI", ERROR_CODE.badValue,
@@ -193,16 +248,39 @@ export function checkDataSourceRow(row, {entities = [], activeEntities = null,
   // 8 — the JSON bag.
   const bag = value("CONTEXT_PROPS");
   if (bag) {
+    let parsed = null;
     try {
-      const parsed = JSON.parse(bag);
+      parsed = JSON.parse(bag);
       if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
         found.push(finding("Error", "CONTEXT_PROPS", ERROR_CODE.badJson,
           "This is valid JSON but not an object, so no setting can be read out "
           + "of it."));
+        parsed = null;
       }
     } catch {
       found.push(finding("Error", "CONTEXT_PROPS", ERROR_CODE.badJson,
         "Not valid JSON, so every setting inside it is ignored."));
+    }
+
+    // THREE SETTINGS THE ADD-IN READS AND THEN IGNORES. Its own Info panel says
+    // so in prose — "sent operators chasing a value that does nothing" — and
+    // says it in a place nobody looks until after the chase. Said here, it is
+    // said at the moment someone types one.
+    if (parsed) {
+      for (const [key, why] of Object.entries(IGNORED_CONTEXT_KEYS)) {
+        if (key in parsed) {
+          found.push(finding("Warning", "CONTEXT_PROPS", ERROR_CODE.badValue,
+            `"${key}" is read and then ignored — ${why}`,
+            "Remove it, or keep it knowing it changes nothing."));
+        }
+      }
+      const unknown = Object.keys(parsed)
+        .filter((key) => !CONTEXT_PROPS_KEYS.includes(key));
+      if (unknown.length) {
+        found.push(finding("Warning", "CONTEXT_PROPS", ERROR_CODE.unknownKey,
+          `${unknown.join(", ")} — the add-in reads no such setting, so it does `
+          + "nothing at all."));
+      }
     }
   }
 

--- a/extension/datasource-rules.js
+++ b/extension/datasource-rules.js
@@ -103,10 +103,26 @@ export function checkSourceUri(uri) {
   // with NO AUTHENTICATION of any kind. Whatever comes back is parsed as the
   // table's rows.
   //
+  // THE SUPPRESSION BELOW, AND WHY IT IS NOT A DISMISSAL.
+  //
+  // This one line is the add-in's own test, reproduced deliberately, and it is
+  // the only place in this module the substring is taken. Nothing is decided by
+  // it: it answers "what will the add-in conclude", and every judgement about
+  // who is really being talked to is made against `reallyGoogle`, which parses.
+  // Deleting it would not close a hole — the hole is in the add-in, on a machine
+  // this code cannot reach — it would only make the Console describe a program
+  // other than the one the owner runs.
+  //
+  // The scanner's real finding is answered on the next line but one, where the
+  // parsed host is compared and the impostor is reported as an Error. Break that
+  // check and `datasource-rules.test.mjs` fails on two named addresses.
+  // codeql[js/incomplete-url-substring-sanitization]
+  const addinReadsThisAsGoogleSheets = lower.includes("docs.google.com");
+
   // The mirror stays, because a Console that warned differently from the add-in
   // would be wrong about what the add-in does. What is added is the thing the
   // add-in cannot tell you.
-  if (isHttp && lower.includes("docs.google.com") && !reallyGoogle) {
+  if (isHttp && addinReadsThisAsGoogleSheets && !reallyGoogle) {
     found.push(finding("Error", "SOURCE_URI", ERROR_CODE.badValue,
       `This address MENTIONS docs.google.com but is served by "${host}". The `
       + "add-in decides an address is Google's by searching the whole string, "
@@ -116,9 +132,10 @@ export function checkSourceUri(uri) {
       + "docs.google.com."));
   }
 
-  // Case-insensitive substring, exactly as the add-in matches — so the Console
-  // asks for output=tsv in precisely the cases the add-in does.
-  if (lower.includes("docs.google.com")) {
+  // The same answer, not a second reading of it — so the Console asks for
+  // output=tsv in precisely the cases the add-in does, including the impostor
+  // above, which the add-in also demands a TSV format from.
+  if (addinReadsThisAsGoogleSheets) {
     if (!lower.includes("output=tsv") && !lower.includes("format=tsv")) {
       found.push(finding("Error", "SOURCE_URI", ERROR_CODE.badValue,
         "A Google Sheets address without a TSV format serves a WEB PAGE. The "

--- a/extension/datasource-rules.js
+++ b/extension/datasource-rules.js
@@ -11,7 +11,8 @@
 // the rest of that row being checked — so the Console stops with it, or it
 // would print a cascade of complaints about a row the add-in never reaches.
 
-import { readBoolean, BOOLEAN_DEFAULTS, ERROR_CODE, CONTEXT_PROPS_KEYS }
+import { readBoolean, readsUriAsGoogleSheets, BOOLEAN_DEFAULTS, ERROR_CODE,
+  CONTEXT_PROPS_KEYS, URI_TSV_MARKERS, URI_TAB_MARKER }
   from "./addin-contract.js";
 
 /**
@@ -92,36 +93,23 @@ export function checkSourceUri(uri) {
   // A DEFECT IN THE ADD-IN, FOUND BY A SCANNER POINTED AT THIS FILE.
   //
   // `SourceUriValidator` decides "is this Google Sheets" with a case-insensitive
-  // SUBSTRING of the whole address, and this module mirrored it because the rule
-  // here is to mirror rather than invent. CodeQL flagged the mirror as
-  // js/incomplete-url-substring-sanitization, and it was right about the
-  // consequence even though the Console is not the thing at risk:
+  // SUBSTRING of the whole address — the host is never parsed. This module used
+  // to reproduce that substring inline, and CodeQL was right to object to the
+  // shape of it. The rule here is still to mirror rather than invent, so the
+  // mirror did not move out of the product: it moved to where the add-in's other
+  // quirks live, beside `readBoolean`, and it says on itself that it decides
+  // nothing. What is left below is this module's own reasoning, on a PARSED host.
+  //
+  // The consequence CodeQL named is real, and it is the add-in's:
   //
   //     https://attacker.example/?x=docs.google.com&output=tsv
   //
   // satisfies every check the add-in makes, and the add-in then downloads it
-  // with NO AUTHENTICATION of any kind. Whatever comes back is parsed as the
-  // table's rows.
-  //
-  // THE SUPPRESSION BELOW, AND WHY IT IS NOT A DISMISSAL.
-  //
-  // This one line is the add-in's own test, reproduced deliberately, and it is
-  // the only place in this module the substring is taken. Nothing is decided by
-  // it: it answers "what will the add-in conclude", and every judgement about
-  // who is really being talked to is made against `reallyGoogle`, which parses.
-  // Deleting it would not close a hole — the hole is in the add-in, on a machine
-  // this code cannot reach — it would only make the Console describe a program
-  // other than the one the owner runs.
-  //
-  // The scanner's real finding is answered on the next line but one, where the
-  // parsed host is compared and the impostor is reported as an Error. Break that
-  // check and `datasource-rules.test.mjs` fails on two named addresses.
-  // codeql[js/incomplete-url-substring-sanitization]
-  const addinReadsThisAsGoogleSheets = lower.includes("docs.google.com");
+  // with no authentication of any kind, following up to five redirects.
+  // Whatever comes back is parsed as the table's rows. The Console cannot fix
+  // that from here — it can only refuse to stay quiet about it.
+  const addinReadsThisAsGoogleSheets = readsUriAsGoogleSheets(value);
 
-  // The mirror stays, because a Console that warned differently from the add-in
-  // would be wrong about what the add-in does. What is added is the thing the
-  // add-in cannot tell you.
   if (isHttp && addinReadsThisAsGoogleSheets && !reallyGoogle) {
     found.push(finding("Error", "SOURCE_URI", ERROR_CODE.badValue,
       `This address MENTIONS docs.google.com but is served by "${host}". The `
@@ -136,7 +124,7 @@ export function checkSourceUri(uri) {
   // output=tsv in precisely the cases the add-in does, including the impostor
   // above, which the add-in also demands a TSV format from.
   if (addinReadsThisAsGoogleSheets) {
-    if (!lower.includes("output=tsv") && !lower.includes("format=tsv")) {
+    if (!URI_TSV_MARKERS.some((marker) => lower.includes(marker))) {
       found.push(finding("Error", "SOURCE_URI", ERROR_CODE.badValue,
         "A Google Sheets address without a TSV format serves a WEB PAGE. The "
         + "add-in downloads it, sees markup where rows should be, and reports a "
@@ -144,7 +132,7 @@ export function checkSourceUri(uri) {
         + "with this address.",
         "Add output=tsv to the end of the address."));
     }
-    if (!lower.includes("gid=")) {
+    if (!lower.includes(URI_TAB_MARKER)) {
       found.push(finding("Warning", "SOURCE_URI", ERROR_CODE.badValue,
         "No gid, so this always reads the FIRST tab of that spreadsheet — "
         + "whichever one that happens to be today.",

--- a/extension/datasource-rules.js
+++ b/extension/datasource-rules.js
@@ -1,0 +1,257 @@
+// One row of 3.DataSource, judged exactly as the add-in judges it.
+//
+// EVERY RULE HERE IS THE ADD-IN'S, NOT MINE. `DataSourceEntity.Validate()` has
+// eight; `SourceUriValidator` has six more for the address. Both were read out
+// of the C# with file:line (docs/reviews/mbiXaddin-config-contract-*.md). A
+// rule invented here would be a Console refusing something the add-in accepts,
+// and that teaches an owner to work around the Console rather than with it.
+//
+// SEVERITY IS THE ADD-IN'S TOO. Its four levels are Info, Warning, Error and
+// Critical, and only Error and above block a sync. Critical additionally stops
+// the rest of that row being checked — so the Console stops with it, or it
+// would print a cascade of complaints about a row the add-in never reaches.
+
+import { readBoolean, BOOLEAN_DEFAULTS, ERROR_CODE } from "./addin-contract.js";
+
+/** Severities in the order the add-in ranks them. */
+const RANK = {Info: 0, Warning: 1, Error: 2, Critical: 3};
+
+const finding = (severity, field, code, detail, fix = "") =>
+  ({severity, field, code, detail, fix});
+
+/**
+ * The address rules, which are the ones an owner gets wrong most often.
+ *
+ * `SourceUriValidator`'s own file header calls rule 4 "the single most common
+ * data-entry mistake": a Google Sheets URL with no `output=tsv`. The add-in
+ * then downloads a WEB PAGE, sniffs the first 256 characters, sees `<!DOCTYPE`
+ * and reports a parse failure — which reads as a problem with the data rather
+ * than with the address, and sends the owner looking in the wrong place.
+ */
+export function checkSourceUri(uri) {
+  const value = String(uri ?? "").trim();
+  const found = [];
+
+  if (!value) {
+    return [finding("Critical", "SOURCE_URI", ERROR_CODE.required,
+      "There is no address, so there is nothing to load.",
+      "In the source spreadsheet: File → Share → Publish to web → select the "
+      + "sheet → TSV format.")];
+  }
+
+  const lower = value.toLowerCase();
+  const isHttp = lower.startsWith("http://") || lower.startsWith("https://");
+  // The add-in accepts a local path too: a leading slash, a backslash anywhere,
+  // or a drive letter followed by a colon.
+  const isLocal = value.startsWith("/") || value.includes("\\")
+    || (value.length > 1 && value[1] === ":");
+
+  if (!isHttp && !isLocal) {
+    // Stops here in the add-in as well — every later rule assumes one of the
+    // two shapes.
+    return [finding("Error", "SOURCE_URI", ERROR_CODE.badValue,
+      "This is neither a web address nor a file path. FTP, relative paths and "
+      + "bare filenames are not supported.")];
+  }
+
+  if (isHttp) {
+    const authority = value.slice(value.indexOf("//") + 2).split("/")[0];
+    if (!authority.includes(".")) {
+      found.push(finding("Warning", "SOURCE_URI", ERROR_CODE.badValue,
+        `"${authority}" has no dot in it, so it is probably not a real host.`));
+    }
+  }
+
+  // Case-insensitive substring, exactly as the add-in matches.
+  if (lower.includes("docs.google.com")) {
+    if (!lower.includes("output=tsv") && !lower.includes("format=tsv")) {
+      found.push(finding("Error", "SOURCE_URI", ERROR_CODE.badValue,
+        "A Google Sheets address without a TSV format serves a WEB PAGE. The "
+        + "add-in downloads it, sees markup where rows should be, and reports a "
+        + "parse failure — which reads as a problem with the data rather than "
+        + "with this address.",
+        "Add output=tsv to the end of the address."));
+    }
+    if (!lower.includes("gid=")) {
+      found.push(finding("Warning", "SOURCE_URI", ERROR_CODE.badValue,
+        "No gid, so this always reads the FIRST tab of that spreadsheet — "
+        + "whichever one that happens to be today.",
+        "Add gid=… naming the tab you mean."));
+    }
+  } else if (isLocal
+             && !/\.(csv|tsv|txt)/i.test(value)) {
+    found.push(finding("Warning", "SOURCE_URI", ERROR_CODE.badValue,
+      "A local path with no .csv, .tsv or .txt in it."));
+  }
+
+  return found;
+}
+
+/**
+ * One DataSource row, against the whole workbook — because half its rules are
+ * about what other sheets contain.
+ *
+ * `others` is every OTHER row of 3.DataSource, so uniqueness can be judged
+ * without the row colliding with itself while it is being edited.
+ */
+export function checkDataSourceRow(row, {entities = [], activeEntities = null,
+                                         profilesDefined = [], others = []} = {}) {
+  const found = [];
+  const value = (name) => String(row?.[name] ?? "").trim();
+
+  // 1 — SOURCE_KEY. Critical, and the add-in ABANDONS the row here: it keys
+  // _SYS_SYNC_STATE and per-row provenance, so without it nothing downstream
+  // can be attributed at all.
+  const key = value("SOURCE_KEY");
+  if (!key) {
+    return [finding("Critical", "SOURCE_KEY", ERROR_CODE.required,
+      "Without a key the add-in stops reading this row entirely — nothing else "
+      + "about it is even checked.",
+      "The convention is {TARGET_ENTITY_KEY}_{PROFILE_KEY}.")];
+  }
+
+  // A duplicate is worse than it sounds: because SOURCE_KEY keys the sync state,
+  // removing one source can delete another's rows.
+  const twin = others.find(
+    (o) => String(o?.SOURCE_KEY ?? "").trim().toLowerCase() === key.toLowerCase());
+  if (twin) {
+    found.push(finding("Error", "SOURCE_KEY", ERROR_CODE.duplicate,
+      `"${key}" is already used${twin._row ? ` on row ${twin._row}` : ""}. Keys `
+      + "identify a source's own stored state, so a duplicate can make removing "
+      + "one source delete another's rows."));
+  }
+
+  // 2 — TARGET_ENTITY_KEY. Critical when blank; and when it names nothing the
+  // add-in does not fail, it SILENTLY DROPS the source from the graph.
+  const entity = value("TARGET_ENTITY_KEY");
+  if (!entity) {
+    found.push(finding("Critical", "TARGET_ENTITY_KEY", ERROR_CODE.required,
+      "This source loads into no table."));
+  } else {
+    const known = entities.some((e) => e.toLowerCase() === entity.toLowerCase());
+    if (!known) {
+      found.push(finding("Error", "TARGET_ENTITY_KEY", ERROR_CODE.reference,
+        `No table is called "${entity}". The add-in drops a source like this `
+        + "from the graph with a warning nobody reads — it never syncs, and "
+        + "nothing says why."));
+    } else if (activeEntities
+               && !activeEntities.some((e) => e.toLowerCase() === entity.toLowerCase())) {
+      // The reference resolves and the table is switched off, so this source
+      // still never runs. A different fault with the same symptom.
+      found.push(finding("Warning", "TARGET_ENTITY_KEY", ERROR_CODE.reference,
+        `"${entity}" exists but is not active, so this source never syncs. `
+        + "The add-in filters inactive tables out before it builds anything."));
+    }
+  }
+
+  // 3 — PROFILE_KEY. Blank WORKS — it resolves to the entity key — and the
+  // add-in records an Error about it anyway. Both halves are true and the
+  // Console has to say both, or the owner "fixes" something that was working
+  // or ignores a message that is real.
+  const profile = value("PROFILE_KEY");
+  const resolved = (!profile || profile.toUpperCase() === "DEFAULT") ? entity : profile;
+  if (!profile) {
+    found.push(finding("Error", "PROFILE_KEY", ERROR_CODE.required,
+      `Blank, which the add-in resolves to "${entity || "the table's key"}" and `
+      + "records an Error about at the same time. It works; it is noisy.",
+      entity ? `Write ${entity} here to say plainly what it already does.` : ""));
+  }
+  if (resolved && profilesDefined.length
+      && !profilesDefined.some((p) => p.toLowerCase() === resolved.toLowerCase())) {
+    found.push(finding("Error", "PROFILE_KEY", ERROR_CODE.orphanMapping,
+      `Nothing in 4.DataMap defines "${resolved}", so this source FAILS to `
+      + "ingest — not silently: the table ends up empty."));
+  }
+
+  // 4 — the address.
+  found.push(...checkSourceUri(row?.SOURCE_URI));
+
+  // 5 — SOURCE_REGION. The consequence is out of all proportion to the typo.
+  const region = value("SOURCE_REGION");
+  if (region && region.toUpperCase() !== "GLOBAL" && !/^[A-Za-z]{2}$/.test(region)) {
+    found.push(finding("Warning", "SOURCE_REGION", ERROR_CODE.badValue,
+      `"${region}" is neither GLOBAL nor a two-letter code, and an unrecognised `
+      + "region BLOCKS EVERY USER from syncing this source.",
+      "Use GLOBAL, or a two-letter country code such as SA or EG."));
+  }
+
+  // 6 — DISPLAY_LABEL.
+  if (!value("DISPLAY_LABEL")) {
+    found.push(finding("Warning", "DISPLAY_LABEL", ERROR_CODE.required,
+      "No label, so this source appears under its key wherever it is named."));
+  }
+
+  // 7 — switched off. Not a fault; said because a table that is empty on
+  // purpose looks exactly like a table that is empty by accident.
+  const active = readBoolean(row?.IS_ACTIVE, BOOLEAN_DEFAULTS["3.DataSource"].IS_ACTIVE);
+  if (!active) {
+    found.push(finding("Info", "IS_ACTIVE", ERROR_CODE.badValue,
+      "Switched off — the add-in skips this source entirely, and its table "
+      + "stays as it was."));
+  }
+
+  // 8 — the JSON bag.
+  const bag = value("CONTEXT_PROPS");
+  if (bag) {
+    try {
+      const parsed = JSON.parse(bag);
+      if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+        found.push(finding("Error", "CONTEXT_PROPS", ERROR_CODE.badJson,
+          "This is valid JSON but not an object, so no setting can be read out "
+          + "of it."));
+      }
+    } catch {
+      found.push(finding("Error", "CONTEXT_PROPS", ERROR_CODE.badJson,
+        "Not valid JSON, so every setting inside it is ignored."));
+    }
+  }
+
+  found.sort((a, b) => RANK[b.severity] - RANK[a.severity]);
+  return found;
+}
+
+/**
+ * Does this source produce NOTHING — and that is a different question from the
+ * severity beside each finding.
+ *
+ * MY FIRST VERSION ASKED "IS ANYTHING HERE AN ERROR", AND IT WAS WRONG. Run
+ * over the owner's real workbook it declared 13 of 17 sources blocked, all of
+ * which sync every day. The reason is that `SyncManager` does not gate on a
+ * DataSource ROW at all: it gates on `ValidateContext`, the per-ENTITY report,
+ * and that report lists "a source whose PROFILE_KEY has no mappings" among the
+ * warnings that explicitly do NOT block. A row's own Error is recorded and
+ * alerted; the sync goes on.
+ *
+ * So severity answers "what does the add-in write in its log", and this answers
+ * "does anything come out of this source". Conflating them is how a Console
+ * reports thirteen catastrophes a day until nobody opens it.
+ *
+ * These five genuinely produce nothing:
+ *   - no SOURCE_KEY      the row is abandoned before anything else is read
+ *   - no TARGET_ENTITY_KEY, or one that names nothing — dropped from the graph
+ *   - a profile with no mappings — IngestionResult.Fail, per source
+ *   - no address, or one the downloader refuses outright
+ *   - switched off — which is not a fault, and is reported separately
+ */
+export function stopsThisSource(found) {
+  return found.some((f) =>
+    f.severity === "Critical"
+    || (f.field === "TARGET_ENTITY_KEY" && f.code === ERROR_CODE.reference
+        && /drops a source/.test(f.detail))
+    || (f.field === "PROFILE_KEY" && f.code === ERROR_CODE.orphanMapping)
+    || (f.field === "SOURCE_URI" && RANK[f.severity] >= RANK.Error));
+}
+
+/** Switched off on purpose — empty, and not a fault. Asked separately. */
+export function switchedOff(found) {
+  return found.some((f) => f.field === "IS_ACTIVE" && f.severity === "Info");
+}
+
+/** The suggested key, by the add-in's own stated convention. */
+export function suggestedKey(row) {
+  const entity = String(row?.TARGET_ENTITY_KEY ?? "").trim();
+  const profile = String(row?.PROFILE_KEY ?? "").trim();
+  if (!entity) return "";
+  return profile && profile.toUpperCase() !== "DEFAULT"
+    ? `${entity}_${profile}` : entity;
+}

--- a/extension/onboarding.html
+++ b/extension/onboarding.html
@@ -23,14 +23,14 @@
 
   <div class="setup">
     <div class="card">
-      <div class="step"><div class="n">1</div><div class="body">
+      <div class="step"><div class="n">1</div><div>
         <h3>Download ScrapeX-Engine</h3>
         <p>Open the <b>Engine</b> page in the ScrapeX panel and press the
            download button. It hands you a single file,
            <span class="cmd">scrapex-engine.exe</span> — there is nothing to
            install first, and no terminal is involved.</p>
       </div></div>
-      <div class="step"><div class="n">2</div><div class="body">
+      <div class="step"><div class="n">2</div><div>
         <h3>Run it once</h3>
         <p>Double-click the file. It installs for you alone and asks for no
            administrator rights.</p>
@@ -39,7 +39,7 @@
            <b>Run anyway</b>. The Engine page shows a checksum if you want to
            prove the download arrived whole.</p>
       </div></div>
-      <div class="step"><div class="n">3</div><div class="body">
+      <div class="step"><div class="n">3</div><div>
         <h3>Come back here</h3>
         <p>Leave the engine's window open — that window <b>is</b> the engine.
            This page notices it by itself within a few seconds; there is

--- a/extension/picker.js
+++ b/extension/picker.js
@@ -1,0 +1,94 @@
+// Choosing a spreadsheet the owner already had.
+//
+// `drive.file` reaches two kinds of file: ones this extension created, and ones
+// the owner HANDS it through Google Picker. Picker loads apis.google.com/js/api.js
+// and MV3 forbids an extension executing code fetched from a server, so the
+// chooser lives on an ordinary web origin and hands an id back through
+// background.js's onMessageExternal listener.
+//
+// WHY THIS IS A MODULE. Two surfaces need it — the side panel, to pick the
+// workbook exports are written into, and the Console, to pick the add-in's
+// CONFIGURATION workbook. A second copy of a nonce handoff is a second place
+// for the token rules to drift, and the token rules are the whole reason this
+// flow is shaped the way it is.
+
+//: Where the chooser lives. It cannot be a page in this extension: Google
+//: Picker loads a remote script and MV3 forbids that.
+export const PICKER_PAGE =
+  "https://muhammadbayoumi.github.io/mbiXsite/scrapex-picker.html";
+
+//: How long the panel waits for a choice, and how long the handoff carrying the
+//: token stays tradeable. The same number deliberately: a handoff outliving the
+//: wait would be a key left under a mat nobody is watching any more.
+export const PICK_WINDOW_MS = 120_000;
+
+/** One chooser at a time, per surface. */
+const inFlight = new Set();
+
+/**
+ * Open the chooser and wait for what comes back.
+ *
+ * THE TOKEN DOES NOT TRAVEL IN THE URL. It did, in the fragment, defended by
+ * the true and irrelevant fact that browsers do not send fragments to servers.
+ * The reader that matters is local: chrome.tabs.create COMMITS the URL, and the
+ * committed URL is delivered whole — fragment included — to every installed
+ * extension holding the `tabs` permission. Erasing it in the page afterwards
+ * cannot help; the delivery already happened.
+ *
+ * So the URL carries a nonce. background.js trades it, once, for the token.
+ *
+ * Returns `{fileId, name}` when a file was chosen, `null` when the owner
+ * cancelled or the window closed, and throws only when it was never opened.
+ */
+export async function chooseSpreadsheet({
+  token,
+  surface = "panel",
+  chromeApi = globalThis.chrome,
+  windowMs = PICK_WINDOW_MS,
+  now = () => Date.now(),
+  newNonce = () => crypto.randomUUID(),
+} = {}) {
+  if (!token) throw new Error("no Google session");
+  if (inFlight.has(surface)) throw new Error("a chooser is already open");
+
+  const nonce = newNonce();
+  await chromeApi.storage.session.set({
+    scrapexPickerHandoff: {nonce, token, expires: now() + windowMs},
+  });
+  // Any earlier answer is not this question's. A stale one left here would be
+  // read within the first second and returned as the owner's new choice.
+  await chromeApi.storage.session.remove("scrapexPickedSpreadsheet");
+
+  chromeApi.tabs.create({
+    url: `${PICKER_PAGE}#n=${encodeURIComponent(nonce)}`
+       + `&ext=${encodeURIComponent(chromeApi.runtime.id)}`,
+  });
+
+  inFlight.add(surface);
+  const deadline = now() + windowMs;
+  try {
+    for (;;) {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      const held = await chromeApi.storage.session.get("scrapexPickedSpreadsheet");
+      const picked = held.scrapexPickedSpreadsheet;
+      if (picked) {
+        await chromeApi.storage.session.remove("scrapexPickedSpreadsheet");
+        return picked.fileId ? picked : null;
+      }
+      if (now() > deadline) {
+        // The handoff dies with the wait. One left behind is a token that can
+        // still be traded by whoever kept the nonce.
+        await chromeApi.storage.session.remove("scrapexPickerHandoff");
+        return null;
+      }
+    }
+  } finally {
+    inFlight.delete(surface);
+  }
+}
+
+/** Whether a chooser is open for this surface — for a button that must wait. */
+export function choosing(surface = "panel") {
+  return inFlight.has(surface);
+}

--- a/extension/tests/datasource-rules.test.mjs
+++ b/extension/tests/datasource-rules.test.mjs
@@ -1,0 +1,382 @@
+// One DataSource row, judged as the add-in judges it.
+//
+// Every expectation here is the add-in's behaviour read out of its C#, not a
+// preference. Where a rule looks strange — a blank PROFILE_KEY that both WORKS
+// and records an Error, a two-letter typo that blocks every user — the strange
+// part is the add-in's and the test says so, because that is exactly the kind of
+// rule someone later "corrects" into something more reasonable and wrong.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { checkSourceUri, checkDataSourceRow, stopsThisSource, switchedOff,
+         suggestedKey } from "../datasource-rules.js";
+
+const PUBLISHED =
+  "https://docs.google.com/spreadsheets/d/e/2PACX-1vAAA/pub?gid=223498986&single=true&output=tsv";
+
+/** A row with nothing wrong with it — the control for every test below. */
+const sound = (over = {}) => ({
+  SOURCE_KEY: "T_DIESEL_P_DIESEL",
+  TARGET_ENTITY_KEY: "T_DIESEL",
+  PROFILE_KEY: "P_DIESEL",
+  SOURCE_URI: PUBLISHED,
+  SOURCE_REGION: "EG",
+  DISPLAY_LABEL: "Diesel prices",
+  IS_ACTIVE: "True",
+  ...over,
+});
+
+const world = (over = {}) => ({
+  entities: ["T_DIESEL"],
+  activeEntities: ["T_DIESEL"],
+  profilesDefined: ["P_DIESEL"],
+  others: [],
+  ...over,
+});
+
+const check = (row, w = {}) => checkDataSourceRow(row, world(w));
+const fields = (found) => found.map((f) => f.field);
+const worst = (found) => found[0]?.severity;
+
+// ---------------------------------------------------------------------------
+// The control
+// ---------------------------------------------------------------------------
+
+test("a sound row produces nothing at all", () => {
+  assert.deepEqual(check(sound()), [],
+    "the checker invented a fault in a row the add-in is happy with, which is "
+    + "how an owner learns to click past it");
+});
+
+test("and a sound row stops nothing", () => {
+  assert.equal(stopsThisSource(check(sound())), false);
+});
+
+// ---------------------------------------------------------------------------
+// SOURCE_KEY — Critical, and the add-in stops reading the row
+// ---------------------------------------------------------------------------
+
+test("no key abandons the row, so nothing else is reported", () => {
+  const found = check(sound({SOURCE_KEY: "", TARGET_ENTITY_KEY: "", SOURCE_URI: ""}));
+
+  assert.equal(found.length, 1,
+    "three faults were listed for a row the add-in stops reading after the "
+    + "first — a cascade about a row nobody reaches");
+  assert.equal(found[0].severity, "Critical");
+  assert.equal(found[0].field, "SOURCE_KEY");
+  assert.match(found[0].fix, /TARGET_ENTITY_KEY.*PROFILE_KEY/);
+});
+
+test("a duplicate key says WHERE the twin is and what it costs", () => {
+  const found = check(sound(), {
+    others: [{SOURCE_KEY: "t_diesel_p_diesel", _row: 9}],   // case-insensitive
+  });
+
+  const key = found.filter((f) => f.field === "SOURCE_KEY");
+  assert.equal(key.length, 1);
+  assert.equal(key[0].severity, "Error");
+  assert.match(key[0].detail, /row 9/);
+  assert.match(key[0].detail, /delete another's rows/);
+});
+
+test("a row does not collide with itself", () => {
+  // `others` is every OTHER row on purpose. Passing the whole sheet would make
+  // every row a duplicate of itself the moment it is opened for editing.
+  assert.deepEqual(check(sound(), {others: []}).filter((f) => f.field === "SOURCE_KEY"), []);
+});
+
+// ---------------------------------------------------------------------------
+// TARGET_ENTITY_KEY — two different faults with the same symptom
+// ---------------------------------------------------------------------------
+
+test("naming no table at all", () => {
+  const found = check(sound({TARGET_ENTITY_KEY: ""}));
+  assert.equal(found[0].severity, "Critical");
+  assert.equal(found[0].field, "TARGET_ENTITY_KEY");
+});
+
+test("naming a table that does not exist — SILENTLY dropped by the add-in", () => {
+  const found = check(sound({TARGET_ENTITY_KEY: "T_TYPO"}))
+    .filter((f) => f.field === "TARGET_ENTITY_KEY");
+
+  assert.equal(found.length, 1);
+  assert.equal(found[0].severity, "Error");
+  assert.match(found[0].detail, /nothing says why/,
+    "the message does not tell the owner the failure is silent, which is the "
+    + "only reason this one is hard to find");
+});
+
+test("naming a table that exists and is switched OFF", () => {
+  // Resolves, and still never syncs. Same symptom, different cause, and an
+  // owner told only "it never syncs" would go looking at the wrong sheet.
+  const found = check(sound(), {activeEntities: []})
+    .filter((f) => f.field === "TARGET_ENTITY_KEY");
+
+  assert.equal(found.length, 1);
+  assert.equal(found[0].severity, "Warning");
+  assert.match(found[0].detail, /not active/);
+});
+
+test("the entity match is case-insensitive, as the add-in's is", () => {
+  assert.deepEqual(
+    check(sound({TARGET_ENTITY_KEY: "t_diesel"}))
+      .filter((f) => f.field === "TARGET_ENTITY_KEY"), []);
+});
+
+// ---------------------------------------------------------------------------
+// PROFILE_KEY — the rule that is true twice over
+// ---------------------------------------------------------------------------
+
+test("a BLANK profile works AND is reported, because both are true", () => {
+  // It resolves to the entity key, so the source syncs. The add-in records an
+  // Error about it anyway. Saying only one half sends the owner to fix
+  // something that works, or to ignore a message that is real.
+  const found = check(sound({PROFILE_KEY: ""}), {profilesDefined: ["T_DIESEL"]})
+    .filter((f) => f.field === "PROFILE_KEY");
+
+  assert.equal(found.length, 1);
+  assert.equal(found[0].severity, "Error");
+  assert.match(found[0].detail, /resolves to "T_DIESEL"/);
+  assert.match(found[0].detail, /It works; it is noisy/);
+  assert.match(found[0].fix, /Write T_DIESEL here/);
+});
+
+test('"DEFAULT" resolves the same way and is NOT reported', () => {
+  // Explicit and legal. Complaining about it would be inventing a rule.
+  for (const spelling of ["DEFAULT", "default", "Default"]) {
+    assert.deepEqual(
+      check(sound({PROFILE_KEY: spelling}), {profilesDefined: ["T_DIESEL"]})
+        .filter((f) => f.field === "PROFILE_KEY"), [],
+      `"${spelling}" was reported`);
+  }
+});
+
+test("a profile no DataMap defines fails the ingest, and says so plainly", () => {
+  const found = check(sound({PROFILE_KEY: "P_NOWHERE"}))
+    .filter((f) => f.field === "PROFILE_KEY");
+
+  assert.equal(found.length, 1);
+  assert.equal(found[0].severity, "Error");
+  assert.match(found[0].detail, /FAILS to ingest/);
+});
+
+test("a BLANK profile whose resolved name has no mappings is caught too", () => {
+  // Both halves of the rule at once: blank is noisy, and the thing it resolves
+  // to does not exist. The first version checked only the literal value and so
+  // missed this entirely.
+  const found = check(sound({PROFILE_KEY: ""}), {profilesDefined: ["SOMETHING_ELSE"]})
+    .filter((f) => f.field === "PROFILE_KEY");
+
+  assert.equal(found.length, 2);
+  assert.ok(found.some((f) => /FAILS to ingest/.test(f.detail)));
+});
+
+// ---------------------------------------------------------------------------
+// The address — where an owner goes wrong most often
+// ---------------------------------------------------------------------------
+
+test("the published TSV shape passes clean", () => {
+  assert.deepEqual(checkSourceUri(PUBLISHED), []);
+});
+
+test("no address is Critical, and the fix is the four menu steps", () => {
+  const found = checkSourceUri("");
+  assert.equal(found.length, 1);
+  assert.equal(found[0].severity, "Critical");
+  assert.match(found[0].fix, /Publish to web/);
+});
+
+test("THE COMMONEST MISTAKE — a Google address with no TSV format", () => {
+  // The add-in downloads a web page, sniffs `<!DOCTYPE`, and reports a PARSE
+  // failure — so the owner goes looking at the data instead of the address.
+  const found = checkSourceUri(
+    "https://docs.google.com/spreadsheets/d/e/2PACX-1vAAA/pub?gid=1&single=true");
+
+  const format = found.filter((f) => /output=tsv/.test(f.fix));
+  assert.equal(format.length, 1);
+  assert.equal(format[0].severity, "Error");
+  assert.match(format[0].detail, /WEB PAGE/);
+});
+
+test("format=tsv is accepted as well as output=tsv", () => {
+  assert.deepEqual(
+    checkSourceUri("https://docs.google.com/spreadsheets/d/x/pub?gid=1&format=tsv"), []);
+});
+
+test("a Google address with no gid reads whichever tab is first", () => {
+  const found = checkSourceUri(
+    "https://docs.google.com/spreadsheets/d/e/2PACX-1vAAA/pub?single=true&output=tsv");
+
+  assert.equal(found.length, 1);
+  assert.equal(found[0].severity, "Warning");
+  assert.match(found[0].detail, /FIRST tab/);
+});
+
+test("the browser's own edit link is refused before anything downloads", () => {
+  const found = checkSourceUri(
+    "https://docs.google.com/spreadsheets/d/1AbCdEf/edit#gid=0");
+  assert.ok(found.some((f) => f.severity === "Error"));
+});
+
+test("neither a web address nor a path stops there", () => {
+  for (const bad of ["ftp://host/file.tsv", "just-a-name.tsv", "sheet1"]) {
+    const found = checkSourceUri(bad);
+    assert.equal(found.length, 1, `${bad} produced ${found.length} findings`);
+    assert.match(found[0].detail, /neither a web address nor a file path/);
+  }
+});
+
+test("a local path is allowed, in all three shapes the add-in accepts", () => {
+  for (const path of ["/srv/data/prices.tsv", "C:\\data\\prices.csv",
+                      "\\\\server\\share\\prices.txt"]) {
+    assert.deepEqual(checkSourceUri(path), [], `${path} was refused`);
+  }
+});
+
+test("a local path with no data extension is only a warning", () => {
+  const found = checkSourceUri("C:\\data\\prices");
+  assert.equal(found.length, 1);
+  assert.equal(found[0].severity, "Warning");
+});
+
+test("a host with no dot is suspected, not refused", () => {
+  const found = checkSourceUri("http://localhost/prices.tsv");
+  assert.equal(found[0].severity, "Warning");
+});
+
+// ---------------------------------------------------------------------------
+// The rest
+// ---------------------------------------------------------------------------
+
+test("a region typo blocks EVERY user, and the message says that", () => {
+  const found = check(sound({SOURCE_REGION: "EGY"}))
+    .filter((f) => f.field === "SOURCE_REGION");
+
+  assert.equal(found.length, 1);
+  assert.match(found[0].detail, /BLOCKS EVERY USER/,
+    "a three-letter code reads as a harmless typo unless the consequence is "
+    + "named beside it");
+});
+
+test("GLOBAL and any two letters are fine; blank is fine", () => {
+  for (const region of ["GLOBAL", "global", "SA", "eg", ""]) {
+    assert.deepEqual(
+      check(sound({SOURCE_REGION: region})).filter((f) => f.field === "SOURCE_REGION"),
+      [], `${region || "(blank)"} was reported`);
+  }
+});
+
+test("no label means the source appears under its key", () => {
+  const found = check(sound({DISPLAY_LABEL: ""}))
+    .filter((f) => f.field === "DISPLAY_LABEL");
+  assert.equal(found[0].severity, "Warning");
+});
+
+test("switched off is Info, not a fault — and it does not block", () => {
+  const found = check(sound({IS_ACTIVE: "False"}));
+  const off = found.filter((f) => f.field === "IS_ACTIVE");
+
+  assert.equal(off[0].severity, "Info");
+  assert.equal(switchedOff(found), true);
+  assert.equal(stopsThisSource(found), false,
+    "a deliberately disabled source was reported as a fault to fix");
+});
+
+test("a BLANK IS_ACTIVE is not off — nothing is reported", () => {
+  // The add-in's default is TRUE. A Console that showed a blank as "off" would
+  // tell the owner a source is disabled while it syncs every day.
+  assert.deepEqual(
+    check(sound({IS_ACTIVE: ""})).filter((f) => f.field === "IS_ACTIVE"), []);
+});
+
+test("Arabic counts, in both directions", () => {
+  assert.equal(
+    check(sound({IS_ACTIVE: "لا"})).filter((f) => f.field === "IS_ACTIVE").length, 1);
+  assert.deepEqual(
+    check(sound({IS_ACTIVE: "نعم"})).filter((f) => f.field === "IS_ACTIVE"), []);
+});
+
+test("a broken CONTEXT_PROPS silently loses every setting in it", () => {
+  const found = check(sound({CONTEXT_PROPS: "{SkipRows: 2}"}))   // not JSON
+    .filter((f) => f.field === "CONTEXT_PROPS");
+  assert.equal(found[0].severity, "Error");
+  assert.match(found[0].detail, /ignored/);
+});
+
+test("valid JSON that is not an object is refused too", () => {
+  for (const bag of ["[1,2]", '"text"', "42", "null"]) {
+    const found = check(sound({CONTEXT_PROPS: bag}))
+      .filter((f) => f.field === "CONTEXT_PROPS");
+    assert.equal(found.length, 1, `${bag} was accepted`);
+  }
+});
+
+test("a good CONTEXT_PROPS passes", () => {
+  assert.deepEqual(
+    check(sound({CONTEXT_PROPS: '{"SkipRows": 2, "SyncFreq": "Daily"}'}))
+      .filter((f) => f.field === "CONTEXT_PROPS"), []);
+});
+
+// ---------------------------------------------------------------------------
+// Ordering and blocking
+// ---------------------------------------------------------------------------
+
+test("the worst is first, so a long list still leads with what breaks", () => {
+  const found = check(sound({
+    DISPLAY_LABEL: "", SOURCE_REGION: "EGY", TARGET_ENTITY_KEY: "T_TYPO",
+  }));
+  assert.equal(worst(found), "Error");
+  assert.equal(found.at(-1).severity, "Warning");
+});
+
+test("SEVERITY IS NOT THE SAME QUESTION AS 'does anything come out'", () => {
+  // The first version of this asked "is anything an Error" and, over the real
+  // workbook, declared 13 of 17 sources blocked — every one of which syncs
+  // daily. SyncManager does not gate on a DataSource row at all; it gates on
+  // the per-entity report, which lists a mapping-less profile among the
+  // warnings that explicitly do NOT block.
+  // Recorded as an Error by the add-in, and the source still syncs: blank
+  // PROFILE_KEY resolves to the entity key.
+  const blank = check(sound({PROFILE_KEY: ""}), {profilesDefined: ["T_DIESEL"]});
+  assert.equal(blank.some((f) => f.severity === "Error"), true,
+    "the add-in records an Error here and the Console should show it");
+  assert.equal(stopsThisSource(blank), false,
+    "a blank PROFILE_KEY was reported as producing nothing, and it produces "
+    + "everything — this is the mistake that called 13 of 17 sources broken");
+
+  // These five really do produce nothing.
+  assert.equal(stopsThisSource(check(sound({SOURCE_KEY: ""}))), true);
+  assert.equal(stopsThisSource(check(sound({TARGET_ENTITY_KEY: ""}))), true);
+  assert.equal(stopsThisSource(check(sound({TARGET_ENTITY_KEY: "T_TYPO"}))), true);
+  assert.equal(stopsThisSource(check(sound({PROFILE_KEY: "P_NOWHERE"}))), true);
+  assert.equal(stopsThisSource(check(sound({SOURCE_URI: ""}))), true);
+
+  // And these do not.
+  assert.equal(stopsThisSource(check(sound({DISPLAY_LABEL: ""}))), false);
+  assert.equal(stopsThisSource(check(sound({SOURCE_REGION: "EGY"}))), false);
+});
+
+test("the suggested key follows the add-in's own convention", () => {
+  assert.equal(suggestedKey({TARGET_ENTITY_KEY: "T_DIESEL", PROFILE_KEY: "P_X"}),
+               "T_DIESEL_P_X");
+  // DEFAULT is not part of a name — it IS the entity.
+  assert.equal(suggestedKey({TARGET_ENTITY_KEY: "T_DIESEL", PROFILE_KEY: "DEFAULT"}),
+               "T_DIESEL");
+  assert.equal(suggestedKey({TARGET_ENTITY_KEY: "T_DIESEL", PROFILE_KEY: ""}),
+               "T_DIESEL");
+  assert.equal(suggestedKey({}), "");
+});
+
+test("every finding names the field it is about", () => {
+  // The Console puts each of these beside its own input. A finding with no
+  // field would render nowhere and be invisible.
+  const found = check({SOURCE_KEY: "K", TARGET_ENTITY_KEY: "T_TYPO",
+                       PROFILE_KEY: "", SOURCE_URI: "", SOURCE_REGION: "EGY"});
+  assert.ok(found.length >= 4);
+  for (const f of found) {
+    assert.ok(f.field, `a finding has no field: ${f.detail?.slice(0, 40)}`);
+    assert.ok(f.code, `a finding has no add-in error code: ${f.field}`);
+  }
+  assert.ok(fields(found).includes("SOURCE_URI"));
+});

--- a/extension/tests/datasource-rules.test.mjs
+++ b/extension/tests/datasource-rules.test.mjs
@@ -11,6 +11,7 @@ import assert from "node:assert/strict";
 
 import { checkSourceUri, checkDataSourceRow, stopsThisSource, switchedOff,
          suggestedKey } from "../datasource-rules.js";
+import { readsUriAsGoogleSheets } from "../addin-contract.js";
 
 const PUBLISHED =
   "https://docs.google.com/spreadsheets/d/e/2PACX-1vAAA/pub?gid=223498986&single=true&output=tsv";
@@ -390,7 +391,38 @@ test("every finding names the field it is about", () => {
 // than invent — but the consequence CodeQL named is real, and it belongs to the
 // add-in: an address that merely MENTIONS docs.google.com passes every check it
 // makes, and is then downloaded with no authentication.
+//
+// So the mirror was not deleted and was not silenced. It was SEPARATED. The
+// add-in's substring test is `readsUriAsGoogleSheets` in the contract module,
+// beside the other quirks it reproduces, and it decides nothing. What decides is
+// the parsed host, here. The two tests below hold that separation in place: one
+// proves the mirror still agrees with the add-in even where the add-in is wrong,
+// the other proves the Console refuses anyway.
 // ---------------------------------------------------------------------------
+
+test("the mirror still agrees with the add-in, INCLUDING where it is wrong", () => {
+  // If this ever goes false, the add-in has been repaired — and then the
+  // impostor Error below becomes unreachable and should be reconsidered, not
+  // deleted on the grounds that nothing hits it.
+  assert.equal(
+    readsUriAsGoogleSheets("https://attacker.example/?x=docs.google.com"), true,
+    "the mirror no longer reproduces SourceUriValidator's substring match");
+  assert.equal(readsUriAsGoogleSheets("https://DOCS.GOOGLE.COM/pub"), true,
+    "the add-in matches case-insensitively and this no longer does");
+  assert.equal(readsUriAsGoogleSheets(""), false);
+  assert.equal(readsUriAsGoogleSheets(null), false);
+});
+
+test("and deciding by the mirror alone would accept the attack", () => {
+  // Stated as an assertion rather than a comment, because this is the whole
+  // reason the two live apart: agreeing with the add-in is NOT a safety verdict.
+  const attack = "https://attacker.example/collect?x=docs.google.com&output=tsv";
+
+  assert.equal(readsUriAsGoogleSheets(attack), true,
+    "the add-in would call this a Google Sheet");
+  assert.ok(checkSourceUri(attack).some((f) => f.severity === "Error"),
+    "and the Console let it through, which means the host check has gone");
+});
 
 test("an address that only MENTIONS Google is refused, and says who serves it", () => {
   const found = checkSourceUri(

--- a/extension/tests/datasource-rules.test.mjs
+++ b/extension/tests/datasource-rules.test.mjs
@@ -380,3 +380,59 @@ test("every finding names the field it is about", () => {
   }
   assert.ok(fields(found).includes("SOURCE_URI"));
 });
+
+// ---------------------------------------------------------------------------
+// A defect in the ADD-IN, found by a scanner pointed at this file.
+//
+// CodeQL flagged `lower.includes("docs.google.com")` as
+// js/incomplete-url-substring-sanitization. The mirror is deliberate — the
+// add-in matches exactly that way and this module's rule is to mirror rather
+// than invent — but the consequence CodeQL named is real, and it belongs to the
+// add-in: an address that merely MENTIONS docs.google.com passes every check it
+// makes, and is then downloaded with no authentication.
+// ---------------------------------------------------------------------------
+
+test("an address that only MENTIONS Google is refused, and says who serves it", () => {
+  const found = checkSourceUri(
+    "https://attacker.example/collect?x=docs.google.com&output=tsv");
+
+  const impostor = found.filter((f) => /MENTIONS/.test(f.detail));
+  assert.equal(impostor.length, 1);
+  assert.equal(impostor[0].severity, "Error");
+  assert.match(impostor[0].detail, /attacker\.example/,
+    "the message does not name the host actually being talked to, which is the "
+    + "one fact that settles it");
+  assert.match(impostor[0].detail, /no authentication/);
+});
+
+test("a look-alike host is refused too", () => {
+  // The other half of the same trick, and the one a reader is likeliest to miss.
+  const found = checkSourceUri(
+    "https://docs.google.com.attacker.example/pub?gid=1&output=tsv");
+  assert.ok(found.some((f) => /MENTIONS/.test(f.detail)),
+    "docs.google.com.attacker.example was accepted as Google's own host");
+});
+
+test("the real thing is not refused, on either Google host shape", () => {
+  for (const uri of [PUBLISHED,
+                     "https://spreadsheets.google.com/pub?gid=1&output=tsv"]) {
+    assert.deepEqual(checkSourceUri(uri).filter((f) => /MENTIONS/.test(f.detail)),
+      [], `${uri} was treated as an impostor`);
+  }
+});
+
+test("the TSV rule still mirrors the add-in's substring match exactly", () => {
+  // Deliberately NOT narrowed to the real host: the Console must ask for
+  // output=tsv in precisely the cases the add-in does, or it is describing a
+  // different program.
+  const found = checkSourceUri("https://attacker.example/?x=docs.google.com");
+  assert.ok(found.some((f) => /output=tsv/.test(f.fix)),
+    "the TSV warning stopped firing for an address the add-in would still "
+    + "treat as a Google Sheet");
+});
+
+test("a malformed address is refused rather than parsed by guesswork", () => {
+  const found = checkSourceUri("https://exa mple.com/x.tsv");
+  assert.equal(found.length, 1);
+  assert.match(found[0].detail, /not a well-formed/);
+});

--- a/extension/tests/workbook.test.mjs
+++ b/extension/tests/workbook.test.mjs
@@ -343,3 +343,79 @@ test("the transform list is the add-in's, and it is chained with a pipe", () => 
   // as one unknown transform and is dropped whole.
   assert.ok(!TRANSFORMS.some((t) => t.includes("|")));
 });
+
+// ---------------------------------------------------------------------------
+// A blank PROFILE_KEY is not an absent one.
+//
+// THIRTEEN OF THE FIFTEEN ORPHANS I FIRST REPORTED WERE MINE. The add-in
+// resolves an empty PROFILE_KEY — and the literal "DEFAULT" — to the row's
+// TARGET_ENTITY_KEY, then looks up DataMap under that name. My checker did not
+// know, so every source that leaves the column blank looked like a source
+// referencing nothing, and every profile named after an entity looked orphaned.
+//
+// Reporting thirteen problems that are not problems is how a checker teaches
+// its owner to stop reading it — which costs more than the two it found.
+// ---------------------------------------------------------------------------
+
+test("a source with a BLANK profile still names one — its entity", () => {
+  const ranges = sound();
+  // The shape the live workbook uses more than any other: no profile column.
+  ranges[2].values[1][2] = "";
+  // values[1] and [2]; values[0] is the header row, and writing over it makes
+  // the whole sheet unparseable — which is how the first draft of this test
+  // passed while asserting nothing.
+  ranges[3].values[1][0] = "T_DIESEL";
+  ranges[3].values[2][0] = "T_DIESEL";
+
+  const orphans = problems(ranges).filter(
+    (p) => p.kind === "profile nothing references");
+  assert.deepEqual(orphans, [],
+    "a profile named after the entity was reported as orphaned, because the "
+    + "blank PROFILE_KEY beside it was read as 'no profile' rather than as "
+    + "'the default one'");
+});
+
+test('the literal "DEFAULT" resolves the same way, in any case', () => {
+  for (const spelling of ["DEFAULT", "default", "Default"]) {
+    const ranges = sound();
+    ranges[2].values[1][2] = spelling;
+    ranges[3].values[1][0] = "T_DIESEL";
+    ranges[3].values[2][0] = "T_DIESEL";
+
+    assert.deepEqual(
+      problems(ranges).filter((p) => p.kind === "profile nothing references"), [],
+      `"${spelling}" was not treated as the default profile`);
+  }
+});
+
+test("and the mapping's target is still judged against the right entity", () => {
+  // The resolution must reach BOTH readings of PROFILE_KEY. If only the orphan
+  // check learned it, a blank-profile source would stop reporting orphans and
+  // start missing attributes that do not exist.
+  const ranges = sound();
+  ranges[2].values[1][2] = "";
+  // values[1] and [2]; values[0] is the header row, and writing over it makes
+  // the whole sheet unparseable — which is how the first draft of this test
+  // passed while asserting nothing.
+  ranges[3].values[1][0] = "T_DIESEL";
+  ranges[3].values[2][0] = "T_DIESEL";
+  ranges[3].values.push(["T_DIESEL", "NotAColumn", "Header", "Exact", "x"]);
+
+  const found = problems(ranges).filter(
+    (p) => p.kind === "attribute not in schema");
+  assert.equal(found.length, 1,
+    "a mapping under a defaulted profile is no longer checked at all");
+  assert.match(found[0].detail, /NotAColumn/);
+});
+
+test("a profile named after nothing at all is STILL an orphan", () => {
+  // The correction must not swallow the two real ones. GARB and GARB2 in the
+  // owner's file match no entity and no source names them.
+  const ranges = sound();
+  ranges[3].values.push(["GARB", "Price", "Header", "Exact", "x"]);
+
+  const orphans = problems(ranges).filter(
+    (p) => p.kind === "profile nothing references");
+  assert.equal(orphans.length, 1);
+  assert.match(orphans[0].detail, /GARB/);
+});

--- a/extension/workbook.js
+++ b/extension/workbook.js
@@ -213,11 +213,27 @@ export function inspect(workbook) {
 
   // A map's target attribute must exist in the schema OF THE ENTITY that map
   // feeds — which is reached through the source that names the profile.
+  // A BLANK PROFILE IS NOT AN ABSENT ONE. The add-in resolves an empty
+  // PROFILE_KEY — and the literal "DEFAULT", case-insensitively — to the row's
+  // TARGET_ENTITY_KEY, then looks up DataMap under that name.
+  //
+  // The first version of this file did not know that and reported FIFTEEN
+  // orphan profiles in the owner's workbook. Thirteen of them were mine: every
+  // source that leaves PROFILE_KEY blank still names a profile, it just names
+  // it by the entity. Two are real — GARB and GARB2. Reporting thirteen
+  // problems that are not problems is how a checker teaches its owner to stop
+  // reading it, which costs more than the two it would have found.
+  const profileOf = (row) => {
+    const named = (row.PROFILE_KEY || "").trim();
+    return (!named || named.toUpperCase() === "DEFAULT")
+      ? (row.TARGET_ENTITY_KEY || "")
+      : named;
+  };
+
   const entityOfProfile = new Map();
   for (const r of rows("3.DataSource")) {
-    if (r.PROFILE_KEY && r.TARGET_ENTITY_KEY) {
-      entityOfProfile.set(r.PROFILE_KEY, r.TARGET_ENTITY_KEY);
-    }
+    const profile = profileOf(r);
+    if (profile && r.TARGET_ENTITY_KEY) entityOfProfile.set(profile, r.TARGET_ENTITY_KEY);
   }
   const attributes = new Map();
   for (const r of rows("2.SchemaRule")) {
@@ -255,7 +271,9 @@ export function inspect(workbook) {
   }
 
   // ---- things nothing consumes --------------------------------------------
-  const referenced = new Set(rows("3.DataSource").map((r) => r.PROFILE_KEY).filter(Boolean));
+  // Through the SAME resolution the add-in uses, or a blank PROFILE_KEY looks
+  // like a source that references nothing while the add-in reads it happily.
+  const referenced = new Set(rows("3.DataSource").map(profileOf).filter(Boolean));
   const defined = new Map();
   for (const r of rows("4.DataMap")) {
     if (r.PROFILE_KEY) defined.set(r.PROFILE_KEY, (defined.get(r.PROFILE_KEY) || 0) + 1);

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -2863,47 +2863,61 @@ def test_a_business_date_is_never_shifted_by_the_display_zone(open_panel):
     assert not page.js_errors
 
 
-def test_a_page_that_is_only_a_shape_says_so_on_itself(open_panel):
-    """Profile, Engine and Console exist so their shape can be agreed before
-    they are written. Every one of them is empty behind the glass.
+def test_anything_that_says_it_is_unbuilt_is_actually_inert(open_panel):
+    """A card that looks finished and does nothing is worse than no card: the
+    owner presses a button, nothing happens, and the product reads as broken
+    rather than unbuilt.
 
-    A page that looks finished and does nothing is worse than no page: the owner
-    presses Install, nothing happens, and the product looks broken rather than
-    unbuilt. So each carries a note naming the milestone it is waiting for, and
-    every control on it is disabled.
+    THIS USED TO BE A LIST OF PAGES, and the list could not survive a page being
+    HALF built — which is what Console became the day it grew a working "Open
+    the Console" button beside an unbuilt Datasets card. Under the old rule the
+    page had to be entirely a shape or entirely real; the honest state was
+    neither, and the test failed for the wrong reason.
 
-    The project's own rule, from the brief: "Clearly identify mock and production
-    integrations." This is the mechanical form of it."""
+    So the rule moved onto the CLASS. Every `.planned-note`, wherever it is,
+    must name its milestone and must sit inside the card whose controls it
+    excuses — and every control in that card must be dead. A note beside a
+    working button is the lie this exists to prevent, and it is now caught
+    wherever it appears rather than only on pages somebody remembered to list.
+
+    The project's own rule, from the brief: "Clearly identify mock and
+    production integrations." This is the mechanical form of it.
+    """
     page = open_panel()
 
-    # PAGES LEAVE THIS LIST AS THEY ARE BUILT, and each has to be taken out by
-    # hand. `engines` went when its rows became real (M1b); `profile` went when
-    # its button started signing people in (M1c). Both would have passed here
-    # afterwards — a note and a disabled control are easy to keep — which is
-    # exactly why the removal is deliberate: a page reporting true facts under
-    # "Not built yet" is lying in the safe direction, and the next reader
-    # trusts neither line.
-    shapes = (("console", "M7"),)
-    assert shapes, (
-        "every page is built, so this test now passes by checking nothing — "
-        "delete it rather than leaving it green over an empty list")
+    notes = page.locator(".planned-note")
+    assert notes.count(), (
+        "nothing declares itself unbuilt anywhere. Either every shape is now "
+        "real — in which case delete this test deliberately rather than leave "
+        "it green over an empty page — or a note was removed from something "
+        "that still does nothing.")
 
-    for view, milestone in shapes:
-        page.click(f"#tab-{view}")
-        panel = page.locator(f"#view-{view}")
-        assert panel.is_visible(), f"the {view} page does not open"
+    for i in range(notes.count()):
+        note = notes.nth(i)
 
-        note = panel.locator(".planned-note")
-        assert note.count() == 1, f"the {view} page does not say it is unbuilt"
-        assert note.get_attribute("data-planned") == milestone, (
-            f"the {view} page does not name the milestone it waits for")
-        assert "Not built yet" in note.inner_text()
+        # Its view has to be open for the DOM to be measurable at all.
+        view = note.evaluate("n => n.closest('[role=tabpanel]')?.id || ''")
+        assert view.startswith("view-"), (
+            "a planned note sits outside every view, so nothing can say what it "
+            "is excusing")
+        page.click(f"#tab-{view[len('view-'):]}")
 
-        buttons = panel.locator("button")
-        for i in range(buttons.count()):
-            assert buttons.nth(i).is_disabled(), (
-                f"a control on the {view} page is pressable while the page does "
-                "nothing — that reads as broken, not as unbuilt")
+        assert note.get_attribute("data-planned"), (
+            f"the note in {view} does not name the milestone it waits for")
+        assert "Not built yet" in note.inner_text(), (
+            f"the note in {view} does not say plainly that it is unbuilt: "
+            f"{note.inner_text()[:60]!r}")
+
+        card = note.locator("xpath=ancestor::section[contains(@class,'card')][1]")
+        assert card.count() == 1, (
+            f"the note in {view} is not inside a card, so which controls it "
+            "excuses is a matter of opinion")
+
+        buttons = card.locator("button")
+        for b in range(buttons.count()):
+            assert buttons.nth(b).is_disabled(), (
+                f"a control in {view} is pressable inside a card that says it is "
+                "not built — that reads as broken, not as unbuilt")
 
 
 def test_the_shape_opens_on_who_you_are_and_what_is_installed(open_panel):

--- a/tests/test_panel_wiring.py
+++ b/tests/test_panel_wiring.py
@@ -145,11 +145,24 @@ def test_the_unbuilt_file_source_is_disabled_not_silent():
             f"the {action} button is enabled but nothing implements it"
 
 
-def test_the_interface_stays_english():
-    """Spec 1: Arabic is data, never interface. The panel's own markup carries
-    no Arabic — the stress fixtures that do live in the screenshot harness."""
-    arabic = re.findall(r"[؀-ۿ]+", HTML)
-    assert not arabic, f"Arabic leaked into the panel markup: {arabic[:3]}"
+@pytest.mark.parametrize(
+    "page", sorted(EXT.glob("*.html")), ids=lambda p: p.name)
+def test_the_interface_stays_english(page):
+    """Spec 1: Arabic is data, never interface. The stress fixtures that do
+    carry Arabic live in the screenshot harness.
+
+    EVERY SHIPPED PAGE, not just the panel. This read only app.html until
+    2026-08-12, so onboarding.html was never checked and neither would the
+    Console have been — and the Console is the page most likely to grow an
+    Arabic label, because it edits a workbook whose own DATA is bilingual.
+
+    The panel's own markup is the strictest case and the others follow it, so
+    one rule covers all of them rather than a list somebody has to remember to
+    extend.
+    """
+    arabic = re.findall(r"[؀-ۿ]+", page.read_text(encoding="utf-8"))
+    assert not arabic, (
+        f"Arabic leaked into {page.name}: {arabic[:3]}")
 
 
 # ---- run modes are offered according to the DATA -----------------------------

--- a/tests/test_the_addin_contract_cannot_drift.py
+++ b/tests/test_the_addin_contract_cannot_drift.py
@@ -160,6 +160,29 @@ def test_the_arabic_spellings_survived_the_json_round_trip():
         "nobody can review them")
 
 
+def test_the_address_markers_are_the_add_ins_own_literals():
+    """`SourceUriValidator` searches the whole address for these three, and every
+    Console warning about an address is keyed on them. Inline, they drifted
+    silently; here, a change to the add-in has to be typed on purpose.
+
+    The lower case matters and is not cosmetic: the add-in lower-cases the
+    address before searching, so a marker carrying a capital would never match
+    and the Console would fall silent about the mistake its own file header calls
+    the commonest one there is."""
+    constants = _contract()["constants"]
+
+    assert constants["URI_GOOGLE_SHEETS_MARKER"] == "docs.google.com"
+    assert constants["URI_TSV_MARKERS"] == ["output=tsv", "format=tsv"]
+    assert constants["URI_TAB_MARKER"] == "gid="
+
+    for name in ("URI_GOOGLE_SHEETS_MARKER", "URI_TAB_MARKER"):
+        assert constants[name] == constants[name].lower(), (
+            f"{name} is compared against a lower-cased address and would never "
+            "match")
+    for marker in constants["URI_TSV_MARKERS"]:
+        assert marker == marker.lower()
+
+
 def test_the_hand_written_half_does_not_redeclare_the_generated_half():
     """Two sources for one list is the defect this whole file exists to prevent,
     and the tidiest place for it to reappear is the module that re-exports the

--- a/tests/test_the_privacy_policy_is_true.py
+++ b/tests/test_the_privacy_policy_is_true.py
@@ -277,6 +277,11 @@ def test_every_place_the_extension_persists_data_is_in_the_policy():
         # where a business's data lands is not a decision to re-make daily —
         # and outliving the panel is exactly what puts it in this table.
         "app.js": "spreadsheet",
+        # The Console remembers WHICH workbook holds the Excel add-in's
+        # configuration, so the owner does not hunt for it every morning. Same
+        # reasoning, different file — and the same row covers both, because a
+        # reader asking "what does this keep about my Drive" wants one answer.
+        "console.js": "spreadsheet",
     }
     missing = [name for name in writers
                if name in described and described[name].lower() not in storage_table.lower()]

--- a/tests/test_ui_kit.py
+++ b/tests/test_ui_kit.py
@@ -51,7 +51,8 @@ ROOT = pathlib.Path(__file__).resolve().parents[1]
 #: `scrapex/webui/static/` are byte-equal to the canon (tests/test_vendor.py),
 #: so reading the canon is reading both.
 CANONICAL = ("design/components.css", "design/tokens.css")
-SURFACE_SHEETS = ("extension/app.css", "extension/onboarding.css")
+SURFACE_SHEETS = ("extension/app.css", "extension/onboarding.css",
+                  "extension/console.css")
 
 #: Class attributes a template computes cannot be resolved by reading the file.
 JINJA = re.compile(r"\{\%.*?\%\}|\{\{.*?\}\}", re.S)
@@ -98,8 +99,19 @@ def defined() -> set[str]:
 
 
 def _markup() -> list[pathlib.Path]:
-    return ([ROOT / "extension" / "app.html"]
-            + sorted((ROOT / "scrapex" / "webui" / "templates").rglob("*.html")))
+    """EVERY page the extension ships, not just the panel.
+
+    This globbed nothing but app.html until 2026-08-12, so onboarding.html's
+    classes were never resolved and neither would any new page's have been —
+    a gate that grows blind spots as the product grows is worse than one that
+    fails, because its green keeps meaning what it used to mean.
+
+    tests/ is excluded: the diagnostic twin exists to be minimal, and holding
+    it to the shared vocabulary would be holding it to the opposite of its
+    purpose.
+    """
+    pages = sorted(page for page in (ROOT / "extension").glob("*.html"))
+    return pages + sorted((ROOT / "scrapex" / "webui" / "templates").rglob("*.html"))
 
 
 def _used() -> dict[str, set[str]]:

--- a/tools/sync_addin_contract.py
+++ b/tools/sync_addin_contract.py
@@ -108,6 +108,12 @@ def render(contract: dict) -> str:
 
     lines.append("// ---- constants " + "-" * 61)
     for name, value in contract["constants"].items():
+        # A `_comment` key carries the reason a constant exists, and the reason
+        # is worth more in the generated file than in the JSON nobody opens.
+        if name.startswith("_"):
+            lines.append("")
+            lines.extend(f"// {line}" for line in value)
+            continue
         lines.append(f"export const {name} = {_js(value)};")
     lines.append("")
 


### PR DESCRIPTION
A page in a **tab** — not a view in the panel, not a page on the website.

| | why not |
|---|---|
| a panel view | six sheets of configuration are a table editor; the panel is 360px |
| a page on the site | the token would have to leave the extension, and the `externally_connectable` widening the Picker needs is not worth repeating for a surface that does not need it — the Sheets API is a plain `fetch` that `host_permissions` already covers |

Cost in the manifest: **zero**. `release-extension.yml` copies the whole directory, so a new page ships by existing.

## The check that comes before every other check

The add-in does not find its configuration by name. `EndpointCatalog` carries **six tab ids compiled into the build** and fetches each directly. So a workbook can have all six tab *names*, look perfect, and be a copy the add-in has never read.

The Console compares the six gids first and **refuses to display anything** if they disagree — naming which tab is which id. Checking the wrong file and reporting it correct is worse than saying nothing.

Then it reports **before** it offers to change: findings first, sheets after. A Console that opened on an editor would invite a change while the file already had faults nobody had been shown.

## One picker, not two

`extension/picker.js` is the nonce handoff extracted whole. The panel picks the workbook exports go into; the Console picks the add-in’s configuration. A second copy of a token flow is a second place for the rules to drift.

## Two guards were blind to every page but `app.html`

Both widened — and the first one immediately earned it:

- `test_ui_kit.py::_markup` globbed one file. Widened to every shipped page, it found **`class="body"` in `onboarding.html`** — three elements carrying a class no stylesheet defines, shipping since it was built. The class is deleted and the elements stay: `.step` is a flex row and that div is what holds the text beside the number.
- `test_the_interface_stays_english` read `app.html` alone. Now parametrised over every page — which matters most for the Console, because it edits a workbook whose own **data** is bilingual.

## And one guard caught me

`test_a_page_that_is_only_a_shape_says_so_on_itself` failed when I deleted the Console view’s "not built" note. **Correctly** — the Datasets card below is still a shape.

But that test could not express a page that is *half* built, which is exactly what Console became. So the rule moved from a list of pages onto the **class**: every `.planned-note` must name its milestone, must sit inside the card whose controls it excuses, and every control in that card must be dead.

| mutation | result |
|---|---|
| a live button inside the card that says it is unbuilt | fails |
| a note with no milestone | fails |
| a note moved outside its card | fails |

It now catches a live button beside a "not built" note **wherever it appears**, rather than only on pages somebody remembered to list.

## Verification

584 extension tests · 210 node · eslint clean · ruff clean · **no engine file changed**.

The privacy policy gained the row the Console’s remembered workbook needs — the guard added earlier today refused the commit until it did.