### PR TITLE
Sign out of all accounts signed out exactly one, and the row menu never offered it at all

### DIFF
--- a/docs/HANDOFF-resume-the-migration.md
+++ b/docs/HANDOFF-resume-the-migration.md
@@ -42,35 +42,78 @@ anywhere, as B1 claims. See the conflict below, though — finishing B2 revives 
 | — | The Data page's first load, which aborted itself (#194); the Profile page's centred account (#196); a second account no longer looking signed out (#199); the Mappings card (#197) |
 | **Console · rendered** | `serve_extension()` + `console_stub()` in `tools/tabpage_harness.py`, and `tests/test_console_dom.py`. The gap below is closed |
 
-## In flight
+## Just landed
 
-**The three sign-out paths, and the owner has ruled on them.** Reviewed
-2026-08-16, off-plan, and two are defects:
+**Sign-out — DONE 2026-08-16.** Reviewed, ruled on, built, and mutation-tested.
 
-1. **`Sign out` in a row's ⋮ menu is a dead end** — and #199 opened it.
-   `accountMenu` draws the item inside `if (signedIn)`; before #199 every other
-   account was drawn signed-out so it never rendered. Now it does, and
-   `signOutOfAccount` (`extension/app.js:2952`) handles only the CURRENT
-   account — anything else prints *"That account has no session on this device
-   to end."*
-2. **`Sign out of all accounts` signs out exactly one.**
-   `signOutOfAllAccounts` (`:2964`) presses `#signout`, which revokes the
-   current account's grant alone. Every other account keeps its standing Google
-   grant — which is precisely what makes `switchToAccount`'s silent mint
-   succeed — so they are still signed in, and still drawn that way.
+**A correction first, because the first diagnosis was wrong.** It was reported
+here that the row's `Sign out` had become a dead end. It had not: `accountMenu`
+was called from exactly ONE place, `renderAccountsCard`, with `{signedIn: false}`
+written out literally — so the item inside `if (signedIn)` had **never once been
+drawn**, before or after any of this. The earlier pull request repaired the
+argument `accountRow` gets and left the menu's, which is why a row could offer a
+switch while its own menu could not offer a sign-out. Not a dead end: a missing
+button, and the thing the owner asked for in the first place.
 
-**THE RULING: a real sign-out.** Silently mint a token for the account, then
-revoke it. One mechanism fixes both — the single row and the button that
-promises all — and it costs a round trip per account, which is to be reported
-rather than swallowed when it fails.
+What was true: **`Sign out of all accounts` signed out exactly one.** It pressed
+the top `#signout`, which revokes only the current account's grant; every other
+account kept the standing Google grant that makes a silent mint succeed.
 
-The top icon (`:5362`) was reviewed and is correct: the generation is bumped
-BEFORE the await, it revokes rather than forgets so a return as someone else is
-possible, the row stays, `local-only` is said out loud, and focus goes back.
+**THE RULING, and what was built: a real sign-out.** `endOtherAccountSession`
+mints a token for the account silently (`login_hint` + `prompt=none`) and revokes
+THAT token. `signOutOfAllAccounts` walks the others first — one at a time, not
+`Promise.all` — and presses `#signout` last, because signing out the current
+account clears `state.token` and `renderAccountsCard` returns early without one.
 
-**Also stale, and mine:** `app.js:2752` and `:2888` both claim this build has no
-Web OAuth client. `identity.js:364` carries a real one, created 2026-08-12. The
-first sits directly above the line #199 changed and contradicts it.
+**THE LOCKOUT IT WOULD OTHERWISE HAVE BEEN.** The panel holds exactly ONE token
+and it belongs to the CURRENT account. The obvious implementation — hand
+`state.token` to `revokeToken` — ends the wrong grant: press Sign out on somebody
+else's row and be signed out of your own. `tests/test_signing_out_really_signs
+_out.py` guards precisely that, and nothing in the suite covered it before,
+because no test had ever driven the per-row menu.
+
+**THE HARNESS HAD TO GROW FIRST, and this is the part worth remembering.**
+`tools/panel_harness.py` stubbed only `getAuthToken` and `removeCachedAuthToken`,
+so `identity.js:authorize()` fell into its `getRedirectURL()` try/catch and
+returned state `failed` under **every panel test ever written**. The whole
+multi-account surface was unreachable, and silently — a test could press the
+button and read a plausible error message. It also had no route for Google's
+revoke endpoint, so every sign-out driven through it took the `local-only` path
+on a 404 and no test ever looked at the message. Both are fixed; `silent_for`
+and `revoke_status` are the new knobs.
+
+### What sign-out still cannot reach, stated rather than left to be found
+
+**There are TWO OAuth clients in this project, and therefore two grants.**
+`manifest.json:oauth2.client_id` is a Chrome-Extension client (used by
+`getAuthToken`); `identity.js:WEB_CLIENT_ID` is a Web client (used by
+`launchWebAuthFlow`). A Google grant is per client, so `revokeToken` ends only
+the grant of the client that minted the token it is given. For an account added
+through the switcher that is complete — it only ever had a Web grant. For the
+Chrome profile's PRIMARY account, which can hold both, one may survive. The
+comment at `identity.js:176-189` is written as though there were one client.
+**Not fixed here, and not to be fixed by revoking both**: on an
+`admin_policy_enforced` Workspace account, `blocked-by-admin` is the branch that
+pressing again cannot fix, so dropping the Chrome-Extension grant could leave an
+owner unable to sign back in at all.
+
+Two more found in the same reading and left alone deliberately:
+
+- **HTTP 400 counts as revoked** (`identity.js:205`). Google answers 400 for an
+  EXPIRED token as well as an already-revoked one, and an implicit-flow token
+  lives about an hour. Sign out after an idle hour and the panel reports a grant
+  ended that is still listed.
+- **Neither `authorize` nor `revokeToken` has a deadline**, while `getToken` and
+  `accountFor` both do. A hung revoke leaves the Sign out button disabled with
+  the panel still holding the token.
+
+### One mutation survives, and it is equivalent
+
+Removing the early return AND switching the message from `ended.revoked` to
+`ended.state === "ok"` — **both at once** — produces identical behaviour on every
+reachable input, because `revokeToken` differs between the two only when handed a
+falsy token. Either mutation ALONE is caught. This is recorded rather than
+papered over: contorting a test to kill an equivalent mutant would be the lie.
 
 ## Resume here — the rest of B2
 

--- a/extension/app.js
+++ b/extension/app.js
@@ -2517,11 +2517,14 @@ function renderAccount({ tokenProblem = null } = {}) {
 //
 // WHAT "SIGNED OUT" MEANS ON A ROW. The directory deliberately stores no session
 // state — a cached "signed in" is a fact that goes stale on disk and then lies.
-// The only account this panel KNOWS it holds a token for is the current one;
-// every other row is offered as signed out until a silent authorisation proves
-// otherwise. That check needs the Web OAuth client, which this build does not
-// have yet, so today every other row renders as signed out. That is the truth
-// about this build rather than a placeholder.
+// So a row is drawn signed out only when this panel has LEARNED it is: either it
+// ended that session itself, or a silent authorisation for it was refused.
+// `state.signedOutAccounts` is that knowledge and it is in memory only, which is
+// the point — it is reasoning about this session, not a record about the person.
+//
+// Everything else is offered as a switch. That is a claim the panel can make
+// good on: `switchToAccount` mints silently through `WEB_CLIENT_ID`, and when
+// Google will not answer, the row becomes a signed-out row at that moment.
 
 function accountInitial(account) {
   const source = String(account.name || account.email || "").trim();
@@ -2749,9 +2752,6 @@ function renderAccountsCard() {
   const list = el("div", "accounts-list");
   list.id = "accounts-list";
   for (const account of others) {
-    // See the note at the top of this section: without the Web OAuth client
-    // nothing can be authorised silently, so no other row can be shown as
-    // signed in without saying something this build cannot know.
     // THE ONE LINE THIS WHOLE DEFECT WAS. It read `signedIn: false`, so every
     // other account was drawn signed-out and `accountRow`'s switch branch —
     // which was written, tested and correct — could never be reached. Signing
@@ -2773,7 +2773,17 @@ function renderAccountsCard() {
 
   const open = others.find((account) => account.id === state.openAccountMenu);
   if (open) {
-    card.append(accountMenu(open, { signedIn: false }));
+    // THE SAME QUESTION THE ROW ASKS, and it was `false` written out literally
+    // until 2026-08-16 — so `accountMenu`'s `if (signedIn)` branch never ran and
+    // the Sign out item it guards had never once been drawn. The pull request
+    // that repaired the ROW's argument left this one, which is why a row could
+    // offer a switch while its own menu still could not offer a sign-out.
+    //
+    // (No PR number here on purpose: `#` plus three hex digits is a colour
+    // literal to tests/test_vendor.py, and this comment cost a red build once.)
+    card.append(accountMenu(open, {
+      signedIn: !state.signedOutAccounts.has(open.id),
+    }));
     placeOpenAccountMenu();
   }
 
