### PR TITLE
A query string killed a source for twelve days, and no guard was watching the add-in

### DIFF
--- a/contract/addin-contract.json
+++ b/contract/addin-contract.json
@@ -30,10 +30,44 @@
     "is made impossible to change SILENTLY."
   ],
 
-  "contractVersion": 1,
-  "behaviourVersion": 1,
-  "readOn": "2026-08-12",
+  "contractVersion": 2,
+  "behaviourVersion": 2,
+  "readOn": "2026-08-13",
   "readFrom": "muhammadbayoumi/mbiXaddin",
+
+  "_comment_read_against": [
+    "WHICH UPSTREAM STATE THIS READING DESCRIBES, as a commit rather than a date,",
+    "because a date cannot be checked and a commit can. Everything the Console",
+    "believes about mbiXaddin was read from the tree at readAgainstCommit.",
+    "",
+    "IT IS RECORDED BECAUSE THE VERSION NUMBERS ABOVE CANNOT DETECT UPSTREAM",
+    "DRIFT. mbiXaddin has no behaviourVersion of its own — both numbers live in",
+    "THIS repository, and the same hand raises both in the same commit, so their",
+    "agreement proves ScrapeX is internally consistent and nothing more. The",
+    "commit is what lets a test go and look: see the file-drift guard in",
+    "tests/test_the_addin_contract_cannot_drift.py, which compares the .cs files",
+    "this reading cites against the add-in's own main branch.",
+    "",
+    "reviewedSince — cited files that HAVE moved since, each read and found not",
+    "to touch what the Console believes, pinned to the blob they were dismissed",
+    "at. A further edit changes the blob and the guard fires again. THIS LIST IS",
+    "EVIDENCE, NOT AN EXEMPTION: an entry with no reason is a hole."
+  ],
+  "readAgainstCommit": "62184eed5d28d04626ae2ac2e0c51b42c75dc295",
+  "reviewedSince": {
+    "EndpointCatalog.cs": {
+      "blob": "4d26c50327fb0eb3e7bb1a1be8fa1fb1a834570d",
+      "why": "A comment rewrite about which release endpoint is still served. The six compiled-in sheet gids the Console refuses a wrong workbook by are untouched."
+    },
+    "HttpClientService.cs": {
+      "blob": "6eaed48e8a27bb1f31ff34083bde9a70c0ddc748",
+      "why": "5xx backoff bounded by the caller's timeout. Network retry behaviour; it decides nothing about the six configuration sheets."
+    },
+    "mbiXRibbon.cs": {
+      "blob": "5dfd107927c72e381407f812ac02d02aeb975dad",
+      "why": "One click throttle and one dialog presenter across five ribbon buttons. UI plumbing, not 6.RibbonControls semantics."
+    }
+  },
 
   "sheets": {
     "1.TableDefinition": {
@@ -166,14 +200,14 @@
     "BLOCKS_SYNC_FROM": "Error",
 
     "_comment_uri": [
-      "The three literals SourceUriValidator searches for inside the WHOLE",
-      "address, case-insensitively (SourceUriValidator.cs:80-118). They are",
-      "contract facts exactly like the transform separator above: change one in",
-      "the add-in and every Console warning about an address becomes wrong.",
-      "They live here rather than inline for the same reason the boolean",
-      "spellings do — so a change to the add-in has one place to land."
+      "SourceUriValidator now parses the URI and compares the normalised HOST",
+      "exactly against these two Google Sheets hosts (SourceUriValidator change",
+      "merged 2026-08-13, mbiXaddin PR #26). It strips trailing root dots and",
+      "compares case-insensitively; userinfo, ports, paths and query strings do",
+      "not participate. The TSV and gid literals are still searched in the",
+      "whole lower-cased address after that host decision."
     ],
-    "URI_GOOGLE_SHEETS_MARKER": "docs.google.com",
+    "URI_GOOGLE_SHEETS_HOSTS": ["docs.google.com", "spreadsheets.google.com"],
     "URI_TSV_MARKERS": ["output=tsv", "format=tsv"],
     "URI_TAB_MARKER": "gid="
   }

--- a/docs/HANDOFF-mbiXaddin-source-uri-validator.md
+++ b/docs/HANDOFF-mbiXaddin-source-uri-validator.md
@@ -1,5 +1,13 @@
 # Handoff — mbiXaddin decides "is this Google Sheets" by searching the whole string
 
+> **Resolved 2026-08-13.** mbiXaddin PR #26 replaced the substring with an
+> absolute-URI host parse, exact `docs.google.com` / `spreadsheets.google.com`
+> matching, trailing-root-dot normalisation, and an `ERR_FORMAT` finding for
+> impostor addresses. The security consequence below was refuted: the rule is
+> advisory and SOURCE_URI is owner-authored. ScrapeX re-read that behaviour and
+> updated its contract mirror on the `the-addin-parses-its-host` branch. The
+> remainder is kept as the historical handoff and mutation checklist.
+
 *Paste everything below into a session working in
 `C:\Users\User01\source\repos\mbiXaddin`. It is self-contained; that session
 needs no knowledge of the conversation this came from.*

--- a/extension/addin-contract.js
+++ b/extension/addin-contract.js
@@ -31,7 +31,7 @@ import {
   BEHAVIOUR_VERSION, TRUE_SPELLINGS, FALSE_SPELLINGS, CLICKABLE_ACTIONS,
   MENU_ACTIONS, ENTITY_TYPES, STORAGE_STRATEGIES, LICENSE_TIERS, SEMANTIC_ROLES,
   DATA_TYPES, SOURCE_TYPES, MATCH_MODES, SHEETS as CONTRACT_SHEETS,
-  URI_GOOGLE_SHEETS_MARKER,
+  URI_GOOGLE_SHEETS_HOSTS,
 } from "./addin-vocabulary.js";
 
 /**
@@ -42,7 +42,7 @@ import {
  * the half that cannot be generated — so the test that compares them says, in
  * its own words, what has to happen first.
  */
-export const READ_AGAINST_BEHAVIOUR_VERSION = 1;
+export const READ_AGAINST_BEHAVIOUR_VERSION = 2;
 
 /** Both halves of ACTION_CLASS, which the add-in routes differently. */
 export const ACTION_CLASSES = [...CLICKABLE_ACTIONS, ...MENU_ACTIONS];
@@ -70,31 +70,34 @@ export function readBoolean(cell, whenUnreadable) {
 }
 
 /**
- * What the add-in makes of an ADDRESS — `SourceUriValidator`'s own test, and a
- * companion to `readBoolean` above in every sense: a quirk of the add-in
- * reproduced here so the Console can report it, with the literals read from the
- * contract rather than written into this line.
+ * What the add-in makes of an ADDRESS — `SourceUriValidator` after mbiXaddin
+ * PR #26 (merged 2026-08-13). The old reading searched the whole string for
+ * `docs.google.com`; it now parses an absolute URI, takes only its host, strips
+ * trailing DNS root dots, and compares exactly against the two hosts in the
+ * generated contract.
  *
- * IT IS A SUBSTRING OF THE WHOLE ADDRESS, and that is a defect. The host is
- * never parsed, so
+ * Invalid, local-path and NON-HTTP shapes return false here. `checkSourceUri`
+ * owns their findings, matching the add-in's separation between "is this
+ * Sheets?" and "is this address valid?".
  *
- *     https://attacker.example/?x=docs.google.com&output=tsv
- *
- * is "a Google Sheet" as far as the add-in is concerned. It then fetches it
- * over plain HTTP with NO AUTHENTICATION, following up to five redirects, and
- * parses whatever returns as the table's rows.
- *
- * THIS FUNCTION IS NOT A SECURITY CHECK AND MUST NEVER BE USED AS ONE. It
- * answers exactly one question — "what will the add-in conclude?" — so the
- * Console's advice about a TSV format and a gid lands in precisely the cases
- * the add-in's does. Whether an address IS Google's is decided by parsing the
- * host, in `checkSourceUri`, which is also where the impostor above is reported.
- *
- * The real repair belongs in the add-in's C#; until it lands, the Console is
- * the only surface that says this out loud.
+ * THE SCHEME GATE IS NOT DECORATION. The add-in reaches this decision only
+ * inside `if (isHttp)`, and anything that is neither http(s) nor a local path
+ * has already failed with ERR_FORMAT and `yield break` by then
+ * (`SourceUriValidator.cs:66-80`). `new URL()` is happy to parse
+ * `ftp://docs.google.com/x` and hand back Google's host, so without this line
+ * the mirror answers TRUE where the add-in never asks the question — the one
+ * thing this function exists not to do.
  */
 export function readsUriAsGoogleSheets(uri) {
-  return String(uri ?? "").toLowerCase().includes(URI_GOOGLE_SHEETS_MARKER);
+  const value = String(uri ?? "");
+  const scheme = value.slice(0, 8).toLowerCase();
+  if (!scheme.startsWith("http://") && !scheme.startsWith("https://")) return false;
+  try {
+    const host = new URL(value).hostname.toLowerCase().replace(/\.+$/, "");
+    return URI_GOOGLE_SHEETS_HOSTS.includes(host);
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/extension/addin-vocabulary.js
+++ b/extension/addin-vocabulary.js
@@ -4,11 +4,11 @@
 // mbiXaddin's C# accepts. A test fails if this file and that one
 // disagree, so a hand edit here is caught rather than shipped.
 //
-// contract version 1 · behaviour version 1 · read 2026-08-12 from muhammadbayoumi/mbiXaddin
+// contract version 2 · behaviour version 2 · read 2026-08-13 from muhammadbayoumi/mbiXaddin
 
-export const CONTRACT_VERSION = 1;
-export const BEHAVIOUR_VERSION = 1;
-export const CONTRACT_READ_ON = "2026-08-12";
+export const CONTRACT_VERSION = 2;
+export const BEHAVIOUR_VERSION = 2;
+export const CONTRACT_READ_ON = "2026-08-13";
 
 // ---- 4.DataMap -----------------------------------------------------------
 export const SOURCE_TYPES = ["Header", "Index", "Context", "Constant", "Formula"];
@@ -112,12 +112,12 @@ export const TRANSFORM_SEPARATOR = "|";
 export const TRANSFORM_ARGUMENT_SEPARATOR = ":";
 export const BLOCKS_SYNC_FROM = "Error";
 
-// The three literals SourceUriValidator searches for inside the WHOLE
-// address, case-insensitively (SourceUriValidator.cs:80-118). They are
-// contract facts exactly like the transform separator above: change one in
-// the add-in and every Console warning about an address becomes wrong.
-// They live here rather than inline for the same reason the boolean
-// spellings do — so a change to the add-in has one place to land.
-export const URI_GOOGLE_SHEETS_MARKER = "docs.google.com";
+// SourceUriValidator now parses the URI and compares the normalised HOST
+// exactly against these two Google Sheets hosts (SourceUriValidator change
+// merged 2026-08-13, mbiXaddin PR #26). It strips trailing root dots and
+// compares case-insensitively; userinfo, ports, paths and query strings do
+// not participate. The TSV and gid literals are still searched in the
+// whole lower-cased address after that host decision.
+export const URI_GOOGLE_SHEETS_HOSTS = ["docs.google.com", "spreadsheets.google.com"];
 export const URI_TSV_MARKERS = ["output=tsv", "format=tsv"];
 export const URI_TAB_MARKER = "gid=";

--- a/extension/datasource-rules.js
+++ b/extension/datasource-rules.js
@@ -12,7 +12,8 @@
 // would print a cascade of complaints about a row the add-in never reaches.
 
 import { readBoolean, readsUriAsGoogleSheets, BOOLEAN_DEFAULTS, ERROR_CODE,
-  CONSOLE_ONLY_CODE, CONTEXT_PROPS_KEYS, URI_TSV_MARKERS, URI_TAB_MARKER }
+  CONSOLE_ONLY_CODE, CONTEXT_PROPS_KEYS, URI_GOOGLE_SHEETS_HOSTS,
+  URI_TSV_MARKERS, URI_TAB_MARKER }
   from "./addin-contract.js";
 
 /**
@@ -87,42 +88,25 @@ export function checkSourceUri(uri) {
     }
   }
 
-  //: Is the address really Google's, rather than merely SAYING so?
-  const reallyGoogle = host === "docs.google.com" || host.endsWith(".google.com");
-
-  // A DEFECT IN THE ADD-IN, FOUND BY A SCANNER POINTED AT THIS FILE.
-  //
-  // `SourceUriValidator` decides "is this Google Sheets" with a case-insensitive
-  // SUBSTRING of the whole address — the host is never parsed. This module used
-  // to reproduce that substring inline, and CodeQL was right to object to the
-  // shape of it. The rule here is still to mirror rather than invent, so the
-  // mirror did not move out of the product: it moved to where the add-in's other
-  // quirks live, beside `readBoolean`, and it says on itself that it decides
-  // nothing. What is left below is this module's own reasoning, on a PARSED host.
-  //
-  // The consequence CodeQL named is real, and it is the add-in's:
-  //
-  //     https://attacker.example/?x=docs.google.com&output=tsv
-  //
-  // satisfies every check the add-in makes, and the add-in then downloads it
-  // with no authentication of any kind, following up to five redirects.
-  // Whatever comes back is parsed as the table's rows. The Console cannot fix
-  // that from here — it can only refuse to stay quiet about it.
+  // mbiXaddin repaired its old whole-string substring decision in PR #26. The
+  // mirror now parses the same host and accepts exactly docs.google.com or
+  // spreadsheets.google.com. An address that merely mentions either literal
+  // still gets the add-in's new ERR_FORMAT finding below; it no longer receives
+  // the TSV/gid rules, because the add-in no longer calls it a Sheet.
   const addinReadsThisAsGoogleSheets = readsUriAsGoogleSheets(value);
+  const mentionsSheetsHost = URI_GOOGLE_SHEETS_HOSTS.some(
+    (candidate) => lower.includes(candidate));
 
-  if (isHttp && addinReadsThisAsGoogleSheets && !reallyGoogle) {
+  if (isHttp && mentionsSheetsHost && !addinReadsThisAsGoogleSheets) {
     found.push(finding("Error", "SOURCE_URI", ERROR_CODE.badFormat,
-      `This address MENTIONS docs.google.com but is served by "${host}". The `
-      + "add-in decides an address is Google's by searching the whole string, "
-      + "so it accepts this one and downloads it with no authentication — and "
-      + "whatever comes back becomes the table's rows.",
+      `This address mentions a Google Sheets host but is served by "${host}". `
+      + "The add-in parses the host and rejects this as an impostor address.",
       "If this is meant to be a Google Sheet, the host itself must be "
-      + "docs.google.com."));
+      + "docs.google.com or spreadsheets.google.com."));
   }
 
-  // The same answer, not a second reading of it — so the Console asks for
-  // output=tsv in precisely the cases the add-in does, including the impostor
-  // above, which the add-in also demands a TSV format from.
+  // The same answer, not a second reading: TSV and gid apply only after the
+  // parsed-host decision, exactly as they now do in SourceUriValidator.
   if (addinReadsThisAsGoogleSheets) {
     if (!URI_TSV_MARKERS.some((marker) => lower.includes(marker))) {
       found.push(finding("Error", "SOURCE_URI", ERROR_CODE.badFormat,

--- a/extension/tests/datasource-rules.test.mjs
+++ b/extension/tests/datasource-rules.test.mjs
@@ -421,84 +421,78 @@ test("every finding names the field it is about", () => {
 });
 
 // ---------------------------------------------------------------------------
-// A defect in the ADD-IN, found by a scanner pointed at this file.
-//
-// CodeQL flagged `lower.includes("docs.google.com")` as
-// js/incomplete-url-substring-sanitization. The mirror is deliberate — the
-// add-in matches exactly that way and this module's rule is to mirror rather
-// than invent — but the consequence CodeQL named is real, and it belongs to the
-// add-in: an address that merely MENTIONS docs.google.com passes every check it
-// makes, and is then downloaded with no authentication.
-//
-// So the mirror was not deleted and was not silenced. It was SEPARATED. The
-// add-in's substring test is `readsUriAsGoogleSheets` in the contract module,
-// beside the other quirks it reproduces, and it decides nothing. What decides is
-// the parsed host, here. The two tests below hold that separation in place: one
-// proves the mirror still agrees with the add-in even where the add-in is wrong,
-// the other proves the Console refuses anyway.
+// The add-in's SourceUriValidator repair, merged 2026-08-13. The old mirror was
+// intentionally wrong in the same way as C#: it searched the whole address for
+// `docs.google.com`. C# now parses and normalises the host, accepts exactly two
+// Sheets hosts, and emits ERR_FORMAT for an address that merely mentions one.
+// These tests pin both halves so ScrapeX cannot keep describing the repaired
+// defect or accidentally broaden "Sheets" to every service under google.com.
 // ---------------------------------------------------------------------------
 
-test("the mirror still agrees with the add-in, INCLUDING where it is wrong", () => {
-  // If this ever goes false, the add-in has been repaired — and then the
-  // impostor Error below becomes unreachable and should be reconsidered, not
-  // deleted on the grounds that nothing hits it.
-  assert.equal(
-    readsUriAsGoogleSheets("https://attacker.example/?x=docs.google.com"), true,
-    "the mirror no longer reproduces SourceUriValidator's substring match");
-  assert.equal(readsUriAsGoogleSheets("https://DOCS.GOOGLE.COM/pub"), true,
-    "the add-in matches case-insensitively and this no longer does");
-  assert.equal(readsUriAsGoogleSheets(""), false);
-  assert.equal(readsUriAsGoogleSheets(null), false);
-});
-
-test("and deciding by the mirror alone would accept the attack", () => {
-  // Stated as an assertion rather than a comment, because this is the whole
-  // reason the two live apart: agreeing with the add-in is NOT a safety verdict.
-  const attack = "https://attacker.example/collect?x=docs.google.com&output=tsv";
-
-  assert.equal(readsUriAsGoogleSheets(attack), true,
-    "the add-in would call this a Google Sheet");
-  assert.ok(checkSourceUri(attack).some((f) => f.severity === "Error"),
-    "and the Console let it through, which means the host check has gone");
+test("the mirror reads the parsed host exactly as the repaired add-in does", () => {
+  for (const uri of [
+    "https://DOCS.GOOGLE.COM/pub",
+    "https://spreadsheets.google.com/pub",
+    "https://user:pw@docs.google.com:443/pub",
+    "https://docs.google.com./pub",
+  ]) {
+    assert.equal(readsUriAsGoogleSheets(uri), true, uri);
+  }
+  for (const uri of [
+    "https://attacker.example/?x=docs.google.com",
+    "https://docs.google.com.attacker.example/pub",
+    "https://docs.google.com@attacker.example/pub",
+    "https://drive.google.com/file/d/1",
+    "https://script.google.com/macros/s/1",
+    // Not http(s): the add-in fails these on FORMAT and yield-breaks before it
+    // ever asks whether they are Sheets. `new URL()` parses them happily and
+    // returns Google's host, so the mirror has to refuse them on the scheme.
+    "ftp://docs.google.com/x",
+    "gopher://docs.google.com/",
+    "",
+    null,
+  ]) {
+    assert.equal(readsUriAsGoogleSheets(uri), false, String(uri));
+  }
 });
 
 test("an address that only MENTIONS Google is refused, and says who serves it", () => {
   const found = checkSourceUri(
     "https://attacker.example/collect?x=docs.google.com&output=tsv");
 
-  const impostor = found.filter((f) => /MENTIONS/.test(f.detail));
+  const impostor = found.filter((f) => /impostor/.test(f.detail));
   assert.equal(impostor.length, 1);
   assert.equal(impostor[0].severity, "Error");
   assert.match(impostor[0].detail, /attacker\.example/,
     "the message does not name the host actually being talked to, which is the "
     + "one fact that settles it");
-  assert.match(impostor[0].detail, /no authentication/);
+  assert.equal(impostor[0].code, "ERR_FORMAT");
 });
 
 test("a look-alike host is refused too", () => {
   // The other half of the same trick, and the one a reader is likeliest to miss.
   const found = checkSourceUri(
     "https://docs.google.com.attacker.example/pub?gid=1&output=tsv");
-  assert.ok(found.some((f) => /MENTIONS/.test(f.detail)),
+  assert.ok(found.some((f) => /impostor/.test(f.detail)),
     "docs.google.com.attacker.example was accepted as Google's own host");
 });
 
 test("the real thing is not refused, on either Google host shape", () => {
   for (const uri of [PUBLISHED,
                      "https://spreadsheets.google.com/pub?gid=1&output=tsv"]) {
-    assert.deepEqual(checkSourceUri(uri).filter((f) => /MENTIONS/.test(f.detail)),
+    assert.deepEqual(checkSourceUri(uri).filter((f) => /impostor/.test(f.detail)),
       [], `${uri} was treated as an impostor`);
   }
 });
 
-test("the TSV rule still mirrors the add-in's substring match exactly", () => {
-  // Deliberately NOT narrowed to the real host: the Console must ask for
-  // output=tsv in precisely the cases the add-in does, or it is describing a
-  // different program.
-  const found = checkSourceUri("https://attacker.example/?x=docs.google.com");
-  assert.ok(found.some((f) => /output=tsv/.test(f.fix)),
-    "the TSV warning stopped firing for an address the add-in would still "
-    + "treat as a Google Sheet");
+test("the TSV rule follows the parsed-host decision, not a mention", () => {
+  const impostor = checkSourceUri("https://attacker.example/?x=docs.google.com");
+  assert.equal(impostor.some((f) => /output=tsv/.test(f.fix)), false,
+    "an impostor still received the old whole-string Sheets rules");
+
+  const real = checkSourceUri("https://docs.google.com/spreadsheets/d/1/pub");
+  assert.ok(real.some((f) => /output=tsv/.test(f.fix)),
+    "a real Sheets host no longer receives the TSV-format rule");
 });
 
 test("a malformed address is refused rather than parsed by guesswork", () => {

--- a/scrapex/capture.py
+++ b/scrapex/capture.py
@@ -281,7 +281,9 @@ def capture_source(conn: sqlite3.Connection, entry: SourceEntry,
             # (owner robots ruling), data warnings at WARNING.
             from .jobs import append_log
             from .vocab import LogLevel
-            flush = [w for t in tables for w in t.warnings]
+            flush = list(dict.fromkeys(
+                [w for t in tables for w in t.warnings]
+                + list(getattr(fetcher, "degradations", []) or [])))
             for w in flush[:12]:
                 append_log(conn, job_id, f"warning: {w}",
                            level=LogLevel.WARNING, source_key=entry.source_key)
@@ -355,9 +357,12 @@ def capture_source(conn: sqlite3.Connection, entry: SourceEntry,
         localinbox.clear(localinbox.JOURNAL_DIR, entry.source_key)
     # rows/tables come from the PAYLOADS: on a resume the fetched tables are
     # only the tail of the crawl, and the F6 volume canary must see the whole.
+    run_warnings = list(dict.fromkeys(
+        [w for t in tables for w in t.warnings]
+        + list(getattr(fetcher, "degradations", []) or [])))
     return CaptureResult(ingest=result, requests_count=requests_count,
                          tables=len(payloads), rows=sum(len(p.rows) for p in payloads),
-                         warnings=[w for t in tables for w in t.warnings],
+                         warnings=run_warnings,
                          notes=list(getattr(fetcher, "robots_warnings", []) or []))
 
 

--- a/scrapex/cli.py
+++ b/scrapex/cli.py
@@ -490,14 +490,17 @@ def _cmd_crawl(args: argparse.Namespace) -> int:
         localinbox.write_payload(base, table.to_payload())
         rows += len(table.rows)
         warnings.extend(table.warnings)
+    warnings = list(dict.fromkeys(
+        warnings + list(getattr(fetcher, "degradations", []) or [])))
     print(f"crawled {entry.source_key}: {rows} rows "
           f"({fetcher.requests_count} requests) -> local inbox {base}")
     # A partial crawl that prints only its row count reads as a clean success.
     for warning in warnings:
         print(f"  warning: {warning}", file=sys.stderr)
     if warnings:
-        print(f"  {len(warnings)} part(s) of this source produced nothing — "
-              "the rows above are INCOMPLETE", file=sys.stderr)
+        print(f"  crawl completed with {len(warnings)} warning(s) — review "
+              "whether rows are incomplete or the fallback merely cost more "
+              "requests", file=sys.stderr)
     return 0
 
 

--- a/scrapex/connectors/base.py
+++ b/scrapex/connectors/base.py
@@ -254,6 +254,11 @@ class HttpFetcher:
     # not silently shrunk to 120s as before.
     MAX_RETRY_AFTER_S = 900.0
     RETRY_STATUSES = frozenset({408, 425, 429, 500, 502, 503, 504})
+    # Statuses that may mean "not in that shape" rather than "not at all", and
+    # so are worth one attempt without the optional parameters. 429 is NOT here:
+    # it is about pace, and asking again immediately in any shape is the one
+    # thing a rate-limited site has just told us not to do.
+    DROP_STATUSES = frozenset({400, 403, 404, 414, 422})
 
     def __init__(
         self,
@@ -316,6 +321,14 @@ class HttpFetcher:
         self.requests_count = 0   # recorded into crawl_run (F5 accounting)
         self.not_modified_count = 0
         self.retry_count = 0
+        #: Requests this run had to make in a costlier shape because the site
+        #: refused the efficient one. Read into the run's warnings — a crawl
+        #: that quietly costs ten times the requests is a bill nobody sees.
+        self.degradations: list[str] = []
+        #: (host, parameter) pairs proven refused, so the lesson is asked once
+        #: on that host and never leaked to a second host the same connector
+        #: happens to visit. A parameter name alone is not a site decision.
+        self._refused_params: set[tuple[str, str]] = set()
         # How many requests this crawl expects to make IN TOTAL, once something
         # actually knows. None until then, and None is the honest answer: a
         # sitemap-driven connector learns its frontier before it fetches a
@@ -433,10 +446,79 @@ class HttpFetcher:
         if keep:
             self._validators[url] = keep
 
+    @staticmethod
+    def _validator_url(url: str, params) -> str:
+        """The exact resource a validator describes, including its query.
+
+        An ETag for ``?page=1`` says nothing about ``?page=2``.  Keying the
+        cache only by the path made the second live samehgabriel page inherit
+        page one's validator and answer 304 with no JSON body.
+        """
+        if params is None:
+            return str(url)
+        return str(httpx.URL(url, params=params))
+
     # ---- the request path ---------------------------------------------------
 
     def get(self, url: str, **kwargs) -> httpx.Response:
         return self._request("GET", url, **kwargs)
+
+    def get_dropping(self, url: str, optional: Iterable[str] = (),
+                     **kwargs) -> httpx.Response:
+        """GET, and if the request is REFUSED, ask again without `optional`.
+
+        WHY THIS EXISTS, measured 2026-08-13 on samehgabriel.com. Its Store API
+        answers 200 to /wp-json/wc/store/products and 403 to the same URL with
+        `?per_page=1` — any value, even 1. Not the page size, not the range: the
+        presence of that one parameter trips a rule at the edge. The crawl had
+        been dead for twelve days over a query string.
+
+        A refusal of the whole endpoint is a decision to respect. A refusal of
+        one OPTIONAL parameter is not the same thing: `per_page` is an
+        efficiency, and asking for the same rows in smaller pages is the request
+        the site is willing to answer. So this degrades ONCE, and only for
+        parameters the caller has named as optional — never the address, never
+        anything the answer depends on.
+
+        THE DEGRADATION IS RECORDED, NOT ABSORBED. `degradations` is read into
+        the run's warnings, because a crawl that quietly costs ten times the
+        requests is a bill nobody sees until it is a block. Silence here would
+        turn one visible outage into a permanent invisible cost.
+
+        `sticky` keeps the lesson for the rest of the run: having learned that
+        the site refuses a parameter, asking 300 more times is both rude and
+        slow.
+        """
+        from urllib.parse import urlsplit
+
+        names = [n for n in optional if n]
+        params = dict(kwargs.pop("params", None) or {})
+        droppable = [n for n in names if n in params]
+        host = urlsplit(url).netloc.lower()
+
+        if droppable and all((host, n) in self._refused_params for n in droppable):
+            for name in droppable:
+                params.pop(name)
+            return self._request("GET", url, params=params or None, **kwargs)
+
+        try:
+            return self._request("GET", url, params=params or None, **kwargs)
+        except httpx.HTTPStatusError as refusal:
+            if not droppable or refusal.response.status_code not in self.DROP_STATUSES:
+                raise
+            lighter = {k: v for k, v in params.items() if k not in droppable}
+            answer = self._request("GET", url, params=lighter or None, **kwargs)
+            # Only now, with proof that the lighter request works, is the lesson
+            # worth keeping — a 403 that was really about something else must
+            # not teach us to drop a parameter for ever.
+            self._refused_params.update((host, name) for name in droppable)
+            self.degradations.append(
+                f"{host} refused "
+                f"{', '.join(sorted(droppable))} with HTTP "
+                f"{refusal.response.status_code} and answered without it — this "
+                "crawl is using the site's own page size, which costs more "
+                "requests for the same rows")
+            return answer
 
     def post(self, url: str, **kwargs) -> httpx.Response:
         return self._request("POST", url, **kwargs)
@@ -487,6 +569,25 @@ class HttpFetcher:
                         "blocked by the site")
         return parser
 
+    def sitemap_urls(self, url: str) -> list[str]:
+        """Sitemap addresses the site's own robots.txt advertises, in order.
+
+        The robots file is already fetched lazily before the first request to a
+        host. Exposing only its `Sitemap:` declarations lets a fallback discover
+        a catalogue without guessing a plugin-specific filename, while keeping
+        the robots cache and its network accounting in one place.
+        """
+        from urllib.parse import urlsplit
+
+        self._robots_for(url)
+        host = urlsplit(url).netloc
+        found: list[str] = []
+        for line in self._robots_text.get(host, "").splitlines():
+            name, separator, value = line.partition(":")
+            if separator and name.strip().lower() == "sitemap" and value.strip():
+                found.append(value.strip())
+        return list(dict.fromkeys(found))
+
     def _request(self, method: str, url: str, **kwargs) -> httpx.Response:
         robots = self._robots_for(url)
         if robots is not None and not robots.can_fetch(self._user_agent, url):
@@ -525,8 +626,11 @@ class HttpFetcher:
                 # collected is the worst failure this product has. The owner
                 # chose to obey; the run must say so out loud and stop.
                 raise RobotsDisallowed(verdict.reason)
+        validator_url = str(url)
         if method == "GET":
-            kwargs["headers"] = self._conditional_headers(url, kwargs.get("headers"))
+            validator_url = self._validator_url(url, kwargs.get("params"))
+            kwargs["headers"] = self._conditional_headers(
+                validator_url, kwargs.get("headers"))
         last_error: Exception | None = None
         for attempt in range(1, self._max_attempts + 1):
             self._throttle()
@@ -574,7 +678,7 @@ class HttpFetcher:
             else:
                 self._consecutive_refusals = 0
 
-            self._store_validators(url, response)
+            self._store_validators(validator_url, response)
             response.raise_for_status()
             return response
 

--- a/scrapex/connectors/jsonld.py
+++ b/scrapex/connectors/jsonld.py
@@ -157,6 +157,7 @@ class WalkTally:
 def walk_product_pages(
         fetcher, urls: Iterable[str], skip_tokens,
         token_of: Callable[[str], str], tally: WalkTally,
+        *, request_kwargs: dict | None = None,
 ) -> Iterator[tuple[str, str, str, dict]]:
     """(url, token, html, product node) for every page that answered and parsed.
 
@@ -176,7 +177,7 @@ def walk_product_pages(
             tally.skipped += 1
             continue
         try:
-            html = fetcher.get(url).text
+            html = fetcher.get(url, **(request_kwargs or {})).text
         except CrawlBlocked:
             raise
         except Exception:
@@ -274,6 +275,21 @@ def offer_price(offers) -> tuple[str, str, str]:
     currency = offers.get("priceCurrency", "") or ""
     availability = str(offers.get("availability", ""))
     price = offers.get("price")
+    # WooCommerce's current schema output puts the actual amount only inside a
+    # UnitPriceSpecification. Measured on samehgabriel.com 2026-08-15: the
+    # enclosing Offer has no `price` and carries a one-item priceSpecification
+    # list. Treating that as priceless would discard a price the page states in
+    # machine-readable form.
+    specifications = offers.get("priceSpecification")
+    if isinstance(specifications, dict):
+        specifications = [specifications]
+    if price in (None, ""):
+        for spec in specifications or []:
+            if not isinstance(spec, dict) or spec.get("price") in (None, ""):
+                continue
+            price = spec["price"]
+            currency = currency or spec.get("priceCurrency", "") or ""
+            break
     if price in (None, "", 0, "0", "0.0", 0.0):     # variant-priced -> AggregateOffer
         price = offers.get("lowPrice")
     return (str(price) if price not in (None, "") else ""), currency, availability

--- a/scrapex/connectors/woocommerce.py
+++ b/scrapex/connectors/woocommerce.py
@@ -13,16 +13,41 @@ request per variation buys the real numbers.
 """
 from __future__ import annotations
 
+import json
 import re
 from collections.abc import Iterable
+from decimal import Decimal, InvalidOperation
+from urllib.parse import urlencode, urlsplit
+
+import httpx
+from bs4 import BeautifulSoup
 
 from ..config import SourceEntry
+from ..localinbox import safe_token
 from ..normalize import brand_pair, option_axes_json, option_fingerprint, strip_markup
 from ..rowspec import ENRICHMENT, PRODUCT_PRICES, RowBuilder
 from ..vocab import Availability, DetailGroup, ExtractKind, group_for_code
-from .base import CrawlBlocked, HttpFetcher, ScrapedTable
+from .base import CrawlBlocked, HttpFetcher, ScrapedTable, declare_frontier
+from .jsonld import (
+    WalkTally,
+    brand_name,
+    category_path,
+    offer_price,
+    sitemap_locs,
+    walk_product_pages,
+)
+from .jsonld import (
+    enrichment_rows as jsonld_enrichment_rows,
+)
+from .jsonld import (
+    product_row as jsonld_product_row,
+)
 
 PER_PAGE = 100
+_API_HEADERS = {"Accept": "application/json"}
+_PAGE_HEADERS = {"Accept": "text/html,application/xhtml+xml"}
+_SITEMAP_HEADERS = {"Accept": "application/xml,text/xml;q=0.9,*/*;q=0.8"}
+_PAGE_FALLBACK_STATUSES = frozenset({400, 401, 403, 404, 405, 406, 410, 414, 422})
 
 
 # Attributes that are NOT details (owner's correction, 2026-07-22): the single
@@ -105,6 +130,175 @@ def _money(prices: dict, key: str) -> str:
     return f"{int(raw) / (10 ** minor):.{minor}f}"
 
 
+def _positive_int(value) -> int | None:
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return None
+    return number if number > 0 else None
+
+
+def _site_host(url: str) -> str:
+    return (urlsplit(url).hostname or "").lower().rstrip(".").removeprefix("www.")
+
+
+def _same_site(url: str, host: str) -> bool:
+    return bool(host) and _site_host(url) == host
+
+
+def _is_product_sitemap(url: str) -> bool:
+    name = urlsplit(url).path.rsplit("/", 1)[-1].lower()
+    excluded = ("product_cat", "product-tag", "product_tag", "taxonom", "shipping", "pa_")
+    return name.endswith(".xml") and "product" in name and not any(
+        marker in name for marker in excluded)
+
+
+def _same_site_products(urls: Iterable[str], host: str,
+                        *, trusted_product_map: bool = False) -> list[str]:
+    products: list[str] = []
+    for url in urls:
+        path = urlsplit(url).path.lower()
+        if not _same_site(url, host) or path.endswith(".xml"):
+            continue
+        if trusted_product_map or "/product/" in path:
+            products.append(url)
+    return list(dict.fromkeys(products))
+
+
+def _decimal_money(value) -> str:
+    try:
+        amount = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return ""
+    if not amount.is_finite() or amount <= 0:
+        return ""
+    return format(amount.quantize(Decimal("0.01")), "f")
+
+
+def _jsonld_product_id(html: str, node: dict, url: str) -> str:
+    soup = BeautifulSoup(html, "lxml")
+    body_classes = soup.body.get("class", []) if soup.body else []
+    for class_name in body_classes:
+        found = re.fullmatch(r"postid-(\d+)", str(class_name))
+        if found:
+            return found.group(1)
+    return str(node.get("productID") or node.get("sku")
+               or str(node.get("@id") or "").removesuffix("#product") or url)
+
+
+def _page_variations(html: str) -> tuple[list[dict], dict[str, tuple[str, dict[str, str]]]]:
+    """Woo's embedded variations and the page's own labels for their slugs."""
+    soup = BeautifulSoup(html, "lxml")
+    form = soup.select_one("form.variations_form[data-product_variations]")
+    if form is None:
+        return [], {}
+    try:
+        variations = json.loads(str(form.get("data-product_variations") or ""))
+    except (json.JSONDecodeError, TypeError):
+        return [], {}
+    if not isinstance(variations, list):
+        return [], {}
+
+    axes: dict[str, tuple[str, dict[str, str]]] = {}
+    for select in form.select("select[name]"):
+        name = str(select.get("name") or "")
+        code = name.removeprefix("attribute_")
+        label_tag = form.find("label", attrs={"for": code})
+        label = label_tag.get_text(" ", strip=True) if label_tag else code
+        values = {str(option.get("value") or ""): option.get_text(" ", strip=True)
+                  for option in select.find_all("option")
+                  if option.get("value") not in (None, "")}
+        axes[name] = (label or code, values)
+    return [v for v in variations if isinstance(v, dict)], axes
+
+
+def _variation_axes_from_page(attributes: dict,
+                              labels: dict[str, tuple[str, dict[str, str]]]
+                              ) -> dict[str, str]:
+    axes: dict[str, str] = {}
+    for name, raw in (attributes or {}).items():
+        value = str(raw or "").strip()
+        if not value:
+            continue
+        label, choices = labels.get(str(name),
+                                    (str(name).removeprefix("attribute_"), {}))
+        axes[label] = choices.get(value, value)
+    return axes
+
+
+def _jsonld_has_unsafe_range(offers) -> bool:
+    candidates = offers if isinstance(offers, list) else [offers]
+    prices = [offer_price(offer)[0] for offer in candidates
+              if isinstance(offer, dict)]
+    stated = {price for price in prices if price}
+    if len(stated) > 1:
+        return True
+    if isinstance(offers, dict):
+        low = str(offers.get("lowPrice") or "")
+        high = str(offers.get("highPrice") or "")
+        return bool(low and high and low != high)
+    return False
+
+
+def _jsonld_price_rows(builder: RowBuilder, node: dict, html: str, url: str,
+                       source: SourceEntry, vat: str,
+                       notes: list[str]) -> tuple[list[list[str]], str]:
+    """Rows from a Woo product page, preserving live variation ids when stated."""
+    pid = _jsonld_product_id(html, node, url)
+    variations, labels = _page_variations(html)
+    if variations:
+        _summary_price, currency, _summary_availability = offer_price(node.get("offers"))
+        rows: list[list[str]] = []
+        skipped = 0
+        for variation in variations:
+            effective = _decimal_money(variation.get("display_price"))
+            if not effective or not variation.get("variation_is_active", True):
+                skipped += 1
+                continue
+            regular = _decimal_money(variation.get("display_regular_price")) or effective
+            axes = _variation_axes_from_page(
+                variation.get("attributes") or {}, labels)
+            option = ", ".join(f"{name}: {value}" for name, value in axes.items())
+            query = urlencode(variation.get("attributes") or {})
+            rows.append(builder.row(
+                external_product_id=pid,
+                external_variant_id=str(variation.get("variation_id") or ""),
+                external_sku=str(variation.get("sku") or node.get("sku") or ""),
+                product_name_ar=str(node.get("name") or ""),
+                **brand_pair(brand_name(node)),
+                product_link=url,
+                variant_url=f"{url}{'&' if '?' in url else '?'}{query}" if query else url,
+                parent_sku=str(node.get("sku") or ""),
+                variant_ar=option,
+                option_fingerprint=option_fingerprint(axes) if axes else "",
+                variant_axes_ar=option_axes_json(axes),
+                country_code_alpha2=source.default_region,
+                currency=currency or source.currency or "UNKNOWN",
+                tax_included=vat,
+                price_before=regular,
+                price_sale=effective if effective != regular else "",
+                price=effective,
+                availability=(Availability.IN_STOCK.value
+                              if variation.get("is_in_stock")
+                              else Availability.OUT_OF_STOCK.value),
+                category_path_ar=category_path(node),
+            ))
+        if skipped:
+            notes.append(
+                f"{skipped} variation(s) on {node.get('name') or url} carried "
+                "no active positive price in the page record and were skipped")
+        return rows, pid
+
+    if _jsonld_has_unsafe_range(node.get("offers")):
+        notes.append(
+            f"{node.get('name') or url}: JSON-LD publishes a price range but "
+            "no individually identified offers — skipped rather than stored "
+            "at the range's low end")
+        return [], pid
+    row = jsonld_product_row(builder, node, url, source, vat, pid)
+    return ([row] if row is not None else []), pid
+
+
 class WooCommerceConnector:
     connector_id = "woocommerce-storeapi"
 
@@ -119,19 +313,83 @@ class WooCommerceConnector:
         base = source.base_url.rstrip("/")
         endpoint = f"{base}/wp-json/wc/store/products"
         vat = "1" if source.vat_mode.value == "incl" else "0"
-        rows: list[list[str]] = []
         notes: list[str] = []
         fetched: list[dict] = []      # kept so enrichment needs no second fetch
 
         page = 1
+        page_size: int | None = None
+        # WHEN THE JSON-LD FALLBACK MAY BE ENTERED, and it is narrower than it
+        # looks: only before the API has answered once (`api_started`) and only
+        # on a crawl with NOTHING JOURNALLED (`not self.skip_tokens`). Every
+        # fallback branch below repeats both halves.
+        #
+        # THE SECOND HALF IS ABOUT DOUBLE INGESTION, not about caution. The two
+        # routes token their pages differently — the API journals `page-1`,
+        # `page-2`, …, the fallback journals `safe_token(product_url)`. Neither
+        # set can recognise the other, so a journal holding API pages plus a
+        # fallback resume would carry the SAME products under two tokens and
+        # ingest them twice. `_fetch_jsonld` honours `skip_tokens` for its own
+        # tokens, which makes an all-fallback journal resumable — but it cannot
+        # tell a `page-3` payload apart from one it has yet to fetch.
+        #
+        # THE COST IS REAL AND ACCEPTED: a fallback crawl that is interrupted
+        # cannot resume. Its next attempt meets the same refusal, finds a
+        # non-empty journal, and FAILS rather than falling back again — and it
+        # will keep failing until that journal is cleared, which discards the
+        # pages it had. Paying that is deliberate: a hard failure is visible and
+        # repairable, while a doubled price history is neither.
+        api_started = False
         while True:
             token = f"page-{page}"
             if token in self.skip_tokens:
                 page += 1
                 continue      # already journaled — never re-asked
-            products = self._fetcher.get(endpoint, params={"per_page": PER_PAGE, "page": page}).json()
-            if not isinstance(products, list) or not products:
+            # `per_page` is an EFFICIENCY, not part of the answer, so it is named
+            # optional: samehgabriel.com answers 200 to this endpoint and 403 to
+            # the same endpoint with `?per_page=1` — any value at all. Twelve
+            # days of that source were lost to a query string. The fetcher asks
+            # again without it and RECORDS that it had to.
+            try:
+                response = self._fetcher.get_dropping(
+                    endpoint, optional=("per_page",),
+                    params={"per_page": PER_PAGE, "page": page},
+                    headers=_API_HEADERS)
+                products = response.json()
+            except CrawlBlocked:
+                raise
+            except httpx.HTTPStatusError as exc:
+                status = exc.response.status_code
+                if (not api_started and not self.skip_tokens
+                        and status in _PAGE_FALLBACK_STATUSES):
+                    yield from self._fetch_jsonld(
+                        source, f"Store API answered HTTP {status} after its "
+                        "optional parameters were removed")
+                    return
+                raise
+            except ValueError as exc:
+                if not api_started and not self.skip_tokens:
+                    yield from self._fetch_jsonld(
+                        source, f"Store API returned unreadable JSON ({exc})")
+                    return
+                raise
+
+            if not isinstance(products, list):
+                if not api_started and not self.skip_tokens:
+                    yield from self._fetch_jsonld(
+                        source, "Store API no longer returned a product array")
+                    return
+                raise RuntimeError(
+                    f"{endpoint}?page={page} returned "
+                    f"{type(products).__name__}, not a product array")
+            if not products:
+                if not api_started and not self.skip_tokens:
+                    yield from self._fetch_jsonld(
+                        source, "Store API returned an empty first page")
+                    return
                 break
+
+            api_started = True
+            before_notes = len(notes)
             page_rows: list[list[str]] = []
             for p in products:
                 made = self._product_rows(builder, p, source, vat, endpoint, notes)
@@ -143,16 +401,26 @@ class WooCommerceConnector:
                     # and arrive as out-of-scope rejects — noise that looks like
                     # a contract breach. What we priced is what we describe.
                     fetched.append(p)
-            rows.extend(page_rows)
             # One table PER PAGE so a pause keeps what it fetched: the journal
             # stores each as it arrives and the resume starts at the tail.
             yield ScrapedTable(
                 source_key=source.source_key, kind=PRODUCT_PRICES.kind,
                 source_url=f"{endpoint}?page={page}", header=builder.header,
-                rows=page_rows, warnings=notes if page == 1 else [],
+                rows=page_rows, warnings=notes[before_notes:],
                 page_token=token,
             )
-            if len(products) < PER_PAGE:
+            # Prefer the API's own frontier when it states one. The live host
+            # that rejects `per_page` still answers X-WP-TotalPages: 2; reading
+            # that is stronger than inferring a rule from one page. A shop that
+            # omits the header falls back to the observed page size — never the
+            # size we asked for, because it may have refused that request.
+            announced_pages = _positive_int(
+                response.headers.get("X-WP-TotalPages"))
+            if announced_pages is not None and page >= announced_pages:
+                break
+            if page_size is None:
+                page_size = len(products)
+            if announced_pages is None and len(products) < page_size:
                 break
             page += 1
         # A SECOND table from the SAME fetch. The attributes, categories, tags,
@@ -169,6 +437,116 @@ class WooCommerceConnector:
                     source_key=source.source_key, kind=ENRICHMENT.kind,
                     source_url=endpoint, header=extra.header, rows=attribute_rows,
                 )
+
+    def _fetch_jsonld(self, source: SourceEntry,
+                      reason: str) -> Iterable[ScrapedTable]:
+        """Fallback to the public product pages when the Store API shape is gone.
+
+        JSON-LD is the stable price summary. WooCommerce's own embedded
+        variation record, when present on the SAME page, preserves the numeric
+        product/variation ids and the per-colour prices the API normally gives
+        us. The route is explicitly a warning: page markup carries fewer
+        enrichment facts and costs one request per product.
+        """
+        base = source.base_url.rstrip("/")
+        urls = self._product_urls(base)
+        if not urls:
+            raise RuntimeError(
+                f"{reason}; the JSON-LD fallback could not discover any product "
+                f"URLs from robots.txt or the WordPress sitemap indexes at {base}")
+
+        remaining = [url for url in urls if safe_token(url) not in self.skip_tokens]
+        declare_frontier(self._fetcher, len(remaining))
+        tally = WalkTally()
+        wants_enrichment = any(spec.kind == ExtractKind.ENRICHMENT
+                               for spec in source.extract)
+        vat = "1" if source.vat_mode.value == "incl" else "0"
+        unlanded_notes: list[str] = []
+
+        fallback_warning = (
+            f"{reason}; used the site's public product pages instead. Prices "
+            "came from Product JSON-LD and WooCommerce's page variation record "
+            "when present. This route costs one request per product and its "
+            "enrichment is narrower than the Store API.")
+
+        for url, token, html, node in walk_product_pages(
+                self._fetcher, urls, self.skip_tokens, safe_token, tally,
+                request_kwargs={"headers": _PAGE_HEADERS}):
+            builder = RowBuilder(PRODUCT_PRICES)
+            page_notes: list[str] = []
+            rows, pid = _jsonld_price_rows(
+                builder, node, html, url, source, vat, page_notes)
+            if not rows:
+                tally.priceless += 1
+                unlanded_notes.extend(page_notes)
+            else:
+                yield ScrapedTable(
+                    source.source_key, PRODUCT_PRICES.kind, url,
+                    builder.header, rows, warnings=page_notes,
+                    page_token=token)
+
+            if wants_enrichment and rows:
+                extra = RowBuilder(ENRICHMENT)
+                details = jsonld_enrichment_rows(extra, node, pid)
+                if details:
+                    yield ScrapedTable(
+                        source.source_key, ENRICHMENT.kind, url,
+                        extra.header, details, page_token=token)
+
+        summary = [fallback_warning, *unlanded_notes, *tally.notes()]
+        yield ScrapedTable(
+            source.source_key, PRODUCT_PRICES.kind, base,
+            RowBuilder(PRODUCT_PRICES).header, [], warnings=summary)
+
+    def _product_urls(self, base: str) -> list[str]:
+        """Product pages from the site's own sitemap declarations.
+
+        robots.txt leads. WordPress core and the two common plugin filenames
+        are fallbacks, tried only until one yields a product frontier.
+        """
+        roots: list[str] = []
+        advertised = getattr(self._fetcher, "sitemap_urls", None)
+        if advertised is not None:
+            try:
+                roots.extend(advertised(base))
+            except CrawlBlocked:
+                raise
+            except Exception:
+                pass
+        roots.extend([
+            f"{base}/wp-sitemap.xml",
+            f"{base}/sitemap_index.xml",
+            f"{base}/product-sitemap.xml",
+        ])
+        host = _site_host(base)
+        for root in dict.fromkeys(roots):
+            locs = self._sitemap_locs(root)
+            direct = _same_site_products(
+                locs, host, trusted_product_map=_is_product_sitemap(root))
+            if direct:
+                return direct
+            children = [url for url in locs
+                        if _same_site(url, host) and _is_product_sitemap(url)]
+            for child in children:
+                products = _same_site_products(
+                    self._sitemap_locs(child), host, trusted_product_map=True)
+                if products:
+                    return products
+        return []
+
+    def _sitemap_locs(self, url: str) -> list[str]:
+        try:
+            return sitemap_locs(
+                self._fetcher.get(url, headers=_SITEMAP_HEADERS).text)
+        except CrawlBlocked:
+            raise
+        except httpx.HTTPStatusError as exc:
+            # A missing guessed filename means try the next one. A rate limit or
+            # an unhealthy server means stop; probing more paths is extra load,
+            # not resilience.
+            if exc.response.status_code in _PAGE_FALLBACK_STATUSES:
+                return []
+            raise
 
     def _product_rows(self, builder: RowBuilder, product: dict, source: SourceEntry,
                       vat: str, endpoint: str, notes: list[str]) -> list[list[str]]:

--- a/scrapex/probe.py
+++ b/scrapex/probe.py
@@ -50,10 +50,11 @@ def _key_from_host(host: str) -> str:
     return key[:64]
 
 
-def _try_json(fetcher, url: str, **kw):
+def _try_json(fetcher, url: str, *, optional=(), **kw):
     """GET and parse JSON, returning None on any failure (probe is best-effort)."""
     try:
-        resp = fetcher.get(url, **kw)
+        resp = (fetcher.get_dropping(url, optional=optional, **kw)
+                if optional else fetcher.get(url, **kw))
     except Exception:
         return None
     try:
@@ -80,7 +81,10 @@ def probe(url: str, fetcher: HttpFetcher | None = None) -> ProbeResult:
             evidence.append("/products.json returned a Shopify products array")
         # 2) WooCommerce Store API
         if family == ConnectorFamily.TBD_PROBE:
-            data = _try_json(fetcher, f"{base}/wp-json/wc/store/products", params={"per_page": 1})
+            data = _try_json(
+                fetcher, f"{base}/wp-json/wc/store/products",
+                optional=("per_page",), params={"per_page": 1},
+                headers={"Accept": "application/json"})
             if isinstance(data, list):
                 reachable = True
                 family = ConnectorFamily.WOOCOMMERCE_STOREAPI

--- a/tests/fixtures/woocommerce_product_jsonld.html
+++ b/tests/fixtures/woocommerce_product_jsonld.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="ar">
+<body class="single-product postid-10150">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Product",
+  "@id": "https://shop.example/product/cable/#product",
+  "name": "سلك نحاس مجدول 3 مم",
+  "url": "https://shop.example/product/cable/",
+  "sku": "PARENT-1",
+  "image": ["https://shop.example/media/cable.jpg"],
+  "description": "سلك نحاس معزول",
+  "offers": [{
+    "@type": "Offer",
+    "priceSpecification": [{
+      "@type": "UnitPriceSpecification",
+      "price": "2776.66",
+      "priceCurrency": "EGP",
+      "valueAddedTaxIncluded": true
+    }],
+    "availability": "https://schema.org/InStock",
+    "url": "https://shop.example/product/cable/"
+  }]
+}
+</script>
+<form class="variations_form"
+      data-product_variations='[
+        {"attributes":{"attribute_pa_color":"earth"},"display_price":2776.6638,"display_regular_price":2985.66,"is_in_stock":true,"sku":"PARENT-1-E","variation_id":10496,"variation_is_active":true,"variation_is_visible":true},
+        {"attributes":{"attribute_pa_color":"red"},"display_price":2500.0,"display_regular_price":2500.0,"is_in_stock":false,"sku":"PARENT-1-R","variation_id":10497,"variation_is_active":true,"variation_is_visible":true}
+      ]'>
+  <label for="pa_color">Color</label>
+  <select name="attribute_pa_color" id="pa_color">
+    <option value="">اختر</option>
+    <option value="earth">أرضي</option>
+    <option value="red">أحمر</option>
+  </select>
+</form>
+</body>
+</html>

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -194,14 +194,24 @@ def _tables_from_live_fixture():
         def get(self, url, **kw):
             class R:
                 status_code = 200
