### PR TITLE
The declared frontier was half the crawl, and only running it found that

### DIFF
--- a/scrapex/sites/muqawil.py
+++ b/scrapex/sites/muqawil.py
@@ -107,6 +107,20 @@ class MuqawilPageSource:
         self._last_page = last_page
         self._locales = tuple(locales)
 
+    @property
+    def listing_requests(self) -> int:
+        """How many requests `listing_urls` will actually make.
+
+        NOT the page count, and the difference cost a wrong progress bar on the
+        first live run: 865 pages in two locales is 1,730 requests, and a caller
+        that passed the page count to `crawlscope.plan` declared a frontier of
+        half the crawl. The bar would have reached its total at the half-way
+        point and sat there for fifteen minutes.
+
+        It lives here because only the site knows it fetches each page twice.
+        """
+        return self._last_page * len(self._locales)
+
     def listing_urls(self, base_url: str) -> Iterable[str]:
         """Every listing page, in both locales, page by page rather than locale
         by locale.

--- a/tests/test_muqawil_pagesource.py
+++ b/tests/test_muqawil_pagesource.py
@@ -94,6 +94,17 @@ def test_both_locales_are_walked_page_by_page_and_not_locale_by_locale(source):
     assert len(urls) == 6, "three pages in both locales is six requests"
 
 
+def test_the_request_count_is_the_pages_times_the_locales(source):
+    """FOUND BY THE FIRST LIVE RUN. The plan reported 865 requests for a crawl
+    that makes 1,730, because each page is fetched in both languages — so the
+    progress bar would have reached its total half way through and sat there.
+
+    The count belongs to the SITE because only the site knows it fetches each
+    page twice; a caller passing `last_page` cannot know that."""
+    assert source.listing_requests == 6, "three pages in two locales"
+    assert source.listing_requests == len(list(source.listing_urls("https://x")))
+
+
 def test_a_trailing_slash_on_the_base_url_does_not_double(source):
     assert next(iter(source.listing_urls("https://muqawil.org/"))) == \
         "https://muqawil.org/en/contractors?page=1"


### PR DESCRIPTION
**Found by the first live run**, six pages into muqawil.org.

The plan reported **865 requests** for a crawl that makes **1,730**. `listing_urls` yields each page in *both* locales, so the page count and the request count are not the same number. A caller handing `crawlscope.plan` the page count declares a frontier of half the crawl — the progress bar reaches its total at the half-way point and then sits there for fifteen minutes while the crawl carries on.

**Nothing static could have caught it.** Every test passed. The walker was correct. `plan` was correct. The number handed to them was wrong.

## Where the fix belongs

`listing_requests` is a property of the **site**, because only the site knows it fetches each page twice. A caller holding `last_page` cannot know that — and the next site that walks a single locale will answer differently without anyone editing a caller.

## Measured after the fix, against the live site

```
last_page          = 865
listing_requests   = 1,730
plan declares      = 1,730 requests, 0.48 h at 1 req/s
```

which is the crawl that actually happens.

Seventeen tests in `test_muqawil_pagesource.py`, and the new one asserts the property against the generator it describes rather than against a constant — so the two cannot drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)