@@ -2885,11 +2895,14 @@ async function removeAccount(id) {
   renderAccountsCard();
 }
 
-// The four actions that need a token for an account this panel is not currently
-// holding one for. Each is a single call into identity.js, and each reports what
-// came back rather than pretending it worked — today that is the same sentence
-// for all of them, because the build has no Web OAuth client yet and
-// `authorize` refuses before opening anything.
+// The actions that need a token for an account this panel is not currently
+// holding one for. Each is a call into identity.js, and each reports what came
+// back rather than pretending it worked.
+//
+// THESE COMMENTS SAID THE BUILD HAD NO WEB OAUTH CLIENT until 2026-08-16, and
+// by then it had had one since 2026-08-12 (`identity.js:WEB_CLIENT_ID`). A
+// comment that describes a build two versions old is worse than none: it was
+// still being read as a reason none of this could work.
 
 async function switchToAccount(id) {
   const account = state.accounts.find((held) => held.id === id);
@@ -2949,23 +2962,101 @@ async function adoptAuthorizedAccount(token) {
   renderAccountsCard();
 }
 
+/**
+ * Really end the session of an account this panel is NOT holding a token for.
+ *
+ * MINT FIRST, AND NEVER `state.token`. The panel holds exactly ONE token and it
+ * belongs to the CURRENT account. Handing that token to `revokeToken` because a
+ * different row's menu was pressed would end the wrong grant entirely — the
+ * owner presses Sign out on somebody else's row and is signed out of his own.
+ * So the token to end is minted for THIS account, silently, and only then
+ * revoked. It is the one ordering in here that cannot be got wrong twice.
+ *
+ * A REFUSED MINT IS ALREADY THE ANSWER, not a failure to report as one. A
+ * `prompt=none` that Google will not answer means there is no live session for
+ * this account — which is what signed out MEANS — so the row becomes the
+ * signed-out row without any grant having to be ended.
+ *
+ * WHAT THIS CANNOT REACH, said plainly rather than left to be discovered: the
+ * mint goes through `WEB_CLIENT_ID`, so the grant it ends is the WEB client's.
+ * An account that also holds a grant under the manifest's Chrome-Extension
+ * client — which only the Chrome profile's primary account can — keeps that
+ * one. `revokeToken` has always had this limit; it is stated here because this
+ * is the first caller that mints the token it revokes.
+ */
+async function endOtherAccountSession(account) {
+  const minted = await authorize({ email: account.email, interactive: false });
+  const marked = () => {
+    state.signedOutAccounts.add(account.id);
+    renderAccountsCard();
+  };
+
+  if (minted.state !== "ok" && minted.state !== "partial") {
+    marked();
+    setAccountsStatus(`${accountLabel(account)} is signed out.`);
+    return;
+  }
+
+  const ended = await revokeToken(minted.token);
+  marked();
+  // `revoked`, NOT `state`, and the honest reason rather than a grander one:
+  // the two can differ in exactly ONE case — `revokeToken` answers
+  // `{state: "ok", revoked: false}` when handed a falsy token, having asked
+  // Google nothing. The early return above is what keeps a refused mint's
+  // `undefined` from ever arriving here, so today the two cannot disagree.
+  // This is the braces to that belt: if the return above is ever moved or
+  // widened, `state` would report a grant ended that was never asked about,
+  // and `revoked` cannot. A mutation confirms the pair — breaking either one
+  // alone leaves the tests green, and breaking both does not.
+  setAccountsStatus(ended.revoked
+    ? `${accountLabel(account)} is signed out.`
+    : `${accountLabel(account)} is signed out here. ${ended.detail} Google may `
+      + "still list ScrapeX under that account's permissions.");
+}
+
 async function signOutOfAccount(id) {
   closeAccountMenu();
   if (id === state.currentAccountId) {
+    // The current account has a whole handler of its own, and its ordering —
+    // the generation bumped before the await, the revoke before the clear, the
+    // focus returned afterwards — is load-bearing and tested. Press it rather
+    // than writing a second copy that drifts from it.
     const button = $("signout");
     if (button) button.click();
     return;
   }
-  // No token is held for any other account — there is nothing to end here, and
-  // saying so is better than a button that appears to work and does nothing.
-  setAccountsStatus("That account has no session on this device to end.");
+  const account = state.accounts.find((held) => held.id === id);
+  if (!account) return;
+  setAccountsStatus(`Signing out of ${accountLabel(account)}…`);
+  await endOtherAccountSession(account);
 }
 
+/**
+ * Sign out of every account, and mean every.
+ *
+ * THE OTHERS FIRST, THE CURRENT ONE LAST, and the order is the whole of it:
+ * signing out the current account clears `state.token`, and `renderAccountsCard`
+ * returns early without a token — so the card, the rows and this button are all
+ * gone before the loop could reach them.
+ *
+ * ONE AT A TIME rather than `Promise.all`. Each one opens a silent auth flow at
+ * Google and then posts a revoke; firing five at once is a burst against
+ * somebody else's service to save a second on an action taken once.
+ *
+ * NO ROW IS ERASED. Signing out ends sessions; removing an account is a
+ * different button with a confirmation on it.
+ */
 async function signOutOfAllAccounts() {
   closeAccountMenu();
+  const others = state.accounts.filter(
+    (account) => account.id !== state.currentAccountId);
+
+  for (const account of others) {
+    setAccountsStatus(`Signing out of ${accountLabel(account)}…`);
+    await endOtherAccountSession(account);
+  }
+
   const button = $("signout");
-  // The current account is the only one holding a session, so ending it ends
-  // them all. The row for every account stays; signing out is not removing.
   if (button) button.click();
 }
 

--- a/tests/test_signing_out_really_signs_out.py
+++ b/tests/test_signing_out_really_signs_out.py
@@ -1,0 +1,269 @@
+"""Signing out of an account the panel is not holding a token for.
+
+WHAT WAS WRONG, both halves owner-reported and both confirmed by reading:
+
+  1. The per-row ⋮ menu had never once offered "Sign out". `accountMenu` guards
+     the item with `if (signedIn)` and `renderAccountsCard` called it with
+     `{signedIn: false}` written out literally — so the branch was unreachable.
+     #199 fixed the argument `accountRow` gets and left this one, which is why a
+     row could offer a switch while its own menu could not offer a sign-out.
+
+  2. "Sign out of all accounts" signed out exactly ONE. It pressed `#signout`,
+     which revokes the CURRENT account's grant; every other account kept its
+     standing Google grant — the very thing that makes a silent mint succeed —
+     so they were still signed in, and still drawn that way.
+
+THE LOCKOUT THIS COULD HAVE BEEN, and the reason these tests exist rather than a
+node suite. The panel holds exactly ONE token and it belongs to the CURRENT
+account. The obvious implementation — hand `state.token` to `revokeToken` —
+would end the wrong grant: press Sign out on somebody else's row and be signed
+out of your own. `test_signing_out_of_another_account_does_not_sign_out_of_this
+_one` is the guard for precisely that, and nothing in the suite covered it
+because no test had ever driven the per-row menu.
+
+WHY THE HARNESS HAD TO GROW FIRST. `tools/panel_harness.py` stubbed only
+`getAuthToken` and `removeCachedAuthToken`, so `identity.js:authorize()` fell
+into its `getRedirectURL()` try/catch and returned state "failed" under every
+panel test ever written. The entire multi-account surface was unreachable, and
+silently — a test could press the button and read a plausible error. It also had
+no route for Google's revoke endpoint, so every sign-out driven here took the
+`local-only` path on a 404 and no test ever looked.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Guards the extension: this file reads extension/ sources, so a change there
+# must run it. See tests/test_the_extension_gate_is_complete.py.
+pytestmark = pytest.mark.extension
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "tools"))
+
+pytest.importorskip("playwright", reason="needs the browser extra")
+
+from playwright.sync_api import sync_playwright  # noqa: E402
+
+import panel_harness as harness  # noqa: E402
+
+#: The account Chrome answers `getAuthToken` for — the panel's current one.
+#: `sub` is Google's stable identifier and the field the directory keys on.
+OWNER = {"sub": "1", "name": "Test Owner", "email": "owner@example.com",
+         "picture": ""}
+
+#: Two more in the directory, neither of them current. `currentId` is left empty
+#: deliberately: the panel fixes it from the token it actually holds.
+OTHERS = {
+    "accounts": [
+        {"id": "2", "email": "second@example.com", "name": "Second", "picture": ""},
+        {"id": "3", "email": "third@example.com", "name": "Third", "picture": ""},
+    ],
+    "currentId": "",
+}
+
+
+@pytest.fixture(scope="module")
+def browser():
+    with sync_playwright() as pw:
+        instance = pw.chromium.launch()
+        try:
+            yield instance
+        finally:
+            instance.close()
+
+
+@pytest.fixture()
+def panel(browser, tmp_path):
+    """A signed-in panel with two other accounts listed, on the Profile view."""
+    pages = []
+
+    def opener(**stub_kwargs):
+        page_file = harness.build_page(
+            tmp_path,
+            harness.stub(signed_in=OWNER, remembered_accounts=OTHERS,
+                         **stub_kwargs),
+            name=f"signout{len(pages)}.html")
+        page = browser.new_page(viewport={"width": 400, "height": 900})
+        errors: list[str] = []
+        page.on("pageerror", lambda e: errors.append(str(e)))
+        page.goto(page_file.as_uri())
+        pages.append(page)
+        page.js_errors = errors
+        page.wait_for_selector("#welcome-signed-in:visible", timeout=10_000)
+        page.wait_for_selector("#accounts-card .account-row", timeout=10_000)
+        return page
+
+    try:
+        yield opener
+    finally:
+        for page in pages:
+            page.close()
+
+
+def open_row_menu(page, email):
+    """Press the ⋮ on the row for this account and return the open menu."""
+    row = page.locator("#accounts-card .account-row").filter(has_text=email)
+    row.locator(".account-menu-button").click()
+    menu = page.locator("#accounts-card .account-menu")
+    menu.wait_for()
+    return menu
+
+
+def revoked(page):
+    return page.evaluate("window.__sx_revoked || []")
+
+
+def directory(page):
+    return page.evaluate(
+        "async () => (await window.chrome.storage.local"
+        ".get('scrapex-accounts-v1'))['scrapex-accounts-v1']")
+
+
+def test_the_row_menu_offers_sign_out_at_all(panel):
+    """The item `accountMenu` has always built and never drawn. It sits inside
+    `if (signedIn)`, and the one call site passed a literal `false`."""
+    page = panel()
+    menu = open_row_menu(page, "second@example.com")
+
+    labels = menu.locator(".account-menu-item").all_inner_texts()
+    assert "Sign out" in labels, (
+        f"the row menu offers {labels} — the Sign out item is still unreachable")
+    assert "Remove from ScrapeX" in labels, "Remove was lost making Sign out work"
+
+
+def test_signing_out_of_another_account_does_not_sign_out_of_this_one(panel):
+    """THE LOCKOUT GUARD, and the reason the token is minted rather than reused.
+
+    `state.token` belongs to the CURRENT account. Revoking it because a
+    different row's menu was pressed would sign the owner out of himself, and
+    the panel would look exactly as if he had asked for that."""
+    page = panel()
+    open_row_menu(page, "second@example.com").get_by_text("Sign out").click()
+    page.wait_for_function("(window.__sx_revoked || []).length > 0", timeout=8000)
+
+    # The redirect's fragment is URL-decoded on the way back through
+    # `readRedirect`, so the token arrives spelled with the address in it.
+    ended = revoked(page)
+    assert ended == ["minted-for-second@example.com"], (
+        f"the token revoked was {ended} — anything but a token minted for "
+        "second@example.com means some other account's grant was ended")
+    assert "stub-token" not in ended, (
+        "the CURRENT account's token was revoked — this is the lockout: the "
+        "owner pressed Sign out on somebody else's row")
+
+    assert page.locator("#welcome-signed-in").is_visible(), (
+        "the panel signed itself out while signing out of somebody else")
+    assert page.text_content("#welcome-name").strip() == OWNER["name"]
+
+
+def test_the_account_signed_out_of_is_drawn_signed_out(panel):
+    page = panel()
+    open_row_menu(page, "second@example.com").get_by_text("Sign out").click()
+    page.wait_for_function("(window.__sx_revoked || []).length > 0", timeout=8000)
+
+    gone = page.locator("#accounts-card .account-row").filter(
+        has_text="second@example.com")
+    gone.locator(".account-badge").wait_for(timeout=5000)
+    assert gone.locator(".account-badge").count() == 1
+
+    # The account NOT signed out of keeps its switch.
+    stays = page.locator("#accounts-card .account-row").filter(
+        has_text="third@example.com")
+    assert stays.locator(".account-switch").count() == 1, (
+        "signing out of one account marked another one signed out too")
+
+
+def test_a_refused_silent_mint_is_the_answer_rather_than_an_error(panel):
+    """`prompt=none` that Google will not answer means there is no live session
+    for the account — which is what signed out MEANS. Nothing is revoked because
+    there is nothing left to revoke, and the row still becomes the signed-out
+    row."""
+    page = panel(silent_for=["third@example.com"])
+    open_row_menu(page, "second@example.com").get_by_text("Sign out").click()
+
+    row = page.locator("#accounts-card .account-row").filter(
+        has_text="second@example.com")
+    row.locator(".account-badge").wait_for(timeout=8000)
+
+    assert revoked(page) == [], (
+        "a token was revoked for an account Google would not mint one for")
+
+    # THE EXACT SENTENCE, because the failure this catches is not a missing
+    # message but a wrong one. Let the refusal fall through to the revoke and
+    # `revokeToken` is handed `undefined`: it asks Google nothing, answers
+    # `revoked: false`, and the panel prints "…is signed out here. undefined
+    # Google may still list…" — doubt cast on a grant that was never asked
+    # about, with the word `undefined` in it.
+    said = page.locator("#accounts-status").inner_text()
+    assert said == "Second is signed out.", said
+    assert "undefined" not in said, said
+    assert "permissions" not in said, (
+        f"the panel raised a doubt about a grant it never asked about: {said!r}")
+
+
+def test_sign_out_of_all_accounts_signs_out_of_all_of_them(panel):
+    """It pressed `#signout` and nothing else, so it ended one session and left
+    every other account's Google grant standing — still switchable, still drawn
+    signed in, under a button that said `all`."""
+    page = panel()
+    page.get_by_text("Sign out of all accounts").click()
+    page.wait_for_function("(window.__sx_revoked || []).length >= 2", timeout=15000)
+    page.wait_for_selector("#welcome-signed-out:visible", timeout=8000)
+
+    ended = revoked(page)
+    assert "minted-for-second@example.com" in ended, ended
+    assert "minted-for-third@example.com" in ended, ended
+    assert "stub-token" in ended, (
+        f"the CURRENT account was left signed in by 'all accounts': {ended}")
+
+
+def test_signing_out_never_erases_a_row(panel):
+    """Ending a session is not removing an account — the row is the way back in
+    without typing the address again. Remove is a different button, and it asks
+    first."""
+    page = panel()
+    page.get_by_text("Sign out of all accounts").click()
+    page.wait_for_function("(window.__sx_revoked || []).length >= 2", timeout=15000)
+
+    # The owner's own row is in there too — signing in put it there — so this
+    # asserts that NOTHING was taken away rather than pinning the whole list.
+    held = directory(page)
+    kept = {account["id"] for account in held["accounts"]}
+    assert {"2", "3"} <= kept, (
+        f"sign out erased rows from the directory: {held}")
+    assert held["currentId"] == "", (
+        "the panel is still acting as an account it has signed out of")
+
+
+def test_a_revoke_google_refuses_is_reported_rather_than_swallowed(panel):
+    """`revoked`, not `state`: revokeToken answers `{state: "ok", revoked:
+    false}` when it was handed nothing at all, so the state alone cannot tell
+    "the grant is gone" from "Google was never asked". Here the browser has
+    forgotten the account and Google has not, and the owner can finish it."""
+    page = panel(revoke_status=500)
+    open_row_menu(page, "second@example.com").get_by_text("Sign out").click()
+    page.wait_for_function("(window.__sx_revoked || []).length > 0", timeout=8000)
+
+    said = page.locator("#accounts-status").inner_text()
+    assert "500" in said, f"the refusal was swallowed: {said!r}"
+    assert "permissions" in said.lower(), (
+        f"nothing tells the owner the grant is still listed at Google: {said!r}")
+
+
+def test_the_silent_mint_names_the_account_it_is_for(panel):
+    """`login_hint` is the whole reason this can speak for an account that is
+    not the Chrome profile's primary one. Without it Google answers for whoever
+    it considers default — which is the current account, again."""
+    page = panel()
+    open_row_menu(page, "third@example.com").get_by_text("Sign out").click()
+    page.wait_for_function("(window.__sx_revoked || []).length > 0", timeout=8000)
+
+    flows = page.evaluate("window.__sx_auth_flows || []")
+    assert flows, "no auth flow was opened at all"
+    assert flows[-1]["hint"] == "third@example.com", flows
+    assert flows[-1]["prompt"] == "none", (
+        f"the mint was not silent: {flows[-1]}")
+    assert flows[-1]["interactive"] is False

--- a/tools/panel_harness.py
+++ b/tools/panel_harness.py
@@ -78,6 +78,7 @@ def stub(backend: str = DEFAULT_BACKEND, *, engine_up=True, sources=None, jobs=N
          signin_never_returns=False, route_delays=None, blackhole_routes=(),
          native_mode="absent", google_account_mode="ok",
          remembered_accounts=None, drive=None,
+         silent_for=None, revoke_status=200,
          worker_alive=True) -> str:
     """A chrome.* shim plus a fetch() interceptor.
 
@@ -306,6 +307,37 @@ window.chrome = {{
         .concat([opts && opts.token]);
       SIGNED_IN = null; cb && cb();
     }},
+    // ---- the multi-account half, absent until 2026-08-16 -------------------
+    //
+    // `getAuthToken` above speaks only for the Chrome profile's PRIMARY
+    // account, so everything the account switcher does -- switching, adding,
+    // and now signing out of a row that is not the current one -- goes through
+    // `launchWebAuthFlow` instead. Neither of these two existed here, so
+    // `identity.js:authorize()` hit the `getRedirectURL()` try/catch and
+    // returned state "failed" under every panel test ever written. The whole
+    // multi-account surface was unreachable, and silently: a test could drive
+    // the button and read a plausible error message.
+    getRedirectURL: () => "https://harness.chromiumapp.org/",
+    launchWebAuthFlow: (opts, cb) => {{
+      const url = new URL(opts.url);
+      const hint = url.searchParams.get("login_hint") || "";
+      window.__sx_auth_flows = (window.__sx_auth_flows || []).concat([
+        {{hint, interactive: Boolean(opts.interactive),
+          prompt: url.searchParams.get("prompt")}}]);
+      // WHO GOOGLE WILL ANSWER FOR, SILENTLY. `prompt=none` succeeds only
+      // where there is a live session, so the test names the set -- and an
+      // account outside it produces the real refusal shape
+      // (`error=login_required`), not a rejected promise.
+      const live = SILENT_FOR === null || SILENT_FOR.includes(hint);
+      if (!opts.interactive && !live) {{
+        cb("https://harness.chromiumapp.org/#error=login_required");
+        return;
+      }}
+      cb("https://harness.chromiumapp.org/#access_token=minted-for-"
+         + encodeURIComponent(hint || "default")
+         + "&token_type=Bearer&expires_in=3599&scope="
+         + encodeURIComponent(url.searchParams.get("scope") || ""));
+    }},
   }},
 }};
 