-                text = Path(__file__).parent.joinpath(
-                    "fixtures/live/samehgabriel_wc_store_products_2026-07-20.json"
-                ).read_text(encoding="utf-8")
+                # A real httpx.Response always carries headers, and the connector
+                # reads X-WP-TotalPages off them. A stub without them would force
+                # a getattr default into the product and let this test travel a
+                # path the live crawl never takes. Empty = "this shop announces
+                # no page count", which is the shape of the 2026-07-20 capture.
+                headers: dict[str, str] = {}
+                def __init__(self, payload):
+                    self._payload = payload
                 def json(self):
-                    return json.loads(self.text)
-                headers = {}
+                    return self._payload
             self.requests_count += 1
-            return R()
+            page = (kw.get("params") or {}).get("page", 1)
+            payload = (json.loads(Path(__file__).parent.joinpath(
+                "fixtures/live/samehgabriel_wc_store_products_2026-07-20.json"
+            ).read_text(encoding="utf-8")) if page == 1 else [])
+            return R(payload)
+        def get_dropping(self, url, optional=(), **kw):
+            return self.get(url, **kw)
         def close(self): pass
 
     connector = WooCommerceConnector(_Fetcher())

--- a/tests/test_http_fetcher.py
+++ b/tests/test_http_fetcher.py
@@ -85,6 +85,69 @@ def test_a_client_error_is_not_retried():
     assert len(seen) == 1
 
 
