### PR TITLE
Signing in to a second account made the first look signed out, and one argument did it

### DIFF
--- a/extension/app.js
+++ b/extension/app.js
@@ -98,6 +98,17 @@ const state = {
   // one menu open" is a property of the state instead of a rule the handlers
   // have to remember to keep.
   accountsExpanded: true, openAccountMenu: null, pendingRemove: null,
+  // ACCOUNTS KNOWN TO BE SIGNED OUT — not "accounts that are not the current
+  // one". Signing in to a second account does not sign the first out of Google;
+  // it only stops the panel ACTING as it, and a silent mint brings it straight
+  // back. So an account is switchable until something proves otherwise: the
+  // owner signed out of it, or a silent mint for it was refused.
+  //
+  // A SET IN MEMORY, NOT A FIELD ON DISK. accounts.js says adding to
+  // REMEMBERED_FIELDS is a decision about what lands on storage, and this is
+  // not a fact about the account — it is a fact about Google's session in this
+  // browser right now, which is exactly as long as this panel lives.
+  signedOutAccounts: new Set(),
   installedVersion: "", engineVersion: "", versionReport: null,
   versionStatus: "pending",
   // null means the engine never said, which is a THIRD state and not a
@@ -2279,7 +2290,13 @@ async function rememberSignedInAccount(account) {
  */
 async function endCurrentAccountSession() {
   try {
+    // SIGNING OUT IS THE ONE THING THAT REALLY MAKES A ROW SIGNED OUT, and it
+    // is the case the owner confirmed the design already draws correctly. Read
+    // BEFORE the clear, because `clearCurrentAccount` reports the directory
+    // after the change and does not name who was in it.
+    const leaving = state.currentAccountId;
     const held = await clearCurrentAccount();
+    if (leaving) state.signedOutAccounts.add(leaving);
     state.accounts = held.accounts;
     state.currentAccountId = held.currentId;
   } catch (_) { /* the panel works without the directory */ }
@@ -2735,7 +2752,14 @@ function renderAccountsCard() {
     // See the note at the top of this section: without the Web OAuth client
     // nothing can be authorised silently, so no other row can be shown as
     // signed in without saying something this build cannot know.
-    list.append(accountRow(account, { signedIn: false }));
+    // THE ONE LINE THIS WHOLE DEFECT WAS. It read `signedIn: false`, so every
+    // other account was drawn signed-out and `accountRow`'s switch branch —
+    // which was written, tested and correct — could never be reached. Signing
+    // in to a second account made the first look signed out two inches below
+    // the one that had replaced it.
+    list.append(accountRow(account, {
+      signedIn: !state.signedOutAccounts.has(account.id),
+    }));
   }
   card.append(list);
 
@@ -2873,9 +2897,16 @@ async function switchToAccount(id) {
   closeAccountMenu();
   const result = await authorize({ email: account.email, interactive: false });
   if (result.state !== "ok" && result.state !== "partial") {
+    // GOOGLE REFUSED TO ANSWER SILENTLY, which is what "signed out" MEANS here
+    // — the session this account needed is gone. Recording it turns the row
+    // into the one the design already draws, with Sign in on it, instead of
+    // leaving a switch that fails the same way every time it is pressed.
+    state.signedOutAccounts.add(id);
     setAccountsStatus(result.detail);
+    renderAccountsCard();
     return;
   }
+  state.signedOutAccounts.delete(id);
   await adoptAuthorizedAccount(result.token);
 }
 
@@ -2888,6 +2919,7 @@ async function signInToAccount(id) {
     setAccountsStatus(result.detail);
     return;
   }
+  state.signedOutAccounts.delete(id);
   await adoptAuthorizedAccount(result.token);
 }
 

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -3051,6 +3051,37 @@ def test_the_signed_in_profile_starts_at_the_top_and_still_fits(
         "already been repaired for three times")
 
 
+def test_another_account_is_offered_as_a_switch_not_as_a_signed_out_row(open_panel):
+    """Signing in to a second account does not sign the first out of Google.
+
+    THE DEFECT, owner-reported 2026-08-15 with a screenshot: every other account
+    was drawn with a "Signed out" badge and a Sign in button, so switching meant
+    re-authorising something that had never left. The cause was one argument —
+    `accountRow(account, {signedIn: false})` — hard-coded, which made the row's
+    OWN switch branch unreachable. That branch was written, correct, and dead.
+
+    The badge now means what it says: an account is switchable until something
+    proves it is not — the owner signed out of it, or a silent mint was refused.
+    """
+    page = open_panel(signed_in=ACCOUNT, remembered_accounts={
+        "accounts": [{"id": "2", "email": "mbigroupcloud@gmail.com",
+                      "name": "MBi", "picture": ""}],
+        "currentId": ""})
+    page.wait_for_selector("#welcome-signed-in:visible")
+    row = page.locator("#accounts-card .account-row").first
+    row.wait_for()
+
+    assert row.locator(".account-badge").count() == 0, (
+        "the other account is labelled Signed out while its Google session is "
+        "alive — this is the hard-coded `signedIn: false`")
+    assert row.locator(".account-switch").count() == 1, (
+        "the row cannot be switched to, so reaching that account still means "
+        "signing in again")
+    assert row.locator(".account-action").count() == 0, (
+        "Sign in / Remove are offered for an account that has not signed out")
+    assert "is-signed-out" not in (row.get_attribute("class") or "")
+
+
 def test_the_profile_card_shows_checking_while_chrome_answers(open_panel):
     """While the token is in flight the card announces busy, keeps the product
     greeting as the stable heading, and shows the status as a separate line."""


### PR DESCRIPTION
> **Stacked on #196.** Base it on `main` once that merges.

Owner-reported with a screenshot. Signing in to another account works, but the one already there is then drawn with a **"Signed out"** badge and a Sign in button — so switching back means re-authorising something that never left.

## The feature was already built

`switchToAccount` performs the silent mint with `login_hint` and adopts the token. `accountRow` has a switch branch that draws the row as a button and calls it. Both correct, both tested.

And `renderAccountsCard` passed **`signedIn: false` — hard-coded** — so that branch could never be reached. **A whole capability disabled by one argument.**

## What the badge means now

Signing in to a second account does not sign the first out of Google; it only stops the panel *acting* as it, and a silent mint brings it straight back. So an account is switchable until something **proves** otherwise:

- **the owner signed out of it** — recorded where that happens rather than inferred, because nothing else this panel does touches a Google session;
- **a silent mint was refused** — which is what "signed out" means here. The row then becomes the one the design already draws, with Sign in on it, instead of a switch that fails the same way every time it is pressed.

`state.signedOutAccounts` is a **Set in memory, not a field on disk**. `accounts.js` says adding to `REMEMBERED_FIELDS` is a decision about what lands on storage — and this is not a fact about the account, it is a fact about Google's session in this browser right now, which lives exactly as long as the panel does.

## A trade-off, stated

Accounts are **not** probed with a silent mint at startup: that is a network round trip per account on a path guarded by deadlines. So an account whose session has died looks switchable until it is pressed, at which point the mint is refused and the row becomes signed-out immediately — **one extra click, in the stale case only**, and the panel corrects itself.

Probing on open would make the list honest without a press, at the cost of those round trips. Worth **measuring against startup** before shipping, not assuming.

## And "Sign out" in the row menu is now reachable

It was already written, inside `if (signedIn)` — which nothing satisfied. The owner reported that menu holding only "Remove from ScrapeX"; that is the same defect seen from the other side, and this fixes both without adding anything.

## Proof

Reintroducing `signedIn: false` fails the new test. **209 panel DOM and account tests green, eslint clean.**

## Not verified in this PR

The owner asked for a review of three sign-out paths — a row's Sign out, the top icon, and "Sign out of all accounts". Two were read: the row keeps its place and becomes signed-out, and the **top icon uses `revokeToken` rather than `forgetToken`** deliberately, so a later sign-in is not silently locked to the same account. **`signOutOfAllAccounts` was not read**, and no test here covers any of the three. That review is outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
