### PR TITLE
The mapping was a list with an arrow in the middle, and it lined nothing up (1a)

### DIFF
--- a/extension/console.css
+++ b/extension/console.css
@@ -194,6 +194,239 @@ button.pair-row:focus-visible { background: var(--surface-subtle); }
   color: var(--muted);
 }
 
+/* ---- the Mappings card ------------------------------------------------------
+   One mapping profile: which source value becomes which add-in attribute, how
+   the source is located, and what runs on the way. Five columns and NO ARROW —
+   the order carries the direction, and a centred arrow column made every row a
+   different width of empty space.
+
+   THE GRID IS DECLARED ONCE, in `--map-columns`, and read by the header row and
+   by every data row. They are separate elements, so two copies of the template
+   would silently misalign the whole table the first time one was widened and
+   the other was not.
+
+   Every fixed track has to fit its longest real value — `StartsWith` is the
+   widest match mode, `TRIM|TO_DECIMAL` the widest transform. Widen the track
+   rather than let either clip: a truncated machine identifier is a value the
+   reader cannot reconstruct. */
+
+/* THE CARD ANSWERS FOR ITS OWN WIDTH, and it has to: the width it gets does not
+   follow the window's. Just above the rail's 56rem breakpoint the rail expands
+   from 3.25rem to 15rem, so a window ONE PIXEL WIDER hands this card 200px
+   less. A width media query switched the table at the wrong moment in both
+   directions; the container asks the only question that matters. */
+.map-card { container: mappings / inline-size; }
+
+/* Declared once, on the one class the header row and every data row share.
+   They are separate elements, and two copies of the template would silently
+   misalign the whole table the first time one was widened and the other not. */
+.map-grid {
+  --map-columns: minmax(0, 1.1fr) 6.5rem 7.25rem minmax(0, 1fr) 10.5rem;
+  display: grid;
+  grid-template-columns: var(--map-columns);
+  gap: var(--sp-2);
+  align-items: center;
+}
+
+.map-head {
+  padding: 0 var(--sp-3) var(--sp-2);
+  border-block-end: 1px solid var(--line);
+  font-size: var(--fs-2xs);
+  font-weight: var(--fw-bold);
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+/* The profile, lifted out of the rows: it is one value for the whole card, and
+   repeating it down a column said nothing new nine times. */
+.map-profile {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--sp-3);
+  align-items: center;
+  margin-block: var(--sp-3) var(--sp-4);
+  padding: var(--sp-3);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: var(--bg);
+}
+
+.map-profile-facts {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+  min-width: 0;
+}
+
+.map-profile-label,
+.map-group-label {
+  font-size: var(--fs-2xs);
+  font-weight: var(--fw-bold);
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.map-profile-key {
+  overflow: hidden;
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-bold);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.map-profile-note {
+  font-size: var(--fs-xs);
+  color: var(--muted);
+}
+
+.map-count { justify-self: end; }
+
+.map-group-label {
+  display: block;
+  padding: var(--sp-3) var(--sp-3) var(--sp-1);
+}
+
+/* The separator is the lighter --chip and not --line. The card already carries
+   a border and a header rule, and a third weight of line at every row makes the
+   table read as a grid of boxes instead of a list. */
+.map-row { border-block-end: 1px solid var(--chip); }
+
+/* A value that comes from anywhere but a header sits on the page tone, so the
+   group reads as a different kind of thing without leaning on its label alone. */
+.map-derived { background: var(--bg); }
+
+.map-cells {
+  width: 100%;
+  min-height: var(--control-height-sm);
+  padding: var(--sp-2) var(--sp-3);
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: start;
+  cursor: pointer;
+}
+
+/* Hover only. :focus-visible is the shared sheet's, and re-declaring it here is
+   how one surface ends up with a focus ring nobody else has. */
+.map-cells:hover { background: var(--control-hover); }
+
+.map-source,
+.map-match,
+.map-target,
+.map-chain {
+  min-width: 0;
+  overflow: hidden;
+  font-family: var(--font-mono);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.map-source { font-size: var(--fs-sm); }
+
+/* THE ONLY ACCENT ON THE CARD, so the eye finds the add-in's side of every row
+   without having to read it. */
+.map-target {
+  font-size: var(--fs-sm);
+  color: var(--accent-ink);
+}
+
+.map-match,
+.map-chain {
+  font-size: var(--fs-xs);
+  color: var(--muted);
+}
+
+/* A match mode on a row that cannot have one. Quieter than --muted, because it
+   is not a value left out — there is nothing there to state. */
+.map-inert { color: var(--line-strong); }
+
+/* The shared chip, squared off: a pill beside four mono columns reads as a
+   control rather than a label. */
+.map-kind {
+  justify-self: start;
+  border-radius: var(--radius-sm);
+  font-weight: var(--fw-medium);
+}
+
+/* ---- the row, restated in words --------------------------------------------
+   Under the row and inside it — not a popover and not a dialog. The sentence is
+   what the five cells mean, and it is only worth showing where the cells are. */
+
+.map-said { padding: 0 var(--sp-3) var(--sp-3); }
+
+.map-sentence {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--sp-1);
+  margin: 0;
+  padding: var(--sp-3);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--surface);
+  font-size: var(--fs-sm);
+  line-height: var(--lh);
+  color: var(--muted);
+}
+
+.map-said-target,
+.map-said-source {
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-bold);
+}
+
+.map-said-target { color: var(--accent-ink); }
+.map-said-source { color: var(--text); }
+
+.map-said-mode {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--text);
+}
+
+/* The flex gap would otherwise put a space in front of the comma. */
+.map-then { margin-inline-start: calc(var(--sp-1) * -1); }
+
+.map-step {
+  padding: 1px var(--sp-2);
+  border-radius: var(--radius-xs);
+  background: var(--bg);
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+}
+
+.map-foot {
+  margin: var(--sp-3) 0 0;
+  font-size: var(--fs-xs);
+  color: var(--muted);
+}
+
+/* WHERE THE TABLE STOPS BEING ONE, rather than being truncated into one.
+   The three fixed tracks and the gaps take 444px whatever the card's width, so
+   below about 47rem of card the two names are squeezed to nothing while
+   `StartsWith` and `TRIM|TO_DECIMAL` keep their full width — the wrong two
+   columns surviving. Widening those is not open: a clipped machine identifier
+   is a value the reader cannot reconstruct. So the row becomes two lines
+   instead: the two names first, their meta underneath. */
+@container mappings (max-width: 47rem) {
+  .map-grid { --map-columns: minmax(0, 1fr) minmax(0, 1fr); }
+  .map-head { display: none; }
+  .map-profile { grid-template-columns: minmax(0, 1fr); }
+  .map-count { justify-self: start; }
+  .map-cells { row-gap: var(--sp-1); }
+  .map-source { grid-area: 1 / 1; }
+  .map-target { grid-area: 1 / 2; }
+  .map-kind { grid-area: 2 / 1; }
+  .map-match { grid-area: 2 / 2; }
+  .map-chain { grid-area: 3 / 1 / auto / -1; }
+}
+
 /* ---- findings -------------------------------------------------------------
    The severity is carried by a border rather than a background, so a long list
    stays readable: fifteen tinted blocks in a column is a wall, and the eye

--- a/extension/console.js
+++ b/extension/console.js
@@ -20,6 +20,8 @@ import { checkTableDefinitionRow, tableProducesNothing }
 import { checkSchemaRuleRow, checkEntityRoles } from "./schemarule-rules.js";
 import { checkDataMapRow, checkProfileCoverage, resolvedProfiles, attributesFor }
   from "./datamap-rules.js";
+import { effectiveSourceType, headerMatch, mappingSentence, mappingGroups }
+  from "./datamap-view.js";
 import { checkExportViewRow, exportsNothing } from "./exportviews-rules.js";
 import { checkRibbonControlRow, rendersNowhere, buildsAMenu,
   effectiveActionClass } from "./ribboncontrols-rules.js";
@@ -859,6 +861,182 @@ function block(title, rows, empty) {
   return card;
 }
 
+// ---- the Mappings card --------------------------------------------------------
+//
+// ONE CARD PER PROFILE. `PROFILE_KEY` is lifted out of the rows into a strip
+// above them because it is one value for the whole set — so a table fed by two
+// sources on two different profiles gets two cards, rather than one strip
+// standing over rows that do not all belong to it.
+//
+// THERE IS NO ARROW COLUMN. Column order carries the direction: what the file
+// holds on the left, what the add-in stores on the right. The list this
+// replaces centred an arrow between three columns, so source and target never
+// lined up and the transform text sat detached from the row it described.
+
+const MAP_COLUMNS = ["Source value", "Source type", "Header match",
+                     "Target attribute", "Transform"];
+
+/** A `<span>`, with a class when it needs one and a direction when it is data. */
+function cell(className, content, {auto = false} = {}) {
+  const node = document.createElement("span");
+  if (className) node.className = className;
+  node.textContent = content;
+  // ENGLISH CHROME, ANY-LANGUAGE DATA. A heading read out of an Arabic sheet is
+  // laid out by the browser rather than guessed at here, and `dir` goes on the
+  // value alone — never on the words around it, which are ours and are English.
+  if (auto) node.dir = "auto";
+  return node;
+}
+
+/** The one value the whole card belongs to, and how many rows that is. */
+function profileStrip(profile, count) {
+  const strip = document.createElement("div");
+  strip.className = "map-profile";
+
+  const facts = document.createElement("span");
+  facts.className = "map-profile-facts";
+  facts.append(
+    cell("map-profile-label", "PROFILE_KEY"),
+    cell("map-profile-key", profile),
+    cell("map-profile-note",
+         "The set every row below belongs to — one value for the whole "
+         + "profile."));
+
+  // DERIVED FROM THE ROWS RENDERED, never a number written beside them: a count
+  // that is typed goes stale the moment a mapping is added, and it goes stale
+  // in silence.
+  strip.append(facts,
+               cell("chip map-count",
+                    `${count} ${count === 1 ? "row" : "rows"}`));
+  return strip;
+}
+
+/**
+ * ONE ROW OPEN AT A TIME, within one card.
+ *
+ * Opening another closes the first, and pressing the open one closes it. A
+ * `null` closes every row, which is what Escape does.
+ */
+function openMapping(card, wanted) {
+  for (const button of card.querySelectorAll(".map-cells")) {
+    const open = button === wanted
+      && button.getAttribute("aria-expanded") !== "true";
+    button.setAttribute("aria-expanded", String(open));
+    button.nextElementSibling.hidden = !open;
+  }
+}
+
+/**
+ * THE ROW, RESTATED IN WORDS.
+ *
+ * Assembled from spans rather than formatted into one string, so the target
+ * keeps its colour and the source its weight — the two halves of the mapping
+ * stay distinguishable inside the sentence exactly as they are in the row.
+ */
+function mappingLine(said) {
+  const line = document.createElement("p");
+  line.className = "map-sentence";
+  line.append(
+    cell("map-said-target", said.target || "(no column)"),
+    cell("", said.verb),
+    cell("map-said-source", said.source || "(no expression)", {auto: true}));
+
+  // Both clauses are appended or omitted, never printed empty. `matched —` and
+  // `, then —` are sentences about nothing.
+  if (said.match) {
+    line.append(cell("", "matched"),
+                cell("map-said-mode", said.match.toLowerCase()));
+  }
+  if (said.steps.length) {
+    line.append(cell("map-then", ", then"));
+    for (const step of said.steps) line.append(cell("map-step", step));
+  }
+  return line;
+}
+
+/** One mapping: five cells that open onto the sentence they mean. */
+function mappingRow(card, row) {
+  const kind = effectiveSourceType(row);
+  const said = mappingSentence(row);
+  const match = headerMatch(row);
+
+  const holder = document.createElement("div");
+  holder.className = "map-row" + (kind === "Header" ? "" : " map-derived");
+
+  // A REAL BUTTON, not a div that listens. It is the only way this row is
+  // reachable by Tab, operable with Enter and Space, and announced with the
+  // state it is actually in — and `:focus-visible` then comes from the shared
+  // sheet rather than being declared again here.
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "map-cells map-grid";
+  button.setAttribute("aria-expanded", "false");
+  button.append(
+    cell("map-source", said.source || "(no expression)", {auto: true}),
+    // The chip says what the SHEET holds and is coloured by what the add-in
+    // will DO with it, so a misspelt type still reads as the Header it will be
+    // treated as without the misspelling being hidden.
+    cell(`chip map-kind${kind === "Header" ? " accent" : ""}`,
+         String(row.SOURCE_TYPE ?? "").trim() || kind),
+    cell("map-match" + (match ? "" : " map-inert"), match || "—"),
+    cell("map-target", said.target || "(no column)"),
+    cell("map-chain", String(row.TRANSFORM_CHAIN ?? "").trim() || "—"));
+
+  const panel = document.createElement("div");
+  panel.className = "map-said";
+  panel.hidden = true;
+  panel.append(mappingLine(said));
+
+  button.addEventListener("click", () => openMapping(card, button));
+  holder.append(button, panel);
+  return holder;
+}
+
+/** One mapping profile, as a card. */
+function mappingsCard(profile, rows) {
+  const card = document.createElement("section");
+  card.className = "card map-card";
+
+  const heading = document.createElement("h2");
+  heading.textContent = "Mappings";
+  card.append(heading, profileStrip(profile, rows.length));
+
+  const head = document.createElement("div");
+  head.className = "map-head map-grid";
+  for (const name of MAP_COLUMNS) head.append(cell("", name));
+  card.append(head);
+
+  for (const group of mappingGroups(rows)) {
+    const holder = document.createElement("div");
+    holder.className = "map-group";
+    holder.append(cell("map-group-label", group.label));
+    for (const row of group.rows) holder.append(mappingRow(card, row));
+    card.append(holder);
+  }
+
+  const foot = document.createElement("p");
+  foot.className = "map-foot";
+  foot.textContent =
+    "Header match only means something when the source type is Header — a "
+    + "constant, an index or a formula has no name to look for.";
+  card.append(foot);
+
+  card.addEventListener("keydown", (event) => {
+    if (event.key !== "Escape") return;
+    const open = card.querySelector('.map-cells[aria-expanded="true"]');
+    if (!open) return;
+    openMapping(card, null);
+    // Back to the row that was open, and not to the top of the document: a key
+    // that closes something should not also lose the reader's place.
+    open.focus();
+  });
+
+  // THE FIRST ROW IS OPEN. A table where every row is shut looks inert, and the
+  // sentence under a row is the thing this card was redrawn to show.
+  openMapping(card, card.querySelector(".map-cells"));
+  return card;
+}
+
 /**
  * ONE TABLE, EVERYWHERE IT APPEARS.
  *
@@ -903,10 +1081,19 @@ function showTable(key) {
     r.SOURCE_REGION || "")),
     "Nothing loads this table."));
 
-  body.append(block("Mappings", maps.map((r) => pairRow(
-    r.SOURCE_EXPRESSION || "(no expression)", `→ ${r.TARGET_ATTRIBUTE_KEY}`,
-    [r.SOURCE_TYPE, r.TRANSFORM_CHAIN].filter(Boolean).join(" · "))),
-    "No mapping tells the add-in how to read this table's source."));
+  // ONE CARD PER PROFILE, because the strip above the rows carries the profile
+  // and that is one value for the whole set. A table fed by two sources on two
+  // profiles is a real shape here, and one card would have to either drop the
+  // strip or put a key over rows that do not all carry it.
+  if (!maps.length) {
+    body.append(block("Mappings", [],
+      "No mapping tells the add-in how to read this table's source."));
+  } else {
+    for (const profile of [...profiles].sort()) {
+      const mine = maps.filter((r) => r.PROFILE_KEY === profile);
+      if (mine.length) body.append(mappingsCard(profile, mine));
+    }
+  }
 
   body.append(block("Export views", views.map((r) => pairRow(
     r.VIEW_KEY, r.LABEL || "—", r.COLUMNS ? `${r.COLUMNS.split(",").length} columns` : "")),

--- a/extension/datamap-view.js
+++ b/extension/datamap-view.js
@@ -1,0 +1,111 @@
+// What one row of 4.DataMap SAYS, in words rather than in five enums.
+//
+// SPLIT OUT OF console.js SO IT CAN BE TESTED. That file reaches for the DOM in
+// its first function and calls `start()` on its last line, so nothing in it can
+// be imported by `node --test`. The sentence under an expanded mapping row is
+// the part of that card with rules of its own — a verb per source type, two
+// clauses that must be DROPPED rather than printed with an em dash, and a chain
+// split into the steps it runs in — and a reader will believe every one of
+// them. extension/tests/datamap-view.test.mjs is the reason this file exists.
+//
+// IT ANSWERS FOR THE ADD-IN, NOT FOR THE CELL. A blank SOURCE_TYPE is Header
+// and a blank MATCH_MODE is Exact, so the card groups and reads a blank cell as
+// the add-in will act on it. What it will NOT do is replace a value the sheet
+// actually holds: an unrecognised mode is shown as typed, because
+// `datamap-rules.js` is already reporting it and a card that quietly printed
+// "Exact" over it would be arguing with the finding beside it.
+
+import { SOURCE_TYPES, MATCH_MODES, TRANSFORM_SEPARATOR }
+  from "./addin-contract.js";
+
+const text = (row, name) => String(row?.[name] ?? "").trim();
+const same = (a, b) => String(a).toUpperCase() === String(b).toUpperCase();
+
+/**
+ * The source type the add-in will USE.
+ *
+ * Blank is Header, and so is a spelling the add-in does not know: the lookup
+ * finds nothing and the branch falls through to the default.
+ * `datamap-rules.js` reads it exactly this way — a card that grouped an
+ * unrecognised type under "somewhere else" would be describing a different
+ * add-in from the one whose findings sit on the same screen.
+ */
+export function effectiveSourceType(row) {
+  return SOURCE_TYPES.find((t) => same(t, text(row, "SOURCE_TYPE"))) || "Header";
+}
+
+/**
+ * What to print under "Header match", which is only ever read for one type.
+ *
+ * Empty for every other type — the caller prints the em dash, because a dash is
+ * a mark on a screen and not a value this module has any business inventing.
+ */
+export function headerMatch(row) {
+  if (effectiveSourceType(row) !== "Header") return "";
+  const named = text(row, "MATCH_MODE");
+  if (!named) return "Exact";                       // a blank cell means Exact
+  // Never over-write what is in the sheet. `options()` in console.js holds the
+  // same line for the same reason: an unknown value is a FACT about the
+  // workbook, and hiding it behind the default is how it stops being fixed.
+  return MATCH_MODES.find((m) => same(m, named)) || named;
+}
+
+/** The chain, one step per element, in the order it runs. Empty when blank. */
+export function transformSteps(row) {
+  return text(row, "TRANSFORM_CHAIN")
+    .split(TRANSFORM_SEPARATOR)
+    .map((step) => step.trim())
+    .filter(Boolean);
+}
+
+//: The verb each source type reads as. The phrasing is the design's, verbatim,
+//: and it is the whole reason the sentence is worth showing: "Index" is a word
+//: about the sheet, "comes from position" is a sentence about the data.
+const VERBS = {
+  Header: "comes from the column",
+  Index: "comes from position",
+  Constant: "is always",
+  Context: "comes from the run's",
+  Formula: "is computed as",
+};
+
+/**
+ * One row, as the parts of a sentence.
+ *
+ * A CLAUSE WITH NOTHING TO SAY IS DROPPED, never printed with an em dash in it.
+ * A constant reads `CURRENCY is always SAR` — no `matched`, no `, then` — and
+ * `matched —` would be a sentence about nothing in a panel whose only job is to
+ * be read as one. `match` and `steps` are empty in exactly those cases, so the
+ * caller appends the clause or does not.
+ */
+export function mappingSentence(row) {
+  return {
+    target: text(row, "TARGET_ATTRIBUTE_KEY"),
+    verb: VERBS[effectiveSourceType(row)],
+    source: text(row, "SOURCE_EXPRESSION"),
+    match: headerMatch(row),
+    steps: transformSteps(row),
+  };
+}
+
+/**
+ * The rows in two groups, by where the value comes from.
+ *
+ * A constant is not a mapping in the same sense as a header lookup — one is a
+ * name that has to be found in a file that may not carry it, the other cannot
+ * fail to resolve — and a flat list said nothing about the difference.
+ *
+ * Membership is DERIVED from the source type and never authored twice, and a
+ * group with no rows is dropped along with its label rather than left standing
+ * over nothing.
+ */
+export function mappingGroups(rows) {
+  const groups = [
+    {label: "From a header — the name is looked up", rows: []},
+    {label: "From somewhere else — no name involved", rows: []},
+  ];
+  for (const row of rows || []) {
+    groups[effectiveSourceType(row) === "Header" ? 0 : 1].rows.push(row);
+  }
+  return groups.filter((group) => group.rows.length);
+}

