### PR TITLE
Cards become a candidate the approval path already knows, and one key could never have matched

### DIFF
--- a/scrapex/extract/muqawil.py
+++ b/scrapex/extract/muqawil.py
@@ -38,6 +38,14 @@ from dataclasses import dataclass, field
 
 from bs4 import BeautifulSoup, Tag
 
+from .html_table import InferredField, TableCandidate
+from .models import MAX_TABLE_ROWS
+
+#: Where a card sits, in the same shape `html_table.py` writes for a `<table>`
+#: (`table#id::row(1)`). It is stored on every record as `source_locator`, so it
+#: has to name something a person could go and look at.
+_LOCATOR = "div.section-card"
+
 #: `label -> field_key`, in the page's own order. English only, on purpose —
 #: see the module docstring. A label this map does not know is KEPT, under a
 #: slug of its own, rather than dropped: a field the site adds is news, and a
@@ -218,6 +226,73 @@ def read_listing(html: str) -> list[dict[str, str]]:
             row[f"card_{_slug(name)}"] = value
         rows.append(row)
     return rows
+
+
+def listing_candidate(html: str, *, table_index: int = 0) -> TableCandidate:
+    """The cards on one listing page, in the shape the approval path already speaks.
+
+    THE MISSING LINK, AND IT IS AN ADAPTER RATHER THAN A SECOND PIPELINE.
+    `approve_candidate` and everything under it — `_validated_rows`,
+    `_schema_payload`, `_ensure_schema`, the upsert, the revision, the
+    idempotent replay — are written against `TableCandidate`. They have nothing
+    to do with `<table>`; only the DETECTION does. A muqawil listing page holds
+    ZERO `<table>` elements, so detection finds nothing — but the cards are rows
+    with named columns, which is all a candidate has ever been.
+
+    So this converts, and not one line of the storage half changes. The
+    alternative — a parallel path from cards to `generic_record` — would be a
+    second copy of the atomicity, the idempotency and the revision history, and
+    the two would drift on the first bug fixed in only one of them.
+
+    WHAT IS NOT CLAIMED HERE. Every field is typed `text`, and deliberately:
+    `html_table.py` infers types from a table's own values, and inference over
+    twenty rows of one page would guess `integer` for a rating that is `4.5` on
+    page two. The owner types the schema at approval, which is the step this
+    whole design exists to keep. Confidence is 1.0 because nothing was guessed.
+    """
+    rows = read_listing(html)
+    if not rows:
+        return TableCandidate(
+            table_index=table_index, name="contractors", locator=_LOCATOR,
+            fields=(), rows=(), confidence=0.0,
+            warnings=("No contractor cards on this page.",),
+            approvable=False, truncated=False)
+
+    # THE UNION, NOT THE FIRST ROW'S KEYS. A contractor with no rating carries
+    # no rating keys at all, so keying the schema off row one would drop a
+    # column for every contractor after it that happened to have one.
+    names: list[str] = []
+    for row in rows:
+        for key in row:
+            if key not in names:
+                names.append(key)
+
+    fields = tuple(
+        InferredField(
+            field_key=name, source_name=name, data_type="text",
+            nullable=any(not row.get(name) for row in rows),
+            position=position, confidence=1.0,
+            uniqueness=_uniqueness(rows, name),
+            null_fraction=sum(1 for row in rows if not row.get(name)) / len(rows),
+            identity_candidate=(name == "contractor_id"),
+        )
+        for position, name in enumerate(names)
+    )
+    return TableCandidate(
+        table_index=table_index, name="contractors", locator=_LOCATOR,
+        fields=fields,
+        # EVERY FIELD ON EVERY ROW, with absent ones as None rather than
+        # missing: `_validated_rows` walks the FIELD list, and a row that
+        # simply lacks a key would raise rather than record an empty cell.
+        rows=tuple({name: (row.get(name) or None) for name in names}
+                   for row in rows),
+        confidence=1.0, warnings=(), approvable=True,
+        truncated=len(rows) >= MAX_TABLE_ROWS)
+
+
+def _uniqueness(rows: list[dict[str, str]], name: str) -> float:
+    seen = {row.get(name) for row in rows if row.get(name)}
+    return len(seen) / len(rows) if rows else 0.0
 
 
 def merge_locales(english: Reading, arabic: Reading) -> dict[str, str]:

