### PR TITLE
Every first load of the Data page aborted itself, and only opening it found that

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,20 +119,42 @@ jobs:
       - name: Validate the manifest (S5 gate — a broken contract can't merge)
         run: python -m scrapex.cli validate-manifest
 
-      - name: The panel suite must RUN, not skip
-        # tests/test_panel_dom.py opens with pytest.importorskip("playwright"),
-        # so before this job installed the browser it skipped in CI on every
-        # run — 48 behavioural tests, including the panel's only XSS guard,
-        # reported as a green suite for months. A guard that can vanish quietly
-        # is the defect; this is what makes the vanishing loud.
+      - name: Every browser-driven suite must RUN, not skip
+        # A suite that opens with pytest.importorskip("playwright") collects
+        # NOTHING when the browser is absent, and pytest reports that as a
+        # skip — not a failure. It happened: 48 behavioural tests, including the
+        # panel's only XSS guard, were reported as a green suite for months.
+        #
+        # THE FILES ARE DISCOVERED, NOT NAMED. This step named test_panel_dom.py
+        # alone until 2026-08-15, and tests/test_tab_page_dom.py — written that
+        # day, to catch a defect no static test could — would have vanished the
+        # same silent way. A guard that lists its subjects fails on the one
+        # nobody added to the list.
         run: |
           # `-q --collect-only` prints one summary line per file:
           #   tests/test_panel_dom.py: 53
           # so the count is the trailing number. tr strips the CR a
           # Windows checkout leaves there, which would eat the match.
-          count=$(python -m pytest tests/test_panel_dom.py --collect-only -q | tr -d '\r' | grep -oE ': [0-9]+$' | grep -oE '[0-9]+' | tail -1)
-          echo "panel tests collected: ${count:-0}"
-          test "${count:-0}" -ge 40
+          collected() {
+            python -m pytest "$1" --collect-only -q | tr -d '\r' \
+              | grep -oE ': [0-9]+$' | grep -oE '[0-9]+' | tail -1
+          }
+          # tests/*.py, NOT -r: a recursive grep also matches the compiled
+          # copies under __pycache__, whose names collect nothing and would fail
+          # this step for a reason that has nothing to do with the browser.
+          suites=$(grep -l 'importorskip("playwright"' tests/*.py | tr -d '\r' | sort)
+          echo "browser suites found:"; echo "$suites"
+          test -n "$suites"
+          for suite in $suites; do
+            count=$(collected "$suite")
+            echo "  $suite: ${count:-0}"
+            # Any zero means the browser is missing and the suite skipped.
+            test "${count:-0}" -ge 1
+          done
+          # The panel's own floor stays a NUMBER, because the count is the thing
+          # that regressed before and a per-file "at least one" would not have
+          # noticed 48 becoming 1.
+          test "$(collected tests/test_panel_dom.py)" -ge 40
 
       - name: The extension gate must not have emptied
         # The same reasoning as the line above, for the set the split depends

--- a/extension/app.html
+++ b/extension/app.html
@@ -1726,15 +1726,6 @@
                     <use href="icons/material-icons.svg#open-in-new"></use>
                   </svg>
                 </button>
-                <!-- The Data page, which now ships INSIDE the extension (plan
-                     B2). It opens per source, so it acts on the selection. -->
-                <button type="button" class="link" id="open-data-table">
-                  Open the data table
-                  <svg class="sx-icon sm" aria-hidden="true">
-                    <use href="icons/material-icons.svg#open-in-new"></use>
-                  </svg>
-                </button>
-                <p id="open-data-note" class="muted text-sm" role="status"></p>
               </div>
             </div>
           </article>

--- a/extension/app.js
+++ b/extension/app.js
@@ -4200,6 +4200,13 @@ function freshnessLine(s) {
 const SOURCE_ACTIONS = [
   {action: "update", label: "Update now",
    why: "Crawl this source once, immediately."},
+  // THE DATA PAGE, WHICH NOW SHIPS INSIDE THE EXTENSION (plan B2). It sits
+  // beside the workbook link rather than replacing it: the engine's page still
+  // has the details drawer, saved views and Choose-Columns, and taking those
+  // away before the replacement carries them would be a downgrade wearing the
+  // word "migration". The workbook entry goes when this one has them.
+  {action: "table", label: "Open the data table",
+   why: "This source's rows, in a page that ships with the extension."},
   {action: "changes", label: "Recent changes",
    why: "What moved since the last crawl."},
   {action: "settings", label: "Source settings",
@@ -4235,6 +4242,13 @@ function sourceMenu(source) {
 
 /** Everything a source menu can do, in one place so the card stays a template. */
 async function runSourceAction(action, key) {
+  // chrome.runtime.getURL, NOT openTab: openTab prefixes the engine's address,
+  // and this page ships in the extension. It still reads the engine for its
+  // rows — the difference is that the PAGE is ours.
+  if (action === "table") {
+    return chrome.tabs.create({url: chrome.runtime.getURL(
+      "data.html?source=" + encodeURIComponent(key))});
+  }
   if (action === "changes") return openTab(`/source/${key}#changes`);
   if (action === "settings") return openTab(`/sources/${key}`);
   if (action === "update") {
@@ -5943,27 +5957,6 @@ function wireDeferredControls() {
   $("console-open").addEventListener("click", () =>
     chrome.tabs.create({ url: chrome.runtime.getURL("console.html") }));
   $("open-browse").addEventListener("click", () => openTab("/"));
-  // chrome.runtime.getURL like the Console, NOT openTab: the page ships in the
-  // extension now. It still reads the engine for its rows, but the PAGE is ours
-  // — which is the whole of what B2 moved.
-  //
-  // It acts on the selection because a data table is per source, and it SAYS SO
-  // rather than opening on an arbitrary one: picking the first of three would
-  // put the wrong shop's prices in front of the owner under a title he did not
-  // choose.
-  $("open-data-table").addEventListener("click", () => {
-    const chosen = [...state.selected];
-    if (chosen.length !== 1) {
-      $("open-data-note").textContent = chosen.length
-        ? `${chosen.length} sources are selected. A data table is one source — `
-          + "select just the one you want to read."
-        : "Select a source first: a data table is one source's rows.";
-      return;
-    }
-    $("open-data-note").textContent = "";
-    chrome.tabs.create({url: chrome.runtime.getURL(
-      "data.html?source=" + encodeURIComponent(chosen[0]))});
-  });
   // The workspace opens with the Storage section already expanded, so the link
   // lands on what it promised rather than on a wall of closed rows.
   $("open-storage").addEventListener("click", () => openTab("/settings#s-storage"));

--- a/extension/data.js
+++ b/extension/data.js
@@ -21,7 +21,7 @@
 // Building this on the card endpoint would have shipped cards and called it the
 // migration.
 
-import { api, backendGeneration } from "./backend.js";
+import { api, backendBase, backendGeneration } from "./backend.js";
 // The reading of a payload lives apart from this page BECAUSE this page cannot
 // be imported under `node --test` — it reads window.location and starts loading
 // the moment it is imported. Everything a wrong number could come from is in
@@ -49,6 +49,17 @@ async function load() {
       + "add ?source=SOURCE_KEY to the address.");
     return;
   }
+  // RESOLVE THE ADDRESS BEFORE READING ITS GENERATION, and the order is the
+  // whole of it. `backendBase()` ACTIVATES the backend the first time it is
+  // called, and activating bumps the generation. Capturing the number first
+  // meant capturing 0, asking, and then finding 1 — so the guard below decided
+  // a different engine was authoritative and returned WITHOUT PAINTING.
+  //
+  // Every first load did that. The page said "Reading…" for ever, in
+  // production, for everyone, and no test saw it: 2,460 engine tests and 398
+  // extension tests all pass on a page nobody had ever rendered. It was found
+  // by opening it in a browser, which is the only thing that could have.
+  await backendBase();
   const generation = backendGeneration();
   show("data-blocked", "");
   $("data-source").textContent = SOURCE_KEY;

--- a/tests/test_tab_page_dom.py
+++ b/tests/test_tab_page_dom.py
@@ -1,0 +1,183 @@
+"""The Data page, RENDERED — the only kind of test that could have caught it.
+
+THE DEFECT THIS FILE EXISTS FOR. The page read the backend generation before
+`backendBase()` had resolved the address; resolving it bumped the generation;
+the freshness guard then decided a different engine was authoritative and
+returned without painting. EVERY FIRST LOAD did that — "Reading…" for ever, in
+production, for everyone.
+
+2,460 engine tests and 398 extension tests were green on it. They could not have
+been otherwise: every one of them is static, or drives a pure function. Nothing
+had ever put the page in a browser and looked.
+
+WHAT THESE TESTS ARE FOR, so the file does not sprawl. They assert what only a
+rendered page can settle: that it paints at all, that the ordering of its awaits
+is right, and that its own sentences reach the screen. Column labels, formatting
+and the payload's arithmetic are covered where they belong — pure, and without a
+browser, in extension/tests/datatable.test.mjs.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Guards the extension: this file reads extension/ sources, so a change there
+# must run it. See tests/test_the_extension_gate_is_complete.py.
+pytestmark = pytest.mark.extension
+
+pytest.importorskip("playwright", reason="needs the browser extra")
+from playwright.sync_api import sync_playwright  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
+import tabpage_harness as harness  # noqa: E402
+
+#: Shaped like `/api/table`'s real answer, small enough to read. The columns and
+#: their order are the payload's, which is the contract this page relies on.
+PAYLOAD = {
+    "source_key": "SAMEHGABRIEL",
+    "columns": [{"key": "product_name_ar", "label": "Product name (AR)"},
+                {"key": "price", "label": "Price"},
+                {"key": "currency", "label": "Currency"}],
+    "rows": [{"offer_id": 1, "product_name_ar": "سلك نحاس شعر 1 مم",
+              "price": "120.00", "currency": "EGP"},
+             {"offer_id": 2, "product_name_ar": "كابل مسلح", "price": "340.50",
+              "currency": "EGP"}],
+    "total": 2, "returned": 2, "truncated": False,
+    "folded": False, "foldable": True, "bilingual": True,
+    "tax_states": {}, "tree": {}, "moved_to_details": [],
+}
+
+
+@pytest.fixture(scope="module")
+def browser():
+    with sync_playwright() as pw:
+        instance = pw.chromium.launch()
+        try:
+            yield instance
+        finally:
+            instance.close()
+
+
+@pytest.fixture()
+def open_data(browser, tmp_path):
+    """Open the Data page against a stubbed engine and return the live page."""
+    pages = []
+
+    def opener(payload=None, *, source="SAMEHGABRIEL", **stub_kwargs):
+        page_file = harness.build_data_page(
+            tmp_path,
+            harness.stub(PAYLOAD if payload is None else payload, **stub_kwargs),
+            name=f"data{len(pages)}.html")
+        page = browser.new_page(viewport={"width": 1280, "height": 800})
+        errors: list[str] = []
+        page.on("pageerror", lambda e: errors.append(str(e)))
+        # The source rides in the address, exactly as it does when the panel
+        # opens this page. A file:// URL carries a query string fine.
+        page.goto(page_file.as_uri() + (f"?source={source}" if source else ""))
+        page.wait_for_timeout(600)
+        page.js_errors = errors
+        pages.append(page)
+        return page
+
+    try:
+        yield opener
+    finally:
+        for page in pages:
+            page.close()
+
+
+def test_the_first_load_paints(open_data):
+    """THE REGRESSION. It failed exactly here, and silently: no exception, no
+    console error, nothing in the DOM but the word "Reading…".
+
+    A page that reports its own staleness before it has any state to be stale
+    against will always abort itself, and only a rendered page can tell."""
+    page = open_data()
+
+    assert page.locator("#data-summary").inner_text() != "Reading…", (
+        "the page never got past its own freshness guard — this is the defect "
+        "of 2026-08-15, where the generation was read before backendBase() had "
+        "resolved the address that creates it")
+    assert page.locator(".tabulator-row").count() == 2
+    assert page.js_errors == [], f"the page threw: {page.js_errors}"
+
+
+def test_it_draws_the_payload_it_was_given(open_data):
+    page = open_data()
+
+    assert page.locator("#data-source").inner_text() == "SAMEHGABRIEL"
+    assert page.locator("#data-summary").inner_text() == "2 rows · bilingual"
+    assert [h.strip() for h in page.locator(".tabulator-col-title").all_inner_texts()] \
+        == ["Product name (AR)", "Price", "Currency"]
+
+
+def test_scraped_text_reaches_the_screen_as_TEXT(open_data):
+    """Every value here came off somebody else's website. A name that arrived as
+    markup and left as markup is the whole reason the formatter is plaintext."""
+    hostile = {**PAYLOAD, "rows": [
+        {"offer_id": 1, "product_name_ar": "<img src=x onerror=alert(1)>",
+         "price": "1", "currency": "EGP"}]}
+    page = open_data(hostile)
+
+    assert page.locator("#data-grid img").count() == 0, (
+        "a product name became an element — the grid is interpreting markup")
+    assert "<img" in page.locator(".tabulator-cell").first.inner_text()
+
+
+def test_arabic_keeps_its_own_direction(open_data):
+    """An Arabic name in a left-to-right table drags the punctuation around it
+    unless the cell is isolated. The rule is stated in CSS; this is what proves
+    it reaches the rendered cell."""
+    page = open_data()
+    direction = page.evaluate(
+        "getComputedStyle(document.querySelector('.tabulator-cell')).unicodeBidi")
+    assert direction == "plaintext", f"cells render as {direction!r}"
+
+
+def test_a_prefix_says_it_is_one(open_data):
+    """The bound exists so a partial table is never read as a whole one."""
+    page = open_data({**PAYLOAD, "total": 91234, "returned": 2, "truncated": True})
+
+    assert page.locator("#data-summary").inner_text().startswith("2 of 91234")
+    notice = page.locator("#data-truncated")
+    assert "PREFIX" in notice.inner_text()
+    assert "hidden" not in (notice.get_attribute("class") or "")
+
+
+def test_a_source_with_nothing_to_fold_gets_a_switch_it_cannot_press(open_data):
+    page = open_data({**PAYLOAD, "foldable": False})
+
+    assert page.locator("#data-fold").is_disabled()
+    assert page.locator("#data-fold-label").inner_text() == \
+        "This source has no variants to fold"
+
+
+def test_a_stopped_engine_is_named_rather_than_left_blank(open_data):
+    """The failure an owner actually meets. A page that shows nothing and says
+    nothing sends them looking at the data for a fault that is in the engine."""
+    page = open_data(fail="Failed to fetch")
+
+    blocked = page.locator("#data-blocked")
+    assert "hidden" not in (blocked.get_attribute("class") or "")
+    assert "engine" in blocked.inner_text().lower()
+    assert page.locator("#data-summary").inner_text() == ""
+
+
+def test_a_page_opened_with_no_source_asks_for_one(open_data):
+    """It must not ask the engine for `/api/table/` and report the 404 as if the
+    engine were down — that sends the owner to restart something that is running
+    perfectly well."""
+    page = open_data(source="")
+
+    assert "needs a source" in page.locator("#data-blocked").inner_text()
+    assert page.evaluate("window.__ASKED__.length") == 0, (
+        "the page asked the engine for a table with no source key")
+
+
+def test_the_page_asks_for_the_source_it_was_opened_for(open_data):
+    page = open_data(source="ALSWEED")
+    asked = page.evaluate("window.__ASKED__")
+
+    assert any("/api/table/ALSWEED" in url for url in asked), asked

--- a/tools/tabpage_harness.py
+++ b/tools/tabpage_harness.py
@@ -1,0 +1,107 @@
+"""Build a runnable copy of an extension TAB page, for DOM tests.
+
+WHY THIS EXISTS, and it is not symmetry with panel_harness.py. The Data page
+shipped with a defect that every static guard passed: `load()` read the backend
+generation BEFORE `backendBase()` had resolved the address, resolving it bumped
+the generation, and the freshness guard then decided a different engine was
+authoritative and returned WITHOUT PAINTING. Every first load did that. The page
+said "Reading…" for ever, in production, and 2,460 engine tests plus 398
+extension tests were green on it — because no test had ever RENDERED the page.
+
+It was found by opening it in a browser. This is what makes that repeatable.
+
+WHAT IT DOES NOT DO. It is not the extension. `chrome.*` is a stub and the
+engine is a fixture, so this proves the page's own behaviour — its ordering, its
+sentences, what it draws — and proves nothing about Chrome's permissions, the
+service worker, or a real 127.0.0.1. Saying so matters: a harness mistaken for
+the product is how "it passed the tests" starts meaning less than it should.
+
+THE MODULE GRAPH IS FLATTENED, not re-declared. Imports are stripped and
+`export` removed, so the files that run here are the files that ship — the same
+choice panel_harness.py makes, for the same reason: a test-only re-declaration
+of a function tests the re-declaration.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+EXT = ROOT / "extension"
+
+#: In dependency order, because flattening removes the imports that expressed it.
+#: startup.js first (backend.js calls its deadline helpers), then engine.js
+#: (backend.js calls getBackend), then backend.js, then the page's own modules.
+DATA_PAGE_MODULES = ("startup.js", "transport.js", "engine.js", "backend.js",
+                     "datatable.js", "data.js")
+
+
+def flatten(source: str) -> str:
+    """One module's code with its imports and `export` keywords removed."""
+    source = re.sub(r"^import[\s\S]*?;\s*$", "", source, flags=re.M)
+    return re.sub(r"\bexport\s+", "", source)
+
+
+def stub(payload: dict | None = None, *, backend: str = "http://127.0.0.1:8000",
+         status: int = 200, fail: str = "") -> str:
+    """The two things a plain browser tab cannot have: chrome, and an engine.
+
+    `fail` makes the engine unreachable the way a stopped engine is — a rejected
+    fetch rather than an HTTP error — because those reach the page by different
+    paths and the page says different things about them.
+    """
+    body = json.dumps(payload or {}, ensure_ascii=False)
+    return f"""
+window.__ASKED__ = [];
+window.chrome = {{
+  storage: {{local: {{
+    get: async () => ({{backend: {json.dumps(backend)}}}),
+    set: async () => {{}},
+  }}}},
+  runtime: {{getURL: (path) => path}},
+  tabs: {{create: () => {{}}}},
+}};
+window.fetch = async (input, options) => {{
+  const url = String(input && input.url ? input.url : input);
+  window.__ASKED__.push(url);
+  if ({json.dumps(bool(fail))}) throw new TypeError({json.dumps(fail or "failed to fetch")});
+  return new Response({json.dumps(body)}, {{
+    status: {status},
+    headers: {{"Content-Type": "application/json"}},
+  }});
+}};
+"""
+
+
+def build_data_page(tmp: Path, stub_js: str, name: str = "data.html") -> Path:
+    """A single self-contained file that runs the real Data page.
+
+    WHICH SOURCE IT SHOWS IS NOT SET HERE. Open it with a query string —
+    `page.goto(path.as_uri() + "?source=KEY")` — because a file:// URL carries
+    one perfectly well and `window.location.search` then reads exactly what the
+    shipped page reads. The first version of this redefined `window.location`
+    instead; that property is not configurable, the assignment threw, and the
+    page fell back to "no source" while looking like a harness fault.
+    """
+    html = (EXT / "data.html").read_text(encoding="utf-8")
+    body = html.split("<body>", 1)[1].split("<script", 1)[0]
+
+    css = "\n".join((EXT / sheet).read_text(encoding="utf-8") for sheet in
+                    ("tokens.css", "components.css", "data.css"))
+    grid_css = (EXT / "vendor" / "tabulator.min.css").read_text(encoding="utf-8")
+    grid_js = (EXT / "vendor" / "tabulator.min.js").read_text(encoding="utf-8")
+    modules = "\n".join(flatten((EXT / m).read_text(encoding="utf-8"))
+                        for m in DATA_PAGE_MODULES)
+
+    page = tmp / name
+    page.write_text(
+        "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">"
+        f"<style>{grid_css}</style><style>{css}</style></head>"
+        f"<body>{body}"
+        f"<script>{stub_js}</script>\n"
+        f"<script>{grid_js}</script>\n"
+        f"<script>{modules}</script>"
+        "</body></html>",
+        encoding="utf-8")
+    return page


### PR DESCRIPTION
**The page merged yesterday did not work at all.** #193 landed with 2,460 engine tests and 398 extension tests green, and every first load aborted itself before painting.

```js
const generation = backendGeneration();   // 0 — the address is unresolved
payload = await api(...)                  // backendBase() resolves it → 1
if (generation !== backendGeneration()) return;   // returns WITHOUT PAINTING
```

`backendBase()` **activates** the backend the first time it is called, and activating bumps the generation. So the freshness guard — which exists to stop one engine's rows appearing under another engine's name — compared `0` against `1` and concluded a different engine was authoritative.

**"Reading…" for ever, in production, for everyone.** No exception, no console error, nothing in the DOM to say why.

The fix is an ordering, not a rule: resolve the address, **then** read the generation it creates. Nothing can be stale against a state that does not exist yet.

## Why nothing caught it

Every test this repository had for that page is **static** — does the id exist, does the class resolve, does a pure function compute — or drives `datatable.js` without a browser. All of them were correct. All of them were green. The defect lived in **the order of two awaits**, which only a rendered page can settle.

I named this gap in #193's own description and proposed closing it before building further. This is that.

## So the page is rendered now

`tools/tabpage_harness.py` flattens the **real** module graph — imports stripped, exports removed, the files that ship are the files that run — and supplies the two things a plain tab cannot have: `chrome`, and an engine.

`tests/test_tab_page_dom.py` drives it in Chromium:

| | |
|---|---|
| **the first load paints** | the regression, named as such |
| the columns are the payload's | in the payload's order |
| a name of `<img src=x onerror=…>` | reaches the screen as **text**, not an element |
| an Arabic cell | keeps `unicode-bidi: plaintext` in the **computed** style |
| a prefix | says it is one |
| a source with nothing to fold | gets a switch it cannot press |
| a stopped engine | is **named**, not left blank |
| a page with no source | does not ask the engine for `/api/table/` |

**Reintroducing the defect fails `test_the_first_load_paints` first, and six more behind it.**

## The harness taught me something too

Its first version redefined `window.location` to carry the source key. That property is **not configurable**, the assignment threw, and the page fell back to "no source" while looking like a harness fault. A `file://` URL carries a query string perfectly well, so the key rides the real path — the same one the panel uses. The reason is written in the file.

## Verified against the live warehouse

Before any of this was written, with real data:

| source | |
|---|---|
| SAMEHGABRIEL | 108 rows, 22 columns, Arabic rendering right |
| MADAR | 3,552 rows, **56 columns**, no horizontal overflow |
| SPARK_ESHOP | **6,298 rows**, 11 MB, forty rows in the DOM at a time |

## The button moved, because I had put it somewhere indefensible

It was in **Settings → Storage** and acted on the selection — but the selection is made on another screen, so the reader had to choose in one place and press in another.

It is an action on **each source's own card** now, beside "Recent changes" and "Export to Google Sheets", where the source key already is. It sits **beside** the workbook link rather than replacing it: the engine's page still has the details drawer, saved views and Choose-Columns, and taking those away before the replacement carries them would be a downgrade wearing the word "migration".

**2469 engine tests · 398 extension tests · eslint and ruff clean.**

## What this harness does not do

It is not the extension. `chrome.*` is a stub and the engine is a fixture, so it proves the page's own behaviour and **nothing** about Chrome's permissions, the service worker, or a real 127.0.0.1. Saying so matters: a harness mistaken for the product is how "it passed the tests" starts meaning less than it should.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
