### PR TITLE
The two editors: rules for 1.TableDefinition and 2.SchemaRule

### DIFF
--- a/contract/addin-contract.json
+++ b/contract/addin-contract.json
@@ -111,6 +111,24 @@
                        "AutoFit"],
     "LOGIC_CONFIG_KEYS": ["Min", "Max", "Formula", "LookupRef", "DefaultVal",
                           "ListSource", "ListItems", "ListStrict"],
+    "_comment_TABLE_UX_CONFIG_KEYS": [
+      "The four JSON bags on 1.TableDefinition, read from the C# classes that",
+      "back them. A key outside these sets is accepted, kept, and never read —",
+      "the add-in warns with a Levenshtein \"did you mean\", so the Console can",
+      "say the same thing while the key is still being typed.",
+      "TableDefinitionEntity.cs:505-575; DisplayModels.cs (Ribbon/Export)."
+    ],
+    "TABLE_UX_CONFIG_KEYS": ["TabColor", "Direction", "FreezePanes", "ZoomLevel",
+                             "ShowGridlines", "AutoFitColumns"],
+    "TABLE_SYS_CONFIG_KEYS": ["AllowEdit", "TeaserRowCount", "TeaserText"],
+    "RIBBON_CONFIG_KEYS": ["Label", "ScreenTip", "SuperTip", "Description", "Icon",
+                           "Group", "Order", "IsVisible", "IsEnabled", "ControlSize",
+                           "ActionClass"],
+    "EXPORT_CONFIG_KEYS": ["LinkedEntities", "FooterText", "FooterStyle",
+                           "HeaderText", "HeaderStyle"],
+    "DIRECTIONS": ["LTR", "RTL"],
+    "CONTROL_SIZES": ["Large", "Regular"],
+    "BANNER_STYLES": ["Note", "Source", "Warning", "Marketing", "TableHeader"],
     "ENTITY_TYPES": ["COST", "PERF", "REF", "COMP", "CONVERSION", "COST_ENG",
                      "AUDIT", "ASSEMBLY", "LIBRARY", "SYSTEM"],
     "STORAGE_STRATEGIES": ["ReplaceAll", "MergeUpsert", "Append"],
@@ -131,10 +149,15 @@
     "TRUE_SPELLINGS": ["1", "true", "yes", "y", "on", "نعم", "صح", "صحيح"],
     "FALSE_SPELLINGS": ["0", "false", "no", "n", "off", "لا", "خطأ", "غلط"],
     "SEVERITIES": ["Info", "Warning", "Error", "Critical"],