+# ---- optional request shape: learn once, never hide the cost ----------------
+
+def test_an_optional_parameter_refused_by_the_host_is_dropped_once_and_recorded():
+    """samehgabriel's live rule: the endpoint answers, `per_page` does not."""
+    fetcher, seen = fetcher_over([
+        httpx.Response(403),
+        httpx.Response(200, json=[{"id": 1}]),
+        httpx.Response(200, json=[]),
+    ], max_attempts=1)
+
+    first = fetcher.get_dropping(
+        URL, optional=("per_page",), params={"per_page": 100, "page": 1})
+    second = fetcher.get_dropping(
+        URL, optional=("per_page",), params={"per_page": 100, "page": 2})
+
+    assert first.json() == [{"id": 1}] and second.json() == []
+    assert dict(seen[0].url.params) == {"per_page": "100", "page": "1"}
+    assert dict(seen[1].url.params) == {"page": "1"}
+    assert dict(seen[2].url.params) == {"page": "2"}, (
+        "the proven-refused parameter was tried again on the next page")
+    assert len(fetcher.degradations) == 1
+    assert "per_page" in fetcher.degradations[0] and "HTTP 403" in fetcher.degradations[0]
+
+
+def test_a_parameter_lesson_belongs_to_the_host_that_taught_it():
+    """One host's edge rule must not rewrite requests to another host."""
+    fetcher, seen = fetcher_over([
+        httpx.Response(403), httpx.Response(200), httpx.Response(200),
+    ], max_attempts=1)
+
+    fetcher.get_dropping(
+        URL, optional=("per_page",), params={"per_page": 100, "page": 1})
+    fetcher.get_dropping(
+        "https://other.test/products", optional=("per_page",),
+        params={"per_page": 100, "page": 1})
+
+    assert seen[-1].url.params["per_page"] == "100"
+
+
+def test_a_rate_limit_is_never_rephrased_as_an_optional_parameter_problem():
+    fetcher, seen = fetcher_over([httpx.Response(429)], max_attempts=1)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        fetcher.get_dropping(
+            URL, optional=("per_page",), params={"per_page": 100, "page": 1})
+
+    assert len(seen) == 1, "429 was followed immediately by a differently shaped request"
+    assert fetcher.degradations == []
+
+
+def test_a_second_refusal_does_not_teach_a_lesson_the_host_never_proved():
+    fetcher, seen = fetcher_over(
+        [httpx.Response(403), httpx.Response(403)], max_attempts=1)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        fetcher.get_dropping(
+            URL, optional=("per_page",), params={"per_page": 100, "page": 1})
+
+    assert len(seen) == 2
+    assert fetcher.degradations == []
+    assert fetcher._refused_params == set()
+
+
 def test_retry_after_is_honoured_over_our_own_backoff(monkeypatch):
     slept: list[float] = []
     monkeypatch.setattr("scrapex.connectors.base.time.sleep", slept.append)