--- a/extension/tests/datamap-view.test.mjs
+++ b/extension/tests/datamap-view.test.mjs
@@ -1,0 +1,130 @@
+// The Mappings card's sentence, which a reader will believe.
+//
+// The card restates each row in words — «ITEM_CODE comes from the column Item
+// Code matched exact, then TRIM UPPER» — and a sentence is read as a statement
+// of fact in a way five enums in a row are not. So the rules under it are
+// pinned here: the verb per source type, the two clauses that are DROPPED
+// rather than printed empty, and the defaults a blank cell means.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { effectiveSourceType, headerMatch, transformSteps, mappingSentence,
+  mappingGroups } from "../datamap-view.js";
+
+const row = (over = {}) => ({
+  PROFILE_KEY: "T_BITUMEN",
+  TARGET_ATTRIBUTE_KEY: "ITEM_CODE",
+  SOURCE_TYPE: "Header",
+  MATCH_MODE: "Exact",
+  SOURCE_EXPRESSION: "Item Code",
+  TRANSFORM_CHAIN: "TRIM|UPPER",
+  ...over,
+});
+
+test("a blank source type is Header, exactly as the add-in reads it", () => {
+  assert.equal(effectiveSourceType(row({SOURCE_TYPE: ""})), "Header");
+  assert.equal(effectiveSourceType(row({SOURCE_TYPE: "  "})), "Header");
+});
+
+test("an unrecognised source type is Header too, because that is what runs", () => {
+  // The add-in's lookup finds nothing and its branch falls to the default.
+  // Grouping this row under "somewhere else" would describe an add-in that
+  // does not exist, while datamap-rules.js reports the spelling separately.
+  assert.equal(effectiveSourceType(row({SOURCE_TYPE: "Headr"})), "Header");
+});
+
+test("a source type is matched whatever its case", () => {
+  assert.equal(effectiveSourceType(row({SOURCE_TYPE: "constant"})), "Constant");
+});
+
+test("a blank match mode is Exact, and only on a Header row", () => {
+  assert.equal(headerMatch(row({MATCH_MODE: ""})), "Exact");
+  assert.equal(headerMatch(row({SOURCE_TYPE: "Constant", MATCH_MODE: ""})), "");
+});
+
+test("a match mode set on a row that cannot use one is still not shown", () => {
+  // The add-in never reads it there, and printing it would state a rule that
+  // does not apply beside four that do.
+  assert.equal(headerMatch(row({SOURCE_TYPE: "Index", MATCH_MODE: "Fuzzy"})), "");
+});
+
+test("a match mode the add-in does not know is shown AS TYPED", () => {
+  // Never over-written with the default: an unknown value is a fact about the
+  // workbook, and a card that hid it behind "Exact" would be arguing with the
+  // finding datamap-rules.js raises about the very same cell.
+  assert.equal(headerMatch(row({MATCH_MODE: "Startswith"})), "StartsWith");
+  assert.equal(headerMatch(row({MATCH_MODE: "Nearly"})), "Nearly");
+});
+
+test("the chain is split into the steps it runs, in order", () => {
+  assert.deepEqual(transformSteps(row({TRANSFORM_CHAIN: "TRIM|TO_DECIMAL"})),
+                   ["TRIM", "TO_DECIMAL"]);
+  assert.deepEqual(transformSteps(row({TRANSFORM_CHAIN: " TRIM | UPPER "})),
+                   ["TRIM", "UPPER"]);
+});
+
+test("no chain is no steps — never one step holding an empty string", () => {
+  assert.deepEqual(transformSteps(row({TRANSFORM_CHAIN: ""})), []);
+  assert.deepEqual(transformSteps(row({TRANSFORM_CHAIN: "||"})), []);
+  assert.deepEqual(transformSteps({}), []);
+});
+
+test("a header row reads as the whole sentence", () => {
+  assert.deepEqual(mappingSentence(row()), {
+    target: "ITEM_CODE",
+    verb: "comes from the column",
+    source: "Item Code",
+    match: "Exact",
+    steps: ["TRIM", "UPPER"],
+  });
+});
+
+test("a constant drops both clauses rather than printing them empty", () => {
+  // «CURRENCY is always SAR» — no `matched —`, no `, then —`. Both are
+  // sentences about nothing, and this panel exists to be read as one.
+  const said = mappingSentence(row({
+    TARGET_ATTRIBUTE_KEY: "CURRENCY", SOURCE_TYPE: "Constant",
+    SOURCE_EXPRESSION: "SAR", MATCH_MODE: "", TRANSFORM_CHAIN: ""}));
+  assert.equal(said.verb, "is always");
+  assert.equal(said.match, "");
+  assert.deepEqual(said.steps, []);
+});
+
+test("every source type has its own verb, and they are not interchangeable", () => {
+  const verb = (type) => mappingSentence(row({SOURCE_TYPE: type})).verb;
+  assert.equal(verb("Header"), "comes from the column");
+  assert.equal(verb("Index"), "comes from position");
+  assert.equal(verb("Constant"), "is always");
+  assert.equal(verb("Context"), "comes from the run's");
+  assert.equal(verb("Formula"), "is computed as");
+});
+
+test("the groups are derived from the source type, never authored twice", () => {
+  const rows = [
+    row({SOURCE_TYPE: "Header"}),
+    row({SOURCE_TYPE: ""}),                       // Header by default
+    row({SOURCE_TYPE: "Constant"}),
+    row({SOURCE_TYPE: "Formula"}),
+  ];
+  const groups = mappingGroups(rows);
+  assert.deepEqual(groups.map((g) => g.label), [
+    "From a header — the name is looked up",
+    "From somewhere else — no name involved",
+  ]);
+  assert.deepEqual(groups.map((g) => g.rows.length), [2, 2]);
+});
+
+test("a group with no rows is dropped along with its label", () => {
+  // A label standing over nothing is a heading that promises rows and has none.
+  const onlyHeaders = mappingGroups([row(), row()]);
+  assert.deepEqual(onlyHeaders.map((g) => g.label),
+                   ["From a header — the name is looked up"]);
+
+  const onlyDerived = mappingGroups([row({SOURCE_TYPE: "Context"})]);
+  assert.deepEqual(onlyDerived.map((g) => g.label),
+                   ["From somewhere else — no name involved"]);
+
+  assert.deepEqual(mappingGroups([]), []);
+  assert.deepEqual(mappingGroups(null), []);
+});


