### PR TITLE
A crawl whose output is evidence, which is the wiring the seam doc says was never written

### DIFF
--- a/scrapex/snapshotcrawl.py
+++ b/scrapex/snapshotcrawl.py
@@ -1,0 +1,140 @@
+"""A crawl whose output is EVIDENCE, not rows.
+
+Step 4 of docs/GENERIC-FETCH-SEAM.md, and the wiring that document says has
+never been written. `scrapex/pagewalk.py` shipped in July with zero production
+callers; `scrapex/extract/service.py:save_snapshot` has only ever been reached
+by a human pressing a button in the General workspace. This joins them, and it
+is the whole of what it does.
+
+ONE PAGE IN, ONE SNAPSHOT OUT, AND NOTHING IS PARSED ON THE WAY. The seam's
+central rule, and the reason is arithmetic rather than taste: interpretation
+re-run against stored snapshots re-fetches nothing. On a source whose full pass
+is thirty-five thousand requests, a parse that turns out wrong costs minutes
+instead of ten hours. That is the product, not an optimisation — so this module
+has no idea what a contractor is, and must not learn.
+
+THE SCOPE COMES FROM THE DATABASE AND NOWHERE ELSE. `site_profile.crawl_scope`
+and `crawl_slice` were added by M6a and, until this file, **nothing in Python
+read them**. A scope the caller could also pass would be a scope enforced in two
+places, which is a scope enforced in neither — so the signature does not offer
+one. `docs/PLATFORM-PLAN.md` Decision 23 is the reason it is per-source at all:
+a new source has no default, and no crawl starts until the owner has answered.
+
+EACH PAGE IS COMMITTED AS IT ARRIVES. A crawl interrupted at page 800 keeps 800
+pages, which is the same reasoning the price side's job journal already
+follows — and evidence is worth less the moment it can be lost by stopping.
+"""
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from .connectors.base import declare_frontier
+from .crawlscope import CrawlScope, Plan, plan
+from .extract.models import SnapshotCreate
+from .extract.service import save_snapshot
+from .pagesource import FetchedPage, PageSource
+from .pagewalk import PageWalker, WalkReport
+
+Fetch = Callable[[str], str]
+
+
+class SiteNotRegistered(LookupError):
+    """No `site_profile` row, so nobody has said how deep this crawl may go.
+
+    RAISED RATHER THAN DEFAULTED. The column's default is `listing_only`, which
+    is the safe scope — but a site with no row at all has not been ASKED, and
+    quietly crawling it at the cheapest scope answers a question the owner was
+    supposed to answer.
+    """
+
+
+@dataclass(frozen=True)
+class CrawlOutcome:
+    """What one snapshot crawl fetched, stored, and failed to."""
+
+    plan: Plan
+    report: WalkReport
+    #: `generic_page_snapshot` ids, in the order the pages arrived.
+    snapshots: tuple[int, ...] = ()
+    #: Pages fetched but NOT stored, with why. Separate from the walker's own
+    #: fetch failures because the two have different remedies: a fetch failure
+    #: is the site's or the network's, a storage failure is ours.
+    unstored: tuple[tuple[str, str], ...] = field(default_factory=tuple)
+
+    @property
+    def stored(self) -> int:
+        return len(self.snapshots)
+
+
+def read_scope(conn: sqlite3.Connection, site_key: str) -> tuple[CrawlScope, str]:
+    """The scope and slice this site was registered with.
+
+    The first reader these two columns have ever had.
+    """
+    row = conn.execute(
+        "SELECT crawl_scope, crawl_slice FROM site_profile WHERE site_key = ?",
+        (site_key,)).fetchone()
+    if row is None:
+        raise SiteNotRegistered(
+            f"no site_profile row for {site_key!r}, so how deep its crawl may "
+            "go has never been decided. Register the site first — a crawl that "
+            "picked the default would be answering for the owner.")
+    return CrawlScope(row[0]), (row[1] or "")
+
+
+def crawl_to_snapshots(conn: sqlite3.Connection, source: PageSource,
+                       base_url: str, *, fetch: Fetch,
+                       listing_pages: int, detail_pages: int = 0,
+                       slice_pages: int = 0, pace_s: float = 1.0,
+                       max_requests: int | None = None,
+                       fetcher: object | None = None) -> CrawlOutcome:
+    """Walk this site at its registered scope, storing every page as evidence.
+
+    `listing_pages` and `detail_pages` are MEASURED BY THE CALLER and passed in,
+    because only the caller has them — 865 is a fact about muqawil discovered by
+    reading page one, and neither this module nor `crawlscope` may carry one
+    site's numbers as though they were every site's.
+
+    `fetcher` is optional and is only ever used to declare the frontier. It is
+    passed through `declare_frontier`, which tolerates a fetcher that cannot
+    hear it: reaching for `expect_requests` directly once turned a progress
+    display into an AttributeError that failed real crawls.
+    """
+    scope, slice_of = read_scope(conn, source.site_key)
+
+    # PLANNED BEFORE THE FIRST REQUEST, and by `crawlscope` rather than here.
+    # It raises SliceRequired for a slice scope with no slice named, and asking
+    # it now means the refusal costs nothing instead of arriving after fourteen
+    # minutes of listing pages. The walker asks it again for itself; that is
+    # deliberate duplication of a CHECK, never of the rule.
+    intended = plan(scope, listing_pages=listing_pages,
+                    detail_pages=detail_pages, slice_pages=slice_pages,
+                    slice_of=slice_of)
+    declare_frontier(fetcher, intended.requests)
+
+    snapshots: list[int] = []
+    unstored: list[tuple[str, str]] = []
+
+    def store(page: FetchedPage) -> None:
+        """One page, straight into evidence, unparsed and committed at once."""
+        try:
+            saved = save_snapshot(conn, SnapshotCreate(
+                source_url=page.url, html_content=page.html))
+            conn.commit()
+        except Exception as exc:
+            # NOT RAISED. One page too large, or one URL the model refuses,
+            # must not discard the eight hundred already stored — the same
+            # reasoning the walker applies to a dead page, one level down.
+            conn.rollback()
+            unstored.append((page.url, f"{type(exc).__name__}: {exc}"))
+            return
+        snapshots.append(int(saved["page_snapshot_id"]))
+
+    walker = PageWalker(source, fetch, pace_s=pace_s)
+    report = walker.walk(base_url, scope, slice_of=slice_of,
+                         max_requests=max_requests, on_page=store)
+
+    return CrawlOutcome(plan=intended, report=report,
+                        snapshots=tuple(snapshots), unstored=tuple(unstored))