@@ -201,6 +264,28 @@ def test_validators_survive_between_crawls():
     later.get(URL)
 
     assert seen[0].headers["If-None-Match"] == '"v1"'
+
+
+def test_a_pages_validator_never_leaks_into_another_page():
+    """A paginated endpoint is several resources even when its path is one.
+
+    The live samehgabriel Store API gives page 1 an ETag. Replaying it against
+    page 2 returns a bodyless 304, which used to make ``response.json()`` fail
+    halfway through the crawl.
+    """
+    fetcher, seen = fetcher_over([
+        httpx.Response(200, text="page one", headers={"ETag": '"p1"'}),
+        httpx.Response(200, text="page two", headers={"ETag": '"p2"'}),
+        httpx.Response(304),
+    ])
+
+    fetcher.get(URL, params={"page": 1})
+    fetcher.get(URL, params={"page": 2})
+    fetcher.get(URL, params={"page": 1})
+
+    assert seen[1].headers.get("If-None-Match") is None
+    assert seen[2].headers["If-None-Match"] == '"p1"'
+    assert set(fetcher.validators()) == {f"{URL}?page=1", f"{URL}?page=2"}
 
 
 # ---- pacing -------------------------------------------------------------------
@@ -346,6 +431,19 @@ def test_no_robots_file_means_no_constraints_and_no_noise():
     fetcher.get(URL)
     assert fetcher._min_interval_s == 0.0
     assert fetcher.robots_warnings == []