-    "ERROR_CODES": ["ERR_REF", "ERR_DUPLICATE", "ORPHAN_MAPPING", "PK_MISSING",
-                    "MANDATORY_UNMAPPED", "INVALID_JSON", "UNKNOWN_KEY",
-                    "INVALID_VALUE", "ERR_REQUIRED", "ERR_TRANSFORM",
-                    "ERR_FORMAT"]
+    "ERROR_CODES": ["ERR_FORMAT", "ERR_NULL", "ERR_LENGTH", "ERR_REF", "ERR_DUPLICATE", "ERR_TIER", "ERR_CIRCULAR", "ERR_REQUIRED", "ERR_PRESET", "ERR_FORMULA", "ERR_TRANSFORM", "ERR_DB_WRITE", "ERR_DB_READ", "ERR_SCHEMA", "ERR_NO_RATE", "ERR_NO_UNIT", "ERR_OVERFLOW", "ERR_NO_COST", "INVALID_JSON", "UNKNOWN_KEY", "INVALID_VALUE", "INVALID_COLOR", "BROKEN_LINK", "ORPHAN_MAPPING", "PK_MISSING", "MANDATORY_UNMAPPED"],
+
+    "_comment_LOG_TAGS": [
+      "Faults the add-in reports ONLY as a bracketed tag on a log line — there is",
+      "no ValidationResult and so no error code. The tag is still the string an",
+      "owner greps for, so the Console prints it rather than inventing a name.",
+      "MetadataOrchestrator.cs:538 (DUPLICATE), :591 (ORPHAN_COLS), :666 (ERR_REF)."
+    ],
+    "LOG_TAGS": ["DUPLICATE", "ORPHAN_COLS"]
   },
 
   "constants": {

--- a/extension/addin-contract.js
+++ b/extension/addin-contract.js
@@ -159,6 +159,21 @@ export const ERROR_CODE = {
   badValue: "INVALID_VALUE",        // ConfigValidator.cs:106,129 — bags only
   required: "ERR_REQUIRED",
   transform: "ERR_TRANSFORM",
+  tooLong: "ERR_LENGTH",            // SystemConstants.cs:358 — the 100-char keys
+  circular: "ERR_CIRCULAR",         // TableDefinitionEntity.cs:461 — PARENT_KEY = itself
+};
+
+/**
+ * Faults the add-in reports ONLY as a bracketed tag on a log line.
+ *
+ * There is no `ValidationResult` behind these, so there is no error code and no
+ * severity — and that is exactly why they matter to the Console: nothing in the
+ * add-in's own report will mention them. The tag is still the string an owner
+ * would search its log for, so it is what gets printed.
+ */
+export const LOG_TAG = {
+  duplicateEntity: "DUPLICATE",     // MetadataOrchestrator.cs:538
+  orphanColumns: "ORPHAN_COLS",     // MetadataOrchestrator.cs:591
 };
 
 /**
@@ -172,6 +187,17 @@ export const ERROR_CODE = {
  */
 export const CONSOLE_ONLY_CODE = {
   notApplied: "NOT_APPLIED",        // accepted, documented, and then ignored
+  // A duplicate (ENTITY_KEY, ATTRIBUTE_KEY) on 2.SchemaRule. The add-in resolves
+  // it by dictionary assignment — LAST WINS — and says NOTHING: no log line, no
+  // ValidationResult, unlike the duplicate on 1.TableDefinition which at least
+  // logs. So one of two column definitions is discarded in silence, and the
+  // Console is the only place it can be seen. MetadataOrchestrator.cs:679-703.
+  silentOverride: "SILENT_OVERRIDE",
+  // MergeUpsert on a table with no IS_PK column anywhere. No PRIMARY KEY is
+  // emitted, so INSERT OR REPLACE has nothing to conflict on and every sync
+  // appends the whole file again. Nothing checks it, because the fatal check
+  // that would have runs only `if (pkCol != null)`. DataIngestionService.cs:1484.
+  duplicatesForever: "NO_CONFLICT_TARGET",
 };
 
 /** The six gids, flattened for the check that a chosen workbook is the right one. */

--- a/extension/addin-contract.js
+++ b/extension/addin-contract.js
@@ -164,6 +164,54 @@ export const ERROR_CODE = {
 };
 
 /**
+ * How the add-in reads a JSON config bag — which is NOT how `JSON.parse` does.
+ *
+ * FOUND BY RUNNING THE RULES AGAINST THE OWNER'S REAL WORKBOOK. Three cells came
+ * back as errors and all three were fine: they end in a trailing comma, and
+ * every bag in this product is parsed by Newtonsoft (`using Newtonsoft.Json` in
+ * ConfigResolver.cs:36 and ConfigValidator.cs:22), which accepts one. A Console
+ * that refused them would be refusing what the add-in reads every day, and the
+ * owner would learn to ignore it.
+ *
+ * Returns `{value, tolerated, unreadable}`:
+ *   value       the object, or null
+ *   tolerated   true when strict JSON refused it and the relaxations below did
+ *               not — worth saying, because it is not portable, but it works
+ *   unreadable  true when nothing could read it; the add-in drops the bag WHOLE
+ *
+ * THE RELAXATIONS ARE NOT ALL OF NEWTONSOFT'S. It also accepts single-quoted
+ * strings and unquoted property names, which are not handled here, so a bag
+ * written that way is reported as unreadable when the add-in would read it. That
+ * is a known and narrow gap; the two below are what hand-edited JSON actually
+ * contains, and both appear in the live workbook.
+ */
+export function readConfigBag(raw) {
+  const text = String(raw ?? "").trim();
+  if (!text) return {value: null, tolerated: false, unreadable: false};
+
+  const object = (parsed) =>
+    parsed !== null && typeof parsed === "object" && !Array.isArray(parsed);
+
+  try {
+    const parsed = JSON.parse(text);
+    return {value: object(parsed) ? parsed : null, tolerated: false,
+      unreadable: !object(parsed)};
+  } catch { /* fall through to the relaxations */ }
+
+  const relaxed = text
+    .replace(/\/\*[\s\S]*?\*\//g, "")            // /* block comments */
+    .replace(/(^|[^:"'\\])\/\/[^\n\r]*/g, "$1")  // // line comments, not in a URL
+    .replace(/,(\s*[}\]])/g, "$1");              // one or more trailing commas
+  try {
+    const parsed = JSON.parse(relaxed);
+    return {value: object(parsed) ? parsed : null, tolerated: true,
+      unreadable: !object(parsed)};
+  } catch {
+    return {value: null, tolerated: false, unreadable: true};
+  }
+}
+
+/**
  * Faults the add-in reports ONLY as a bracketed tag on a log line.
  *
  * There is no `ValidationResult` behind these, so there is no error code and no

--- a/extension/addin-vocabulary.js
+++ b/extension/addin-vocabulary.js
@@ -33,6 +33,19 @@ export const STORAGE_STRATEGY_ALIASES = ["REPLACE", "UPSERT", "MERGE", "INSERT"]
 export const LICENSE_TIERS = ["Free", "Standard", "Premium", "Admin"];
 export const VIEW_MODES = ["Table", "Card", "Chart"];
 export const BUSINESS_DOMAINS = ["MATERIAL", "LABOR", "EQUIPMENT", "VENDOR", "PROJECT", "FINANCE", "SYSTEM", "GARB"];
+
+// The four JSON bags on 1.TableDefinition, read from the C# classes that
+// back them. A key outside these sets is accepted, kept, and never read —
+// the add-in warns with a Levenshtein "did you mean", so the Console can
+// say the same thing while the key is still being typed.
+// TableDefinitionEntity.cs:505-575; DisplayModels.cs (Ribbon/Export).
+export const TABLE_UX_CONFIG_KEYS = ["TabColor", "Direction", "FreezePanes", "ZoomLevel", "ShowGridlines", "AutoFitColumns"];
+export const TABLE_SYS_CONFIG_KEYS = ["AllowEdit", "TeaserRowCount", "TeaserText"];
+export const RIBBON_CONFIG_KEYS = ["Label", "ScreenTip", "SuperTip", "Description", "Icon", "Group", "Order", "IsVisible", "IsEnabled", "ControlSize", "ActionClass"];
+export const EXPORT_CONFIG_KEYS = ["LinkedEntities", "FooterText", "FooterStyle", "HeaderText", "HeaderStyle"];
+export const DIRECTIONS = ["LTR", "RTL"];
+export const CONTROL_SIZES = ["Large", "Regular"];
+export const BANNER_STYLES = ["Note", "Source", "Warning", "Marketing", "TableHeader"];
 export const CONTEXT_PROPS_KEYS = ["SourceType", "SyncFreq", "SkipRows", "Encoding", "Delimiter", "TimeoutSeconds", "ActionUrl"];
 export const CONTEXT_SOURCE_TYPES = ["GoogleSheetTsv", "LocalCsv", "RestApi", "LocalSqlite", "Manual"];
 export const SYNC_FREQUENCIES = ["Hourly", "Daily", "Weekly", "Monthly"];
@@ -46,7 +59,13 @@ export const MENU_ACTIONS = ["Menu", "Library", "ExportTree", "ViewList"];
 export const TRUE_SPELLINGS = ["1", "true", "yes", "y", "on", "نعم", "صح", "صحيح"];
 export const FALSE_SPELLINGS = ["0", "false", "no", "n", "off", "لا", "خطأ", "غلط"];
 export const SEVERITIES = ["Info", "Warning", "Error", "Critical"];
-export const ERROR_CODES = ["ERR_REF", "ERR_DUPLICATE", "ORPHAN_MAPPING", "PK_MISSING", "MANDATORY_UNMAPPED", "INVALID_JSON", "UNKNOWN_KEY", "INVALID_VALUE", "ERR_REQUIRED", "ERR_TRANSFORM", "ERR_FORMAT"];
+export const ERROR_CODES = ["ERR_FORMAT", "ERR_NULL", "ERR_LENGTH", "ERR_REF", "ERR_DUPLICATE", "ERR_TIER", "ERR_CIRCULAR", "ERR_REQUIRED", "ERR_PRESET", "ERR_FORMULA", "ERR_TRANSFORM", "ERR_DB_WRITE", "ERR_DB_READ", "ERR_SCHEMA", "ERR_NO_RATE", "ERR_NO_UNIT", "ERR_OVERFLOW", "ERR_NO_COST", "INVALID_JSON", "UNKNOWN_KEY", "INVALID_VALUE", "INVALID_COLOR", "BROKEN_LINK", "ORPHAN_MAPPING", "PK_MISSING", "MANDATORY_UNMAPPED"];
+
+// Faults the add-in reports ONLY as a bracketed tag on a log line — there is
+// no ValidationResult and so no error code. The tag is still the string an
+// owner greps for, so the Console prints it rather than inventing a name.
+// MetadataOrchestrator.cs:538 (DUPLICATE), :591 (ORPHAN_COLS), :666 (ERR_REF).
+export const LOG_TAGS = ["DUPLICATE", "ORPHAN_COLS"];
 
 // ---- the sheets, and the gids compiled into the add-in ----------------------
 export const SHEETS = {

--- a/extension/console.html
+++ b/extension/console.html
@@ -140,7 +140,200 @@
       <button class="link-back" id="inspect-back" type="button">← Tables</button>
       <h1 id="inspect-name">—</h1>
       <p id="inspect-lede"></p>
+      <div class="row">
+        <button id="inspect-edit" class="button ghost" type="button">
+          Edit this table</button>
+        <button id="column-add" class="button ghost" type="button">
+          Add a column</button>
+      </div>
     </header>
+
+    <!-- 1.TableDefinition ────────────────────────────────────────────────────
+         THE FIELDS ARE WRITTEN OUT, not generated. `test_panel_wiring.py` reads
+         both the ids a page defines and the ids its scripts reach for — and it
+         matches literal text, so a form built from `id="f-${name}"` would leave
+         the guard reading nothing on either side. Verbose, and still checked. -->
+    <section class="card hidden" id="td-editor-card" aria-labelledby="td-editor-title">
+      <h2 id="td-editor-title">Editing the table</h2>
+      <p class="hint" id="td-editor-where"></p>
+
+      <div class="field">
+        <label for="td-f-ENTITY_KEY">Key</label>
+        <input id="td-f-ENTITY_KEY" type="text" autocomplete="off" spellcheck="false">
+        <p class="field-note" id="td-n-ENTITY_KEY"></p>
+      </div>
+      <div class="field">
+        <label for="td-f-DISPLAY_NAME">Name shown in Excel</label>
+        <input id="td-f-DISPLAY_NAME" type="text" autocomplete="off">
+        <p class="field-note" id="td-n-DISPLAY_NAME"></p>
+      </div>
+      <div class="field">
+        <label for="td-f-ENTITY_TYPE">Kind of table</label>
+        <select id="td-f-ENTITY_TYPE"></select>
+        <p class="field-note" id="td-n-ENTITY_TYPE"></p>
+      </div>
+      <div class="field">
+        <label for="td-f-STORAGE_STRATEGY">How each sync writes</label>
+        <select id="td-f-STORAGE_STRATEGY"></select>
+        <p class="field-note" id="td-n-STORAGE_STRATEGY"></p>
+      </div>
+      <div class="field">
+        <label for="td-f-PARENT_KEY">Inherits from</label>
+        <select id="td-f-PARENT_KEY"></select>
+        <p class="field-note" id="td-n-PARENT_KEY"></p>
+      </div>
+      <div class="field">
+        <label for="td-f-LICENSE_TIER">Licence</label>
+        <select id="td-f-LICENSE_TIER"></select>
+        <p class="field-note" id="td-n-LICENSE_TIER"></p>
+      </div>
+      <div class="field">
+        <label for="td-f-BUSINESS_DOMAIN">Domain</label>
+        <select id="td-f-BUSINESS_DOMAIN"></select>
+        <p class="field-note" id="td-n-BUSINESS_DOMAIN"></p>
+      </div>
+      <div class="field">
+        <label for="td-f-VIEW_MODE">View</label>
+        <select id="td-f-VIEW_MODE"></select>
+        <p class="field-note" id="td-n-VIEW_MODE"></p>
+      </div>
+      <div class="field">
+        <label for="td-f-IS_ACTIVE">Active</label>
+        <select id="td-f-IS_ACTIVE">
+          <option value="TRUE">TRUE</option>
+          <option value="FALSE">FALSE</option>
+        </select>
+        <p class="field-note" id="td-n-IS_ACTIVE"></p>
+      </div>
+      <div class="field">
+        <label for="td-f-IS_VISIBLE">Visible in the ribbon</label>
+        <select id="td-f-IS_VISIBLE">
+          <option value="TRUE">TRUE</option>
+          <option value="FALSE">FALSE</option>
+        </select>
+        <p class="field-note" id="td-n-IS_VISIBLE"></p>
+      </div>
+      <div class="field">
+        <label for="td-f-UX_CONFIG">Appearance (JSON)</label>
+        <input id="td-f-UX_CONFIG" type="text" autocomplete="off" spellcheck="false">
+        <p class="field-note" id="td-n-UX_CONFIG"></p>
+      </div>
+      <div class="field">
+        <label for="td-f-SYS_CONFIG">Behaviour (JSON)</label>
+        <input id="td-f-SYS_CONFIG" type="text" autocomplete="off" spellcheck="false">
+        <p class="field-note" id="td-n-SYS_CONFIG"></p>
+      </div>
+      <div class="field">
+        <label for="td-f-RIBBON_CONFIG">Ribbon button (JSON)</label>
+        <input id="td-f-RIBBON_CONFIG" type="text" autocomplete="off" spellcheck="false">
+        <p class="field-note" id="td-n-RIBBON_CONFIG"></p>
+      </div>
+      <div class="field">
+        <label for="td-f-EXPORT_CONFIG">Export (JSON)</label>
+        <input id="td-f-EXPORT_CONFIG" type="text" autocomplete="off" spellcheck="false">
+        <p class="field-note" id="td-n-EXPORT_CONFIG"></p>
+      </div>
+
+      <p id="td-editor-verdict" class="hint" role="status" aria-live="polite"></p>
+      <div class="row">
+        <button id="td-editor-save" class="button" type="button">Save to the sheet</button>
+        <button id="td-editor-cancel" class="button ghost" type="button">Cancel</button>
+      </div>
+    </section>
+
+    <!-- 2.SchemaRule ──────────────────────────────────────────────────────── -->
+    <section class="card hidden" id="sr-editor-card" aria-labelledby="sr-editor-title">
+      <h2 id="sr-editor-title">Editing a column</h2>
+      <p class="hint" id="sr-editor-where"></p>
+
+      <div class="field">
+        <label for="sr-f-ATTRIBUTE_KEY">Column name</label>
+        <input id="sr-f-ATTRIBUTE_KEY" type="text" autocomplete="off" spellcheck="false">
+        <p class="field-note" id="sr-n-ATTRIBUTE_KEY"></p>
+      </div>
+      <div class="field">
+        <label for="sr-f-DISPLAY_HEADER">Header shown in Excel</label>
+        <input id="sr-f-DISPLAY_HEADER" type="text" autocomplete="off">
+        <p class="field-note" id="sr-n-DISPLAY_HEADER"></p>
+      </div>
+      <div class="field">
+        <label for="sr-f-DATA_TYPE">Type</label>
+        <select id="sr-f-DATA_TYPE"></select>
+        <p class="field-note" id="sr-n-DATA_TYPE"></p>
+      </div>
+      <div class="field">
+        <label for="sr-f-SEMANTIC_ROLE">Meaning to the engine</label>
+        <select id="sr-f-SEMANTIC_ROLE"></select>
+        <p class="field-note" id="sr-n-SEMANTIC_ROLE"></p>
+      </div>
+      <div class="field">
+        <label for="sr-f-ORDINAL_POS">Position</label>
+        <input id="sr-f-ORDINAL_POS" type="text" inputmode="numeric" autocomplete="off">
+        <p class="field-note" id="sr-n-ORDINAL_POS"></p>
+      </div>
+      <div class="field">
+        <label for="sr-f-LICENSE_TIER">Licence</label>
+        <select id="sr-f-LICENSE_TIER"></select>
+        <p class="field-note" id="sr-n-LICENSE_TIER"></p>
+      </div>
+      <div class="field">
+        <label for="sr-f-IS_PK">Primary key</label>
+        <select id="sr-f-IS_PK">
+          <option value="TRUE">TRUE</option>
+          <option value="FALSE">FALSE</option>
+        </select>
+        <p class="field-note" id="sr-n-IS_PK"></p>
+      </div>
+      <div class="field">
+        <label for="sr-f-IS_MANDATORY">Required</label>
+        <select id="sr-f-IS_MANDATORY">
+          <option value="TRUE">TRUE</option>
+          <option value="FALSE">FALSE</option>
+        </select>
+        <p class="field-note" id="sr-n-IS_MANDATORY"></p>
+      </div>
+      <div class="field">
+        <label for="sr-f-IS_VIRTUAL">Virtual (not stored)</label>
+        <select id="sr-f-IS_VIRTUAL">
+          <option value="TRUE">TRUE</option>
+          <option value="FALSE">FALSE</option>
+        </select>
+        <p class="field-note" id="sr-n-IS_VIRTUAL"></p>
+      </div>
+      <div class="field">
+        <label for="sr-f-IS_DERIVED">Derived from a formula</label>
+        <select id="sr-f-IS_DERIVED">
+          <option value="TRUE">TRUE</option>
+          <option value="FALSE">FALSE</option>
+        </select>
+        <p class="field-note" id="sr-n-IS_DERIVED"></p>
+      </div>
+      <div class="field">
+        <label for="sr-f-IS_VISIBLE">Visible</label>
+        <select id="sr-f-IS_VISIBLE">
+          <option value="TRUE">TRUE</option>
+          <option value="FALSE">FALSE</option>
+        </select>
+        <p class="field-note" id="sr-n-IS_VISIBLE"></p>
+      </div>
+      <div class="field">
+        <label for="sr-f-UX_CONFIG">Appearance (JSON)</label>
+        <input id="sr-f-UX_CONFIG" type="text" autocomplete="off" spellcheck="false">
+        <p class="field-note" id="sr-n-UX_CONFIG"></p>
+      </div>
+      <div class="field">
+        <label for="sr-f-LOGIC_CONFIG">Rules (JSON)</label>
+        <input id="sr-f-LOGIC_CONFIG" type="text" autocomplete="off" spellcheck="false">
+        <p class="field-note" id="sr-n-LOGIC_CONFIG"></p>
+      </div>
+
+      <p id="sr-editor-verdict" class="hint" role="status" aria-live="polite"></p>
+      <div class="row">
+        <button id="sr-editor-save" class="button" type="button">Save to the sheet</button>
+        <button id="sr-editor-cancel" class="button ghost" type="button">Cancel</button>
+      </div>
+    </section>
+
     <div id="inspect-body" class="inspect-body"></div>
   </section>
 

--- a/extension/console.js
+++ b/extension/console.js
@@ -8,10 +8,14 @@
 import { getToken } from "./identity.js";
 import { chooseSpreadsheet } from "./picker.js";
 import { TAB_NAMES, parseWorkbook, inspect, vocabularies, SHEETS } from "./workbook.js";
-import { KNOWN_VOCABULARIES, SHEET_GIDS, LICENSE_TIERS, readBoolean,
-         BOOLEAN_DEFAULTS } from "./addin-contract.js";
+import { KNOWN_VOCABULARIES, SHEET_GIDS, LICENSE_TIERS, ENTITY_TYPES,
+         STORAGE_STRATEGIES, BUSINESS_DOMAINS, VIEW_MODES, DATA_TYPES,
+         SEMANTIC_ROLES, readBoolean, BOOLEAN_DEFAULTS } from "./addin-contract.js";
 import { checkDataSourceRow, stopsThisSource, switchedOff, suggestedKey }
   from "./datasource-rules.js";
+import { checkTableDefinitionRow, tableProducesNothing }
+  from "./tabledefinition-rules.js";
+import { checkSchemaRuleRow, checkEntityRoles } from "./schemarule-rules.js";
 
 const $ = (id) => document.getElementById(id);
 const SHEETS_API = "https://sheets.googleapis.com/v4/spreadsheets";
@@ -234,7 +238,7 @@ function renderSources(workbook) {
     item.type = "button";
     item.className = "source-row"
       + (stops ? " source-stopped" : found.length ? " source-noted" : "");
-    item.addEventListener("click", () => edit(row));
+    item.addEventListener("click", () => edit(EDITORS.source, row));
 
     const key = document.createElement("span");
     key.className = "source-key";
@@ -290,24 +294,133 @@ function options(id, values, current, {blank = ""} = {}) {
   select.value = current ?? "";
 }
 
-const FIELDS = ["SOURCE_KEY", "TARGET_ENTITY_KEY", "PROFILE_KEY", "SOURCE_URI",
-                "DISPLAY_LABEL", "SOURCE_REGION", "IS_ACTIVE", "MIN_LICENSE_REQ",
-                "VERSION_TAG", "CONTEXT_PROPS"];
+// ---- one editor, three sheets -----------------------------------------------
+//
+// THE THREE FORMS SHARE EVERYTHING EXCEPT THEIR SPEC. Reading the controls,
+// putting each finding under its own field, deciding whether Save is allowed,
+// and writing one row's own span are the same problem on every sheet, and three
+// copies of them would drift apart at the first correction — which is the exact
+// failure this page exists to catch in the workbook.
+//
+// What differs is declared below and nothing else: which tab, which controls,
+// where the drop-down values come from, and what makes a row so broken that
+// saving it would be pointless.
 
-function readForm() {
+const EDITORS = {
+  source: {
+    tab: SOURCES,
+    card: "editor-card", prefix: "",
+    fields: ["SOURCE_KEY", "TARGET_ENTITY_KEY", "PROFILE_KEY", "SOURCE_URI",
+             "DISPLAY_LABEL", "SOURCE_REGION", "IS_ACTIVE", "MIN_LICENSE_REQ",
+             "VERSION_TAG", "CONTEXT_PROPS"],
+    booleans: ["IS_ACTIVE"],
+    view: "sources",
+    lists(workbook) {
+      const known = vocabularies(workbook, KNOWN_VOCABULARIES);
+      return {
+        TARGET_ENTITY_KEY: {values: known.entityKeys, blank: "— choose a table —"},
+        PROFILE_KEY: {values: [...new Set([...known.profileKeys, "DEFAULT"])].sort(),
+          blank: "— blank: use the table's own key —"},
+        SOURCE_REGION: {values: ["GLOBAL", ...known.regions], blank: "— none —"},
+        MIN_LICENSE_REQ: {values: LICENSE_TIERS, blank: "— none —"},
+      };
+    },
+    check: (row, workbook, editing) =>
+      checkDataSourceRow(row, worldFor(workbook, editing)),
+    refuse: (found) => stopsThisSource(found),
+    refused: "As it stands this source produces nothing. Saving is refused.",
+    where: (row) => row._row ? `${SOURCES}, row ${row._row}`
+      : `${SOURCES}, a new row at the end`,
+  },
+
+  table: {
+    tab: "1.TableDefinition",
+    card: "td-editor-card", prefix: "td-",
+    fields: ["ENTITY_KEY", "DISPLAY_NAME", "ENTITY_TYPE", "STORAGE_STRATEGY",
+             "PARENT_KEY", "LICENSE_TIER", "BUSINESS_DOMAIN", "VIEW_MODE",
+             "IS_ACTIVE", "IS_VISIBLE", "UX_CONFIG", "SYS_CONFIG",
+             "RIBBON_CONFIG", "EXPORT_CONFIG"],
+    booleans: ["IS_ACTIVE", "IS_VISIBLE"],
+    view: "inspect",
+    lists(workbook, row) {
+      const others = rowsOf(workbook, "1.TableDefinition")
+        .map((r) => r.ENTITY_KEY).filter(Boolean)
+        // A table may not be its own parent, so it is not offered as one. The
+        // rule still exists and still fires — this only keeps the list honest.
+        .filter((k) => k.toUpperCase() !== (row.ENTITY_KEY || "").toUpperCase());
+      return {
+        ENTITY_TYPE: {values: ENTITY_TYPES, blank: "— none —"},
+        STORAGE_STRATEGY: {values: STORAGE_STRATEGIES,
+          blank: "— blank: MergeUpsert —"},
+        PARENT_KEY: {values: others.sort(), blank: "— none: a root table —"},
+        LICENSE_TIER: {values: LICENSE_TIERS, blank: "— blank: Free —"},
+        BUSINESS_DOMAIN: {values: BUSINESS_DOMAINS, blank: "— none —"},
+        VIEW_MODE: {values: VIEW_MODES, blank: "— blank: Table —"},
+      };
+    },
+    check: (row, workbook, editing) => checkTableDefinitionRow(
+      row,
+      rowsOf(workbook, "1.TableDefinition").filter((r) => r !== editing),
+      rowsOf(workbook, "2.SchemaRule")),
+    refuse: (found) => tableProducesNothing(found),
+    refused: "As it stands this row defines no table. Saving is refused.",
+    where: (row) => row._row ? `1.TableDefinition, row ${row._row}`
+      : "1.TableDefinition, a new row at the end",
+  },
+
+  column: {
+    tab: "2.SchemaRule",
+    card: "sr-editor-card", prefix: "sr-",
+    // ENTITY_KEY IS NOT A CONTROL. Which table a column belongs to is settled by
+    // the screen you opened it from, and a free field for it is how a column
+    // ends up orphaned — the fault this sheet reports most often.
+    fields: ["ATTRIBUTE_KEY", "DISPLAY_HEADER", "DATA_TYPE", "SEMANTIC_ROLE",
+             "ORDINAL_POS", "LICENSE_TIER", "IS_PK", "IS_MANDATORY", "IS_VIRTUAL",
+             "IS_DERIVED", "IS_VISIBLE", "UX_CONFIG", "LOGIC_CONFIG"],
+    booleans: ["IS_PK", "IS_MANDATORY", "IS_VIRTUAL", "IS_DERIVED", "IS_VISIBLE"],
+    view: "inspect",
+    lists: () => ({
+      DATA_TYPE: {values: DATA_TYPES, blank: "— blank: TEXT —"},
+      SEMANTIC_ROLE: {values: SEMANTIC_ROLES, blank: "— none: an ordinary column —"},
+      LICENSE_TIER: {values: LICENSE_TIERS, blank: "— blank: Free —"},
+    }),
+    check: (row, workbook, editing) => checkSchemaRuleRow(
+      row,
+      rowsOf(workbook, "2.SchemaRule").filter((r) => r !== editing),
+      rowsOf(workbook, "1.TableDefinition")),
+    refuse: (found) => found.some((f) => f.severity === "Critical"),
+    refused: "As it stands this row defines no column. Saving is refused.",
+    where: (row) => row._row ? `2.SchemaRule, row ${row._row}`
+      : "2.SchemaRule, a new row at the end",
+  },
+};
+
+const rowsOf = (workbook, tab) => workbook?.sheets?.[tab]?.rows || [];
+
+/** The control ids a spec owns. Written out so a typo is a missing element. */
+const control = (spec, name) => `${spec.prefix}f-${name}`;
+const noteId = (spec, name) => `${spec.prefix}n-${name}`;
+
+function readForm(spec) {
   const row = {};
-  for (const name of FIELDS) row[name] = $(`f-${name}`).value.trim();
-  if (state.editing?._row) row._row = state.editing._row;
+  for (const name of spec.fields) {
+    const node = $(control(spec, name));
+    if (node) row[name] = node.value.trim();
+  }
+  // Carried rather than typed: the row's line on the sheet, and for a column the
+  // table it belongs to.
+  if (state.editing?.row?._row) row._row = state.editing.row._row;
+  if (state.editing?.entity) row.ENTITY_KEY = state.editing.entity;
   return row;
 }
 
 /** Re-judge the form as it stands and put each finding beside its own field. */
-function judge() {
-  const row = readForm();
-  const found = checkDataSourceRow(row, worldFor(state.workbook, state.editing));
+function judge(spec) {
+  const row = readForm(spec);
+  const found = spec.check(row, state.workbook, state.editing?.row);
 
-  for (const name of FIELDS) {
-    const note = $(`n-${name}`);
+  for (const name of spec.fields) {
+    const note = $(noteId(spec, name));
     if (!note) continue;
     const mine = found.filter((f) => f.field === name);
     note.textContent = mine
@@ -318,7 +431,11 @@ function judge() {
          : mine.length ? " note-warn" : "");
   }
 
-  const stops = stopsThisSource(found);
+  // A finding about a field this form has no control for still has to be seen —
+  // ENTITY_KEY on a column, for one, which is decided by the screen. It goes to
+  // the verdict line rather than nowhere.
+  const homeless = found.filter((f) => !spec.fields.includes(f.field));
+  const stops = spec.refuse(found);
   const blocking = found.filter(
     (f) => f.severity === "Critical" || f.severity === "Error");
 
@@ -326,65 +443,78 @@ function judge() {
   // merely complains about is a row the add-in still runs, and a Console that
   // refused it would be stricter than the thing it configures — which teaches
   // an owner to edit the sheet directly and never come back.
-  $("editor-save").disabled = stops;
-  say("editor-verdict",
+  $(`${spec.prefix}editor-save`).disabled = stops;
+  say(`${spec.prefix}editor-verdict`,
       stops
-        ? "As it stands this source produces nothing. Saving is refused."
-        : blocking.length
-          ? `Saveable. The add-in will record ${blocking.length} `
-            + `${blocking.length === 1 ? "complaint" : "complaints"} about it and sync it anyway.`
-          : "Nothing to report.",
-      stops ? "err" : blocking.length ? "" : "ok");
+        ? spec.refused
+        : homeless.length
+          ? homeless.map((f) => f.detail).join(" ")
+          : blocking.length
+            ? `Saveable. The add-in will record ${blocking.length} `
+              + `${blocking.length === 1 ? "complaint" : "complaints"} about it `
+              + "and sync it anyway."
+            // COUNTED, NOT IGNORED. This line said "Nothing to report" beside
+            // two amber notes, because it counted only what blocks. A verdict
+            // that disagrees with the fields above it teaches the owner to
+            // trust neither.
+            : found.length
+              ? `Saveable. ${found.length} ${found.length === 1 ? "note" : "notes"} `
+                + "above, none of which stops the add-in."
+              : "Nothing to report.",
+      stops ? "err" : blocking.length || homeless.length || found.length ? "" : "ok");
   return found;
 }
 
-function edit(row) {
-  state.editing = row;
-  const workbook = state.workbook;
-  const lists = vocabularies(workbook, KNOWN_VOCABULARIES);
-  const profiles = [...new Set([...lists.profileKeys, "DEFAULT"])].sort();
+/**
+ * Open one form on one row.
+ *
+ * `entity` is passed for a column and settles its ENTITY_KEY without a control.
+ */
+function edit(spec, row, entity = "") {
+  state.editing = {spec, row, entity};
+  const lists = spec.lists(state.workbook, row);
 
-  $("editor-where").textContent = row._row
-    ? `${SOURCES}, row ${row._row}`
-    : `${SOURCES}, a new row at the end`;
+  $(`${spec.prefix}editor-where`).textContent = spec.where(row);
 
-  $("f-SOURCE_KEY").value = row.SOURCE_KEY || "";
-  options("f-TARGET_ENTITY_KEY", lists.entityKeys, row.TARGET_ENTITY_KEY || "",
-          {blank: "— choose a table —"});
-  options("f-PROFILE_KEY", profiles, row.PROFILE_KEY || "",
-          {blank: "— blank: use the table's own key —"});
-  $("f-SOURCE_URI").value = row.SOURCE_URI || "";
-  $("f-DISPLAY_LABEL").value = row.DISPLAY_LABEL || "";
-  options("f-SOURCE_REGION", ["GLOBAL", ...lists.regions], row.SOURCE_REGION || "",
-          {blank: "— none —"});
-  $("f-IS_ACTIVE").value =
-    readBoolean(row.IS_ACTIVE, BOOLEAN_DEFAULTS[SOURCES].IS_ACTIVE) ? "TRUE" : "FALSE";
-  options("f-MIN_LICENSE_REQ", LICENSE_TIERS, row.MIN_LICENSE_REQ || "",
-          {blank: "— none —"});
-  $("f-VERSION_TAG").value = row.VERSION_TAG || "";
-  $("f-CONTEXT_PROPS").value = row.CONTEXT_PROPS || "";
+  for (const name of spec.fields) {
+    const node = $(control(spec, name));
+    if (!node) continue;
+    const value = row[name] ?? "";
+    if (spec.booleans.includes(name)) {
+      node.value = readBoolean(value, BOOLEAN_DEFAULTS[spec.tab][name])
+        ? "TRUE" : "FALSE";
+    } else if (lists[name]) {
+      options(control(spec, name), lists[name].values, String(value),
+              {blank: lists[name].blank});
+    } else {
+      node.value = value;
+    }
+  }
 
-  showView("sources");
-  $("editor-card").classList.remove("hidden");
-  judge();
-  $("editor-card").scrollIntoView({behavior: "smooth", block: "start"});
+  // Only one form at a time, or two verdicts disagree on the same screen.
+  for (const other of Object.values(EDITORS)) {
+    $(other.card).classList.toggle("hidden", other !== spec);
+  }
+  showView(spec.view);
+  judge(spec);
+  $(spec.card).scrollIntoView({behavior: "smooth", block: "start"});
 }
 
 /** Write the row back, and only that row. */
-async function save() {
-  const row = readForm();
-  const columns = SHEETS.find((s) => s.tab === SOURCES).columns;
+async function save(spec) {
+  const row = readForm(spec);
+  const columns = SHEETS.find((s) => s.tab === spec.tab).columns;
   const values = [columns.map((name) => row[name] ?? "")];
 
   // A1 for the row's OWN span, so a save cannot touch a neighbour. A new row
   // goes to the first line after the last one read.
-  const last = state.workbook.sheets[SOURCES].rows.at(-1);
+  const last = rowsOf(state.workbook, spec.tab).at(-1);
   const line = row._row || ((last?._row || 1) + 1);
   const end = String.fromCharCode("A".charCodeAt(0) + columns.length - 1);
-  const range = `'${SOURCES}'!A${line}:${end}${line}`;
+  const range = `'${spec.tab}'!A${line}:${end}${line}`;
 
-  $("editor-save").disabled = true;
-  say("editor-verdict", "Saving…");
+  $(`${spec.prefix}editor-save`).disabled = true;
+  say(`${spec.prefix}editor-verdict`, "Saving…");
   try {
     const answer = await fetch(
       `${SHEETS_API}/${encodeURIComponent(state.fileId)}/values/`
@@ -399,17 +529,20 @@ async function save() {
       throw new Error(detail);
     }
   } catch (error) {
-    say("editor-verdict", `Not saved: ${error.message}`, "err");
-    $("editor-save").disabled = false;
+    say(`${spec.prefix}editor-verdict`, `Not saved: ${error.message}`, "err");
+    $(`${spec.prefix}editor-save`).disabled = false;
     return;
   }
 
   // RE-READ RATHER THAN PATCH IN MEMORY. The sheet is the truth, another editor
   // may have moved something, and a Console showing its own optimistic copy is
   // the beginning of the drift this page exists to prevent.
-  $("editor-card").classList.add("hidden");
+  const returning = state.editing;
+  $(spec.card).classList.add("hidden");
   state.editing = null;
   await show(state.fileId);
+  // A column was opened from a table's screen, so put that screen back.
+  if (returning?.entity) showTable(returning.entity);
 }
 
 
@@ -553,7 +686,8 @@ function showTable(key) {
   body.append(block("Fields", fields.map((r) => pairRow(
     r.ATTRIBUTE_KEY, r.DATA_TYPE || "TEXT",
     [r.SEMANTIC_ROLE, readBoolean(r.IS_PK, false) ? "key" : "",
-     readBoolean(r.IS_MANDATORY, false) ? "required" : ""].filter(Boolean).join(" · "))),
+     readBoolean(r.IS_MANDATORY, false) ? "required" : ""].filter(Boolean).join(" · "),
+    "", () => edit(EDITORS.column, r, key))),
     "No fields, so this table has no columns — the add-in refuses to sync it."));
 
   body.append(block("Sources", sources.map((r) => pairRow(
@@ -587,37 +721,35 @@ function showTable(key) {
     [r.ACTION_CLASS, r.REGION].filter(Boolean).join(" · "))),
     "No ribbon entry points at this table, so nothing in Excel opens it."));
 
-  // ---- the two warnings the add-in's Info panel gets right --------------------
-  const notes = [];
-  const strategy = (definition?.STORAGE_STRATEGY || "").toLowerCase();
-  if (strategy === "replaceall") {
-    notes.push(["ReplaceAll", "Every sync DELETES all rows in this table before "
-      + "writing. Nothing accumulates, and nothing survives a source that comes "
-      + "back empty."]);
-  }
-  const keys = fields.filter((r) => readBoolean(r.IS_PK, false));
-  if (strategy === "mergeupsert" && !keys.length) {
-    notes.push(["MergeUpsert with no key", "There is no IS_PK column to match "
-      + "on, so every sync APPENDS the same rows again. The table grows a "
-      + "duplicate set each time."]);
-  }
-  if (keys.length > 1) {
-    notes.push(["Composite key", `${keys.length} columns are marked IS_PK and the `
-      + `add-in uses only the first (${keys[0].ATTRIBUTE_KEY}). Composite keys are `
-      + "not supported."]);
-  }
+  // ---- what the add-in would make of this table ------------------------------
+  //
+  // READ FROM THE RULES, not written again here. These three notes existed
+  // before `tabledefinition-rules.js` did, and one of them was already wrong —
+  // it repeated the add-in's own claim that a composite key is unsupported,
+  // which is true of three call sites and false of the database that builds a
+  // real compound key. Two statements of one fact is how that happens.
+  const about = definition
+    ? checkTableDefinitionRow(
+      definition,
+      rows("1.TableDefinition").filter((r) => r !== definition),
+      rows("2.SchemaRule"))
+    : [];
+  const roles = definition ? checkEntityRoles(key, fields, definition) : [];
+  const notes = [...about, ...roles].filter((f) => f.severity !== "Info");
+
   if (notes.length) {
     const card = document.createElement("section");
     card.className = "card";
     const heading = document.createElement("h2");
     heading.textContent = "How this table is written";
     card.append(heading);
-    for (const [title, detail] of notes) {
+    for (const found of notes) {
       const line = document.createElement("p");
-      line.className = "hint err";
+      line.className = found.severity === "Warning" ? "hint" : "hint err";
       const strong = document.createElement("b");
-      strong.textContent = `${title}. `;
-      line.append(strong, document.createTextNode(detail));
+      strong.textContent = `${found.field}. `;
+      line.append(strong, document.createTextNode(
+        found.fix ? `${found.detail} ${found.fix}` : found.detail));
       card.append(line);
     }
     body.append(card);
@@ -741,26 +873,48 @@ $("workbook-recheck").addEventListener("click", () => {
   if (state.fileId) show(state.fileId);
 });
 $("workbook-choose").addEventListener("click", () => pick());
-$("source-add").addEventListener("click", () => edit({}));
-$("editor-cancel").addEventListener("click", () => {
-  state.editing = null;
-  $("editor-card").classList.add("hidden");
+$("source-add").addEventListener("click", () => edit(EDITORS.source, {}));
+
+// Both buttons on the inspect screen act on the table currently open, which is
+// the one fact neither form asks for.
+$("inspect-edit").addEventListener("click", () => {
+  const key = $("inspect-name").textContent;
+  const row = rowsOf(state.workbook, "1.TableDefinition")
+    .find((r) => (r.ENTITY_KEY || "").toLowerCase() === key.toLowerCase());
+  // A name used elsewhere in the workbook with no definition behind it is a real
+  // state of this screen, and the answer to it is to write the definition.
+  edit(EDITORS.table, row || {ENTITY_KEY: key});
 });
-$("editor-save").addEventListener("click", () => save());
-// Judged on every keystroke and every choice, because a rule the owner meets
-// only when he presses Save is a rule that arrives after the work.
-for (const name of FIELDS) {
-  const control = $(`f-${name}`);
-  control.addEventListener("input", () => judge());
-  control.addEventListener("change", () => judge());
+$("column-add").addEventListener("click", () => {
+  const key = $("inspect-name").textContent;
+  edit(EDITORS.column, {ENTITY_KEY: key}, key);
+});
+
+// Wiring is per editor and identical for each, which is the point of the spec.
+for (const spec of Object.values(EDITORS)) {
+  $(`${spec.prefix}editor-cancel`).addEventListener("click", () => {
+    state.editing = null;
+    $(spec.card).classList.add("hidden");
+  });
+  $(`${spec.prefix}editor-save`).addEventListener("click", () => save(spec));
+  // Judged on every keystroke and every choice, because a rule the owner meets
+  // only when he presses Save is a rule that arrives after the work.
+  for (const name of spec.fields) {
+    const node = $(control(spec, name));
+    if (!node) continue;
+    node.addEventListener("input", () => judge(spec));
+    node.addEventListener("change", () => judge(spec));
+  }
 }
-// The key has a stated convention; offer it rather than making him retype it.
+
+// The source key has a stated convention; offer it rather than making him
+// retype it. Only this sheet has one.
 for (const name of ["TARGET_ENTITY_KEY", "PROFILE_KEY"]) {
   $(`f-${name}`).addEventListener("change", () => {
     const key = $("f-SOURCE_KEY");
     if (!key.value.trim()) {
-      key.value = suggestedKey(readForm());
-      judge();
+      key.value = suggestedKey(readForm(EDITORS.source));
+      judge(EDITORS.source);
     }
   });
 }

--- a/extension/schemarule-rules.js
+++ b/extension/schemarule-rules.js
@@ -1,0 +1,312 @@
+// One row of 2.SchemaRule, judged exactly as the add-in judges it.
+//
+// THIS SHEET IS WHERE SILENCE IS WORST. Two rows with the same
+// (ENTITY_KEY, ATTRIBUTE_KEY) are resolved by dictionary assignment — last one
+// wins — and NOTHING is written anywhere: no log line, no ValidationResult, not
+// even the `[DUPLICATE]` warning its sibling sheet gets. A column definition is
+// discarded and no surface in the add-in will ever mention it. That is the
+// single strongest argument for editing this sheet through the Console.
+//
+// Every rule below was read out of the C# with file:line
+// (docs/reviews/mbiXaddin-config-contract-*.md).
+
+import { readBoolean, BOOLEAN_DEFAULTS, ERROR_CODE, LOG_TAG, CONSOLE_ONLY_CODE,
+  SEMANTIC_ROLES, REPEATABLE_ROLES, DATA_TYPES, LICENSE_TIERS, UX_CONFIG_KEYS,
+  LOGIC_CONFIG_KEYS } from "./addin-contract.js";
+
+const KEY_LIMIT = 100;
+
+const finding = (severity, field, code, detail, fix = "") =>
+  ({severity, field, code, detail, fix});
+
+const text = (row, name) => String(row?.[name] ?? "").trim();
+const same = (a, b) => a.toUpperCase() === b.toUpperCase();
+const flag = (row, name) =>
+  readBoolean(row?.[name], BOOLEAN_DEFAULTS["2.SchemaRule"][name]);
+
+/**
+ * Aliases the parser normalises BEFORE parsing DATA_TYPE, so the Console must
+ * accept them too or it will refuse a spelling the add-in is happy with.
+ * TsvParser.cs:186-198.
+ */
+const DATA_TYPE_ALIASES = {
+  BOOLEAN: "BOOL", BIT: "BOOL",
+  STRING: "TEXT", VARCHAR: "TEXT", NVARCHAR: "TEXT", CHAR: "TEXT",
+  INTEGER: "INT",
+  NUMBER: "DECIMAL", FLOAT: "DECIMAL", DOUBLE: "DECIMAL", NUMERIC: "DECIMAL",
+};
+
+/** The ten menu roles the add-in warns about when tagged more than once. */
+const WARNED_SINGULAR_ROLES = [
+  "MENU_KEY", "MENU_LABEL", "MENU_URL", "MENU_DRIVE_URL", "MENU_SCREENTIP",
+  "MENU_SUPERTIP", "MENU_ICON", "MENU_ACTION", "MENU_FORMAT", "MENU_ORDER",
+];
+
+const BAGS = {
+  UX_CONFIG: UX_CONFIG_KEYS,
+  LOGIC_CONFIG: LOGIC_CONFIG_KEYS,
+};
+
+function checkBag(row, name, found) {
+  const raw = text(row, name);
+  if (!raw) return;
+  let parsed = null;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    found.push(finding("Error", name, ERROR_CODE.badJson,
+      "Not valid JSON, so the whole bag is dropped and every setting in it "
+      + "stops applying."));
+    return;
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    found.push(finding("Error", name, ERROR_CODE.badJson,
+      "Valid JSON, but not an object — nothing can be read out of it."));
+    return;
+  }
+  for (const key of Object.keys(parsed)) {
+    if (!BAGS[name].includes(key)) {
+      found.push(finding("Warning", name, ERROR_CODE.unknownKey,
+        `"${key}" is not a setting the add-in reads. It is kept and ignored.`,
+        `Accepted here: ${BAGS[name].join(", ")}.`));
+    }
+  }
+}
+
+/**
+ * One SchemaRule row, against the rest of the workbook.
+ *
+ * `others` is every OTHER row of 2.SchemaRule — the same convention as
+ * `checkDataSourceRow`, so the caller excludes the row under edit and the
+ * Console's `worldFor` helper does it in one place.
+ *
+ * It may be the whole sheet: the per-entity rules narrow it themselves rather
+ * than trusting the caller to. That part is NOT convention but a correction —
+ * CODE, NAME and UNIT repeat across nearly every table there is, and a caller
+ * that filtered by nothing would be told its whole workbook was a mass of
+ * clashes. A module about human error should not keep one in its own signature.
+ *
+ * `definitions` is all of 1.TableDefinition, needed to tell an orphan from a
+ * good column.
+ */
+export function checkSchemaRuleRow(row, others = [], definitions = []) {
+  const found = [];
+  const entity = text(row, "ENTITY_KEY");
+  const attribute = text(row, "ATTRIBUTE_KEY");
+  const siblings = (others || []).filter(
+    (other) => same(text(other, "ENTITY_KEY"), entity));
+
+  // 1 and 2 — the two Critical fields. Either blank stops the add-in's own
+  // validation (yield break), so the Console stops with it.
+  if (!entity) {
+    return [finding("Critical", "ENTITY_KEY", ERROR_CODE.required,
+      "No table named, so this column belongs to nothing and the row is "
+      + "rejected whole.")];
+  }
+  if (!attribute) {
+    return [finding("Critical", "ATTRIBUTE_KEY", ERROR_CODE.required,
+      "No column name. The row is rejected whole — it defines nothing.")];
+  }
+  if (attribute.length > KEY_LIMIT) {
+    found.push(finding("Error", "ATTRIBUTE_KEY", ERROR_CODE.tooLong,
+      `${attribute.length} characters; the add-in refuses anything over `
+      + `${KEY_LIMIT}.`));
+  }
+
+  // 3 — THE SILENT ONE. Both keys together are the primary key of
+  // _SYS_SCHEMA_RULES, and a repeat is resolved last-wins with no record.
+  if (siblings.some((other) => same(text(other, "ATTRIBUTE_KEY"), attribute))) {
+    found.push(finding("Error", "ATTRIBUTE_KEY", CONSOLE_ONLY_CODE.silentOverride,
+      `"${attribute}" is defined more than once for ${entity}. The LAST row `
+      + "wins and the others are discarded — with no log line and no warning "
+      + "anywhere. Whichever definition you are looking at may not be the one "
+      + "in use.",
+      "Delete the duplicate, or rename one of them."));
+  }
+
+  // 4 — is there a table to belong to? Matched against ACTIVE definitions only.
+  if (definitions.length) {
+    const match = definitions.find((d) => same(text(d, "ENTITY_KEY"), entity));
+    const live = match
+      && readBoolean(match.IS_ACTIVE, BOOLEAN_DEFAULTS["1.TableDefinition"].IS_ACTIVE);
+    if (!match) {
+      found.push(finding("Error", "ENTITY_KEY", LOG_TAG.orphanColumns,
+        `No table is called "${entity}", so this column is dropped from the `
+        + "graph entirely.",
+        "Fix the spelling, or define the table on 1.TableDefinition."));
+    } else if (!live) {
+      found.push(finding("Warning", "ENTITY_KEY", LOG_TAG.orphanColumns,
+        `"${entity}" exists but is switched off, and the lookup is built from `
+        + "ACTIVE tables only — so this column is dropped exactly as if the "
+        + "table were missing."));
+    }
+  }
+
+  // 5 — DISPLAY_HEADER. A Fail, but the export has a fallback chain, so the
+  // consequence is cosmetic and the severity says so rather than the code.
+  if (!text(row, "DISPLAY_HEADER")) {
+    found.push(finding("Warning", "DISPLAY_HEADER", ERROR_CODE.required,
+      "No header. The Excel column falls back to the attribute key, which is "
+      + "readable but not what a reader expects to see."));
+  }
+
+  // 6 — the closed lists. A blank SEMANTIC_ROLE is NONE, which is a real member
+  // meaning "no engine meaning", and must never be flagged.
+  const role = text(row, "SEMANTIC_ROLE");
+  if (role && !SEMANTIC_ROLES.some((allowed) => same(allowed, role))) {
+    found.push(finding("Error", "SEMANTIC_ROLE", ERROR_CODE.badValue,
+      `"${role}" is not a role the add-in knows.`,
+      `Leave it empty for an ordinary column, or use one of: `
+      + `${SEMANTIC_ROLES.join(", ")}.`));
+  }
+
+  const dataType = text(row, "DATA_TYPE");
+  if (dataType) {
+    const upper = dataType.toUpperCase();
+    const resolved = DATA_TYPE_ALIASES[upper] || upper;
+    if (!DATA_TYPES.includes(resolved)) {
+      found.push(finding("Error", "DATA_TYPE", ERROR_CODE.badValue,
+        `"${dataType}" is not a type. An unreadable value leaves the column as `
+        + "TEXT, so numbers arrive in Excel as text and stop adding up.",
+        `Accepted: ${DATA_TYPES.join(", ")}.`));
+    } else if (resolved !== upper) {
+      found.push(finding("Info", "DATA_TYPE", ERROR_CODE.badValue,
+        `"${dataType}" is accepted and read as ${resolved}.`));
+    }
+  }
+
+  const tier = text(row, "LICENSE_TIER");
+  if (tier && !LICENSE_TIERS.some((allowed) => same(allowed, tier))) {
+    found.push(finding("Error", "LICENSE_TIER", ERROR_CODE.badValue,
+      `"${tier}" is not a tier.`, `Accepted: ${LICENSE_TIERS.join(", ")}.`));
+  }
+
+  // 7 — ORDINAL_POS. Blank is 0 and legitimate; a negative draws a warning and
+  // is then used as 0 anyway.
+  const ordinal = text(row, "ORDINAL_POS");
+  if (ordinal && !/^-?\d+$/.test(ordinal)) {
+    found.push(finding("Error", "ORDINAL_POS", ERROR_CODE.badValue,
+      `"${ordinal}" is not a whole number, so the position falls back to 0 and `
+      + "this column ties with every other blank one."));
+  } else if (ordinal && Number(ordinal) < 0) {
+    found.push(finding("Warning", "ORDINAL_POS", ERROR_CODE.badValue,
+      "A negative position is not used — the add-in substitutes 0."));
+  }
+
+  // 8 — the flags, and the three combinations the add-in refuses.
+  const isPk = flag(row, "IS_PK");
+  if (isPk && flag(row, "IS_VIRTUAL")) {
+    found.push(finding("Error", "IS_PK", ERROR_CODE.badValue,
+      "A primary key cannot be virtual: a virtual column is never stored, so "
+      + "there is nothing for the key to be."));
+  }
+  if (isPk && flag(row, "IS_DERIVED")) {
+    found.push(finding("Error", "IS_PK", ERROR_CODE.badValue,
+      "A primary key cannot be derived — it must come from the source, not "
+      + "from a formula."));
+  }
+  if (isPk && !flag(row, "IS_MANDATORY")) {
+    found.push(finding("Warning", "IS_PK", ERROR_CODE.badValue,
+      "A key that is allowed to be empty breaks MergeUpsert: a null key matches "
+      + "nothing, so those rows duplicate on every sync.",
+      "Switch IS_MANDATORY on as well."));
+  }
+
+  // 9 — one key per table. The DDL supports a composite key and the rest of the
+  // add-in does not, which is a split worth stating precisely.
+  if (isPk && siblings.some((other) => flag(other, "IS_PK"))) {
+    found.push(finding("Warning", "IS_PK", ERROR_CODE.badValue,
+      "More than one column of this table is a key. SQLite gets a genuine "
+      + "compound key and de-duplicates correctly — but the pre-flight check, "
+      + "the row lookup and the library menu all read only the FIRST key column "
+      + "in ordinal order, and the add-in's own warning says composite keys are "
+      + "unsupported, which is true of those three and false of the database.",
+      "Use one key column unless you know only SQLite will enforce the rest."));
+  }
+
+  // 10 — repeated roles. Three roles are repeatable by design; of the rest,
+  // ten warn and the engine roles do not warn at all.
+  if (role && !REPEATABLE_ROLES.some((r) => same(r, role))
+      && siblings.some((other) => same(text(other, "SEMANTIC_ROLE"), role))) {
+    const upper = role.toUpperCase();
+    const quiet = !WARNED_SINGULAR_ROLES.includes(upper);
+    found.push(finding("Warning", "SEMANTIC_ROLE",
+      quiet ? CONSOLE_ONLY_CODE.silentOverride : ERROR_CODE.duplicate,
+      `${role} is used by more than one column of ${entity}. Only the first in `
+      + "ordinal order is read and the rest are ignored"
+      + (quiet
+        ? " — and for this role the add-in says NOTHING about it at all."
+        : ", with a warning in the log."),
+      `Repeatable roles are ${REPEATABLE_ROLES.join(", ")}; every other role `
+      + "belongs to one column."));
+  }
+
+  // 11 — the two bags.
+  for (const name of Object.keys(BAGS)) checkBag(row, name, found);
+
+  return found;
+}
+
+/**
+ * Roles a whole entity is REQUIRED to carry, given what kind of table it is.
+ *
+ * Kept apart from the row rules because none of it can be judged one row at a
+ * time — and because the guided workflow asks this question at a different
+ * moment: after the columns are defined, before a source is attached.
+ */
+export function checkEntityRoles(entityKey, rows, definition) {
+  const found = [];
+  const roles = rows.map((r) => text(r, "SEMANTIC_ROLE").toUpperCase());
+  const type = text(definition, "ENTITY_TYPE").toUpperCase();
+  const missing = (name) => !roles.includes(name);
+
+  if (type === "CONVERSION") {
+    for (const needed of ["CONV_SOURCE", "CONV_TARGET", "CONV_FACTOR"]) {
+      if (missing(needed)) {
+        found.push(finding("Error", "SEMANTIC_ROLE", ERROR_CODE.mandatoryUnmapped,
+          `A CONVERSION table needs a ${needed} column and ${entityKey} has none. `
+          + "Conversion cannot run.",
+          `Tag the column that holds it with ${needed}.`));
+      }
+    }
+  }
+  if (type === "COST" && missing("PRICE")) {
+    found.push(finding("Warning", "SEMANTIC_ROLE", ERROR_CODE.mandatoryUnmapped,
+      `${entityKey} is a COST table with no PRICE column, so nothing that reads `
+      + "a price will find one here."));
+  }
+  if (type === "LIBRARY") {
+    if (missing("MENU_KEY") && !rows.some((r) => flag(r, "IS_PK"))) {
+      found.push(finding("Error", "SEMANTIC_ROLE", ERROR_CODE.mandatoryUnmapped,
+        "A LIBRARY table needs either a MENU_KEY column or a primary key. "
+        + "Without one its menu cannot identify a row."));
+    }
+    if (missing("MENU_URL") && missing("MENU_DRIVE_URL")) {
+      found.push(finding("Warning", "SEMANTIC_ROLE", ERROR_CODE.mandatoryUnmapped,
+        "No MENU_URL and no MENU_DRIVE_URL, so nothing in this library can be "
+        + "downloaded."));
+    }
+    if (roles.includes("MENU_URL") && roles.includes("MENU_DRIVE_URL")) {
+      found.push(finding("Info", "SEMANTIC_ROLE", ERROR_CODE.duplicate,
+        "Both MENU_URL and MENU_DRIVE_URL are tagged. MENU_URL wins and the "
+        + "Drive column is never converted."));
+    }
+    if (missing("MENU_LABEL")) {
+      found.push(finding("Warning", "SEMANTIC_ROLE", ERROR_CODE.mandatoryUnmapped,
+        "No MENU_LABEL, so entries are named by their file name and then by "
+        + "their key."));
+    }
+  }
+
+  // Independent of the table's type: an export tree with nothing to group by
+  // renders as "No documents available" rather than as an error.
+  if (roles.includes("EXPORT_GROUP") === false
+      && rows.some((r) => text(r, "SEMANTIC_ROLE").toUpperCase()
+        .startsWith("MENU_")) && type === "LIBRARY") {
+    found.push(finding("Info", "SEMANTIC_ROLE", ERROR_CODE.mandatoryUnmapped,
+      "No EXPORT_GROUP column. An export-tree menu built from this table shows "
+      + "\"No documents available\" instead of saying what is wrong."));
+  }
+
+  return found;
+}

--- a/extension/schemarule-rules.js
+++ b/extension/schemarule-rules.js
@@ -10,7 +10,8 @@
 // Every rule below was read out of the C# with file:line
 // (docs/reviews/mbiXaddin-config-contract-*.md).
 
-import { readBoolean, BOOLEAN_DEFAULTS, ERROR_CODE, LOG_TAG, CONSOLE_ONLY_CODE,
+import { readBoolean, readConfigBag, BOOLEAN_DEFAULTS, ERROR_CODE, LOG_TAG,
+  CONSOLE_ONLY_CODE,
   SEMANTIC_ROLES, REPEATABLE_ROLES, DATA_TYPES, LICENSE_TIERS, UX_CONFIG_KEYS,
   LOGIC_CONFIG_KEYS } from "./addin-contract.js";
 
@@ -50,19 +51,18 @@ const BAGS = {
 function checkBag(row, name, found) {
   const raw = text(row, name);
   if (!raw) return;
-  let parsed = null;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
+  const {value: parsed, tolerated, unreadable} = readConfigBag(raw);
+  if (unreadable) {
     found.push(finding("Error", name, ERROR_CODE.badJson,
-      "Not valid JSON, so the whole bag is dropped and every setting in it "
-      + "stops applying."));
+      "Nothing here can be read as a settings object, so the whole bag is "
+      + "dropped and every setting in it stops applying."));
     return;
   }
-  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-    found.push(finding("Error", name, ERROR_CODE.badJson,
-      "Valid JSON, but not an object — nothing can be read out of it."));
-    return;
+  if (!parsed) return;
+  if (tolerated) {
+    found.push(finding("Info", name, ERROR_CODE.badJson,
+      "Not strict JSON — a trailing comma or a comment. The add-in's parser "
+      + "accepts it, so nothing is broken."));
   }
   for (const key of Object.keys(parsed)) {
     if (!BAGS[name].includes(key)) {
@@ -226,7 +226,15 @@ export function checkSchemaRuleRow(row, others = [], definitions = []) {
 
   // 10 — repeated roles. Three roles are repeatable by design; of the rest,
   // ten warn and the engine roles do not warn at all.
-  if (role && !REPEATABLE_ROLES.some((r) => same(r, role))
+  //
+  // NONE IS NOT A ROLE, and excluding it is not a nicety. It is the default for
+  // every ordinary column — "no engine meaning" — so a rule that counted it
+  // would fire on nearly every table in the workbook. Measured against the
+  // owner's real sheet before this line existed: 23 warnings, every one of them
+  // wrong. A blank cell reads as NONE too, which is why both are excluded here
+  // rather than only the blank.
+  if (role && !same(role, "NONE")
+      && !REPEATABLE_ROLES.some((r) => same(r, role))
       && siblings.some((other) => same(text(other, "SEMANTIC_ROLE"), role))) {
     const upper = role.toUpperCase();
     const quiet = !WARNED_SINGULAR_ROLES.includes(upper);

--- a/extension/tabledefinition-rules.js
+++ b/extension/tabledefinition-rules.js
@@ -1,0 +1,263 @@
+// One row of 1.TableDefinition, judged exactly as the add-in judges it.
+//
+// SAME DISCIPLINE AS `datasource-rules.js`, and for the same reason: every rule
+// below was read out of the C# with file:line
+// (docs/reviews/mbiXaddin-config-contract-*.md). A rule invented here would be a
+// Console refusing something the add-in accepts, and that teaches an owner to
+// work around the Console rather than with it.
+//
+// THIS SHEET IS THE REGISTRY. A DataSource points at a table; a SchemaRule
+// describes its columns; a DataMap fills them. If the row here is wrong or
+// missing, none of that runs — so several of the rules below are about what
+// OTHER sheets contain, and take them as arguments rather than guessing.
+
+import { readBoolean, BOOLEAN_DEFAULTS, ERROR_CODE, LOG_TAG, CONSOLE_ONLY_CODE,
+  ENTITY_TYPES, STORAGE_STRATEGIES, STORAGE_STRATEGY_ALIASES, LICENSE_TIERS,
+  VIEW_MODES, BUSINESS_DOMAINS, TABLE_UX_CONFIG_KEYS, TABLE_SYS_CONFIG_KEYS,
+  RIBBON_CONFIG_KEYS, EXPORT_CONFIG_KEYS, DIRECTIONS, CONTROL_SIZES,
+  BANNER_STYLES } from "./addin-contract.js";
+
+/** The add-in's own cap on both key columns. SystemConstants ERR_LENGTH. */
+const KEY_LIMIT = 100;
+
+const finding = (severity, field, code, detail, fix = "") =>
+  ({severity, field, code, detail, fix});
+
+const text = (row, name) => String(row?.[name] ?? "").trim();
+
+/**
+ * The four JSON bags, and the closed lists inside two of them.
+ *
+ * A malformed bag is dropped WHOLE at runtime — not partially — so one stray
+ * comma silently discards every setting in it. That is why a parse failure is
+ * an Error here and not a warning.
+ */
+const BAGS = {
+  UX_CONFIG: {keys: TABLE_UX_CONFIG_KEYS,
+              closed: {Direction: DIRECTIONS}},
+  SYS_CONFIG: {keys: TABLE_SYS_CONFIG_KEYS, closed: {}},
+  RIBBON_CONFIG: {keys: RIBBON_CONFIG_KEYS,
+                  closed: {ControlSize: CONTROL_SIZES}},
+  EXPORT_CONFIG: {keys: EXPORT_CONFIG_KEYS,
+                  closed: {HeaderStyle: BANNER_STYLES, FooterStyle: BANNER_STYLES}},
+};
+
+/** Case-insensitive throughout, because the add-in matches keys that way. */
+const same = (a, b) => a.toUpperCase() === b.toUpperCase();
+
+/**
+ * Is this table's primary key defined anywhere on 2.SchemaRule?
+ *
+ * Exported because it is the hinge of the worst fault this sheet can carry, and
+ * the guided workflow needs to ask the same question before it lets a table be
+ * saved with MergeUpsert.
+ */
+export function hasPrimaryKey(entityKey, schemaRules) {
+  return (schemaRules || []).some(
+    (rule) => same(String(rule?.ENTITY_KEY ?? "").trim(), entityKey)
+      && readBoolean(rule?.IS_PK, BOOLEAN_DEFAULTS["2.SchemaRule"].IS_PK));
+}
+
+function checkBag(row, name, found) {
+  const raw = text(row, name);
+  if (!raw) return;                          // blank is a default object, never a fault
+
+  let parsed = null;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    found.push(finding("Error", name, ERROR_CODE.badJson,
+      "Not valid JSON. The whole bag is dropped at runtime, not just the broken "
+      + "part, so EVERY setting in it stops applying.",
+      "Check the quotes and commas, or empty the cell."));
+    return;
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    found.push(finding("Error", name, ERROR_CODE.badJson,
+      "This is valid JSON but not an object, so no setting can be read out of it."));
+    return;
+  }
+
+  const {keys, closed} = BAGS[name];
+  for (const key of Object.keys(parsed)) {
+    if (!keys.includes(key)) {
+      found.push(finding("Warning", name, ERROR_CODE.unknownKey,
+        `"${key}" is not a setting the add-in reads. It is kept and ignored.`,
+        `Accepted here: ${keys.join(", ")}.`));
+      continue;
+    }
+    const allowed = closed[key];
+    const value = parsed[key];
+    if (allowed && value !== null && value !== undefined
+        && !allowed.includes(String(value))) {
+      found.push(finding("Error", name, ERROR_CODE.badValue,
+        `${key}="${value}" is not one of the values the add-in accepts.`,
+        `Use one of: ${allowed.join(", ")}.`));
+    }
+  }
+}
+
+/**
+ * One TableDefinition row, against the rest of the workbook.
+ *
+ * `others` is every OTHER row of this sheet — needed for the duplicate key and
+ * for resolving PARENT_KEY, which is looked up among ACTIVE rows only.
+ * `schemaRules` is all of 2.SchemaRule, needed for the MergeUpsert rule.
+ */
+export function checkTableDefinitionRow(row, others = [], schemaRules = []) {
+  const found = [];
+  const key = text(row, "ENTITY_KEY");
+
+  // 1 — ENTITY_KEY. Critical, and the add-in stops here (yield break), so the
+  // Console stops too rather than printing a cascade about a row nothing reads.
+  if (!key) {
+    return [finding("Critical", "ENTITY_KEY", ERROR_CODE.required,
+      "There is no key, so this row defines no table. It is rejected whole, and "
+      + "every source and column pointing at it is orphaned.")];
+  }
+  if (key.length > KEY_LIMIT) {
+    found.push(finding("Error", "ENTITY_KEY", ERROR_CODE.tooLong,
+      `${key.length} characters; the add-in refuses anything over ${KEY_LIMIT}.`));
+  }
+  if (others.some((other) => same(text(other, "ENTITY_KEY"), key))) {
+    found.push(finding("Error", "ENTITY_KEY", LOG_TAG.duplicateEntity,
+      `"${key}" is defined more than once. Only the FIRST row is used — the rest `
+      + "are dropped, so edits made to the wrong one appear to do nothing.",
+      "Rename one of them, or delete the row that is not wanted."));
+  }
+
+  // 2 — DISPLAY_NAME. A Fail, so the row survives — but the fallback everyone
+  // assumes is there does not exist.
+  if (!text(row, "DISPLAY_NAME")) {
+    found.push(finding("Error", "DISPLAY_NAME", ERROR_CODE.required,
+      "No name. It does NOT fall back to the key: `EffectiveLabel` reads "
+      + "`RIBBON_CONFIG?.Label ?? DISPLAY_NAME ?? ENTITY_KEY`, and because "
+      + "DISPLAY_NAME starts as an empty string rather than null, the last "
+      + "branch can never run. The ribbon button renders with a BLANK label.",
+      "Type the name that should appear in Excel."));
+  }
+
+  // 3 — the closed lists. A value outside one is not coerced; it is recorded and
+  // the property keeps its declared default.
+  for (const [field, vocabulary] of [["ENTITY_TYPE", ENTITY_TYPES],
+                                     ["LICENSE_TIER", LICENSE_TIERS],
+                                     ["VIEW_MODE", VIEW_MODES],
+                                     ["BUSINESS_DOMAIN", BUSINESS_DOMAINS]]) {
+    const value = text(row, field);
+    if (value && !vocabulary.some((allowed) => same(allowed, value))) {
+      found.push(finding("Error", field, ERROR_CODE.badValue,
+        `"${value}" is not a value the add-in knows.`,
+        `Accepted: ${vocabulary.join(", ")}.`));
+    }
+  }
+
+  // 4 — STORAGE_STRATEGY, and the fault that costs the most.
+  const strategyText = text(row, "STORAGE_STRATEGY");
+  const knownStrategy = STORAGE_STRATEGIES.find((s) => same(s, strategyText))
+    || (STORAGE_STRATEGY_ALIASES.some((a) => same(a, strategyText))
+      ? strategyText : "");
+  if (strategyText && !knownStrategy) {
+    found.push(finding("Error", "STORAGE_STRATEGY", ERROR_CODE.badValue,
+      `"${strategyText}" is not a strategy. It is NOT coerced to the first enum `
+      + "value — the parser records the error and leaves MergeUpsert in place, "
+      + "which is deliberate: enum zero is ReplaceAll, and that would delete "
+      + "everything.",
+      `Accepted: ${STORAGE_STRATEGIES.join(", ")}.`));
+  }
+
+  // Blank means MergeUpsert, so the check below must treat blank as MergeUpsert
+  // too — this is the case a reader is most likely to miss.
+  const effective = knownStrategy && same(knownStrategy, "ReplaceAll") ? "ReplaceAll"
+    : knownStrategy && same(knownStrategy, "Append") ? "Append"
+      : "MergeUpsert";
+
+  if (effective === "MergeUpsert" && !hasPrimaryKey(key, schemaRules)) {
+    found.push(finding("Error", "STORAGE_STRATEGY",
+      CONSOLE_ONLY_CODE.duplicatesForever,
+      (strategyText ? "MergeUpsert" : "A blank strategy means MergeUpsert, and it")
+      + ` needs a primary key. No column of "${key}" on 2.SchemaRule has IS_PK, `
+      + "so no PRIMARY KEY is created, INSERT OR REPLACE has nothing to match "
+      + "on, and EVERY SYNC APPENDS THE WHOLE FILE AGAIN. Nothing reports this: "
+      + "the check that would have runs only when a PK column exists.",
+      "Set IS_PK on the column that identifies a row, or use Append."));
+  }
+  if (effective === "ReplaceAll") {
+    found.push(finding("Warning", "STORAGE_STRATEGY", ERROR_CODE.badValue,
+      "Every sync DELETES every row of this table first, then loads the file. "
+      + "Anything the source has dropped since last time is gone from Excel too."));
+  }
+  if (effective === "Append") {
+    found.push(finding("Info", "STORAGE_STRATEGY", ERROR_CODE.badValue,
+      "Rows are only added. A row already present is silently skipped, and a "
+      + "row the source has corrected keeps its OLD value."));
+  }
+
+  // 5 — PARENT_KEY. Blank is the normal case for most rows and is never a fault.
+  const parent = text(row, "PARENT_KEY");
+  if (parent && same(parent, key)) {
+    found.push(finding("Critical", "PARENT_KEY", ERROR_CODE.circular,
+      "A table cannot inherit from itself. This is one of the few things the "
+      + "add-in refuses outright."));
+  } else if (parent) {
+    const match = others.find((other) => same(text(other, "ENTITY_KEY"), parent));
+    const parentIsLive = match
+      && readBoolean(match.IS_ACTIVE, BOOLEAN_DEFAULTS["1.TableDefinition"].IS_ACTIVE);
+    if (!match) {
+      found.push(finding("Warning", "PARENT_KEY", ERROR_CODE.reference,
+        `Nothing is named "${parent}". Inheritance is skipped and this becomes a `
+        + "root table — silently, with only a line in the log."));
+    } else if (!parentIsLive) {
+      found.push(finding("Warning", "PARENT_KEY", ERROR_CODE.reference,
+        `"${parent}" exists but is switched off, and the lookup is built from `
+        + "ACTIVE rows only. So this behaves exactly as if the parent did not "
+        + "exist at all — which is the harder version to spot.",
+        "Switch the parent on, or clear this."));
+    } else if (text(match, "PARENT_KEY")) {
+      found.push(finding("Info", "PARENT_KEY", ERROR_CODE.reference,
+        `"${parent}" has a parent of its own, and inheritance is applied ONCE. `
+        + "Nothing from the grandparent reaches this table."));
+    }
+  }
+
+  // 6 — the switches, and what each one actually turns off.
+  if (!readBoolean(row?.IS_ACTIVE, BOOLEAN_DEFAULTS["1.TableDefinition"].IS_ACTIVE)) {
+    const orphaned = others.filter((other) => same(text(other, "PARENT_KEY"), key));
+    found.push(finding("Info", "IS_ACTIVE", ERROR_CODE.badFormat,
+      "Switched off. The table is removed from the graph before anything is "
+      + "built, so its sources never sync and it cannot be anyone's parent."));
+    if (orphaned.length) {
+      found.push(finding("Warning", "IS_ACTIVE", ERROR_CODE.reference,
+        `${orphaned.map((o) => text(o, "ENTITY_KEY")).join(", ")} inherit from `
+        + "this table, and a switched-off parent is invisible to the lookup. "
+        + "They quietly became root tables.",
+        "Switch this back on, or give them their own settings."));
+    }
+  } else if (!readBoolean(row?.IS_VISIBLE,
+    BOOLEAN_DEFAULTS["1.TableDefinition"].IS_VISIBLE)) {
+    found.push(finding("Info", "IS_VISIBLE", ERROR_CODE.badFormat,
+      "Hidden from the ribbon menus only. It still syncs, and its data is still "
+      + "written."));
+  }
+
+  // 7 — the four bags.
+  for (const name of Object.keys(BAGS)) checkBag(row, name, found);
+
+  return found;
+}
+
+/**
+ * Does anything at all come out of this table?
+ *
+ * The counterpart of `stopsThisSource` on the other sheet, and split from
+ * "switched off" for the same reason: a table that is empty on purpose must not
+ * be reported next to one that is empty by accident.
+ */
+export function tableProducesNothing(found) {
+  return found.some((f) => f.severity === "Critical");
+}
+
+/** Deliberately empty, rather than broken. */
+export function tableSwitchedOff(row) {
+  return !readBoolean(row?.IS_ACTIVE,
+    BOOLEAN_DEFAULTS["1.TableDefinition"].IS_ACTIVE);
+}

--- a/extension/tabledefinition-rules.js
+++ b/extension/tabledefinition-rules.js
@@ -153,6 +153,21 @@ export function checkTableDefinitionRow(row, others = [], schemaRules = []) {
     }
   }
 
+  // 3b — a blank ENTITY_TYPE is inherited before it is judged. The add-in warns
+  // only when it is still null AFTER MergeWithParent, so a child of a typed
+  // parent is silent and a root with no type is not. Found by opening the real
+  // T_BITUMEN, whose type is blank and whose parent is nothing.
+  if (!text(row, "ENTITY_TYPE")) {
+    const parentRow = others.find(
+      (other) => same(text(other, "ENTITY_KEY"), text(row, "PARENT_KEY")));
+    if (!text(parentRow || {}, "ENTITY_TYPE")) {
+      found.push(finding("Warning", "ENTITY_TYPE", ERROR_CODE.required,
+        "No kind, and nothing to inherit one from. The table still syncs, but "
+        + "every rule that turns on the kind — a CONVERSION's three columns, a "
+        + "COST table's price, a LIBRARY's menu — is skipped without comment."));
+    }
+  }
+
   // 4 — STORAGE_STRATEGY, and the fault that costs the most.
   const strategyText = text(row, "STORAGE_STRATEGY");
   const knownStrategy = STORAGE_STRATEGIES.find((s) => same(s, strategyText))

--- a/extension/tabledefinition-rules.js
+++ b/extension/tabledefinition-rules.js
@@ -11,7 +11,8 @@
 // missing, none of that runs — so several of the rules below are about what
 // OTHER sheets contain, and take them as arguments rather than guessing.
 
-import { readBoolean, BOOLEAN_DEFAULTS, ERROR_CODE, LOG_TAG, CONSOLE_ONLY_CODE,
+import { readBoolean, readConfigBag, BOOLEAN_DEFAULTS, ERROR_CODE, LOG_TAG,
+  CONSOLE_ONLY_CODE,
   ENTITY_TYPES, STORAGE_STRATEGIES, STORAGE_STRATEGY_ALIASES, LICENSE_TIERS,
   VIEW_MODES, BUSINESS_DOMAINS, TABLE_UX_CONFIG_KEYS, TABLE_SYS_CONFIG_KEYS,
   RIBBON_CONFIG_KEYS, EXPORT_CONFIG_KEYS, DIRECTIONS, CONTROL_SIZES,
@@ -62,20 +63,21 @@ function checkBag(row, name, found) {
   const raw = text(row, name);
   if (!raw) return;                          // blank is a default object, never a fault
 
-  let parsed = null;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
+  const {value: parsed, tolerated, unreadable} = readConfigBag(raw);
+  if (unreadable) {
     found.push(finding("Error", name, ERROR_CODE.badJson,
-      "Not valid JSON. The whole bag is dropped at runtime, not just the broken "
-      + "part, so EVERY setting in it stops applying.",
-      "Check the quotes and commas, or empty the cell."));
+      "Nothing here can be read as a settings object — not even allowing for "
+      + "the add-in's own leniency. The whole bag is dropped at runtime, not "
+      + "just the broken part, so EVERY setting in it stops applying.",
+      "Check the brackets and quotes, or empty the cell."));
     return;
   }
-  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-    found.push(finding("Error", name, ERROR_CODE.badJson,
-      "This is valid JSON but not an object, so no setting can be read out of it."));
-    return;
+  if (!parsed) return;
+  if (tolerated) {
+    found.push(finding("Info", name, ERROR_CODE.badJson,
+      "Not strict JSON — a trailing comma or a comment. The add-in's parser "
+      + "accepts it and always has, so nothing is broken; anything else reading "
+      + "this cell would refuse it."));
   }
 
   const {keys, closed} = BAGS[name];

--- a/extension/tests/schemarule-rules.test.mjs
+++ b/extension/tests/schemarule-rules.test.mjs
@@ -1,0 +1,249 @@
+// One SchemaRule row, judged as the add-in judges it.
+//
+// The sheet where the add-in is quietest: a repeated column name is resolved
+// last-wins with NO record anywhere. Several tests below exist only to hold that
+// distinction — between a fault the add-in reports and one it does not — because
+// it is the distinction the Console is for.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { checkSchemaRuleRow, checkEntityRoles } from "../schemarule-rules.js";
+
+const sound = (over = {}) => ({
+  ENTITY_KEY: "T_BITUMEN",
+  ATTRIBUTE_KEY: "PRICE_SAR",
+  DISPLAY_HEADER: "Price (SAR)",
+  ORDINAL_POS: "3",
+  LICENSE_TIER: "Free",
+  SEMANTIC_ROLE: "PRICE",
+  DATA_TYPE: "DECIMAL",
+  IS_PK: "FALSE",
+  IS_MANDATORY: "FALSE",
+  IS_VIRTUAL: "FALSE",
+  IS_DERIVED: "FALSE",
+  IS_VISIBLE: "TRUE",
+  UX_CONFIG: "",
+  LOGIC_CONFIG: "",
+  ...over,
+});
+
+const live = [{ENTITY_KEY: "T_BITUMEN", IS_ACTIVE: "TRUE"}];
+const codes = (found) => found.map((f) => f.code);
+const fields = (found) => found.map((f) => f.field);
+
+test("a sound row produces nothing at all", () => {
+  assert.deepEqual(checkSchemaRuleRow(sound(), [], live), []);
+});
+
+test("either key blank rejects the row and stops", () => {
+  for (const blank of ["ENTITY_KEY", "ATTRIBUTE_KEY"]) {
+    const found = checkSchemaRuleRow(sound({[blank]: ""}), [], live);
+    assert.equal(found.length, 1, `${blank} produced a cascade`);
+    assert.equal(found[0].severity, "Critical");
+    assert.equal(found[0].field, blank);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// The fault the add-in never mentions.
+// ---------------------------------------------------------------------------
+
+test("a repeated column name is LAST-wins, silently, and the Console says so", () => {
+  const found = checkSchemaRuleRow(
+    sound(), [sound({DISPLAY_HEADER: "Price", SEMANTIC_ROLE: ""})], live);
+  const clash = found.filter((f) => f.field === "ATTRIBUTE_KEY");
+  assert.equal(clash.length, 1);
+  assert.equal(clash[0].severity, "Error");
+  assert.match(clash[0].detail, /LAST row/);
+  assert.match(clash[0].detail, /no log line/,
+    "the message does not say that nothing anywhere records this");
+});
+
+test("the duplicate is per ENTITY, not per sheet", () => {
+  // A column of the same name on a DIFFERENT table is normal and must not be
+  // flagged — CODE, NAME and UNIT repeat across nearly every table there is.
+  const otherTable = [{...sound(), ENTITY_KEY: "T_DIESEL"}];
+  assert.deepEqual(
+    checkSchemaRuleRow(sound(), otherTable, live).filter(
+      (f) => f.code === "SILENT_OVERRIDE"),
+    [],
+    "siblings are being read as the whole sheet rather than one table's rows");
+});
+
+test("a column whose table does not exist is dropped from the graph", () => {
+  const found = checkSchemaRuleRow(sound({ENTITY_KEY: "T_GHOST"}), [], live);
+  const orphan = found.filter((f) => f.code === "ORPHAN_COLS");
+  assert.equal(orphan.length, 1);
+  assert.equal(orphan[0].severity, "Error");
+});
+
+test("a table that is switched OFF drops its columns just the same", () => {
+  const found = checkSchemaRuleRow(
+    sound(), [], [{ENTITY_KEY: "T_BITUMEN", IS_ACTIVE: "FALSE"}]);
+  const orphan = found.find((f) => f.code === "ORPHAN_COLS");
+  assert.ok(orphan, "a switched-off table stopped orphaning its columns");
+  assert.match(orphan.detail, /ACTIVE tables only/);
+});
+
+// ---------------------------------------------------------------------------
+// The key, and the three combinations the add-in refuses.
+// ---------------------------------------------------------------------------
+
+test("a key cannot be virtual or derived", () => {
+  for (const flag of ["IS_VIRTUAL", "IS_DERIVED"]) {
+    const found = checkSchemaRuleRow(
+      sound({IS_PK: "TRUE", IS_MANDATORY: "TRUE", [flag]: "TRUE"}), [], live);
+    const refused = found.filter((f) => f.field === "IS_PK"
+      && f.severity === "Error");
+    assert.equal(refused.length, 1, `IS_PK + ${flag} was allowed`);
+  }
+});
+
+test("a key that may be empty breaks the merge it exists for", () => {
+  const found = checkSchemaRuleRow(sound({IS_PK: "TRUE"}), [], live);
+  const said = found.find((f) => f.field === "IS_PK");
+  assert.equal(said.severity, "Warning");
+  assert.match(said.fix, /IS_MANDATORY/);
+});
+
+test("a composite key is described exactly, not as unsupported", () => {
+  // The add-in's own warning says composite keys are unsupported. That is true
+  // of three call sites and FALSE of the database, which builds a real compound
+  // key — so repeating the add-in's wording would teach the wrong thing.
+  const found = checkSchemaRuleRow(
+    sound({ATTRIBUTE_KEY: "CODE", IS_PK: "TRUE", IS_MANDATORY: "TRUE"}),
+    [sound({ATTRIBUTE_KEY: "REGION", IS_PK: "TRUE"})], live);
+  const said = found.find((f) => f.field === "IS_PK" && f.severity === "Warning");
+  assert.match(said.detail, /compound key and de-duplicates correctly/);
+  assert.match(said.detail, /FIRST key column/);
+});
+
+// ---------------------------------------------------------------------------
+// Vocabularies, and the blanks that are legitimate.
+// ---------------------------------------------------------------------------
+
+test("a blank role is NONE, which is a real value and never a fault", () => {
+  assert.deepEqual(checkSchemaRuleRow(sound({SEMANTIC_ROLE: ""}), [], live), [],
+    "an ordinary data column with no engine meaning was flagged");
+});
+
+test("a blank ordinal is 0 and legitimate; a negative one is not used", () => {
+  assert.deepEqual(checkSchemaRuleRow(sound({ORDINAL_POS: ""}), [], live), []);
+  const negative = checkSchemaRuleRow(sound({ORDINAL_POS: "-1"}), [], live);
+  assert.equal(negative.length, 1);
+  assert.equal(negative[0].severity, "Warning");
+  const words = checkSchemaRuleRow(sound({ORDINAL_POS: "third"}), [], live);
+  assert.equal(words[0].severity, "Error");
+});
+
+test("the DATA_TYPE aliases the parser normalises are accepted, and named", () => {
+  for (const [typed, meant] of [["Boolean", "BOOL"], ["Varchar", "TEXT"],
+                                ["Integer", "INT"], ["Double", "DECIMAL"]]) {
+    const found = checkSchemaRuleRow(sound({DATA_TYPE: typed}), [], live);
+    assert.equal(found.length, 1, `${typed} was refused`);
+    assert.equal(found[0].severity, "Info");
+    assert.match(found[0].detail, new RegExp(meant));
+  }
+});
+
+test("an unreadable type leaves the column as TEXT, and says what that costs", () => {
+  const found = checkSchemaRuleRow(sound({DATA_TYPE: "Money"}), [], live);
+  assert.equal(found[0].severity, "Error");
+  assert.match(found[0].detail, /stop adding up/);
+});
+
+test("repeatable roles repeat; singular ones do not", () => {
+  const twice = (role) => checkSchemaRuleRow(
+    sound({SEMANTIC_ROLE: role}),
+    [sound({ATTRIBUTE_KEY: "OTHER", SEMANTIC_ROLE: role})], live)
+    .filter((f) => f.field === "SEMANTIC_ROLE");
+
+  assert.deepEqual(twice("MENU_GROUP"), [],
+    "MENU_GROUP is the one repeatable menu role and was refused");
+  assert.deepEqual(twice("EXPORT_GROUP"), []);
+
+  const menu = twice("MENU_LABEL");
+  assert.equal(menu.length, 1);
+  assert.equal(menu[0].code, "ERR_DUPLICATE",
+    "MENU_LABEL is one of the ten the add-in warns about");
+
+  // An engine role repeats with NO warning anywhere in the add-in — two PRICE
+  // columns is entirely silent, which is why this one is Console-only.
+  const price = twice("PRICE");
+  assert.equal(price.length, 1);
+  assert.equal(price[0].code, "SILENT_OVERRIDE");
+  assert.match(price[0].detail, /NOTHING about it at all/);
+});
+
+test("a broken bag loses all of its settings", () => {
+  const found = checkSchemaRuleRow(
+    sound({LOGIC_CONFIG: "{Min: 0}"}), [], live);
+  assert.deepEqual(fields(found), ["LOGIC_CONFIG"]);
+  assert.equal(found[0].code, "INVALID_JSON");
+});
+
+// ---------------------------------------------------------------------------
+// What a whole entity needs, which no single row can answer.
+// ---------------------------------------------------------------------------
+
+test("a CONVERSION table without its three roles cannot convert", () => {
+  const found = checkEntityRoles("T_UNITS", [sound({SEMANTIC_ROLE: "NAME"})],
+    {ENTITY_KEY: "T_UNITS", ENTITY_TYPE: "CONVERSION"});
+  assert.equal(found.length, 3);
+  for (const role of ["CONV_SOURCE", "CONV_TARGET", "CONV_FACTOR"]) {
+    assert.ok(found.some((f) => f.detail.includes(role)), `${role} not demanded`);
+  }
+  assert.deepEqual([...new Set(found.map((f) => f.severity))], ["Error"]);
+});
+
+test("a COST table with no PRICE is a warning, not an error", () => {
+  // The add-in's own severity. Raising it would block a table it happily syncs.
+  const found = checkEntityRoles("T_BITUMEN", [sound({SEMANTIC_ROLE: "NAME"})],
+    {ENTITY_KEY: "T_BITUMEN", ENTITY_TYPE: "COST"});
+  assert.deepEqual([...new Set(found.map((f) => f.severity))], ["Warning"]);
+});
+
+test("a LIBRARY table needs a way to identify and a way to download", () => {
+  const bare = checkEntityRoles("T_DOCS", [sound({SEMANTIC_ROLE: "NAME"})],
+    {ENTITY_KEY: "T_DOCS", ENTITY_TYPE: "LIBRARY"});
+  assert.ok(bare.some((f) => f.severity === "Error" && /MENU_KEY/.test(f.detail)));
+  assert.ok(bare.some((f) => /downloaded/.test(f.detail)));
+
+  // A primary key satisfies the identity requirement on its own.
+  const keyed = checkEntityRoles("T_DOCS",
+    [sound({SEMANTIC_ROLE: "NAME", IS_PK: "TRUE"}),
+     sound({ATTRIBUTE_KEY: "URL", SEMANTIC_ROLE: "MENU_URL"}),
+     sound({ATTRIBUTE_KEY: "LBL", SEMANTIC_ROLE: "MENU_LABEL"})],
+    {ENTITY_KEY: "T_DOCS", ENTITY_TYPE: "LIBRARY"});
+  assert.deepEqual(keyed.filter((f) => f.severity === "Error"), []);
+});
+
+test("both URL roles together is not an error — one simply wins", () => {
+  const found = checkEntityRoles("T_DOCS",
+    [sound({ATTRIBUTE_KEY: "A", SEMANTIC_ROLE: "MENU_KEY"}),
+     sound({ATTRIBUTE_KEY: "B", SEMANTIC_ROLE: "MENU_URL"}),
+     sound({ATTRIBUTE_KEY: "C", SEMANTIC_ROLE: "MENU_DRIVE_URL"}),
+     sound({ATTRIBUTE_KEY: "D", SEMANTIC_ROLE: "MENU_LABEL"})],
+    {ENTITY_KEY: "T_DOCS", ENTITY_TYPE: "LIBRARY"});
+  const both = found.find((f) => /MENU_URL wins/.test(f.detail));
+  assert.ok(both);
+  assert.equal(both.severity, "Info");
+});
+
+test("an ordinary table demands no roles at all", () => {
+  assert.deepEqual(
+    checkEntityRoles("T_REF", [sound({SEMANTIC_ROLE: ""})],
+      {ENTITY_KEY: "T_REF", ENTITY_TYPE: "REF"}),
+    [], "a plain reference table was made to justify itself");
+});
+
+test("every finding carries a code", () => {
+  const messy = checkSchemaRuleRow(
+    sound({ENTITY_KEY: "T_GHOST", DATA_TYPE: "Money", DISPLAY_HEADER: "",
+      IS_PK: "TRUE", IS_VIRTUAL: "TRUE"}), [], live);
+  assert.ok(messy.length >= 4);
+  for (const found of messy) assert.ok(found.code, `${found.field} has no code`);
+  assert.ok(!codes(messy).includes("INVALID_VALUE")
+    || messy.every((f) => f.code !== "INVALID_VALUE" || f.field !== "ENTITY_KEY"));
+});

--- a/extension/tests/schemarule-rules.test.mjs
+++ b/extension/tests/schemarule-rules.test.mjs
@@ -163,6 +163,13 @@ test("repeatable roles repeat; singular ones do not", () => {
     "MENU_GROUP is the one repeatable menu role and was refused");
   assert.deepEqual(twice("EXPORT_GROUP"), []);
 
+  // NONE is not a role. It is what every ordinary column carries, so counting
+  // it as singular fires on nearly every table there is — measured at 23 false
+  // warnings against the owner's real workbook before this was excluded.
+  assert.deepEqual(twice("NONE"), [],
+    "NONE is being counted as a repeated role");
+  assert.deepEqual(twice("none"), [], "and the check is case-sensitive again");
+
   const menu = twice("MENU_LABEL");
   assert.equal(menu.length, 1);
   assert.equal(menu[0].code, "ERR_DUPLICATE",

--- a/extension/tests/tabledefinition-rules.test.mjs
+++ b/extension/tests/tabledefinition-rules.test.mjs
@@ -197,11 +197,49 @@ test("hidden is not the same as off", () => {
 
 test("a broken bag loses ALL of its settings, not the broken part", () => {
   const found = checkTableDefinitionRow(
-    sound({UX_CONFIG: '{"TabColor": "#FF0000",}'}), [], withKey);
+    sound({UX_CONFIG: '{"TabColor": '}), [], withKey);
   const bad = found.filter((f) => f.field === "UX_CONFIG");
   assert.equal(bad.length, 1);
   assert.equal(bad[0].severity, "Error");
   assert.match(bad[0].detail, /EVERY setting in it/);
+});
+
+test("but a trailing comma is NOT broken — the add-in's parser accepts it", () => {
+  // Found by running these rules against the owner's real workbook: three cells
+  // came back as errors and all three were fine. Every bag in the product is
+  // parsed by Newtonsoft, which takes a trailing comma; JSON.parse does not.
+  // This is the exact text of one of those cells.
+  const real = `{
+"HeaderText":"الهيئة العامة للطرق والكباري",
+"HeaderStyle":"TableHeader",
+}`;
+  const found = checkTableDefinitionRow(
+    sound({EXPORT_CONFIG: real}), [], withKey);
+
+  assert.equal(found.length, 1, "the tolerated cell produced more than a note");
+  assert.equal(found[0].severity, "Info",
+    "a cell the add-in reads every day is being reported as a fault");
+  assert.match(found[0].detail, /trailing comma/);
+  // And the settings inside it are still read, so HeaderStyle is still checked.
+  const wrongStyle = checkTableDefinitionRow(
+    sound({EXPORT_CONFIG: '{"HeaderStyle":"Fancy",}'}), [], withKey);
+  assert.ok(wrongStyle.some((f) => f.severity === "Error"),
+    "tolerating the comma stopped the values inside being checked");
+});
+
+test("a comment is tolerated too, and a URL inside a string is not a comment", () => {
+  const commented = checkTableDefinitionRow(
+    sound({SYS_CONFIG: `{ // how many rows the teaser shows
+"TeaserRowCount": 5 }`}),
+    [], withKey);
+  assert.equal(commented.length, 1);
+  assert.equal(commented[0].severity, "Info");
+
+  // The relaxation strips `//`, and a value like "https://x" contains one. If
+  // that were cut, a perfectly good bag would become unreadable.
+  const url = checkTableDefinitionRow(
+    sound({SYS_CONFIG: '{"TeaserText": "see https://example.com/x"}'}), [], withKey);
+  assert.deepEqual(url, [], "a URL in a string was mistaken for a comment");
 });
 
 test("a misspelt key is kept and ignored, and the accepted set is offered", () => {

--- a/extension/tests/tabledefinition-rules.test.mjs
+++ b/extension/tests/tabledefinition-rules.test.mjs
@@ -1,0 +1,232 @@
+// One TableDefinition row, judged as the add-in judges it.
+//
+// Every expectation is the add-in's behaviour read out of its C#, not a
+// preference. Where a rule looks strange — a blank strategy that means
+// MergeUpsert, a switched-off parent that behaves like a missing one — the
+// strange part is the add-in's and the test says so, because that is exactly the
+// kind of rule someone later "corrects" into something more reasonable.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { checkTableDefinitionRow, hasPrimaryKey, tableSwitchedOff }
+  from "../tabledefinition-rules.js";
+
+/** A row with nothing wrong with it — the control for every test below. */
+const sound = (over = {}) => ({
+  ENTITY_KEY: "T_BITUMEN",
+  DISPLAY_NAME: "Bitumen",
+  ENTITY_TYPE: "COST",
+  LICENSE_TIER: "Free",
+  IS_ACTIVE: "TRUE",
+  IS_VISIBLE: "TRUE",
+  STORAGE_STRATEGY: "MergeUpsert",
+  PARENT_KEY: "",
+  VIEW_MODE: "Table",
+  BUSINESS_DOMAIN: "MATERIAL",
+  UX_CONFIG: "",
+  SYS_CONFIG: "",
+  RIBBON_CONFIG: "",
+  EXPORT_CONFIG: "",
+  ...over,
+});
+
+/** A key column for T_BITUMEN, so the MergeUpsert rule is satisfied by default. */
+const withKey = [{ENTITY_KEY: "T_BITUMEN", ATTRIBUTE_KEY: "CODE", IS_PK: "TRUE"}];
+
+const codes = (found) => found.map((f) => f.code);
+const fields = (found) => found.map((f) => f.field);
+const worst = (found) => found.map((f) => f.severity);
+
+test("a sound row produces nothing at all", () => {
+  assert.deepEqual(checkTableDefinitionRow(sound(), [], withKey), []);
+});
+
+test("no key rejects the row and says nothing else", () => {
+  const found = checkTableDefinitionRow(sound({ENTITY_KEY: ""}), [], withKey);
+  // The add-in stops at this one (yield break), so a second complaint here would
+  // be the Console describing checks that never run.
+  assert.equal(found.length, 1);
+  assert.equal(found[0].severity, "Critical");
+  assert.equal(found[0].field, "ENTITY_KEY");
+});
+
+test("a repeated key says which row wins, because edits go to the wrong one", () => {
+  const found = checkTableDefinitionRow(
+    sound(), [sound({DISPLAY_NAME: "Bitumen (old)"})], withKey);
+  const dup = found.filter((f) => f.code === "DUPLICATE");
+  assert.equal(dup.length, 1);
+  assert.match(dup[0].detail, /FIRST row is used/);
+});
+
+test("a missing name does NOT fall back to the key, and says so", () => {
+  const found = checkTableDefinitionRow(sound({DISPLAY_NAME: ""}), [], withKey);
+  const named = found.filter((f) => f.field === "DISPLAY_NAME");
+  assert.equal(named.length, 1);
+  // The whole point: the fallback everyone assumes exists is dead code.
+  assert.match(named[0].detail, /BLANK label/);
+});
+
+// ---------------------------------------------------------------------------
+// The worst fault this sheet can carry, and the one nothing reports.
+// ---------------------------------------------------------------------------
+
+test("MergeUpsert with no key column duplicates the file on every sync", () => {
+  const found = checkTableDefinitionRow(sound(), [], []);   // no SchemaRule rows
+  const fatal = found.filter((f) => f.code === "NO_CONFLICT_TARGET");
+  assert.equal(fatal.length, 1);
+  assert.equal(fatal[0].severity, "Error");
+  assert.match(fatal[0].detail, /EVERY SYNC APPENDS/);
+});
+
+test("and a BLANK strategy is MergeUpsert, so it carries the same fault", () => {
+  // The case a reader is likeliest to miss: blank is not "no strategy", it is
+  // MergeUpsert — chosen deliberately, because enum zero would be ReplaceAll.
+  const found = checkTableDefinitionRow(
+    sound({STORAGE_STRATEGY: ""}), [], []);
+  assert.ok(codes(found).includes("NO_CONFLICT_TARGET"),
+    "a blank strategy stopped being treated as MergeUpsert");
+  assert.match(found.find((f) => f.code === "NO_CONFLICT_TARGET").detail,
+    /blank strategy means MergeUpsert/);
+});
+
+test("a key column anywhere on the sheet settles it", () => {
+  assert.deepEqual(
+    checkTableDefinitionRow(sound(), [], withKey).filter(
+      (f) => f.code === "NO_CONFLICT_TARGET"), []);
+  // And the helper the workflow will ask directly, including the case-folding
+  // the add-in does throughout.
+  assert.equal(hasPrimaryKey("t_bitumen", withKey), true);
+  assert.equal(hasPrimaryKey("T_OTHER", withKey), false);
+});
+
+test("a key column that is switched OFF is still a key", () => {
+  // IS_PK is what the DDL reads; there is no IS_ACTIVE on 2.SchemaRule at all.
+  // Inventing one here would refuse a table the add-in is happy with.
+  assert.equal(hasPrimaryKey("T_BITUMEN", [
+    {ENTITY_KEY: "T_BITUMEN", ATTRIBUTE_KEY: "CODE", IS_PK: "نعم"}]), true,
+  "the Arabic spelling for true stopped counting");
+});
+
+test("Append and ReplaceAll each say what they cost", () => {
+  const replace = checkTableDefinitionRow(
+    sound({STORAGE_STRATEGY: "ReplaceAll"}), [], withKey);
+  assert.match(replace.find((f) => f.field === "STORAGE_STRATEGY").detail,
+    /DELETES every row/);
+
+  const append = checkTableDefinitionRow(
+    sound({STORAGE_STRATEGY: "Append"}), [], withKey);
+  const note = append.find((f) => f.field === "STORAGE_STRATEGY");
+  assert.equal(note.severity, "Info");
+  assert.match(note.detail, /keeps its OLD value/);
+  // Append needs no key, so the fatal rule must not fire on it.
+  assert.deepEqual(append.filter((f) => f.code === "NO_CONFLICT_TARGET"), []);
+});
+
+test("an unreadable strategy is not coerced to the first enum value", () => {
+  const found = checkTableDefinitionRow(
+    sound({STORAGE_STRATEGY: "Replace All"}), [], withKey);
+  const bad = found.find((f) => f.field === "STORAGE_STRATEGY"
+    && f.code === "INVALID_VALUE");
+  assert.ok(bad, "an unknown strategy stopped being reported");
+  assert.match(bad.detail, /would delete everything/);
+});
+
+// ---------------------------------------------------------------------------
+// Inheritance, where two different faults look identical from the sheet.
+// ---------------------------------------------------------------------------
+
+test("a table cannot be its own parent", () => {
+  const found = checkTableDefinitionRow(
+    sound({PARENT_KEY: "t_bitumen"}), [], withKey);
+  const loop = found.filter((f) => f.code === "ERR_CIRCULAR");
+  assert.equal(loop.length, 1);
+  assert.equal(loop[0].severity, "Critical");
+});
+
+test("a parent that is switched off is reported differently from a missing one", () => {
+  const missing = checkTableDefinitionRow(
+    sound({PARENT_KEY: "T_NOWHERE"}), [], withKey);
+  assert.match(missing.find((f) => f.field === "PARENT_KEY").detail,
+    /Nothing is named/);
+
+  const off = checkTableDefinitionRow(
+    sound({PARENT_KEY: "T_BASE"}),
+    [sound({ENTITY_KEY: "T_BASE", IS_ACTIVE: "FALSE"})], withKey);
+  const said = off.find((f) => f.field === "PARENT_KEY");
+  assert.match(said.detail, /switched off/,
+    "the harder case reads as a plain missing parent");
+  assert.match(said.detail, /ACTIVE rows only/);
+});
+
+test("inheritance is one level, and a grandparent is called out", () => {
+  const found = checkTableDefinitionRow(
+    sound({PARENT_KEY: "T_MID"}),
+    [sound({ENTITY_KEY: "T_MID", PARENT_KEY: "T_ROOT"})], withKey);
+  const note = found.find((f) => f.field === "PARENT_KEY");
+  assert.equal(note.severity, "Info");
+  assert.match(note.detail, /applied ONCE/);
+});
+
+test("switching a table off orphans the tables that inherit from it", () => {
+  const found = checkTableDefinitionRow(
+    sound({IS_ACTIVE: "FALSE"}),
+    [sound({ENTITY_KEY: "T_CHILD", PARENT_KEY: "T_BITUMEN"})], withKey);
+  const orphans = found.filter((f) => f.field === "IS_ACTIVE"
+    && f.severity === "Warning");
+  assert.equal(orphans.length, 1);
+  assert.match(orphans[0].detail, /T_CHILD/,
+    "the message does not name the tables that just lost their parent");
+});
+
+test("hidden is not the same as off", () => {
+  const hidden = checkTableDefinitionRow(
+    sound({IS_VISIBLE: "FALSE"}), [], withKey);
+  assert.match(hidden.find((f) => f.field === "IS_VISIBLE").detail,
+    /still syncs/);
+  assert.equal(tableSwitchedOff(sound({IS_VISIBLE: "FALSE"})), false);
+  assert.equal(tableSwitchedOff(sound({IS_ACTIVE: "FALSE"})), true);
+  // A blank IS_ACTIVE means LIVE on this sheet. Reading it as "off" would make
+  // the Console call every incomplete row disabled.
+  assert.equal(tableSwitchedOff(sound({IS_ACTIVE: ""})), false);
+});
+
+// ---------------------------------------------------------------------------
+// The four JSON bags.
+// ---------------------------------------------------------------------------
+
+test("a broken bag loses ALL of its settings, not the broken part", () => {
+  const found = checkTableDefinitionRow(
+    sound({UX_CONFIG: '{"TabColor": "#FF0000",}'}), [], withKey);
+  const bad = found.filter((f) => f.field === "UX_CONFIG");
+  assert.equal(bad.length, 1);
+  assert.equal(bad[0].severity, "Error");
+  assert.match(bad[0].detail, /EVERY setting in it/);
+});
+
+test("a misspelt key is kept and ignored, and the accepted set is offered", () => {
+  const found = checkTableDefinitionRow(
+    sound({SYS_CONFIG: '{"AllowEdits": true}'}), [], withKey);
+  const said = found.find((f) => f.field === "SYS_CONFIG");
+  assert.equal(said.code, "UNKNOWN_KEY");
+  assert.match(said.fix, /AllowEdit/);
+});
+
+test("the closed lists inside the bags are checked too", () => {
+  const found = checkTableDefinitionRow(
+    sound({UX_CONFIG: '{"Direction": "RTL"}',
+      RIBBON_CONFIG: '{"ControlSize": "Huge"}',
+      EXPORT_CONFIG: '{"HeaderStyle": "Note"}'}), [], withKey);
+  assert.deepEqual(fields(found), ["RIBBON_CONFIG"],
+    "a valid Direction or HeaderStyle was refused, or a bad ControlSize passed");
+  assert.equal(found[0].severity, "Error");
+});
+
+test("every finding carries a code the add-in would print", () => {
+  const messy = checkTableDefinitionRow(
+    sound({DISPLAY_NAME: "", ENTITY_TYPE: "COSTS", STORAGE_STRATEGY: ""}),
+    [], []);
+  assert.ok(messy.length >= 3);
+  assert.ok(!worst(messy).includes(undefined));
+  for (const found of messy) assert.ok(found.code, `${found.field} has no code`);
+});

--- a/extension/tests/tabledefinition-rules.test.mjs
+++ b/extension/tests/tabledefinition-rules.test.mjs
@@ -268,3 +268,28 @@ test("every finding carries a code the add-in would print", () => {
   assert.ok(!worst(messy).includes(undefined));
   for (const found of messy) assert.ok(found.code, `${found.field} has no code`);
 });
+
+test("a table with no kind and nothing to inherit one from is warned", () => {
+  // Found by opening the real T_BITUMEN, whose ENTITY_TYPE is blank and whose
+  // PARENT_KEY is nothing. The add-in warns only when it is STILL null after
+  // inheritance, so the check has to look at the parent, not just the cell.
+  const rootless = checkTableDefinitionRow(
+    sound({ENTITY_TYPE: ""}), [], withKey);
+  const said = rootless.filter((f) => f.field === "ENTITY_TYPE");
+  assert.equal(said.length, 1);
+  assert.equal(said[0].severity, "Warning");
+  assert.match(said[0].detail, /nothing to inherit one from/);
+
+  // A child of a typed parent inherits one, and the add-in stays silent.
+  const inherited = checkTableDefinitionRow(
+    sound({ENTITY_TYPE: "", PARENT_KEY: "T_BASE"}),
+    [sound({ENTITY_KEY: "T_BASE", ENTITY_TYPE: "COST"})], withKey);
+  assert.deepEqual(inherited.filter((f) => f.field === "ENTITY_TYPE"), [],
+    "a child that inherits a kind was made to declare one");
+
+  // And a parent with no kind either leaves the child with nothing.
+  const neither = checkTableDefinitionRow(
+    sound({ENTITY_TYPE: "", PARENT_KEY: "T_BASE"}),
+    [sound({ENTITY_KEY: "T_BASE", ENTITY_TYPE: ""})], withKey);
+  assert.equal(neither.filter((f) => f.field === "ENTITY_TYPE").length, 1);
+});

--- a/tests/test_the_addin_contract_cannot_drift.py
+++ b/tests/test_the_addin_contract_cannot_drift.py
@@ -204,9 +204,13 @@ def test_every_code_the_console_reports_is_one_the_add_in_can_emit():
     ERR_FORMAT. INVALID_VALUE is real, but it lives in `ConfigValidator` and is
     reached only through a JSON config bag."""
     hand_written = HAND_WRITTEN.read_text(encoding="utf-8")
-    known = set(_contract()["vocabularies"]["ERROR_CODES"])
+    vocabularies = _contract()["vocabularies"]
+    # A LOG_TAG is not an error code — there is no ValidationResult behind it —
+    # but it IS a string the add-in prints, which is the only property that
+    # matters here: an owner can search its log for it and find something.
+    known = set(vocabularies["ERROR_CODES"]) | set(vocabularies["LOG_TAGS"])
 
-    borrowed = _js_object(hand_written, "ERROR_CODE")
+    borrowed = _js_object(hand_written, "ERROR_CODE") | _js_object(hand_written, "LOG_TAG")
     unknown = sorted({code for code in borrowed.values() if code not in known})
     assert not unknown, (
         f"{unknown} are reported by the Console and are not in the add-in's "

--- a/tools/sync_addin_contract.py
+++ b/tools/sync_addin_contract.py
@@ -42,12 +42,22 @@ ORDER = [
                       "UX_CONFIG_KEYS", "LOGIC_CONFIG_KEYS"]),
     ("1.TableDefinition and 3.DataSource",
      ["ENTITY_TYPES", "STORAGE_STRATEGIES", "STORAGE_STRATEGY_ALIASES",
-      "LICENSE_TIERS", "VIEW_MODES", "BUSINESS_DOMAINS", "CONTEXT_PROPS_KEYS",
+      "LICENSE_TIERS", "VIEW_MODES", "BUSINESS_DOMAINS", "TABLE_UX_CONFIG_KEYS",
+      "TABLE_SYS_CONFIG_KEYS", "RIBBON_CONFIG_KEYS", "EXPORT_CONFIG_KEYS",
+      "DIRECTIONS", "CONTROL_SIZES", "BANNER_STYLES", "CONTEXT_PROPS_KEYS",
       "CONTEXT_SOURCE_TYPES", "SYNC_FREQUENCIES"]),
     ("6.RibbonControls", ["MENU_LAYOUTS", "CLICKABLE_ACTIONS", "MENU_ACTIONS"]),
     ("booleans, severities and the add-in's own error codes",
-     ["TRUE_SPELLINGS", "FALSE_SPELLINGS", "SEVERITIES", "ERROR_CODES"]),
+     ["TRUE_SPELLINGS", "FALSE_SPELLINGS", "SEVERITIES", "ERROR_CODES",
+      "LOG_TAGS"]),
 ]
+
+
+def _emit_comment(lines: list[str], value: list[str]) -> None:
+    """A `_comment` key carries the reason an entry exists, and the reason is
+    worth more in the generated file than in the JSON nobody opens."""
+    lines.append("")
+    lines.extend(f"// {line}" for line in value)
 
 
 def _js(value: object) -> str:
@@ -58,7 +68,8 @@ def _js(value: object) -> str:
 
 def render(contract: dict) -> str:
     vocabularies = contract["vocabularies"]
-    unknown = sorted(set(vocabularies) - {n for _, names in ORDER for n in names})
+    unknown = sorted(set(vocabularies) - {n for _, names in ORDER for n in names}
+                     - {n for n in vocabularies if n.startswith("_")})
 
     lines = [
         "// GENERATED — do not edit. Run `python tools/sync_addin_contract.py`.",
@@ -82,6 +93,9 @@ def render(contract: dict) -> str:
         for name in names:
             if name not in vocabularies:
                 continue
+            comment = vocabularies.get(f"_comment_{name}")
+            if comment:
+                _emit_comment(lines, comment)
             lines.append(f"export const {name} = {_js(vocabularies[name])};")
         lines.append("")
 
@@ -111,8 +125,7 @@ def render(contract: dict) -> str:
         # A `_comment` key carries the reason a constant exists, and the reason
         # is worth more in the generated file than in the JSON nobody opens.
         if name.startswith("_"):
-            lines.append("")
-            lines.extend(f"// {line}" for line in value)
+            _emit_comment(lines, value)
             continue
         lines.append(f"export const {name} = {_js(value)};")
     lines.append("")


### PR DESCRIPTION
The prerequisite the guided workflow has been waiting on. Until now the Console could edit exactly one of the six sheets.

Both modules follow `datasource-rules.js` exactly: every rule read out of the C# with `file:line`, nothing invented, severities the add-in's own.

## Then they were run against the owner's real workbook

20 tables, 263 column definitions, 17 sources. That run found **four defects no fixture had**:

| | what was wrong |
|---|---|
| **1** | Bags are parsed by **Newtonsoft**, not `JSON.parse`. Three live cells came back as Errors and all three are fine — they end in a trailing comma, which Newtonsoft accepts. A Console refusing what the add-in reads every day teaches an owner to ignore it. |
| **2** | **`NONE` is not a role.** It is what every ordinary column carries, so counting it among the singular roles produced **23 warnings, every one wrong**. |
| **3** | `checkSchemaRuleRow` trusted the caller to pass one table's rows. `CODE`, `NAME` and `UNIT` repeat across nearly every table — a caller that forgot would be told its whole workbook was a mass of clashes. |
| **4** | Mine, not the rules': `openpyxl` types a whole number as `1.0`, the published TSV carries `1`. **145 phantom errors**, gone by fixing the probe rather than the rule. |

Bag reading now lives in `readConfigBag` in the contract module, beside `readBoolean` — same kind of thing, same home. Its docstring names the remaining gap: Newtonsoft also accepts single quotes and unquoted keys, which it does not handle.

## What the live workbook actually contains

**93 findings over 283 rows, 3 of them blocking** — three rows on `1.TableDefinition` carrying `EXPORT_CONFIG` with no `ENTITY_KEY`. The add-in rejects those rows whole, so that export configuration has never applied to anything.

## The rule worth having on its own

`STORAGE_STRATEGY = MergeUpsert` on a table with **no `IS_PK` column anywhere** emits no `PRIMARY KEY`, so `INSERT OR REPLACE` has nothing to conflict on and every sync appends the whole file again — forever, silently. Nothing in the add-in reports it, because the fatal check that would have runs only `if (pkCol != null)`. And a **blank** strategy means MergeUpsert, so a half-filled row carries it too.

## Proof

Four mutations, each undoing one correction, each caught:

| mutation | result |
|---|---|
| stop tolerating the trailing comma | 1 failure |
| count `NONE` as singular again | 1 failure |
| trust the caller to filter siblings | 1 failure |
| read a blank strategy as "no strategy" | 2 failures |

**301 node tests · eslint clean.**

Also carries `LOG_TAG` for the two faults the add-in reports only as a bracketed log line, and two more `CONSOLE_ONLY_CODE` entries for faults it does not report at all.

Next on this branch: the forms themselves, wired into `console.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)