### PR TITLE
What muqawil.org knows about its own pages, which is step 3 of a seam built in July

### DIFF
--- a/docs/CANDIDATE-SOURCES.md
+++ b/docs/CANDIDATE-SOURCES.md
@@ -128,7 +128,8 @@ generally.
 
 | lead | what is needed |
 |---|---|
-| «اسعار مواد البناء **القاول** السعودية» — Saudi building-materials prices | **Q-L** — the URL, and what «القاول» names: a site, a platform, a publication, or *المقاول* (the contractor) as a category. Recorded verbatim because guessing which would be inventing a source. |
+| **A CONTRACTOR DIRECTORY**, specified in full 2026-08-16 — see `docs/CONTRACTOR-SOURCE.md` | **The four URLs.** The instruction names the contractors list in English and in Arabic and one example profile in each, but the links did not arrive with the message. The ~60 columns are specified exactly and the owner has ruled it gets **a table of its own, separate from the product tables** — it produces companies, not offers. Nothing can be probed until the addresses are in hand. |
+| «اسعار مواد البناء **القاول** السعودية» — Saudi building-materials prices | **Q-L** — the URL, and what «القاول» names: a site, a platform, a publication, or *المقاول* (the contractor) as a category. **Half-answered 2026-08-16**: the owner has now asked for a contractor directory outright, so *المقاول* as a category is real work he wants. Whether it is the SAME lead as this line, or a second one, is still his to say — and the URL is still missing for both. |
 | UAE — *لجنة أسعار الوقود الإماراتية* (fuel pricing committee) | the URL |
 | Bahrain — *لجنة تسعير ومراقبة الوقود* (fuel pricing and monitoring committee) | the URL |
 