+
+
+def test_a_sitemap_fallback_reads_the_addresses_the_site_itself_advertises():
+    fetcher, seen = _fetcher_with_robots(
+        "User-agent: *\nSitemap: https://example.test/wp-sitemap.xml\n"
+        "Sitemap: https://example.test/catalogue.xml\n")
+
+    assert fetcher.sitemap_urls(URL) == [
+        "https://example.test/wp-sitemap.xml",
+        "https://example.test/catalogue.xml",
+    ]
+    assert seen == ["https://example.test/robots.txt"]
+    assert fetcher.requests_count == 0, "the robots lookup became a crawl request"
 
 
 def test_a_huge_retry_after_is_capped_loudly_not_shrunk_silently():

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -599,6 +599,56 @@ def test_the_db_lock_wraps_only_the_ingest_not_the_network_fetch(tmp_path):
     assert held == [False], "the DB lock was held across the network fetch"
 
 
+def test_capture_reports_a_fetcher_degradation_once(tmp_path):
+    """A recovered request is still evidence about how the crawl succeeded.
+
+    samehgabriel refuses ``per_page`` but accepts the same Store API request
+    without it.  The adaptive fetcher keeps the crawl alive; capture must carry
+    that fact to the caller instead of losing it between HTTP and the run log.
+    """
+    from scrapex.capture import capture_source
+    from scrapex.config import ExtractSpec, SourceEntry
+    from scrapex.connectors.base import ScrapedTable
+    from scrapex.rowspec import PRODUCT_PRICES
+    from scrapex.vocab import ExtractKind, ExtractScope
+
+    conn = dbmod.connect(tmp_path / "degradation.db")
+    dbmod.migrate(conn)
+    entry = SourceEntry.model_validate(dict(
+        source_key="SAMEHGABRIEL", source_name="Sameh Gabriel",
+        base_url="https://samehgabriel.com", family="woocommerce-storeapi",
+        currency="EGP", default_region="EG",
+        extract=[ExtractSpec(kind=ExtractKind.PRODUCT_PRICES,
+                             scope=ExtractScope.CENSUS)]))
+    note = "samehgabriel.com refused optional query parameter per_page; retried without it"
+
+    class _Connector:
+        connector_id = "woocommerce-store-api"
+
+        def fetch(self, source):
+            yield ScrapedTable(source.source_key, PRODUCT_PRICES.kind, source.base_url,
+                               list(PRODUCT_PRICES.columns), [], warnings=[note])
+
+    class _Fetcher:
+        requests_count = 2
+        degradations = [note]
+        robots_warnings = []
+
+        def close(self):
+            pass
+
+    import scrapex.capture as capmod
+    original = capmod.build_connector
+    capmod.build_connector = lambda e, crawl=None: (_Connector(), _Fetcher())
+    try:
+        result = capture_source(conn, entry)
+    finally:
+        capmod.build_connector = original
+        conn.close()
+
+    assert result.warnings == [note], "the degradation was lost or duplicated"
+
+
 def test_locked_capture_forwards_every_capture_keyword(tmp_path):
     """Regression (owner-reported: every full_rebuild failed on an unexpected
     'archive_first'). run_job_once passes history/resume/archive_first through

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -29,6 +29,8 @@ class _StubFetcher:
             if needle in url:
                 return resp
         raise RuntimeError("404")
+    def get_dropping(self, url, optional=(), **kw):
+        return self.get(url, **kw)
     def close(self):
         pass
 

--- a/tests/test_salla.py
+++ b/tests/test_salla.py
@@ -39,6 +39,16 @@ def test_offer_price_falls_back_to_lowprice():
     assert offer_price({"price": 0})[0] == ""  # no fallback -> skipped upstream
 
 
+def test_offer_price_reads_woocommerces_unit_price_specification():
+    price, currency, availability = offer_price({
+        "priceSpecification": [{"@type": "UnitPriceSpecification",
+                                "price": "2776.66", "priceCurrency": "EGP"}],
+        "availability": "https://schema.org/InStock",
+    })
+    assert (price, currency) == ("2776.66", "EGP")
+    assert availability.endswith("/InStock")
+
+
 # ---- full fetch (stubbed) ----------------------------------------------------
 
 class _Resp:

--- a/tests/test_the_addin_contract_cannot_drift.py
+++ b/tests/test_the_addin_contract_cannot_drift.py
@@ -19,11 +19,24 @@ TWO KINDS OF DRIFT, AND ONLY ONE CAN BE AUTOMATED.
   transform is dropped rather than refused", "a source with no mappings hard-fails"
   — none of that is in a type, and no generator will ever find it.
 
-So behaviour is pinned to a NUMBER instead. mbiXaddin raises `behaviourVersion`
-when it changes how a fault is handled; extension/addin-contract.js records the
-version its reading was taken against; and the second test fails when they
-differ. It cannot force anyone to re-read the code. It can make it impossible to
-change the behaviour SILENTLY, which is the whole of what a guard can do here.
+So behaviour is pinned to a NUMBER — and that number is BOOKKEEPING, not a
+signal from upstream. This file said otherwise until 2026-08-15, and the
+correction matters more than the sentence it replaces:
+
+  mbiXaddin HAS NO `behaviourVersion`. It was proposed to them in
+  docs/HANDOFF-mbiXaddin-contract-producer.md and has not been built. Both
+  numbers — contract/addin-contract.json's and extension/addin-contract.js's —
+  live in THIS repository, and the same commit raises both. Their agreement
+  proves ScrapeX is internally consistent about which reading generation it is
+  on. IT CANNOT DETECT THAT MBIXADDIN CHANGED. Believing it could is what let
+  three of this reading's own cited files move unnoticed.
+
+WHAT ACTUALLY LOOKS UPSTREAM is the last test here. The reading records the
+COMMIT it was taken against, and the .cs files it cites are its surface — so
+"has anything I read moved?" is a real question with a computable answer. That
+test needs the add-in's checkout beside this one; where it is absent it SKIPS
+AND SAYS SO, because a guard that is quietly green is the defect this file was
+written about.
 """
 from __future__ import annotations
 