--- a/tests/test_a_crawl_that_stores_evidence.py
+++ b/tests/test_a_crawl_that_stores_evidence.py
@@ -1,0 +1,267 @@
+"""The wiring that turns a walk into stored evidence.
+
+Step 4 of docs/GENERIC-FETCH-SEAM.md. `scrapex/pagewalk.py` shipped in July with
+ZERO production callers, and `save_snapshot` had only ever been reached by a
+human pressing a button. Nothing joined them, so nothing could crawl a generic
+site automatically — which is the sentence that document opens with.
+
+WHAT THESE TESTS ARE FOR. Three things that only this join can get wrong:
+
+  * the scope must come from `site_profile` and from nowhere else, or it is
+    enforced in two places and therefore in neither;
+  * every page must reach `generic_page_snapshot` UNPARSED, because a parse
+    re-run against stored evidence re-fetches nothing and that is the whole
+    economics of a thirty-five-thousand-request source;
+  * a page that cannot be stored must not discard the eight hundred already
+    stored.
+
+No network: the fetch is a dict lookup.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scrapex.crawlscope import CrawlScope, SliceRequired
+from scrapex.databases import DatabaseRegistry, EngineDatabase
+from scrapex.pagesource import FetchedPage
+from scrapex.snapshotcrawl import (
+    SiteNotRegistered,
+    crawl_to_snapshots,
+    read_scope,
+)
+
+BASE = "https://site.test"
+
+
+class TwoPageSite:
+    """Two listing pages, one detail link each, and a city on every row."""
+
+    site_key = "site.test"
+
+    def listing_urls(self, base_url: str):
+        for page in (1, 2):
+            yield f"{base_url}/list?page={page}"
+
+    def detail_urls(self, page: FetchedPage):
+        number = page.url.rsplit("=", 1)[-1]
+        return [f"{BASE}/entity/{number}"]
+
+    def belongs_to_slice(self, page: FetchedPage, row_index: int, slice_of: str):
+        return slice_of in page.html
+
+
+PAGES = {
+    f"{BASE}/list?page=1": "<html>RIYADH one</html>",
+    f"{BASE}/list?page=2": "<html>JEDDAH two</html>",
+    f"{BASE}/entity/1": "<html>detail one</html>",
+    f"{BASE}/entity/2": "<html>detail two</html>",
+}
+
+
+def fetch(url: str) -> str:
+    return PAGES[url]
+
+
+@pytest.fixture()
+def conn(tmp_path: Path):
+    registry = DatabaseRegistry(EngineDatabase(tmp_path / "scrapex-engine.db"),
+                               pointer_file=tmp_path / "databases.json")
+    registry.initialize()
+    connection = registry.engine.connect()
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def register(conn, scope: str = "listing_only", slice_of: str | None = None):
+    conn.execute(
+        "INSERT INTO site_profile (site_key, display_name, base_url, "
+        "crawl_scope, crawl_slice) VALUES (?,?,?,?,?)",
+        ("site.test", "A site", BASE, scope, slice_of))
+    conn.commit()
+
+
+def stored_urls(conn) -> list[str]:
+    return [row[0] for row in conn.execute(
+        "SELECT source_url FROM generic_page_snapshot ORDER BY page_snapshot_id")]
+
+
+def crawl(conn, **kwargs):
+    return crawl_to_snapshots(conn, TwoPageSite(), BASE, fetch=fetch,
+                              listing_pages=2, detail_pages=2, slice_pages=1,
+                              pace_s=0, **kwargs)
+
+
+# ---- the scope, which had no reader in Python until this file ----------------
+
+def test_the_scope_is_read_from_the_site_and_not_from_the_caller(conn):
+    """M6a added `crawl_scope` and `crawl_slice` and NOTHING read them. There is
+    deliberately no parameter to pass one: a scope the caller could also supply
+    is enforced in two places, and therefore in neither."""
+    register(conn, "listing_plus_slice", "RIYADH")
+
+    assert read_scope(conn, "site.test") == (CrawlScope.LISTING_PLUS_SLICE, "RIYADH")
+
+
+def test_a_site_nobody_registered_is_refused_rather_than_defaulted(conn):
+    """The column's default is the SAFE scope, which is exactly why defaulting
+    here would be wrong: a site with no row has not been ASKED, and crawling it
+    cheaply still answers a question that was the owner's."""
+    with pytest.raises(SiteNotRegistered, match="never been decided"):
+        crawl(conn)
+
+
+def test_a_slice_scope_with_no_slice_is_refused_before_the_first_request(conn):
+    """`crawlscope.plan` raises it and this calls `plan` rather than re-checking
+    — two copies of a rule disagree eventually. Refusing now costs nothing;
+    refusing after fourteen minutes of listing pages costs fourteen minutes."""
+    register(conn, "listing_plus_slice", None)
+
+    with pytest.raises(SliceRequired):
+        crawl(conn)
+    assert stored_urls(conn) == [], "a refused crawl stored something"
+
+
+# ---- one page in, one snapshot out -------------------------------------------
+
+def test_every_page_reaches_storage_unparsed(conn):
+    register(conn, "listing_only")
+
+    outcome = crawl(conn)
+
+    assert stored_urls(conn) == [f"{BASE}/list?page=1", f"{BASE}/list?page=2"]
+    assert outcome.stored == 2
+    assert outcome.report.listing_pages == 2
+    assert outcome.report.detail_pages == 0, "listing_only fetched a detail page"
+
+    kept = conn.execute(
+        "SELECT html_content FROM generic_page_snapshot ORDER BY page_snapshot_id"
+    ).fetchone()[0]
+    assert kept == "<html>RIYADH one</html>", (
+        "the HTML was altered on the way in — evidence that has been touched "
+        "cannot settle what the page said")
+
+
+def test_the_full_scope_stores_the_detail_pages_too(conn):
+    register(conn, "full_then_listing")
+
+    outcome = crawl(conn)
+
+    assert outcome.stored == 4
+    assert f"{BASE}/entity/1" in stored_urls(conn)
+
+
+def test_a_slice_fetches_only_the_rows_it_named(conn):
+    """The whole reason the slice scope is worth having: one city's detail pages
+    without the rest."""
+    register(conn, "listing_plus_slice", "RIYADH")
+
+    outcome = crawl(conn)
+
+    assert outcome.report.detail_pages == 1
+    assert f"{BASE}/entity/1" in stored_urls(conn)
+    assert f"{BASE}/entity/2" not in stored_urls(conn)
+
+
+def test_the_plan_is_reported_so_the_cost_can_be_seen(conn):
+    register(conn, "listing_only")
+
+    outcome = crawl(conn)
+
+    assert outcome.plan.scope is CrawlScope.LISTING_ONLY
+    assert outcome.plan.requests == 2
+
+
+# ---- what must not be lost ---------------------------------------------------
+
+def test_a_page_that_cannot_be_stored_does_not_discard_the_rest(conn):
+    """One page too large, or one URL the model refuses, must not throw away the
+    eight hundred already kept — the same reasoning the walker applies to a dead
+    page, one level down."""
+    register(conn, "listing_only")
+    broken = dict(PAGES, **{f"{BASE}/list?page=2": ""})   # min_length=1 refuses
+
+    outcome = crawl_to_snapshots(conn, TwoPageSite(), BASE,
+                                 fetch=broken.__getitem__,
+                                 listing_pages=2, detail_pages=0, pace_s=0)
+
+    assert outcome.stored == 1, "the good page was lost with the bad one"
+    assert len(outcome.unstored) == 1
+    assert outcome.unstored[0][0] == f"{BASE}/list?page=2"
+
+
+def test_a_dead_page_is_recorded_and_the_crawl_goes_on(conn):
+    register(conn, "listing_only")
+
+    def flaky(url: str) -> str:
+        if url.endswith("page=1"):
+            raise TimeoutError("the site did not answer")
+        return PAGES[url]
+
+    outcome = crawl_to_snapshots(conn, TwoPageSite(), BASE, fetch=flaky,
+                                 listing_pages=2, detail_pages=0, pace_s=0)
+
+    assert outcome.stored == 1
+    assert outcome.report.failures, "a dead page vanished without a record"
+
+
+def test_a_ceiling_stops_the_crawl_and_says_so(conn):
+    register(conn, "full_then_listing")
+
+    outcome = crawl(conn, max_requests=1)
+
+    assert outcome.stored == 1
+    assert outcome.report.requests <= 2
+
+
+# ---- the frontier ------------------------------------------------------------
+
+def test_the_frontier_is_declared_before_anything_is_fetched(conn):
+    """So the Activity panel's denominator is a count and not a guess. Unlike
+    GPP — whose frontier grows material by material, and which declines to
+    declare one for that reason — this site's size is known up front."""
+    register(conn, "listing_only")
+    told: list[int] = []
+
+    class Fetcher:
+        def expect_requests(self, pages: int) -> None:
+            told.append(pages)
+
+    crawl(conn, fetcher=Fetcher())
+
+    assert told == [2]
+
+
+def test_a_slice_declares_the_slice_s_size_and_not_the_whole_site_s(conn):
+    """WHY `crawlscope.plan` IS CALLED AND NOT RE-IMPLEMENTED, made observable.
+
+    The walker checks the scope again for itself, so skipping `plan` here still
+    refuses a slice with no slice named — that duplication is deliberate. What
+    it does NOT protect is the number: only `plan` knows that a slice crawl
+    costs `listing + slice`, not `listing + every detail page`. Get it from
+    anywhere else and the progress bar counts to a total the crawl will never
+    reach, which is the bar running backwards that GPP refuses to ship at all.
+    """
+    register(conn, "listing_plus_slice", "RIYADH")
+    told: list[int] = []
+
+    class Fetcher:
+        def expect_requests(self, pages: int) -> None:
+            told.append(pages)
+
+    outcome = crawl(conn, fetcher=Fetcher())
+
+    assert told == [3], "2 listing pages + 1 sliced detail page, not 2 + 2"
+    assert outcome.plan.requests == 3
+
+
+def test_a_fetcher_that_cannot_hear_the_frontier_is_not_an_error(conn):
+    """`declare_frontier` exists because reaching for `expect_requests` directly
+    once turned a progress display into an AttributeError that failed real
+    crawls. A display fact must never be able to do that."""
+    register(conn, "listing_only")
+
+    assert crawl(conn, fetcher=object()).stored == 2


