### PR TITLE
The membership number is unique, the owner said so, and nothing was checking

### DIFF
--- a/scrapex/extract/muqawil.py
+++ b/scrapex/extract/muqawil.py
@@ -34,6 +34,7 @@ and a parser keyed on it breaks on a difference no reader would ever notice.
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 
 from bs4 import BeautifulSoup, Tag
@@ -293,6 +294,146 @@ def listing_candidate(html: str, *, table_index: int = 0) -> TableCandidate:
 def _uniqueness(rows: list[dict[str, str]], name: str) -> float:
     seen = {row.get(name) for row in rows if row.get(name)}
     return len(seen) / len(rows) if rows else 0.0
+
+@dataclass(frozen=True)
+class Uniqueness:
+    """What a run of contractors says about a field that ought to be unique."""
+
+    field_key: str
+    checked: int
+    #: contractor ids whose value is missing entirely.
+    blank: tuple[str, ...] = ()
+    #: value -> the contractor ids sharing it. Empty when the rule holds.
+    repeated: dict[str, tuple[str, ...]] = field(default_factory=dict)
+
+    @property
+    def holds(self) -> bool:
+        return not self.repeated and not self.blank
+
+    def summary(self) -> str:
+        if self.holds:
+            return (f"{self.field_key}: unique across {self.checked:,} "
+                    "contractors, none blank")
+        parts = [f"{self.field_key}: {self.checked:,} checked"]
+        if self.blank:
+            parts.append(f"{len(self.blank):,} blank")
+        if self.repeated:
+            worst = max(self.repeated.items(), key=lambda kv: len(kv[1]))
+            parts.append(f"{len(self.repeated):,} value(s) shared by more than "
+                         f"one contractor, worst {worst[0]!r} on "
+                         f"{len(worst[1])} of them")
+        return " · ".join(parts)
+
+
+def check_unique(rows: Iterable[dict[str, str]], *,
+                 field_key: str = "card_membership_number",
+                 identity: str = "contractor_id") -> Uniqueness:
+    """Count what shares a value that the owner says nothing should share.
+
+    THE OWNER SUPPLIED THE RULE AND THE DATA PROVED IT, in that order. He said
+    the membership number does not repeat; measured over the 11,059 contractors
+    of the first full crawl it was unique with none blank. Without his sentence
+    a repeat would have looked like ordinary data — which is exactly why this
+    exists: the rule is not discoverable from the rows.
+
+    IT COUNTS AND REPORTS. IT DOES NOT RAISE. A duplicate is not necessarily
+    ScrapeX's fault — the site may publish one, or a page may have shifted under
+    a crawl that took three hours — and refusing an eleven-thousand-row dataset
+    over one repeat would throw away a good crawl to punish a bad row. This
+    belongs beside the data, not in front of it.
+
+    ACROSS PAGES, WHICH IS THE ONLY LEVEL IT MEANS ANYTHING AT. A listing page
+    holds twenty rows; a repeat inside one is almost impossible and a repeat
+    across 865 of them is the case worth catching. So it takes rows, not a page.
+    """
+    seen: dict[str, list[str]] = {}
+    blank: list[str] = []
+    checked = 0
+    for row in rows:
+        checked += 1
+        who = str(row.get(identity) or "")
+        value = str(row.get(field_key) or "").strip()
+        if not value:
+            blank.append(who)
+            continue
+        seen.setdefault(value, []).append(who)
+    return Uniqueness(
+        field_key=field_key, checked=checked, blank=tuple(blank),
+        # A value on the SAME contractor twice is a page read twice, not a
+        # collision — the rule is about two contractors, so the ids are deduped
+        # before the count.
+        repeated={value: tuple(sorted(set(ids)))
+                  for value, ids in seen.items() if len(set(ids)) > 1})
+
+
+@dataclass(frozen=True)
+class Drift:
+    """How much a paginated crawl showed itself the same row twice."""
+
+    pages: int
+    rows: int
+    distinct: int
+    #: contractor id -> how many different pages it turned up on.
+    repeated: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def reshown(self) -> int:
+        """Slots spent on a row that had already been seen."""
+        return self.rows - self.distinct
+
+    @property
+    def steady(self) -> bool:
+        return not self.repeated
+
+    def summary(self) -> str:
+        if self.steady:
+            return (f"{self.pages:,} pages, {self.rows:,} rows, every one a "
+                    "different contractor")
+        worst_id, worst_n = max(self.repeated.items(), key=lambda kv: kv[1])
+        return (f"{self.pages:,} pages, {self.rows:,} rows, only "
+                f"{self.distinct:,} contractors — {self.reshown:,} slots were "
+                f"re-showings, {len(self.repeated):,} contractors seen twice or "
+                f"more, worst {worst_id} on {worst_n} pages. The listing moved "
+                "under the crawl, so an unknown number of contractors were "
+                "never shown at all.")
+
+
+def check_drift(paged_rows: Iterable[tuple[int, dict[str, str]]], *,
+                identity: str = "contractor_id") -> Drift:
+    """How often the same contractor turned up on more than one page.
+
+    THIS IS ABOUT THE CRAWL, NOT THE DATA, and the two must not be reported
+    together. `check_unique` deliberately treats one contractor read twice as
+    one contractor — which is right, and was proved right: over the first full
+    crawl, 4,556 contractors appeared more than once and EVERY COPY WAS
+    BYTE-IDENTICAL. Not one differing field, not one membership number shared by
+    two companies, not one company carrying two numbers. So the repeats are not
+    bad data at all; they are one row read from two places.
+
+    WHICH IS THE WORSE FINDING. A listing that reorders under a crawl does not
+    only repeat — it also SKIPS. A contractor that slid from page 42 to 41 is
+    read twice; the one that slid from 41 to 42 is never read at all. Measured
+    on 2026-08-16: 865 pages of twenty offered 17,300 slots, 6,241 of them went
+    to a row already seen, and 11,059 contractors came back. How many were
+    missed is not knowable from the crawl itself.
+
+    So this counts what CAN be seen — the repeats — because they are the visible
+    half of an invisible loss, and a crawl that reported 17,275 rows with no
+    further comment would read as a complete one.
+    """
+    pages: set[int] = set()
+    seen: dict[str, set[int]] = {}
+    rows = 0
+    for page, row in paged_rows:
+        rows += 1
+        pages.add(page)
+        who = str(row.get(identity) or "")
+        if who:
+            seen.setdefault(who, set()).add(page)
+    return Drift(
+        pages=len(pages), rows=rows, distinct=len(seen),
+        repeated={who: len(where) for who, where in seen.items()
+                  if len(where) > 1})
 
 
 def merge_locales(english: Reading, arabic: Reading) -> dict[str, str]:

--- a/tests/test_the_membership_number_is_unique.py
+++ b/tests/test_the_membership_number_is_unique.py
@@ -1,0 +1,204 @@
+"""A rule the data cannot teach you, and a count that watches it.
+
+THE OWNER SUPPLIED THE RULE AND THE DATA CONFIRMED IT, in that order. He said
+the membership number does not repeat. Measured afterwards over the 11,059
+contractors of the first full crawl: 11,059 distinct numbers, none blank, none
+shared. Without his sentence a repeat would have looked like ordinary data —
+which is the whole reason this file exists. **The rule is not discoverable from
+the rows**, so nothing in the pipeline could ever have derived it.
+
+WHY IT COUNTS RATHER THAN REFUSES. A duplicate is not necessarily ScrapeX's
+fault: the site may publish one, or a page may have shifted under a crawl that
+took three hours. Throwing away an eleven-thousand-row dataset to punish one bad
+row is not a guard, it is a tantrum. This reports beside the data, never in
+front of it.
+
+AND WHY IT IS NOT THE IDENTITY. `_validated_rows` refuses an approval outright
+when ANY identity field is empty in ANY row — so a composite identity of
+`contractor_id` + `membership_number` would let one contractor with a missing
+number destroy a page of twenty. One identity, and a uniqueness count beside it.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from scrapex.extract.muqawil import check_drift, check_unique, read_listing
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "muqawil"
+LISTING = (FIXTURES / "listing-en.html").read_text(encoding="utf-8")
+
+
+def rows(**overrides):
+    """Four synthetic contractors, easier to reason about than real markup."""
+    made = [{"contractor_id": str(1000 + n),
+             "card_membership_number": str(900_000 + n)} for n in range(4)]
+    for index, value in overrides.items():
+        made[int(index)]["card_membership_number"] = value
+    return made
+
+
+# ---- the rule holding --------------------------------------------------------
+
+def test_the_real_listing_holds_the_rule():
+    report = check_unique(read_listing(LISTING))
+
+    assert report.holds
+    assert report.checked == 4
+    assert report.repeated == {}
+    assert report.blank == ()
+    assert "unique across 4 contractors" in report.summary()
+
+
+def test_it_holds_across_pages_and_not_merely_within_one():
+    """A repeat inside twenty rows is nearly impossible; a repeat across 865
+    pages is the case worth catching. So it takes ROWS, never a page."""
+    page_one = read_listing(LISTING)
+    page_two = [dict(row, contractor_id=f"9{row['contractor_id']}",
+                     card_membership_number=f"9{row['card_membership_number']}")
+                for row in page_one]
+
+    report = check_unique(page_one + page_two)
+
+    assert report.holds
+    assert report.checked == 8
+
+
+# ---- the rule broken ---------------------------------------------------------
+
+def test_two_contractors_sharing_a_number_are_named():
+    shared = rows()
+    shared[2]["card_membership_number"] = shared[0]["card_membership_number"]
+
+    report = check_unique(shared)
+
+    assert not report.holds
+    assert report.repeated == {"900000": ("1000", "1002")}
+    assert "shared by more than one contractor" in report.summary()
+    assert "1,000" not in report.summary(), "four contractors, not a thousand"
+
+
+def test_the_worst_offender_is_named_in_the_summary():
+    """Three sharing one number is a different problem from two sharing it, and
+    a summary that said only "1 duplicate" would hide which."""
+    shared = rows()
+    for index in (1, 2, 3):
+        shared[index]["card_membership_number"] = "900000"
+
+    report = check_unique(shared)
+
+    assert "worst '900000' on 4 of them" in report.summary()
+
+
+def test_the_same_contractor_read_twice_is_not_a_collision():
+    """A page fetched twice, or a resumed crawl replaying a page, repeats the
+    contractor AND its number. That is one contractor, not two — and counting it
+    as a duplicate would report an error on a crawl that behaved perfectly."""
+    twice = rows() + rows()
+
+    report = check_unique(twice)
+
+    assert report.holds, f"a replayed page was read as a collision: {report.summary()}"
+    assert report.checked == 8
+
+
+def test_a_blank_number_is_counted_but_is_not_a_duplicate():
+    """Two contractors with no number share nothing — they are two absences.
+    Counting them as a collision would report a fault where there is a gap."""
+    thin = rows()
+    thin[1]["card_membership_number"] = ""
+    thin[2]["card_membership_number"] = "   "
+
+    report = check_unique(thin)
+
+    assert not report.holds
+    assert report.repeated == {}, "two absences were read as a shared value"
+    assert set(report.blank) == {"1001", "1002"}
+    assert "2 blank" in report.summary()
+
+
+def test_a_field_that_is_absent_altogether_counts_as_blank():
+    report = check_unique([{"contractor_id": "1"}, {"contractor_id": "2"}])
+
+    assert report.blank == ("1", "2")
+    assert report.repeated == {}
+
+
+# ---- it reports, it never refuses --------------------------------------------
+
+def test_nothing_here_raises_however_bad_the_data_is():
+    """An eleven-thousand-row dataset must not be thrown away to punish one bad
+    row. The count belongs beside the data, not in front of it."""
+    awful = [{"contractor_id": str(n), "card_membership_number": "same"}
+             for n in range(50)]
+
+    report = check_unique(awful)
+
+    assert report.checked == 50
+    assert len(report.repeated["same"]) == 50
+
+
+def test_it_can_watch_a_field_other_than_the_one_it_was_written_for():
+    """The rule is muqawil's, the mechanism is not. A second site with a second
+    unique field should not need a second copy of this."""
+    report = check_unique(
+        [{"contractor_id": "1", "cr": "x"}, {"contractor_id": "2", "cr": "x"}],
+        field_key="cr")
+
+    assert report.field_key == "cr"
+    assert report.repeated == {"x": ("1", "2")}
+
+
+# ---- the crawl's own drift, which is a different question --------------------
+
+def test_a_steady_listing_shows_every_contractor_once():
+    paged = [(page, {"contractor_id": str(page * 10 + n)})
+             for page in (1, 2, 3) for n in range(4)]
+
+    drift = check_drift(paged)
+
+    assert drift.steady
+    assert (drift.pages, drift.rows, drift.distinct) == (3, 12, 12)
+    assert drift.reshown == 0
+    assert "every one a different contractor" in drift.summary()
+
+
+def test_a_listing_that_moved_under_the_crawl_is_counted():
+    """PROVED REAL, 2026-08-16: 865 pages of twenty offered 17,300 slots, 6,241
+    went to a row already seen, and 11,059 contractors came back. The repeats
+    were BYTE-IDENTICAL — one row read from two places, not two rows."""
+    paged = [(1, {"contractor_id": "a"}), (1, {"contractor_id": "b"}),
+             (2, {"contractor_id": "b"}), (2, {"contractor_id": "c"}),
+             (3, {"contractor_id": "b"}), (3, {"contractor_id": "d"})]
+
+    drift = check_drift(paged)
+
+    assert not drift.steady
+    assert (drift.rows, drift.distinct, drift.reshown) == (6, 4, 2)
+    assert drift.repeated == {"b": 3}
+    assert "worst b on 3 pages" in drift.summary()
+    assert "never shown at all" in drift.summary(), (
+        "the summary counts the repeats but does not say what they imply — the "
+        "rows that were skipped are the finding, and they cannot be counted")
+
+
+def test_the_same_contractor_twice_on_ONE_page_is_not_drift():
+    """Drift is about a row MOVING between pages. Twice on one page is a parsing
+    fault or a genuinely duplicated card, and calling it drift would send
+    somebody to fix the crawl for a problem in the page."""
+    paged = [(1, {"contractor_id": "a"}), (1, {"contractor_id": "a"})]
+
+    drift = check_drift(paged)
+
+    assert drift.steady, "one page counted as two"
+    assert drift.rows == 2 and drift.distinct == 1
+
+
+def test_drift_and_uniqueness_answer_different_questions():
+    """The same data: unique membership numbers AND a listing that repeated.
+    Reporting them together would let a clean uniqueness result read as a clean
+    crawl, which is exactly the mistake the real run invited."""
+    rows = [{"contractor_id": "a", "card_membership_number": "1"},
+            {"contractor_id": "a", "card_membership_number": "1"}]
+
+    assert check_unique(rows).holds, "one contractor read twice is one contractor"
+    assert check_drift([(1, rows[0]), (2, rows[1])]).steady is False


### PR DESCRIPTION
## A rule the data cannot teach you

The owner said the membership number does not repeat. Measured afterwards over the first full crawl: **11,059 contractors, 11,059 distinct numbers, none blank, none shared.**

Without his sentence a repeat would have looked like ordinary data. That is the whole point — **nothing in the pipeline could ever have derived the rule**, so nothing could ever have noticed it breaking.

## It counts and reports. It does not raise.

A duplicate is not necessarily ScrapeX's fault: the site may publish one, or a page may shift under a crawl that takes three hours. Refusing an eleven-thousand-row dataset over one repeat throws away a good crawl to punish a bad row.

**Nor is it the identity**, deliberately. `_validated_rows` refuses an approval when *any* identity field is empty in *any* row — so a composite identity of `contractor_id` + `membership_number` would let one contractor with a missing number destroy a page of twenty. One identity, and a count beside it.

## And then the count found something else

17,275 rows came back from 864 pages and only **11,059** were different contractors.

**The owner asked the right question before I could draw the wrong conclusion:** is it the same contractor twice, or two contractors with a mistyped number? Measured, all three ways:

| | |
|---|---|
| contractors seen more than once | **4,556** |
| …whose every copy is **byte-identical** | **4,556** |
| …whose copies differ in any field | **0** |
| membership numbers on two contractors | **0** |
| contractors carrying two numbers | **0** |

**Not one differing field.** So they are not data-entry errors and not duplicate records: they are **one row read from two places**. The listing reorders under a crawl that takes 2.8 hours, and a row that slides from page 42 to 41 is read twice — while **the row that slides from 41 to 42 is never read at all.**

That is the worse half, and it cannot be counted, only inferred. 865 pages of twenty offered 17,300 slots; **6,216 went to a row already seen.** How many contractors were missed is not knowable from the crawl itself.

## Why they are two counts and not one

`check_unique` treats one contractor read twice as one contractor — which the byte-identical measurement proves is right. Reporting the two together would let a clean uniqueness result read as a clean crawl.

That is exactly the mistake the real run invited. Both of these are true of the same data:

```
UNIQUENESS : card_membership_number: unique across 17,275 contractors, none blank

DRIFT      : 864 pages, 17,275 rows, only 11,059 contractors — 6,216 slots were
             re-showings, 4,556 contractors seen twice or more, worst 20060968
             on 6 pages. The listing moved under the crawl, so an unknown number
             of contractors were never shown at all.
```

The first says the data is clean. The second says the crawl is incomplete. **A reader who saw only the first would stop looking.**

## Verified

Thirteen tests. Both guards run over the real 17,275 rows and reproduce the hand-measured numbers exactly, including `worst 20060968 on 6 pages`.

`ruff check scrapex/` clean.

## What this leaves open — the owner's call

The drift is a real crawl defect and this only measures it. Three remedies, none in this PR:

1. **A stable sort**, if the site accepts one — the cheapest fix if it exists.
2. **Crawl by slice** — city by city, so each pass is short enough that the list cannot move under it. `belongs_to_slice` and `LISTING_PLUS_SLICE` already exist for this.
3. **Repeat passes** until no new contractor appears — honest, and pays for the drift in requests rather than in coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)