@@ -80,15 +93,19 @@ def test_the_generated_file_says_it_is_generated():
 
 
 def test_the_behaviour_reading_is_not_older_than_the_contract():
-    """THE HALF NO GENERATOR CAN CHECK.
+    """THE TWO HALVES OF ScrapeX'S OWN RECORD AGREE ON WHICH READING THEY ARE ON.
 
     extension/addin-contract.js holds what had to be READ rather than reflected
-    over — what a blank means, what is dropped, what fails a table. When
-    mbiXaddin raises its behaviourVersion it is saying one of those answers has
-    moved, and this fails until someone goes and looks.
+    over — what a blank means, what is dropped, what fails a table. The JSON
+    declares which generation of that reading the repository is shipping; the
+    module declares which one it was written against. When they disagree, half
+    the reading was updated and half was not.
 
-    Raising the number here WITHOUT re-reading would satisfy this test and
-    defeat the only mechanism guarding that half. The message says so.
+    WHAT THIS DOES NOT DO, stated here because the docstring claimed it for
+    three days: it is NOT a signal from mbiXaddin. Both numbers are ours and one
+    commit raises both, so nothing here notices the add-in changing. That is
+    test_no_cited_addin_file_has_moved_since_the_reading below, and the number
+    is the bookkeeping beside it — not a substitute for it.
     """
     declared = _contract()["behaviourVersion"]
     read_against = re.search(
@@ -101,11 +118,13 @@ def test_the_behaviour_reading_is_not_older_than_the_contract():
 
     assert int(read_against.group(1)) == declared, (
         f"the contract declares behaviour version {declared} and the Console's "
-        f"reading was taken against {read_against.group(1)}. mbiXaddin changed "
-        "how it handles a fault or a default — go and re-read that behaviour "
-        "from its code, update extension/addin-contract.js, and only then raise "
-        "READ_AGAINST_BEHAVIOUR_VERSION. Raising the number alone makes this "
-        "test green and the Console wrong.")
+        f"reading was taken against {read_against.group(1)}, so one half of the "
+        "record moved without the other. Whichever is behind, the repair is the "
+        "same: re-read the behaviour from the add-in's code at the contract's "
+        "readAgainstCommit, update extension/addin-contract.js, and raise both "
+        "numbers together. Raising them alone makes this test green and proves "
+        "nothing — these numbers are ScrapeX's bookkeeping, not mbiXaddin's "
+        "signal.")
 
 
 def test_every_sheet_the_contract_names_carries_a_gid_and_its_columns():
@@ -161,26 +180,124 @@ def test_the_arabic_spellings_survived_the_json_round_trip():
 
 
 def test_the_address_markers_are_the_add_ins_own_literals():
-    """`SourceUriValidator` searches the whole address for these three, and every
-    Console warning about an address is keyed on them. Inline, they drifted
-    silently; here, a change to the add-in has to be typed on purpose.
+    """The parsed Sheets hosts and the two whole-address parameter markers.
 
-    The lower case matters and is not cosmetic: the add-in lower-cases the
-    address before searching, so a marker carrying a capital would never match
-    and the Console would fall silent about the mistake its own file header calls
-    the commonest one there is."""
+    These moved in mbiXAddin PR #26: host equality replaced a whole-string
+    `docs.google.com` substring and added the genuine spreadsheets host. A
+    stale single marker would recreate the repaired false positives here."""
     constants = _contract()["constants"]
 
-    assert constants["URI_GOOGLE_SHEETS_MARKER"] == "docs.google.com"
+    assert constants["URI_GOOGLE_SHEETS_HOSTS"] == [
+        "docs.google.com", "spreadsheets.google.com"]
     assert constants["URI_TSV_MARKERS"] == ["output=tsv", "format=tsv"]
     assert constants["URI_TAB_MARKER"] == "gid="
 
-    for name in ("URI_GOOGLE_SHEETS_MARKER", "URI_TAB_MARKER"):
-        assert constants[name] == constants[name].lower(), (
-            f"{name} is compared against a lower-cased address and would never "
-            "match")
+    for host in constants["URI_GOOGLE_SHEETS_HOSTS"]:
+        assert host == host.lower() and host == host.strip("."), (
+            f"{host!r} is not the normalised host SourceUriValidator compares")
+    assert constants["URI_TAB_MARKER"] == constants["URI_TAB_MARKER"].lower()
     for marker in constants["URI_TSV_MARKERS"]:
         assert marker == marker.lower()
+
+
+# ---- the guard that actually looks upstream ---------------------------------
+#
+# WHERE THE ADD-IN'S CHECKOUT IS EXPECTED. A sibling of this repository, which is
+# how the owner keeps them. Absent — on CI, on a fresh clone — the test below
+# SKIPS and names what it could not do. That is deliberate: it is the one guard
+# here whose subject lives outside the repository, and pretending otherwise is
+# the failure this whole file is about.
+ADDIN_CHECKOUT = ROOT.parent / "mbiXaddin"
+READING = ROOT / "docs" / "reviews" / "mbiXaddin-config-contract-20260812.md"
+
+
+def _addin_git(*args: str) -> str | None:
+    """`git` inside the add-in checkout, or None when it cannot answer."""
+    try:
+        done = subprocess.run(("git", "-C", str(ADDIN_CHECKOUT), *args),
+                              capture_output=True, text=True, timeout=60)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return done.stdout.strip() if done.returncode == 0 else None
+
+
+def test_no_cited_addin_file_has_moved_since_the_reading():
+    """Has anything the Console's reading was taken FROM changed since?
+
+    THIS IS THE ONE THAT LOOKS UPSTREAM, and until 2026-08-15 nothing did. The
+    behaviour numbers above are both ours; they cannot notice mbiXaddin moving.
+    Measured the day this was written: three of the eighty .cs files this
+    reading cites had already moved, and no test anywhere had an opinion.
+
+    THE SURFACE IS THE READING'S OWN CITATIONS. Every answer in
+    docs/reviews/mbiXaddin-config-contract-20260812.md carries the file it came
+    from, so those files are exactly what the Console believes it has read. The
+    whole add-in is the wrong unit — it releases constantly, and a guard that
+    fired on every unrelated commit is a guard that gets skipped.
+
+    A file that has moved is a QUESTION, not a verdict. Read it; if it does not
+    touch what the Console believes, record it in `reviewedSince` with the blob
+    it was dismissed at and why. Pinning the blob is what stops that entry
+    becoming a permanent exemption: the next edit changes it and this fires
+    again.
+    """
+    contract = _contract()
+    read_against = contract.get("readAgainstCommit", "")
+    assert re.fullmatch(r"[0-9a-f]{40}", read_against), (
+        "contract/addin-contract.json does not record the 40-character commit "
+        "its reading was taken against, so nothing can ask what has moved since")
+
+    if _addin_git("rev-parse", "--git-dir") is None:
+        pytest.skip(
+            f"the add-in checkout is not at {ADDIN_CHECKOUT} — upstream drift "
+            "since " + read_against[:12] + " was NOT checked by this run")
+    if _addin_git("cat-file", "-t", read_against) != "commit":
+        pytest.skip(
+            f"{ADDIN_CHECKOUT} does not contain {read_against[:12]}; fetch it "
+            "before trusting a green run here")
+    if _addin_git("rev-parse", "--verify", "origin/main") is None:
+        pytest.skip(f"{ADDIN_CHECKOUT} has no origin/main to compare against")
+
+    assert READING.exists(), (
+        f"{READING.name} is the reading itself — its file:line citations ARE the "
+        "surface this guard watches. Moved or deleted, there is nothing left to "
+        "compare and the Console's knowledge has no recorded source")
+    cited = set(re.findall(r"[A-Za-z0-9_]+\.cs", READING.read_text(encoding="utf-8")))
+    changed = _addin_git("diff", "--name-only", read_against, "origin/main", "--", "*.cs")
+    # The reading cites bare filenames; git answers with repository paths. Keep
+    # the path so the blob below is looked up rather than guessed at.
+    moved = {path.rsplit("/", 1)[-1]: path
+             for path in (changed or "").splitlines() if path}
+
+    reviewed = contract.get("reviewedSince", {})
+    unexplained = []
+    for name in sorted(cited & set(moved)):
+        entry = reviewed.get(name)
+        blob = _addin_git("rev-parse", f"origin/main:{moved[name]}")
+        if entry is None:
+            unexplained.append(f"{name} — moved and is not in reviewedSince")
+        elif not str(entry.get("why", "")).strip():
+            unexplained.append(f"{name} — recorded with no reason")
+        elif blob is not None and entry.get("blob") != blob:
+            unexplained.append(
+                f"{name} — dismissed at blob {str(entry.get('blob'))[:12]} and "
+                f"has since moved to {blob[:12]}")
+
+    assert not unexplained, (
+        "the Console's reading of mbiXaddin cites files that have changed since "
+        f"{read_against[:12]}, and this is the only thing that would have said "
+        "so:\n  " + "\n  ".join(unexplained)
+        + "\n\nRead each one at origin/main. If it does not change what the "
+          "Console believes, add or update its entry in the contract's "
+          "reviewedSince with the current blob and the reason. If it does, the "
+          "reading is stale — re-read it and raise behaviourVersion.")
+
+    stale = set(reviewed) - (cited & set(moved))
+    assert not stale, (
+        f"reviewedSince still carries {sorted(stale)}, which no longer appear "
+        "as moved cited files — either the reading was refreshed past them or "
+        "they were never cited. A dismissal list nobody prunes becomes a "
+        "permission slip.")
 
 
 def _js_object(source: str, name: str) -> dict[str, str]:

--- a/tests/test_woocommerce.py
+++ b/tests/test_woocommerce.py
@@ -11,6 +11,9 @@ import json
 import sqlite3
 from pathlib import Path
 
+import httpx
+import pytest
+
 from scrapex import db as dbmod
 from scrapex.config import ExtractSpec, SourceEntry
 from scrapex.connectors.woocommerce import WooCommerceConnector
@@ -25,7 +28,10 @@ VARIATION = json.loads((FX / "woocommerce_variation_10491.json").read_text(encod
 
 
 class _StubResponse:
-    def __init__(self, payload): self._payload = payload
+    def __init__(self, payload=None, *, text="", headers=None):
+        self._payload = payload
+        self.text = text
+        self.headers = headers or {}
     def json(self): return self._payload
 
 
@@ -37,6 +43,8 @@ class _StubFetcher:
             return _StubResponse(VARIATION)
         page = (params or {}).get("page", 1)
         return _StubResponse(FIXTURE if page == 1 else [])
+    def get_dropping(self, url, optional=(), **kwargs):
+        return self.get(url, **kwargs)
     def close(self): pass
 
 
@@ -283,3 +291,99 @@ def test_every_live_variation_price_survives_the_new_guard():
     table = next(iter(WooCommerceConnector(_Live()).fetch(make_entry())))
     assert len(table.rows) == sum(len(p.get("variations") or []) for p in LIVE)
     assert not any("RANGE" in w for w in table.warnings)
+
+
+# ---- a host may refuse the Store API shape without losing its public pages ---
+
+class _PageFallbackFetcher:
+    def __init__(self):
+        self.requests_count = 0
+        self.calls: list[tuple[str, dict]] = []
+
+    def sitemap_urls(self, base):
+        return [f"{base}/wp-sitemap.xml"]
+
+    def get_dropping(self, url, optional=(), **kwargs):
+        self.requests_count += 1
+        self.calls.append((url, kwargs))
+        request = httpx.Request("GET", url)
+        response = httpx.Response(403, request=request)
+        raise httpx.HTTPStatusError("refused", request=request, response=response)
+
+    def get(self, url, **kwargs):
+        self.requests_count += 1
+        self.calls.append((url, kwargs))
+        if url.endswith("/wp-sitemap.xml"):
+            return _StubResponse(text=(
+                '<sitemapindex><sitemap><loc>'
+                'https://samehgabriel.com/wp-sitemap-posts-product-1.xml'
+                '</loc></sitemap></sitemapindex>'))
+        if url.endswith("/wp-sitemap-posts-product-1.xml"):
+            return _StubResponse(text=(
+                '<urlset><url><loc>https://samehgabriel.com/product/cable/'
+                '</loc></url></urlset>'))
+        if url == "https://samehgabriel.com/product/cable/":
+            html = (FX / "woocommerce_product_jsonld.html").read_text(encoding="utf-8")
+            return _StubResponse(text=html)
+        raise AssertionError(f"unexpected request: {url}")
+
+
+def test_store_api_refusal_falls_back_to_jsonld_without_losing_variation_ids():
+    fetcher = _PageFallbackFetcher()
+
+    tables = list(WooCommerceConnector(fetcher).fetch(make_entry()))
+    price_tables = [table for table in tables if table.rows]
+    summary = tables[-1]
+
+    assert len(price_tables) == 1 and len(price_tables[0].rows) == 2
+    view = RowView(PRODUCT_PRICES, price_tables[0].header)
+    earth, red = [view.as_dict(row) for row in price_tables[0].rows]
+    assert earth["external_product_id"] == "10150"
+    assert earth["external_variant_id"] == "10496"
+    assert earth["variant_ar"] == "Color: أرضي"
+    assert earth["price"] == "2776.66" and earth["price_sale"] == "2776.66"
+    assert red["external_variant_id"] == "10497"
+    assert red["availability"] == "out_of_stock"
+    assert any("public product pages" in warning for warning in summary.warnings)
+    product_call = next(call for call in fetcher.calls if call[0].endswith("/product/cable/"))
+    assert "text/html" in product_call[1]["headers"]["Accept"]
+
+
+@pytest.mark.parametrize("status", [429, 500, 503])
+def test_rate_limits_and_server_failures_never_trigger_more_fallback_requests(status):
+    """A sick or rate-limited server needs less traffic, not a sitemap walk."""
+    class _FailingFetcher:
+        requests_count = 1
+
+        def get_dropping(self, url, optional=(), **kwargs):
+            request = httpx.Request("GET", url)
+            response = httpx.Response(status, request=request)
+            raise httpx.HTTPStatusError("unavailable", request=request,
+                                        response=response)
+
+        def get(self, url, **kwargs):
+            raise AssertionError("a failure was expanded into a fallback request")
+
+    with pytest.raises(httpx.HTTPStatusError):
+        list(WooCommerceConnector(_FailingFetcher()).fetch(make_entry()))
+
+
+def test_the_api_uses_its_announced_last_page_instead_of_probing_an_empty_one():
+    class _TwoPages(_StubFetcher):
+        def __init__(self):
+            super().__init__()
+            self.pages: list[int] = []
+        def get(self, url, params=None, **kwargs):
+            if not url.endswith("/products"):
+                return super().get(url, params=params, **kwargs)
+            self.requests_count += 1
+            page = (params or {}).get("page", 1)
+            self.pages.append(page)
+            payload = [FIXTURE[0]] if page in (1, 2) else []
+            return _StubResponse(payload, headers={"X-WP-TotalPages": "2"})
+
+    fetcher = _TwoPages()
+    tables = list(WooCommerceConnector(fetcher).fetch(make_entry()))
+
+    assert len([table for table in tables if table.kind == PRODUCT_PRICES.kind]) == 2
+    assert fetcher.pages == [1, 2]


### PR DESCRIPTION
**Three things, and the second and third are what the first uncovered.**

## samehgabriel was dead since 1 August over one parameter

Measured — and the measurement overturned three things I had said out loud before it.

| request | answer |
|---|---|
| `/wp-json/wc/store/products` | **200** |
| `…?page=1` | **200** |
| `…?per_page=1` · `10` · `20` · `50` · `100` | **403**, every value |

Not the page size, not the range. **Not a firewall and not our user-agent** — a browser UA was tried and changed nothing. The presence of that one parameter trips a rule at the edge.

`HttpFetcher.get_dropping` asks again **without** the parameters the caller named optional — once, and only for statuses that can mean *"not in that shape"*. **429 is deliberately excluded**: asking again immediately in any shape is the one thing a rate-limited site has just told us not to do. The lesson is kept per `(host, parameter)`, because a parameter name alone is not a site decision.

And the degradation is **recorded into the run's warnings, not absorbed** — a crawl that quietly costs ten times the requests is a bill nobody sees until it is a block.

### The page size is now observed, and that is the dangerous half

`len(products) < PER_PAGE` is only true while the site honours the size we asked for. The moment one refuses `per_page` and answers with its own default of ten, **that test is true on the first page**: the crawl stops after ten products *while reporting success*. That is a worse failure than the 403 it replaced, because it looks like a complete run.

The API's own `X-WP-TotalPages` leads; the observed size is the fallback; the size we asked for is never trusted.

### A second defect nobody was looking for

Validators were cached by path, so **page two inherited page one's ETag and answered 304 with no body**. An ETag for `?page=1` says nothing about `?page=2`.

### And a JSON-LD fallback, with its cost written down

Over the site's own sitemap when the Store API shape is gone — never on 429 or 5xx, never mid-crawl. The entry gate is narrow and the comment now says why: the two routes token their pages differently (`page-1` vs `safe_token(url)`), so a journal holding both would **ingest the same products twice**.

The cost is stated rather than discovered: **an interrupted fallback crawl cannot resume** and fails until its journal is cleared. A visible failure was chosen over a doubled price history.

## The mirror of SourceUriValidator, after mbiXaddin merged its repair

Their PR #26. It decides by **parsed host** now — `docs.google.com` and `spreadsheets.google.com` exactly, trailing root dot normalised away. The Console's TSV and gid rules follow that decision instead of a mention, and an impostor address gets the add-in's own `ERR_FORMAT` naming the host actually serving it.

The **scheme gate** on that mirror is not decoration: the add-in reaches the Sheets question only inside `if (isHttp)`, and `new URL()` will happily parse `ftp://docs.google.com/x` and hand back Google's host.

## And the guard over all of it was not a guard

This is the finding this PR exists for.

`behaviourVersion` lives in `contract/addin-contract.json` and `READ_AGAINST_BEHAVIOUR_VERSION` in `extension/addin-contract.js` — **both ours, raised by the same commit**. mbiXaddin has no `behaviourVersion`; it was proposed to them and has not been built. Their agreement proved this repository was internally consistent and *nothing whatever* about the add-in. The docstring claimed otherwise and I repeated that claim twice.

So the reading now records the **commit** it was taken against, and a test asks the add-in's own checkout what has moved since — scoped to the `.cs` files the reading cites, because the whole add-in releases constantly and a guard that fires on every unrelated commit is one people learn to skip.

### It found three already

Of the **eighty** files this reading cites, three had moved and nothing anywhere had an opinion:

| file | read, and dismissed because |
|---|---|
| `EndpointCatalog.cs` | a comment about which release endpoint is still served — **the six compiled-in sheet gids the Console refuses a wrong workbook by are untouched** (checked, not assumed) |
| `HttpClientService.cs` | 5xx backoff bounded by the caller's timeout — network retry, decides nothing about the six sheets |
| `mbiXRibbon.cs` | one click throttle across five ribbon buttons — UI plumbing, not `6.RibbonControls` semantics |

Each is pinned to the **blob** it was dismissed at, so the next edit fires the guard again. The list is pruned by its own test: a dismissal list nobody prunes becomes a permission slip.

Where the add-in's checkout is absent — CI, a fresh clone — the test **skips and says what it did not check**. A quietly green guard is the defect it was written about.

## Proof

**Thirteen mutations, each caught:** the scheme gate removed · the response-headers stub emptied · every `reviewedSince` entry deleted, blob-staled, reason-emptied and left stale · `readAgainstCommit` removed. And the absent-checkout case skips loudly rather than passing.

**Live verification of the connector:** two pages, 10 + 8 = 18 products.

**2441 engine tests · 326 extension tests · ruff clean · generator consistent.**

## One question for the owner

`scrapex/version.py` was **not** touched, following #190 (T1), which changed crawl pacing the same way and shipped without a ledger entry. The capability gate is green either way. But *"the crawl falls back to product pages when the Store API refuses"* is exactly the kind of thing you will later ask **"does my build do that?"** about — which is the failure `test_version.py`'s own docstring says the ledger exists to prevent. **Should this get a capability and a version bump?** Your call, not mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
