### PR TITLE
A source may declare the pace it needs (T1)

### DIFF
--- a/extension/console.css
+++ b/extension/console.css
@@ -379,3 +379,38 @@ button.pair-row:focus-visible { background: var(--surface-subtle); }
 .field-note:empty { display: none; }
 .note-error { color: var(--red); }
 .note-warn { color: var(--amber); }
+
+/* ---- the guided order --------------------------------------------------------
+   A step that is waiting is not hidden and not greyed into illegibility: the
+   owner has to be able to read what is coming, or the order looks arbitrary. It
+   is dimmed, and only its button is disabled. */
+
+.build-steps {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+  margin-block-start: var(--sp-4);
+}
+
+.build-step h2 {
+  display: flex;
+  align-items: baseline;
+  gap: var(--sp-3);
+}
+
+.build-sheet {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-regular);
+  color: var(--muted);
+}
+
+/* The state is carried on the left edge, the same vocabulary the findings list
+   and the source list already use. A fourth way of saying "this one" would have
+   to be learned separately. */
+.build-step { border-inline-start: 3px solid var(--amber); }
+.build-done { border-inline-start-color: var(--green); }
+.build-blocked {
+  border-inline-start-color: var(--line);
+  opacity: .6;
+}

--- a/extension/console.html
+++ b/extension/console.html
@@ -65,6 +65,13 @@
       <span>Sources</span>
       <span class="rail-count" id="count-sources"></span>
     </button>
+    <button class="rail-link" id="cv-tab-build" role="tab" data-view="build"
+            aria-controls="cv-build" aria-selected="false" tabindex="-1">
+      <svg class="sx-icon" aria-hidden="true">
+        <use href="icons/material-icons.svg#account-tree"></use>
+      </svg>
+      <span>Build</span>
+    </button>
     <button class="rail-link" id="cv-tab-problems" role="tab" data-view="problems"
             aria-controls="cv-problems" aria-selected="false" tabindex="-1">
       <svg class="sx-icon" aria-hidden="true">
@@ -334,7 +341,90 @@
       </div>
     </section>
 
+    <!-- 4.DataMap ─────────────────────────────────────────────────────────── -->
+    <section class="card hidden" id="dm-editor-card" aria-labelledby="dm-editor-title">
+      <h2 id="dm-editor-title">Editing a mapping</h2>
+      <p class="hint" id="dm-editor-where"></p>
+
+      <div class="field">
+        <label for="dm-f-PROFILE_KEY">Profile</label>
+        <select id="dm-f-PROFILE_KEY"></select>
+        <p class="field-note" id="dm-n-PROFILE_KEY"></p>
+      </div>
+      <div class="field">
+        <label for="dm-f-TARGET_ATTRIBUTE_KEY">Column it fills</label>
+        <select id="dm-f-TARGET_ATTRIBUTE_KEY"></select>
+        <p class="field-note" id="dm-n-TARGET_ATTRIBUTE_KEY"></p>
+      </div>
+      <div class="field">
+        <label for="dm-f-SOURCE_TYPE">Where the value comes from</label>
+        <select id="dm-f-SOURCE_TYPE"></select>
+        <p class="field-note" id="dm-n-SOURCE_TYPE"></p>
+      </div>
+      <div class="field">
+        <label for="dm-f-SOURCE_EXPRESSION">Which one</label>
+        <input id="dm-f-SOURCE_EXPRESSION" type="text" autocomplete="off" spellcheck="false">
+        <p class="field-note" id="dm-n-SOURCE_EXPRESSION"></p>
+      </div>
+      <div class="field">
+        <label for="dm-f-MATCH_MODE">How the heading is matched</label>
+        <select id="dm-f-MATCH_MODE"></select>
+        <p class="field-note" id="dm-n-MATCH_MODE"></p>
+      </div>
+      <div class="field">
+        <label for="dm-f-TRANSFORM_CHAIN">Transforms, left to right</label>
+        <input id="dm-f-TRANSFORM_CHAIN" type="text" autocomplete="off" spellcheck="false">
+        <p class="field-note" id="dm-n-TRANSFORM_CHAIN"></p>
+      </div>
+      <div class="field">
+        <label for="dm-f-PROCESS_CONFIG">Handling (JSON)</label>
+        <input id="dm-f-PROCESS_CONFIG" type="text" autocomplete="off" spellcheck="false">
+        <p class="field-note" id="dm-n-PROCESS_CONFIG"></p>
+      </div>
+
+      <p id="dm-editor-verdict" class="hint" role="status" aria-live="polite"></p>
+      <div class="row">
+        <button id="dm-editor-save" class="button" type="button">Save to the sheet</button>
+        <button id="dm-editor-cancel" class="button ghost" type="button">Cancel</button>
+      </div>
+    </section>
+
     <div id="inspect-body" class="inspect-body"></div>
+  </section>
+
+  <!-- ── Build: the guided order ──────────────────────────────────────────────
+       FOUR SHEETS HAVE TO AGREE BEFORE ONE TABLE LOADS, and the order they have
+       to be filled in is not written anywhere in the add-in. This screen states
+       it and refuses to let a step be taken before the one it depends on.
+
+       Its state is DERIVED, never stored. It asks the workbook where you are —
+       so a table half-built by hand in Google Sheets is picked up exactly where
+       it stands, and a wizard that thought it was on step 3 while the sheet said
+       otherwise cannot happen. -->
+  <section id="cv-build" class="cv hidden" role="tabpanel" aria-labelledby="cv-tab-build">
+    <header class="cv-head">
+      <h1>Build a table</h1>
+      <p>Four sheets have to agree before a table loads. This is the order.</p>
+    </header>
+
+    <section class="card" aria-labelledby="build-pick-title">
+      <h2 id="build-pick-title">Which table</h2>
+      <div class="field">
+        <label for="build-entity">Table</label>
+        <select id="build-entity"></select>
+        <p class="field-note" id="build-entity-note"></p>
+      </div>
+      <div class="field">
+        <label for="build-new">…or start a new one</label>
+        <input id="build-new" type="text" autocomplete="off" spellcheck="false"
+               placeholder="T_SOMETHING">
+        <p class="field-note">
+          A key of your own. Nothing is written until you fill in the first step.
+        </p>
+      </div>
+    </section>
+
+    <div id="build-steps" class="build-steps"></div>
   </section>
 
   <!-- ── Sources ──────────────────────────────────────────────────────────── -->

--- a/extension/console.js
+++ b/extension/console.js
@@ -10,12 +10,15 @@ import { chooseSpreadsheet } from "./picker.js";
 import { TAB_NAMES, parseWorkbook, inspect, vocabularies, SHEETS } from "./workbook.js";
 import { KNOWN_VOCABULARIES, SHEET_GIDS, LICENSE_TIERS, ENTITY_TYPES,
          STORAGE_STRATEGIES, BUSINESS_DOMAINS, VIEW_MODES, DATA_TYPES,
-         SEMANTIC_ROLES, readBoolean, BOOLEAN_DEFAULTS } from "./addin-contract.js";
+         SEMANTIC_ROLES, SOURCE_TYPES, MATCH_MODES, readBoolean,
+         BOOLEAN_DEFAULTS } from "./addin-contract.js";
 import { checkDataSourceRow, stopsThisSource, switchedOff, suggestedKey }
   from "./datasource-rules.js";
 import { checkTableDefinitionRow, tableProducesNothing }
   from "./tabledefinition-rules.js";
 import { checkSchemaRuleRow, checkEntityRoles } from "./schemarule-rules.js";
+import { checkDataMapRow, checkProfileCoverage, resolvedProfiles, attributesFor }
+  from "./datamap-rules.js";
 
 const $ = (id) => document.getElementById(id);
 const SHEETS_API = "https://sheets.googleapis.com/v4/spreadsheets";