@@ -324,6 +356,11 @@ let SIGNED_IN = {json.dumps(signed_in)};
 const SIGNIN_ERROR = {json.dumps(signin_error)};
 const SIGNIN_DELAY_MS = {json.dumps(signin_delay_ms)};
 const SIGNIN_NEVER_RETURNS = {str(signin_never_returns).lower()};
+// `null` means Google answers a silent mint for ANY account, which is the
+// ordinary case. A list names the ones with a live session, so a test can say
+// "this account's session has ended" without inventing an error shape.
+const SILENT_FOR = {json.dumps(silent_for)};
+const REVOKE_STATUS = {json.dumps(revoke_status)};
 const NATIVE_MODE = {json.dumps(native_mode)};
 const GOOGLE_ACCOUNT_MODE = {json.dumps(google_account_mode)};
 const DRIVE = {json.dumps(drive)};
@@ -369,6 +406,21 @@ window.fetch = async (url, options = {{}}) => {{
     try {{ body = JSON.parse((options && options.body) || "null"); }} catch (_) {{}}
     window.__writes.push({{path, method, body}});
   }}
+  // GOOGLE'S REVOKE ENDPOINT, which had no route here at all — so it fell
+  // through to the generic 404, `identity.js` counted that as NOT revoked
+  // (only `ok || 400` is), and EVERY sign-out driven through this harness
+  // silently took the `local-only` path and painted "Google answered 404 to
+  // the revoke request." No test read that element, which is the only reason
+  // it went unnoticed. The tokens are recorded because which token was ended
+  // is the whole question when several accounts are signed out at once.
+  if (String(url).includes("oauth2.googleapis.com/revoke")) {{
+    let ended = "";
+    try {{ ended = new URLSearchParams(options.body || "").get("token") || ""; }}
+    catch (_) {{}}
+    window.__sx_revoked = (window.__sx_revoked || []).concat([ended]);
+    return new Response("", {{status: REVOKE_STATUS}});
+  }}
+
   // GOOGLE DRIVE. Without this every Drive read 404s and the Manage-account
   // screen can only ever be seen in its failure state — which is how it was
   // first shipped to review. `drive: None` keeps that behaviour deliberately,


