### PR TITLE
Reading a contractor off the page, where two of the failures are silent ones

### DIFF
--- a/scrapex/extract/muqawil.py
+++ b/scrapex/extract/muqawil.py
@@ -1,0 +1,263 @@
+"""Reading one contractor off muqawil.org's pages.
+
+Step 2 of the contractor plan, and it sits BESIDE `html_table.py` rather than
+replacing it: a profile page carries five real `<table>` elements — the licences
+and their readiness, the two contractor lists, the technical rating and the
+contract counts — and those go through `detect_html_tables` exactly as any other
+site's would. What this file reads is everything that is NOT a table, which on a
+listing page is all of it: **a listing page contains zero `<table>` elements.**
+
+TWO FAILURES HERE ARE SILENT, AND BOTH HAVE A GUARD OF THEIR OWN.
+
+  1. THE EMAIL IS NOT IN THE HTML. Cloudflare replaces it with the literal
+     `[email protected]` and an attribute `data-cfemail` holding the address
+     XOR-ed byte by byte under a key that is its own first byte. A parser that
+     does not decode stores that literal for every contractor in the country,
+     and a test asking "is this column populated?" passes forever.
+
+     THE KEY ROTATES PER RENDER. The same address came back as
+     `670e1327140406491406` and `f9908db98a9a98d78a98` on two fetches minutes
+     apart. So nothing may pin the ciphertext — only the address it decodes to.
+
+  2. THE COORDINATES ARE IN AN INLINE SCRIPT. Not a `data-` attribute, not a map
+     iframe: `lat:` and `lng:` inside a `<script>`. The day that script changes
+     there is no error to catch — only two columns that quietly become NULL.
+
+WHY THE ENGLISH LABEL IS THE KEY, AND THE ARABIC ONE IS NEVER READ. Measured on
+the two committed fixtures: a profile has ELEVEN `.info-box` pairs in BOTH
+locales, in the same order, index for index. So the English page is read by its
+labels — which are stable — and the Arabic value is taken from the SAME INDEX.
+The Arabic labels are never matched against anything, which is the point: the
+Arabic membership-number label is spelled `رقم العضويه`, with `ه` and not `ة`,
+and a parser keyed on it breaks on a difference no reader would ever notice.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+from bs4 import BeautifulSoup, Tag
+
+#: `label -> field_key`, in the page's own order. English only, on purpose —
+#: see the module docstring. A label this map does not know is KEPT, under a
+#: slug of its own, rather than dropped: a field the site adds is news, and a
+#: parser that silently discards what it was not told about is how it stays
+#: news for a year.
+PROFILE_FIELDS: dict[str, str] = {
+    "Membership Number": "membership_number",
+    "Membership": "membership_type",
+    "Member Since": "member_since",
+    "Company Size": "company_size",
+    "Training credit hours": "training_credit_hours",
+    "Organization Mobile Number": "organization_mobile_number",
+    "Organization Email": "organization_email",
+    "City": "city",
+    "Region": "region",
+    "Address": "address",
+    "Activity": "activity",
+}
+
+#: Fields whose Arabic value is a DIFFERENT value rather than the same one
+#: written twice. Everything else pairs by default; these are the exceptions
+#: measured on the fixtures — a date reads `2018/08/25` in both, and the address
+#: is published in Arabic on the ENGLISH page, so neither earns an `_ar`.
+NOT_BILINGUAL = frozenset({"membership_number", "member_since",
+                           "organization_mobile_number", "organization_email",
+                           "address"})
+
+_CFEMAIL = re.compile(r'data-cfemail="([0-9a-fA-F]+)"')
+_LATLNG = re.compile(
+    r"lat:\s*(-?\d+(?:\.\d+)?).{0,80}?lng:\s*(-?\d+(?:\.\d+)?)", re.DOTALL)
+_PROFILE_HREF = re.compile(r"/(?:en|ar)/contractors/(\d+)/\d+")
+
+
+class CoordinatesMoved(LookupError):
+    """The inline script no longer carries `lat:`/`lng:` where it did.
+
+    RAISED, NOT ANSWERED None. None means "this contractor has no location",
+    which is a real state for a page that never had one — and a parser that
+    returned it for a script that MOVED would turn a layout change into
+    seventeen thousand contractors quietly losing their coordinates.
+    """
+
+
+@dataclass(frozen=True)
+class Reading:
+    """One contractor, as one page in one language published it."""
+
+    fields: dict[str, str] = field(default_factory=dict)
+    #: Every label the page carried, in order, whether or not it was recognised.
+    labels: tuple[str, ...] = ()
+    values: tuple[str, ...] = ()
+    latitude: float | None = None
+    longitude: float | None = None
+
+
+def decode_cfemail(encoded: str) -> str:
+    """Cloudflare's email obfuscation, undone.
+
+    The first byte is the key and every byte after it is XOR-ed with it. There
+    is nothing clever here; the only thing worth writing down is that this must
+    happen at all, because the alternative reads as success.
+    """
+    if len(encoded) < 4 or len(encoded) % 2:
+        raise ValueError(f"not a data-cfemail payload: {encoded!r}")
+    key = int(encoded[:2], 16)
+    return "".join(chr(int(encoded[i:i + 2], 16) ^ key)
+                   for i in range(2, len(encoded), 2))
+
+
+def read_email(html: str) -> str:
+    """The organisation's address, decoded. Empty when the page carries none."""
+    found = _CFEMAIL.search(html)
+    return decode_cfemail(found.group(1)) if found else ""
+
+
+def read_coordinates(html: str) -> tuple[float, float] | None:
+    """`(latitude, longitude)` from the inline script, or None if this page has
+    no map at all.
+
+    The difference between "no map" and "the map moved" is the whole guard: a
+    page with a map section but no readable pair raises `CoordinatesMoved`.
+    """
+    found = _LATLNG.search(html)
+    if found is not None:
+        return float(found.group(1)), float(found.group(2))
+    if re.search(r"\blat\s*:|initMap|new\s+google\.maps", html):
+        raise CoordinatesMoved(
+            "this page has map machinery but no readable lat/lng pair — the "
+            "inline script's shape has changed, and every contractor would "
+            "otherwise lose its coordinates without an error")
+    return None
+
+
+def _text(node: Tag | None) -> str:
+    """Collapsed text. muqawil pads its cells with newlines and long runs of
+    spaces, so nothing may be compared before this has run."""
+    return " ".join(node.get_text(" ", strip=True).split()) if node else ""
+
+
+def _slug(label: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", label.lower()).strip("_") or "unnamed"
+
+
+def _boxes(soup: BeautifulSoup) -> list[tuple[str, str]]:
+    pairs = []
+    for box in soup.select(".info-box"):
+        name, value = box.select_one(".info-name"), box.select_one(".info-value")
+        if name is not None and value is not None:
+            pairs.append((_text(name), _text(value)))
+    return pairs
+
+
+def read_profile(html: str) -> Reading:
+    """One profile page, in whichever language it was fetched.
+
+    The labels are returned alongside the mapped fields so the Arabic page can
+    be paired to the English one BY INDEX — which is the only pairing that does
+    not depend on reading an Arabic label correctly.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    pairs = _boxes(soup)
+
+    fields: dict[str, str] = {}
+    for label, value in pairs:
+        key = PROFILE_FIELDS.get(label)
+        fields[key or f"x_{_slug(label)}"] = value
+
+    email = read_email(html)
+    if email:
+        fields["organization_email"] = email
+
+    latitude = longitude = None
+    coordinates = read_coordinates(html)
+    if coordinates is not None:
+        latitude, longitude = coordinates
+
+    return Reading(fields=fields,
+                   labels=tuple(label for label, _ in pairs),
+                   values=tuple(value for _, value in pairs),
+                   latitude=latitude, longitude=longitude)
+
+
+def read_listing(html: str) -> list[dict[str, str]]:
+    """Every contractor a listing page names, with what the card publishes.
+
+    Cards are those `div.section-card` that hold a profile link — a page has
+    twenty-one and twenty contractors, and the twenty-first is not one.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    rows: list[dict[str, str]] = []
+    for card in soup.select("div.section-card"):
+        link = card.find("a", href=_PROFILE_HREF)
+        if link is None:
+            continue
+        found = _PROFILE_HREF.search(link["href"])
+        row: dict[str, str] = {"contractor_id": found.group(1)}
+
+        title = card.select_one("h2.card-title a")
+        row["company_name"] = _text(title)
+        row["membership_level"] = " ".join(
+            str(card.get("data-membership-text", "")).split())
+
+        logo = card.select_one("img.card-img")
+        source = (logo.get("src") or "") if logo else ""
+        # THE PLACEHOLDER IS NOT A LOGO. The site's own `onerror` names
+        # `default.jpg`; a card already showing it has no logo, and storing the
+        # placeholder URL would make every logo-less contractor look like one
+        # that has a picture nobody can tell apart from the others.
+        row["logo_url"] = "" if source.endswith("companies/default.jpg") else source
+
+        rater = card.select_one(".rater")
+        row["customer_rating_score"] = (rater.get("data-rate-value") or "") if rater else ""
+        votes = _text(card.select_one(".votes-num"))
+        count = re.search(r"(\d+)", votes)
+        row["customer_rating_count"] = count.group(1) if count else ""
+
+        for name, value in _boxes(card):
+            row[f"card_{_slug(name)}"] = value
+        rows.append(row)
+    return rows
+
+
+def merge_locales(english: Reading, arabic: Reading) -> dict[str, str]:
+    """One contractor from its two pages, with the `_ar` half attached.
+
+    PAIRED BY INDEX, NEVER BY LABEL. Both locales publish the same eleven boxes
+    in the same order, so the English label names the field and the Arabic page
+    supplies the value sitting at the same position. Nothing here ever reads an
+    Arabic label, which is exactly why a spelling difference in one cannot break
+    it.
+
+    A page whose box count differs from its sibling's is REFUSED rather than
+    zipped to the shorter of the two: zipping would silently attach the wrong
+    Arabic value to every field after the divergence, and a wrong value is worse
+    than a missing one in a table whose whole purpose is to be believed.
+    """
+    if len(english.labels) != len(arabic.labels):
+        raise ValueError(
+            f"the English page published {len(english.labels)} fields and the "
+            f"Arabic one {len(arabic.labels)}; pairing them by position would "
+            "attach the wrong Arabic value to every field after the difference")
+
+    merged = dict(english.fields)
+    for index, label in enumerate(english.labels):
+        key = PROFILE_FIELDS.get(label) or f"x_{_slug(label)}"
+        if key in NOT_BILINGUAL:
+            continue
+        arabic_value = arabic.values[index]
+        if arabic_value and arabic_value != merged.get(key):
+            merged[f"{key}_ar"] = arabic_value
+
+    # DERIVED, never read twice. `Is Saudi Contractor` is the same fact as
+    # `Membership Type` and the owner asked for both; computing it here means
+    # the two can never disagree.
+    membership = merged.get("membership_type", "")
+    if membership:
+        merged["is_saudi_contractor"] = str(
+            "non" not in membership.lower()).lower()
+
+    if english.latitude is not None:
+        merged["latitude"] = str(english.latitude)
+        merged["longitude"] = str(english.longitude)
+    return merged

--- a/tests/test_muqawil_parser.py
+++ b/tests/test_muqawil_parser.py
@@ -1,0 +1,235 @@
+"""Reading a contractor off muqawil.org's pages, proved against real HTML.
+
+THE TWO FAILURES THIS FILE EXISTS FOR ARE BOTH SILENT.
+
+The email is not in the page — Cloudflare leaves the literal `[email protected]`
+and hides the address in `data-cfemail`. A parser that skips the decode stores
+that literal for every contractor, and a test asking "is the column populated?"
+passes forever. So the assertions here are about the DECODED ADDRESS, never
+about presence — and never about the ciphertext either, which rotates per
+render: the same address came back as `670e…` and `f990…` minutes apart.
+
+The coordinates are in an inline script. A change there raises nothing; it just
+turns two columns NULL for seventeen thousand rows.
+
+Fixtures are `tests/fixtures/muqawil/`, taken 2026-08-16. No network.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from scrapex.extract.muqawil import (
+    CoordinatesMoved,
+    decode_cfemail,
+    merge_locales,
+    read_coordinates,
+    read_email,
+    read_listing,
+    read_profile,
+)
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "muqawil"
+
+
+def html(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+@pytest.fixture()
+def english():
+    return read_profile(html("profile-en.html"))
+
+
+@pytest.fixture()
+def arabic():
+    return read_profile(html("profile-ar.html"))
+
+
+# ---- the email, which is the guard this file was written for -----------------
+
+def test_the_address_is_decoded_and_not_the_literal_the_page_shows(english):
+    assert english.fields["organization_email"] == "it@sca.sa"
+    assert "[email" not in english.fields["organization_email"], (
+        "the page's own placeholder was stored — every contractor in the "
+        "country would carry this string and no emptiness check would fail")
+
+
+def test_the_ciphertext_rotates_so_only_the_address_may_be_asserted():
+    """Two fetches of the same profile minutes apart returned different
+    payloads. A test pinned to the hex would break on every fixture refresh and
+    teach whoever refreshed it that the parser was wrong."""
+    assert decode_cfemail("670e1327140406491406") == "it@sca.sa"
+    assert decode_cfemail("f9908db98a9a98d78a98") == "it@sca.sa"
+
+
+def test_a_page_with_no_protected_address_yields_nothing_rather_than_guessing():
+    assert read_email("<html><body>no address here</body></html>") == ""
+
+
+def test_a_payload_that_is_not_one_is_refused():
+    with pytest.raises(ValueError, match="not a data-cfemail"):
+        decode_cfemail("abc")
+
+
+# ---- the coordinates, the second silent one ----------------------------------
+
+def test_the_coordinates_come_off_the_inline_script(english):
+    assert english.latitude == pytest.approx(24.671699788528482)
+    assert english.longitude == pytest.approx(46.39415764160163)
+
+
+def test_a_plausible_pair_and_not_merely_a_present_one(english):
+    """Riyadh is near 24.7N 46.7E. Asserting "not None" would pass on a parser
+    that read the two numbers in the wrong order, or read a zoom level."""
+    assert 16 < english.latitude < 33, "outside Saudi Arabia's latitudes"
+    assert 34 < english.longitude < 56, "outside Saudi Arabia's longitudes"
+
+
+def test_a_page_with_no_map_at_all_is_not_an_error():
+    assert read_coordinates("<html><body>a page with no map</body></html>") is None
+
+
+def test_a_map_whose_script_moved_refuses_rather_than_returning_none():
+    """None means "this contractor has no location", which is a real state. A
+    layout change answering it would lose every coordinate without an error."""
+    with pytest.raises(CoordinatesMoved, match="shape has changed"):
+        read_coordinates("<script>initMap(); centre = [24.6, 46.4];</script>")
+
+
+# ---- the profile's own fields ------------------------------------------------
+
+def test_the_english_page_is_read_by_its_labels(english):
+    assert english.fields["membership_number"] == "10000861"
+    assert english.fields["membership_type"] == "Saudi Contractor"
+    assert english.fields["member_since"] == "2018/08/25"
+    assert english.fields["city"] == "RIYADH"
+    assert english.fields["region"] == "Riyadh"
+    assert english.fields["training_credit_hours"] == "308 h"
+
+
+def test_a_label_nobody_mapped_is_kept_rather_than_dropped(english):
+    """A field the site adds is news. A parser that discards what it was not
+    told about is how it stays news for a year."""
+    kept = read_profile(html("profile-en.html").replace(
+        ">Region<", ">Some New Thing<"))
+
+    assert kept.fields.get("x_some_new_thing") == "Riyadh"
+
+
+# ---- the pairing, which is the whole reason both languages are fetched -------
+
+def test_the_two_languages_pair_by_position_and_never_by_arabic_label(english, arabic):
+    """The Arabic membership-number label is spelled `رقم العضويه`, with `ه` and
+    not `ة`. Nothing here reads it, which is exactly why that cannot break."""
+    merged = merge_locales(english, arabic)
+
+    assert merged["membership_type"] == "Saudi Contractor"
+    assert merged["membership_type_ar"] == "مقاول سعودي"
+    assert merged["company_size"] == "Small Company Size"
+    assert merged["company_size_ar"] == "منشأة صغيرة"
+    assert merged["city"] == "RIYADH"
+    assert merged["city_ar"] == "الرياض"
+
+
+def test_a_field_declared_untranslatable_earns_no_second_column(english, arabic):
+    """`2018/08/25` reads identically in Arabic, and the membership number is a
+    number. Both are named in `NOT_BILINGUAL`, so neither is even offered a
+    pair."""
+    merged = merge_locales(english, arabic)
+
+    assert merged["member_since"] == "2018/08/25"
+    assert "member_since_ar" not in merged
+    assert "membership_number_ar" not in merged
+
+
+def test_a_translatable_field_the_site_has_not_translated_earns_none_either(english):
+    """THE SECOND GUARD, AND IT NEEDED ITS OWN TEST. The one above proves the
+    `NOT_BILINGUAL` list; it never reaches the equality check, because those
+    fields are skipped before it. This does: `city` IS a paired field, so a
+    site that publishes `RIYADH` in both languages must still produce one
+    column, not two holding the same string in every row of seventeen
+    thousand."""
+    untranslated = read_profile(html("profile-ar.html").replace(
+        '<div class="info-value">الرياض', '<div class="info-value">RIYADH', 1))
+
+    merged = merge_locales(english, untranslated)
+
+    assert merged["city"] == "RIYADH"
+    assert "city_ar" not in merged, (
+        "the Arabic page repeated the English value and it was stored twice")
+    assert merged["region_ar"] == "الرياض", (
+        "only the repeated field may be dropped — the rest still pair")
+
+
+def test_the_address_has_no_english_half_so_it_gets_no_pair(english, arabic):
+    """Measured: the ENGLISH page prints the Arabic address. There is no English
+    one to pair it with."""
+    merged = merge_locales(english, arabic)
+
+    assert "الرياض" in merged["address"]
+    assert "address_ar" not in merged
+
+
+def test_pages_that_disagree_about_their_shape_are_refused(english, arabic):
+    """Zipping to the shorter of the two would attach the wrong Arabic value to
+    every field after the divergence — and a wrong value is worse than a missing
+    one in a table whose whole purpose is to be believed."""
+    short = read_profile(html("profile-ar.html").replace(
+        '<div class="info-name">المدينة</div>', ""))
+
+    with pytest.raises(ValueError, match="attach the wrong Arabic value"):
+        merge_locales(english, short)
+
+
+def test_being_a_saudi_contractor_is_derived_and_never_read_twice(english, arabic):
+    merged = merge_locales(english, arabic)
+    assert merged["is_saudi_contractor"] == "true"
+
+    other = read_profile(html("profile-en.html").replace(
+        "Saudi Contractor", "Non-Saudi Contractor"))
+    assert merge_locales(other, arabic)["is_saudi_contractor"] == "false"
+
+
+# ---- the listing card --------------------------------------------------------
+
+def test_every_contractor_on_the_listing_is_read(english):
+    rows = read_listing(html("listing-en.html"))
+
+    assert len(rows) == 4, "the fixture holds four cards"
+    assert rows[0]["contractor_id"] == "20008518"
+    assert rows[0]["company_name"] == "Awared General Contracting Company"
+    assert rows[0]["membership_level"] == "Platinum Membership"
+    assert rows[0]["customer_rating_score"] == "5"
+    assert rows[0]["customer_rating_count"] == "1"
+
+
+def test_a_real_logo_is_kept():
+    rows = read_listing(html("listing-en.html"))
+    assert rows[0]["logo_url"].startswith(
+        "https://muqawil.org/public/contractor/companyLogo/")
+
+
+def test_the_placeholder_is_not_stored_as_a_logo():
+    """The site's own `onerror` names `default.jpg`, and a card already showing
+    it has no logo. Storing that URL would make every logo-less contractor look
+    like one with a picture — and every such contractor look identical."""
+    placeholder = "https://muqawil.org/public_assets/img/companies/default.jpg"
+    swapped = re.sub(r'src="https://muqawil\.org/public/contractor/companyLogo/[^"]*"',
+                     f'src="{placeholder}"', html("listing-en.html"))
+
+    rows = read_listing(swapped)
+    assert rows, "the substitution destroyed the fixture"
+    for row in rows:
+        assert row["logo_url"] == "", (
+            f"the placeholder was stored as a logo: {row['logo_url']!r}")
+
+
+def test_the_impostor_card_is_not_read_as_a_contractor():
+    padded = html("listing-en.html").replace(
+        "<div class='container'>",
+        "<div class='container'><div class='section-card'>an advert</div>")
+
+    assert len(read_listing(padded)) == len(read_listing(html("listing-en.html")))


### PR DESCRIPTION
Step 2 of the contractor plan. It sits **beside** `extract/html_table.py`, not in place of it: a profile carries five real `<table>` elements — the licences and their readiness, the two contractor lists, the technical rating, the contract counts — and those go through `detect_html_tables` as any other site's would.

This reads everything that is *not* a table. On a **listing** page that is all of it: a listing page contains **zero** `<table>` elements.

## The Arabic label is never read, and that is the design

Measured on the two committed fixtures: a profile publishes **eleven `.info-box` pairs in both locales, in the same order, index for index.**

So the English page is read by its labels — which are stable — and the Arabic value is taken from the **same index**. The Arabic membership-number label is spelled `رقم العضويه`, with `ه` and not `ة`. A parser keyed on it breaks on a difference no reader would ever notice; nothing here can break that way, because nothing here matches an Arabic label.

## Two silent failures, two guards

### The email is not in the HTML

Cloudflare leaves the literal `[email protected]` and hides the address in `data-cfemail`, XOR-ed under a key that is its own first byte. **A parser that skips the decode stores that literal for every contractor in the country, and a test asking "is this column populated?" passes forever.**

**The key rotates per render.** The same address came back as `670e1327140406491406` and `f9908db98a9a98d78a98` minutes apart. So nothing may pin the ciphertext — only the address it decodes to. A test pinned to the hex would break on every fixture refresh and teach whoever refreshed it that the parser was wrong.

### The coordinates are in an inline script

Not an attribute, not an iframe. A change there raises nothing; it turns two columns NULL for seventeen thousand rows.

`read_coordinates` distinguishes **"no map"** (`None`, a real state) from **"the map moved"** (`CoordinatesMoved`). And the test asserts a *plausible* pair — `16 < lat < 33`, `34 < lng < 56` — not a present one. **A mutation that swapped lat and lng was caught by exactly that; asserting `is not None` would have let it through.**

## Three smaller refusals, each because the alternative is quiet

| situation | what it does | why |
|---|---|---|
| a label nobody mapped | **kept**, under a slug of its own | a field the site adds is news; a parser that discards what it was not told about is how it stays news for a year |
| two pages disagreeing about their shape | **refused** | zipping to the shorter attaches the wrong Arabic value to every field after the divergence — and a wrong value is worse than a missing one in a table whose purpose is to be believed |
| the site's own `default.jpg` | stored as **empty** | storing the URL makes every logo-less contractor look like one with a picture nobody can tell from the others |

`is_saudi_contractor` is **derived** from the membership type rather than read twice, so the two columns the owner asked for cannot disagree.

## Verified — twenty tests, all seven mutations caught

| mutation | verdict |
|---|---|
| store the placeholder instead of decoding the address | **CAUGHT** |
| a moved script answers `None` instead of refusing | **CAUGHT** |
| read lat and lng the wrong way round | **CAUGHT** |
| zip pages of different shapes to the shorter | **CAUGHT** |
| an identical Arabic value still earns its own column | **CAUGHT** (see below) |
| drop an unmapped label | **CAUGHT** |
| store the placeholder as a logo | **CAUGHT** |

**One survived the first pass, and the survival was a defect in the test.** The two fields it checked are named in `NOT_BILINGUAL` and are skipped *before* the equality check is ever reached — so it proved the list and not the check. A second test now reaches it: an Arabic page that repeats the English value, which is a site that has not translated a field yet. The mutation is caught.

Full suite green with `SCRAPEX_FULL_MIGRATIONS=1`. `ruff check scrapex/` clean.

## Not in this PR

Nothing crawls yet. The walker is still not wired to `save_snapshot` — that is step 4, and it is the wiring `docs/GENERIC-FETCH-SEAM.md` says has never been written. No record reaches `generic_record` until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)