@@ -185,7 +188,8 @@ function renderSheets(workbook) {
 // `inspect` is in the registry and NOT in the rail: it is reached by choosing a
 // table, and a rail button for it would be a button with nothing to show.
 
-const VIEWS = ["overview", "scrapex", "tables", "inspect", "sources", "problems"];
+const VIEWS = ["overview", "scrapex", "tables", "inspect", "sources", "build",
+               "problems"];
 
 function showView(name) {
   for (const view of VIEWS) {
@@ -392,6 +396,39 @@ const EDITORS = {
     refused: "As it stands this row defines no column. Saving is refused.",
     where: (row) => row._row ? `2.SchemaRule, row ${row._row}`
       : "2.SchemaRule, a new row at the end",
+  },
+  mapping: {
+    tab: "4.DataMap",
+    card: "dm-editor-card", prefix: "dm-",
+    fields: ["PROFILE_KEY", "TARGET_ATTRIBUTE_KEY", "SOURCE_TYPE",
+             "SOURCE_EXPRESSION", "MATCH_MODE", "TRANSFORM_CHAIN",
+             "PROCESS_CONFIG"],
+    booleans: [],
+    view: "inspect",
+    lists(workbook, row) {
+      const sources = rowsOf(workbook, SOURCES);
+      const profile = String(row.PROFILE_KEY ?? "").trim();
+      return {
+        // THE RESOLVED profiles, not the raw PROFILE_KEY column. A source with
+        // a blank profile resolves to its table's key, so the raw column would
+        // offer "DEFAULT" — which is a dead row on this sheet.
+        PROFILE_KEY: {values: resolvedProfiles(sources), blank: "— choose —"},
+        TARGET_ATTRIBUTE_KEY: {
+          values: attributesFor(profile, sources, rowsOf(workbook, "2.SchemaRule")),
+          blank: "— choose a column —"},
+        SOURCE_TYPE: {values: SOURCE_TYPES, blank: "— blank: Header —"},
+        MATCH_MODE: {values: MATCH_MODES, blank: "— blank: Exact —"},
+      };
+    },
+    check: (row, workbook, editing) => checkDataMapRow(
+      row,
+      rowsOf(workbook, "4.DataMap").filter((r) => r !== editing),
+      rowsOf(workbook, SOURCES),
+      rowsOf(workbook, "2.SchemaRule")),
+    refuse: (found) => found.some((f) => f.severity === "Critical"),
+    refused: "As it stands this row maps nothing. Saving is refused.",
+    where: (row) => row._row ? `4.DataMap, row ${row._row}`
+      : "4.DataMap, a new row at the end",
   },
 };
 
@@ -758,6 +795,185 @@ function showTable(key) {
   showView("inspect");
 }
 
+// ---- the guided order --------------------------------------------------------
+//
+// FOUR SHEETS HAVE TO AGREE BEFORE ONE TABLE LOADS, and the order they must be
+// filled in is written down nowhere in the add-in. A table with no columns is
+// refused; a source whose profile has no mappings FAILS OUTRIGHT; a mandatory
+// column with no mapping rejects the source before any write. So the order is
+// not a preference — it is the dependency graph, and getting it wrong produces
+// a table that looks configured and loads nothing.
+//
+// NOTHING HERE IS STORED. Each step asks the workbook whether it is done, so a
+// table half-built by hand in Google Sheets is picked up exactly where it
+// stands — and a wizard that believed it was on step three while the sheet said
+// otherwise cannot happen, because there is no belief to be wrong.
+
+function buildSteps(workbook, entity) {
+  const definitions = rowsOf(workbook, "1.TableDefinition");
+  const schema = rowsOf(workbook, "2.SchemaRule");
+  const sources = rowsOf(workbook, SOURCES);
+  const maps = rowsOf(workbook, "4.DataMap");
+  const mine = (key) => (row) =>
+    (row[key] || "").toLowerCase() === entity.toLowerCase();
+
+  const definition = definitions.find(mine("ENTITY_KEY"));
+  const columns = schema.filter(mine("ENTITY_KEY"));
+  const feeds = sources.filter(mine("TARGET_ENTITY_KEY"));
+
+  const steps = [];
+
+  // 1 — the table itself.
+  const tableFound = definition
+    ? checkTableDefinitionRow(
+      definition, definitions.filter((r) => r !== definition), schema)
+    : [];
+  steps.push({
+    title: "The table",
+    sheet: "1.TableDefinition",
+    done: Boolean(definition) && !tableProducesNothing(tableFound),
+    why: definition
+      ? "Defined."
+      : `Nothing on 1.TableDefinition is called ${entity}. Until there is, `
+        + "every column and every source pointing at it is orphaned.",
+    act: definition ? "Edit it" : "Define it",
+    open: () => edit(EDITORS.table, definition || {ENTITY_KEY: entity}),
+    notes: tableFound.filter((f) => f.severity !== "Info"),
+  });
+
+  // 2 — its columns, and the key that MergeUpsert cannot work without.
+  const keys = columns.filter(
+    (r) => readBoolean(r.IS_PK, BOOLEAN_DEFAULTS["2.SchemaRule"].IS_PK));
+  const strategy = (definition?.STORAGE_STRATEGY || "").trim().toLowerCase();
+  const needsKey = !strategy || strategy === "mergeupsert" || strategy === "upsert"
+    || strategy === "merge";
+  steps.push({
+    title: "Its columns",
+    sheet: "2.SchemaRule",
+    done: columns.length > 0 && (!needsKey || keys.length > 0),
+    why: !columns.length
+      ? "No columns, so there is no table to create and nothing to write into."
+      : needsKey && !keys.length
+        ? `${columns.length} columns and no key. This table merges on every `
+          + "sync, and with no key to match on it appends the whole file again "
+          + "each time — silently, for ever."
+        : keys.length
+          ? `${columns.length} columns, ${keys.length} of them the key.`
+          : `${columns.length} columns and no key — which is right here, because `
+            + "this table replaces its rows rather than merging them.",
+    act: columns.length ? "Add another column" : "Add the first column",
+    open: () => edit(EDITORS.column, {ENTITY_KEY: entity}, entity),
+    notes: [],
+  });
+
+  // 3 — where the rows come from.
+  const liveFeeds = feeds.filter(
+    (row) => !stopsThisSource(checkDataSourceRow(row, worldFor(workbook, row))));
+  steps.push({
+    title: "A source",
+    sheet: SOURCES,
+    done: liveFeeds.length > 0,
+    why: !feeds.length
+      ? "Nothing loads this table, so it will be created and stay empty."
+      : liveFeeds.length
+        ? `${liveFeeds.length} of ${feeds.length} can produce rows.`
+        : `${feeds.length} attached, and none of them produces anything.`,
+    act: feeds.length ? "Add another source" : "Add the source",
+    open: () => edit(EDITORS.source, {TARGET_ENTITY_KEY: entity}),
+    notes: [],
+  });
+
+  // 4 — the mappings, per profile, which is where the add-in stops rather than
+  // warns. A profile with no mappings does not degrade — it fails.
+  const profiles = resolvedProfiles(liveFeeds.length ? liveFeeds : feeds);
+  const gaps = profiles.flatMap(
+    (profile) => checkProfileCoverage(profile, maps, sources, schema)
+      .map((f) => ({...f, profile})));
+  steps.push({
+    title: "The mappings",
+    sheet: "4.DataMap",
+    done: profiles.length > 0 && !gaps.length,
+    why: !profiles.length
+      ? "No profile to map yet — a source has to exist first."
+      : gaps.length
+        ? gaps.map((f) => `${f.profile}: ${f.detail}`).join(" ")
+        : `${profiles.length} ${profiles.length === 1 ? "profile" : "profiles"}, `
+          + "each mapping its key and every required column.",
+    act: "Add a mapping",
+    open: () => edit(EDITORS.mapping,
+                     {PROFILE_KEY: profiles[0] || entity}, entity),
+    notes: [],
+  });
+
+  return steps;
+}
+
+function renderBuild() {
+  const holder = $("build-steps");
+  holder.textContent = "";
+  const entity = ($("build-new").value.trim() || $("build-entity").value || "").trim();
+  if (!entity) {
+    say("build-entity-note", "Choose a table, or type a new key above.");
+    return;
+  }
+  say("build-entity-note", "");
+
+  const steps = buildSteps(state.workbook, entity);
+  let blocked = false;
+
+  steps.forEach((step, index) => {
+    const card = document.createElement("section");
+    card.className = "card build-step" + (step.done ? " build-done" : "")
+      + (blocked ? " build-blocked" : "");
+
+    const heading = document.createElement("h2");
+    heading.textContent = `${index + 1}. ${step.title}`;
+    const sheet = document.createElement("span");
+    sheet.className = "build-sheet";
+    sheet.textContent = step.sheet;
+    heading.append(sheet);
+    card.append(heading);
+
+    const why = document.createElement("p");
+    why.className = "hint" + (step.done ? " ok" : blocked ? "" : " err");
+    why.textContent = blocked
+      ? `Waiting for step ${index}. ${steps[index - 1].title.toLowerCase()}.`
+      : step.why;
+    card.append(why);
+
+    for (const note of step.notes) {
+      const line = document.createElement("p");
+      line.className = "hint";
+      line.textContent = `${note.field}: ${note.detail}`;
+      card.append(line);
+    }
+
+    const row = document.createElement("div");
+    row.className = "row";
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = step.done ? "button ghost" : "button";
+    button.textContent = step.act;
+    // THE REFUSAL, and the whole point of the screen. A step cannot be taken
+    // before the one it depends on, because taking it out of order is how a
+    // table ends up looking configured and loading nothing.
+    button.disabled = blocked;
+    button.addEventListener("click", step.open);
+    row.append(button);
+    card.append(row);
+
+    holder.append(card);
+    if (!step.done) blocked = true;
+  });
+}
+
+function renderBuildPicker(workbook) {
+  const keys = rowsOf(workbook, "1.TableDefinition")
+    .map((r) => r.ENTITY_KEY).filter(Boolean).sort();
+  options("build-entity", keys, $("build-entity").value || "",
+          {blank: "— choose a table —"});
+}
+
 // ---- the flow ---------------------------------------------------------------
 
 async function show(fileId) {
@@ -816,6 +1032,8 @@ async function show(fileId) {
   renderSources(workbook);
   renderScrapeX(workbook);
   renderTables(workbook);
+  renderBuildPicker(workbook);
+  renderBuild();
   renderSheets(workbook);
   $("sheets-card").classList.remove("hidden");
   $("count-problems").textContent = found.length || "";
@@ -874,6 +1092,14 @@ $("workbook-recheck").addEventListener("click", () => {
 });
 $("workbook-choose").addEventListener("click", () => pick());
 $("source-add").addEventListener("click", () => edit(EDITORS.source, {}));
+
+// The build screen re-derives on every change, because its answer is a question
+// about the workbook and not a position it is holding.
+$("build-entity").addEventListener("change", () => {
+  $("build-new").value = "";
+  renderBuild();
+});
+$("build-new").addEventListener("input", () => renderBuild());
 
 // Both buttons on the inspect screen act on the table currently open, which is
 // the one fact neither form asks for.

--- a/extension/datamap-rules.js
+++ b/extension/datamap-rules.js
@@ -1,0 +1,413 @@
+// One row of 4.DataMap, judged exactly as the add-in judges it.
+//
+// THE SHEET WHERE A WRONG VALUE BECOMES WRONG DATA. The add-in's own summary of
+// its DataMap validation is that it is ADVISORY: findings become log lines and
+// ETL alerts, and nothing filters a bad row out of the graph. The only things
+// that actually stop a sync are four ingestion-time gates. So for SOURCE_TYPE,
+// MATCH_MODE, TRANSFORM_CHAIN and PROCESS_CONFIG a wrong value reaches Excel as
+// a warning plus wrong numbers, not as a refusal — which is the whole argument
+// for a closed list at the moment of typing.
+//
+// Every rule below was read out of the C# with file:line
+// (docs/reviews/mbiXaddin-config-contract-*.md).
+
+import { readConfigBag, ERROR_CODE, CONSOLE_ONLY_CODE, SOURCE_TYPES, MATCH_MODES,
+  CONTEXT_EXPRESSIONS, TRANSFORMS, PROCESS_CONFIG_KEYS, MAP_STRATEGIES,
+  ROW_FILTER_OPERATORS, TRANSFORM_SEPARATOR, TRANSFORM_ARGUMENT_SEPARATOR }
+  from "./addin-contract.js";
+
+const finding = (severity, field, code, detail, fix = "") =>
+  ({severity, field, code, detail, fix});
+
+const text = (row, name) => String(row?.[name] ?? "").trim();
+const same = (a, b) => a.toUpperCase() === b.toUpperCase();
+
+/** Transforms that take arguments, and how many the code actually reads. */
+const TRANSFORM_ARGUMENTS = {
+  SUBSTRING: {least: 1, most: 2, what: "a 0-based start, and optionally a length"},
+  JSON_EXTRACT: {least: 1, most: 1, what: "a key or a JSONPath"},
+};
+
+/**
+ * What a source's PROFILE_KEY RESOLVES to — the value a DataMap row must carry.
+ *
+ * This is the join nobody can see from the sheet. `ResolveProfileKey` returns
+ * the TARGET_ENTITY_KEY when the source's own PROFILE_KEY is blank or literally
+ * "DEFAULT", and the custom key otherwise. So a DataMap row saying "DEFAULT" is
+ * a dead row unless a table is literally named DEFAULT — and the add-in's own
+ * doc comment offers "DEFAULT" as an example.
+ */
+export function resolvedProfiles(sources) {
+  const keys = new Set();
+  for (const source of sources || []) {
+    const named = String(source?.PROFILE_KEY ?? "").trim();
+    const entity = String(source?.TARGET_ENTITY_KEY ?? "").trim();
+    keys.add(!named || same(named, "DEFAULT") ? entity : named);
+  }
+  keys.delete("");
+  return [...keys].sort();
+}
+
+/** The attributes a profile may target: the columns of the table behind it. */
+export function attributesFor(profile, sources, schemaRules) {
+  const entities = new Set();
+  for (const source of sources || []) {
+    const named = String(source?.PROFILE_KEY ?? "").trim();
+    const entity = String(source?.TARGET_ENTITY_KEY ?? "").trim();
+    const resolved = !named || same(named, "DEFAULT") ? entity : named;
+    if (same(resolved, profile)) entities.add(entity.toUpperCase());
+  }
+  // A profile named after a table with no source of its own still means that
+  // table — which is the case while a wizard is building one.
+  if (!entities.size) entities.add(profile.toUpperCase());
+  return [...new Set((schemaRules || [])
+    .filter((r) => entities.has(String(r?.ENTITY_KEY ?? "").trim().toUpperCase()))
+    .map((r) => String(r?.ATTRIBUTE_KEY ?? "").trim())
+    .filter(Boolean))].sort();
+}
+
+function checkTransformChain(chain, found) {
+  if (!chain) return;                       // no chain: the raw value is stored
+  for (const step of chain.split(TRANSFORM_SEPARATOR)) {
+    const command = step.trim();
+    if (!command) continue;                 // RemoveEmptyEntries, as the add-in does
+    const [name, ...args] = command.split(TRANSFORM_ARGUMENT_SEPARATOR);
+    const upper = name.trim().toUpperCase();
+
+    if (!TRANSFORMS.includes(upper)) {
+      found.push(finding("Error", "TRANSFORM_CHAIN", ERROR_CODE.transform,
+        `"${name.trim()}" is not a transform the add-in has. It does NOT fail — `
+        + "the value passes through UNCHANGED with a line in the log. So raw "
+        + "text lands where a number was expected, and the type cast then "
+        + "stores nothing at all.",
+        `The ten it has: ${TRANSFORMS.join(", ")}.`));
+      continue;
+    }
+    const wants = TRANSFORM_ARGUMENTS[upper];
+    if (!wants && args.length) {
+      found.push(finding("Warning", "TRANSFORM_CHAIN", ERROR_CODE.transform,
+        `${upper} takes no arguments, and "${args.join(":")}" is ignored.`));
+    } else if (wants && (args.length < wants.least || args.length > wants.most)) {
+      found.push(finding("Error", "TRANSFORM_CHAIN", ERROR_CODE.transform,
+        `${upper} needs ${wants.what}.`,
+        `Write it as ${upper}:${"…"}.`));
+    } else if (upper === "SUBSTRING"
+               && args.some((a) => !/^-?\d+$/.test(a.trim()))) {
+      // A malformed argument leaves the value unchanged rather than failing,
+      // which is the same silent pass-through as an unknown command.
+      found.push(finding("Error", "TRANSFORM_CHAIN", ERROR_CODE.transform,
+        "SUBSTRING takes whole numbers. Anything else leaves the value "
+        + "untouched, with no error and no sign that the step did nothing."));
+    }
+  }
+}
+
+function checkProcessConfig(raw, found) {
+  if (!raw) return;
+  if (!raw.startsWith("{")) {
+    found.push(finding("Error", "PROCESS_CONFIG", ERROR_CODE.badFormat,
+      "This must be a JSON object starting with a brace. Anything else — "
+      + "including the retired $preset form — is logged and the WHOLE bag "
+      + "falls back to its defaults."));
+    return;
+  }
+  const {value: parsed, tolerated, unreadable} = readConfigBag(raw);
+  if (unreadable) {
+    found.push(finding("Error", "PROCESS_CONFIG", ERROR_CODE.badJson,
+      "Nothing here can be read as an object, so every setting in it reverts "
+      + "to its default."));
+    return;
+  }
+  if (!parsed) return;
+  if (tolerated) {
+    found.push(finding("Info", "PROCESS_CONFIG", ERROR_CODE.badJson,
+      "Not strict JSON — a trailing comma or a comment. The add-in's parser "
+      + "accepts it."));
+  }
+
+  for (const key of Object.keys(parsed)) {
+    // THE UNKNOWN-KEY CHECK IS EXACT-CASE in the add-in, while the value that
+    // binds it is not — so "nullstrategy" is flagged as unknown AND still
+    // applied. The Console reports the flag, because that is what the owner
+    // will see in the log.
+    if (!PROCESS_CONFIG_KEYS.includes(key)) {
+      const meant = PROCESS_CONFIG_KEYS.find((k) => same(k, key));
+      found.push(finding("Warning", "PROCESS_CONFIG", ERROR_CODE.unknownKey,
+        meant
+          ? `"${key}" is spelled with the wrong case. The add-in flags it as an `
+            + `unknown key even though it still binds.`
+          : `"${key}" is not a setting the add-in reads.`,
+        meant ? `Write it as "${meant}".`
+          : `Accepted: ${PROCESS_CONFIG_KEYS.join(", ")}.`));
+    }
+  }
+
+  // THE CASE TRAP. Validation compares these case-insensitively; the runtime is
+  // a C# string switch, which is not. So "usedefault" passes every check the
+  // add-in makes and then silently behaves as Skip.
+  for (const name of ["NullStrategy", "ErrorStrategy"]) {
+    const value = parsed[name];
+    if (value === undefined || value === null || value === "") continue;
+    const asText = String(value);
+    const exact = MAP_STRATEGIES.includes(asText);
+    const loose = MAP_STRATEGIES.find((s) => same(s, asText));
+    if (!loose) {
+      found.push(finding("Error", "PROCESS_CONFIG", ERROR_CODE.badValue,
+        `${name}="${asText}" is not a strategy.`,
+        `Accepted: ${MAP_STRATEGIES.join(", ")}.`));
+    } else if (!exact) {
+      found.push(finding("Error", "PROCESS_CONFIG", ERROR_CODE.badValue,
+        `${name}="${asText}" passes every check the add-in makes and then does `
+        + `NOTHING: the runtime compares it exactly, so it falls through to `
+        + `Skip. Nothing anywhere records that ${asText} was not understood.`,
+        `Write it as "${loose}".`));
+    }
+  }
+
+  if (parsed.NullStrategy === "UseDefault"
+      && (parsed.DefaultValue === undefined || parsed.DefaultValue === null)) {
+    found.push(finding("Warning", "PROCESS_CONFIG", ERROR_CODE.badValue,
+      "UseDefault with no DefaultValue substitutes an empty value, which is "
+      + "usually not what was meant."));
+  }
+
+  if ("AutoTrim" in parsed && typeof parsed.AutoTrim !== "boolean") {
+    // A wrong JSON TYPE makes ToObject<T> throw and the ENTIRE bag reverts —
+    // not just this key. That is worse than the key being wrong.
+    found.push(finding("Error", "PROCESS_CONFIG", ERROR_CODE.badValue,
+      `AutoTrim must be true or false, not "${parsed.AutoTrim}". A wrong type `
+      + "here throws while the object is being read, and EVERY setting in the "
+      + "bag reverts to its default — not just this one."));
+  }
+
+  const filter = parsed.RowFilter;
+  if (filter) {
+    const asText = String(filter);
+    const cut = asText.indexOf(":");
+    const operator = (cut > 0 ? asText.slice(0, cut) : asText).trim().toUpperCase();
+    if (!ROW_FILTER_OPERATORS.includes(operator)) {
+      found.push(finding("Error", "PROCESS_CONFIG", ERROR_CODE.badValue,
+        `RowFilter "${asText}" starts with "${operator}", which is not an `
+        + "operator. An unknown one KEEPS every row — the filter is silently "
+        + "inert rather than refused.",
+        `Accepted: ${ROW_FILTER_OPERATORS.join(", ")}.`));
+    } else if (!["EMPTY", "NOT_EMPTY"].includes(operator) && cut < 1) {
+      found.push(finding("Error", "PROCESS_CONFIG", ERROR_CODE.badValue,
+        `${operator} needs a value after a colon, as in "${operator}:something". `
+        + "Without one it compares against nothing."));
+    }
+  }
+}
+
+/**
+ * One DataMap row, against the rest of the workbook.
+ *
+ * `others` is every OTHER row of 4.DataMap — the same convention as the three
+ * sheets before it. `sources` and `schemaRules` are needed for the join that
+ * cannot be seen from this sheet at all: which table a profile actually feeds.
+ */
+export function checkDataMapRow(row, others = [], sources = [], schemaRules = []) {
+  const found = [];
+  const profile = text(row, "PROFILE_KEY");
+  const target = text(row, "TARGET_ATTRIBUTE_KEY");
+
+  // 1 and 2 — the add-in's two Critical fields. It stops at either.
+  if (!profile) {
+    return [finding("Critical", "PROFILE_KEY", ERROR_CODE.required,
+      "Every mapping must belong to a profile. With none, nothing can ever "
+      + "look this row up.")];
+  }
+  if (!target) {
+    return [finding("Critical", "TARGET_ATTRIBUTE_KEY", ERROR_CODE.required,
+      "No column to write into, so this mapping has nowhere to put a value.")];
+  }
+
+  // 3 — the trap in the add-in's own documentation.
+  if (same(profile, "DEFAULT")) {
+    found.push(finding("Error", "PROFILE_KEY", ERROR_CODE.reference,
+      "A profile literally named DEFAULT is a DEAD ROW. A source with a blank "
+      + "or DEFAULT profile resolves to its TABLE's key, so the mapping has to "
+      + "carry the table name here — never the word DEFAULT, which the add-in's "
+      + "own comment offers as an example.",
+      "Use the table's key."));
+  } else if (sources.length) {
+    const live = resolvedProfiles(sources);
+    if (!live.some((p) => same(p, profile))) {
+      found.push(finding("Warning", "PROFILE_KEY", ERROR_CODE.orphanMapping,
+        `No source resolves to "${profile}", so these mappings never run. They `
+        + "are not an error and nothing reports them at sync time — they simply "
+        + "sit there."));
+    }
+  }
+
+  // 4 — the column it writes into. A name the schema does not have is dropped
+  // with a yellow warning and the column is never written.
+  if (/\s/.test(target)) {
+    found.push(finding("Warning", "TARGET_ATTRIBUTE_KEY", ERROR_CODE.badFormat,
+      "Internal spaces are silently replaced with underscores before the "
+      + "lookup. It usually works, and it means the name here is not the name "
+      + "being matched.",
+      "Type it with underscores."));
+  }
+  if (schemaRules.length) {
+    const allowed = attributesFor(profile, sources, schemaRules);
+    const cleaned = target.replace(/\s+/g, "_");
+    if (allowed.length && !allowed.some((a) => same(a, cleaned))) {
+      found.push(finding("Error", "TARGET_ATTRIBUTE_KEY", ERROR_CODE.orphanMapping,
+        `No column called "${cleaned}" is defined for this profile's table. The `
+        + "mapping is dropped as an orphan and its data is lost — with a "
+        + "warning, and the sync carries on.",
+        `Defined: ${allowed.slice(0, 12).join(", ")}`
+        + `${allowed.length > 12 ? ", …" : ""}.`));
+    }
+  }
+
+  // 5 — two rows writing the same column. Not enforced anywhere: both survive
+  // unless the expression is identical too, both run, and the LAST in sheet
+  // order wins — while either one's RowFilter can still drop the row.
+  const twin = others.find((other) => same(text(other, "PROFILE_KEY"), profile)
+    && same(text(other, "TARGET_ATTRIBUTE_KEY"), target));
+  if (twin) {
+    found.push(finding("Error", "TARGET_ATTRIBUTE_KEY",
+      CONSOLE_ONLY_CODE.silentOverride,
+      `"${target}" is mapped more than once in ${profile}. Both rows run and the `
+      + "LAST one on the sheet wins, so which value is stored depends on row "
+      + "order — and either row's filter can still drop the whole row.",
+      "Delete the mapping that is not wanted."));
+  }
+
+  // 6 — where the value comes from.
+  const sourceType = text(row, "SOURCE_TYPE");
+  const kind = SOURCE_TYPES.find((t) => same(t, sourceType)) || "";
+  if (sourceType && !kind) {
+    found.push(finding("Error", "SOURCE_TYPE", ERROR_CODE.badValue,
+      `"${sourceType}" is not a source type.`,
+      `Accepted: ${SOURCE_TYPES.join(", ")}.`));
+  }
+  const effective = kind || "Header";        // a blank cell means Header
+  const expression = text(row, "SOURCE_EXPRESSION");
+
+  if (effective === "Formula") {
+    found.push(finding("Error", "SOURCE_TYPE", CONSOLE_ONLY_CODE.notApplied,
+      "Formula is NOT IMPLEMENTED. It has no branch in the code, so it falls to "
+      + "the default and returns null for EVERY row — and if this column is a "
+      + "key or is required, every row is then dropped.",
+      "Use Header, Index, Context or Constant."));
+  }
+  if (effective === "Index") {
+    if (!/^\d+$/.test(expression)) {
+      found.push(finding("Error", "SOURCE_EXPRESSION", ERROR_CODE.badValue,
+        `Index reads a COLUMN POSITION, counted from 0 — not a row number, `
+        + "whatever the add-in's own documentation says. "
+        + `"${expression || "(empty)"}" is not one.`,
+        "Type the column's position, starting at 0."));
+    }
+  } else if (effective === "Context") {
+    if (!CONTEXT_EXPRESSIONS.some((t) => same(t, expression))) {
+      found.push(finding("Error", "SOURCE_EXPRESSION", ERROR_CODE.badValue,
+        `Context accepts exactly four tokens, and "${expression || "(empty)"}" `
+        + "is not one of them — it writes null into every row. The add-in's own "
+        + "comments advertise CurrentCountry and CurrentUser, and both are "
+        + "documentation only.",
+        `The four: ${CONTEXT_EXPRESSIONS.join(", ")}.`));
+    }
+  } else if (effective === "Header" && !expression) {
+    found.push(finding("Error", "SOURCE_EXPRESSION", ERROR_CODE.required,
+      "Header needs the column heading to look for in the file. With none, "
+      + "nothing matches and this column is never filled."));
+  } else if (effective === "Constant" && !expression) {
+    found.push(finding("Warning", "SOURCE_EXPRESSION", ERROR_CODE.required,
+      "A constant with no value writes an empty string into every row."));
+  }
+
+  // 7 — how the heading is matched, which only matters for one source type.
+  const matchMode = text(row, "MATCH_MODE");
+  const mode = MATCH_MODES.find((m) => same(m, matchMode)) || "";
+  if (matchMode && !mode) {
+    found.push(finding("Error", "MATCH_MODE", ERROR_CODE.badValue,
+      `"${matchMode}" is not a match mode.`,
+      `Accepted: ${MATCH_MODES.join(", ")}.`));
+  }
+  if (mode && !same(mode, "Exact") && effective !== "Header") {
+    found.push(finding("Warning", "MATCH_MODE", ERROR_CODE.badValue,
+      `${mode} is read only when the source type is Header. Here it does `
+      + "nothing at all.",
+      "Leave it blank, or set it to Exact."));
+  }
+  if (same(mode, "Regex") && effective === "Header" && expression) {
+    try {
+      new RegExp(expression);
+    } catch {
+      found.push(finding("Error", "SOURCE_EXPRESSION", ERROR_CODE.badValue,
+        "This pattern does not compile. The add-in does NOT fail on it — it "
+        + "logs the error and then matches nothing, which surfaces later as "
+        + "\"header not found\" and sends you looking at the file instead."));
+    }
+  }
+  if (same(mode, "Fuzzy") && effective === "Header") {
+    found.push(finding("Warning", "MATCH_MODE", ERROR_CODE.badValue,
+      "Fuzzy accepts any heading within two edits, and the FIRST one that "
+      + "close wins. Two similar headings in one file bind the wrong column "
+      + "with no warning."));
+  }
+
+  checkTransformChain(text(row, "TRANSFORM_CHAIN"), found);
+  checkProcessConfig(text(row, "PROCESS_CONFIG"), found);
+  return found;
+}
+
+/**
+ * What a profile is MISSING, which no single row can answer.
+ *
+ * Two of the four gates that actually stop a sync live here: a profile with no
+ * mappings at all, and a required column whose mapping never resolved.
+ */
+export function checkProfileCoverage(profile, maps, sources, schemaRules) {
+  const found = [];
+  const mine = (maps || []).filter(
+    (m) => same(String(m?.PROFILE_KEY ?? "").trim(), profile));
+
+  if (!mine.length) {
+    return [finding("Critical", "PROFILE_KEY", ERROR_CODE.orphanMapping,
+      `Nothing maps ${profile}. Every source using it FAILS OUTRIGHT — this is `
+      + "one of the four faults that stop a sync rather than warn about it.",
+      "Map at least the key column.")];
+  }
+
+  const mapped = new Set(mine.map(
+    (m) => String(m?.TARGET_ATTRIBUTE_KEY ?? "").trim().replace(/\s+/g, "_")
+      .toUpperCase()));
+  const entities = new Set();
+  for (const source of sources || []) {
+    const named = String(source?.PROFILE_KEY ?? "").trim();
+    const entity = String(source?.TARGET_ENTITY_KEY ?? "").trim();
+    if (same(!named || same(named, "DEFAULT") ? entity : named, profile)) {
+      entities.add(entity.toUpperCase());
+    }
+  }
+  if (!entities.size) entities.add(profile.toUpperCase());
+
+  for (const rule of schemaRules || []) {
+    if (!entities.has(String(rule?.ENTITY_KEY ?? "").trim().toUpperCase())) continue;
+    const attribute = String(rule?.ATTRIBUTE_KEY ?? "").trim();
+    if (!attribute || mapped.has(attribute.toUpperCase())) continue;
+    const isKey = String(rule?.IS_PK ?? "").trim().toLowerCase();
+    const required = String(rule?.IS_MANDATORY ?? "").trim().toLowerCase();
+    const truthy = (v) => ["1", "true", "yes", "y", "on", "نعم", "صح", "صحيح"]
+      .includes(v);
+    if (truthy(isKey)) {
+      found.push(finding("Critical", "TARGET_ATTRIBUTE_KEY",
+        ERROR_CODE.mandatoryUnmapped,
+        `The key column ${attribute} has no mapping. Under MergeUpsert the sync `
+        + "is refused before anything is written.",
+        `Map ${attribute}.`));
+    } else if (truthy(required)) {
+      found.push(finding("Critical", "TARGET_ATTRIBUTE_KEY",
+        ERROR_CODE.mandatoryUnmapped,
+        `${attribute} is required and has no mapping, so the whole source is `
+        + "rejected before any write.",
+        `Map ${attribute}.`));
+    }
+  }
+  return found;
+}

--- a/extension/tests/datamap-rules.test.mjs
+++ b/extension/tests/datamap-rules.test.mjs
@@ -1,0 +1,311 @@
+// One DataMap row, judged as the add-in judges it.
+//
+// This sheet's validation is ADVISORY in the add-in — findings become log lines
+// and nothing filters a bad row out. So several tests below pin a fault the
+// add-in accepts and then gets wrong, because that is the only place it can be
+// caught: here, while it is being typed.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { checkDataMapRow, checkProfileCoverage, resolvedProfiles, attributesFor }
+  from "../datamap-rules.js";
+
+const sound = (over = {}) => ({
+  PROFILE_KEY: "T_BITUMEN",
+  TARGET_ATTRIBUTE_KEY: "current_price",
+  SOURCE_TYPE: "Header",
+  MATCH_MODE: "Exact",
+  SOURCE_EXPRESSION: "Price",
+  TRANSFORM_CHAIN: "TRIM|TO_DECIMAL",
+  PROCESS_CONFIG: "",
+  ...over,
+});
+
+/** One source pointing at T_BITUMEN with a blank profile — the common shape. */
+const sources = [{SOURCE_KEY: "SRC_A", TARGET_ENTITY_KEY: "T_BITUMEN",
+                  PROFILE_KEY: ""}];
+const schema = [
+  {ENTITY_KEY: "T_BITUMEN", ATTRIBUTE_KEY: "code", IS_PK: "TRUE", IS_MANDATORY: "TRUE"},
+  {ENTITY_KEY: "T_BITUMEN", ATTRIBUTE_KEY: "current_price", IS_MANDATORY: "FALSE"},
+];
+
+const codes = (found) => found.map((f) => f.code);
+const fields = (found) => found.map((f) => f.field);
+
+test("a sound row produces nothing at all", () => {
+  assert.deepEqual(checkDataMapRow(sound(), [], sources, schema), []);
+});
+
+test("either mandatory field blank rejects the row and stops", () => {
+  for (const blank of ["PROFILE_KEY", "TARGET_ATTRIBUTE_KEY"]) {
+    const found = checkDataMapRow(sound({[blank]: ""}), [], sources, schema);
+    assert.equal(found.length, 1, `${blank} produced a cascade`);
+    assert.equal(found[0].severity, "Critical");
+    assert.equal(found[0].field, blank);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// The join nobody can see from the sheet.
+// ---------------------------------------------------------------------------
+
+test("a source with a blank profile resolves to its TABLE, not to DEFAULT", () => {
+  assert.deepEqual(resolvedProfiles(sources), ["T_BITUMEN"]);
+  assert.deepEqual(resolvedProfiles(
+    [{TARGET_ENTITY_KEY: "T_X", PROFILE_KEY: "DEFAULT"}]), ["T_X"]);
+  assert.deepEqual(resolvedProfiles(
+    [{TARGET_ENTITY_KEY: "T_X", PROFILE_KEY: "CUSTOM"}]), ["CUSTOM"]);
+});
+
+test("a mapping literally named DEFAULT is a dead row, and says so", () => {
+  const found = checkDataMapRow(
+    sound({PROFILE_KEY: "DEFAULT"}), [], sources, schema);
+  const dead = found.filter((f) => f.field === "PROFILE_KEY");
+  assert.equal(dead.length, 1);
+  assert.equal(dead[0].severity, "Error");
+  assert.match(dead[0].detail, /DEAD ROW/);
+  // And the reason it is easy to get wrong is named.
+  assert.match(dead[0].detail, /own comment offers as an example/);
+});
+
+test("a profile nothing resolves to is a warning, not an error", () => {
+  // Nothing reports these at sync time either — they simply sit there.
+  const found = checkDataMapRow(
+    sound({PROFILE_KEY: "T_NOWHERE"}), [], sources, schema);
+  const orphan = found.find((f) => f.field === "PROFILE_KEY");
+  assert.equal(orphan.severity, "Warning");
+});
+
+test("a column the schema does not have loses its data, and lists what exists", () => {
+  const found = checkDataMapRow(
+    sound({TARGET_ATTRIBUTE_KEY: "price"}), [], sources, schema);
+  const orphan = found.find((f) => f.field === "TARGET_ATTRIBUTE_KEY");
+  assert.equal(orphan.severity, "Error");
+  assert.match(orphan.detail, /data is lost/);
+  assert.match(orphan.fix, /current_price/, "the message does not offer the real names");
+  assert.deepEqual(attributesFor("T_BITUMEN", sources, schema),
+                   ["code", "current_price"]);
+});
+
+test("internal spaces are auto-corrected, and the Console does not rely on it", () => {
+  const found = checkDataMapRow(
+    sound({TARGET_ATTRIBUTE_KEY: "current price"}), [], sources, schema);
+  const said = found.filter((f) => f.field === "TARGET_ATTRIBUTE_KEY");
+  // One note about the spaces, and NO orphan error — because the cleaned name
+  // does resolve, which is exactly what the add-in does before looking it up.
+  assert.equal(said.length, 1);
+  assert.equal(said[0].severity, "Warning");
+  assert.match(said[0].detail, /replaced with underscores/);
+});
+
+test("two mappings for one column: last on the sheet wins", () => {
+  const found = checkDataMapRow(
+    sound(), [sound({SOURCE_EXPRESSION: "Cost"})], sources, schema);
+  const clash = found.find((f) => f.code === "SILENT_OVERRIDE");
+  assert.ok(clash, "a duplicated target stopped being reported");
+  assert.match(clash.detail, /depends on row order/);
+});
+
+// ---------------------------------------------------------------------------
+// Where the value comes from.
+// ---------------------------------------------------------------------------
+
+test("Formula is not implemented, and nulls every row", () => {
+  const found = checkDataMapRow(
+    sound({SOURCE_TYPE: "Formula"}), [], sources, schema);
+  const said = found.find((f) => f.field === "SOURCE_TYPE");
+  assert.equal(said.severity, "Error");
+  assert.equal(said.code, "NOT_APPLIED");
+  assert.match(said.detail, /NOT IMPLEMENTED/);
+});
+
+test("Index is a COLUMN position from zero, whatever the docs say", () => {
+  assert.deepEqual(
+    checkDataMapRow(sound({SOURCE_TYPE: "Index", SOURCE_EXPRESSION: "0"}),
+                    [], sources, schema),
+    [], "a valid column position was refused");
+  for (const bad of ["-1", "2.5", "first", ""]) {
+    const found = checkDataMapRow(
+      sound({SOURCE_TYPE: "Index", SOURCE_EXPRESSION: bad}), [], sources, schema);
+    assert.ok(found.some((f) => f.field === "SOURCE_EXPRESSION"),
+      `Index accepted "${bad}"`);
+  }
+});
+
+test("Context accepts exactly four tokens, and names the two that are fiction", () => {
+  for (const good of ["SYNC_DATE", "synctime", "CURRENTTIER"]) {
+    assert.deepEqual(
+      checkDataMapRow(sound({SOURCE_TYPE: "Context", SOURCE_EXPRESSION: good,
+        MATCH_MODE: ""}), [], sources, schema),
+      [], `${good} was refused`);
+  }
+  const found = checkDataMapRow(
+    sound({SOURCE_TYPE: "Context", SOURCE_EXPRESSION: "CurrentCountry",
+      MATCH_MODE: ""}), [], sources, schema);
+  const said = found.find((f) => f.field === "SOURCE_EXPRESSION");
+  assert.match(said.detail, /documentation only/,
+    "the message does not say that the add-in's own examples do not work");
+});
+
+test("MATCH_MODE is dead unless the source type is Header", () => {
+  const found = checkDataMapRow(
+    sound({SOURCE_TYPE: "Constant", SOURCE_EXPRESSION: "SAR",
+      MATCH_MODE: "Contains"}), [], sources, schema);
+  const said = found.find((f) => f.field === "MATCH_MODE");
+  assert.equal(said.severity, "Warning");
+  assert.match(said.detail, /does nothing at all/);
+});
+
+test("a Regex that does not compile matches NOTHING rather than failing", () => {
+  const found = checkDataMapRow(
+    sound({MATCH_MODE: "Regex", SOURCE_EXPRESSION: "Price(["}),
+    [], sources, schema);
+  const said = found.find((f) => f.field === "SOURCE_EXPRESSION");
+  assert.equal(said.severity, "Error");
+  assert.match(said.detail, /does NOT fail/);
+});
+
+test("Fuzzy is warned about even when it is spelled correctly", () => {
+  // Two edits of tolerance and first-past-the-post is a silent wrong binding,
+  // and there is no setting to tighten it.
+  const found = checkDataMapRow(sound({MATCH_MODE: "Fuzzy"}), [], sources, schema);
+  assert.match(found.find((f) => f.field === "MATCH_MODE").detail, /two edits/);
+});
+
+// ---------------------------------------------------------------------------
+// The chain, where a typo is silent data corruption.
+// ---------------------------------------------------------------------------
+
+test("an unknown transform passes the value through UNCHANGED", () => {
+  const found = checkDataMapRow(
+    sound({TRANSFORM_CHAIN: "TRIM|TO_NUMBER"}), [], sources, schema);
+  const said = found.find((f) => f.field === "TRANSFORM_CHAIN");
+  assert.equal(said.severity, "Error");
+  assert.match(said.detail, /UNCHANGED/);
+});
+
+test("the chain is case-insensitive and tolerates empty steps", () => {
+  assert.deepEqual(
+    checkDataMapRow(sound({TRANSFORM_CHAIN: "trim||Upper"}), [], sources, schema),
+    [], "the add-in accepts both and this refused one");
+});
+
+test("SUBSTRING and JSON_EXTRACT are checked for their arguments", () => {
+  assert.deepEqual(
+    checkDataMapRow(sound({TRANSFORM_CHAIN: "SUBSTRING:0:3"}), [], sources, schema),
+    []);
+  assert.deepEqual(
+    checkDataMapRow(sound({TRANSFORM_CHAIN: "JSON_EXTRACT:addr.city"}),
+                    [], sources, schema), []);
+  for (const bad of ["SUBSTRING", "SUBSTRING:x", "JSON_EXTRACT"]) {
+    const found = checkDataMapRow(
+      sound({TRANSFORM_CHAIN: bad}), [], sources, schema);
+    assert.ok(found.some((f) => f.field === "TRANSFORM_CHAIN"),
+      `"${bad}" was accepted`);
+  }
+  // A transform that takes none is only a note when given one — the add-in
+  // ignores the argument rather than failing.
+  const extra = checkDataMapRow(
+    sound({TRANSFORM_CHAIN: "TRIM:2"}), [], sources, schema);
+  assert.equal(extra[0].severity, "Warning");
+});
+
+// ---------------------------------------------------------------------------
+// PROCESS_CONFIG, and the trap that passes every check the add-in makes.
+// ---------------------------------------------------------------------------
+
+test("a strategy in the wrong case passes validation and then does nothing", () => {
+  const found = checkDataMapRow(
+    sound({PROCESS_CONFIG: '{"NullStrategy":"usedefault"}'}), [], sources, schema);
+  const said = found.find((f) => f.field === "PROCESS_CONFIG");
+  assert.equal(said.severity, "Error");
+  assert.match(said.detail, /falls through to Skip/);
+  assert.match(said.fix, /UseDefault/);
+
+  // And the correct spelling is accepted, with only the missing default noted.
+  const right = checkDataMapRow(
+    sound({PROCESS_CONFIG: '{"NullStrategy":"UseDefault","DefaultValue":"0"}'}),
+    [], sources, schema);
+  assert.deepEqual(right, []);
+});
+
+test("a wrong TYPE reverts the whole bag, not just its own key", () => {
+  const found = checkDataMapRow(
+    sound({PROCESS_CONFIG: '{"AutoTrim":"yes","RowFilter":"NOT_EMPTY"}'}),
+    [], sources, schema);
+  const said = found.find((f) => /AutoTrim/.test(f.detail));
+  assert.equal(said.severity, "Error");
+  assert.match(said.detail, /EVERY setting in the/);
+});
+
+test("an unknown row-filter operator keeps every row rather than failing", () => {
+  const found = checkDataMapRow(
+    sound({PROCESS_CONFIG: '{"RowFilter":"MATCHES:EG"}'}), [], sources, schema);
+  const said = found.find((f) => f.field === "PROCESS_CONFIG");
+  assert.match(said.detail, /KEEPS every row/);
+
+  assert.deepEqual(
+    checkDataMapRow(sound({PROCESS_CONFIG: '{"RowFilter":"IN:EG,SA,AE"}'}),
+                    [], sources, schema), []);
+  // EMPTY and NOT_EMPTY take no value; everything else needs one.
+  assert.deepEqual(
+    checkDataMapRow(sound({PROCESS_CONFIG: '{"RowFilter":"NOT_EMPTY"}'}),
+                    [], sources, schema), []);
+  assert.ok(checkDataMapRow(sound({PROCESS_CONFIG: '{"RowFilter":"EQ"}'}),
+                            [], sources, schema).length);
+});
+
+test("a bag that is not an object at all reverts to defaults", () => {
+  const found = checkDataMapRow(
+    sound({PROCESS_CONFIG: '$preset:standard'}), [], sources, schema);
+  assert.equal(found[0].severity, "Error");
+  assert.match(found[0].detail, /starting with a brace/);
+});
+
+// ---------------------------------------------------------------------------
+// What a profile is missing — two of the four gates that stop a sync.
+// ---------------------------------------------------------------------------
+
+test("a profile with no mappings at all fails every source using it", () => {
+  const found = checkProfileCoverage("T_BITUMEN", [], sources, schema);
+  assert.equal(found.length, 1);
+  assert.equal(found[0].severity, "Critical");
+  assert.match(found[0].detail, /FAILS OUTRIGHT/);
+});
+
+test("an unmapped key or required column is refused before any write", () => {
+  // `code` is both the key and required; only current_price is mapped.
+  const found = checkProfileCoverage("T_BITUMEN", [sound()], sources, schema);
+  assert.equal(found.length, 1);
+  assert.equal(found[0].severity, "Critical");
+  assert.match(found[0].detail, /key column code/);
+
+  const complete = checkProfileCoverage(
+    "T_BITUMEN", [sound(), sound({TARGET_ATTRIBUTE_KEY: "code"})], sources, schema);
+  assert.deepEqual(complete, []);
+});
+
+test("an ordinary column left unmapped is not a fault", () => {
+  // Only IS_PK and IS_MANDATORY stop a sync. Demanding the rest would make the
+  // Console refuse a configuration the add-in syncs happily every day.
+  const optional = [...schema,
+    {ENTITY_KEY: "T_BITUMEN", ATTRIBUTE_KEY: "note", IS_MANDATORY: "FALSE"}];
+  const found = checkProfileCoverage(
+    "T_BITUMEN", [sound(), sound({TARGET_ATTRIBUTE_KEY: "code"})],
+    sources, optional);
+  assert.deepEqual(found, []);
+});
+
+test("every finding carries a code and a field", () => {
+  const messy = checkDataMapRow(
+    sound({SOURCE_TYPE: "Formula", TRANSFORM_CHAIN: "NOPE",
+      PROCESS_CONFIG: '{"NullStrategy":"fail"}'}), [], sources, schema);
+  assert.ok(messy.length >= 3);
+  for (const found of messy) {
+    assert.ok(found.code, `${found.field} has no code`);
+    assert.ok(found.field, "a finding with no field cannot be shown anywhere");
+  }
+  assert.ok(!codes(messy).includes(undefined));
+  assert.ok(!fields(messy).includes(undefined));
+});

--- a/scrapex/config.py
+++ b/scrapex/config.py
@@ -360,6 +360,18 @@ class SourceEntry(BaseModel):
     #: Only read when `robots` is "custom": {enforce_disallow: bool,
     #: crawl_delay_s: float | null}. A null delay means the site's own.
     robots_custom: dict | None = None
+    # THE PACE THIS SITE NEEDS, when it needs one it never asked for.
+    #
+    # A site that publishes a Crawl-delay is already honoured. This is for the
+    # other kind: alsweed.sa publishes NO delay and then answers 429 anyway, and
+    # the only lever before this was the tool-wide `crawl_min_interval_s` —
+    # which would have slowed elburoj's 6,720 products to spare one site.
+    #
+    # Seconds between requests, for this source alone. Null means it has no
+    # opinion and the tool-wide pace stands. It can only ever SLOW a crawl:
+    # `resolve_fetcher` takes the slowest of every opinion, so naming 0.1 here
+    # cannot make a source faster than the owner's own setting.
+    crawl_pace_s: float | None = Field(default=None, gt=0)
     # Ordered families to try if `family` fails (spec 32). Recorded per source so
     # the choice is visible in the manifest rather than hidden in code.
     fallback_families: list[ConnectorFamily] = Field(default_factory=list)

--- a/scrapex/connectors/base.py
+++ b/scrapex/connectors/base.py
@@ -702,9 +702,30 @@ def resolve_fetcher(source: SourceEntry,
     # to ignore a site's asked-for pace — the safe reading of silence is the
     # polite one.
     honour = chosen.get("honour_crawl_delay")
+    # ONE PLACE DECIDES THE PACE, AND IT TAKES THE SLOWEST OPINION.
+    #
+    # There were three of these and only one was connected. The owner's setting
+    # reached the fetcher; a site's own robots Crawl-delay is applied later in
+    # `_robots_for`; and `robots_custom.crawl_delay_s` — declared in the
+    # manifest, documented, shown in the web UI, computed all the way into
+    # `Decision.delay_s` — was read by nobody. `decide()`'s verdict is consulted
+    # only for `may_fetch`, and only on a path robots.txt DISALLOWS, so an owner
+    # who set a per-source delay saw it in the interface and it did nothing.
+    #
+    # Slowest wins, which is the rule `_robots_for` already follows in its own
+    # words: "slowing down is never the wrong direction". So a per-source pace
+    # can hold a site back and can never push one forward past the owner's
+    # setting — including a `crawl_pace_s` typed too small by accident.
+    paces = [1.0 if interval is None else float(interval)]
+    if source.crawl_pace_s:
+        paces.append(float(source.crawl_pace_s))
+    custom_delay = (source.robots_custom or {}).get("crawl_delay_s")
+    if custom_delay:
+        paces.append(float(custom_delay))
+
     return HttpFetcher(
         user_agent=source.user_agent or chosen.get("user_agent") or DEFAULT_USER_AGENT,
-        min_interval_s=1.0 if interval is None else float(interval),
+        min_interval_s=max(paces),
         timeout_s=30.0 if timeout is None else float(timeout),
         honour_crawl_delay=True if honour is None else bool(honour),
         # The source's own answer, and what it means when the source did not

--- a/sources.yaml
+++ b/sources.yaml
@@ -235,6 +235,23 @@ sources:
     active: true
     currency: SAR
     default_region: SA
+    # THIS SITE REFUSES AT ONE REQUEST A SECOND, and never says so in robots.txt.
+    #
+    # Measured 2026-08-13 against the live warehouse: five jobs aborted on
+    # "5 refusals in a row (last: HTTP 429)" — 84 and 85 on 1 Aug, 98 on 2 Aug,
+    # 120 and 121 on 11 Aug. Each of those runs collected nothing at all.
+    #
+    # alsweed.sa/robots.txt publishes a Sitemap, one Disallow and NO Crawl-delay,
+    # so `crawl_honour_delay` has nothing here to honour and turning it back on
+    # would have changed nothing. The tool-wide pace was the only other lever,
+    # and raising it would have slowed elburoj's 6,720 products — which already
+    # asks for 10 seconds — to spare this one shop.
+    #
+    # 3 seconds is a first estimate, not a measurement: nobody knows this site's
+    # real limit, and finding it by probing is the behaviour that got us refused.
+    # At ~1,200 products it costs about an hour instead of twenty minutes. Raise
+    # it if the 429s come back; lower it only with a run that proves they do not.
+    crawl_pace_s: 3.0
     vat_mode: incl
     extract:
       - kind: product_prices

--- a/tests/test_a_panel_edit_keeps_what_it_did_not_touch.py
+++ b/tests/test_a_panel_edit_keeps_what_it_did_not_touch.py
@@ -56,6 +56,7 @@ sources:
     robots_custom:
       enforce_disallow: true
       crawl_delay_s: 9.0
+    crawl_pace_s: 7.0
     extract:
       - kind: product_prices
         scope: census

--- a/tests/test_the_pace_a_source_asks_for.py
+++ b/tests/test_the_pace_a_source_asks_for.py
@@ -1,0 +1,152 @@
+"""T1: a source may declare the pace it needs, and slowest always wins.
+
+WHY THIS EXISTS, measured 2026-08-13 against the live warehouse. ALSWEED was
+aborting on "5 refusals in a row (last: HTTP 429)" — jobs 84 and 85 on 1 August,
+98 on 2 August, 120 and 121 on 11 August — and each of those runs collected
+nothing at all.
+
+The remedy on record was to restore `crawl_honour_delay`. It would not have
+worked: alsweed.sa/robots.txt publishes a Sitemap, one Disallow and NO
+Crawl-delay, and `honour_crawl_delay` only takes effect when a site declares one
+(connectors/base.py, `_robots_for`). The switch would have been flipped, nothing
+would have improved, and the diagnosis would have lost its credibility.
+
+The only other lever was the tool-wide `crawl_min_interval_s`, and raising that
+slows elburoj's 6,720 products — a source that already asks for ten seconds — to
+spare one shop.
+
+AND ONE OF THE THREE PACES WAS NEVER CONNECTED. `robots_custom.crawl_delay_s` is
+declared in the manifest, documented on the model, shown in the web UI and
+computed all the way into `Decision.delay_s` — and `decide()`'s verdict is read
+only for `may_fetch`, on a path robots.txt DISALLOWS. An owner who set a
+per-source delay saw it in the interface and it did nothing.
+"""
+from __future__ import annotations
+
+import pytest
+
+from scrapex.config import ExtractSpec, SourceEntry
+from scrapex.connectors.base import resolve_fetcher
+from scrapex.vocab import ExtractKind, ExtractScope
+
+
+def entry(**over) -> SourceEntry:
+    return SourceEntry.model_validate(dict(
+        source_key="TESTSHOP", source_name="Test Shop",
+        base_url="https://example.test", family="zid-html",
+        currency="SAR", default_region="SA", vat_mode="incl",
+        extract=[ExtractSpec(kind=ExtractKind.PRODUCT_PRICES,
+                             scope=ExtractScope.CENSUS)],
+        **over))
+
+
+def pace(source, **settings) -> float:
+    fetcher = resolve_fetcher(source, {"min_interval_s": 1.0, **settings})
+    return fetcher._min_interval_s
+
+
+def test_a_source_that_asks_for_nothing_keeps_the_owners_pace():
+    """The overwhelmingly common case, and the one a regression would hit
+    first: eleven of twelve sources declare no pace at all."""
+    assert pace(entry()) == 1.0
+    assert pace(entry(), min_interval_s=2.5) == 2.5
+
+
+def test_a_source_may_ask_to_be_crawled_more_slowly():
+    assert pace(entry(crawl_pace_s=3.0)) == 3.0
+
+
+def test_it_can_only_ever_slow_a_crawl_down():
+    """A per-source pace is a brake, never an accelerator.
+
+    Otherwise a number typed too small — or copied from another source — would
+    quietly overrule the owner's own setting and crawl FASTER than he chose,
+    which is the one direction politeness never goes."""
+    assert pace(entry(crawl_pace_s=0.2), min_interval_s=2.0) == 2.0
+    assert pace(entry(crawl_pace_s=5.0), min_interval_s=2.0) == 5.0
+
+
+def test_a_pace_of_zero_or_less_is_refused_by_the_manifest():
+    """Not clamped quietly. Zero seconds between requests is not a pace anyone
+    means, and accepting it would put the fastest possible crawl one typo away
+    from a field whose entire purpose is to slow one down."""
+    for refused in (0, -1, -0.5):
+        with pytest.raises(Exception):
+            entry(crawl_pace_s=refused)
+
+
+def test_the_custom_robots_delay_finally_reaches_the_fetcher():
+    """THE DEFECT THIS TEST WAS WRITTEN FOR.
+
+    `robots_custom.crawl_delay_s` was declared, documented, surfaced in the web
+    UI and computed into `Decision.delay_s`, and no code read it. Break the
+    `custom_delay` branch in `resolve_fetcher` and this fails."""
+    source = entry(robots="custom",
+                   robots_custom={"enforce_disallow": False, "crawl_delay_s": 4.0})
+    assert pace(source) == 4.0
+
+
+def test_when_both_are_declared_the_slower_one_wins():
+    source = entry(crawl_pace_s=2.0, robots="custom",
+                   robots_custom={"enforce_disallow": False, "crawl_delay_s": 6.0})
+    assert pace(source) == 6.0
+
+    source = entry(crawl_pace_s=8.0, robots="custom",
+                   robots_custom={"enforce_disallow": False, "crawl_delay_s": 6.0})
+    assert pace(source) == 8.0
+
+
+def test_a_null_custom_delay_still_means_the_sites_own():
+    """The documented meaning of a null: "A null delay means the site's own."
+    So it must NOT be read as zero and must not disturb the pace here — the
+    site's own delay is applied later, in `_robots_for`."""
+    source = entry(robots="custom",
+                   robots_custom={"enforce_disallow": True, "crawl_delay_s": None})
+    assert pace(source, min_interval_s=1.5) == 1.5
+
+
+def test_alsweed_carries_the_pace_this_task_was_about():
+    """Pinned against the real manifest, because a per-source setting that gets
+    dropped in an edit is invisible: the crawl simply speeds back up and the
+    429s return weeks later."""
+    from scrapex import config
+
+    manifest = config.load_manifest()
+    sources = getattr(manifest, "sources", manifest)
+    alsweed = next(s for s in sources if s.source_key == "ALSWEED")
+    assert alsweed.crawl_pace_s is not None, (
+        "ALSWEED's per-source pace is gone; it was refused with HTTP 429 at the "
+        "tool-wide one second")
+    assert alsweed.crawl_pace_s >= 2.0
+    # And it must actually reach the transport, not merely sit in the file.
+    assert pace(alsweed) == alsweed.crawl_pace_s
+
+
+def test_the_pace_survives_the_panel_saving_that_source(tmp_path, monkeypatch):
+    """A per-source setting that the panel silently drops on the next edit is
+    worse than one that never existed: the crawl speeds back up and the 429s
+    return weeks later with nothing to point at.
+
+    manifest_io.py already carries a warning about exactly this — twelve fields
+    were once rebuilt out of existence every time the panel saved a rename — so
+    the new field is driven through the REAL writer rather than trusted to a
+    generic loop that looks like it covers everything."""
+    from scrapex import config, manifest_io
+
+    written = tmp_path / "sources.yaml"
+    written.write_text(
+        __import__("pathlib").Path("sources.yaml").read_text(encoding="utf-8"),
+        encoding="utf-8")
+    monkeypatch.setenv("SCRAPEX_SOURCES", str(written))
+
+    def alsweed():
+        manifest = config.load_manifest()
+        sources = getattr(manifest, "sources", manifest)
+        return next(s for s in sources if s.source_key == "ALSWEED")
+
+    before = alsweed()
+    assert before.crawl_pace_s == 3.0
+    manifest_io.update_source("ALSWEED", before, path=written)
+
+    assert alsweed().crawl_pace_s == 3.0, (
+        "saving ALSWEED through the panel's own writer dropped its pace")


### PR DESCRIPTION
**Measured first, and the measurement changed the task.**

ALSWEED was aborting on *"5 refusals in a row (last: HTTP 429)"* — jobs 84 and 85 on 1 Aug, 98 on 2 Aug, 120 and 121 on 11 Aug. Each of those runs collected nothing.

## The remedy on record would not have worked

The task said: restore `crawl_honour_delay`. But `alsweed.sa/robots.txt` publishes a Sitemap, one Disallow and **no Crawl-delay** — and `honour_crawl_delay` only takes effect when a site *declares* one. The switch would have been flipped, nothing would have improved, and the diagnosis would have lost its credibility.

Two more things in that task were wrong, and are corrected in it:

| claim | what the warehouse says |
|---|---|
| "0 products = collecting nothing" | `products_discovered` counts **new** products. The 12 Aug run logged *"17 observations, 0 new products, 199 requests"* |
| "we are bleeding data" | `price_observation` records **changes only**. 1203 rows on 25 Jul is the first harvest; the trickle after is prices that moved. ADVANCEDCASTLE (168→25) and ELBUROJ (3441→22) show the same shape |

ALSWEED is not bleeding data. It loses the runs that get refused.

## What this adds

**`crawl_pace_s` on a source** — the seconds it needs between requests when it needs a pace it never asked for in robots.txt. ALSWEED declares `3.0`, with the evidence beside it, and stated plainly as **an estimate**: nobody knows that site's real limit, and finding it by probing is the behaviour that got us refused.

The alternative was raising the tool-wide `crawl_min_interval_s`, which would slow elburoj's 6,720 products — a source that already asks for ten seconds — to spare one shop.

## And one place now decides the pace, taking the slowest opinion

There were three and **only one was connected**. `robots_custom.crawl_delay_s` is declared in the manifest, documented on the model, shown in the web UI, and computed all the way into `Decision.delay_s` — and the verdict is read only for `may_fetch`, on a path robots.txt *disallows*. An owner who set a per-source delay saw it in the interface and it did nothing. It is wired now.

Slowest wins, which is the rule `_robots_for` already states in its own words: *"slowing down is never the wrong direction"*. So a per-source pace is a **brake, never an accelerator** — a number typed too small cannot overrule the owner's own setting.

## Proof

Four mutations, each caught: ignoring the per-source pace · leaving the custom delay disconnected as it was · `min` for `max` · dropping the line from the manifest.

**And two of my own checks were not enough, while the repository's were.** A first round-trip check found no writer, wrote nothing, and passed proving nothing. The rewrite drove `manifest_io.update_source` — the writer the panel itself uses — and I took that for coverage. It was not: `test_the_check_covers_every_field_the_model_has` then failed, because a field absent from `FULL_SOURCE` cannot be noticed being dropped — *"the same shape of silence as the defect itself"*. It is in that fixture now.

**1841 engine tests · ruff clean.**

Separately, on the owner's instruction, `crawl_honour_delay` was restored to `1` in the live database — no code change, and it does not affect ALSWEED, but it stops us overriding elburoj's declared ten seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)