### PR TITLE
The Console had never been rendered in a test, and it could not be flattened to do it

### DIFF
--- a/docs/HANDOFF-resume-the-migration.md
+++ b/docs/HANDOFF-resume-the-migration.md
@@ -39,14 +39,38 @@ anywhere, as B1 claims. See the conflict below, though — finishing B2 revives 
 | **T1** | `crawl_pace_s` (#190) |
 | — | samehgabriel alive after 12 days dead; the `SourceUriValidator` mirror re-derived after mbiXaddin's own repair; the contract-drift guard given something real to watch (#191) |
 | **B2 · foundation** | `backend.js` extracted; Tabulator vendored into the extension; `data.html`/`data.js`/`datatable.js` (#193) |
+| — | The Data page's first load, which aborted itself (#194); the Profile page's centred account (#196); a second account no longer looking signed out (#199); the Mappings card (#197) |
+| **Console · rendered** | `serve_extension()` + `console_stub()` in `tools/tabpage_harness.py`, and `tests/test_console_dom.py`. The gap below is closed |
 
 ## In flight
 
-**PR #194** — the Data page's first load aborted itself and never painted; the
-fix is an ordering, plus `tools/tabpage_harness.py` and
-`tests/test_tab_page_dom.py` so a tab page is now RENDERED in tests. Also
-generalises CI's "must RUN, not skip" step: seven suites depend on playwright,
-and it named one.
+**The three sign-out paths, and the owner has ruled on them.** Reviewed
+2026-08-16, off-plan, and two are defects:
+
+1. **`Sign out` in a row's ⋮ menu is a dead end** — and #199 opened it.
+   `accountMenu` draws the item inside `if (signedIn)`; before #199 every other
+   account was drawn signed-out so it never rendered. Now it does, and
+   `signOutOfAccount` (`extension/app.js:2952`) handles only the CURRENT
+   account — anything else prints *"That account has no session on this device
+   to end."*
+2. **`Sign out of all accounts` signs out exactly one.**
+   `signOutOfAllAccounts` (`:2964`) presses `#signout`, which revokes the
+   current account's grant alone. Every other account keeps its standing Google
+   grant — which is precisely what makes `switchToAccount`'s silent mint
+   succeed — so they are still signed in, and still drawn that way.
+
+**THE RULING: a real sign-out.** Silently mint a token for the account, then
+revoke it. One mechanism fixes both — the single row and the button that
+promises all — and it costs a round trip per account, which is to be reported
+rather than swallowed when it fails.
+
+The top icon (`:5362`) was reviewed and is correct: the generation is bumped
+BEFORE the await, it revokes rather than forgets so a return as someone else is
+possible, the row stays, `local-only` is said out loud, and focus goes back.
+
+**Also stale, and mine:** `app.js:2752` and `:2888` both claim this build has no
+Web OAuth client. `identity.js:364` carries a real one, created 2026-08-12. The
+first sits directly above the line #199 changed and contradicts it.
 
 ## Resume here — the rest of B2
 
@@ -86,11 +110,24 @@ a saved view. A saved view that cannot be deleted is a defect, not a feature —
 it is the owner's call, and B1's list should be edited rather than quietly
 contradicted.
 
+**HELD, 2026-08-16.** The owner has comments on B1 itself and will raise them
+first. Do not start step 3 until he has.
+
 ## Named gaps, not forgotten
 
-- **No DOM test for the Console.** `tools/tabpage_harness.py` was written for the
-  Data page and would extend to `console.html` cheaply. Until then the Console's
-  only proof is static plus one manual browser pass (#186).
+- ~~**No DOM test for the Console.**~~ **CLOSED.** `tests/test_console_dom.py`
+  renders `console.html` for real — ten tests, every one of them broken
+  deliberately first to prove it fails. It could NOT be built the way the Data
+  page's was: the Console's fourteen modules declare **nineteen colliding
+  top-level names** between them (six rule modules each declare `finding`, `text`
+  and `same`; two declare `SHEETS`), so flattening them into one scope is a
+  SyntaxError before a line runs. It is served over http and loads its real
+  module graph instead — the stronger arrangement, and the one to copy next time.
+
+  What it found: `showView("inspect")` is the LAST line of `showTable`, so a
+  throw anywhere above it means pressing a table does **nothing at all** — the
+  sections are built into a view that is never revealed. No error, no half-drawn
+  page, no clue.
 - **`behaviourVersion` is ScrapeX's own bookkeeping, not a signal.** mbiXaddin has
   no such field; both numbers live here and one commit raises both. The real fix
   is `docs/HANDOFF-mbiXaddin-contract-producer.md`. What DOES look upstream is
@@ -101,7 +138,64 @@ contradicted.
   crawl falls back to product pages when the Store API refuses"* is exactly the
   kind of thing the owner asks *"does my build do that?"* about — which is the
   failure `tests/test_version.py`'s own docstring says the ledger exists to
-  prevent. **Open question, owner's call.**
+  prevent.
+
+  **RULED, 2026-08-16: it moves with every new commit.** Not "per user-visible
+  capability", which was the old rule and left the judgement to whoever was
+  writing — and who kept deciding no. Every commit on `main` is one squashed
+  pull request here, so the rule reads: **every merged PR raises VERSION, and
+  regenerates the baseline and CHANGELOG in the same commit.**
+
+  **Measured, because the owner said it had never moved and he was right.**
+  `git log -G'^VERSION = "'` names three commits in the project's whole life:
+  `7ca7a75` created the ledger, `9a0d399` cut 0.2.1, `adf31b2` cut 0.2.2 on
+  10 August. **48 commits since** — Phase A entire, T1, B2 — with the number
+  standing still. (`-S` finds only one of the three: 0.2.1 → 0.2.2 leaves the
+  count of the searched string unchanged. Use `-G` on this file.)
+
+  ### It is NOT just a bump, and this is the blocker
+
+  Raising VERSION to 0.2.3 was tried on 2026-08-16 and reverted the same day.
+  Two things happened, and the second is the reason it needs its own PR.
+
+  **The ledger's own guard fired, correctly.** `robots_per_source` is dated
+  0.2.2 and cited no commit, and a capability older than the build must cite the
+  work that built it. Read out of `git log`, not remembered: both
+  `-S"crawl_obey_disallow"` and `-S"source-edit-robots"` name `adf31b2` alone,
+  so the setting, the panel control and the ledger line landed together. Write
+  `commit="adf31b2"` as part of that PR.
+
+  **THE ENGINE ADVERTISES A NUMBER IT CANNOT KNOW.** `version_report` sends
+  `"latest_extension_version": VERSION` (`scrapex/version.py:484`, and again in
+  `scrapex/webui/app.py:1355`), so the moment the engine moves ahead of
+  `extension/manifest.json` the panel draws *"This ScrapeX extension is older
+  than the engine it is talking to"*. Measured at 320x440: the profile page's
+  legal line went from 396 to 494 against a 440 viewport — 54px clipped, caught
+  by `test_the_signed_in_profile_starts_at_the_top_and_still_fits`.
+
+  Under "bump every commit" that notice becomes PERMANENT and FALSE.
+
+  It is a leftover from before the release paths were unwelded. PLATFORM-PLAN
+  Decision 21 (done 2026-08-05, PR #112) is explicit — *"the extension can be
+  tagged for the Chrome Web Store, **or** the engine tagged for GitHub Releases,
+  with the other number untouched"*, and *"Google reviews the extension and does
+  not review the engine"*. #112 unwelded the numbers and CI and left the REPORT
+  welded. Three constants still speak the old model: `latest_extension_version`,
+  `LATEST_SOURCE` (*"it ships with the extension"*, `:289`) and
+  `UPDATE_INSTRUCTIONS` (*"it carries the new extension with it"*, `:292`).
+
+  **The remedy, ruled 2026-08-16: the engine keeps the GATE and drops the
+  ADVERT.** `MINIMUM_EXTENSION_VERSION` is a fact the engine owns and is derived
+  from the ledger — it stays. "What is the newest extension available" is
+  Chrome's answer, not the engine's — it goes, with the two sentences that say
+  the engine carries the extension. Then VERSION moves every commit and no false
+  card appears, because the floor has not moved.
+
+  **Do NOT instead bump `extension/manifest.json` alongside VERSION.** That
+  re-welds precisely what #112 unwelded and breaks its stated "Done when".
+
+  Its own PR. Add a guard that fails if the engine ever answers for the
+  extension's head again.
 
 ## Phases not started
 

--- a/tests/test_console_dom.py
+++ b/tests/test_console_dom.py
@@ -1,0 +1,354 @@
+"""The Console's inspect screen, RENDERED — the gap this repository named.
+
+WHY IT IS WORTH THE MACHINERY. The Console is where all six sheets are read and
+edited, and until now its only proof was static analysis plus one manual pass in
+a browser (#186). `docs/HANDOFF-resume-the-migration.md` has carried "No DOM
+test for the Console" as a named gap since it was written.
+
+THE FAILURE THIS SHAPE OF SCREEN HAS. `showTable` appends its sections in order:
+
+    Fields → Sources → Mappings → Export views → Ribbon
+
+and they are appended by one function, in one pass. A throw anywhere in the
+middle stops everything after it WITHOUT AN ERROR ON SCREEN — the owner opens a
+table, sees Fields and Sources, and concludes the table has no export views and
+no ribbon entry. Nothing static can see that; the page has to be built.
+
+It is not idle worry. #197 replaced the Mappings block with 195 lines of new DOM
+and merged with every guard green, having never once been drawn. The Data page
+did exactly that two days earlier and was broken in production the whole time.
+
+WHAT THESE TESTS ARE FOR, so the file does not sprawl. What only a rendered page
+settles: that the screen is whole, that no row is dropped between the sheet and
+the card, and that the layout claims made in CSS survive to computed style. The
+sentence rules underneath are pure and are tested pure, without a browser, in
+extension/tests/datamap-view.test.mjs.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Guards the extension: this file reads extension/ sources, so a change there
+# must run it. See tests/test_the_extension_gate_is_complete.py.
+pytestmark = pytest.mark.extension
+
+pytest.importorskip("playwright", reason="needs the browser extra")
+from playwright.sync_api import sync_playwright  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
+import tabpage_harness as harness  # noqa: E402
+
+#: One table fed by TWO profiles, because that is the shape #197 draws one card
+#: per and the shape a single card would have to lie about. The blank
+#: PROFILE_KEY on the first source is not decoration: a blank resolves to the
+#: ENTITY, which is the rule `resolvedProfiles` keeps — and the reason the
+#: mappings for that profile are keyed T_BITUMEN and not "".
+WORKBOOK = {
+    "1.TableDefinition": [
+        {"ENTITY_KEY": "T_BITUMEN", "DISPLAY_NAME": "Bitumen",
+         "ENTITY_TYPE": "COST", "STORAGE_STRATEGY": "MergeUpsert",
+         "LICENSE_TIER": "Standard", "IS_ACTIVE": "TRUE"},
+        {"ENTITY_KEY": "T_UNMAPPED", "DISPLAY_NAME": "Nothing maps here",
+         "ENTITY_TYPE": "REF", "STORAGE_STRATEGY": "ReplaceAll",
+         "LICENSE_TIER": "Free", "IS_ACTIVE": "TRUE"},
+    ],
+    "2.SchemaRule": [
+        {"ENTITY_KEY": "T_BITUMEN", "ATTRIBUTE_KEY": "ITEM_CODE",
+         "DATA_TYPE": "TEXT", "IS_PK": "TRUE", "ORDINAL_POS": "1"},
+        {"ENTITY_KEY": "T_BITUMEN", "ATTRIBUTE_KEY": "PRICE",
+         "DATA_TYPE": "DECIMAL", "SEMANTIC_ROLE": "PRICE", "ORDINAL_POS": "2"},
+        {"ENTITY_KEY": "T_BITUMEN", "ATTRIBUTE_KEY": "CURRENCY",
+         "DATA_TYPE": "TEXT", "ORDINAL_POS": "3"},
+    ],
+    "3.DataSource": [
+        {"SOURCE_KEY": "S_BITUMEN", "TARGET_ENTITY_KEY": "T_BITUMEN",
+         "PROFILE_KEY": "", "SOURCE_URI": "https://example.test/a.csv",
+         "SOURCE_REGION": "MAIN", "IS_ACTIVE": "TRUE"},
+        {"SOURCE_KEY": "S_BITUMEN_ALT", "TARGET_ENTITY_KEY": "T_BITUMEN",
+         "PROFILE_KEY": "P_ALT", "SOURCE_URI": "https://example.test/b.csv",
+         "SOURCE_REGION": "ALT", "IS_ACTIVE": "TRUE"},
+    ],
+    "4.DataMap": [
+        {"PROFILE_KEY": "T_BITUMEN", "TARGET_ATTRIBUTE_KEY": "ITEM_CODE",
+         "SOURCE_TYPE": "Header", "MATCH_MODE": "Exact",
+         "SOURCE_EXPRESSION": "Item Code", "TRANSFORM_CHAIN": "TRIM|UPPER"},
+        {"PROFILE_KEY": "T_BITUMEN", "TARGET_ATTRIBUTE_KEY": "PRICE",
+         "SOURCE_TYPE": "Header", "MATCH_MODE": "StartsWith",
+         "SOURCE_EXPRESSION": "Unit Price", "TRANSFORM_CHAIN": "TRIM|TO_DECIMAL"},
+        {"PROFILE_KEY": "T_BITUMEN", "TARGET_ATTRIBUTE_KEY": "CURRENCY",
+         "SOURCE_TYPE": "Constant", "MATCH_MODE": "",
+         "SOURCE_EXPRESSION": "SAR", "TRANSFORM_CHAIN": ""},
+        {"PROFILE_KEY": "P_ALT", "TARGET_ATTRIBUTE_KEY": "ITEM_CODE",
+         "SOURCE_TYPE": "Index", "MATCH_MODE": "",
+         "SOURCE_EXPRESSION": "0", "TRANSFORM_CHAIN": ""},
+    ],
+    "5.ExportViews": [
+        {"VIEW_KEY": "V_BITUMEN", "ENTITY_KEY": "T_BITUMEN", "LABEL": "Bitumen",
+         "COLUMNS": "ITEM_CODE,PRICE", "IS_ACTIVE": "TRUE"},
+    ],
+    "6.RibbonControls": [
+        {"ITEM_KEY": "R_BITUMEN", "CONTROL_KEY": "mnuCost", "REGION": "MAIN",
+         "ACTION_CLASS": "LoadTable", "ACTION_TAG": "T_BITUMEN",
+         "LABEL": "Bitumen", "ORDER": "1", "IS_ACTIVE": "TRUE"},
+    ],
+}
+
+#: Every section `showTable` appends, in the order it appends them. The point of
+#: naming all five is the failure described at the top of this file: the screen
+#: stops at the throw, so only the LAST one proves the ones before it ran.
+#:
+#: A SUBSEQUENCE, NOT THE WHOLE LIST, and both reasons are real behaviour rather
+#: than slack. "Mappings" appears once PER PROFILE, so a two-profile table shows
+#: it twice; and a table with findings against it gains "How this table is
+#: written" at the end. Pinning the list exactly would make this test fail for a
+#: second profile, which is the very shape #197 was built to draw.
+SECTIONS = ["Fields", "Sources", "Mappings", "Export views", "Ribbon"]
+
+
+@pytest.fixture(scope="module")
+def browser():
+    with sync_playwright() as pw:
+        instance = pw.chromium.launch()
+        try:
+            yield instance
+        finally:
+            instance.close()
+
+
+@pytest.fixture(scope="module")
+def served():
+    with harness.serve_extension() as base:
+        yield base
+
+
+@pytest.fixture()
+def inspect(browser, served):
+    """Open the Console, click a table, and return the page on its inspect screen.
+
+    `table=None` stops at the workbook screen — which is where a REFUSED
+    workbook stays, so waiting for a table list there would time out on the one
+    path that is behaving correctly.
+    """
+    pages = []
+
+    def opener(table="T_BITUMEN", *, rows=None, refused=False, **stub_kwargs):
+        page = browser.new_page(viewport={"width": 1280, "height": 900})
+        errors: list[str] = []
+        page.on("pageerror", lambda e: errors.append(str(e)))
+        page.add_init_script(
+            harness.console_stub(WORKBOOK if rows is None else rows,
+                                 **stub_kwargs))
+        page.goto(f"{served}/console.html")
+        pages.append(page)
+        page.js_errors = errors
+
+        # The workbook arrives over two awaited round trips before anything is
+        # drawn. Wait for what proves both landed, rather than for a clock.
+        if refused:
+            page.wait_for_function(
+                "document.getElementById('workbook-state').className"
+                ".includes('err')", timeout=10_000)
+            return page
+
+        # ATTACHED, not visible: the Console opens on its overview and every
+        # other view is hidden until its rail tab is pressed. Waiting for the
+        # list to be VISIBLE waits for a click this fixture has not made yet.
+        page.wait_for_selector("#tables-list button.pair-row",
+                               state="attached", timeout=10_000)
+        if table:
+            page.click("#cv-tab-tables")
+            page.locator("#tables-list button.pair-row",
+                         has_text=table).first.click()
+            # ATTACHED again, and this one matters. `showView("inspect")` is the
+            # LAST line of `showTable`, so a throw anywhere above it leaves the
+            # sections built but the screen never switched. Waiting for VISIBLE
+            # would fail here as a timeout — and a guard whose failure message
+            # is a stopwatch teaches nobody what broke. `assert_whole` says it.
+            page.wait_for_selector("#inspect-body .card", state="attached",
+                                   timeout=10_000)
+        return page
+
+    try:
+        yield opener
+    finally:
+        for page in pages:
+            page.close()
+
+
+def headings(page):
+    return page.locator("#inspect-body h2").all_inner_texts()
+
+
+def assert_whole(page):
+    """Every section of `showTable` reached the screen, in order — and the
+    screen is on screen.
+
+    `showView("inspect")` is the last line of `showTable`. A throw above it
+    builds the sections into a view that is never revealed, so the owner presses
+    a table and NOTHING HAPPENS — no error, no half-drawn page, no clue.
+    """
+    assert page.locator("#inspect-body").is_visible(), (
+        "the table was pressed and the inspect screen never appeared — "
+        "showTable threw before its final showView(\"inspect\")")
+
+    drawn = headings(page)
+    remaining = list(SECTIONS)
+    for heading in drawn:
+        if remaining and heading == remaining[0]:
+            remaining.pop(0)
+    assert not remaining, (
+        f"the inspect screen never reached {remaining[0]!r} — it drew {drawn}. "
+        "A section missing from the TAIL means something above it threw and "
+        "took the rest of the page with it, silently")
+
+
+def card_for(page, profile):
+    """The mappings card whose strip carries this profile key.
+
+    BY KEY AND NOT BY POSITION. The cards are drawn in sorted order, so `P_ALT`
+    comes first and a test reaching for "the card" by index quietly asserts
+    against the wrong profile the day a key is renamed.
+    """
+    return page.locator("#inspect-body .map-card").filter(
+        has=page.locator(".map-profile-key", has_text=profile))
+
+
+def test_the_console_gets_as_far_as_a_list_of_tables(inspect):
+    """The floor. Everything below assumes the page boots, reads a workbook over
+    two round trips, and accepts it as the file the add-in reads — and if any of
+    that is broken, every other failure in this file is a symptom of it."""
+    page = inspect(table=None)
+
+    assert page.locator("#tables-list button.pair-row").count() == 2
+    assert page.locator("#workbook-identity").inner_text() == "mbiX Configuration"
+    assert page.js_errors == [], f"the page threw: {page.js_errors}"
+
+
+def test_the_inspect_screen_is_whole(inspect):
+    """THE TEST THIS FILE EXISTS FOR.
+
+    `showTable` appends five sections in one pass, so a throw in any of them
+    truncates the screen in silence — no error, no empty state, just a page that
+    ends early and reads as a table with nothing in it. Ribbon is last, which is
+    why its absence is the sensitive end of this assertion."""
+    page = inspect()
+
+    assert_whole(page)
+    assert page.js_errors == [], f"the page threw: {page.js_errors}"
+
+
+def test_no_mapping_is_lost_between_the_sheet_and_the_card(inspect):
+    """The card is drawn by looping over PROFILES and filtering the rows into
+    them, not by looping over the rows. That is only complete while every row's
+    profile is in the resolved set — so this counts what the sheet holds against
+    what the screen shows, and would catch the day those two stop agreeing."""
+    page = inspect()
+
+    on_screen = page.locator("#inspect-body .map-row").count()
+    in_sheet = len(WORKBOOK["4.DataMap"])
+    assert on_screen == in_sheet, (
+        f"{in_sheet} mappings in the sheet, {on_screen} rows drawn — a mapping "
+        "whose profile is not in the resolved set is dropped without a word")
+
+
+def test_each_profile_gets_its_own_card_carrying_its_own_key(inspect):
+    """One strip per card, and the strip is a claim about every row beneath it.
+    Two profiles on one table is a real shape, and one card would have to stand
+    a single PROFILE_KEY over rows that do not all carry it."""
+    page = inspect()
+
+    assert page.locator("#inspect-body .map-card").count() == 2
+    assert sorted(page.locator("#inspect-body .map-profile-key")
+                  .all_inner_texts()) == ["P_ALT", "T_BITUMEN"]
+
+    # Derived from the rows rendered, never a number typed beside them.
+    assert card_for(page, "T_BITUMEN").locator(".map-count").inner_text() \
+        == "3 rows"
+    assert card_for(page, "P_ALT").locator(".map-count").inner_text() == "1 row"
+
+
+def test_the_header_and_every_row_resolve_to_one_grid(inspect):
+    """The template is declared once, in `--map-columns`, and read by two
+    separate elements. Nothing but computed style can prove they still agree —
+    and a header that has drifted from its rows is a table that mislabels every
+    value under it."""
+    page = inspect()
+
+    templates = page.evaluate("""() => {
+      const card = document.querySelector('.map-card');
+      return [card.querySelector('.map-head'),
+              ...card.querySelectorAll('.map-cells')]
+        .map((node) => getComputedStyle(node).gridTemplateColumns);
+    }""")
+
+    assert len(set(templates)) == 1, (
+        f"the header and its rows resolved to different grids: {templates}")
+
+
+def test_a_row_says_in_words_what_its_five_cells_say_in_enums(inspect):
+    page = inspect()
+    row = card_for(page, "T_BITUMEN").locator(".map-row").nth(1)
+    row.locator(".map-cells").click()
+
+    said = row.locator(".map-said").inner_text().lower()
+    for part in ("price", "comes from the column", "unit price", "matched",
+                 "startswith", "then", "trim", "to_decimal"):
+        assert part in said, f"{part!r} missing from {said!r}"
+
+
+def test_a_constant_drops_the_clause_that_would_say_nothing(inspect):
+    """`CURRENCY is always SAR` — no `matched`, because a constant has no name
+    to look for and `matched —` is a sentence about nothing. The rule is pure
+    and tested pure; this proves the DOM assembly honours it."""
+    page = inspect()
+    row = card_for(page, "T_BITUMEN").locator(".map-row").nth(2)
+    row.locator(".map-cells").click()
+
+    said = row.locator(".map-said").inner_text()
+    assert "is always" in said and "SAR" in said, said
+    assert "matched" not in said.lower(), f"a constant claimed a match: {said!r}"
+
+
+def test_one_row_is_open_and_opening_another_closes_it(inspect):
+    """A table where every row is shut looks inert, and a table where they all
+    open at once stops being a table. Both are one function's job."""
+    page = inspect()
+    rows = card_for(page, "T_BITUMEN").locator(".map-cells")
+
+    assert rows.nth(0).get_attribute("aria-expanded") == "true", (
+        "no row was open — the sentence is the thing this card was redrawn for")
+
+    rows.nth(1).click()
+    assert [rows.nth(i).get_attribute("aria-expanded") for i in range(3)] \
+        == ["false", "true", "false"]
+
+    rows.nth(1).click()
+    assert rows.nth(1).get_attribute("aria-expanded") == "false", (
+        "pressing the open row did not close it")
+
+
+def test_a_table_nothing_maps_to_still_says_so(inspect):
+    """The empty state is the one path the new card does NOT draw, so it is the
+    one most easily lost when a block becomes a card."""
+    page = inspect("T_UNMAPPED")
+
+    assert_whole(page)
+    assert page.locator("#inspect-body .map-card").count() == 0
+    assert "No mapping" in page.locator("#inspect-body").inner_text()
+
+
+def test_a_workbook_that_is_not_the_add_ins_is_refused_by_tab_id(inspect):
+    """The check that comes before every other check. A copy with all six tab
+    NAMES looks perfect and is a file the add-in has never opened — and a
+    Console that checked it would report that everything is fine about it."""
+    page = inspect(table=None, refused=True,
+                   tabs={"1.TableDefinition": "999999"})
+
+    state = page.locator("#workbook-state").inner_text()
+    assert "not the workbook the add-in reads" in state, state
+    assert "1.TableDefinition is tab 999999 here" in state, state
+    assert page.locator("#tables-list button.pair-row").count() == 0, (
+        "the workbook was refused and its tables were listed anyway")

--- a/tools/tabpage_harness.py
+++ b/tools/tabpage_harness.py
@@ -16,15 +16,22 @@ sentences, what it draws — and proves nothing about Chrome's permissions, the
 service worker, or a real 127.0.0.1. Saying so matters: a harness mistaken for
 the product is how "it passed the tests" starts meaning less than it should.
 
-THE MODULE GRAPH IS FLATTENED, not re-declared. Imports are stripped and
-`export` removed, so the files that run here are the files that ship — the same
+THE MODULE GRAPH IS NEVER RE-DECLARED, by either of the two mechanisms here.
+The Data page is FLATTENED — imports stripped, `export` removed — the same
 choice panel_harness.py makes, for the same reason: a test-only re-declaration
-of a function tests the re-declaration.
+of a function tests the re-declaration. The Console is SERVED instead and loads
+its real modules, because flattening it is not possible; see the section at the
+foot of this file for the nineteen name collisions that decide it.
 """
 from __future__ import annotations
 
+import contextlib
+import functools
 import json
 import re
+import threading
+from collections.abc import Iterator
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -105,3 +112,131 @@ def build_data_page(tmp: Path, stub_js: str, name: str = "data.html") -> Path:
         "</body></html>",
         encoding="utf-8")
     return page
+
+
+# ---- the Console -------------------------------------------------------------
+#
+# A DIFFERENT MECHANISM, and not by preference. The Data page above is FLATTENED,
+# and the Console cannot be: its fourteen modules declare NINETEEN colliding
+# top-level names between them. Six of the rule modules each declare `finding`,
+# `text` and `same`; two declare `SHEETS`, `RANK`, `BAGS`, `KEY_LIMIT` and
+# `checkBag`. Concatenated into one scope, the first duplicate `const` is a
+# SyntaxError before a single line runs.
+#
+# So the Console is SERVED and loaded as the real module graph — which is the
+# stronger arrangement anyway. Nothing is rewritten, the browser resolves the
+# imports the shipped page declares, and the files under test are the files on
+# disk rather than a transformation of them. The reason to prefer flattening is
+# that it needs no server; the reason to prefer this is everything else.
+
+
+class _QuietHandler(SimpleHTTPRequestHandler):
+    """`SimpleHTTPRequestHandler`, minus a log line per module fetched."""
+
+    def log_message(self, *args, **kwargs):
+        pass
+
+
+@contextlib.contextmanager
+def serve_extension() -> Iterator[str]:
+    """The shipped `extension/` directory over http. Yields its base URL.
+
+    ES modules will not load over file:// — the browser refuses every import as
+    cross-origin and the page stays blank, which looks exactly like the kind of
+    defect this file exists to catch. NOTHING IS COPIED: the directory served is
+    the one that ships, so a module deleted from the repository is a module
+    missing from the test.
+    """
+    server = ThreadingHTTPServer(
+        ("127.0.0.1", 0), functools.partial(_QuietHandler, directory=str(EXT)))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def console_stub(rows: dict[str, list[dict]] | None = None, *,
+                 title: str = "mbiX Configuration", token: str = "harness-token",
+                 remembered: str | None = "FILE-1",
+                 tabs: dict[str, str] | None = None, fail: str = "") -> str:
+    """Chrome and Google, for a page that has neither. Feed to `add_init_script`.
+
+    THE CONTRACT IS NOT RESTATED HERE, and that is the whole design of it. The
+    two answers this stub gives — which tabs the file has, and what is in
+    them — are built from `addin-contract.js` and `workbook.js`, imported at
+    call time from the same directory the page was served from. A harness that
+    typed the six gids and the column order out again would keep passing after
+    the add-in's contract moved, which is the one thing it exists to notice.
+
+    `rows` is keyed by tab name and holds plain dicts: {"4.DataMap": [{...}]}.
+    Each is placed into the columns `workbook.js` declares for that sheet, so a
+    test says what it means and never counts commas.
+
+    `tabs` is MERGED OVER the real ids rather than replacing them, so
+    {"1.TableDefinition": "999"} is a workbook with all six tabs and one wrong
+    id — the case worth forcing. Replacing the map wholesale would make every
+    other tab *absent* instead, and the Console reports those two states
+    differently and correctly.
+    """
+    return f"""
+window.__ASKED__ = [];
+window.__ROWS__ = {json.dumps(rows or {}, ensure_ascii=False)};
+window.__TABS__ = {json.dumps(tabs) if tabs else "null"};
+
+window.chrome = {{
+  identity: {{
+    getAuthToken: (options, callback) => callback({json.dumps(token)}),
+    removeCachedAuthToken: (options, callback) => callback(),
+    getRedirectURL: () => "https://harness.chromiumapp.org/",
+    launchWebAuthFlow: (options, callback) => callback(""),
+  }},
+  // ANSWERS FOR WHATEVER KEY IS ASKED. console.js remembers the chosen workbook
+  // under a name of its own, and a harness that hard-coded that name would go
+  // quietly inert the day it changed.
+  storage: {{local: {{
+    get: async (key) => ({json.dumps(bool(remembered))}
+      ? {{[key]: {{fileId: {json.dumps(remembered)}, name: {json.dumps(title)}}}}}
+      : {{}}),
+    set: async () => {{}},
+  }}}},
+  runtime: {{lastError: null, getURL: (path) => path, id: "harness"}},
+  tabs: {{create: () => {{}}}},
+}};
+
+window.fetch = async (input, options) => {{
+  const url = String(input && input.url ? input.url : input);
+  window.__ASKED__.push(url);
+  if ({json.dumps(bool(fail))}) throw new TypeError({json.dumps(fail or "failed")});
+  const answer = (body) => new Response(JSON.stringify(body),
+    {{status: 200, headers: {{"Content-Type": "application/json"}}}});
+
+  // The add-in's own six tab ids, so the Console's identity check passes for
+  // the reason it is meant to pass and not because the check was skipped.
+  if (url.includes("fields=properties.title")) {{
+    const {{ SHEET_GIDS }} = await import("./addin-contract.js");
+    const tabs = {{...SHEET_GIDS, ...(window.__TABS__ || {{}})}};
+    return answer({{
+      properties: {{title: {json.dumps(title)}}},
+      sheets: Object.entries(tabs).map(
+        ([name, sheetId]) => ({{properties: {{title: name, sheetId}}}})),
+    }});
+  }}
+
+  // Sheets answers a GRID, header first — and TRUNCATES trailing blanks, which
+  // is what `parseWorkbook` pads for. Building the grid from the sheet's own
+  // declared columns keeps this honest in both directions.
+  if (url.includes("values:batchGet")) {{
+    const {{ SHEETS }} = await import("./workbook.js");
+    return answer({{valueRanges: SHEETS.map((spec) => ({{
+      range: `'${{spec.tab}}'!A1:CA2000`,
+      values: [spec.columns, ...(window.__ROWS__[spec.tab] || []).map(
+        (row) => spec.columns.map((name) => row[name] ?? ""))],
+    }}))}});
+  }}
+  return answer({{}});
+}};
+"""


### PR DESCRIPTION
Closes the gap `docs/HANDOFF-resume-the-migration.md` has carried since it was written: **no DOM test for the Console** — the screen where all six sheets are read and edited, whose only proof was static analysis plus one manual browser pass (#186).

#197 has just added **195 lines of new DOM** to that screen. Nothing had ever drawn it. The Data page did exactly that two days earlier and was broken in production the whole time (#194).

## Flattening is not available here, and that decided the design

The Data page's harness strips imports and concatenates modules into one scope. The Console's fourteen modules declare **nineteen colliding top-level names** between them:

| name | declared by |
|---|---|
| `finding`, `text`, `same` | six of the rule modules each |
| `SHEETS` | `addin-vocabulary.js` and `workbook.js` |
| `RANK`, `BAGS`, `KEY_LIMIT`, `checkBag` | two each |

Concatenated, the first duplicate `const` is a SyntaxError before a line runs.

So `serve_extension()` puts the shipped `extension/` directory behind an http server and the page loads its **real module graph**. Nothing rewritten, nothing copied — the browser resolves the imports the page itself declares. Stronger than flattening; flattening's only advantage was needing no server.

**The stub does not restate the contract.** The two answers Google gives — which tabs the file has, and what is in them — are built by importing `addin-contract.js` and `workbook.js` at call time. A harness that typed the six gids and the column order out again would keep passing after the add-in's contract moved, which is the one thing it exists to notice.

## What it found

`showView("inspect")` is the **last** line of `showTable`. A throw anywhere above it leaves all five sections built into a view that is never revealed — so pressing a table does **nothing at all**. No error, no half-drawn page, no clue. Worse than the truncation the tests were written for.

The guard says that in its own words. That took a second pass: waiting for the card to be *visible* made the failure a stopwatch, and a guard whose message is a timeout teaches nobody what broke.

## Every one of the ten was broken deliberately first

| mutation | verdict |
|---|---|
| the card throws | CAUGHT — 7 tests, including the whole-screen guard |
| a profile dropped from the loop | CAUGHT — the row-count guard |
| the header gets a grid of its own | CAUGHT — the computed-style guard |
| a constant claims a header match | CAUGHT — the sentence guard |
| every row left open at once | CAUGHT — the disclosure guard |

`SECTIONS` is asserted as a **subsequence**, and that is behaviour rather than slack: "Mappings" appears once per profile, so #197's two-profile shape draws it twice, and a table with findings gains "How this table is written" at the end. Pinning the list exactly would fail on the very shape #197 was built for.

## Verified

- `pytest -m extension` — **629** collected, all pass (was 619)
- `node --test extension/tests/*.test.mjs` — 411 pass, 0 fail
- eslint clean
- CI will discover the new suite: it is found by `grep -l 'importorskip("playwright"'`, not by name

## Also recorded in the handoff, not in code

**The three sign-out paths**, reviewed, with two defects named — the row's `Sign out` is a dead end for any non-current account (a consequence of #199), and `Sign out of all accounts` signs out exactly one — plus the owner's ruling: a real sign-out, silent mint then revoke.

**Why raising `VERSION` needs its own PR.** It was tried here and reverted the same day. `version_report` sends `"latest_extension_version": VERSION`, so the moment the engine moves ahead of `extension/manifest.json` the panel draws *"This ScrapeX extension is older than the engine it is talking to"*. Measured at 320×440: the profile page's legal line went 396 → 494 against a 440 viewport, 54px clipped — caught by the test added in #199. Under "bump every commit" that card becomes permanent and false. It is a leftover from before PLATFORM-PLAN Decision 21 unwelded the two release paths (PR #112), and the remedy is that the engine keeps the **gate** and drops the **advert**.

## Not verified in this PR

The harness proves the page's own behaviour. `chrome.*` is a stub and Google is a fixture, so it proves nothing about Chrome's permissions, the service worker, or a real spreadsheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)