### PR DESCRIPTION
Step 4 of `docs/GENERIC-FETCH-SEAM.md`, and the last piece missing before this project can crawl a non-price site at all.

`scrapex/pagewalk.py` shipped in July with **zero production callers**. `scrapex/extract/service.py:save_snapshot` had only ever been reached by a human pressing a button in the General workspace. Nothing joined them — which is why that document still opens *"M6 needs muqawil.org crawled automatically. Today nothing can."*

## One page in, one snapshot out, and nothing is parsed on the way

The reason is arithmetic rather than taste: interpretation re-run against stored snapshots **re-fetches nothing**. On a source whose full pass is thirty-five thousand requests, a parse that turns out wrong costs minutes instead of ten hours.

So this module has no idea what a contractor is, and must not learn.

## The scope comes from the database and nowhere else

M6a added `site_profile.crawl_scope` and `crawl_slice` and **nothing in Python has ever read them**. `read_scope` is their first reader.

There is deliberately **no parameter** to pass a scope: one the caller could also supply is enforced in two places, and therefore in neither. PLATFORM-PLAN Decision 23 is why it is per-source at all.

A site with **no `site_profile` row is refused, not defaulted** — and the column's default being the *safe* scope is exactly why. A site with no row has not been *asked*, and crawling it cheaply still answers a question that was the owner's.