### PR DESCRIPTION
Builds option `1a` of the Mappings handoff — the card on the Console's inspect
screen that displays a profile's `4.DataMap` rows. Options `1d` and `1h` in the
design file are rejected alternatives and are **not** built.

## What changed

The block this replaces was `pairRow(source, "→ " + target, meta)`: three
centred columns with an arrow between them. The source and the attribute it
fills never sat on the same axis twice, every row was a different width of empty
space, and the transform text drifted away from the row it described.

- **The arrow is gone.** Column order carries the direction — what the file
  holds on the left, what the add-in stores on the right. Five columns, no arrow
  anywhere.
- **Rows are grouped by where the value comes from.** A header lookup is a name
  that has to be found in a file that may not carry it; a constant cannot fail
  to resolve. The flat list said nothing about the difference. Membership is
  derived from `SOURCE_TYPE`, never authored twice, and a group with no rows is
  dropped along with its label.
- **`PROFILE_KEY` is lifted out of the rows** into a strip above them — one
  value for the whole set, instead of the same word repeated down a column nine
  times. `SOURCE_TYPE` and `MATCH_MODE` stay per row. The `N rows` pill is
  derived from the rows rendered.
- **Clicking a row opens one line of prose under it** — «ITEM_CODE comes from
  the column Item Code matched exact, then TRIM UPPER». One row open at a time,
  the first open by default, `Escape` closes and keeps focus on the row.

