### PR TITLE
A governor that learns each server, because muqawil said it was hurting without refusing

### DIFF
--- a/scrapex/pacegovernor.py
+++ b/scrapex/pacegovernor.py
@@ -1,0 +1,196 @@
+"""How hard to press one server, learned from how that server answers.
+
+WHAT THIS IS NOT. It is not a way past anything. `HttpFetcher`'s own doctrine
+already names what this project refuses — "user-agent rotation, proxy rotation,
+header spoofing, CAPTCHA handling … those evade a decision the site has made" —
+and that line holds here. This governor only ever makes a crawl *gentler* than
+its ceiling; it cannot raise one above what the owner allowed, and every signal
+it reads is one the server chose to send.
+
+WHY IT EXISTS. Measured on muqawil.org, 2026-08-16: a page costs 5.84s, of which
+**5.69s is the server thinking** and 0.51s is the wire. Compression is already
+on, HTTP/2 changed nothing, and there is no `ETag` — so nothing client-side
+touches the cost. The one lever that moved it was concurrency: four in flight
+took 9.5s where four in series took 26.4s, a 2.8x gain with every answer a 200.
+
+AND THE PRICE WAS VISIBLE IN THE SAME MEASUREMENT. Per-request latency rose from
+~6.6s to ~9.2s under those four — a 40% rise. The server never refused, never
+sent 429, never closed a connection. It just got slower. **That is a server
+saying it is hurting in the only language it has**, and a crawler that waits for
+a 429 before easing off has ignored the polite warning to wait for the rude one.
+
+SO THE RULE IS AIMD, which is what TCP does about exactly this problem:
+
+    additive increase       one more in flight, only after a clean, quiet run
+    multiplicative decrease HALVE, at the first sign of strain
+
+Slow to take, quick to give back. The asymmetry is the whole algorithm: the cost
+of being one too gentle is a longer crawl, and the cost of being one too greedy
+is somebody else's website.
+
+THE BASELINE IS MEASURED UNCONTENDED, and this is the subtle part. If the
+baseline were a rolling average of every request, it would rise as concurrency
+rose, the comparison would always find "normal", and the latency signal would
+never fire once. So the baseline is only ever learned at a concurrency of ONE —
+the uncontended truth about this server — and everything else is compared
+against it.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+
+class Strain(StrEnum):
+    """Why the governor eased off, so a report can say which it was."""
+
+    NONE = "none"
+    #: 429 or 503 — the server said so in words.
+    REFUSED = "refused"
+    #: `Retry-After` — it also named its price.
+    TOLD_TO_WAIT = "told-to-wait"
+    #: No refusal, just slower. The polite warning.
+    SLOWED = "slowed"
+    #: The connection failed outright.
+    BROKE = "broke"
+
+
+@dataclass(frozen=True)
+class Answer:
+    """One completed request, as the governor needs to see it.
+
+    Deliberately not an `httpx.Response`: this module must stay testable without
+    a network, and a governor that knew about HTTP would be a governor nobody
+    could prove the behaviour of.
+    """
+
+    latency_s: float
+    status: int | None = None
+    retry_after_s: float | None = None
+    failed: bool = False
+
+
+@dataclass
+class HostPace:
+    """What has been learned about one host. One per host, never shared."""
+
+    #: How many requests may be in flight. Starts at one: nothing is assumed
+    #: about a server nobody has met.
+    concurrency: int = 1
+    #: The uncontended latency, learned at concurrency 1 and only there.
+    baseline_s: float = 0.0
+    #: Clean answers in a row at the current width.
+    clean_run: int = 0
+    #: Requests still to pass before another increase may be considered.
+    cooldown: int = 0
+    #: Seconds the server explicitly asked to be left alone for.
+    owed_wait_s: float = 0.0
+    last_strain: Strain = Strain.NONE
+    #: Every easing, for the report: (from, to, why).
+    eased: list[tuple[int, int, Strain]] = field(default_factory=list)
+
+
+class PaceGovernor:
+    """One governor for a whole crawl; one `HostPace` for each host in it."""
+
+    def __init__(self, *, ceiling: int = 4, floor: int = 1,
+                 clean_before_widening: int = 8,
+                 slowdown_factor: float = 1.4,
+                 cooldown_after_easing: int = 12) -> None:
+        """`ceiling` is the OWNER'S limit and the governor never exceeds it.
+
+        `slowdown_factor` of 1.4 comes from the muqawil measurement: four in
+        flight cost 40% more per request. Set at exactly the rise that was
+        observed to hurt, so the governor eases at the point the evidence says
+        it should — not at a number chosen because it looked round.
+        """
+        if floor < 1:
+            raise ValueError("a floor below one request in flight is a stopped crawl")
+        if ceiling < floor:
+            raise ValueError(f"ceiling {ceiling} is below floor {floor}")
+        self._ceiling = ceiling
+        self._floor = floor
+        self._clean_before_widening = clean_before_widening
+        self._slowdown_factor = slowdown_factor
+        self._cooldown_after_easing = cooldown_after_easing
+        self._hosts: dict[str, HostPace] = {}
+
+    def pace_for(self, host: str) -> HostPace:
+        """This host's learned state, created at the floor if it is new."""
+        return self._hosts.setdefault(
+            host, HostPace(concurrency=self._floor))
+
+    def concurrency(self, host: str) -> int:
+        return self.pace_for(host).concurrency
+
+    def owed_wait_s(self, host: str) -> float:
+        """Seconds this host asked to be left alone for, and paid once.
+
+        Read-and-clear, because a `Retry-After` is a debt discharged by waiting
+        it out. Leaving it set would make every later request pay it again.
+        """
+        pace = self.pace_for(host)
+        owed, pace.owed_wait_s = pace.owed_wait_s, 0.0
+        return owed
+
+    def record(self, host: str, answer: Answer) -> Strain:
+        """Take one answer and adjust. Returns what it made of it."""
+        pace = self.pace_for(host)
+        strain = self._strain(pace, answer)
+        pace.last_strain = strain
+
+        if strain is not Strain.NONE:
+            self._ease(pace, strain, answer)
+            return strain
+
+        # LEARNED ONLY AT ONE IN FLIGHT. See the module docstring: a baseline
+        # that moved with the load could never detect the load.
+        if pace.concurrency == self._floor and answer.latency_s > 0:
+            pace.baseline_s = (answer.latency_s if not pace.baseline_s
+                               else (pace.baseline_s * 3 + answer.latency_s) / 4)
+
+        if pace.cooldown > 0:
+            pace.cooldown -= 1
+            return strain
+
+        pace.clean_run += 1
+        if (pace.clean_run >= self._clean_before_widening
+                and pace.concurrency < self._ceiling):
+            pace.concurrency += 1
+            pace.clean_run = 0
+        return strain
+
+    # -- what counts as the server saying "enough" -----------------------------
+
+    def _strain(self, pace: HostPace, answer: Answer) -> Strain:
+        if answer.retry_after_s:
+            return Strain.TOLD_TO_WAIT
+        if answer.failed:
+            return Strain.BROKE
+        if answer.status in (429, 503):
+            return Strain.REFUSED
+        # THE POLITE WARNING, and the only signal here that is not an error.
+        # Needs a baseline to compare against, and there is none until the
+        # governor has run at one in flight — so a crawl that starts wide by
+        # configuration never gets this signal, which is a reason not to.
+        if (pace.baseline_s > 0
+                and answer.latency_s > pace.baseline_s * self._slowdown_factor):
+            return Strain.SLOWED
+        return Strain.NONE
+
+    def _ease(self, pace: HostPace, strain: Strain, answer: Answer) -> None:
+        """Halve, and remember why.
+
+        HALVED RATHER THAN DECREMENTED. Stepping down by one from four to three
+        keeps three quarters of the pressure that just caused this, and on a
+        server already struggling that is another two rounds of strain before it
+        gets relief. Multiplicative decrease is how the algorithm apologises.
+        """
+        was = pace.concurrency
+        pace.concurrency = max(self._floor, pace.concurrency // 2)
+        pace.clean_run = 0
+        pace.cooldown = self._cooldown_after_easing
+        if answer.retry_after_s:
+            pace.owed_wait_s = max(pace.owed_wait_s, answer.retry_after_s)
+        if pace.concurrency != was:
+            pace.eased.append((was, pace.concurrency, strain))

--- a/tests/test_a_governor_that_learns_each_server.py
+++ b/tests/test_a_governor_that_learns_each_server.py
@@ -1,0 +1,253 @@
+"""How hard to press one server, learned from how that server answers.
+
+WHY THE LATENCY SIGNAL IS THE POINT OF THIS FILE. Measured on muqawil.org,
+2026-08-16: four requests in flight cost 9.5s where four in series cost 26.4s —
+a 2.8x gain, every answer a 200. And in the same measurement, per-request
+latency rose from ~6.6s to ~9.2s. The server never refused, never sent 429,
+never closed a connection. It just got slower.
+
+That is a server saying it is hurting in the only language it has, and a crawler
+that waits for a 429 before easing off has ignored the polite warning in order
+to wait for the rude one. Half these tests are about hearing the polite one.
+
+No network, no clock, no sleeping: the governor takes answers as data.
+"""
+from __future__ import annotations
+
+import pytest
+
+from scrapex.pacegovernor import Answer, PaceGovernor, Strain
+
+HOST = "muqawil.org"
+
+
+def clean(latency_s: float = 6.0) -> Answer:
+    return Answer(latency_s=latency_s, status=200)
+
+
+def settle(governor: PaceGovernor, host: str = HOST, *, at: float = 6.0,
+           rounds: int = 40) -> None:
+    """Feed clean answers until the governor has widened as far as it will."""
+    for _ in range(rounds):
+        governor.record(host, clean(at))
+
+
+# ---- it starts by assuming nothing -------------------------------------------
+
+def test_a_server_nobody_has_met_gets_one_request_at_a_time():
+    """Starting wide would press an unknown server hardest at the moment least
+    is known about it — and would also destroy the baseline, which can only be
+    learned uncontended."""
+    assert PaceGovernor().concurrency("a-site-never-seen.test") == 1
+
+
+def test_it_widens_only_after_a_run_of_clean_answers():
+    governor = PaceGovernor(ceiling=4, clean_before_widening=8)
+
+    for _ in range(7):
+        governor.record(HOST, clean())
+    assert governor.concurrency(HOST) == 1, "widened before it had earned it"
+
+    governor.record(HOST, clean())
+    assert governor.concurrency(HOST) == 2
+
+
+def test_it_never_goes_past_the_ceiling_the_owner_set():
+    """The ceiling is the owner's decision about his relationship with a site.
+    Nothing the server does may talk the governor above it."""
+    governor = PaceGovernor(ceiling=3, clean_before_widening=2)
+    settle(governor)
+
+    assert governor.concurrency(HOST) == 3
+
+
+# ---- the polite warning, which is the reason this file exists ----------------
+
+def test_a_server_that_only_got_slower_is_heard():
+    """No refusal, no 429, no broken connection — just 40% more latency, which
+    is exactly what muqawil did under four in flight."""
+    governor = PaceGovernor(ceiling=8, clean_before_widening=2, slowdown_factor=1.4)
+    settle(governor, at=6.0)
+    was = governor.concurrency(HOST)
+    assert was > 1, "the run never widened, so there is nothing to ease"
+
+    strain = governor.record(HOST, Answer(latency_s=9.2, status=200))
+
+    assert strain is Strain.SLOWED
+    assert governor.concurrency(HOST) == was // 2
+
+
+def test_a_slowdown_within_the_normal_spread_is_not_a_signal():
+    """Servers vary. Easing on every wobble would ratchet a crawl down to one
+    and keep it there, which is a crawl that never finishes rather than a polite
+    one."""
+    governor = PaceGovernor(ceiling=8, clean_before_widening=2, slowdown_factor=1.4)
+    settle(governor, at=6.0)
+    was = governor.concurrency(HOST)
+
+    assert governor.record(HOST, Answer(latency_s=8.0, status=200)) is Strain.NONE
+    assert governor.concurrency(HOST) == was
+
+
+def test_the_baseline_is_learned_uncontended_and_never_drifts_up_with_the_load():
+    """THE SUBTLE ONE, AND THE TEST FOR IT HAD TO BE BUILT TWICE.
+
+    A baseline averaged over every request would rise as concurrency rose, the
+    comparison would always find "normal", and the latency signal would never
+    fire again in the life of the crawl.
+
+    The first version of this test fed obviously-slow answers and proved
+    nothing: a slow answer is classified as strain and returns BEFORE the
+    baseline is touched, so the drift it was written to catch was unreachable.
+
+    The drift only happens through answers that are slower but still CLEAN —
+    inside the tolerated band. So this widens, feeds a long run at 1.3x (below
+    the 1.4 threshold, so never strain), and then asks whether a genuinely slow
+    answer is still recognised. With a drifting baseline it would not be: 8.4s
+    would have become the new normal and 9.0s would read as fine.
+    """
+    governor = PaceGovernor(ceiling=8, clean_before_widening=2, slowdown_factor=1.4)
+
+    for _ in range(6):
+        governor.record(HOST, clean(6.0))
+    baseline = governor.pace_for(HOST).baseline_s
+    assert governor.concurrency(HOST) > 1, "it never widened, so nothing can drift"
+
+    # Acceptably slower, over and over. Never strain, so never an early return.
+    for _ in range(20):
+        assert governor.record(HOST, clean(7.8)) is Strain.NONE
+
+    assert governor.pace_for(HOST).baseline_s == pytest.approx(baseline, rel=0.01), (
+        "the baseline moved with the load, so the load can never be detected")
+    assert governor.record(HOST, clean(9.0)) is Strain.SLOWED, (
+        "a 50% slowdown went unheard — the baseline had crept up behind it")
+
+
+# ---- the rude warnings -------------------------------------------------------
+
+@pytest.mark.parametrize("status, why", [(429, Strain.REFUSED), (503, Strain.REFUSED)])
+def test_a_refusal_halves_it(status, why):
+    governor = PaceGovernor(ceiling=8, clean_before_widening=2)
+    settle(governor)
+    was = governor.concurrency(HOST)
+
+    assert governor.record(HOST, Answer(latency_s=1.0, status=status)) is why
+    assert governor.concurrency(HOST) == was // 2
+
+
+def test_a_broken_connection_is_strain_and_not_merely_a_failure():
+    governor = PaceGovernor(ceiling=8, clean_before_widening=2)
+    settle(governor)
+    was = governor.concurrency(HOST)
+
+    assert governor.record(HOST, Answer(latency_s=0.0, failed=True)) is Strain.BROKE
+    assert governor.concurrency(HOST) == was // 2
+
+
+def test_it_halves_rather_than_stepping_down_by_one():
+    """Stepping four down to three keeps three quarters of the pressure that
+    just caused the strain, and on a server already struggling that is two more
+    rounds of it before any relief. Multiplicative decrease is the apology."""
+    governor = PaceGovernor(ceiling=8, clean_before_widening=1)
+    settle(governor)
+    assert governor.concurrency(HOST) == 8
+
+    governor.record(HOST, Answer(latency_s=1.0, status=429))
+    assert governor.concurrency(HOST) == 4, "stepped down by one instead of halving"
+
+
+def test_it_never_eases_below_the_floor():
+    governor = PaceGovernor(ceiling=4, floor=1)
+
+    for _ in range(10):
+        governor.record(HOST, Answer(latency_s=1.0, status=429))
+
+    assert governor.concurrency(HOST) == 1, "a floor of zero is a stopped crawl"
+
+
+# ---- Retry-After, which is the server naming its own price -------------------
+
+def test_a_named_wait_is_owed_and_paid_once():
+    governor = PaceGovernor()
+
+    governor.record(HOST, Answer(latency_s=1.0, status=429, retry_after_s=30.0))
+
+    assert governor.owed_wait_s(HOST) == 30.0
+    assert governor.owed_wait_s(HOST) == 0.0, (
+        "the debt was charged twice — a Retry-After is discharged by waiting it "
+        "out once, not by every request after it")
+
+
+def test_the_longest_named_wait_wins_when_two_arrive():
+    governor = PaceGovernor()
+
+    governor.record(HOST, Answer(latency_s=1.0, status=429, retry_after_s=10.0))
+    governor.record(HOST, Answer(latency_s=1.0, status=429, retry_after_s=60.0))
+
+    assert governor.owed_wait_s(HOST) == 60.0
+
+
+# ---- recovery, and not oscillating -------------------------------------------
+
+def test_it_does_not_widen_again_the_moment_after_it_eased():
+    """Without a cooldown the governor oscillates: ease, widen, ease, widen —
+    pressing hardest exactly when the server is least able to take it."""
+    governor = PaceGovernor(ceiling=8, clean_before_widening=2,
+                            cooldown_after_easing=12)
+    settle(governor)
+    governor.record(HOST, Answer(latency_s=1.0, status=429))
+    eased_to = governor.concurrency(HOST)
+
+    for _ in range(11):
+        governor.record(HOST, clean())
+    assert governor.concurrency(HOST) == eased_to, "widened during the cooldown"
+
+
+def test_it_does_recover_once_the_server_has_been_quiet_for_a_while():
+    """A governor that only ever eased would end every long crawl at one."""
+    governor = PaceGovernor(ceiling=8, clean_before_widening=2,
+                            cooldown_after_easing=4)
+    settle(governor)
+    governor.record(HOST, Answer(latency_s=1.0, status=429))
+    eased_to = governor.concurrency(HOST)
+
+    settle(governor)
+    assert governor.concurrency(HOST) > eased_to
+
+
+# ---- one host's lesson is not another's --------------------------------------
+
+def test_what_was_learned_about_one_server_is_not_applied_to_another():
+    """muqawil taking five seconds a page says nothing about alsweed, and a
+    429 from one must not throttle a crawl of the other."""
+    governor = PaceGovernor(ceiling=4, clean_before_widening=2)
+    settle(governor, "muqawil.org")
+    settle(governor, "alsweed.sa")
+    assert governor.concurrency("alsweed.sa") == 4
+
+    governor.record("muqawil.org", Answer(latency_s=1.0, status=429))
+
+    assert governor.concurrency("muqawil.org") == 2
+    assert governor.concurrency("alsweed.sa") == 4, "one site's 429 throttled another"
+
+
+# ---- what it refuses to be built as ------------------------------------------
+
+def test_a_floor_below_one_is_refused():
+    with pytest.raises(ValueError, match="stopped crawl"):
+        PaceGovernor(floor=0)
+
+
+def test_a_ceiling_below_the_floor_is_refused():
+    with pytest.raises(ValueError, match="below floor"):
+        PaceGovernor(ceiling=1, floor=2)
+
+
+def test_every_easing_is_remembered_so_a_report_can_say_what_happened():
+    """A crawl that quietly ran at one for nine hours because of a 429 in
+    minute two is a crawl whose duration nobody can explain afterwards."""
+    governor = PaceGovernor(ceiling=8, clean_before_widening=1)
+    settle(governor)
+    governor.record(HOST, Answer(latency_s=1.0, status=429, retry_after_s=5.0))
+
+    assert governor.pace_for(HOST).eased == [(8, 4, Strain.TOLD_TO_WAIT)]


### PR DESCRIPTION
## What this is not, first, because the boundary is the design

`HttpFetcher`'s own doctrine already names what this project refuses:

> Deliberately NOT here: user-agent rotation, proxy rotation, header spoofing, CAPTCHA handling. **Those evade a decision the site has made.**

That line holds. This governor only ever makes a crawl **gentler** than its ceiling. It cannot raise one above what the owner allowed, and every signal it reads is one the server chose to send.

## Why it exists — measured, not reasoned

On muqawil.org, 2026-08-16:

```
page cost      5.84 s
  server think 5.69 s   ← 92%
  the wire     0.51 s
Content-Encoding: gzip  (already on)
HTTP/2:  negotiated, no faster
ETag:    NONE           (no cheap re-crawl, ever)
```

Nothing client-side touches that. **The one lever that moved it was concurrency**: four in flight took **9.5 s** where four in series took **26.4 s** — a 2.8× gain, every answer a 200.

### And the price was in the same measurement

Per-request latency rose from **~6.6 s to ~9.2 s** under those four. **40%.** The server never refused, never sent 429, never closed a connection. It just got slower.

That is a server saying it is hurting in the only language it has — and a crawler that waits for a 429 before easing off has ignored the polite warning in order to wait for the rude one.

`slowdown_factor` defaults to **1.4** because that is the rise that was observed to hurt. Not a number chosen for looking round.

## AIMD, which is what TCP does about exactly this problem

| | |
|---|---|
| **additive increase** | one more in flight, only after a clean run |
| **multiplicative decrease** | **halved**, at the first sign of strain |

Slow to take, quick to give back. The asymmetry *is* the algorithm: being one too gentle costs a longer crawl; being one too greedy costs somebody else's website.

Halved rather than decremented, because stepping four down to three keeps three quarters of the pressure that just caused the strain.

**Four signals**, one of them not an error: `429`/`503`, `Retry-After`, a broken connection — and a latency rise past the baseline.

## The baseline is learned uncontended

At a concurrency of **one**, and only there. A baseline averaged over every request would rise as concurrency rose, the comparison would always find *"normal"*, and the latency signal would never fire again in the life of the crawl.

## Per host

muqawil taking five seconds a page says nothing about alsweed, and a 429 from one cannot throttle a crawl of the other. Every easing is remembered with its reason — a crawl that quietly ran at one for nine hours after a 429 in minute two is a crawl whose duration nobody can explain afterwards.

## Verified — nineteen tests, all seven mutations caught

| mutation | verdict |
|---|---|
| the baseline follows the load | **CAUGHT** (see below) |
| step down by one instead of halving | **CAUGHT** |
| a slower server is not heard at all | **CAUGHT** |
| drop the cooldown, so it oscillates | **CAUGHT** |
| charge a named wait to every later request | **CAUGHT** |
| hosts share one state | **CAUGHT** |
| ignore the owner's ceiling | **CAUGHT** |

**The baseline one survived the first pass because the *test* was wrong** — the third time today. It fed obviously-slow answers, which are classified as strain and **return before the baseline is touched**, so the drift it was written to catch was unreachable. The drift only happens through answers that are slower but still *clean*, inside the tolerated band. The test now feeds twenty at 1.3× and then asks whether a genuine 1.5× is still heard.

No network, no clock, no sleeping: the governor takes answers as data, which is what makes any of this provable.

## Not in this PR

Nothing calls it yet. `HttpFetcher` is still serial and `PageWalker` still fetches one page at a time — wiring the governor into them is the next step, and it is the step that changes how the crawler behaves rather than what it knows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)