### PR DESCRIPTION
Two defects, both owner-reported. **The first diagnosis of one of them was wrong, and this corrects it.**

## The correction

It was reported that the row's ⋮ `Sign out` had become a dead end. **It had not.** `accountMenu` is called from exactly one place — `renderAccountsCard` — with `{signedIn: false}` written out literally, so the item inside `if (signedIn)` had **never once been drawn**. The PR that repaired the argument `accountRow` gets left the menu's, which is why a row could offer a switch while its own menu could not offer a sign-out.

Not a dead end: a missing button, and the thing the owner asked for in the first place.

## What stands as reported

**`Sign out of all accounts` signed out exactly one.** It pressed the top `#signout`, which revokes only the current account's grant. Every other account kept the standing Google grant that is *precisely what makes a silent mint succeed* — so they were still signed in, still drawn that way, under a button that said `all`.

## The fix

`endOtherAccountSession` mints a token for the account silently — `login_hint` + `prompt=none` — and revokes **that** token. A refused mint is not an error to report: `prompt=none` that Google will not answer means there is no live session, which is what signed out *means*, so the row becomes the signed-out row with nothing revoked.

`signOutOfAllAccounts` walks the others **first**, one at a time rather than `Promise.all`, and presses `#signout` **last** — signing out the current account clears `state.token`, and `renderAccountsCard` returns early without one, so the card and every row are gone before a loop could reach them.