--- a/scrapex/extract/service.py
+++ b/scrapex/extract/service.py
@@ -313,11 +313,26 @@ def _dataset_public(conn: sqlite3.Connection, dataset_id: int) -> dict[str, Any]
 
 
 def approve_candidate(
-    conn: sqlite3.Connection, snapshot_id: int, approval: CandidateApproval
+    conn: sqlite3.Connection, snapshot_id: int, approval: CandidateApproval,
+    *, candidate: TableCandidate | None = None
 ) -> dict[str, Any]:
-    """Atomically turn one reviewed candidate into definitions and generic rows."""
+    """Atomically turn one reviewed candidate into definitions and generic rows.
+
+    `candidate` LETS A SITE SUPPLY ITS OWN, and everything below this line is
+    unchanged by it. Nothing in the storage half has anything to do with
+    `<table>` — only the DETECTION does — and a page can hold rows without
+    holding a table: muqawil.org's contractor listing has TWENTY rows and ZERO
+    `<table>` elements, so `detect_html_tables` finds nothing on it at all.
+
+    The alternative was a second path from such a page to `generic_record`, and
+    that would be a second copy of the atomicity, the idempotency and the
+    revision history — two copies that drift apart on the first bug fixed in
+    only one of them. `scrapex/extract/muqawil.py:listing_candidate` is the
+    first caller.
+    """
     snapshot = _snapshot_row(conn, snapshot_id)