## Three decisions worth reviewing

**One card per profile, not one card.** The strip carries `PROFILE_KEY` as one
value for the whole set, but a table fed by two sources on two profiles is a
real shape in this workbook. One card would have to either drop the strip or put
a key over rows that do not all carry it.

**A module of its own for the sentence.** `console.js` reaches for the DOM in
its first function and calls `start()` on its last line, so nothing in it can be
imported by `node --test`. A sentence is believed in a way five enums in a row
are not, so its rules — the verb per source type, the clauses that are dropped
rather than printed with an em dash, the chain split into steps — live in
`extension/datamap-view.js` with 13 tests on them.

It answers for the add-in, not for the cell: a blank `SOURCE_TYPE` is Header and
a blank `MATCH_MODE` is Exact, which is the same reading `datamap-rules.js`
already makes, so the card and the findings beside it describe one add-in. What
it will not do is over-write a value the sheet holds — an unrecognised match
mode is shown as typed, because it is a fact about the workbook and hiding it
behind the default is how it stops being fixed.

**`@container`, not `@media`.** A width media query was written first and was
wrong in both directions: just above the rail's 56rem breakpoint the rail
expands from `3.25rem` to `15rem`, so a window **one pixel wider** hands this
card 200px **less**. What it switches to is a two-line row rather than a
narrower table, because the three fixed tracks take 444px whatever the card's
width — the two names get squeezed to nothing while `StartsWith` and
`TRIM|TO_DECIMAL` keep their full width, the wrong two columns surviving — and
widening those is not open either: a clipped machine identifier is a value the
reader cannot reconstruct.

