### PR TITLE
The account floated in the middle of the Profile page, and two auto margins put it there

### DIFF
--- a/extension/app.css
+++ b/extension/app.css
@@ -1452,11 +1452,21 @@
     box-shadow: none;
     overflow: visible;
   }
+  /* THE HEADER SITS AT THE TOP, and this rule is where it stopped doing that.
+     `margin-bottom: auto` here and `margin-top: auto` on .profile-legal are two
+     auto margins facing each other in one flex column: they SPLIT the free
+     space between them, which centres everything in the middle. Measured at
+     400x800 before this: the topbar ended at 48 and the avatar began at 240 —
+     a 192px hole above the account, with the lists pushed down behind it.
+
+     Only the bottom one is needed. The legal line keeps its `margin-top: auto`
+     and stays pinned to the bottom edge; removing this one lets the summary,
+     the accounts card and everything after them start where the reader looks
+     first. Owner-reported from the running panel, 2026-08-15. */
   .profile-topbar {
     align-self: stretch;
     display: flex;
     justify-content: flex-end;
-    margin-bottom: auto;
   }
   /* Borderless and quiet — it takes its weight from position, not from paint.
      Every state is spelled out rather than left to one flat rule: the base

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -3009,6 +3009,48 @@ def test_the_profile_states_live_in_one_persistent_centered_card(open_panel):
     assert card.get_attribute("aria-modal") is None
 
 
+@pytest.mark.parametrize("width,height", [(400, 800), (400, 520), (320, 440)])
+def test_the_signed_in_profile_starts_at_the_top_and_still_fits(
+        open_panel, width, height):
+    """The account belongs under the sign-out row, not floating in the middle.
+
+    TWO AUTO MARGINS FACING EACH OTHER is what put it there: `margin-bottom:
+    auto` on .profile-topbar and `margin-top: auto` on .profile-legal SPLIT the
+    free space between them, which centres everything in between. Measured at
+    400x800 before the fix: the topbar ended at 48 and the summary began at 240
+    — a 192px hole above the avatar, with the accounts list pushed down behind
+    it. Owner-reported from the running panel, 2026-08-15.
+
+    THE SECOND HALF OF THIS TEST IS THE PART THAT MATTERS LATER. The rules
+    around here have been repaired three times for CLIPPING — 75px at 400x520
+    under Chrome's very large font, 67px at 400x700, 22px at 320x440 — so a
+    later change that pulls the content up must not push the legal line off the
+    bottom. The sizes are the ones those repairs name.
+    """
+    page = open_panel(signed_in=ACCOUNT)
+    page.wait_for_selector("#welcome-signed-in:visible")
+    page.set_viewport_size({"width": width, "height": height})
+    page.wait_for_timeout(200)
+
+    box = page.evaluate("""() => {
+      const r = (s) => { const n = document.querySelector(s); if (!n) return null;
+        const b = n.getBoundingClientRect();
+        return {top: Math.round(b.top), bottom: Math.round(b.bottom)}; };
+      return {bar: r('.profile-topbar'), summary: r('#welcome-summary'),
+              legal: r('.profile-legal'), viewport: window.innerHeight};
+    }""")
+
+    gap = box["summary"]["top"] - box["bar"]["bottom"]
+    assert gap < 80, (
+        f"{gap}px between the sign-out row and the account at {width}x{height}. "
+        "The summary is being centred again — check for a second auto margin "
+        "above it")
+    assert box["legal"]["bottom"] <= box["viewport"], (
+        f"the legal line ends {box['legal']['bottom'] - box['viewport']}px past "
+        f"the bottom at {width}x{height}, which is the clipping this area has "
+        "already been repaired for three times")
+
+
 def test_the_profile_card_shows_checking_while_chrome_answers(open_panel):
     """While the token is in flight the card announces busy, keeps the product
     greeting as the stable heading, and shows the status as a separate line."""


### PR DESCRIPTION
Owner-reported from the running panel. The avatar, the greeting and the address sat **centred vertically**, with a hole above them and the accounts list pushed down behind it.

## The cause is a pair, not a line

`.profile-topbar` carried `margin-bottom: auto`, and `.profile-legal` carries `margin-top: auto`.

Two auto margins facing each other in one flex column **split the free space between them** — and splitting it is what centres everything in between. Neither is wrong on its own; together they are a centring nobody asked for.

Only the bottom one is needed. The legal line keeps its auto margin and stays pinned to the bottom; removing the top one lets the summary and the accounts card start where the reader looks first.

## Measured, at 400×800

| | topbar ends | summary begins | accounts card |
|---|---|---|---|
| **before** | 48 | **240** | 462 |
| **after** | 48 | **72** | 294 |

The 192px hole is 24px now, and the same holds at 400×520, 400×700 and 320×440.

## Why this is not just a CSS edit

The rules around here have been repaired **three times for clipping** — 75px at 400×520 under Chrome's very large font, 67px at 400×700, 22px at 320×440. Pulling content *up* is exactly the kind of change that pushes the legal line off the bottom instead.

So the test asserts **both**: the gap is small **and** nothing ends past the viewport, at the three sizes those earlier repairs name. Reintroducing the margin fails it.

**253 panel and design guards green.**

## Not in this change

The mockup the owner supplied also drops the email line, renames the button to "Manage your Google Account", removes the per-row `⋮` menu and adds a camera badge on the avatar. **He asked for all four to be left as they are** — this is the layout only.

The other half of his report — signing in with a second account signs out the first, so every other account shows "Signed out" — is a separate change and is next. The mechanism is already there (`WEB_CLIENT_ID` is configured and `launchWebAuthFlow` takes `login_hint`); what is wrong is that the badge means *"not the current one"* when it should mean *"actually signed out"*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