-    candidate = _candidate(snapshot, approval.table_index)
+    if candidate is None:
+        candidate = _candidate(snapshot, approval.table_index)
     if not candidate.approvable:
         reason = candidate.warnings[0] if candidate.warnings else "The table is incomplete."
         raise CandidateNotApprovable(

--- a/scrapex/sites/muqawil.py
+++ b/scrapex/sites/muqawil.py
@@ -93,7 +93,14 @@ def _cards(page: FetchedPage) -> list:
 class MuqawilPageSource:
     """What muqawil.org knows about its own pages."""
 
-    site_key = "muqawil.org"
+    #: THE CATALOGUE'S KEY, NOT THE HOSTNAME, and the difference is not
+    #: cosmetic. `PageSource.site_key` is what `snapshotcrawl.read_scope` looks
+    #: up in `site_profile`, and rows get there through `catalog.register_site`,
+    #: whose `CatalogKey` is `^[a-z][a-z0-9_]{1,63}$` — no dots, no hyphens. A
+    #: `site_key` of "muqawil.org" can therefore never match a row that was
+    #: registered properly, and every crawl of it would raise SiteNotRegistered
+    #: while the row sat there under a name one character different.
+    site_key = "muqawil_org"
 
     def __init__(self, *, last_page: int, locales: Iterable[str] = LOCALES) -> None:
         """`last_page` is REQUIRED, and that is the point.

--- a/tests/test_a_contractor_reaches_generic_storage.py
+++ b/tests/test_a_contractor_reaches_generic_storage.py
@@ -1,0 +1,230 @@
+"""A contractor, all the way from a saved page into `generic_record`.
+
+THE SENTENCE THIS FILE MAKES TRUE. `scrapex/features.py` gates
+`generic_extraction` on *"an approved non-product extraction reaching generic
+storage"*, and that gate has been closed since the day it was written because
+nothing had ever done it. Every other test in this project's generic half proves
+one link; this one walks the whole chain:
+
+    a real muqawil listing page
+      -> save_snapshot          (evidence, unparsed)
+      -> listing_candidate      (cards, in the shape the approval path speaks)
+      -> approve_candidate      (the owner's schema, atomically)
+      -> generic_record         (a contractor, with a revision behind it)
+
+THE LINK THIS TESTS IS AN ADAPTER, NOT A SECOND PIPELINE. A muqawil listing has
+TWENTY rows and ZERO `<table>` elements, so `detect_html_tables` finds nothing on
+it. But nothing under `approve_candidate` cares about tables — only the
+detection does — so the cards are converted into a `TableCandidate` and every
+guarantee below it (atomicity, idempotent replay, revision history) is the one
+that was already tested, not a copy of it.
+
+The fixture is real, committed HTML. No network.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scrapex.databases import DatabaseRegistry, EngineDatabase
+from scrapex.extract import service
+from scrapex.extract.models import (
+    ApprovalField,
+    CandidateApproval,
+    SnapshotCreate,
+)
+from scrapex.extract.muqawil import listing_candidate, read_listing
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "muqawil"
+LISTING = (FIXTURES / "listing-en.html").read_text(encoding="utf-8")
+URL = "https://muqawil.org/en/contractors?page=1"
+
+
+@pytest.fixture()
+def conn(tmp_path: Path):
+    registry = DatabaseRegistry(EngineDatabase(tmp_path / "scrapex-engine.db"),
+                               pointer_file=tmp_path / "databases.json")
+    registry.initialize()
+    connection = registry.engine.connect()
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def approval_for(candidate, **overrides):
+    """The owner's answer: every detected field, typed, with the identity named."""
+    body = dict(
+        table_index=0,
+        site_key="muqawil_org",
+        site_display_name="Saudi Contractors Authority",
+        dataset_key="contractors",
+        dataset_name="Contractors",
+        fields=[ApprovalField(field_key=f.field_key, display_name=f.source_name,
+                              data_type="text",
+                              identity=(f.field_key == "contractor_id"))
+                for f in candidate.fields],
+    )
+    body.update(overrides)
+    return CandidateApproval(**body)
+
+
+def store(conn, html: str = LISTING, url: str = URL) -> int:
+    saved = service.save_snapshot(conn, SnapshotCreate(source_url=url,
+                                                       html_content=html))
+    return int(saved["page_snapshot_id"])
+
+
+def approve(conn, snapshot_id: int, html: str = LISTING):
+    candidate = listing_candidate(html)
+    return service.approve_candidate(conn, snapshot_id,
+                                     approval_for(candidate),
+                                     candidate=candidate)
+
+
+# ---- the chain, end to end ---------------------------------------------------
+
+def test_a_contractor_arrives_in_generic_storage(conn):
+    """THE GATE. `generic_extraction` is enabled only after this has happened."""
+    snapshot_id = store(conn)
+
+    result = approve(conn, snapshot_id)
+
+    stored = conn.execute(
+        "SELECT record_key, data_json FROM generic_record "
+        "ORDER BY generic_record_id").fetchall()
+    assert len(stored) == len(read_listing(LISTING)) == 4
+    assert result["recovered"] is False
+
+    first = dict(stored[0])
+    assert "Awared General Contracting Company" in first["data_json"]
+    assert "20008518" in first["data_json"]
+
+
+def test_the_record_key_is_stable_for_the_same_contractor(conn):
+    """THE KEY IS A DIGEST OF THE IDENTITY FIELDS, not the id itself — which is
+    how `_validated_rows` supports a composite identity without putting a value
+    in a key. What matters is not its spelling but that the SAME contractor
+    always lands on the SAME key: anything else and every crawl mints a second
+    row for a company that was already there.
+
+    Proved across two different pages rather than twice on one, because a key
+    that depended on position or on the page would pass the easy version.
+    """
+    first_page = store(conn)
+    approve(conn, first_page)
+    key = conn.execute(
+        "SELECT record_key FROM generic_record ORDER BY generic_record_id"
+    ).fetchone()[0]
+
+    # The same contractor, read from a page with different neighbours around it.
+    moved = LISTING.replace("<div class='container'>",
+                            "<div class='container'><p>a banner</p>")
+    again = store(conn, moved, url=URL + "&again=1")
+    service.approve_candidate(conn, again,
+                              approval_for(listing_candidate(moved)),
+                              candidate=listing_candidate(moved))
+
+    assert conn.execute("SELECT count(*) FROM generic_record").fetchone()[0] == 4, (
+        "the same four contractors became eight — the key is not stable")
+    assert conn.execute(
+        "SELECT count(*) FROM generic_record WHERE record_key = ?", (key,)
+    ).fetchone()[0] == 1
+
+
+def test_the_listing_holds_no_table_at_all_which_is_why_the_adapter_exists(conn):
+    """If detection could see these rows the adapter would be dead weight. It
+    cannot: the page is cards."""
+    from scrapex.extract.html_table import detect_html_tables
+
+    assert detect_html_tables(LISTING) == [], (
+        "the listing grew a <table>, so the reason this adapter exists has "
+        "changed and the decision should be revisited")
+
+
+def test_every_record_carries_a_revision_behind_it(conn):
+    """The revision is what makes "this contractor's grade changed on that date"
+    a claim rather than an opinion."""
+    approve(conn, store(conn))
+
+    revisions = conn.execute(
+        "SELECT count(*) FROM generic_record_revision").fetchone()[0]
+    assert revisions == 4
+
+
+def test_a_second_reading_of_the_same_page_is_recovered_and_not_duplicated(conn):
+    """Idempotent replay, inherited from `approve_candidate` rather than
+    rewritten — a lost response must not double every contractor."""
+    snapshot_id = store(conn)
+    first = approve(conn, snapshot_id)
+
+    second = approve(conn, snapshot_id)
+
+    assert second["recovered"] is True
+    assert second["dataset_definition_id"] == first["dataset_definition_id"]
+    assert conn.execute("SELECT count(*) FROM generic_record").fetchone()[0] == 4
+
+
+def test_the_site_and_the_dataset_are_registered_by_the_same_act(conn):
+    approve(conn, store(conn))
+
+    site = conn.execute("SELECT site_key, base_url FROM site_profile").fetchone()
+    assert site["site_key"] == "muqawil_org"
+    assert "muqawil.org" in site["base_url"]
+
+    dataset = conn.execute(
+        "SELECT dataset_key, dataset_kind FROM dataset_definition").fetchone()
+    assert dataset["dataset_key"] == "contractors"
+
+
+# ---- what the adapter must get right -----------------------------------------
+
+def test_the_schema_is_the_union_of_every_card_and_not_the_first_one():
+    """A contractor with no rating carries no rating keys. Keying the schema off
+    row one would drop a column for every contractor after it that had one."""
+    candidate = listing_candidate(LISTING)
+    keys = {f.field_key for f in candidate.fields}
+
+    assert "customer_rating_score" in keys
+    assert "contractor_id" in keys and "company_name" in keys
+    for row in candidate.rows:
+        assert set(row) == keys, (
+            "a row is missing a field the schema declares — `_validated_rows` "
+            "walks the field list and would raise rather than record a blank")
+
+
+def test_a_missing_value_is_None_and_not_an_absent_key():
+    candidate = listing_candidate(LISTING)
+    thin = [row for row in candidate.rows if row["customer_rating_score"] is None]
+
+    assert thin, "the fixture has no unrated contractor, so this proves nothing"
+    assert "customer_rating_score" in thin[0]
+
+
+def test_the_contractor_id_is_offered_as_the_identity():
+    """Not guessed by uniqueness — named. Two contractors can share a name, a
+    city and a membership level; only the id is theirs."""
+    candidate = listing_candidate(LISTING)
+    identity = [f.field_key for f in candidate.fields if f.identity_candidate]
+
+    assert identity == ["contractor_id"]
+
+
+def test_nothing_is_typed_beyond_text():
+    """`html_table.py` infers types from one page's values, and twenty rows
+    would type a rating `integer` because none of them happened to be 4.5. The
+    owner types the schema at approval; that step is the whole design."""
+    candidate = listing_candidate(LISTING)
+
+    assert {f.data_type for f in candidate.fields} == {"text"}
+
+
+def test_a_page_with_no_cards_is_refused_rather_than_approved_empty():
+    """An empty approval would register a dataset, write no rows, and report
+    success — a crawl of nothing, recorded as a crawl."""
+    candidate = listing_candidate("<html><body>nothing here</body></html>")
+
+    assert candidate.approvable is False
+    assert candidate.rows == ()
+    assert "No contractor cards" in candidate.warnings[0]

--- a/tests/test_muqawil_pagesource.py
+++ b/tests/test_muqawil_pagesource.py
@@ -13,6 +13,7 @@ a test that needs muqawil to be up is a test that fails on a train.
 """
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -52,7 +53,22 @@ def test_it_is_a_page_source_and_not_a_connector(source):
     comment. A generic source written against `SiteConnector` instead would
     compile, pass its own tests, and put nothing in the generic tables."""
     assert isinstance(source, PageSource)
-    assert source.site_key == "muqawil.org"
+
+
+def test_the_site_key_is_the_catalogue_s_and_not_the_hostname(source):
+    """IT READ `muqawil.org` UNTIL THE TWO HALVES WERE FIRST JOINED, and could
+    never have worked. `snapshotcrawl.read_scope` looks this up in
+    `site_profile`, and rows get there through `catalog.register_site`, whose
+    `CatalogKey` is `^[a-z][a-z0-9_]{1,63}$` — no dots, no hyphens.
+
+    So a hostname here means every crawl raises SiteNotRegistered while the row
+    sits in the table under a name one character different. Asserted against the
+    pattern itself rather than the literal, so the rule is what is pinned.
+    """
+    assert re.fullmatch(r"[a-z][a-z0-9_]{1,63}", source.site_key), (
+        f"{source.site_key!r} cannot be registered as a site_profile row, so "
+        "no crawl of it will ever find its scope")
+    assert source.site_key == "muqawil_org"
 
 
 # ---- how big the crawl is ----------------------------------------------------


### PR DESCRIPTION
## The missing link, and it is an adapter rather than a second pipeline

`approve_candidate` and everything under it — the atomicity, the idempotent replay, the revision history, `_validated_rows`, `_ensure_schema` — are written against `TableCandidate` and have **nothing to do with `<table>`**. Only the *detection* does.

A muqawil listing page holds **twenty rows and zero `<table>` elements**, so `detect_html_tables` finds nothing on it at all.

So `listing_candidate` converts the cards into the shape that path already speaks, and `approve_candidate` gains one optional argument:

```python
def approve_candidate(conn, snapshot_id, approval, *, candidate=None):
    if candidate is None:
        candidate = _candidate(snapshot, approval.table_index)
```

Not a line of the storage half changed. The alternative was a second route from cards to `generic_record` — a second copy of the atomicity, the idempotency and the revision history. **Two copies drift apart on the first bug fixed in only one of them.**

## What the adapter does not claim

**Every field is typed `text`, deliberately.** `html_table.py` infers a type from one page's values, and twenty rows would type a rating `integer` because none of them happened to be `4.5`. The owner types the schema at approval, and that step is the whole design.

**The schema is the union of every card's keys, not the first card's.** A contractor with no rating carries no rating keys, and keying off row one would drop a column for every contractor after it that had one.

## A defect that could never have worked

`MuqawilPageSource.site_key` read **`muqawil.org`** — merged, and wrong.

`snapshotcrawl.read_scope` looks that up in `site_profile`. Rows get there through `catalog.register_site`, whose `CatalogKey` is `^[a-z][a-z0-9_]{1,63}$` — **no dots, no hyphens**.

So every crawl would have raised `SiteNotRegistered` while the row sat in the table under a name one character different. **No unit test could have caught it**; only running the chain could, which is what this file does. The guard now asserts the *pattern* rather than the literal, so the rule is what is pinned.

## And one expectation of mine that was wrong

`record_key` is `_digest(_canonical(identity))`, not the contractor id — which is the **better** design: it supports a composite identity and puts no value in a key.

The test now proves what actually matters — that the same contractor lands on the same key when read from a page with different neighbours around it. Anything else and every crawl mints a second row for a company already there.

## Verified

**Eleven tests walking the whole chain:**

```
a real committed listing page
  → save_snapshot        (evidence, unparsed)
  → listing_candidate    (cards, in the shape the path speaks)
  → approve_candidate    (the owner's schema, atomically)
  → generic_record       (a contractor, with a revision behind it)
```

Plus a guard that the listing still holds **zero** `<table>` elements — if it ever grows one, the reason this adapter exists has changed and the decision should be revisited.

Full suite green with `SCRAPEX_FULL_MIGRATIONS=1`. `ruff check scrapex/` clean.

## What this unlocks

`scrapex/features.py` gates `generic_extraction` on *"enabled only after an approved non-product extraction reaches generic storage"* — and until now nothing had ever done it. **This is that extraction.**

Flipping the flag is deliberately not in this PR: it belongs with a real approval over the 11,059 contractors already crawled to disk, not with the code that makes one possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)