## Three checklist items deliberately unticked

1. **`--radius-xl` on the card.** The shared `.card` uses `--radius-lg`. A
   corner of its own would make this the one card on the Console shaped
   differently from every other.
2. **A size and margin on the heading.** Every Console card leaves `<h2>` to the
   shared rule; a heading rule for one card is a page-local system.
3. **"Five columns in this order"** holds above 47rem of card width. Below it
   the row becomes two lines and the header row is dropped, for the reason
   above.

## Measured, not assumed

- Header row and every data row resolve to one identical grid template.
- No fixed track clips its longest real value: `StartsWith` 70.3px in a 116px
  track, `TRIM|TO_DECIMAL` 105.5px in a 168px track.
- No horizontal scrollbar at any of ten widths from 1200px to 320px.
- Every text-on-background pair ≥ 4.27:1 across light, dark, device/light and
  device/dark. The one low reading is the em dash at 1.52:1 — the handoff's own
  choice of `--line-strong` for "there is nothing here to state", flagged for a
  ruling rather than changed.
- `605 passed, 1 skipped` (`pytest -m extension`) · `411 passed`
  (`node --test extension/tests/*.test.mjs`) · eslint clean ·
  `sync_design_assets --check` clean.

## Out of scope, found on the way

`extension/console.css:664` uses `var(--green)`, which is defined nowhere — a
completed step on the Build screen draws its left edge in the text colour
instead of green. Left alone here; it is a separate change on a different
screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