## The lockout this would otherwise have been

The panel holds exactly **one** token and it belongs to the **current** account. Handing `state.token` to `revokeToken` because a different row's menu was pressed ends the wrong grant — press Sign out on somebody else's row and be signed out of your own. Nothing in the suite covered it, because **no test had ever driven the per-row menu**.

## The harness had to grow first, and this is the part worth remembering

`tools/panel_harness.py` stubbed only `getAuthToken` and `removeCachedAuthToken`, so `identity.js:authorize()` fell into its `getRedirectURL()` try/catch and returned state `failed` under **every panel test ever written**. The whole multi-account surface was unreachable — and silently: a test could press the button and read a plausible error message. It also had no route for Google's revoke endpoint, so every sign-out driven here took the `local-only` path on a 404 and no test ever read the message.

New knobs: `silent_for` (which accounts Google will answer a silent mint for) and `revoke_status`.

## Mutations — five of six caught

| mutation | verdict |
|---|---|
| revoke `state.token` instead of the minted one | **CAUGHT** — the lockout guard |
| the menu back to `signedIn: false` | **CAUGHT** |
| sign-out-of-all back to pressing `#signout` only | **CAUGHT** |
| the mint drops its `login_hint` | **CAUGHT** |
| the refused mint falls through to the revoke | **CAUGHT** |
| remove the early return **and** report `state` instead of `revoked` | **survives — equivalent** |

