### PR TITLE
The Console printed a code the add-in cannot emit, on nine findings

### DIFF
--- a/contract/addin-contract.json
+++ b/contract/addin-contract.json
@@ -133,7 +133,8 @@
     "SEVERITIES": ["Info", "Warning", "Error", "Critical"],
     "ERROR_CODES": ["ERR_REF", "ERR_DUPLICATE", "ORPHAN_MAPPING", "PK_MISSING",
                     "MANDATORY_UNMAPPED", "INVALID_JSON", "UNKNOWN_KEY",
-                    "INVALID_VALUE", "ERR_REQUIRED", "ERR_TRANSFORM"]
+                    "INVALID_VALUE", "ERR_REQUIRED", "ERR_TRANSFORM",
+                    "ERR_FORMAT"]
   },
 
   "constants": {

--- a/docs/HANDOFF-mbiXaddin-source-uri-validator.md
+++ b/docs/HANDOFF-mbiXaddin-source-uri-validator.md
@@ -1,0 +1,177 @@
+# Handoff — mbiXaddin decides "is this Google Sheets" by searching the whole string
+
+*Paste everything below into a session working in
+`C:\Users\User01\source\repos\mbiXaddin`. It is self-contained; that session
+needs no knowledge of the conversation this came from.*
+
+---
+
+## Before anything: your first job is to REFUTE this
+
+A finding arrived from another repository. It was found by CodeQL pointed at a
+*copy* of your rule, not at your rule, and the person reporting it has not run
+your code. **Treat it as a claim, not as a work order.**
+
+Do not open an editor until you have answered, from the code in front of you:
+
+1. Does `SourceUriValidator` really decide by substring, or is there a host check
+   somewhere else — earlier in the pipeline, in a policy class, in a config
+   allow-list — that makes this unreachable?
+2. Is the address that reaches the HTTP client the same string that was
+   validated, or is it rewritten in between?
+3. Does anything authenticate the fetch, refuse redirects to another host, or
+   check the content type before parsing?
+4. Can a value that fails these checks actually be *stored* in the workbook by
+   somebody who is not already the owner? **Who is the attacker here, and what
+   access do they need?**
+
+Question 4 is the one that decides whether this is worth fixing at all, and it
+is the one most likely to shrink the finding. Say plainly what you conclude.
+
+**If you cannot reproduce it, say so and stop.** A refutation with file:line is a
+better outcome than a repair of something that was never broken. The reporting
+session has been wrong twice recently in exactly this way — it read a rule
+correctly and then *assumed a consequence* — so it will not be surprised.
+
+---
+
+## The claim
+
+`mbiXaddin/Core/Validation/SourceUriValidator.cs:79-80`:
+
+```csharp
+bool isGoogleSheets = sourceUri.IndexOf("docs.google.com",
+    StringComparison.OrdinalIgnoreCase) >= 0;
+```
+
+The host is never parsed. The substring may appear anywhere — in the query
+string, in the path, in a subdomain of somebody else's domain. So both of these
+are "a Google Sheet" as far as this validator is concerned:
+
+```
+https://attacker.example/collect?x=docs.google.com&output=tsv
+https://docs.google.com.attacker.example/pub?gid=1&output=tsv
+```
+
+Each satisfies **every** check the file makes: it starts with `https://`
+(`:44-49`), its authority contains a dot (`:66-75`), it contains `output=tsv`
+(`:83-85`) and it contains `gid=` (`:87-88`). Validation passes clean.
+
+### Why that matters more than a validator usually does
+
+The claim is that what happens next has no second line of defence. Verify each
+of these yourself — they are the whole argument:
+
+| | claimed location |
+|---|---|
+| the only runtime check is `StartsWith("http")` | `Infrastructure/Services/Ingestion/DataIngestionService.cs:734` |
+| plain GET, **no Authorization header, no cookies, no OAuth** | `Infrastructure/Network/HttpClientService.cs:393-465`; the comment saying so is at `Core/Entities/DataSourceEntity.cs:666-668` |
+| follows up to **5 redirects**, including cross-host | `Infrastructure/Network/HappyEyeballsHandler.cs:97-108,442` |
+| **Content-Type is never inspected** | `Infrastructure/Services/Sync/Metadata/TsvParser.cs:48-52` |
+| the bytes are then parsed as the table's rows | `Infrastructure/Services/Ingestion/StreamingTsvReader.cs:62-72,101-108` |
+
+The markup sniff at `SourceIntegrityGate.cs:64-69` rejects a payload starting
+with `<!DOCTYPE`, `<HTML` or `<?XML` — **note that it does not help here**, since
+a TSV response is not markup. Confirm that reading.
+
+If all of the above holds, the consequence is: an address in the `SOURCE_URI`
+column can point anywhere, and whatever it returns becomes rows in the owner's
+Excel table, unauthenticated.
+
+---
+
+## If it holds — the repair
+
+Parse the host and compare it. Keep everything else exactly as it is: the TSV
+error, the gid warning, the wording, the error codes, the order they are
+yielded in.
+
+```csharp
+// Sketch, not a patch — write it to fit the file.
+bool isGoogleSheets = false;
+if (Uri.TryCreate(sourceUri, UriKind.Absolute, out var parsed))
+{
+    var host = parsed.Host;                      // already lower-cased by Uri
+    isGoogleSheets = host.Equals("docs.google.com", StringComparison.OrdinalIgnoreCase)
+                  || host.EndsWith(".google.com", StringComparison.OrdinalIgnoreCase);
+}
+```
+
+Three things to decide deliberately rather than by accident, and to **write down
+in the commit message**:
+
+1. **`.google.com` or only `docs.google.com`?** Broader accepts
+   `spreadsheets.google.com`, which the current substring rule *rejects* — so
+   this is a behaviour change in the permissive direction, not only the strict
+   one. Say which you chose and why.
+2. **What happens to an address that mentions Google but is not served by it?**
+   Silently dropping to "not a Google Sheet" means it skips the TSV and gid
+   checks and is fetched anyway. A new `ValidationResult.Fail` naming the real
+   host is the more useful answer. Its code should be
+   `SystemConstants.ErrorCodes.InvalidFormat` (`ERR_FORMAT`) — the same code
+   every other rule in this file uses (`SystemConstants.cs:356`).
+3. **Local paths.** The `isLocal` branch at `:44-49` never had a host. Make sure
+   the change does not alter it.
+
+### Tests
+
+`tests/Core.Tests/SourceUriValidatorTests.cs` already exists and already uses the
+real published shape at `:64,74`. Add cases there — at minimum the two attack
+addresses above, plus `https://spreadsheets.google.com/pub?gid=1&output=tsv` for
+whichever decision you took on point 1.
+
+**Then break your own fix and confirm the tests fail.** A guard that passes
+against its own mutation is not a guard. If a test still passes with
+`isGoogleSheets` forced to `true`, it is testing something else.
+
+### While you are in there
+
+Check whether the same `IndexOf`-a-hostname style appears anywhere else in the
+add-in's URL handling. If it does, report it — do not fix it in the same change.
+
+---
+
+## What NOT to do
+
+- **Do not modify `C:\Users\User01\source\repos\ScrapeX`.** Another session owns
+  it and has work in flight.
+- **Do not broaden this into a security review of the add-in.** One finding, one
+  repair, one commit.
+- **Do not add authentication to the fetch.** The sources are published public
+  URLs by design; that is a separate decision and not yours to take here.
+- Do not rename error codes or change severities that are not part of this fix.
+
+---
+
+## When you are done, report back these five things
+
+The owner will carry your answer to the ScrapeX session, which has to react to
+it. Be precise:
+
+1. **Confirmed or refuted**, with the file:line that settled it — including your
+   answer to "who is the attacker and what access do they need".
+2. Which host rule you chose (point 1 above) and why.
+3. Whether an impostor address now produces a finding, and at what severity and
+   code.
+4. The mutation you ran and which test caught it.
+5. Whether you found the same style elsewhere.
+
+### And one thing ScrapeX needs from you specifically
+
+ScrapeX reproduces your validator deliberately, so that its Console warns in
+exactly the cases you do. That copy lives in
+`extension/addin-contract.js` as `readsUriAsGoogleSheets`, and it is documented
+as reproducing a defect **on purpose**. There is a test in
+`extension/tests/datasource-rules.test.mjs` named
+
+> *"the mirror still agrees with the add-in, INCLUDING where it is wrong"*
+
+which is designed to **fail the day you fix this**. That failure is the signal,
+not a bug — its comment says the impostor warning should then be reconsidered
+rather than deleted for lack of coverage.
+
+So: **say clearly in your report that the behaviour changed.** There is no
+`behaviourVersion` in this repository yet (a separate handoff,
+`docs/HANDOFF-mbiXaddin-contract-producer.md`, proposes adding one for exactly
+this reason). Until it exists, your written report is the only mechanism that
+tells ScrapeX its reading has gone stale.

--- a/extension/addin-contract.js
+++ b/extension/addin-contract.js
@@ -148,9 +148,30 @@ export const ERROR_CODE = {
   mandatoryUnmapped: "MANDATORY_UNMAPPED",
   badJson: "INVALID_JSON",
   unknownKey: "UNKNOWN_KEY",
-  badValue: "INVALID_VALUE",
+  // THE TWO ARE NOT INTERCHANGEABLE, and the Console had them the wrong way
+  // round on every DataSource field. `DataSourceEntity.Validate()` and
+  // `SourceUriValidator` emit only ERR_REQUIRED and ERR_FORMAT — never
+  // INVALID_VALUE, which lives one layer down in `ConfigValidator` and is
+  // reached only through a JSON config bag. A Console code the add-in does not
+  // emit for that fault sends an owner searching the add-in's log for a string
+  // that is not in it, which is the exact failure this map exists to prevent.
+  badFormat: "ERR_FORMAT",          // DataSourceEntity.cs:355, SourceUriValidator.cs:59
+  badValue: "INVALID_VALUE",        // ConfigValidator.cs:106,129 — bags only
   required: "ERR_REQUIRED",
   transform: "ERR_TRANSFORM",
+};
+
+/**
+ * Faults the Console reports that the add-in HAS NO RULE FOR.
+ *
+ * Kept apart from `ERROR_CODE` on purpose, and enforced apart by a test: every
+ * code above must appear in the add-in's vocabulary, and every code here must
+ * appear in none of it. Borrowing one of the add-in's names for a finding it
+ * never makes would claim a parity that does not exist — and the owner would
+ * search its log for a code it cannot produce.
+ */
+export const CONSOLE_ONLY_CODE = {
+  notApplied: "NOT_APPLIED",        // accepted, documented, and then ignored
 };
 
 /** The six gids, flattened for the check that a chosen workbook is the right one. */

--- a/extension/addin-vocabulary.js
+++ b/extension/addin-vocabulary.js
@@ -46,7 +46,7 @@ export const MENU_ACTIONS = ["Menu", "Library", "ExportTree", "ViewList"];
 export const TRUE_SPELLINGS = ["1", "true", "yes", "y", "on", "نعم", "صح", "صحيح"];
 export const FALSE_SPELLINGS = ["0", "false", "no", "n", "off", "لا", "خطأ", "غلط"];
 export const SEVERITIES = ["Info", "Warning", "Error", "Critical"];
-export const ERROR_CODES = ["ERR_REF", "ERR_DUPLICATE", "ORPHAN_MAPPING", "PK_MISSING", "MANDATORY_UNMAPPED", "INVALID_JSON", "UNKNOWN_KEY", "INVALID_VALUE", "ERR_REQUIRED", "ERR_TRANSFORM"];
+export const ERROR_CODES = ["ERR_REF", "ERR_DUPLICATE", "ORPHAN_MAPPING", "PK_MISSING", "MANDATORY_UNMAPPED", "INVALID_JSON", "UNKNOWN_KEY", "INVALID_VALUE", "ERR_REQUIRED", "ERR_TRANSFORM", "ERR_FORMAT"];
 
 // ---- the sheets, and the gids compiled into the add-in ----------------------
 export const SHEETS = {

--- a/extension/datasource-rules.js
+++ b/extension/datasource-rules.js
@@ -12,7 +12,7 @@
 // would print a cascade of complaints about a row the add-in never reaches.
 
 import { readBoolean, readsUriAsGoogleSheets, BOOLEAN_DEFAULTS, ERROR_CODE,
-  CONTEXT_PROPS_KEYS, URI_TSV_MARKERS, URI_TAB_MARKER }
+  CONSOLE_ONLY_CODE, CONTEXT_PROPS_KEYS, URI_TSV_MARKERS, URI_TAB_MARKER }
   from "./addin-contract.js";
 
 /**
@@ -66,7 +66,7 @@ export function checkSourceUri(uri) {
   if (!isHttp && !isLocal) {
     // Stops here in the add-in as well — every later rule assumes one of the
     // two shapes.
-    return [finding("Error", "SOURCE_URI", ERROR_CODE.badValue,
+    return [finding("Error", "SOURCE_URI", ERROR_CODE.badFormat,
       "This is neither a web address nor a file path. FTP, relative paths and "
       + "bare filenames are not supported.")];
   }
@@ -78,11 +78,11 @@ export function checkSourceUri(uri) {
     try {
       host = new URL(value).hostname.toLowerCase();
     } catch {
-      return [finding("Error", "SOURCE_URI", ERROR_CODE.badValue,
+      return [finding("Error", "SOURCE_URI", ERROR_CODE.badFormat,
         "This is not a well-formed web address.")];
     }
     if (!host.includes(".")) {
-      found.push(finding("Warning", "SOURCE_URI", ERROR_CODE.badValue,
+      found.push(finding("Warning", "SOURCE_URI", ERROR_CODE.badFormat,
         `"${host}" has no dot in it, so it is probably not a real host.`));
     }
   }
@@ -111,7 +111,7 @@ export function checkSourceUri(uri) {
   const addinReadsThisAsGoogleSheets = readsUriAsGoogleSheets(value);
 
   if (isHttp && addinReadsThisAsGoogleSheets && !reallyGoogle) {
-    found.push(finding("Error", "SOURCE_URI", ERROR_CODE.badValue,
+    found.push(finding("Error", "SOURCE_URI", ERROR_CODE.badFormat,
       `This address MENTIONS docs.google.com but is served by "${host}". The `
       + "add-in decides an address is Google's by searching the whole string, "
       + "so it accepts this one and downloads it with no authentication — and "
@@ -125,7 +125,7 @@ export function checkSourceUri(uri) {
   // above, which the add-in also demands a TSV format from.
   if (addinReadsThisAsGoogleSheets) {
     if (!URI_TSV_MARKERS.some((marker) => lower.includes(marker))) {
-      found.push(finding("Error", "SOURCE_URI", ERROR_CODE.badValue,
+      found.push(finding("Error", "SOURCE_URI", ERROR_CODE.badFormat,
         "A Google Sheets address without a TSV format serves a WEB PAGE. The "
         + "add-in downloads it, sees markup where rows should be, and reports a "
         + "parse failure — which reads as a problem with the data rather than "
@@ -133,14 +133,14 @@ export function checkSourceUri(uri) {
         "Add output=tsv to the end of the address."));
     }
     if (!lower.includes(URI_TAB_MARKER)) {
-      found.push(finding("Warning", "SOURCE_URI", ERROR_CODE.badValue,
+      found.push(finding("Warning", "SOURCE_URI", ERROR_CODE.badFormat,
         "No gid, so this always reads the FIRST tab of that spreadsheet — "
         + "whichever one that happens to be today.",
         "Add gid=… naming the tab you mean."));
     }
   } else if (isLocal
              && !/\.(csv|tsv|txt)/i.test(value)) {
-    found.push(finding("Warning", "SOURCE_URI", ERROR_CODE.badValue,
+    found.push(finding("Warning", "SOURCE_URI", ERROR_CODE.badFormat,
       "A local path with no .csv, .tsv or .txt in it."));
   }
 
@@ -229,7 +229,7 @@ export function checkDataSourceRow(row, {entities = [], activeEntities = null,
   // 5 — SOURCE_REGION. The consequence is out of all proportion to the typo.
   const region = value("SOURCE_REGION");
   if (region && region.toUpperCase() !== "GLOBAL" && !/^[A-Za-z]{2}$/.test(region)) {
-    found.push(finding("Warning", "SOURCE_REGION", ERROR_CODE.badValue,
+    found.push(finding("Warning", "SOURCE_REGION", ERROR_CODE.badFormat,
       `"${region}" is neither GLOBAL nor a two-letter code, and an unrecognised `
       + "region BLOCKS EVERY USER from syncing this source.",
       "Use GLOBAL, or a two-letter country code such as SA or EG."));
@@ -243,9 +243,18 @@ export function checkDataSourceRow(row, {entities = [], activeEntities = null,
 
   // 7 — switched off. Not a fault; said because a table that is empty on
   // purpose looks exactly like a table that is empty by accident.
+  //
+  // THE ADD-IN DISAGREES WITH ITSELF HERE, and the Console follows one half
+  // deliberately. `DataSourceEntity.cs:379-387` yields a `ValidationResult.Warn`
+  // — but writes `[INFO]` at the front of its own message and says in the
+  // comment above it "Not an error". The code it carries is ERR_FORMAT, which is
+  // the code taken below so a search matches; the severity is the one the
+  // message means rather than the one the call says, because a source switched
+  // off on purpose ranked amber would sit among real faults for as long as it
+  // stayed off. Neither choice blocks a sync: only Error and above do.
   const active = readBoolean(row?.IS_ACTIVE, BOOLEAN_DEFAULTS["3.DataSource"].IS_ACTIVE);
   if (!active) {
-    found.push(finding("Info", "IS_ACTIVE", ERROR_CODE.badValue,
+    found.push(finding("Info", "IS_ACTIVE", ERROR_CODE.badFormat,
       "Switched off — the add-in skips this source entirely, and its table "
       + "stays as it was."));
   }
@@ -274,7 +283,11 @@ export function checkDataSourceRow(row, {entities = [], activeEntities = null,
     if (parsed) {
       for (const [key, why] of Object.entries(IGNORED_CONTEXT_KEYS)) {
         if (key in parsed) {
-          found.push(finding("Warning", "CONTEXT_PROPS", ERROR_CODE.badValue,
+          // CONSOLE-ONLY. The add-in has no rule for this at all: the key is
+          // known, its value is valid, and it is simply never applied. There is
+          // therefore no add-in code to share, and borrowing one would send an
+          // owner searching its log for something it cannot emit.
+          found.push(finding("Warning", "CONTEXT_PROPS", CONSOLE_ONLY_CODE.notApplied,
             `"${key}" is read and then ignored — ${why}`,
             "Remove it, or keep it knowing it changes nothing."));
         }

--- a/extension/tests/datasource-rules.test.mjs
+++ b/extension/tests/datasource-rules.test.mjs
@@ -13,6 +13,44 @@ import { checkSourceUri, checkDataSourceRow, stopsThisSource, switchedOff,
          suggestedKey } from "../datasource-rules.js";
 import { readsUriAsGoogleSheets } from "../addin-contract.js";
 
+// ---------------------------------------------------------------------------
+// THE CODE ON A FINDING IS THE HANDLE AN OWNER SEARCHES BOTH SURFACES BY, so it
+// has to be the one the add-in would print. The Console had INVALID_VALUE on
+// every DataSource field; `DataSourceEntity.Validate()` and
+// `SourceUriValidator` emit ERR_FORMAT and never INVALID_VALUE, which lives in
+// `ConfigValidator` and is reached only through a JSON bag.
+// ---------------------------------------------------------------------------
+
+test("every DataSource finding carries a code the add-in would print", () => {
+  // Driven through the whole row, not through one rule, so a new rule added
+  // later with a borrowed code is caught by a test nobody had to remember.
+  const wrong = checkDataSourceRow(sound({
+    SOURCE_URI: "https://docs.google.com/spreadsheets/d/e/2PACX-1vAAA/pub",
+    SOURCE_REGION: "SAUDI",
+    IS_ACTIVE: "FALSE",
+  }), []);
+
+  assert.ok(wrong.length >= 3, "the row under test stopped producing findings");
+  for (const found of wrong) {
+    if (found.field === "CONTEXT_PROPS") continue;   // the bag has its own codes
+    assert.notEqual(found.code, "INVALID_VALUE",
+      `${found.field} is tagged INVALID_VALUE, which no DataSource rule emits`);
+  }
+
+  const byField = (name) => wrong.filter((f) => f.field === name).map((f) => f.code);
+  assert.deepEqual([...new Set(byField("SOURCE_URI"))], ["ERR_FORMAT"]);
+  assert.deepEqual(byField("SOURCE_REGION"), ["ERR_FORMAT"]);
+  assert.deepEqual(byField("IS_ACTIVE"), ["ERR_FORMAT"]);
+});
+
+test("a blank address is ERR_REQUIRED, not ERR_FORMAT", () => {
+  // The one place SourceUriValidator reaches for a different code
+  // (SourceUriValidator.cs:33-39), and the retagging must not have flattened it.
+  const [found] = checkSourceUri("");
+  assert.equal(found.code, "ERR_REQUIRED");
+  assert.equal(found.severity, "Critical");
+});
+
 const PUBLISHED =
   "https://docs.google.com/spreadsheets/d/e/2PACX-1vAAA/pub?gid=223498986&single=true&output=tsv";
 

--- a/tests/test_the_addin_contract_cannot_drift.py
+++ b/tests/test_the_addin_contract_cannot_drift.py
@@ -183,6 +183,47 @@ def test_the_address_markers_are_the_add_ins_own_literals():
         assert marker == marker.lower()
 
 
+def _js_object(source: str, name: str) -> dict[str, str]:
+    """The string values of a flat `export const NAME = {...}` literal.
+
+    Deliberately crude — it reads the declaration as text rather than running it.
+    Comments inside the object are skipped, which is why the values are matched
+    rather than the whole body scanned."""
+    body = re.search(rf"export const {name} = {{(.*?)\n}};", source, re.S)
+    assert body, f"{name} is no longer a flat object literal, and this test read it as one"
+    return dict(re.findall(r'(\w+):\s*"([^"]+)"', body.group(1)))
+
+
+def test_every_code_the_console_reports_is_one_the_add_in_can_emit():
+    """The Console prints a code so an owner can search BOTH surfaces for it. A
+    code the add-in never emits sends them looking through its log for a string
+    that is not in it — which is worse than printing no code at all.
+
+    This was wrong on nine DataSource findings: the Console said INVALID_VALUE
+    where `DataSourceEntity.Validate()` and `SourceUriValidator` both emit
+    ERR_FORMAT. INVALID_VALUE is real, but it lives in `ConfigValidator` and is
+    reached only through a JSON config bag."""
+    hand_written = HAND_WRITTEN.read_text(encoding="utf-8")
+    known = set(_contract()["vocabularies"]["ERROR_CODES"])
+
+    borrowed = _js_object(hand_written, "ERROR_CODE")
+    unknown = sorted({code for code in borrowed.values() if code not in known})
+    assert not unknown, (
+        f"{unknown} are reported by the Console and are not in the add-in's "
+        "vocabulary. Either the add-in gained a code and the contract has not "
+        "been re-read, or the Console invented one")
+
+    # And the other direction, which is the half that actually went wrong: a
+    # finding with no add-in rule must NOT be dressed in one of its codes.
+    console_only = _js_object(hand_written, "CONSOLE_ONLY_CODE")
+    assert console_only, "CONSOLE_ONLY_CODE is empty; it is the escape hatch this test depends on"
+    borrowed_by_mistake = sorted({code for code in console_only.values() if code in known})
+    assert not borrowed_by_mistake, (
+        f"{borrowed_by_mistake} claim to be Console-only and are the add-in's "
+        "own codes. If the add-in now has a rule for that fault, the code "
+        "belongs in ERROR_CODE instead")
+
+
 def test_the_hand_written_half_does_not_redeclare_the_generated_half():
     """Two sources for one list is the defect this whole file exists to prevent,
     and the tidiest place for it to reappear is the module that re-exports the


### PR DESCRIPTION
Found while reading `SourceUriValidator.cs` to write a handoff brief — not by a test, which is why one is added here.

## What was wrong

Every `3.DataSource` finding carried **`INVALID_VALUE`**. Between them, `DataSourceEntity.Validate()` and `SourceUriValidator` emit exactly **two** codes and neither is that one:

| | code | where |
|---|---|---|
| blank `SOURCE_URI` | `ERR_REQUIRED` | `SourceUriValidator.cs:33-39` |
| everything else on this sheet | `ERR_FORMAT` | `SourceUriValidator.cs:59,74,103,116,135`; `DataSourceEntity.cs:355,386` |

`INVALID_VALUE` is real, but it lives in `ConfigValidator.cs:106,129` and is reached only through a JSON config bag. So an owner who read a code off a Console finding and searched the add-in's log for it found nothing — the exact failure the `ERROR_CODE` map's own docstring says it exists to prevent.

**Nine sites retagged.** The blank address stays `ERR_REQUIRED`, and a test pins that it was not flattened with the rest.

## The tenth was the opposite mistake

The warning about a `CONTEXT_PROPS` key that is *read and then ignored* has **no add-in rule behind it at all**. It was wearing one of the add-in's codes and claiming a parity that does not exist.

It moves to a new `CONSOLE_ONLY_CODE` map — kept apart **structurally**, not by comment. A test asserts every `ERROR_CODE` value is in the add-in's vocabulary and every `CONSOLE_ONLY_CODE` value is in none of it, so both mistakes are now caught in whichever direction they are made.

## One disagreement recorded rather than resolved

On `IS_ACTIVE` the add-in yields `ValidationResult.Warn`, writes `[INFO]` at the front of its own message, and comments "Not an error" (`DataSourceEntity.cs:379-387`). The Console takes its **code** and the severity its **message** means, and the file says so. Neither choice blocks a sync — only `Error` and above do.

## Proof

Three mutations, each caught:

| mutation | caught by |
|---|---|
| a borrowed code back on a Console-only finding | `test_every_code_the_console_reports_is_one_the_add_in_can_emit` |
| an invented code in `ERROR_CODE` | same test, other branch — plus 1 node failure |
| blank address flattened onto `ERR_FORMAT` | `a blank address is ERR_REQUIRED, not ERR_FORMAT` |

586 extension tests · 259 node tests · 10 contract tests · eslint clean.

Also carries `docs/HANDOFF-mbiXaddin-source-uri-validator.md` — the brief for repairing the substring host check in the add-in itself (T11), which is where the real defect is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)