## What must not be lost

Each page is **committed as it arrives**, so a crawl interrupted at page 800 keeps 800 pages — the same reasoning the price side's job journal already follows.

A page that cannot be **stored** is recorded and skipped rather than raised, one level down from the walker's own rule about a page that cannot be **fetched**. The two are reported separately because a fetch failure is the site's or the network's, and a storage failure is ours.

## Verified — thirteen tests, all five mutations caught

| mutation | verdict |
|---|---|
| an unregistered site is quietly crawled at the default scope | **CAUGHT** |
| a page that cannot be stored ends the crawl | **CAUGHT** |
| the frontier is never declared | **CAUGHT** |
| `expect_requests` is reached for directly, as it once was | **CAUGHT** |
| the plan is built here instead of by `crawlscope` | **CAUGHT** (see below) |

**The last one survived the first pass, and the survival was correct.** Skipping `crawlscope.plan` still refuses a slice with no slice named — because the *walker* checks the scope again for itself, and that duplication is deliberate.

What the duplication does **not** protect is the **number**. Only `plan` knows a slice crawl costs `listing + slice` rather than `listing + every detail page`. So a test now asserts the declared frontier is **3 and not 4**. Get that number from anywhere else and the progress bar counts to a total the crawl will never reach — which is the bar running backwards that GPP refuses to ship a denominator for at all.

No network in any test: the fetch is a dict lookup.

## Not in this PR

Still no live crawl and no contractor in the database. This makes the crawl *possible*; running one, registering the dataset and approving the fields are the steps after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)