The sixth is an equivalent mutant: `revokeToken` differs between `state === "ok"` and `revoked` only when handed a falsy token, and the early return is what prevents that. **Either mutation alone is caught.** Recorded in the code and the handoff rather than papered over — contorting a test to kill an equivalent mutant would be the lie.

## Also

Three stale comments went with it. All three said this build has no Web OAuth client; it has had one since 2026-08-12, and one sat directly above the line it contradicted.

## Verified

- `pytest -m extension` — **637** collected, all pass (was 629)
- `node --test extension/tests/*.test.mjs` — 411 pass, 0 fail
- eslint clean, `ruff check scrapex/` clean
- the three existing account/sign-in suites (209 tests) pass unchanged with the grown harness

## Not fixed here, and recorded in the handoff

**There are two OAuth clients in this project, and therefore two grants.** `manifest.json:oauth2.client_id` is a Chrome-Extension client (`getAuthToken`); `identity.js:WEB_CLIENT_ID` is a Web client (`launchWebAuthFlow`). `revokeToken` ends only the grant of the client that minted the token it is given. For an account added through the switcher that is complete. For the Chrome profile's **primary** account, which can hold both, one may survive.

**Deliberately not fixed by revoking both**: on an `admin_policy_enforced` Workspace account, `blocked-by-admin` is the branch that pressing again cannot fix, so dropping the Chrome-Extension grant could leave an owner unable to sign back in at all. That is the owner's call, not a cleanup.

Two more found in the same reading and left alone: **HTTP 400 counts as revoked** (an expired implicit-flow token answers 400 too, and they live about an hour), and **neither `authorize` nor `revokeToken` has a deadline** while `getToken` and `accountFor` both do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)