--- a/docs/CONTRACTOR-SOURCE.md
+++ b/docs/CONTRACTOR-SOURCE.md
@@ -1,0 +1,560 @@
+# A contractor source, and a table of its own
+
+Opened **2026-08-16** on the owner's instruction: «اريد اضافة مصدر مقاول (جدول منفصل تماما
+جدول سيكون لهذا المصدر فقط) جدول منفصل تماما عن جداول المنتجات» — *I want to add a
+contractor source (a completely separate table, a table that will be for this source only),
+a table completely separate from the product tables.*
+
+**Nothing here is declared or crawled.** SR-13 stands: nothing is collected that is not in
+`sources.yaml`, and this is not in `sources.yaml`. This file exists so the specification the
+owner wrote by hand does not live only in a chat transcript — he works from two machines,
+and everything this work depends on goes in the repository.
+
+## What makes this different from every source before it
+
+Every source in this project so far produces **offers** — a product, a price, a currency, a
+moment. The warehouse, the ingest path, the Data page and the panel's cards are all built
+around that shape.
+
+A contractor is not an offer. It is a **company**: one row per organisation, ~60 columns,
+several of them hierarchical and multi-valued, and no price at the centre of it. The owner
+has asked for a table of its own rather than an attempt to bend the offer tables around it,
+and the reasoning is his: *«جدول منفصل تمامًا عن جداول المنتجات»*.
+
+## The columns, as the owner specified them
+
+He reviewed the results page and the detailed contractor profile **in both languages** and
+wrote the grouping below. `[ar]` means the column carries the Arabic value of the same
+field — not a translation made here, but the value the site itself publishes in Arabic.
+
+| group | columns |
+|---|---|
+| **Identity** | Contractor ID, Company Name, Company Name [ar], Logo URL |
+| **Links** | Profile URL, Profile URL [ar], Contract Request URL, Contract Request URL [ar], Map Location URL |
+| **Membership** | Membership Level, Membership Level [ar], Account Status, Account Status [ar], Membership Number, Membership Type, Membership Type [ar], Member Since |
+| **Size and training** | Company Size, Company Size [ar], Training Credit Hours |
+| **Contact** | Organization Mobile Number, Organization Email |
+| **Location** | City, City [ar], Region, Region [ar], Address, Address [ar] |
+| **Rating, overall** | Customer Rating Score, Customer Rating Count, Customer Rating Grade, Customer Rating Grade [ar] |
+| **Rating, detail** | Quality Rating Score, Schedule Rating Score, Environment Health and Safety Rating Score, Value Rating Score, Communication and Responsiveness Rating Score |
+| **Classification and relations** | Contractor Classification, Contractor Classification [ar], Contractor Classification Grade, Main Contractor Count, Subcontractor Count |
+| **Company** | Company Description, Company Description [ar] |
+| **Programmes and services** | Qualification Programs, Qualification Programs [ar], Balady Services, Balady Services [ar] |
+| **Licences and readiness** | Licensed Activities, Licensed Activities [ar], Readiness Level, Readiness Level [ar] |
+| **Activities and interests** | Interests, Interests [ar] |
+| **Contractor relations** | Main Contractors, Main Contractors [ar], Subcontractors, Subcontractors [ar] |
+| **Technical rating** | Technical Rating by Activity, Technical Rating by Activity [ar], Technical Rating by Company Size, Technical Rating by Company Size [ar] |
+| **Contracts and projects** | Standard Contracts Count, Registered Contracts Count |
+| **Self-build prices** | Self-Build Price per sqm (&lt;5 Projects), Self-Build Price per sqm (5–10 Projects), Self-Build Price per sqm (&gt;10 Projects) |
+| **Addendum, 2026-08-16** | Is Saudi Contractor, Latitude, Longitude |
+
+The addendum also named `Membership Type`, `Membership Type [ar]` and
+`Map Location URL`; all three were already in the groups above and are not repeated.
+`Is Saudi Contractor` is the boolean behind `Membership Type`, whose two values are
+`Saudi Contractor` / *مقاول سعودي* and `Non-Saudi Contractor` / *مقاول غير سعودي*.
+
+Where each half lives: the **results card** carries name, membership, size, training hours,
+status, location, rating, contracting relations and classification. The **detailed profile**
+adds contact, address, activities, licences, projects and the rest.
+
+## The owner's own notes, which are design rulings and not asides
+
+1. **`Interests` is hierarchical and multi-valued.** Store it as JSON or in a table of its
+   own — **not** as `Activity 1, Activity 2, …`. The same applies to **Licensed Activities**,
+   **Qualification Programs**, **Balady Services**, and the **contractor relations**
+   (Main Contractors / Subcontractors).
+2. **Commercial Registration Number** is offered as a way to SEARCH, but he did not find it
+   displayed as a public field on the profiles he read. It may be added as an optional
+   column — it is not promised.
+3. **The Saudi / non-Saudi contractor counts at the top of the page are site-wide
+   statistics**, not per-contractor columns. They do not belong in this table.
+4. **Many fields are optional and will be missing for some contractors** — especially the
+   description, the address, the licences, the readiness level, the prices and the technical
+   rating. A column that is absent is not a fault to report.
+
+## The site, PROBED 2026-08-16 — `muqawil.org`, the Saudi Contractors Authority
+
+The owner gave two addresses: `https://muqawil.org/en/contractors` and
+`.../ar/contractors`. Four pages were loaded — `robots.txt`, the English listing, one
+English profile, and nothing else. **This was a probe, not a crawl.**
+
+### robots.txt says yes to ScrapeX, and this is worth stating precisely
+
+```
+User-agent: *
+Content-Signal: search=yes,ai-train=no,use=reference
+Allow: /
+```
+
+`Allow: /` for the general agent, **no `Crawl-delay`, no `Sitemap`**. Nine AI crawlers are
+named and disallowed — `ClaudeBot`, `GPTBot`, `CCBot`, `Google-Extended`, `Bytespider`,
+`Amazonbot`, `Applebot-Extended`, `meta-externalagent`,
+`CloudflareBrowserRenderingCrawler`. **ScrapeX is none of them and is permitted.** Recorded
+this way deliberately: the owner asked to "bypass robots.txt", and there is nothing to
+bypass — writing that ScrapeX ignores robots would be recording a false thing about a tool
+that complies. `ai-train=no` also does not bind a warehouse that trains nothing.
+
+The absence of a declared `Crawl-delay` means the pace is the OWNER's setting, not the
+site's — the same finding that made T1's `crawl_honour_delay` a no-op and produced
+`crawl_pace_s` (#190).
+
+### What the platform is
+
+**Laravel + Livewire, server-rendered.** `vendor/livewire/livewire.min.js` is loaded and
+`window.Livewire` is defined. The contractor rows arrive **inside the HTML**; no JSON API
+answers for them. jQuery, bootstrap, select2, jstree and checkboxTree do the widgets — the
+hierarchical Interests filter is a `jstree`.
+
+**Cloudflare sits in front of it** — `cdn-cgi/challenge-platform/h/g/scripts/jsd/…` is
+fetched and a `POST …/jsd/oneshot/…` follows on every page load in a browser.
+
+**It does not block ScrapeX.** That was the first guess written here and measurement
+overturned it within the hour; see §1 below. `Fetcher.HTTP` is enough and Playwright is not
+needed — which is an order of magnitude off the crawl cost. The lesson is the one this
+project keeps relearning: the presence of a challenge SCRIPT is not the presence of a
+challenge.
+
+### The addresses, as observed
+
+| what | shape |
+|---|---|
+| listing | `https://muqawil.org/{en\|ar}/contractors?page=N` — **865 pages, 20 rows each** |
+| profile | `https://muqawil.org/{en\|ar}/contractors/{contractor_id}/{143}` |
+| logo | `https://muqawil.org/public/contractor/companyLogo/CompanyLogo-{unix_ts}_{name}.{ext}` |
+| map page | `https://muqawil.org/{en\|ar}/contractors/map` |
+
+The second path segment was `143` on every row of page 1. **Whether it is constant, a
+category, or per-contractor is NOT known** — one listing page is not evidence enough, and
+guessing it is how a crawler builds ten thousand dead URLs.
+
+### Latitude and Longitude — found, and not where a data attribute would be
+
+They are in an **inline `<script>` on the profile page**:
+
+```
+lat: 24.671699788528482
+lng: 46.39415764160163
+```
+
+No `data-lat`, no coordinates in any attribute, no map iframe. So the extraction is a script
+scrape, and a change to that script breaks it silently — it needs its own guard.
+
+### The card carries most of the specified columns already
+
+Read off the listing: Company Name, rating score and rating count, Membership Number,
+Company Size, Training Credit Hours, Status, `City - Region`, Main Contractor count,
+Sub Contractor count, classification (`Second Classified 2` … `Unclassified`), and the
+Contract Request link. The profile adds Membership Level (`Platinum Membership`),
+**`Membership: Saudi Contractor`** — which is the addendum's `Is Saudi Contractor` —
+Member Since, mobile, email, City, Region, Address, Activity, the licences-and-readiness
+table, the Interests tree, `عدد العقود النموذجية / عدد العقود المسجلة` (455 / 64 on the one
+read) and an empty self-build price table.
+
+**The site-wide counters the owner excluded are real and visible**: `122,785 Saudi
+Contractor` and `1,640 Non-Saudi contractor` sit above the results. He was right that they
+are statistics, not columns. They are also **not** the size of the crawl — 864 listing pages
+is.
+
+### The finding that touches ~20 of the specified columns
+
+**`/en/` is only partly English, and one cell can hold both languages.** On the English
+profile, whole sections render in Arabic regardless: `التراخيص ومستوى الجاهزية`,
+`المقاولين بالباطن`, `المقاولين الرئيسيين`, `التقييم الفني`, `العقود سعر البناء`. And the
+Licensed Activities cell stacks the two languages **in the same cell**:
+
+```
+تشييد المباني - تشييد المباني - جميع الأنواع
+Construction of Buildings - Construction of Buildings – All Types
+```
+
+with readiness written `أساسي | Basic`.
+
+So the `[ar]` convention — *"the column holds the Arabic value of the same field"* — is
+sound for the fields the site really does localise (name, city, region, membership level,
+status), but for these it is **not two pages of the same field**: it is one cell to be
+split. Which fields are genuinely bilingual and which are one stacked cell has to be
+decided per column, and only the AR page beside the EN page can settle it.
+
+## What is NOT known yet, and blocks the connector
+
+~~The site's address.~~ **Given 2026-08-16 and probed.** All four follow-up questions were
+then settled by measurement the same day, with `httpx` carrying ScrapeX's own
+`DEFAULT_USER_AGENT` — not by the browser, so what is recorded here is what the CRAWLER
+will meet.
+
+### 1. A plain HTTP fetch passes Cloudflare — `fetcher: http`
+
+**This corrects what is written further up this file.** The challenge script is injected
+into every page by Cloudflare as a matter of course; its presence is not a block. Measured
+on three addresses: **HTTP 200**, full bodies (375 KB, 382 KB, 138 KB), the real
+`<title>Contractors | Muqawil Platform</title>`, twenty contractor links per listing page,
+and **not one interstitial marker** — no *"Just a moment"*, no `cf_chl_opt`, no *"Checking
+your browser"*.
+
+So `Fetcher.HTTP`, and **no Playwright**. That is an order of magnitude off the crawl cost
+this file assumed an hour earlier.
+
+### 2. The trailing segment is NOT decorative — it switches a column group on
+
+`/en/contractors/881/143`, `/881/1` and `/881/999` all answer 200 and all show the SAME
+contractor, so it plays no part in identity. But diffing the rendered text of `/143`
+against `/999` leaves exactly one difference:
+
+```
+only in /143: ['العقود سعر البناء (برنامج البناء الذاتي)', 'القيمة']
+only in /999: nothing
+```
+
+**`143` is what makes the self-build price section render at all.** The owner's last three
+columns — Self-Build Price per sqm (<5 / 5–10 / >10 Projects) — exist only under it. A
+connector that treated the segment as noise would have shipped those three columns
+permanently empty, and nothing would have said so.
+
+Every profile link on listing pages 1 and 2 carried `143`. Whether another value ever
+appears is unproven, but the value can be a literal rather than read per row.
+
+### 3. AR against EN, measured on one contractor
+
+| field | EN page | AR page | verdict |
+|---|---|---|---|
+| Membership | `Saudi Contractor` | `مقاول سعودي` | **two real values** — the addendum's pair, confirmed |
+| Company Size | `Small Company Size` | `منشأة صغيرة` | **two real values** |
+| City | `RIYADH` | `الرياض` | **two real values** |
+| Member Since | `2018/08/25` | `2018/08/25` | identical — a date needs no `[ar]` |
+| Address | `الرياض الملقا انس بن مالك` | — | **the EN page prints the ARABIC address.** There is no English one, so `Address` and `Address [ar]` are a single value |
+| Training Credit Hours | `308 H` | not found as `308 H` | formatted differently per locale; read it, never assume it |
+
+**Do not extract by label text.** The AR page spells the membership-number label
+`رقم العضويه` — with `ه`, not `ة`. A label-matched extractor breaks on a spelling variant
+no human reader would notice.
+
+### 4. No page-size parameter is honoured
+
+`per_page`, `perPage`, `limit`, `size`, `page_size` and `take` were each tried at 60
+against `?page=2`. All six returned **exactly 20 rows**. So the bound is fixed:
+
+> **865 listing pages × 20 rows ≈ 17,300 contractor profiles.**
+
+Not the 122,785 the site's own counter shows — that is total membership, and the owner was
+right to call those counters statistics rather than columns.
+
+### 5. Found while measuring: the email is obfuscated, and a naive scrape never gets it
+
+`Organization Email` is not in the HTML. What is there is Cloudflare's email protection:
+
+```html
+data-cfemail="670e1327140406491406"      →  it@sca.sa
+```
+
+The first byte is the XOR key and every following byte is XORed with it. The literal
+`it@sca.sa` appears nowhere in the source. **A connector that does not decode
+`data-cfemail` stores the string `[email protected]` for every contractor**, forever — and
+no test asking "is this column populated?" would ever fail. It needs a guard of its own,
+exactly like the coordinates in the inline script.
+
+## What this costs — read 2026-08-16, not guessed
+
+### The house already exists, it has never had a tenant, and it is switched off
+
+`db/engine/schema.sql` already carries a complete entity-shaped path, built as **G1** and
+described in `docs/GENERIC_CATALOG.md`:
+
+| table | line | what it holds |
+|---|---|---|
+| `site_profile` | — | one website |
+| `dataset_definition` | 158 | one table / list / detail record on that site |
+| `field_definition` | 241 | that dataset's OWN field set — stable keys, original names, display order |
+| `dataset_schema_version` · `generic_page_snapshot` | — | which shape a reading was taken against |
+| `generic_record` | 287 | one row, as `data_json` — `CHECK (json_valid(...) AND json_type(...) = 'object')` |
+| `generic_record_revision` | 307 | the history of one row, keyed `(record, snapshot, content_hash)` |
+| `dataset_relationship` · `relationship_field_pair` | — | directed joins, single **and composite** |
+
+`field_definition.data_type` (`:248`) already admits
+`'text','integer','decimal','boolean','date','datetime','url','json','unknown'` — **`json`
+and `url` are both there.** The owner's ruling that the five multi-valued groups be stored
+as JSON or as their own table is not a request for something new: it is the choice this
+schema was designed to offer, and `dataset_relationship` is the second half of it.
+
+**Both switches are off** (`scrapex/features.py:52-63`):
+
+- `generic_dataset_catalog` — `False`, stage `foundation`, *"Definitions and API exist;
+  enable only after generic rows and the catalogue UI ship."*
+- `generic_extraction` — `False`, stage `not_started`, *"Enabled only after an approved
+  non-product extraction reaches generic storage."*
+
+A contractor directory **is** an approved non-product extraction reaching generic storage.
+It is the tenant those two sentences are waiting for.
+
+### The price path is closed against it, and must stay closed
+
+Bending the offer tables was never available, which is what the owner's instinct already
+said. Measured:
+
+- `scrapex/vocab.py:352` — `ExtractKind` has exactly three members. `config.py:58` types
+  `ExtractSpec.kind` to it, so a manifest **cannot declare a fourth**: `load_manifest`
+  refuses the YAML outright.
+- `scrapex/rowspec.py:49` — `PRODUCT_PRICES.required` includes `price`, `currency`,
+  `tax_included`. `RowBuilder.row` raises on an empty required field, so a company row
+  cannot be BUILT, let alone stored. `COMMODITY_PRICE` (`:265`) still mandates a price.
+- `scrapex/connectors/base.py:83` and `scrapex/payload.py:234` — `ScrapedTable.kind` and
+  `FunnelPayload.kind` are both typed to the same three, and the payload is the FROZEN wire
+  contract shared with the extension and Apps Script.
+- `scrapex/ingest.py:989` — the explicit refusal: *"kind … not ingestable"*. `_persist_row`
+  (`:1389`) hard-codes product → variant → offer → `price_observation`, whose `price`,
+  `currency` and `tax_included` are all `NOT NULL` (`schema.sql:406`). Storing a company
+  there means minting a synthetic variant and a synthetic offer for each one — the thing the
+  owner refused in the sentence that opened this file.
+- `scrapex/ingest.py:1268` — the append gate is keyed on `price_hash` / `price_fields` /
+  `price_trade` against an open price period. There is no analogue for *"this company's
+  profile is unchanged"*, so a second crawl would write nothing at all. **A directory needs
+  its own change detection**, and `generic_record.content_hash` is exactly that.
+
+### The display path gives a directory nothing for free
+
+- `scrapex/reports.py:182` — `_LATEST_PER_OFFER` defines a row as *the newest price
+  observation for an active variant of an active offer*. `browse` and the export both build
+  on it, so `/api/table/{key}` returns **zero rows and `total: 0`** for a directory.
+- `scrapex/reports.py:672` — `BROWSE_COLUMNS` is ~40 keys, every one an offer fact.
+  `column_presence` (`:843`) starts from that set and **only ever discards** — it cannot ADD
+  a column, so a directory's columns resolve to an empty list.
+- `scrapex/reports.py:835` — `ESSENTIAL_COLUMNS = frozenset({"price"})`, stated as *"without
+  it the table is not a price list at all"*. That is a floor a company row cannot clear.
+- `BILINGUAL_COLUMNS` (`:817`) is a hard-coded product map. **The `[ar]` pairing the owner
+  specified for ~20 columns has no per-source declaration anywhere** — this is real new work
+  wherever the directory is displayed.
+
+So the Data page cannot show this source through `/api/table`. That is a second surface,
+and it should be weighed against finishing B2 first.
+
+### The add-in contract does not block anything
+
+The six sheets are the **Excel add-in's** configuration and the engine's warehouse does not
+read them. A contractor entity would only need workbook rows if the owner wants it in Excel.
+If he does, two mismatches are worth knowing rather than discovering: `ENTITY_TYPES`
+(`addin-vocabulary.js:30`) is cost-shaped and has no `DIRECTORY`/`COMPANY` value — `REF` is
+the nearest borrow — and `SEMANTIC_ROLES` (`:23`) has no role for a company attribute, so
+every column would be `NONE` and no add-in feature could key off them.
+
+## The markup, read 2026-08-16 while writing the `PageSource`
+
+### The card, and the twenty-first one that is not a contractor
+
+A contractor is `div.section-card`. **A listing page holds twenty-one of them and only
+twenty are contractors** — so cards are selected by *holding a profile link*, never by
+counting or by position. Selecting by position would be off by one for every row after the
+impostor, and a slice would then be chosen from the wrong contractor.
+
+```html
+<div class="section-card has-action has-membership platinum-membership"
+     data-membership-text=" Platinum Membership ">
+  <img class="card-img" src="…/CompanyLogo-1710325829_….jpg"
+       onerror="this.src='…/companies/default.jpg'">
+  <h2 class="card-title"><a href="…/contractors/20008518/143">Awared General …</a></h2>
+  <div class="card-rating" onclick="showRatingModal('1010754424',event)">
+    <div class="rater readonly" data-rate-value="5"></div>
+    <span class="rating-value">5</span>
+    <span class="votes-num">( Number of ratings : 1 )</span>
+```
+
+`Membership Level` is an **attribute**, `data-membership-text`, mirrored in the class
+(`platinum-membership`). The logo's `onerror` names the placeholder, which is how a
+contractor with no logo is told from one whose file failed: if `src` already IS
+`default.jpg`, store NULL.
+
+### Key on the ICON, never on the label
+
+Every field is an `.info-box` of `.info-name` + `.info-value`, and each carries an icon
+whose class is **identical in both locales**:
+
+| icon class | English label | Arabic label |
+|---|---|---|
+| `icon-ID` | Membership Number | `رقم العضويه` |
+| `icon-company` | Company Size | `حجم المنشأة` |
+| `icon-time` | Training credit hours | `عدد الساعات التدريبية` |
+| `icon-verifiy` | Status · *and* the classification | `الحالة` · `مصنف درجة ثانية` |
+| `icon-locaion` | City – Region | `المدينة - المنطقه` |
+| `icon` (bare) | Main Contractor · Sub Contractor | `مقاول رئيسي` · `مقاول من الباطن` |
+
+**This is the answer to the `رقم العضويه` trap** — the Arabic label is spelled with `ه`, not
+`ة`, and a label-matched selector breaks on a difference no reader would notice. The icon
+does not move between languages.
+
+`icon-verifiy` and `icon-locaion` are **their** spellings of *verify* and *location*. They
+are matched exactly. The day the site corrects them, these selectors are what will say so.
+
+**The icon is not unique** — `icon-verifiy` serves both Status and the classification, and
+the bare `icon` serves both contractor counts. So the key is icon *plus position*, never the
+icon alone.
+
+### Two cells that carry two facts each
+
+1. **City and Region are ONE cell**, dash-separated across a newline and a wall of
+   whitespace: `RIYADH\n<spaces>- Riyadh`, and in Arabic `الرياض - الرياض` where the two are
+   the same word. So `City` and `Region` are a split, not two fields.
+2. **The classification puts the DATA IN THE LABEL.** `.info-name` reads
+   `Second Classified` and `.info-value` reads `2` — so `Contractor Classification` comes
+   from the name and `Contractor Classification Grade` from the value, which is the reverse
+   of every other box on the card.
+
+### A lead on the Commercial Registration Number
+
+`onclick="showRatingModal('1010754424', event)"` carries a **ten-digit number in the Saudi
+CR format**, distinct from the nine-digit membership number on the same card. It is a
+plausible `Commercial Registration Number` — the field the owner said he could not find
+displayed anywhere.
+
+**Recorded as a lead, not a promise.** It appears only on cards that HAVE a rating (two of
+the three cards checked had no rating and no modal), so it cannot be a reliable source for
+the column even if the identification is right.
+
+## The design
+
+### Where it lives: one `dataset_definition`, and the G1 path unchanged
+
+| what | where |
+|---|---|
+| the site | one `site_profile` row for `muqawil.org` |
+| the table | one `dataset_definition`, `dataset_key = "contractors"` |
+| the columns | one `field_definition` row per field below |
+| a contractor | one `generic_record`, `record_key` = the contractor id, body in `data_json` |
+| its history | `generic_record_revision`, one per changed reading |
+
+That is the owner's «جدول منفصل تمامًا … سيكون لهذا المصدر فقط» exactly: **one table, for
+this source only**, sharing nothing with `price_observation`.
+
+**The five hierarchical groups go in JSON inside `data_json`, not in child tables.** The
+owner allowed either. JSON is chosen because he asked for ONE table and child tables would
+make six; because `generic_record.data_json` already carries a `json_valid` +
+`json_type='object'` CHECK; and because `field_definition.data_type` already admits `json`.
+Nothing is invented. `Interests` keeps its real tree shape instead of being flattened into
+`Activity 1, Activity 2, …`, which is what he ruled out.
+
+**The one place a child table would earn its keep** is `Main Contractors` /
+`Subcontractors`: those are contractor-to-contractor edges, and a JSON blob cannot answer
+*"who subcontracts for X"*. `dataset_relationship` + `relationship_field_pair` exist for
+exactly that. **Deferred, not dismissed** — it is an owner question below.
+
+### Bilingual: DERIVED from the `_ar` suffix, never a hand-written list
+
+This is why the owner asked for both languages at all: *«صفحة داتا … بتعرض البيانات بلغتين
+فى toggle»*. The engine's `grid.js:1900 wireLanguageToggle()` builds that toggle from
+`payload.bilingual`, which the server fills from `reports.BILINGUAL_COLUMNS` — **a dict
+written out by hand, product-only, with no per-source declaration anywhere.**
+
+So for this dataset the pairing is **derived**: any `field_definition` whose key ends `_ar`
+pairs with the field of the same name without it. It matches what products already do
+(`product_name` / `product_name_ar`), it cannot go stale when a column is added, and it is
+the rule this repository keeps choosing — *a guard that lists its subjects fails on the one
+nobody added to the list*.
+
+### The fields
+
+`sc` = the search card · `pr` = the profile page · `js` = an inline script · `u` = built
+from the id, not fetched. Types are `field_definition.data_type`.
+
+| field_key | type | from | note |
+|---|---|---|---|
+| `contractor_id` | text | sc | the identity; also `record_key` |
+| `company_name` / `company_name_ar` | text | sc | genuinely two values |
+| `logo_url` | url | sc | absent for some; the site falls back to `default.jpg`, which must be stored as NULL and never as the placeholder |
+| `profile_url` / `profile_url_ar` | url | u | `/{lang}/contractors/{id}/143` |
+| `contract_request_url` / `_ar` | url | u | |
+| `map_location_url` | url | pr | |
+| `latitude` · `longitude` | decimal | **js** | inline script only |
+| `membership_level` / `_ar` | text | pr | e.g. `Platinum Membership` |
+| `account_status` / `_ar` | text | sc | e.g. `Account Verified` |
+| `membership_number` | text | sc | **text, not integer** — leading zeros are real |
+| `membership_type` / `_ar` | text | pr | `Saudi Contractor` / `مقاول سعودي` |
+| `is_saudi_contractor` | boolean | pr | derived from the pair above |
+| `member_since` | date | pr | identical in both languages |
+| `company_size` / `_ar` | text | sc | `Small Company Size` / `منشأة صغيرة` |
+| `training_credit_hours` | integer | sc | formatted per locale — parse, never assume |
+| `organization_mobile_number` | text | pr | text: a leading `+` or `0` is real |
+| `organization_email` | text | pr | **Cloudflare-obfuscated — must decode `data-cfemail`** |
+| `city` / `city_ar` · `region` / `region_ar` | text | sc | |
+| `address` | text | pr | **one value.** The EN page prints the Arabic address; there is no English one, so there is no `address_ar` |
+| `customer_rating_score` | decimal | sc | |
+| `customer_rating_count` | integer | sc | |
+| `contractor_classification` / `_ar` | text | sc | e.g. `Second Classified` |
+| `contractor_classification_grade` | integer | sc | the numeral beside it |
+| `main_contractor_count` · `subcontractor_count` | integer | sc | |
+| `standard_contracts_count` · `registered_contracts_count` | integer | pr | 455 / 64 on the one read |
+| `interests` | **json** | pr | the tree, nested as published |
+| `licensed_activities` | **json** | pr | each entry `{ar, en, readiness_ar, readiness_en}` |
+| `qualification_programs` | **json** | pr | |
+| `balady_services` | **json** | pr | |
+| `main_contractors` · `subcontractors` | **json** | pr | edges; see the deferred question |
+| `technical_rating_by_activity` | **json** | pr | |
+| `technical_rating_by_company_size` | **json** | pr | |
+| `self_build_price_per_sqm` | **json** | pr | the three bands as one object; **renders only under `/143`** |
+| `commercial_registration_number` | text | — | optional and unobserved |
+| `company_description` / `_ar` | text | — | unobserved on four profiles |
+
+**`licensed_activities` is NOT an `[ar]`/non-`[ar]` pair.** The site stacks both languages
+in ONE cell —
+
+```
+تشييد المباني - تشييد المباني - جميع الأنواع
+Construction of Buildings - Construction of Buildings – All Types
+```
+
+— with readiness written `أساسي | Basic`. So it is one JSON field carrying both, not two
+columns. The same holds for every section that stays Arabic on the `/en/` page.
+
+### What CANNOT be filled from public pages — measured, not assumed
+
+| specified column | verdict |
+|---|---|
+| Quality / Schedule / Environment Health and Safety / Value / Communication Rating Score | **not published per contractor.** Absent from four profiles, including three that HAVE ratings. The five names appear only on `/contractors-rate/info`, which describes the criteria. Behind login, or not published at all |
+| `Customer Rating Grade` / `[ar]` | not found on any profile read |
+| `Company Description` / `[ar]` | not found on four profiles — already called optional by the owner |
+| `Commercial Registration Number` | not found; he had not seen it either |
+
+**Nine specified columns therefore have no public source.** They stay in the field list as
+nullable and are simply never written — a column that exists and is empty is a fact; a
+column quietly removed is a question nobody thinks to ask.
+
+### The second crawl, and history
+
+`generic_record.content_hash` over the normalised `data_json` is the change detector. It
+replaces nothing: the price path's `_still_the_same_price` gate is keyed on `price_hash` and
+has no meaning here. An unchanged contractor moves `last_seen_at` and writes **no**
+revision; a changed one writes a `generic_record_revision`; one that stops appearing becomes
+`status = 'unavailable'` rather than being deleted.
+
+**History is kept**, because a classification, a rating, a readiness level and a membership
+level are exactly the things whose CHANGE is the answer worth having.
+
+### The crawl
+
+`fetcher: http`, ScrapeX's own user agent, the owner's pace (the site declares no
+`Crawl-delay`). **865 listing pages**, then **~17,300 profiles**, each in two languages —
+roughly **35,500 requests** for a full pass, about ten hours at one per second.
+
+The listing pages alone are ~1,730 requests and carry most of the card fields. **A
+listing-only first pass is a real option** and is worth weighing before committing to the
+profiles.
+
+### Two guards this design needs, because both failures are silent
+
+1. **The email.** A connector that does not decode `data-cfemail` stores the literal
+   `[email protected]` for every contractor, and any test asking *"is the column populated?"*
+   passes forever. The guard must assert a decoded address, not a non-empty string.
+2. **The coordinates.** They come from an inline script, so a change to that script yields
+   no error — just permanently NULL columns. The guard must assert a plausible latitude and
+   longitude, not merely presence.
+
+## Open, and for the owner to rule on
+
+Recorded here rather than decided quietly; see `docs/BACKLOG.md` for how decisions are
+numbered when they are taken.
+
+- **JSON column or child table** for the five multi-valued groups. The owner allowed either.
+  The trade is queryability against one table instead of six.
+- **Does this entity also belong in the mbiXaddin workbook** — a `1.TableDefinition` row and
+  its `2.SchemaRule` columns — or is it engine-only until it has proved itself?
+- **Refresh shape.** A directory is re-read whole rather than watched for price changes, so
+  the append-gate reasoning that governs `price_observation` does not apply. What DOES a
+  second crawl of an unchanged contractor write?
+- **Retention.** Offers are kept as history because a price has a date. Does a contractor's
+  profile keep history, or is the latest reading the only one?

--- a/scrapex/sites/__init__.py
+++ b/scrapex/sites/__init__.py
@@ -1,0 +1,9 @@
+"""One module per site whose pages ScrapeX knows how to enumerate.
+
+A `PageSource` (see `scrapex/pagesource.py`) is NOT a connector. Connectors live
+in `scrapex/connectors/` and return priced offers; these return only pages, and
+what a page means is decided later, against a stored snapshot. Keeping the two
+in separate packages is the cheapest way to stop somebody writing a generic
+source against `SiteConnector` — which would compile, pass, and put nothing in
+the generic tables.
+"""

--- a/scrapex/sites/muqawil.py
+++ b/scrapex/sites/muqawil.py
@@ -1,0 +1,209 @@
+"""muqawil.org — the Saudi Contractors Authority's public contractor directory.
+
+Step 3 of docs/GENERIC-FETCH-SEAM.md, and the first concrete `PageSource` this
+project has. Everything here is about THIS SITE'S LAYOUT and nothing else: no
+fetching, no pacing, no request counting, no database. All of that belongs to
+`scrapex/pagewalk.py`, and it belongs there so that every site behaves the same
+way about the things that are not about the site.
+
+WHAT WAS MEASURED, 2026-08-16, and why each measurement is load-bearing. The
+full record is `docs/CONTRACTOR-SOURCE.md`; these four decide the code:
+
+  * The listing is `?page=1..865`, TWENTY rows a page, and **no page-size
+    parameter is honoured** — `per_page`, `perPage`, `limit`, `size`,
+    `page_size` and `take` were each tried at 60 and each answered twenty. So
+    the page count is the crawl's whole bound and cannot be traded down.
+
+  * A profile is `/{lang}/contractors/{id}/{143}`. The trailing segment plays NO
+    part in identity — `/881/1` and `/881/999` return the same contractor — but
+    `143` is what makes the self-build price section render at all. Diffing the
+    two, the only difference was `العقود سعر البناء (برنامج البناء الذاتي)`
+    appearing under `143` and vanishing under `999`. A crawl that treated the
+    segment as noise would ship three of the owner's columns permanently empty
+    and nothing would say so. It is a literal here, deliberately.
+
+  * A contractor card is `div.section-card`, and there are TWENTY-ONE of them on
+    a listing page. The twenty-first is not a contractor. Cards are therefore
+    selected by holding a profile link, never by counting.
+
+  * Cloudflare fronts the site and does NOT block: a plain HTTP fetch with
+    ScrapeX's own user agent answers 200 with the full body and no interstitial.
+    No browser is needed, which is an order of magnitude off the crawl's cost.
+"""
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+from bs4 import BeautifulSoup
+
+from ..pagesource import FetchedPage, SliceNotSupported
+
+#: The trailing path segment that makes a profile render its self-build prices.
+#: A literal because it is one, and named because `143` in a URL template is the
+#: kind of number a later reader deletes as noise. See the module docstring.
+SELF_BUILD_SEGMENT = "143"
+
+#: Both locales, because the `[ar]` half of every column comes from the second.
+#: The owner's reason: the Data page switches language behind one toggle, so a
+#: row that carries only one language cannot be shown in the other.
+LOCALES = ("en", "ar")
+
+#: A profile link, in either locale. The id is the identity; the tail is not.
+_PROFILE = re.compile(r"/(?:en|ar)/contractors/(\d+)/\d+")
+
+#: The city, keyed by the ICON and never by the label beside it. The Arabic page
+#: spells the membership-number label `رقم العضويه` — with `ه`, not `ة` — and a
+#: label-matched selector breaks on a spelling difference no reader would ever
+#: notice. The icon class is identical in both locales, which makes it the only
+#: honest key. `icon-locaion` is THEIR spelling of "location"; it is matched
+#: exactly, and the day they fix it this selector is what will say so.
+_CITY_ICON = "icon-locaion"
+
+
+def read_last_page(html: str) -> int:
+    """The highest page number the listing's own pagination links to.
+
+    READ, NEVER ASSUMED. 865 was true on 2026-08-16 and a directory grows; a
+    constant here would quietly stop crawling the tail the week it changed. The
+    caller reads page one, calls this, and only then builds the source — which
+    is why `MuqawilPageSource` demands the number instead of defaulting it.
+    """
+    pages = [int(found) for found in re.findall(r"[?&]page=(\d+)", html)]
+    if not pages:
+        raise ValueError(
+            "no pagination on this listing page, so the crawl's size is "
+            "unknown — refusing to guess it. Check the page really is a "
+            "contractor listing before treating this as a layout change.")
+    return max(pages)
+
+
+def _cards(page: FetchedPage) -> list:
+    """Every contractor card on a listing page, in the order it is published.
+
+    SELECTED BY HOLDING A PROFILE LINK. `div.section-card` matches twenty-one
+    elements and only twenty are contractors, so a slice keyed on position would
+    be off by one for every row after the impostor.
+    """
+    soup = BeautifulSoup(page.html, "html.parser")
+    return [card for card in soup.select("div.section-card")
+            if card.find("a", href=_PROFILE)]
+
+
+class MuqawilPageSource:
+    """What muqawil.org knows about its own pages."""
+
+    site_key = "muqawil.org"
+
+    def __init__(self, *, last_page: int, locales: Iterable[str] = LOCALES) -> None:
+        """`last_page` is REQUIRED, and that is the point.
+
+        A default would let a caller crawl page one, get twenty contractors out
+        of seventeen thousand, and have nothing tell them the other 864 pages
+        were never asked for. `read_last_page` is how the number is obtained.
+        """
+        if last_page < 1:
+            raise ValueError(f"last_page must be at least 1, got {last_page}")
+        self._last_page = last_page
+        self._locales = tuple(locales)
+
+    def listing_urls(self, base_url: str) -> Iterable[str]:
+        """Every listing page, in both locales, page by page rather than locale
+        by locale.
+
+        THE ORDER IS DELIBERATE: `en?page=1`, `ar?page=1`, `en?page=2`, … so a
+        crawl stopped half way holds BOTH languages for the pages it reached,
+        rather than every English page and no Arabic one. The owner's columns
+        come in pairs; half a pair is not half a row, it is an unusable one.
+        """
+        base = base_url.rstrip("/")
+        for page in range(1, self._last_page + 1):
+            for locale in self._locales:
+                yield f"{base}/{locale}/contractors?page={page}"
+
+    def detail_urls(self, page: FetchedPage) -> Iterable[str]:
+        """The profile of every contractor this listing page names, in both
+        locales, deduplicated by contractor id.
+
+        The id is taken from the href and the tail is REBUILT as
+        `SELF_BUILD_SEGMENT` rather than carried over — the site's own links use
+        it today, and rebuilding means a page that ever links some other value
+        still gets crawled at the one that renders every section.
+        """
+        base = _origin(page.url)
+        seen: list[str] = []
+        for card in _cards(page):
+            link = card.find("a", href=_PROFILE)
+            found = _PROFILE.search(link["href"])
+            if found is None or found.group(1) in seen:
+                continue
+            seen.append(found.group(1))
+        for contractor_id in seen:
+            for locale in self._locales:
+                yield (f"{base}/{locale}/contractors/"
+                       f"{contractor_id}/{SELF_BUILD_SEGMENT}")
+
+    def belongs_to_slice(self, page: FetchedPage, row_index: int,
+                         slice_of: str) -> bool:
+        """Whether one row of this listing is in the named city.
+
+        ANSWERED FROM THE LISTING, which is what makes the slice scope worth
+        having: muqawil publishes the city on the card, so one city's profiles
+        can be crawled without fetching the other sixteen thousand.
+
+        The slice must be named in the SAME LANGUAGE as the page — `RIYADH` for
+        an English listing, `الرياض` for an Arabic one. Translating here would
+        mean shipping a city gazetteer and getting it wrong for the first city
+        nobody thought of.
+        """
+        if not slice_of.strip():
+            raise SliceNotSupported(
+                "a slice of muqawil is a city and no city was named")
+
+        cards = _cards(page)
+        if row_index >= len(cards):
+            return False
+
+        icon = cards[row_index].select_one(f".info-icon span.{_CITY_ICON}")
+        if icon is None:
+            # The card carries no city. NOT an answer of False, which would
+            # quietly drop a contractor from every slice and read as a smaller
+            # city rather than as a layout that moved.
+            raise SliceNotSupported(
+                f"no {_CITY_ICON} on card {row_index} of {page.url} — the "
+                "listing's city marker has moved, and a slice cannot be "
+                "chosen from a page that no longer publishes one")
+
+        box = icon.find_parent(class_="info-box")
+        value = box.select_one(".info-value") if box else None
+        return _city_of(value) == slice_of.strip().casefold()
+
+
+def _city_of(value) -> str:
+    """The city out of the card's location cell, folded for comparison.
+
+    ONE CELL HOLDS TWO FACTS. The card publishes city and region together,
+    separated by a dash and a great deal of whitespace:
+
+        RIYADH
+                                    - Riyadh
+
+    and in Arabic `الرياض - الرياض`, where the two happen to be the same word.
+    So the cell is not the city — the head of it is. Whitespace is collapsed
+    first, because the separator is only recognisable once it is.
+
+    The split is on the FIRST dash, which assumes no Saudi city name carries
+    one. That held for every city seen (RIYADH, JEDDAH, DAMMAM, AL KHOBAR); if
+    one ever does, this is the line that will be wrong, and it is written here
+    rather than left as an accident of a regex.
+    """
+    if value is None:
+        return ""
+    text = " ".join(value.get_text(" ", strip=True).split())
+    return text.split("-", 1)[0].strip().casefold()
+
+
+def _origin(url: str) -> str:
+    """`https://host` from any URL on it, without importing urllib for one job."""
+    parts = url.split("/", 3)
+    return "/".join(parts[:3]) if len(parts) >= 3 else url.rstrip("/")

--- a/tests/fixtures/muqawil/listing-ar.html
+++ b/tests/fixtures/muqawil/listing-ar.html
@@ -1,0 +1,454 @@
+<!-- TRIMMED FIXTURE: pagination + the 20 contractor cards only. -->
+<html><body><section class='service'><div class='container'>
+<div class="section-card has-action has-membership platinum-membership" data-membership-text="
+ عضوية بلاتينية                        ">
+<div class="row">
+<div class="col-auto">
+<img alt="" class="card-img" onerror="this.src='https://muqawil.org/public_assets/img/companies/default.jpg'" src="https://muqawil.org/public/contractor/companyLogo/CompanyLogo-1710325829_شعارة شركة عوارض.jpg"/>
+<a class="btn btn-primary mt-2" href="https://muqawil.org/ar/contractors/20008518/143"> طلب تعاقد
+                                        </a>
+</div>
+<div class="col">
+<h2 class="card-title">
+<a href="https://muqawil.org/ar/contractors/20008518/143">شركة عوارض للمقاولات العامة</a>
+</h2>
+<div class="card-rating" onclick="showRatingModal('1010754424',event)">
+<div class="rater readonly" data-rate-value="5"></div>
+<span class="rating-value">5</span>
+<span class="votes-num">( عدد المقيمين : 1
+                                                )</span>
+</div>
+<div class="info-box-wrapper mt-4">
+<div class="row">
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-ID"></span>
+</div>
+<div class="info-details">
+<div class="info-name">رقم العضويه</div>
+<div class="info-value">160916095</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-company"></span>
+</div>
+<div class="info-details">
+<div class="info-name">حجم المنشأة</div>
+<div class="info-value">منشأة صغيرة</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-time"></span>
+</div>
+<div class="info-details">
+<div class="info-name">عدد الساعات التدريبية</div>
+<div class="info-value">96 س                                                            </div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-verifiy"></span>
+</div>
+<div class="info-details">
+<div class="info-name">الحالة</div>
+<div class="info-value">الحساب مفعل</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-locaion"></span>
+</div>
+<div class="info-details">
+<div class="info-name">المدينة                                                                    - المنطقه</div>
+<div class="info-value">الرياض
+                                                                    - الرياض</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon"><img alt="" class="card-img" onerror="this.src='https://muqawil.org/public_assets/img/companies/website_icon-01.svg'" src="https://muqawil.org/public_assets/img/companies/website_icon-01.svg" style="width: 25px;"/></span>
+</div>
+<div class="info-details">
+<div class="info-name">مقاول رئيسي</div>
+<div class="info-value">0</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon"><img alt="" class="card-img" onerror="this.src='https://muqawil.org/public_assets/img/companies/website_icon-02.svg'" src="https://muqawil.org/public_assets/img/companies/website_icon-02.svg" style="width: 25px;"/></span>
+</div>
+<div class="info-details">
+<div class="info-name">مقاول من الباطن</div>
+<div class="info-value">0</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-verifiy"></span>
+</div>
+<div class="info-details">
+<div class="info-name">مصنف درجة ثانية</div>
+<div class="info-value">2</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="section-card has-action has-membership platinum-membership" data-membership-text="
+ عضوية بلاتينية                        ">
+<div class="row">
+<div class="col-auto">
+<img alt="" class="card-img" onerror="this.src='https://muqawil.org/public_assets/img/companies/default.jpg'" src="https://muqawil.org/public/contractor/companyLogo/CompanyLogo-1780991935_logo-green.png"/>
+<a class="btn btn-primary mt-2" href="https://muqawil.org/ar/contractors/881/143"> طلب تعاقد
+                                        </a>
+</div>
+<div class="col">
+<h2 class="card-title">
+<a href="https://muqawil.org/ar/contractors/881/143">شركة البناء التجريبية</a>
+</h2>
+<div class="info-box-wrapper mt-4">
+<div class="row">
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-ID"></span>
+</div>
+<div class="info-details">
+<div class="info-name">رقم العضويه</div>
+<div class="info-value">10000861</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-company"></span>
+</div>
+<div class="info-details">
+<div class="info-name">حجم المنشأة</div>
+<div class="info-value">منشأة صغيرة</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-time"></span>
+</div>
+<div class="info-details">
+<div class="info-name">عدد الساعات التدريبية</div>
+<div class="info-value">308 س                                                            </div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-verifiy"></span>
+</div>
+<div class="info-details">
+<div class="info-name">الحالة</div>
+<div class="info-value">الحساب مفعل</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-locaion"></span>
+</div>
+<div class="info-details">
+<div class="info-name">المدينة                                                                    - المنطقه</div>
+<div class="info-value">الرياض
+                                                                    - الرياض</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon"><img alt="" class="card-img" onerror="this.src='https://muqawil.org/public_assets/img/companies/website_icon-01.svg'" src="https://muqawil.org/public_assets/img/companies/website_icon-01.svg" style="width: 25px;"/></span>
+</div>
+<div class="info-details">
+<div class="info-name">مقاول رئيسي</div>
+<div class="info-value">0</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon"><img alt="" class="card-img" onerror="this.src='https://muqawil.org/public_assets/img/companies/website_icon-02.svg'" src="https://muqawil.org/public_assets/img/companies/website_icon-02.svg" style="width: 25px;"/></span>
+</div>
+<div class="info-details">
+<div class="info-name">مقاول من الباطن</div>
+<div class="info-value">0</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-verifiy"></span>
+</div>
+<div class="info-details">
+<div class="info-name">مصنف درجة خامسة</div>
+<div class="info-value">5</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="section-card has-action has-membership platinum-membership" data-membership-text="
+ عضوية بلاتينية                        ">
+<div class="row">
+<div class="col-auto">
+<img alt="" class="card-img" onerror="this.src='https://muqawil.org/public_assets/img/companies/default.jpg'" src="https://muqawil.org/public/contractor/companyLogo/CompanyLogo-1756358336_LOGO-22.png"/>
+<a class="btn btn-primary mt-2" href="https://muqawil.org/ar/contractors/20075373/143"> طلب تعاقد
+                                        </a>
+</div>
+<div class="col">
+<h2 class="card-title">
+<a href="https://muqawil.org/ar/contractors/20075373/143">شركة الابحاث الاحصائية للاعمال</a>
+</h2>
+<div class="info-box-wrapper mt-4">
+<div class="row">
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-ID"></span>
+</div>
+<div class="info-details">
+<div class="info-name">رقم العضويه</div>
+<div class="info-value">713971398</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-company"></span>
+</div>
+<div class="info-details">
+<div class="info-name">حجم المنشأة</div>
+<div class="info-value">منشأة صغيرة</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-time"></span>
+</div>
+<div class="info-details">
+<div class="info-name">عدد الساعات التدريبية</div>
+<div class="info-value">50 س                                                            </div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-verifiy"></span>
+</div>
+<div class="info-details">
+<div class="info-name">الحالة</div>
+<div class="info-value">الحساب مفعل</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-locaion"></span>
+</div>
+<div class="info-details">
+<div class="info-name">المدينة                                                                    - المنطقه</div>
+<div class="info-value">جدة
+                                                                    - مكة المكرمة</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon"><img alt="" class="card-img" onerror="this.src='https://muqawil.org/public_assets/img/companies/website_icon-01.svg'" src="https://muqawil.org/public_assets/img/companies/website_icon-01.svg" style="width: 25px;"/></span>
+</div>
+<div class="info-details">
+<div class="info-name">مقاول رئيسي</div>
+<div class="info-value">0</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon"><img alt="" class="card-img" onerror="this.src='https://muqawil.org/public_assets/img/companies/website_icon-02.svg'" src="https://muqawil.org/public_assets/img/companies/website_icon-02.svg" style="width: 25px;"/></span>
+</div>
+<div class="info-details">
+<div class="info-name">مقاول من الباطن</div>
+<div class="info-value">0</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-verifiy"></span>
+</div>
+<div class="info-details">
+<div class="info-name">غير مصنف</div>
+<div class="info-value"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="section-card has-action has-membership platinum-membership" data-membership-text="
+ عضوية بلاتينية                        ">
+<div class="row">
+<div class="col-auto">
+<img alt="" class="card-img" onerror="this.src='https://muqawil.org/public_assets/img/companies/default.jpg'" src="https://muqawil.org/public/contractor/companyLogo/CompanyLogo-1757586955_Untitled.png"/>
+<a class="btn btn-primary mt-2" href="https://muqawil.org/ar/contractors/20014964/143"> طلب تعاقد
+                                        </a>
+</div>
+<div class="col">
+<h2 class="card-title">
+<a href="https://muqawil.org/ar/contractors/20014964/143">شركة انمائيون للمقاولات</a>
+</h2>
+<div class="info-box-wrapper mt-4">
+<div class="row">
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-ID"></span>
+</div>
+<div class="info-details">
+<div class="info-name">رقم العضويه</div>
+<div class="info-value">215421544</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-company"></span>
+</div>
+<div class="info-details">
+<div class="info-name">حجم المنشأة</div>
+<div class="info-value">منشأة صغيرة</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-time"></span>
+</div>
+<div class="info-details">
+<div class="info-name">عدد الساعات التدريبية</div>
+<div class="info-value">3 س                                                            </div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-verifiy"></span>
+</div>
+<div class="info-details">
+<div class="info-name">الحالة</div>
+<div class="info-value">الحساب مفعل</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-locaion"></span>
+</div>
+<div class="info-details">
+<div class="info-name">المدينة                                                                    - المنطقه</div>
+<div class="info-value">الرياض
+                                                                    - الرياض</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon"><img alt="" class="card-img" onerror="this.src='https://muqawil.org/public_assets/img/companies/website_icon-01.svg'" src="https://muqawil.org/public_assets/img/companies/website_icon-01.svg" style="width: 25px;"/></span>
+</div>
+<div class="info-details">
+<div class="info-name">مقاول رئيسي</div>
+<div class="info-value">0</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon"><img alt="" class="card-img" onerror="this.src='https://muqawil.org/public_assets/img/companies/website_icon-02.svg'" src="https://muqawil.org/public_assets/img/companies/website_icon-02.svg" style="width: 25px;"/></span>
+</div>
+<div class="info-details">
+<div class="info-name">مقاول من الباطن</div>
+<div class="info-value">0</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-verifiy"></span>
+</div>
+<div class="info-details">
+<div class="info-name">مصنف درجة أولى</div>
+<div class="info-value">1</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<ul class="pagination">
+<li class="page-item disabled"><a class="page-link" href="https://muqawil.org/ar/contractors?page=1">«</a></li>
+<li aria-disabled="true" aria-label="pagination.previous" class="page-item disabled">
+<span aria-hidden="true" class="page-link">‹</span>
+</li>
+<li aria-current="page" class="page-item active"><span class="page-link">1</span></li>
+<li class="page-item"><a class="page-link" href="https://muqawil.org/ar/contractors?page=2">2</a></li>
+<li class="page-item"><a class="page-link" href="https://muqawil.org/ar/contractors?page=3">3</a></li>
+<li class="page-item">
+<a aria-label="pagination.next" class="page-link" href="https://muqawil.org/ar/contractors?page=2" rel="next">›</a>
+</li>
+<li class="page-item"><a class="page-link" href="https://muqawil.org/ar/contractors?page=865">»</a></li>
+</ul>
+</div></section></body></html>

--- a/tests/fixtures/muqawil/listing-en.html
+++ b/tests/fixtures/muqawil/listing-en.html
@@ -1,0 +1,454 @@
+<!-- TRIMMED FIXTURE: pagination + the 20 contractor cards only. -->
+<html><body><section class='service'><div class='container'>
+<div class="section-card has-action has-membership platinum-membership" data-membership-text="
+ Platinum Membership                        ">
+<div class="row">
+<div class="col-auto">
+<img alt="" class="card-img" onerror="this.src='https://muqawil.org/public_assets/img/companies/default.jpg'" src="https://muqawil.org/public/contractor/companyLogo/CompanyLogo-1710325829_شعارة شركة عوارض.jpg"/>
+<a class="btn btn-primary mt-2" href="https://muqawil.org/en/contractors/20008518/143"> Contract Request
+                                        </a>
+</div>
+<div class="col">
+<h2 class="card-title">
+<a href="https://muqawil.org/en/contractors/20008518/143">Awared General Contracting Company</a>
+</h2>
+<div class="card-rating" onclick="showRatingModal('1010754424',event)">
+<div class="rater readonly" data-rate-value="5"></div>
+<span class="rating-value">5</span>
+<span class="votes-num">(   Number of ratings : 1
+                                                )</span>
+</div>
+<div class="info-box-wrapper mt-4">
+<div class="row">
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-ID"></span>
+</div>
+<div class="info-details">
+<div class="info-name">Membership Number</div>
+<div class="info-value">160916095</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-company"></span>
+</div>
+<div class="info-details">
+<div class="info-name">Company Size</div>
+<div class="info-value">Small</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-time"></span>
+</div>
+<div class="info-details">
+<div class="info-name">Training credit hours</div>
+<div class="info-value">96 h                                                            </div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-verifiy"></span>
+</div>
+<div class="info-details">
+<div class="info-name">Status</div>
+<div class="info-value">Account Verified</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-locaion"></span>
+</div>
+<div class="info-details">
+<div class="info-name">City                                                                    - Region</div>
+<div class="info-value">RIYADH
+                                                                    - Riyadh</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon"><img alt="" class="card-img" onerror="this.src='https://muqawil.org/public_assets/img/companies/website_icon-01.svg'" src="https://muqawil.org/public_assets/img/companies/website_icon-01.svg" style="width: 25px;"/></span>
+</div>
+<div class="info-details">
+<div class="info-name">Main Contractor</div>
+<div class="info-value">0</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon"><img alt="" class="card-img" onerror="this.src='https://muqawil.org/public_assets/img/companies/website_icon-02.svg'" src="https://muqawil.org/public_assets/img/companies/website_icon-02.svg" style="width: 25px;"/></span>
+</div>
+<div class="info-details">
+<div class="info-name">Sub Contractor</div>
+<div class="info-value">0</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-verifiy"></span>
+</div>
+<div class="info-details">
+<div class="info-name">Second Classified</div>
+<div class="info-value">2</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="section-card has-action has-membership platinum-membership" data-membership-text="
+ Platinum Membership                        ">
+<div class="row">
+<div class="col-auto">
+<img alt="" class="card-img" onerror="this.src='https://muqawil.org/public_assets/img/companies/default.jpg'" src="https://muqawil.org/public/contractor/companyLogo/CompanyLogo-1780991935_logo-green.png"/>
+<a class="btn btn-primary mt-2" href="https://muqawil.org/en/contractors/881/143"> Contract Request
+                                        </a>
+</div>
+<div class="col">
+<h2 class="card-title">
+<a href="https://muqawil.org/en/contractors/881/143">sca</a>
+</h2>
+<div class="info-box-wrapper mt-4">
+<div class="row">
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-ID"></span>
+</div>
+<div class="info-details">
+<div class="info-name">Membership Number</div>
+<div class="info-value">10000861</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-company"></span>
+</div>
+<div class="info-details">
+<div class="info-name">Company Size</div>
+<div class="info-value">Small</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-time"></span>
+</div>
+<div class="info-details">
+<div class="info-name">Training credit hours</div>
+<div class="info-value">308 h                                                            </div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-verifiy"></span>
+</div>
+<div class="info-details">
+<div class="info-name">Status</div>
+<div class="info-value">Account Verified</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-locaion"></span>
+</div>
+<div class="info-details">
+<div class="info-name">City                                                                    - Region</div>
+<div class="info-value">RIYADH
+                                                                    - Riyadh</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon"><img alt="" class="card-img" onerror="this.src='https://muqawil.org/public_assets/img/companies/website_icon-01.svg'" src="https://muqawil.org/public_assets/img/companies/website_icon-01.svg" style="width: 25px;"/></span>
+</div>
+<div class="info-details">
+<div class="info-name">Main Contractor</div>
+<div class="info-value">0</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon"><img alt="" class="card-img" onerror="this.src='https://muqawil.org/public_assets/img/companies/website_icon-02.svg'" src="https://muqawil.org/public_assets/img/companies/website_icon-02.svg" style="width: 25px;"/></span>
+</div>
+<div class="info-details">
+<div class="info-name">Sub Contractor</div>
+<div class="info-value">0</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-verifiy"></span>
+</div>
+<div class="info-details">
+<div class="info-name">Fifth Classified</div>
+<div class="info-value">5</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="section-card has-action has-membership platinum-membership" data-membership-text="
+ Platinum Membership                        ">
+<div class="row">
+<div class="col-auto">
+<img alt="" class="card-img" onerror="this.src='https://muqawil.org/public_assets/img/companies/default.jpg'" src="https://muqawil.org/public/contractor/companyLogo/CompanyLogo-1756358336_LOGO-22.png"/>
+<a class="btn btn-primary mt-2" href="https://muqawil.org/en/contractors/20075373/143"> Contract Request
+                                        </a>
+</div>
+<div class="col">
+<h2 class="card-title">
+<a href="https://muqawil.org/en/contractors/20075373/143">Statistical Research Company</a>
+</h2>
+<div class="info-box-wrapper mt-4">
+<div class="row">
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-ID"></span>
+</div>
+<div class="info-details">
+<div class="info-name">Membership Number</div>
+<div class="info-value">713971398</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-company"></span>
+</div>
+<div class="info-details">
+<div class="info-name">Company Size</div>
+<div class="info-value">Small</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-time"></span>
+</div>
+<div class="info-details">
+<div class="info-name">Training credit hours</div>
+<div class="info-value">50 h                                                            </div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-verifiy"></span>
+</div>
+<div class="info-details">
+<div class="info-name">Status</div>
+<div class="info-value">Account Verified</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-locaion"></span>
+</div>
+<div class="info-details">
+<div class="info-name">City                                                                    - Region</div>
+<div class="info-value">JEDDAH
+                                                                    - Makkah</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon"><img alt="" class="card-img" onerror="this.src='https://muqawil.org/public_assets/img/companies/website_icon-01.svg'" src="https://muqawil.org/public_assets/img/companies/website_icon-01.svg" style="width: 25px;"/></span>
+</div>
+<div class="info-details">
+<div class="info-name">Main Contractor</div>
+<div class="info-value">0</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon"><img alt="" class="card-img" onerror="this.src='https://muqawil.org/public_assets/img/companies/website_icon-02.svg'" src="https://muqawil.org/public_assets/img/companies/website_icon-02.svg" style="width: 25px;"/></span>
+</div>
+<div class="info-details">
+<div class="info-name">Sub Contractor</div>
+<div class="info-value">0</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-verifiy"></span>
+</div>
+<div class="info-details">
+<div class="info-name">Unclassified</div>
+<div class="info-value"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="section-card has-action has-membership platinum-membership" data-membership-text="
+ Platinum Membership                        ">
+<div class="row">
+<div class="col-auto">
+<img alt="" class="card-img" onerror="this.src='https://muqawil.org/public_assets/img/companies/default.jpg'" src="https://muqawil.org/public/contractor/companyLogo/CompanyLogo-1757586955_Untitled.png"/>
+<a class="btn btn-primary mt-2" href="https://muqawil.org/en/contractors/20014964/143"> Contract Request
+                                        </a>
+</div>
+<div class="col">
+<h2 class="card-title">
+<a href="https://muqawil.org/en/contractors/20014964/143">Inmayoun Contracting Company</a>
+</h2>
+<div class="info-box-wrapper mt-4">
+<div class="row">
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-ID"></span>
+</div>
+<div class="info-details">
+<div class="info-name">Membership Number</div>
+<div class="info-value">215421544</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-company"></span>
+</div>
+<div class="info-details">
+<div class="info-name">Company Size</div>
+<div class="info-value">Small</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-time"></span>
+</div>
+<div class="info-details">
+<div class="info-name">Training credit hours</div>
+<div class="info-value">3 h                                                            </div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-verifiy"></span>
+</div>
+<div class="info-details">
+<div class="info-name">Status</div>
+<div class="info-value">Account Verified</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-locaion"></span>
+</div>
+<div class="info-details">
+<div class="info-name">City                                                                    - Region</div>
+<div class="info-value">RIYADH
+                                                                    - Riyadh</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon"><img alt="" class="card-img" onerror="this.src='https://muqawil.org/public_assets/img/companies/website_icon-01.svg'" src="https://muqawil.org/public_assets/img/companies/website_icon-01.svg" style="width: 25px;"/></span>
+</div>
+<div class="info-details">
+<div class="info-name">Main Contractor</div>
+<div class="info-value">0</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon"><img alt="" class="card-img" onerror="this.src='https://muqawil.org/public_assets/img/companies/website_icon-02.svg'" src="https://muqawil.org/public_assets/img/companies/website_icon-02.svg" style="width: 25px;"/></span>
+</div>
+<div class="info-details">
+<div class="info-name">Sub Contractor</div>
+<div class="info-value">0</div>
+</div>
+</div>
+</div>
+<div class="col-md-6">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-verifiy"></span>
+</div>
+<div class="info-details">
+<div class="info-name">First Classified</div>
+<div class="info-value">1</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<ul class="pagination">
+<li class="page-item disabled"><a class="page-link" href="https://muqawil.org/en/contractors?page=1">«</a></li>
+<li aria-disabled="true" aria-label="« Previous" class="page-item disabled">
+<span aria-hidden="true" class="page-link">‹</span>
+</li>
+<li aria-current="page" class="page-item active"><span class="page-link">1</span></li>
+<li class="page-item"><a class="page-link" href="https://muqawil.org/en/contractors?page=2">2</a></li>
+<li class="page-item"><a class="page-link" href="https://muqawil.org/en/contractors?page=3">3</a></li>
+<li class="page-item">
+<a aria-label="Next »" class="page-link" href="https://muqawil.org/en/contractors?page=2" rel="next">›</a>
+</li>
+<li class="page-item"><a class="page-link" href="https://muqawil.org/en/contractors?page=865">»</a></li>
+</ul>
+</div></section></body></html>

--- a/tests/fixtures/muqawil/profile-ar.html
+++ b/tests/fixtures/muqawil/profile-ar.html
@@ -1,0 +1,1337 @@
+<!DOCTYPE html>
+
+<html dir="rtl" lang="ar" xmlns="jspwiki" xmlns:jspwiki="">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
+<!-- Dynamic SEO -->
+<title>المقاولون | شركة البناء التجريبية</title>
+<meta content="اعثر على مقاولك من منشآت مسجّلة وموثوقة." name="description"/>
+<meta content="Saudi Contractor Authority,Muqawil,مقاول,الهيئة السعودية للمقاولين" name="keywords"/>
+
+<!-- Author / Publisher -->
+<meta content="الهيئة السعودية للمقاولين" name="author"/>
+<meta content="الهيئة السعودية للمقاولين" name="publisher"/>
+<!-- Robots -->
+<meta content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" name="robots"/>
+<!-- Preconnect & DNS Prefetch -->
+
+<!-- Hreflang -->
+
+
+<!-- Open Graph -->
+<meta content="ar" property="og:locale"/>
+<meta content="en" property="og:locale:alternate"/>
+<meta content="website" property="og:type"/>
+<meta content="Muqawil - مقاول" property="og:title"/>
+<meta content="اعثر على مقاولك من منشآت مسجّلة وموثوقة." property="og:description"/>
+<meta content="https://muqawil.org/ar/contractors/881/143" property="og:url"/>
+<meta content="Muqawil - مقاول" property="og:site_name"/>
+<meta content="https://muqawil.org/theme2025/dist/images/logo.svg" property="og:image"/>
+<meta content="520" property="og:image:width"/>
+<meta content="400" property="og:image:height"/>
+<meta content="image/jpeg" property="og:image:type"/>
+<!-- Twitter -->
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Muqawil - مقاول" name="twitter:title"/>
+<meta content="اعثر على مقاولك من منشآت مسجّلة وموثوقة." name="twitter:description"/>
+<meta content="https://muqawil.org/theme2025/dist/images/logo.svg" name="twitter:image"/>
+<!-- Image Source -->
+
+<!-- Favicons -->
+
+
+
+<meta content="https://muqawil.org/theme2025/dist/fav.ico" name="msapplication-TileImage"/>
+
+<!-- Twitter -->
+<meta content="summary" name="twitter:card"/>
+<meta content="@SCA2030" name="twitter:site"/>
+<meta content="@SCA2030" name="twitter:creator"/>
+<meta content="article" property="og:type"/>
+<meta content="شركة البناء التجريبية" property="og:url"/>
+<meta content="https://muqawil.org/ar/contractors/881/143" property="og:title"/>
+<meta content="https://muqawil.org/public_assets/img/logo.png" property="og:image"/>
+<meta content="muqawil.org" property="og:site_name"/>
+<!--<meta property='article:published_time' content="8  Dec, 2019" />
+            <meta property='article:section'  content="OpEd" />-->
+
+
+
+
+
+
+<!-- Livewire Styles -->
+<!-- Google Tag Manager -->
+
+<!-- End Google Tag Manager -->
+</head>
+<body class="flex-column d-flex h-100">
+<!-- Google Tag Manager (noscript) -->
+
+<!-- End Google Tag Manager (noscript) -->
+<!-- Header Start-->
+<header class="header">
+<div class="header__mobile-nav">
+<div class="container header__mobile-nav__container d-flex align-items-center justify-content-between">
+<div class="d-flex align-items-center justify-content-between">
+<a aria-expanded="false" aria-haspopup="true" class="header__mobile-nav__account" data-bs-offset="0,28" data-bs-toggle="dropdown" href="#" id="changeLang" type="button">‏
+                        <i class="icon icon-user"></i>
+</a>
+<ul aria-labelledby="dropdownMenuButton1" class="dropdown-menu">
+<li>
+<a class="dropdown-item has-icon" href="https://muqawil.org/en/contractors/881/143" title="English">
+<span class="icon-global"><span class="path1"></span><span class="path2"></span><span class="path3"></span><span class="path4"></span></span>
+                                    English
+                                </a>
+</li>
+<li>
+<a class="dropdown-item has-icon" href="https://muqawil.org/ar/login">تسجيل الدخول</a>
+</li>
+<li>
+<a class="dropdown-item has-icon" href="https://muqawil.org/ar/newregister">
+<button class="btn btn-primary" type="button">التسجيل</button>
+</a>
+</li>
+</ul>
+</div>
+<a class="header__mobile-nav__logo" href="https://muqawil.org" title="منصة مقاول">
+<img alt="منصة مقاول" src="https://muqawil.org/theme2025/dist/images/logo.svg" title="منصة مقاول"/>
+</a>
+<div class="d-flex align-items-center justify-content-between">
+<a aria-label="OpenMenu" class="header__mobile-nav__burger-menu" href="#" id="openMenu">
+<i class="icon icon-menu"></i>
+</a>
+</div>
+</div>
+</div>
+<div class="header__mobile">
+<nav class="nav-drill">
+<a href="#" id="closeMenu">x</a>
+<ul class="nav-items nav-level-1">
+<li class="nav-item">
+<a class="nav-link" href="https://muqawil.org/ar/contractors/info" title="المقاولون">المقاولون</a>
+</li>
+<li class="nav-item">
+<a class="nav-link" href="/ar/consulting/public/info" title="الاستشارات">الاستشارات</a>
+</li>
+<li class="nav-item">
+<a class="nav-link" href="/ar/training/info" title="التدريب">التدريب</a>
+</li>
+<li class="nav-item">
+<a class="nav-link" href="/ar/allevents/info" title="التدريب">الفعاليات</a>
+</li>
+<li class="nav-item"><a class="nav-link" href="https://muqawil.org/ar/decision-making/info">مركز المعلومات</a>
+</li>
+<li class="nav-item">
+<span aria-expanded="false" class="nav-link" data-bs-target="#e-services" data-bs-toggle="collapse">
+                            الخدمات الإلكترونية 
+                            <span class="icon-arrow_1"></span>
+</span>
+<ul class="nav-items collapse" id="e-services">
+<li class="nav-item"><a class="nav-link" href="/ar/market">مشاريع</a>
+</li>
+<li class="nav-item"><a class="nav-link" href="https://muqawil.org/ar/consortium/landing">منصة التحالف</a>
+</li>
+<li class="nav-item"><a class="nav-link" href="https://muqawil.org/ar/suppliers/info">الموردون</a>
+</li>
+<li class="nav-item"><a class="nav-link" href="https://muqawil.org/ar/contractors-rate/info">تقييم المقاولين</a>
+</li>
+<li class="nav-item"><a class="nav-link" href="/ar/pmc/getAllPmc/info">مدراء المشاريع</a>
+</li>
+<li class="nav-item"><a class="nav-link" href="/ar/localization/info">توطين</a>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</div>
+<div class="header__nav__wrapper d-none d-lg-block">
+<div class="container">
+<div class="header__nav">
+<ul class="header__nav__items">
+<li class="header__nav__item header__nav__item--logo">
+<a href="https://muqawil.org" title="منصة مقاول">
+<img alt="منصة مقاول" class="header__logo" src="https://muqawil.org/theme2025/dist/images/logo.svg" title="منصة مقاول"/>
+</a>
+</li>
+<li class="nav-item active-page">
+<a class="nav-link" href="https://muqawil.org">
+                                الرئيسية
+                            </a>
+</li>
+<li class="header__nav__item">
+<a class="nav-link" href="https://muqawil.org/ar/contractors/info">المقاولون</a>
+</li>
+<li class="header__nav__item">
+<a class="nav-link" href="/ar/consulting/public/info">الاستشارات</a>
+</li>
+<li class="header__nav__item">
+<a class="nav-link" href="/ar/training/info">التدريب</a>
+</li>
+<li class="header__nav__item">
+<a class="nav-link" href="/ar/allevents/info">الفعاليات</a>
+</li>
+<li class="header__nav__item">
+<a class="nav-link" href="https://muqawil.org/ar/decision-making/info">مركز المعلومات</a>
+</li>
+<li class="header__nav__item">
+<a aria-expanded="false" class="nav-link" data-bs-offset="0,28" data-bs-toggle="dropdown" href="#">
+                                الخدمات الإلكترونية                                <span class="icon-arrow-down-main header__nav__item__icon">
+<span class="path1"></span><span class="path2"></span>
+</span>
+</a>
+<ul aria-labelledby="dropdownMenuButton1" class="dropdown-menu">
+<li>
+<a class="dropdown-item" href="/ar/market">مشاريع</a>
+</li>
+<li>
+<a class="dropdown-item" href="https://muqawil.org/ar/consortium/landing">منصة التحالف</a>
+</li>
+<li>
+<a class="dropdown-item" href="https://muqawil.org/ar/suppliers/info">الموردون</a>
+</li>
+<li>
+<a class="dropdown-item" href="https://muqawil.org/ar/contractors-rate/info">تقييم المقاولين</a>
+</li>
+<li>
+<a class="dropdown-item disable-project-management" href="/ar/pmc/getAllPmc/info">مدراء المشاريع</a>
+</li>
+<li class="disable-localization">
+<a class="dropdown-item" href="/ar/localization/info">توطين</a>
+</li>
+<li>
+<a class="dropdown-item" href="/ar/scavo/info">تتبع المشاريع (SCAVO)</a>
+</li>
+<li>
+<a class="dropdown-item" href="https://muqawil.org/ar/jisr/landing">جسر</a>
+</li>
+<li>
+<a class="dropdown-item" href="https://muqawil.org/ar/marketplace/info">سوق مقاول</a>
+</li>
+</ul>
+</li>
+</ul>
+<ul class="header__nav__items">
+<li class="header__nav__item">
+<a class="nav-link has-icon" href="https://muqawil.org/en/contractors/881/143">
+                                    English
+                                    <span class="icon-translate"><span class="path1"></span><span class="path2"></span><span class="path3"></span><span class="path4"></span><span class="path5"></span><span class="path6"></span>
+</span>
+</a>
+</li>
+<li class="header__nav__item">
+<a class="nav-link has-icon" href="https://muqawil.org/ar/login">تسجيل الدخول</a>
+</li>
+<li class="header__nav__item">
+<a class="btn btn-primary" href="https://muqawil.org/ar/newregister">التسجيل</a>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<header class="inner-header" style="background-image: url(https://muqawil.org/theme2025/dist/images/services-bg-header/ar/1w.webp);">
+<div class="container">
+<div class="inner-header__content">
+<div class="inner-header__info">
+<h1 class="inner-header__title">شركة البناء التجريبية</h1>
+<nav class="inner-header__breadcrumb">
+<i class="inner-header__separator icon icon-home"></i>
+<a class="inner-header__link" href="https://muqawil.org">الرئيسية</a>
+<i class="inner-header__separator icon icon-arrow-left"></i>
+<a class="inner-header__link" href="https://muqawil.org/ar/contractors/info">المقاولون</a>
+<i class="inner-header__separator icon icon-arrow-left"></i>
+<a class="inner-header__link" href="https://muqawil.org/ar/contractors">البحث</a>
+<i class="inner-header__separator icon icon-arrow-left"></i>
+<span class="inner-header__link">شركة البناء التجريبية</span>
+</nav>
+</div>
+</div>
+</div>
+</header>
+</header>
+<!-- Header END-->
+<section class="main mb-5">
+<!--  ABOUT THE SERVICE SECTION START   -->
+<section class="service">
+<div class="container" style="overflow: hidden">
+<div class="row">
+<div class="col-12">
+<div class="section-card">
+<div class="row">
+<div class="col-auto">
+<img alt="" class="card-img" src="https://muqawil.org/public/contractor/companyLogo/https://muqawil.org/public/contractor/companyLogo/CompanyLogo-1780991935_logo-green.png"/>
+</div>
+<div class="col" style="position: relative">
+<div class="scg-badges-wrapper">
+<div class="pscg-logo"></div>
+<div class="pscg-lic"></div>
+<div class="pscg-tier_box">
+<img src="https://muqawil.org/ar/pscg/preview/OGNkMGI5Y2QtZjBhZi00MTQzLTk1MzItNGIzYmMxODFiZmJkMDQwNTIwMjYxMjE3MDMucG5n"/>
+</div>
+<div class="pscg-title">مستوي <br/> الجاهزية</div>
+</div>
+<h3 class="card-title">شركة البناء التجريبية </h3>
+<div class="badges">
+<div class="badge">
+<span class="icon-medal-platinum"><span class="path1"></span><span class="path2"></span><span class="path3"></span><span class="path4"></span><span class="path5"></span><span class="path6"></span></span>
+                                            عضوية بلاتينية                                        </div>
+<div class="badge transparent">
+<span class="icon-verifiy-dark text-primary"></span>
+                                                                                    الحساب مفعل                                        
+                                    </div>
+</div>
+<div class="info-box-wrapper">
+<div class="row">
+<div class="col-md-6 col-lg-4">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-ID"></span>
+</div>
+<div class="info-details">
+<div class="info-name">رقم العضويه</div>
+<div class="info-value">10000861</div>
+</div>
+</div>
+</div>
+<div class="col-md-6 col-lg-4">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-ID"></span>
+</div>
+<div class="info-details">
+<div class="info-name">العضوية</div>
+<div class="info-value">
+                                                        مقاول سعودي</div>
+</div>
+</div>
+</div>
+<div class="col-md-6 col-lg-4">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-ID"></span>
+</div>
+<div class="info-details">
+<div class="info-name">عضو منذ</div>
+<div class="info-value">2018/08/25
+                                                    </div>
+</div>
+</div>
+</div>
+<div class="col-md-6 col-lg-4">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-company"></span>
+</div>
+<div class="info-details">
+<div class="info-name">حجم المنشأة</div>
+<div class="info-value">منشأة صغيرة</div>
+</div>
+</div>
+</div>
+<div class="col-md-6 col-lg-4">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-time"></span>
+</div>
+<div class="info-details">
+<div class="info-name">عدد الساعات التدريبية</div>
+<div class="info-value">308 س                                                    </div>
+</div>
+</div>
+</div>
+<div class="col-md-6 col-lg-4">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-phone"></span>
+</div>
+<div class="info-details">
+<div class="info-name">رقم جوال المنشأة</div>
+<div class="info-value">966920000968</div>
+</div>
+</div>
+</div>
+<div class="col-md-6 col-lg-4">
+<div class="info-box has-action">
+<div class="info-icon">
+<span class="icon-email"></span>
+</div>
+<div class="info-details">
+<div class="info-name">البريد الإلكتروني للمنشأة </div>
+<div class="info-value"><a href="/cdn-cgi/l/email-protection#cda4b98dbeaeace3beac"><span class="__cf_email__" data-cfemail="046d70447767652a7765">[email protected]</span></a>
+</div>
+</div>
+</div>
+</div>
+<div class="col-md-6 col-lg-4">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-locaion"></span>
+</div>
+<div class="info-details">
+<div class="info-name">المدينة</div>
+<div class="info-value">الرياض</div>
+</div>
+</div>
+</div>
+<div class="col-md-6 col-lg-4">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-locaion"></span>
+</div>
+<div class="info-details">
+<div class="info-name">المنطقه</div>
+<div class="info-value">الرياض</div>
+</div>
+</div>
+</div>
+<div class="col-md-6 col-lg-4">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-locaion"></span>
+</div>
+<div class="info-details">
+<div class="info-name">عنوان</div>
+<div class="info-value">الرياض  الملقا انس بن مالك                                                    </div>
+</div>
+</div>
+</div>
+<div class="col-md-6 col-lg-4">
+<div class="info-box">
+<div class="info-icon">
+<img src="https://muqawil.org/assets/files/baladyServices/icon-tag.png" style="height: 24px;width: 24px;"/>
+</div>
+<div class="info-details">
+<div class="info-name">الخدمة</div>
+<div class="info-value">
+                                                                                                                            مراكز الخدمة
+                                                                <span class="info-value-balady"> , </span>
+                                                                                                                            المطاعم و المطابخ
+                                                                <span class="info-value-balady"> , </span>
+                                                                                                                            تسوير مواقع الأعمال الأنشائية
+                                                                <span class="info-value-balady"> , </span>
+                                                                                                                            تسوير الأراضي الفضاء
+                                                                <span class="info-value-balady"> , </span>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sharethis-inline-share-buttons" data-image="https://muqawil.org/public_assets/img/logo.png" data-title="شركة البناء التجريبية" data-url="https://muqawil.org/ar/contractors/881/143" style="margin-top: 15px;"></div>
+</div>
+</div>
+
+
+<div class="section-card">
+<div class="row">
+<div class="col-auto">
+<img alt="" class="card-img" src="https://muqawil.org/public/contractor/companyLogo/https://muqawil.org/public/contractor/companyLogo/CompanyLogo-1780991935_logo-green.png"/>
+</div>
+<div class="col" style="position: relative">
+<h1 class="card-title color-primary">
+<b>
+
+                                        طلب تعاقد
+
+                                    </b>
+</h1>
+<br/>
+<span class="card-title color-primary">
+                                    لحفظ حقوق جميع الأطراف في العلاقة التعاقدية، تقدم الهيئة السعودية للمقاولين 36 عقد نموذجي معتمد وموثق يمكن اختيار أحدها أدناه
+
+                                </span>
+<br/>
+<br/>
+<div class="info-box-wrapper">
+<div class="row">
+<form action="https://muqawil.org/init_econtract_draft" class="login-box" enctype="multipart/form-data" form="" id="econtractForm" method="post" role="form">
+<input autocomplete="off" name="_token" type="hidden" value="t3bUK5zOFxcZxeka5u6pNw2Ac2d3DqcauqHeVlae"/>
+<div id="errormessage"></div> <!-- Error message container -->
+
+<input class="btn btn-secondary" id="_submitAction" name="_submitAction" type="hidden" value="econtractForm"/>
+<div class="row">
+<div class="col-md-6 col-sm-12">
+<div class="form-group">
+<label class="form-label" for="template_id">
+
+                                                            العقد
+
+                                                        </label>
+<select class="_change form-select form-control form-input select2" id="template_id" name="template_id" style="height: 50px;">
+<option value="">اختر العقد</option>
+<option value="2">
+                                                                    عقد أعمال تجهيز الموقع و التسوير </option>
+<option value="3">
+                                                                    عقد أعمال الهيكل الإنشائي - تنفيذ و مواد </option>
+<option selected="" value="4">
+                                                                    عقد أعمال الهيكل الإنشائي - تنفيذ بدون مواد </option>
+<option value="5">
+                                                                    عقد أعمال الإنشاء الكامل - تسليم المفتاح </option>
+<option value="6">
+                                                                    عقد أعمال الطلاء </option>
+<option value="7">
+                                                                    عقد أعمال البستنة وأنظمة الري </option>
+<option value="8">
+                                                                    عقد أعمال اللياسة - تنفيذ بدون مواد </option>
+<option value="9">
+                                                                    عقد أعمال اللياسة  - تنفيذ ومواد </option>
+<option value="10">
+                                                                    عقد أعمال الأبواب الحديدية </option>
+<option value="11">
+                                                                    عقد أعمال الهدم وترحيل المخلفات </option>
+<option value="12">
+                                                                    عقد أعمال الديكور - تنفيذ ومواد </option>
+<option value="13">
+                                                                    عقد أعمال الديكور - تنفيذ بدون مواد </option>
+<option value="14">
+                                                                    عقد أعمال الكهرباء - تنفيذ بدون مواد </option>
+<option value="15">
+                                                                    عقد أعمال تركيب المطابخ </option>
+<option value="16">
+                                                                    عقد أعمال أنظمة الطاقة الشمسية </option>
+<option value="17">
+                                                                    عقد أعمال التكييف </option>
+<option value="18">
+                                                                    عقد أعمال نوافذ و أبواب ألمنيوم </option>
+<option value="19">
+                                                                    عقد أعمال تمديدات الغاز </option>
+<option value="20">
+                                                                    عقد إشراف </option>
+<option value="21">
+                                                                    عقد أنظمة الاتصال والصوتيات </option>
+<option value="22">
+                                                                    عقد أعمال تركيب المصاعد </option>
+<option value="23">
+                                                                    عقد اعمال التكسية الخارجية - تنفيذ بدون مواد </option>
+<option value="24">
+                                                                    عقد أعمال التكسية الخارجية - تنفيذ ومواد </option>
+<option value="25">
+                                                                    عقد أعمال الأرضيات - تنفيذ ومواد </option>
+<option value="26">
+                                                                    عقد أعمال الأرضيات - تنفيذ بدون مواد </option>
+<option value="27">
+                                                                    عقد أعمال المسابح </option>
+<option value="28">
+                                                                    عقد أعمال العزل المائي والحراري </option>
+<option value="29">
+                                                                    عقد أعمال الترميم </option>
+<option value="30">
+                                                                    عقد أعمال السباكة - تنفيذ بدون مواد </option>
+<option value="31">
+                                                                    عقد أعمال السباكة - تنفيذ ومواد </option>
+<option value="32">
+                                                                    عقد أعمال الدرابزين </option>
+<option value="33">
+                                                                    عقد أعمال الأبواب الخشبية </option>
+<option value="34">
+                                                                    عقد أعمال الأنظمة الأمنية </option>
+<option value="35">
+                                                                    عقد أعمال إنذار ومكافحة الحريق </option>
+<option value="36">
+                                                                    عقد أعمال الكهرباء - تنفيذ ومواد </option>
+<option value="37">
+                                                                    عقد مطور عقاري </option>
+</select>
+<p class="text-danger">
+</p>
+</div>
+</div>
+</div>
+<div class="row">
+<div class="col-md-6 col-sm-12 form-group">
+<label class="form-label" for="title">
+                                                        اسم الطرف الاول
+                                                    </label>
+<input class="form-control form-input" id="first_party_name" name="first_party_name" type="text" value=""/>
+<p class="text-danger">
+</p>
+</div>
+</div>
+<div class="row">
+<div class="col-md-6 col-sm-12 form-group">
+<label class="form-label" for="title">
+                                                        جوال الطرف الاول
+
+                                                    </label>
+<input class="form-control form-input" id="first_party_phone" name="first_party_phone" type="text" value=""/>
+<p class="text-danger">
+</p>
+</div>
+</div>
+<div class="row">
+<div class="col-md-6 col-sm-12 form-group">
+<label class="form-label" for="title">
+                                                        هوية الطرف الاول
+
+                                                    </label>
+<input class="form-control form-input" id="first_party_national_id" name="first_party_national_id" type="text" value=""/>
+<p class="text-danger">
+</p>
+</div>
+</div>
+<div class="row">
+<div class="col-md-6 col-sm-12">
+<button aria-controls="step2" class="btn btn-primary nex-tab ml-2 tab-link" id="submitNDEcontractForm" role="tab" type="submit">
+                                                        ارسال الطلب
+
+                                                    </button>
+</div>
+</div>
+<div class="row d-none">
+<div class="col-6 form-group">
+<label class="form-label" for="title">
+                                                        اسم الطرف الثاني
+                                                        
+                                                    </label>
+<input class="form-control form-input" id="cr" name="cr" type="text" value="7007506731"/>
+<p class="text-danger">
+</p>
+</div>
+<div class="col-6 form-group">
+<label class="form-label" for="title">
+                                                        جوال الطرف الثاني
+
+                                                    </label>
+<input class="form-control form-input" id="second_party_phone" name="second_party_phone" type="text" value="966920000968"/>
+<p class="text-danger">
+</p>
+</div>
+<div class="col-6 form-group">
+<label class="form-label" for="title">
+                                                        هوية الطرف الثاني
+
+                                                    </label>
+<input class="form-control form-input" id="second_party_national_id" name="second_party_national_id" type="text" value=""/>
+<p class="text-danger">
+</p>
+</div>
+</div>
+</form>
+
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="section-card">
+<h4 class="card-title">
+                            التراخيص ومستوى الجاهزية
+                        </h4>
+<div class="table-responsive">
+<table class="table">
+<thead>
+<tr>
+<th scope="col">الأنشطة المرخصة</th>
+<th class="text-center" scope="col">مستوى الجاهزية</th>
+</tr>
+</thead>
+<tbody>
+<tr class="pscg-tbl-row-tr">
+<td scope="col">
+<div class="pscg-tbl-row-item-box">
+<div class="pscg-data-box">
+<div>تشييد المباني - تشييد المباني - جميع الأنواع</div>
+<div>Construction of Buildings - Construction of Buildings – All Types</div>
+</div>
+</div>
+</td>
+<td scope="col">
+<div class="pscg-tbl-row-grade-box">
+<div class=""> <img class="pscg-tbl-row-grade-img" src="https://muqawil.org/ar/pscg/preview/OGNkMGI5Y2QtZjBhZi00MTQzLTk1MzItNGIzYmMxODFiZmJkMDQwNTIwMjYxMjE3MDMucG5n"/>
+</div>
+<div class="grade-hint"> أساسي
+                                                                | Basic</div>
+</div>
+</td>
+</tr>
+<tr class="pscg-tbl-row-tr">
+<td scope="col">
+<div class="pscg-tbl-row-item-box">
+<div class="pscg-data-box">
+<div>أنشطة التشييد المتخصصة - تشطيب المباني</div>
+<div>Specialized Construction Activities - Building Finishing</div>
+</div>
+</div>
+</td>
+<td scope="col">
+</td>
+</tr>
+<tr class="pscg-tbl-row-tr">
+<td scope="col">
+<div class="pscg-tbl-row-item-box">
+<div class="pscg-data-box">
+<div>التشغيل والصيانة - المباني المتخصصة والتنظيف الصناعي</div>
+<div>Operations and Maintenance Activities - Specialized Buildings &amp; Industrial Cleaning</div>
+</div>
+</div>
+</td>
+<td scope="col">
+</td>
+</tr>
+<tr class="pscg-tbl-row-tr">
+<td scope="col">
+<div class="pscg-tbl-row-item-box">
+<div class="pscg-data-box">
+<div>التشغيل والصيانة - مكافحة الآفات والتطهير البيئي</div>
+<div>Operations and Maintenance Activities - Pest Control &amp; Environmental Disinfection</div>
+</div>
+</div>
+</td>
+<td scope="col">
+</td>
+</tr>
+<tr class="pscg-tbl-row-tr">
+<td scope="col">
+<div class="pscg-tbl-row-item-box">
+<div class="pscg-data-box">
+<div>التشغيل والصيانة - العناية بأعمال البستنة وصيانتها</div>
+<div>Operations and Maintenance Activities - Gardening &amp; Landscaping Maintenance</div>
+</div>
+</div>
+</td>
+<td scope="col">
+</td>
+</tr>
+<tr class="pscg-tbl-row-tr">
+<td scope="col">
+<div class="pscg-tbl-row-item-box">
+<div class="pscg-data-box">
+<div>الهندسة المدنية - الصرف الصحي</div>
+<div>Civil Engineering - </div>
+</div>
+</div>
+</td>
+<td scope="col">
+</td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<!--For Hafiz-->
+<div class="section-card">
+<ul class="nav nav-pills" id="pills-tab" role="tablist">
+<li class="nav-item" role="presentation">
+<button aria-controls="pills-home" aria-selected="true" class="nav-link active" data-bs-target="#contractor-tab1" data-bs-toggle="pill" id="contractortab1" role="tab" type="button">
+
+                                    تفاصيل الشركة
+                                </button>
+</li>
+<li class="nav-item" role="presentation">
+<button aria-controls="pills-profile" aria-selected="false" class="nav-link" data-bs-target="#contractor-tab2" data-bs-toggle="pill" id="contractortab2" role="tab" type="button">
+
+                                    المقاولين بالباطن
+
+                                </button>
+</li>
+<li class="nav-item" role="presentation">
+<button aria-controls="pills-contact" aria-selected="false" class="nav-link" data-bs-target="#contractor-tab3" data-bs-toggle="pill" id="contractortab3" role="tab" type="button">
+
+                                    المقاولين الرئيسيين
+
+                                </button>
+</li>
+<li class="nav-item" role="presentation">
+<button aria-controls="pills-contact" aria-selected="false" class="nav-link" data-bs-target="#contractor-tab4" data-bs-toggle="pill" id="contractortab4" onclick="getRadarChart()" role="tab" type="button">
+                                    التقييم الفني
+                                </button>
+</li>
+</ul>
+<div class="tab-content" id="pills-tabContent">
+<div aria-labelledby="contractor-tab1" class="tab-pane fade show mb-5 active" id="contractor-tab1" role="tabpanel">
+<div>
+<!--                                    <h4 class="card-title">
+                                            تفاصيل الشركة                                        </h4>-->
+<div class="card-inner-section card-text">
+                                        الرياض  الملقا انس بن مالك                                    </div>
+</div>
+<!-- Begin Contractor Licnesing Field Values -->
+</div>
+<div aria-labelledby="contractor-tab2" class="tab-pane fade" id="contractor-tab2" role="tabpanel">
+<div class="table-responsive">
+<table class="table table-striped">
+<thead>
+<tr>
+<th scope="col">#</th>
+<th scope="col">الإسم</th>
+</tr>
+</thead>
+<tbody>
+</tbody>
+</table>
+</div>
+</div>
+<div aria-labelledby="contractor-tab3" class="tab-pane fade" id="contractor-tab3" role="tabpanel">
+<div class="table-responsive">
+<table class="table table-striped">
+<thead>
+<tr>
+<th scope="col">#</th>
+<th scope="col">الإسم</th>
+</tr>
+</thead>
+<tbody>
+</tbody>
+</table>
+</div>
+</div>
+<div aria-labelledby="contractor-tab4" class="tab-pane fade" id="contractor-tab4" role="tabpanel" style="margin-bottom: 30px">
+<div id="radar_chart_container"></div>
+</div>
+</div>
+</div>
+<!--For Hafiz-->
+<div class="section-card">
+<h4 class="card-title">
+                            العقود سعر البناء (برنامج البناء الذاتي)
+                        </h4>
+<div class="table-responsive">
+<table class="table table-striped">
+<thead>
+<tr>
+<th scope="col">الإسم</th>
+<th scope="col">القيمة</th>
+</tr>
+</thead>
+<tbody>
+</tbody>
+</table>
+</div>
+</div>
+<!-- End Contractor Licensing Field Values -->
+<!-- Econtract Start -->
+<div class="section-card">
+<h4 class="card-title">
+                            المشاريع السابقة                        </h4>
+<div class="table-responsive">
+<table class="table table-striped">
+<thead>
+<tr>
+<th scope="col">عدد العقود النموذجية</th>
+<th scope="col">عدد العقود المسجلة</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>455</td>
+<td>64</td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<!-- Econtract End -->
+<!--Interests Start-->
+<div class="section-card">
+<h3 class="card-title">الأنشطة</h3>
+<ul class="list list-numerical">
+<li class="list-item">تشييد المباني</li>
+<ul class="list list-numerical" type="1">
+<li class="list-item">تشييد المباني
+ </li>
+<ul class="list list-numerical" type="1">
+<li class="list-item">الإنشاءات العامة للمباني السكنية
+
+                                                                    </li>
+<li class="list-item">الإنشاءات العامة للمباني الغير السكنية ، يشمل ( المدارس ، المستشفيات، الفنادق ...الخ )
+
+                                                                    </li>
+<li class="list-item">الإنشاءات العامة للمباني الغير السكنية  المطارات 
+
+                                                                    </li>
+<li class="list-item">الإنشاءات العامة للمباني الغير السكنية  الحديدية
+
+                                                                    </li>
+<li class="list-item">إنشاءات المباني الجاهزة في المواقع 
+
+                                                                    </li>
+<li class="list-item">ترميمات المباني السكنية والغير سكنية
+
+                                                                    </li>
+</ul>
+</ul>
+<li class="list-item">الهندسة المدنية</li>
+<ul class="list list-numerical" type="1">
+<li class="list-item">إنشاء الطرق وخطوط السكك الحديدية
+ </li>
+<ul class="list list-numerical" type="1">
+<li class="list-item">إنشاء واصلاح الطرق  والشوارع والارصفة ومستلزمات الطرق 
+
+                                                                    </li>
+<li class="list-item">إنشاء واصلاح الجسور والانفاق
+
+                                                                    </li>
+<li class="list-item">إصلاح وصيانة الطرق والشوارع والأرصفة ومستلزمات الطرق
+
+                                                                    </li>
+<li class="list-item">إصلاح وصيانة الجسور والأنفاق
+                                                                    </li>
+</ul>
+</ul>
+<li class="list-item">أنشطة التشييد المتخصصة </li>
+<ul class="list list-numerical" type="1">
+<li class="list-item">التركيبات الكهربائية
+ </li>
+<ul class="list list-numerical" type="1">
+<li class="list-item">تمديد الاسلاك الكهربائية 
+
+                                                                    </li>
+<li class="list-item">تمديد  اسلاك الاتصالات
+
+                                                                    </li>
+<li class="list-item">تمديدات  الشبكات
+
+                                                                    </li>
+</ul>
+<li class="list-item">أعمال السباكة والتدفئة وتكييف الهواء
+ </li>
+<ul class="list list-numerical" type="1">
+<li class="list-item">تركيب الادوات الصحية وصيانتها واصلاحها
+
+                                                                    </li>
+<li class="list-item">تركيب انظمة التبريد وتكييف الهواء وصيانتها واصلاحها
+
+                                                                    </li>
+<li class="list-item">تركيب وتمديد انابيب تكييف الهواء وصيانتها واصلاحها
+
+                                                                    </li>
+</ul>
+<li class="list-item">اكمال المباني وتشطيبها
+ </li>
+<ul class="list list-numerical" type="1">
+<li class="list-item"> تشطيب المباني 
+
+                                                                    </li>
+</ul>
+</ul>
+</ul>
+</div>
+<!--Interests End-->
+<!--Map Start-->
+<div class="section-card">
+<h3 class="card-title">الموقع</h3>
+<div id="map" style="width:100%;height:400px; margin-top: 30px;margin-bottom: 30px;display:none;">
+</div>
+<div id="show_map_button">
+<button class="btn btn-primary" onclick="myMap();" style="width:100%;"><i class="fa fa-map"></i>اعرض الموقع على الخريطة</button>
+</div>
+<!--Map End-->
+</div>
+</div>
+</div>
+</div>
+</section>
+</section>
+<button aria-label="Scroll to top" id="up-to-top">
+<span class="icon-arrow-down2"></span>
+</button>
+<!-- Footer Start-->
+<footer class="footer mt-0">
+<div class="container">
+<div class="row justify-content-between">
+<div class="col-md-3">
+<img alt="Saudi 2030" class="footer__logo" src="https://muqawil.org/theme2025/dist/images/footer-image2.svg" title="Saudi 2030"/>
+<p class="text-light mt-4 footer__logo__heading">
+                        منصة مقاول تمكنك من البحث عن أفضل شركة مقاولات مسجلة في عضوية الهيئة لتنفيذ مشاريع القطاع الحكومي والخاص أو الأفراد حسب اختصاص المنشأة وحجمها وموقعها.                    </p>
+</div>
+<div class="col-md-2">
+<h2 class="footer__heading mb-4">روابط سريعة</h2>
+<ul>
+<li>
+<a class="footer-link" href="#" target="_blank">الهيئة السعودية للمقاولين</a>
+</li>
+<li>
+<a class="footer-link" href="https://muqawil.org/ar/contractors">المقاولون</a>
+</li>
+<li>
+<a class="footer-link" href="https://muqawil.org/ar/registrationprocess">عملية التسجيل في عضوية الهيئة السعودية للمقاولين</a>
+</li>
+</ul>
+</div>
+<div class="col-md-2">
+<h2 class="footer__heading mb-4">روابط هامة</h2>
+<ul>
+<li>
+<a class="footer-link" href="#" target="_blank">اتصل بنا</a>
+</li>
+<li>
+<a class="footer-link" href="https://muqawil.org/ar/rulespageone">سياسة الخصوصية والسرية</a>
+</li>
+<li>
+<a class="footer-link" href="https://muqawil.org/ar/rulespagetwo">مبادئ الاستخدام</a>
+</li>
+</ul>
+</div>
+<div class="col-md-3">
+<h2 class="footer__heading">اتصل بنا</h2>
+<div class="footer__links flex-column flex-lg-row justify-content-lg-between">
+<!-- <div class="d-flex align-items-center ">-->
+<nav class="footer__social-links">
+<a class="nav-link" href="https://www.linkedin.com/company/sca2030" rel="noreferrer" target="_blank" title="Linkedin">
+<i class="icon-linkedin"></i>
+</a>
+<a class="nav-link" href="https://www.youtube.com/channel/UCNWAjpcKW3EJfdtLpXmmuqQ" rel="noreferrer" target="_blank" title="Youtube">
+<i class="icon-youtube"></i>
+</a>
+<a class="nav-link" href="https://x.com/SCA2030" rel="noreferrer" target="_blank" title="X">
+<i class="icon-x"></i>
+</a>
+<a class="nav-link" href="https://www.facebook.com/SCA2030F" rel="noreferrer" target="_blank" title="Facebook">
+<i class="icon-facebook"></i>
+</a>
+</nav>
+<!-- </div>-->
+</div>
+<h2 class="footer__heading my-3">يمكنك تحميل التطبيق من خلال</h2>
+<div class="footer__apps">
+<a href="https://apps.apple.com/us/app/muqawil/id1548938688" target="_blank"><img alt="App Store" src="https://muqawil.org/theme2025/dist/images/app-store.svg" title="App Store"/></a>
+<a href="https://play.google.com/store/apps/details?id=sa.sca.muqawilapp" target="_blank"><img alt="App Store" src="https://muqawil.org/theme2025/dist/images/google-play.svg" title="App Store"/></a>
+</div>
+</div>
+</div>
+</div>
+<div class="footer__copyrights">
+<p>© Copyright 2026                |
+                الهيئة السعودية للمقاولين
+                .</p>
+</div>
+</footer>
+<!-- Footer End-->
+<div aria-modal="true" class="modal fade rating-auto-modal" data-auto="1" data-dismiss-days="1" data-service-id="1" data-trigger-after-seconds="60" data-trigger-scroll-percent="50" id="ratingReminderModal" role="dialog" style="display:none;" tabindex="-1">
+<div class="modal-backdrop fade" id="ratingReminderBackdrop" onclick="window.closeRatingModal(true)" style="z-index:1040; display:none;"></div>
+<div class="modal-dialog modal-dialog-centered" style="z-index:1050;">
+<div class="modal-content">
+<div class="modal-header position-relative">
+<h5 class="modal-title w-100 text-center">
+                    من فضلك قم بتقييم                </h5>
+<button class="btn-close position-absolute top-50 translate-middle-y" onclick="window.closeRatingModal(true)" style="left:15px;" type="button">
+</button>
+</div>
+<div class="modal-body text-center">
+<div class="rating-widget text-center" data-item-id="" data-service-id="1" data-show-stats="0" data-user-email="" data-user-id="" data-user-mobile="" data-user-type="client" data-website="https://muqawil.org/ar/contractors/881/143">
+<form class="ratingForm d-flex flex-column align-items-center justify-content-center">
+<div class="rating-stars text-center">
+<input class="ratingValue" type="hidden" value="0"/>
+<i class="rating-stars__icon" data-value="1">★</i>
+<i class="rating-stars__icon" data-value="2">★</i>
+<i class="rating-stars__icon" data-value="3">★</i>
+<i class="rating-stars__icon" data-value="4">★</i>
+<i class="rating-stars__icon" data-value="5">★</i>
+</div>
+<div class="ratingMessage mt-2 w-100"></div>
+<button class="btn btn-primary mt-3 mx-auto" type="submit">
+            قيّم الخدمة        </button>
+</form>
+</div>
+ </div>
+</div>
+</div>
+</div>
+<input id="hosturl" type="hidden" value="https://muqawil.org"/>
+<input id="_token" type="hidden" value="t3bUK5zOFxcZxeka5u6pNw2Ac2d3DqcauqHeVlae"/>
+<input id="_lang" type="hidden" value="ar"/>
+
+
+
+
+
+
+
+
+
+
+
+
+
+<script>
+    var isRadarChartLoaded = false;
+
+    function getRadarChart() {
+        if (!isRadarChartLoaded) {
+            LoadRadarChart();
+        }
+    }
+
+    function addRadarChartHTML(item, index) {
+        var _lang = document.getElementById('_lang').value;
+        var chartContainer = document.getElementById("radar_chart_container");
+        chartContainer.innerHTML = `<div>
+                        <h4 class="card-title">
+
+                            ${_lang == 'ar' ? item.categoryNameAr : item.categoryNameEn} <span>  على حسب النشاط </span>
+                        </h4>
+                        <div class="radar-chart-wrapper">
+                            <canvas id="radarChart_${index + 1}"></canvas>
+                        </div>
+                    </div>
+                    <div class="section-card">
+                        <h4 class="card-title">
+                            ${_lang == 'ar' ? item.categoryNameAr : item.categoryNameEn} <span>  على حسب الحجم </span>
+                        </h4>
+                        <div class="radar-chart-wrapper">
+                            <canvas id="radarChartBySize_${index + 1}"></canvas>
+                        </div>
+                    </div>`;
+    }
+
+    function LoadRadarChart() {
+        console.log('Radar Chart Loaded');
+
+        // return false;
+        var _lang = document.getElementById('_lang').value;
+
+        var organization_registration_number = 7007506731;
+
+        if (organization_registration_number != null) {
+
+
+            var URL = 'https://muqawil.org/ar/contractors/getContractorRadarChart/:id';
+
+            URL = URL.replace(':id', 7007506731);
+
+            $.ajax({
+                url: URL,
+                type: "GET",
+                data: {},
+
+                success: function(result) {
+
+                    isRadarChartLoaded = true;
+                    console.log('chart: ', result)
+                    if (result.length > 0) {
+                        // console.log('chart: ',result)
+                        //right chart HTML =================>
+
+                        result.forEach((itm, index) => {
+                            //radar_chart_container
+                            addRadarChartHTML(itm, index)
+
+
+                        })
+                        var radarReportObject = JSON.stringify(result).replace(/&quot;/g, '"');
+                        radarReportObject = JSON.parse(radarReportObject);
+                        var responseArray = Object.entries(radarReportObject[0].data);
+
+                        var responseFormatedArray = [];
+                        responseArray.forEach((itm) => {
+                            responseFormatedArray.push(itm[1]);
+
+                        })
+
+
+                        radarReportObject[0].data = responseFormatedArray;
+                        Chart.defaults.font.size = 18;
+                        for (var i = 0; i < radarReportObject.length; i++) {
+
+                            const data = {
+
+                                labels: [],
+                                datasets: [{
+                                        label: 'معدل اداء المنشأة',
+                                        data: [],
+                                        fill: true,
+                                        backgroundColor: 'rgba(72, 160, 53, 0.2)',
+                                        borderColor: 'rgb(72, 160, 53)',
+                                        pointBackgroundColor: 'rgb(72, 160, 53)',
+                                        pointBorderColor: '#fff',
+                                        pointHoverBackgroundColor: '#fff',
+                                        pointHoverBorderColor: 'rgb(72, 160, 53)'
+                                    },
+                                    {
+                                        label: 'معدل اداء المنشأت في نفس الفئة',
+                                        data: [],
+                                        fill: true,
+                                        backgroundColor: 'rgba(0,121,235, 0.2)',
+                                        borderColor: 'rgb(0,121,235)',
+                                        pointBackgroundColor: 'rgb(0,121,235)',
+                                        pointBorderColor: '#fff',
+                                        pointHoverBackgroundColor: '#fff',
+                                        pointHoverBorderColor: 'rgb(0,121,235)'
+                                    }
+                                ]
+                            };
+                            radarReportObject[i].data.forEach(s => {
+                                data.labels.push(_lang == 'ar' ? s.displayNameAr : s.displayNameEn);
+                                data.datasets[0].data.push(s.contractorValue);
+                                data.datasets[1].data.push(s.othersValue);
+                            });
+
+
+                            const dataBySize = {
+
+                                labels: [],
+                                datasets: [{
+                                        label: 'معدل اداء المنشأة',
+                                        data: [],
+                                        fill: true,
+                                        backgroundColor: 'rgba(72, 160, 53, 0.2)',
+                                        borderColor: 'rgb(72, 160, 53)',
+                                        pointBackgroundColor: 'rgb(72, 160, 53)',
+                                        pointBorderColor: '#fff',
+                                        pointHoverBackgroundColor: '#fff',
+                                        pointHoverBorderColor: 'rgb(72, 160, 53)'
+                                    },
+                                    {
+                                        label: 'معدل اداء المنشأت في نفس الفئة',
+                                        data: [],
+                                        fill: true,
+                                        backgroundColor: 'rgba(0,121,235, 0.2)',
+                                        borderColor: 'rgb(0,121,235)',
+                                        pointBackgroundColor: 'rgb(0,121,235)',
+                                        pointBorderColor: '#fff',
+                                        pointHoverBackgroundColor: '#fff',
+                                        pointHoverBorderColor: 'rgb(0,121,235)'
+                                    }
+                                ]
+                            };
+                            radarReportObject[i].data.forEach(s => {
+                                dataBySize.labels.push(_lang == 'ar' ? s.displayNameAr : s
+                                    .displayNameEn);
+                                dataBySize.datasets[0].data.push(s.contractorValue);
+                                dataBySize.datasets[1].data.push(s.otherValueBySize);
+                            });
+
+                            new Chart(document.getElementById('radarChart_' + (i + 1)), {
+                                type: 'radar',
+                                data: data,
+                                options: {
+                                    scales: {
+
+                                        r: {
+                                            ticks: {
+                                                beginAtZero: true,
+                                                min: 0,
+                                            },
+                                            pointLabels: {
+                                                font: {
+                                                    fontSize: 50,
+                                                    family: '"NeoSansArabicRegular" !important'
+                                                }
+                                            }
+                                        }
+                                    },
+                                    elements: {
+                                        line: {
+                                            borderWidth: 3
+                                        }
+                                    },
+                                    plugins: {
+                                        legend: {
+                                            //display: false, // This hides all text in the legend and also the labels.
+                                        }
+                                    }
+                                }
+                            });
+
+                            new Chart(document.getElementById('radarChartBySize_' + (i + 1)), {
+                                type: 'radar',
+                                data: dataBySize,
+                                options: {
+                                    scales: {
+                                        r: {
+                                            ticks: {
+                                                beginAtZero: true,
+                                                min: 0,
+                                            },
+                                            pointLabels: {
+                                                font: {
+                                                    // size: '40px !important',
+                                                    family: '"NeoSansArabicRegular" !important'
+                                                }
+                                            }
+                                        }
+                                    },
+                                    elements: {
+                                        line: {
+                                            borderWidth: 3
+                                        }
+                                    },
+                                    plugins: {
+                                        legend: {
+                                            //display: false, // This hides all text in the legend and also the labels.
+                                        }
+                                    }
+                                }
+                            });
+                        }
+                    }
+
+                }
+            });
+        }
+    }
+
+    $(document).ready(function() {
+
+        // getRadarChart();
+
+
+    });
+
+
+    function myMap() {
+        $("#show_map_button").hide();
+        $("#map").show();
+
+        var mapCanvas = document.getElementById("map");
+        // The location of Uluru
+        var latlang = {
+            lat: 24.671699788528482,
+            lng: 46.39415764160163
+        };
+
+
+        var mapOptions = {
+            center: latlang,
+            zoom: 10,
+            mapTypeControl: true,
+
+        };
+        var map = new google.maps.Map(mapCanvas, mapOptions);
+
+
+        var latlang881 = {
+            lat: 24.671699788528482,
+            lng: 46.39415764160163
+        };
+
+        var contentString881 = '<div id="content">' +
+            '<div id="siteNotice">' +
+            '</div>' +
+            '<h1 id="firstHeading" class="firstHeading" style="font-size:14px">الإسم الكامل : شركة البناء التجريبية</h1>' +
+            '<h1 id="firstHeading" class="firstHeading" style="font-size:13px">رقم الجوال : 966544622796</h1>' +
+            '</div>';
+
+        var infowindow881 = new google.maps.InfoWindow({
+            content: contentString881
+        });
+
+        var marker881 = new google.maps.Marker({
+            position: latlang881,
+            map: map,
+            title: 'شركة البناء التجريبية'
+        });
+        marker881.addListener('click', function() {
+            infowindow881.open(map, marker881);
+        });
+
+
+    }
+
+    function contractor_licnesing_field_values_display(flag) {
+        if (flag == 'show') {
+            $('#contractor_licnesing_field_values_main_heading').hide();
+            $('#contractor_licnesing_field_values_detail').show();
+        } else {
+            $('#contractor_licnesing_field_values_detail').hide();
+            $('#contractor_licnesing_field_values_main_heading').show();
+        }
+
+    }
+</script>
+
+
+</body>
+</html>

--- a/tests/fixtures/muqawil/profile-en.html
+++ b/tests/fixtures/muqawil/profile-en.html
@@ -1,0 +1,1318 @@
+<!DOCTYPE html>
+
+<html lang="en" xmlns="jspwiki" xmlns:jspwiki="">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport"/>
+<!-- Dynamic SEO -->
+<title>Contractors | sca</title>
+<meta content="Find your contractor from registered and trusted establishments." name="description"/>
+<meta content="Saudi Contractor Authority,Muqawil,مقاول,الهيئة السعودية للمقاولين" name="keywords"/>
+
+<!-- Author / Publisher -->
+<meta content="الهيئة السعودية للمقاولين" name="author"/>
+<meta content="الهيئة السعودية للمقاولين" name="publisher"/>
+<!-- Robots -->
+<meta content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" name="robots"/>
+<!-- Preconnect & DNS Prefetch -->
+
+<!-- Hreflang -->
+
+
+<!-- Open Graph -->
+<meta content="en" property="og:locale"/>
+<meta content="ar" property="og:locale:alternate"/>
+<meta content="website" property="og:type"/>
+<meta content="Muqawil - مقاول" property="og:title"/>
+<meta content="Find your contractor from registered and trusted establishments." property="og:description"/>
+<meta content="https://muqawil.org/en/contractors/881/143" property="og:url"/>
+<meta content="Muqawil - مقاول" property="og:site_name"/>
+<meta content="https://muqawil.org/theme2025/dist/images/logo.svg" property="og:image"/>
+<meta content="520" property="og:image:width"/>
+<meta content="400" property="og:image:height"/>
+<meta content="image/jpeg" property="og:image:type"/>
+<!-- Twitter -->
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Muqawil - مقاول" name="twitter:title"/>
+<meta content="Find your contractor from registered and trusted establishments." name="twitter:description"/>
+<meta content="https://muqawil.org/theme2025/dist/images/logo.svg" name="twitter:image"/>
+<!-- Image Source -->
+
+<!-- Favicons -->
+
+
+
+<meta content="https://muqawil.org/theme2025/dist/fav.ico" name="msapplication-TileImage"/>
+
+<!-- Twitter -->
+<meta content="summary" name="twitter:card"/>
+<meta content="@SCA2030" name="twitter:site"/>
+<meta content="@SCA2030" name="twitter:creator"/>
+<meta content="article" property="og:type"/>
+<meta content="sca" property="og:url"/>
+<meta content="https://muqawil.org/en/contractors/881/143" property="og:title"/>
+<meta content="https://muqawil.org/public_assets/img/logo.png" property="og:image"/>
+<meta content="muqawil.org" property="og:site_name"/>
+<!--<meta property='article:published_time' content="8  Dec, 2019" />
+            <meta property='article:section'  content="OpEd" />-->
+
+
+
+
+
+
+
+<!-- Livewire Styles -->
+<!-- Google Tag Manager -->
+
+<!-- End Google Tag Manager -->
+</head>
+<body class="flex-column d-flex h-100">
+<!-- Google Tag Manager (noscript) -->
+
+<!-- End Google Tag Manager (noscript) -->
+<!-- Header Start-->
+<header class="header">
+<div class="header__mobile-nav">
+<div class="container header__mobile-nav__container d-flex align-items-center justify-content-between">
+<div class="d-flex align-items-center justify-content-between">
+<a aria-expanded="false" aria-haspopup="true" class="header__mobile-nav__account" data-bs-offset="0,28" data-bs-toggle="dropdown" href="#" id="changeLang" type="button">‏
+                        <i class="icon icon-user"></i>
+</a>
+<ul aria-labelledby="dropdownMenuButton1" class="dropdown-menu">
+<li>
+<a class="dropdown-item has-icon" href="https://muqawil.org/ar/contractors/881/143" title="العربية">
+<span class="icon-ksa-flag"></span>
+                                    العربية
+                                </a>
+</li>
+<li>
+<a class="dropdown-item has-icon" href="https://muqawil.org/en/login">Login</a>
+</li>
+<li>
+<a class="dropdown-item has-icon" href="https://muqawil.org/en/newregister">
+<button class="btn btn-primary" type="button">Registration</button>
+</a>
+</li>
+</ul>
+</div>
+<a class="header__mobile-nav__logo" href="https://muqawil.org" title="Muqawil Platform">
+<img alt="Muqawil Platform" src="https://muqawil.org/theme2025/dist/images/logo.svg" title="Muqawil Platform"/>
+</a>
+<div class="d-flex align-items-center justify-content-between">
+<a aria-label="OpenMenu" class="header__mobile-nav__burger-menu" href="#" id="openMenu">
+<i class="icon icon-menu"></i>
+</a>
+</div>
+</div>
+</div>
+<div class="header__mobile">
+<nav class="nav-drill">
+<a href="#" id="closeMenu">x</a>
+<ul class="nav-items nav-level-1">
+<li class="nav-item">
+<a class="nav-link" href="https://muqawil.org/en/contractors/info" title="Contractors">Contractors</a>
+</li>
+<li class="nav-item">
+<a class="nav-link" href="/en/consulting/public/info" title="Consultations">Consultations</a>
+</li>
+<li class="nav-item">
+<a class="nav-link" href="/en/training/info" title="Training">Training</a>
+</li>
+<li class="nav-item">
+<a class="nav-link" href="/en/allevents/info" title="Training">Events</a>
+</li>
+<li class="nav-item"><a class="nav-link" href="https://muqawil.org/en/decision-making/info">Information Center</a>
+</li>
+<li class="nav-item">
+<span aria-expanded="false" class="nav-link" data-bs-target="#e-services" data-bs-toggle="collapse">
+                            E-Services 
+                            <span class="icon-arrow_1"></span>
+</span>
+<ul class="nav-items collapse" id="e-services">
+<li class="nav-item"><a class="nav-link" href="/en/market">Projects</a>
+</li>
+<li class="nav-item"><a class="nav-link" href="https://muqawil.org/en/consortium/landing">Contractors Consortium Platform</a>
+</li>
+<li class="nav-item"><a class="nav-link" href="https://muqawil.org/en/suppliers/info">Suppliers</a>
+</li>
+<li class="nav-item"><a class="nav-link" href="https://muqawil.org/en/contractors-rate/info">Contractors Rating</a>
+</li>
+<li class="nav-item"><a class="nav-link" href="/en/pmc/getAllPmc/info">Project Managers</a>
+</li>
+<li class="nav-item"><a class="nav-link" href="/en/localization/info">Tawteen</a>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</div>
+<div class="header__nav__wrapper d-none d-lg-block">
+<div class="container">
+<div class="header__nav">
+<ul class="header__nav__items">
+<li class="header__nav__item header__nav__item--logo">
+<a href="https://muqawil.org" title="Muqawil Platform">
+<img alt="Muqawil Platform" class="header__logo" src="https://muqawil.org/theme2025/dist/images/logo.svg" title="Muqawil Platform"/>
+</a>
+</li>
+<li class="nav-item active-page">
+<a class="nav-link" href="https://muqawil.org">
+                                Home
+                            </a>
+</li>
+<li class="header__nav__item">
+<a class="nav-link" href="https://muqawil.org/en/contractors/info">Contractors</a>
+</li>
+<li class="header__nav__item">
+<a class="nav-link" href="/en/consulting/public/info">Consultations</a>
+</li>
+<li class="header__nav__item">
+<a class="nav-link" href="/en/training/info">Training</a>
+</li>
+<li class="header__nav__item">
+<a class="nav-link" href="/en/allevents/info">Events</a>
+</li>
+<li class="header__nav__item">
+<a class="nav-link" href="https://muqawil.org/en/decision-making/info">Information Center</a>
+</li>
+<li class="header__nav__item">
+<a aria-expanded="false" class="nav-link" data-bs-offset="0,28" data-bs-toggle="dropdown" href="#">
+                                E-Services                                <span class="icon-arrow-down-main header__nav__item__icon">
+<span class="path1"></span><span class="path2"></span>
+</span>
+</a>
+<ul aria-labelledby="dropdownMenuButton1" class="dropdown-menu">
+<li>
+<a class="dropdown-item" href="/en/market">Projects</a>
+</li>
+<li>
+<a class="dropdown-item" href="https://muqawil.org/en/consortium/landing">Contractors Consortium Platform</a>
+</li>
+<li>
+<a class="dropdown-item" href="https://muqawil.org/en/suppliers/info">Suppliers</a>
+</li>
+<li>
+<a class="dropdown-item" href="https://muqawil.org/en/contractors-rate/info">Contractors Rating</a>
+</li>
+<li>
+<a class="dropdown-item disable-project-management" href="/en/pmc/getAllPmc/info">Project Managers</a>
+</li>
+<li class="disable-localization">
+<a class="dropdown-item" href="/en/localization/info">Tawteen</a>
+</li>
+<li>
+<a class="dropdown-item" href="/en/scavo/info">Project Tracking (SCAVO)</a>
+</li>
+<li>
+<a class="dropdown-item" href="https://muqawil.org/en/jisr/landing">Jisr</a>
+</li>
+<li>
+<a class="dropdown-item" href="https://muqawil.org/en/marketplace/info">Contractors Market</a>
+</li>
+</ul>
+</li>
+</ul>
+<ul class="header__nav__items">
+<li class="header__nav__item">
+<a class="nav-link has-icon" href="https://muqawil.org/ar/contractors/881/143">
+                                    العربية
+                                    <span class="icon-translate"><span class="path1"></span><span class="path2"></span><span class="path3"></span><span class="path4"></span><span class="path5"></span><span class="path6"></span>
+</span>
+</a>
+</li>
+<li class="header__nav__item">
+<a class="nav-link has-icon" href="https://muqawil.org/en/login">Login</a>
+</li>
+<li class="header__nav__item">
+<a class="btn btn-primary" href="https://muqawil.org/en/newregister">Registration</a>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<header class="inner-header" style="background-image: url(https://muqawil.org/theme2025/dist/images/services-bg-header/en/1w.webp);">
+<div class="container">
+<div class="inner-header__content">
+<div class="inner-header__info">
+<h1 class="inner-header__title">sca</h1>
+<nav class="inner-header__breadcrumb">
+<i class="inner-header__separator icon icon-home"></i>
+<a class="inner-header__link" href="https://muqawil.org">Home</a>
+<i class="inner-header__separator icon icon-arrow-left"></i>
+<a class="inner-header__link" href="https://muqawil.org/en/contractors/info">Contractors</a>
+<i class="inner-header__separator icon icon-arrow-left"></i>
+<a class="inner-header__link" href="https://muqawil.org/en/contractors">البحث</a>
+<i class="inner-header__separator icon icon-arrow-left"></i>
+<span class="inner-header__link">sca</span>
+</nav>
+</div>
+</div>
+</div>
+</header>
+</header>
+<!-- Header END-->
+<section class="main mb-5">
+<!--  ABOUT THE SERVICE SECTION START   -->
+<section class="service">
+<div class="container" style="overflow: hidden">
+<div class="row">
+<div class="col-12">
+<div class="section-card">
+<div class="row">
+<div class="col-auto">
+<img alt="" class="card-img" src="https://muqawil.org/public/contractor/companyLogo/https://muqawil.org/public/contractor/companyLogo/CompanyLogo-1780991935_logo-green.png"/>
+</div>
+<div class="col" style="position: relative">
+<div class="scg-badges-wrapper">
+<div class="pscg-logo"></div>
+<div class="pscg-lic"></div>
+<div class="pscg-tier_box">
+<img src="https://muqawil.org/en/pscg/preview/OGNkMGI5Y2QtZjBhZi00MTQzLTk1MzItNGIzYmMxODFiZmJkMDQwNTIwMjYxMjE3MDMucG5n"/>
+</div>
+<div class="pscg-title">مستوي <br/> الجاهزية</div>
+</div>
+<h3 class="card-title">sca </h3>
+<div class="badges">
+<div class="badge">
+<span class="icon-medal-platinum"><span class="path1"></span><span class="path2"></span><span class="path3"></span><span class="path4"></span><span class="path5"></span><span class="path6"></span></span>
+                                            Platinum Membership                                        </div>
+<div class="badge transparent">
+<span class="icon-verifiy-dark text-primary"></span>
+                                                                                    Account Verified                                        
+                                    </div>
+</div>
+<div class="info-box-wrapper">
+<div class="row">
+<div class="col-md-6 col-lg-4">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-ID"></span>
+</div>
+<div class="info-details">
+<div class="info-name">Membership Number</div>
+<div class="info-value">10000861</div>
+</div>
+</div>
+</div>
+<div class="col-md-6 col-lg-4">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-ID"></span>
+</div>
+<div class="info-details">
+<div class="info-name">Membership</div>
+<div class="info-value">
+                                                        Saudi Contractor</div>
+</div>
+</div>
+</div>
+<div class="col-md-6 col-lg-4">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-ID"></span>
+</div>
+<div class="info-details">
+<div class="info-name">Member Since</div>
+<div class="info-value">2018/08/25
+                                                    </div>
+</div>
+</div>
+</div>
+<div class="col-md-6 col-lg-4">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-company"></span>
+</div>
+<div class="info-details">
+<div class="info-name">Company Size</div>
+<div class="info-value">Small Company Size</div>
+</div>
+</div>
+</div>
+<div class="col-md-6 col-lg-4">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-time"></span>
+</div>
+<div class="info-details">
+<div class="info-name">Training credit hours</div>
+<div class="info-value">308 h                                                    </div>
+</div>
+</div>
+</div>
+<div class="col-md-6 col-lg-4">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-phone"></span>
+</div>
+<div class="info-details">
+<div class="info-name">Organization Mobile Number</div>
+<div class="info-value">966920000968</div>
+</div>
+</div>
+</div>
+<div class="col-md-6 col-lg-4">
+<div class="info-box has-action">
+<div class="info-icon">
+<span class="icon-email"></span>
+</div>
+<div class="info-details">
+<div class="info-name">Organization Email </div>
+<div class="info-value"><a href="/cdn-cgi/l/email-protection#701904300313115e0311"><span class="__cf_email__" data-cfemail="f9908db98a9a98d78a98">[email protected]</span></a>
+</div>
+</div>
+</div>
+</div>
+<div class="col-md-6 col-lg-4">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-locaion"></span>
+</div>
+<div class="info-details">
+<div class="info-name">City</div>
+<div class="info-value">RIYADH</div>
+</div>
+</div>
+</div>
+<div class="col-md-6 col-lg-4">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-locaion"></span>
+</div>
+<div class="info-details">
+<div class="info-name">Region</div>
+<div class="info-value">Riyadh</div>
+</div>
+</div>
+</div>
+<div class="col-md-6 col-lg-4">
+<div class="info-box">
+<div class="info-icon">
+<span class="icon-locaion"></span>
+</div>
+<div class="info-details">
+<div class="info-name">Address</div>
+<div class="info-value">الرياض  الملقا انس بن مالك                                                    </div>
+</div>
+</div>
+</div>
+<div class="col-md-6 col-lg-4">
+<div class="info-box">
+<div class="info-icon">
+<img src="https://muqawil.org/assets/files/baladyServices/icon-tag.png" style="height: 24px;width: 24px;"/>
+</div>
+<div class="info-details">
+<div class="info-name">Activity</div>
+<div class="info-value">
+                                                                                                                            service center
+                                                                <span class="info-value-balady"> , </span>
+                                                                                                                            Restaurants and kitchens
+                                                                <span class="info-value-balady"> , </span>
+                                                                                                                            Fencing construction sites
+                                                                <span class="info-value-balady"> , </span>
+                                                                                                                            Fencing land space
+                                                                <span class="info-value-balady"> , </span>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sharethis-inline-share-buttons" data-image="https://muqawil.org/public_assets/img/logo.png" data-title="sca" data-url="https://muqawil.org/en/contractors/881/143" style="margin-top: 15px;"></div>
+</div>
+</div>
+
+
+<div class="section-card">
+<div class="row">
+<div class="col-auto">
+<img alt="" class="card-img" src="https://muqawil.org/public/contractor/companyLogo/https://muqawil.org/public/contractor/companyLogo/CompanyLogo-1780991935_logo-green.png"/>
+</div>
+<div class="col" style="position: relative">
+<h1 class="card-title color-primary">
+<b>
+
+                                        Contract Request
+
+                                    </b>
+</h1>
+<br/>
+<span class="card-title color-primary">
+                                    To preserve the rights of all parties in the contractual relationship, the Saudi Contractors Authority provides 36 approved and documented model contracts, one of which can be chosen below.
+
+                                </span>
+<br/>
+<br/>
+<div class="info-box-wrapper">
+<div class="row">
+<form action="https://muqawil.org/init_econtract_draft" class="login-box" enctype="multipart/form-data" form="" id="econtractForm" method="post" role="form">
+<input autocomplete="off" name="_token" type="hidden" value="MToBsgq0RGZNo6MnwJzwsO3DHtU9uEr6na7dE8rr"/>
+<div id="errormessage"></div> <!-- Error message container -->
+
+<input class="btn btn-secondary" id="_submitAction" name="_submitAction" type="hidden" value="econtractForm"/>
+<div class="row">
+<div class="col-md-6 col-sm-12">
+<div class="form-group">
+<label class="form-label" for="template_id">
+
+                                                            Contract
+
+                                                        </label>
+<select class="_change form-select form-control form-input select2" id="template_id" name="template_id" style="height: 50px;">
+<option value="">اختر العقد</option>
+<option value="2">
+                                                                    Site preparation and fencing works contract </option>
+<option value="3">
+                                                                    Structural works contract –material and execution </option>
+<option selected="" value="4">
+                                                                    Structural works contract – execution </option>
+<option value="5">
+                                                                    عقد أعمال الإنشاء الكامل - تسليم المفتاح </option>
+<option value="6">
+                                                                    Paint works contract </option>
+<option value="7">
+                                                                    Gardening works and irrigation systems </option>
+<option value="8">
+                                                                    Plaster works contract –execution </option>
+<option value="9">
+                                                                    Plaster works contract –material and execution </option>
+<option value="10">
+                                                                    Iron doors works contract </option>
+<option value="11">
+                                                                    Demolition work contract </option>
+<option value="12">
+                                                                    Decoration works contract – material and execution </option>
+<option value="13">
+                                                                    Decoration works contract –execution </option>
+<option value="14">
+                                                                    Electrical works contract –execution </option>
+<option value="15">
+                                                                    Kitchen installation works contract </option>
+<option value="16">
+                                                                    Solar energy systems contract </option>
+<option value="17">
+                                                                    Air conditioning works contract </option>
+<option value="18">
+                                                                    Aluminum windows and doors works contract </option>
+<option value="19">
+                                                                    Gas system installation works contract </option>
+<option value="20">
+                                                                    Managment Contract </option>
+<option value="21">
+                                                                    Telecommunication and sound system installation contract </option>
+<option value="22">
+                                                                    Elevator installation works contract </option>
+<option value="23">
+                                                                    Cladding works contract –execution </option>
+<option value="24">
+                                                                    Cladding works contract –material and execution </option>
+<option value="25">
+                                                                    Flooring works contract –material and execution </option>
+<option value="26">
+                                                                    Flooring works contract –execution </option>
+<option value="27">
+                                                                    Swimming pools contract </option>
+<option value="28">
+                                                                    Waterproofing and thermal insulation works contract </option>
+<option value="29">
+                                                                    Renovation works contract </option>
+<option value="30">
+                                                                    Plumbing works contract –execution </option>
+<option value="31">
+                                                                    Plumbing works contract –materials and execution </option>
+<option value="32">
+                                                                    handrails Installation contract </option>
+<option value="33">
+                                                                    Wooden doors works contract </option>
+<option value="34">
+                                                                    Security system works contract </option>
+<option value="35">
+                                                                    alert and Firefighting works contract </option>
+<option value="36">
+                                                                    Electrical works contract – Materials and execution </option>
+<option value="37">
+                                                                    Real estate developer contract </option>
+</select>
+<p class="text-danger">
+</p>
+</div>
+</div>
+</div>
+<div class="row">
+<div class="col-md-6 col-sm-12 form-group">
+<label class="form-label" for="title">
+                                                        First Party Name
+                                                    </label>
+<input class="form-control form-input" id="first_party_name" name="first_party_name" type="text" value=""/>
+<p class="text-danger">
+</p>
+</div>
+</div>
+<div class="row">
+<div class="col-md-6 col-sm-12 form-group">
+<label class="form-label" for="title">
+                                                        First Party Phone
+
+                                                    </label>
+<input class="form-control form-input" id="first_party_phone" name="first_party_phone" type="text" value=""/>
+<p class="text-danger">
+</p>
+</div>
+</div>
+<div class="row">
+<div class="col-md-6 col-sm-12 form-group">
+<label class="form-label" for="title">
+                                                        First Party ID
+
+                                                    </label>
+<input class="form-control form-input" id="first_party_national_id" name="first_party_national_id" type="text" value=""/>
+<p class="text-danger">
+</p>
+</div>
+</div>
+<div class="row">
+<div class="col-md-6 col-sm-12">
+<button aria-controls="step2" class="btn btn-primary nex-tab ml-2 tab-link" id="submitNDEcontractForm" role="tab" type="submit">
+                                                        Send Request
+
+                                                    </button>
+</div>
+</div>
+<div class="row d-none">
+<div class="col-6 form-group">
+<label class="form-label" for="title">
+                                                        اسم الطرف الثاني
+                                                        
+                                                    </label>
+<input class="form-control form-input" id="cr" name="cr" type="text" value="7007506731"/>
+<p class="text-danger">
+</p>
+</div>
+<div class="col-6 form-group">
+<label class="form-label" for="title">
+                                                        جوال الطرف الثاني
+
+                                                    </label>
+<input class="form-control form-input" id="second_party_phone" name="second_party_phone" type="text" value="966920000968"/>
+<p class="text-danger">
+</p>
+</div>
+<div class="col-6 form-group">
+<label class="form-label" for="title">
+                                                        هوية الطرف الثاني
+
+                                                    </label>
+<input class="form-control form-input" id="second_party_national_id" name="second_party_national_id" type="text" value=""/>
+<p class="text-danger">
+</p>
+</div>
+</div>
+</form>
+
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="section-card">
+<h4 class="card-title">
+                            التراخيص ومستوى الجاهزية
+                        </h4>
+<div class="table-responsive">
+<table class="table">
+<thead>
+<tr>
+<th scope="col">الأنشطة المرخصة</th>
+<th class="text-center" scope="col">مستوى الجاهزية</th>
+</tr>
+</thead>
+<tbody>
+<tr class="pscg-tbl-row-tr">
+<td scope="col">
+<div class="pscg-tbl-row-item-box">
+<div class="pscg-data-box">
+<div>تشييد المباني - تشييد المباني - جميع الأنواع</div>
+<div>Construction of Buildings - Construction of Buildings – All Types</div>
+</div>
+</div>
+</td>
+<td scope="col">
+<div class="pscg-tbl-row-grade-box">
+<div class=""> <img class="pscg-tbl-row-grade-img" src="https://muqawil.org/en/pscg/preview/OGNkMGI5Y2QtZjBhZi00MTQzLTk1MzItNGIzYmMxODFiZmJkMDQwNTIwMjYxMjE3MDMucG5n"/>
+</div>
+<div class="grade-hint"> أساسي
+                                                                | Basic</div>
+</div>
+</td>
+</tr>
+<tr class="pscg-tbl-row-tr">
+<td scope="col">
+<div class="pscg-tbl-row-item-box">
+<div class="pscg-data-box">
+<div>أنشطة التشييد المتخصصة - تشطيب المباني</div>
+<div>Specialized Construction Activities - Building Finishing</div>
+</div>
+</div>
+</td>
+<td scope="col">
+</td>
+</tr>
+<tr class="pscg-tbl-row-tr">
+<td scope="col">
+<div class="pscg-tbl-row-item-box">
+<div class="pscg-data-box">
+<div>التشغيل والصيانة - المباني المتخصصة والتنظيف الصناعي</div>
+<div>Operations and Maintenance Activities - Specialized Buildings &amp; Industrial Cleaning</div>
+</div>
+</div>
+</td>
+<td scope="col">
+</td>
+</tr>
+<tr class="pscg-tbl-row-tr">
+<td scope="col">
+<div class="pscg-tbl-row-item-box">
+<div class="pscg-data-box">
+<div>التشغيل والصيانة - مكافحة الآفات والتطهير البيئي</div>
+<div>Operations and Maintenance Activities - Pest Control &amp; Environmental Disinfection</div>
+</div>
+</div>
+</td>
+<td scope="col">
+</td>
+</tr>
+<tr class="pscg-tbl-row-tr">
+<td scope="col">
+<div class="pscg-tbl-row-item-box">
+<div class="pscg-data-box">
+<div>التشغيل والصيانة - العناية بأعمال البستنة وصيانتها</div>
+<div>Operations and Maintenance Activities - Gardening &amp; Landscaping Maintenance</div>
+</div>
+</div>
+</td>
+<td scope="col">
+</td>
+</tr>
+<tr class="pscg-tbl-row-tr">
+<td scope="col">
+<div class="pscg-tbl-row-item-box">
+<div class="pscg-data-box">
+<div>الهندسة المدنية - الصرف الصحي</div>
+<div>Civil Engineering - </div>
+</div>
+</div>
+</td>
+<td scope="col">
+</td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<!--For Hafiz-->
+<div class="section-card">
+<ul class="nav nav-pills" id="pills-tab" role="tablist">
+<li class="nav-item" role="presentation">
+<button aria-controls="pills-home" aria-selected="true" class="nav-link active" data-bs-target="#contractor-tab1" data-bs-toggle="pill" id="contractortab1" role="tab" type="button">
+
+                                    Contractor Detail
+                                </button>
+</li>
+<li class="nav-item" role="presentation">
+<button aria-controls="pills-profile" aria-selected="false" class="nav-link" data-bs-target="#contractor-tab2" data-bs-toggle="pill" id="contractortab2" role="tab" type="button">
+
+                                    المقاولين بالباطن
+
+                                </button>
+</li>
+<li class="nav-item" role="presentation">
+<button aria-controls="pills-contact" aria-selected="false" class="nav-link" data-bs-target="#contractor-tab3" data-bs-toggle="pill" id="contractortab3" role="tab" type="button">
+
+                                    المقاولين الرئيسيين
+
+                                </button>
+</li>
+<li class="nav-item" role="presentation">
+<button aria-controls="pills-contact" aria-selected="false" class="nav-link" data-bs-target="#contractor-tab4" data-bs-toggle="pill" id="contractortab4" onclick="getRadarChart()" role="tab" type="button">
+                                    التقييم الفني
+                                </button>
+</li>
+</ul>
+<div class="tab-content" id="pills-tabContent">
+<div aria-labelledby="contractor-tab1" class="tab-pane fade show mb-5 active" id="contractor-tab1" role="tabpanel">
+<div>
+<!--                                    <h4 class="card-title">
+                                            Contractor Detail                                        </h4>-->
+<div class="card-inner-section card-text">
+                                        Al Riyadh Al Malga anas bin malik road                                    </div>
+</div>
+<!-- Begin Contractor Licnesing Field Values -->
+</div>
+<div aria-labelledby="contractor-tab2" class="tab-pane fade" id="contractor-tab2" role="tabpanel">
+<div class="table-responsive">
+<table class="table table-striped">
+<thead>
+<tr>
+<th scope="col">#</th>
+<th scope="col">الإسم</th>
+</tr>
+</thead>
+<tbody>
+</tbody>
+</table>
+</div>
+</div>
+<div aria-labelledby="contractor-tab3" class="tab-pane fade" id="contractor-tab3" role="tabpanel">
+<div class="table-responsive">
+<table class="table table-striped">
+<thead>
+<tr>
+<th scope="col">#</th>
+<th scope="col">الإسم</th>
+</tr>
+</thead>
+<tbody>
+</tbody>
+</table>
+</div>
+</div>
+<div aria-labelledby="contractor-tab4" class="tab-pane fade" id="contractor-tab4" role="tabpanel" style="margin-bottom: 30px">
+<div id="radar_chart_container"></div>
+</div>
+</div>
+</div>
+<!--For Hafiz-->
+<div class="section-card">
+<h4 class="card-title">
+                            العقود سعر البناء (برنامج البناء الذاتي)
+                        </h4>
+<div class="table-responsive">
+<table class="table table-striped">
+<thead>
+<tr>
+<th scope="col">الإسم</th>
+<th scope="col">القيمة</th>
+</tr>
+</thead>
+<tbody>
+</tbody>
+</table>
+</div>
+</div>
+<!-- End Contractor Licensing Field Values -->
+<!-- Econtract Start -->
+<div class="section-card">
+<h4 class="card-title">
+                            Previous Projects                        </h4>
+<div class="table-responsive">
+<table class="table table-striped">
+<thead>
+<tr>
+<th scope="col">عدد العقود النموذجية</th>
+<th scope="col">عدد العقود المسجلة</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>455</td>
+<td>64</td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<!-- Econtract End -->
+<!--Interests Start-->
+<div class="section-card">
+<h3 class="card-title">Interests</h3>
+<ul class="list list-numerical">
+<li class="list-item">Construction of buildings</li>
+<ul class="list list-numerical" type="1">
+<li class="list-item">Construction of buildings </li>
+<ul class="list list-numerical" type="1">
+<li class="list-item">Construction of all types of residential buildings
+                                                                    </li>
+<li class="list-item">Construction of all types of non-residential buildings including schools, hospitals, hotels … etc.
+
+                                                                    </li>
+<li class="list-item">Construction of all types of non-residential buildings such as airport buildings
+                                                                    </li>
+<li class="list-item">Construction of all types of non-residential steel buildings
+                                                                    </li>
+<li class="list-item">Erection of prefabricated constructions on the site
+                                                                    </li>
+<li class="list-item">Remodeling or renovating existing residential and non- residential structures
+                                                                    </li>
+</ul>
+</ul>
+<li class="list-item">Civil engineering</li>
+<ul class="list list-numerical" type="1">
+<li class="list-item">Construction of roads and railways </li>
+<ul class="list list-numerical" type="1">
+<li class="list-item">Construction and repair of motorways, streets, roads, other vehicular and pedestrian ways
+                                                                    </li>
+<li class="list-item">Construction and repair of bridges or tunnels
+                                                                    </li>
+<li class="list-item">Repair and maintenance of motorways, streets, roads, other vehicular and pedestrian ways
+                                                                    </li>
+<li class="list-item">Repair and maintenance of bridges or tunnels
+                                                                    </li>
+</ul>
+</ul>
+<li class="list-item">Specialized construction activities</li>
+<ul class="list list-numerical" type="1">
+<li class="list-item">Electrical installation </li>
+<ul class="list list-numerical" type="1">
+<li class="list-item">Electrical wiring
+                                                                    </li>
+<li class="list-item">Telecommunications wiring
+                                                                    </li>
+<li class="list-item">Network wiring
+                                                                    </li>
+</ul>
+<li class="list-item">Plumbing, heat and air-conditioning installation </li>
+<ul class="list list-numerical" type="1">
+<li class="list-item">Installation, maintenance and repair of plumbing and sanitary equipment
+                                                                    </li>
+<li class="list-item">Installation, maintenance and repair of refrigeration or air-conditioning equipment
+                                                                    </li>
+<li class="list-item">Installation, maintenance and repair of air- conditioning ducts
+                                                                    </li>
+</ul>
+<li class="list-item">Building completion and finishing </li>
+<ul class="list list-numerical" type="1">
+<li class="list-item">Building finishing
+                                                                    </li>
+</ul>
+</ul>
+</ul>
+</div>
+<!--Interests End-->
+<!--Map Start-->
+<div class="section-card">
+<h3 class="card-title">Map</h3>
+<div id="map" style="width:100%;height:400px; margin-top: 30px;margin-bottom: 30px;display:none;">
+</div>
+<div id="show_map_button">
+<button class="btn btn-primary" onclick="myMap();" style="width:100%;"><i class="fa fa-map"></i>Show Location on Map</button>
+</div>
+<!--Map End-->
+</div>
+</div>
+</div>
+</div>
+</section>
+</section>
+<button aria-label="Scroll to top" id="up-to-top">
+<span class="icon-arrow-down2"></span>
+</button>
+<!-- Footer Start-->
+<footer class="footer mt-0">
+<div class="container">
+<div class="row justify-content-between">
+<div class="col-md-3">
+<img alt="Saudi 2030" class="footer__logo" src="https://muqawil.org/theme2025/dist/images/footer-image2.svg" title="Saudi 2030"/>
+<p class="text-light mt-4 footer__logo__heading">
+                        The Muqawil platform allows you to search for the best contracting companies registered with the association to execute public, private, or individual projects according to the establishment’s specialization, size, and location.                    </p>
+</div>
+<div class="col-md-2">
+<h2 class="footer__heading mb-4">Quick Links</h2>
+<ul>
+<li>
+<a class="footer-link" href="#" target="_blank">Saudi Contractors Authority</a>
+</li>
+<li>
+<a class="footer-link" href="https://muqawil.org/en/contractors">Contractors</a>
+</li>
+<li>
+<a class="footer-link" href="https://muqawil.org/en/registrationprocess">Registration process in the SCA</a>
+</li>
+</ul>
+</div>
+<div class="col-md-2">
+<h2 class="footer__heading mb-4">Important Links</h2>
+<ul>
+<li>
+<a class="footer-link" href="#" target="_blank">Contact Us</a>
+</li>
+<li>
+<a class="footer-link" href="https://muqawil.org/en/rulespageone">Privacy Policy</a>
+</li>
+<li>
+<a class="footer-link" href="https://muqawil.org/en/rulespagetwo">Term Of Use</a>
+</li>
+</ul>
+</div>
+<div class="col-md-3">
+<h2 class="footer__heading">Contact Us</h2>
+<div class="footer__links flex-column flex-lg-row justify-content-lg-between">
+<!-- <div class="d-flex align-items-center ">-->
+<nav class="footer__social-links">
+<a class="nav-link" href="https://www.linkedin.com/company/sca2030" rel="noreferrer" target="_blank" title="Linkedin">
+<i class="icon-linkedin"></i>
+</a>
+<a class="nav-link" href="https://www.youtube.com/channel/UCNWAjpcKW3EJfdtLpXmmuqQ" rel="noreferrer" target="_blank" title="Youtube">
+<i class="icon-youtube"></i>
+</a>
+<a class="nav-link" href="https://x.com/SCA2030" rel="noreferrer" target="_blank" title="X">
+<i class="icon-x"></i>
+</a>
+<a class="nav-link" href="https://www.facebook.com/SCA2030F" rel="noreferrer" target="_blank" title="Facebook">
+<i class="icon-facebook"></i>
+</a>
+</nav>
+<!-- </div>-->
+</div>
+<h2 class="footer__heading my-3">You can download the app through</h2>
+<div class="footer__apps">
+<a href="https://apps.apple.com/us/app/muqawil/id1548938688" target="_blank"><img alt="App Store" src="https://muqawil.org/theme2025/dist/images/app-store.svg" title="App Store"/></a>
+<a href="https://play.google.com/store/apps/details?id=sa.sca.muqawilapp" target="_blank"><img alt="App Store" src="https://muqawil.org/theme2025/dist/images/google-play.svg" title="App Store"/></a>
+</div>
+</div>
+</div>
+</div>
+<div class="footer__copyrights">
+<p>© Copyright 2026                |
+                Saudi Contractors Authority
+                .</p>
+</div>
+</footer>
+<!-- Footer End-->
+<div aria-modal="true" class="modal fade rating-auto-modal" data-auto="1" data-dismiss-days="1" data-service-id="1" data-trigger-after-seconds="60" data-trigger-scroll-percent="50" id="ratingReminderModal" role="dialog" style="display:none;" tabindex="-1">
+<div class="modal-backdrop fade" id="ratingReminderBackdrop" onclick="window.closeRatingModal(true)" style="z-index:1040; display:none;"></div>
+<div class="modal-dialog modal-dialog-centered" style="z-index:1050;">
+<div class="modal-content">
+<div class="modal-header position-relative">
+<h5 class="modal-title w-100 text-center">
+                    Please rate                </h5>
+<button class="btn-close position-absolute top-50 translate-middle-y" onclick="window.closeRatingModal(true)" style="left:15px;" type="button">
+</button>
+</div>
+<div class="modal-body text-center">
+<div class="rating-widget text-center" data-item-id="" data-service-id="1" data-show-stats="0" data-user-email="" data-user-id="" data-user-mobile="" data-user-type="client" data-website="https://muqawil.org/en/contractors/881/143">
+<form class="ratingForm d-flex flex-column align-items-center justify-content-center">
+<div class="rating-stars text-center">
+<input class="ratingValue" type="hidden" value="0"/>
+<i class="rating-stars__icon" data-value="1">★</i>
+<i class="rating-stars__icon" data-value="2">★</i>
+<i class="rating-stars__icon" data-value="3">★</i>
+<i class="rating-stars__icon" data-value="4">★</i>
+<i class="rating-stars__icon" data-value="5">★</i>
+</div>
+<div class="ratingMessage mt-2 w-100"></div>
+<button class="btn btn-primary mt-3 mx-auto" type="submit">
+            Rate the Service        </button>
+</form>
+</div>
+ </div>
+</div>
+</div>
+</div>
+<input id="hosturl" type="hidden" value="https://muqawil.org"/>
+<input id="_token" type="hidden" value="MToBsgq0RGZNo6MnwJzwsO3DHtU9uEr6na7dE8rr"/>
+<input id="_lang" type="hidden" value="en"/>
+
+
+
+
+
+
+
+
+
+
+
+
+
+<script>
+    var isRadarChartLoaded = false;
+
+    function getRadarChart() {
+        if (!isRadarChartLoaded) {
+            LoadRadarChart();
+        }
+    }
+
+    function addRadarChartHTML(item, index) {
+        var _lang = document.getElementById('_lang').value;
+        var chartContainer = document.getElementById("radar_chart_container");
+        chartContainer.innerHTML = `<div>
+                        <h4 class="card-title">
+
+                            ${_lang == 'ar' ? item.categoryNameAr : item.categoryNameEn} <span>  على حسب النشاط </span>
+                        </h4>
+                        <div class="radar-chart-wrapper">
+                            <canvas id="radarChart_${index + 1}"></canvas>
+                        </div>
+                    </div>
+                    <div class="section-card">
+                        <h4 class="card-title">
+                            ${_lang == 'ar' ? item.categoryNameAr : item.categoryNameEn} <span>  على حسب الحجم </span>
+                        </h4>
+                        <div class="radar-chart-wrapper">
+                            <canvas id="radarChartBySize_${index + 1}"></canvas>
+                        </div>
+                    </div>`;
+    }
+
+    function LoadRadarChart() {
+        console.log('Radar Chart Loaded');
+
+        // return false;
+        var _lang = document.getElementById('_lang').value;
+
+        var organization_registration_number = 7007506731;
+
+        if (organization_registration_number != null) {
+
+
+            var URL = 'https://muqawil.org/en/contractors/getContractorRadarChart/:id';
+
+            URL = URL.replace(':id', 7007506731);
+
+            $.ajax({
+                url: URL,
+                type: "GET",
+                data: {},
+
+                success: function(result) {
+
+                    isRadarChartLoaded = true;
+                    console.log('chart: ', result)
+                    if (result.length > 0) {
+                        // console.log('chart: ',result)
+                        //right chart HTML =================>
+
+                        result.forEach((itm, index) => {
+                            //radar_chart_container
+                            addRadarChartHTML(itm, index)
+
+
+                        })
+                        var radarReportObject = JSON.stringify(result).replace(/&quot;/g, '"');
+                        radarReportObject = JSON.parse(radarReportObject);
+                        var responseArray = Object.entries(radarReportObject[0].data);
+
+                        var responseFormatedArray = [];
+                        responseArray.forEach((itm) => {
+                            responseFormatedArray.push(itm[1]);
+
+                        })
+
+
+                        radarReportObject[0].data = responseFormatedArray;
+                        Chart.defaults.font.size = 18;
+                        for (var i = 0; i < radarReportObject.length; i++) {
+
+                            const data = {
+
+                                labels: [],
+                                datasets: [{
+                                        label: 'معدل اداء المنشأة',
+                                        data: [],
+                                        fill: true,
+                                        backgroundColor: 'rgba(72, 160, 53, 0.2)',
+                                        borderColor: 'rgb(72, 160, 53)',
+                                        pointBackgroundColor: 'rgb(72, 160, 53)',
+                                        pointBorderColor: '#fff',
+                                        pointHoverBackgroundColor: '#fff',
+                                        pointHoverBorderColor: 'rgb(72, 160, 53)'
+                                    },
+                                    {
+                                        label: 'معدل اداء المنشأت في نفس الفئة',
+                                        data: [],
+                                        fill: true,
+                                        backgroundColor: 'rgba(0,121,235, 0.2)',
+                                        borderColor: 'rgb(0,121,235)',
+                                        pointBackgroundColor: 'rgb(0,121,235)',
+                                        pointBorderColor: '#fff',
+                                        pointHoverBackgroundColor: '#fff',
+                                        pointHoverBorderColor: 'rgb(0,121,235)'
+                                    }
+                                ]
+                            };
+                            radarReportObject[i].data.forEach(s => {
+                                data.labels.push(_lang == 'ar' ? s.displayNameAr : s.displayNameEn);
+                                data.datasets[0].data.push(s.contractorValue);
+                                data.datasets[1].data.push(s.othersValue);
+                            });
+
+
+                            const dataBySize = {
+
+                                labels: [],
+                                datasets: [{
+                                        label: 'معدل اداء المنشأة',
+                                        data: [],
+                                        fill: true,
+                                        backgroundColor: 'rgba(72, 160, 53, 0.2)',
+                                        borderColor: 'rgb(72, 160, 53)',
+                                        pointBackgroundColor: 'rgb(72, 160, 53)',
+                                        pointBorderColor: '#fff',
+                                        pointHoverBackgroundColor: '#fff',
+                                        pointHoverBorderColor: 'rgb(72, 160, 53)'
+                                    },
+                                    {
+                                        label: 'معدل اداء المنشأت في نفس الفئة',
+                                        data: [],
+                                        fill: true,
+                                        backgroundColor: 'rgba(0,121,235, 0.2)',
+                                        borderColor: 'rgb(0,121,235)',
+                                        pointBackgroundColor: 'rgb(0,121,235)',
+                                        pointBorderColor: '#fff',
+                                        pointHoverBackgroundColor: '#fff',
+                                        pointHoverBorderColor: 'rgb(0,121,235)'
+                                    }
+                                ]
+                            };
+                            radarReportObject[i].data.forEach(s => {
+                                dataBySize.labels.push(_lang == 'ar' ? s.displayNameAr : s
+                                    .displayNameEn);
+                                dataBySize.datasets[0].data.push(s.contractorValue);
+                                dataBySize.datasets[1].data.push(s.otherValueBySize);
+                            });
+
+                            new Chart(document.getElementById('radarChart_' + (i + 1)), {
+                                type: 'radar',
+                                data: data,
+                                options: {
+                                    scales: {
+
+                                        r: {
+                                            ticks: {
+                                                beginAtZero: true,
+                                                min: 0,
+                                            },
+                                            pointLabels: {
+                                                font: {
+                                                    fontSize: 50,
+                                                    family: '"NeoSansArabicRegular" !important'
+                                                }
+                                            }
+                                        }
+                                    },
+                                    elements: {
+                                        line: {
+                                            borderWidth: 3
+                                        }
+                                    },
+                                    plugins: {
+                                        legend: {
+                                            //display: false, // This hides all text in the legend and also the labels.
+                                        }
+                                    }
+                                }
+                            });
+
+                            new Chart(document.getElementById('radarChartBySize_' + (i + 1)), {
+                                type: 'radar',
+                                data: dataBySize,
+                                options: {
+                                    scales: {
+                                        r: {
+                                            ticks: {
+                                                beginAtZero: true,
+                                                min: 0,
+                                            },
+                                            pointLabels: {
+                                                font: {
+                                                    // size: '40px !important',
+                                                    family: '"NeoSansArabicRegular" !important'
+                                                }
+                                            }
+                                        }
+                                    },
+                                    elements: {
+                                        line: {
+                                            borderWidth: 3
+                                        }
+                                    },
+                                    plugins: {
+                                        legend: {
+                                            //display: false, // This hides all text in the legend and also the labels.
+                                        }
+                                    }
+                                }
+                            });
+                        }
+                    }
+
+                }
+            });
+        }
+    }
+
+    $(document).ready(function() {
+
+        // getRadarChart();
+
+
+    });
+
+
+    function myMap() {
+        $("#show_map_button").hide();
+        $("#map").show();
+
+        var mapCanvas = document.getElementById("map");
+        // The location of Uluru
+        var latlang = {
+            lat: 24.671699788528482,
+            lng: 46.39415764160163
+        };
+
+
+        var mapOptions = {
+            center: latlang,
+            zoom: 10,
+            mapTypeControl: true,
+
+        };
+        var map = new google.maps.Map(mapCanvas, mapOptions);
+
+
+        var latlang881 = {
+            lat: 24.671699788528482,
+            lng: 46.39415764160163
+        };
+
+        var contentString881 = '<div id="content">' +
+            '<div id="siteNotice">' +
+            '</div>' +
+            '<h1 id="firstHeading" class="firstHeading" style="font-size:14px">Name : sca</h1>' +
+            '<h1 id="firstHeading" class="firstHeading" style="font-size:13px">phone : 966544622796</h1>' +
+            '</div>';
+
+        var infowindow881 = new google.maps.InfoWindow({
+            content: contentString881
+        });
+
+        var marker881 = new google.maps.Marker({
+            position: latlang881,
+            map: map,
+            title: 'sca'
+        });
+        marker881.addListener('click', function() {
+            infowindow881.open(map, marker881);
+        });
+
+
+    }
+
+    function contractor_licnesing_field_values_display(flag) {
+        if (flag == 'show') {
+            $('#contractor_licnesing_field_values_main_heading').hide();
+            $('#contractor_licnesing_field_values_detail').show();
+        } else {
+            $('#contractor_licnesing_field_values_detail').hide();
+            $('#contractor_licnesing_field_values_main_heading').show();
+        }
+
+    }
+</script>
+
+
+</body>
+</html>

--- a/tests/test_muqawil_pagesource.py
+++ b/tests/test_muqawil_pagesource.py
@@ -1,0 +1,204 @@
+"""What muqawil.org knows about its own pages, proved against real HTML.
+
+Step 3 of docs/GENERIC-FETCH-SEAM.md. `scrapex/pagewalk.py` and
+`scrapex/pagesource.py` shipped tested against a `FakeSite`, which proves the
+walker and says nothing about any real site. This is the first `PageSource` with
+a site behind it.
+
+THE FIXTURES ARE REAL, TRIMMED, AND COMMITTED — `tests/fixtures/muqawil/`, taken
+2026-08-16. Trimmed to the pagination and four cards for the listings, and to
+everything but the scripts for the profiles (the one script carrying `lat:` is
+kept, because the coordinates are only there). Nothing here touches the network:
+a test that needs muqawil to be up is a test that fails on a train.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scrapex.pagesource import (
+    FetchedPage,
+    PageKind,
+    PageSource,
+    SliceNotSupported,
+    supports_slices,
+)
+from scrapex.sites.muqawil import (
+    SELF_BUILD_SEGMENT,
+    MuqawilPageSource,
+    read_last_page,
+)
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "muqawil"
+
+
+def listing(locale: str = "en") -> FetchedPage:
+    return FetchedPage(
+        url=f"https://muqawil.org/{locale}/contractors?page=1",
+        html=(FIXTURES / f"listing-{locale}.html").read_text(encoding="utf-8"),
+        kind=PageKind.LISTING)
+
+
+@pytest.fixture()
+def source() -> MuqawilPageSource:
+    return MuqawilPageSource(last_page=3)
+
+
+# ---- the protocol itself -----------------------------------------------------
+
+def test_it_is_a_page_source_and_not_a_connector(source):
+    """`PageSource` is runtime-checkable, so this is a real assertion and not a
+    comment. A generic source written against `SiteConnector` instead would
+    compile, pass its own tests, and put nothing in the generic tables."""
+    assert isinstance(source, PageSource)
+    assert source.site_key == "muqawil.org"
+
+
+# ---- how big the crawl is ----------------------------------------------------
+
+def test_the_page_count_is_read_from_the_listing_rather_than_assumed():
+    """865 was true on the day it was measured and a directory grows. A constant
+    would stop crawling the tail the week it changed, and say nothing."""
+    assert read_last_page(listing().html) == 865
+
+
+def test_a_page_with_no_pagination_refuses_rather_than_guessing():
+    """Returning 1 would be the dangerous answer: a crawl of twenty contractors
+    out of seventeen thousand, reported as complete."""
+    with pytest.raises(ValueError, match="refusing to guess"):
+        read_last_page("<html><body>no pagination here</body></html>")
+
+
+def test_the_source_will_not_be_built_without_a_page_count():
+    """A default would let a caller crawl page one and never learn that 864
+    pages were not asked for."""
+    with pytest.raises(TypeError):
+        MuqawilPageSource()          # type: ignore[call-arg]
+
+
+# ---- the listing frontier ----------------------------------------------------
+
+def test_both_locales_are_walked_page_by_page_and_not_locale_by_locale(source):
+    """THE ORDER IS THE POINT. A crawl stopped half way must hold BOTH languages
+    for the pages it reached — the owner's columns come in pairs, and half a
+    pair is not half a row, it is an unusable one."""
+    urls = list(source.listing_urls("https://muqawil.org"))
+
+    assert urls[:4] == [
+        "https://muqawil.org/en/contractors?page=1",
+        "https://muqawil.org/ar/contractors?page=1",
+        "https://muqawil.org/en/contractors?page=2",
+        "https://muqawil.org/ar/contractors?page=2",
+    ]
+    assert len(urls) == 6, "three pages in both locales is six requests"
+
+
+def test_a_trailing_slash_on_the_base_url_does_not_double(source):
+    assert next(iter(source.listing_urls("https://muqawil.org/"))) == \
+        "https://muqawil.org/en/contractors?page=1"
+
+
+# ---- the detail frontier -----------------------------------------------------
+
+def test_every_contractor_on_the_page_is_offered_in_both_languages(source):
+    urls = list(source.detail_urls(listing()))
+    ids = {url.rsplit("/", 2)[-2] for url in urls}
+
+    assert len(ids) == 4, "the fixture holds four cards"
+    assert len(urls) == 8, "each contractor is wanted in both locales"
+    for contractor_id in ids:
+        assert f"https://muqawil.org/en/contractors/{contractor_id}/143" in urls
+        assert f"https://muqawil.org/ar/contractors/{contractor_id}/143" in urls
+
+
+def test_the_self_build_segment_is_rebuilt_and_never_inherited(source):
+    """`/143` is not decoration. `/881/1` and `/881/999` return the same
+    contractor, but only `143` renders the self-build price section — measured
+    by diffing the two, where the ONLY difference was that section appearing.
+    A crawl that carried some other value would ship three of the owner's
+    columns permanently empty and nothing would say so."""
+    assert SELF_BUILD_SEGMENT == "143"
+
+    strange = FetchedPage(
+        url="https://muqawil.org/en/contractors?page=1",
+        html=listing().html.replace("/143", "/999"),
+        kind=PageKind.LISTING)
+
+    for url in source.detail_urls(strange):
+        assert url.endswith("/143"), (
+            f"{url} carried the listing's own tail instead of the one that "
+            "renders every section")
+
+
+def test_the_impostor_card_is_not_taken_for_a_contractor(source):
+    """A listing page holds twenty-one `div.section-card` and only twenty are
+    contractors. Selecting by position rather than by holding a profile link
+    would be off by one for every row after the impostor."""
+    padded = FetchedPage(
+        url=listing().url,
+        html=listing().html.replace(
+            "<div class='container'>",
+            "<div class='container'><div class='section-card'>an advert</div>"),
+        kind=PageKind.LISTING)
+
+    assert len(list(source.detail_urls(padded))) == \
+        len(list(source.detail_urls(listing())))
+
+
+def test_one_contractor_listed_twice_is_asked_for_once(source):
+    doubled = FetchedPage(url=listing().url,
+                          html=listing().html + listing().html,
+                          kind=PageKind.LISTING)
+
+    assert len(list(doubled_ids(source, doubled))) == 4
+
+
+def doubled_ids(source, page):
+    return {url.rsplit("/", 2)[-2] for url in source.detail_urls(page)}
+
+
+# ---- the slice, which is what makes a cheap first crawl possible -------------
+
+def test_a_city_is_read_off_the_listing_in_either_language(source):
+    """ANSWERED FROM THE LISTING, which is the whole reason the slice scope is
+    affordable: one city's profiles without fetching the other sixteen
+    thousand."""
+    assert source.belongs_to_slice(listing("en"), 0, "RIYADH") is True
+    assert source.belongs_to_slice(listing("en"), 0, "riyadh") is True, \
+        "case is the reader's business, not the owner's"
+    assert source.belongs_to_slice(listing("ar"), 0, "الرياض") is True
+
+
+def test_a_city_that_is_not_this_row_is_a_plain_no(source):
+    assert source.belongs_to_slice(listing("en"), 0, "JEDDAH") is False
+
+
+def test_a_row_past_the_end_of_the_page_is_not_in_any_slice(source):
+    assert source.belongs_to_slice(listing("en"), 99, "RIYADH") is False
+
+
+def test_naming_no_city_refuses_rather_than_answering_no(source):
+    """False would mean 'this row is not in the slice', and a site answering it
+    for every row produces an EMPTY crawl that reads as a successful one."""
+    with pytest.raises(SliceNotSupported):
+        source.belongs_to_slice(listing("en"), 0, "  ")
+
+
+def test_a_listing_that_stopped_publishing_the_city_refuses(source):
+    """The same reasoning one level down: a moved marker must not read as a
+    smaller city."""
+    moved = FetchedPage(url=listing().url,
+                        html=listing().html.replace("icon-locaion", "icon-where"),
+                        kind=PageKind.LISTING)
+
+    with pytest.raises(SliceNotSupported, match="city marker has moved"):
+        source.belongs_to_slice(moved, 0, "RIYADH")
+
+
+def test_the_walker_can_ask_up_front_whether_slicing_is_available(source):
+    """`supports_slices` is how the walker refuses a slice scope before the
+    first request instead of half way through a crawl."""
+    assert supports_slices(source, base_url="https://muqawil.org") is False, (
+        "asked with an EMPTY page and no city named, muqawil must refuse — "
+        "which is what lets the walker offer the scope honestly")


### PR DESCRIPTION
**The seam was designed for this site and has been waiting for it.**

`docs/GENERIC-FETCH-SEAM.md` opens: *"M6 needs muqawil.org crawled automatically. Today nothing can."* Its `PageSource` sketch gives `?page=1..860` as the example. Steps 1 and 2 — `scrapex/pagesource.py` and `scrapex/pagewalk.py` — shipped in July, tested against a `FakeSite`, which proves the walker and says nothing about any real site. **`PageWalker` has had zero production callers since the day it merged.**

This is the first concrete `PageSource`.

## What it may not do is most of the design

It does not fetch, pace, count requests, decide depth, or touch the database. All of that is the walker's — and it is the walker's so that every site behaves the same way about the things that are not about the site.

## Four measurements decide the code

All taken 2026-08-16 with ScrapeX's own user agent; the full record is in `docs/CONTRACTOR-SOURCE.md`.

**`/143` is not decoration.** `/881/1` and `/881/999` return the same contractor, so the segment plays no part in identity. But diffing the two rendered pages leaves *exactly one* difference:

```
only in /143: ['العقود سعر البناء (برنامج البناء الذاتي)', 'القيمة']
only in /999: nothing
```

A crawl that carried the listing's own tail would ship three of the owner's columns permanently empty and nothing would say so. It is **rebuilt, never inherited**.

**A listing page holds twenty-one `div.section-card` and twenty contractors.** Cards are selected by *holding a profile link*. By position, every row after the impostor is off by one — and a slice would then be chosen from the wrong contractor.

**The icon is the key, never the label.** Every field is `.info-name` + `.info-value` under an icon whose class is identical in both locales. The Arabic membership-number label is spelled `رقم العضويه` — with `ه`, not `ة` — and a label-matched selector breaks on a difference no reader would notice. `icon-verifiy` and `icon-locaion` are **their** spellings of *verify* and *location*; matched exactly, and the day they are corrected these selectors will say so.

**City and Region are one cell**, dash-separated across a newline and a wall of whitespace — and in Arabic the two are the same word. The city is the *head* of the cell, not the cell.

## Three refusals, each because the alternative is a silent lie

| situation | what it does | why not the obvious thing |
|---|---|---|
| listing has no pagination | raises | answering `1` is a crawl of twenty out of seventeen thousand, reported as complete |
| `MuqawilPageSource()` with no `last_page` | `TypeError` | a default lets a caller crawl page one and never learn 864 pages were not asked for |
| no city named, or the city marker moved | raises `SliceNotSupported` | `False` means *"this row is not in the slice"*; answering it for every row is an empty crawl that reads as a successful one |

Both locales are walked **page by page**, not locale by locale, so a crawl stopped half way holds both languages for the pages it reached. The owner's columns come in pairs; half a pair is not half a row, it is an unusable one.

## Verified

**Sixteen tests on real, trimmed, committed HTML** — `tests/fixtures/muqawil/`. No network: a test that needs muqawil to be up is a test that fails on a train.

| mutation | verdict |
|---|---|
| inherit the listing's tail instead of rebuilding `/143` | **CAUGHT** |
| take cards by position, impostor and all | **CAUGHT** |
| guess the page count at 1 | **CAUGHT** |
| swallow a moved city marker | **CAUGHT** |
| walk locale by locale | **CAUGHT** |
| compare the whole location cell, region and all | **CAUGHT** |

`ruff check scrapex/` clean. The seam's own suites (`pagesource`, `pagewalk`, `crawlscope`) pass unchanged alongside it.

## One pre-existing failure, measured and not mine

The full suite with `SCRAPEX_FULL_MIGRATIONS=1` passes except `test_a_killed_engine_does_not_leave_a_job_claiming_to_run`, which is intermittent. **Measured on a stashed tree at clean `HEAD`: it failed 3 of 6 runs.** That is OP-19, and nothing in this change touches the job or engine path.

## Not in this PR

No crawl runs. The walker is still not wired to `save_snapshot` — that is step 4 — and no field is parsed yet, which is step 2 of the plan. This adds only what the site knows about its own pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)