### PR TITLE
Passes until the names stop coming, because two other remedies were measured and died

### DIFF
--- a/scrapex/sweep.py
+++ b/scrapex/sweep.py
@@ -1,0 +1,138 @@
+"""Passing over a listing until the new names stop coming.
+
+WHY A LISTING HAS TO BE READ MORE THAN ONCE. Measured on muqawil.org
+2026-08-16: the same listing page is byte-stable for about thirty seconds and
+then exchanges four of its twenty rows. Over a crawl of 865 pages taking 2.8
+hours the effect is severe and one-sided — 17,275 rows came back and only
+**11,059 were different contractors**. 6,216 slots went to a row already seen.
+
+AND THE REPEATS ARE THE VISIBLE HALF OF AN INVISIBLE LOSS. A contractor that
+slides from page 42 to page 41 is read twice; the one that slides from 41 to 42
+is never read at all. All 4,556 repeats were byte-identical — not one differing
+field, not one membership number on two companies — so this is not bad data. It
+is one row read from two places, and the rows that were skipped left no trace.
+
+TWO REMEDIES WERE MEASURED AND SET ASIDE BEFORE THIS ONE WAS BUILT:
+
+  * A STABLE SORT. `sort`, `order`, `order_by`, `orderby`, `sort_by`,
+    `direction` and `sort_field` were each tried against the live listing and
+    NOT ONE changed the order. There is nothing to build.
+  * A SLICE. `region_id` and `city_id` ARE honoured over GET, and blind
+    pagination works under them — but a region is still hundreds of pages, so a
+    sliced pass does not finish inside the thirty-second window either. It
+    narrows the problem; it does not end it.
+
+So: pass again, and keep passing while new names keep arriving. It assumes
+nothing about the ordering, which is the only assumption this site has not
+already broken.
+
+WHAT "DRY" DOES NOT MEAN, and the owner named this himself: it does not mean the
+directory is complete. It means THIS RUN stopped finding names IT had not seen.
+The next run will legitimately find contractors that were registered since, and
+find changed data on ones it already had — that is the directory living, not the
+crawl failing. `generic_record.content_hash` and `generic_record_revision` are
+what carry that across runs; this module is only ever about one run's own
+convergence.
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Pass:
+    """One complete read of the listing."""
+
+    number: int
+    seen: int
+    #: Ids this pass produced that no earlier pass in this run had.
+    fresh: int
+
+    @property
+    def dry(self) -> bool:
+        return self.fresh == 0
+
+
+class Sweep:
+    """Passes over one listing, and when to stop making them."""
+
+    def __init__(self, *, dry_passes_before_stopping: int = 2,
+                 max_passes: int = 10) -> None:
+        """TWO DRY PASSES, NOT ONE, and the difference is not caution.
+
+        A single dry pass is ordinary luck on a list that reshuffles: the pass
+        can happen to revisit the same window twice and find nothing new while
+        a thousand contractors sit in a part of the ordering it did not reach.
+        Two in a row is a much weaker coincidence.
+
+        `max_passes` is a CEILING AND NOT A TARGET. A sweep that hits it has NOT
+        converged, and `converged` says so — a run that stopped counting is not
+        a run that finished, and the two must never print the same word.
+        """
+        if dry_passes_before_stopping < 1:
+            raise ValueError("a sweep that stops before a dry pass has not swept")
+        if max_passes < 1:
+            raise ValueError("a sweep of no passes reads nothing")
+        self._needed = dry_passes_before_stopping
+        self._max = max_passes
+        self._found: set[str] = set()
+        self._passes: list[Pass] = []
+        self._dry_streak = 0
+
+    def record(self, ids: Iterable[str]) -> Pass:
+        """Take one pass's ids and say what it added."""
+        before = len(self._found)
+        # `if one` BEFORE `str(one)`, and the order is the bug that was there
+        # first: `str(None)` is `"None"`, a perfectly non-empty string, so a
+        # parser that failed to find an id would have contributed a contractor
+        # called None to every pass — and it would have been the same one each
+        # time, so the sweep would have gone dry looking convergent.
+        self._found.update(str(one) for one in ids if one and str(one).strip())
+        made = Pass(number=len(self._passes) + 1,
+                    seen=len(self._found),
+                    fresh=len(self._found) - before)
+        self._passes.append(made)
+        # THE STREAK RESETS ON ANY FIND, never decrements. One new contractor
+        # after four dry passes means the list is still moving under us, and
+        # counting that as "three quarters done" would stop a sweep that had
+        # just proved it should not.
+        self._dry_streak = self._dry_streak + 1 if made.dry else 0
+        return made
+
+    @property
+    def keep_going(self) -> bool:
+        if len(self._passes) >= self._max:
+            return False
+        return self._dry_streak < self._needed
+
+    @property
+    def converged(self) -> bool:
+        """Dry for long enough — as opposed to merely stopped."""
+        return self._dry_streak >= self._needed
+
+    @property
+    def found(self) -> frozenset[str]:
+        return frozenset(self._found)
+
+    @property
+    def passes(self) -> tuple[Pass, ...]:
+        return tuple(self._passes)
+
+    def summary(self) -> str:
+        made = len(self._passes)
+        counts = " + ".join(str(one.fresh) for one in self._passes)
+        if not self._passes:
+            return "no passes made"
+        if self.converged:
+            return (f"{len(self._found):,} contractors after {made} passes "
+                    f"({counts} new) — {self._dry_streak} dry passes in a row, so "
+                    "this run has stopped finding names it had not seen. That is "
+                    "not the directory being complete: a later run will "
+                    "legitimately find contractors registered since, and changed "
+                    "data on ones it already had.")
+        return (f"{len(self._found):,} contractors after {made} passes "
+                f"({counts} new) — STOPPED AT THE CEILING, NOT CONVERGED. The "
+                f"last pass still brought {self._passes[-1].fresh:,} new names, "
+                "so an unknown number remain unseen. Raise max_passes or accept "
+                "a partial directory, but do not record this as complete.")

--- a/tests/test_passes_until_the_names_stop_coming.py
+++ b/tests/test_passes_until_the_names_stop_coming.py
@@ -1,0 +1,142 @@
+"""Passing over a listing until the new names stop coming.
+
+WHY THIS EXISTS, measured: muqawil's listing is byte-stable for about thirty
+seconds and then exchanges four of its twenty rows. A 2.8-hour crawl of 865
+pages returned 17,275 rows and only 11,059 different contractors — 6,216 slots
+spent on a row already seen, and an unknown number of rows never shown at all.
+
+The two other remedies were measured first and set aside: no ordering parameter
+is honoured (seven were tried), and a region slice is still hundreds of pages so
+it does not finish inside the window either.
+
+THE DISTINCTION THIS FILE GUARDS MOST CAREFULLY is the owner's own: a sweep that
+goes dry has not proved the directory complete. It has proved that THIS RUN
+stopped finding names IT had not seen. The next run will legitimately find new
+contractors and changed data, and a report that said "complete" would make that
+read as a fault.
+"""
+from __future__ import annotations
+
+import pytest
+
+from scrapex.sweep import Sweep
+
+
+def test_a_sweep_that_finds_nothing_new_twice_has_converged():
+    sweep = Sweep(dry_passes_before_stopping=2)
+
+    sweep.record(["a", "b", "c"])
+    assert sweep.keep_going, "stopped after one pass, having proved nothing"
+    sweep.record(["a", "b", "c"])
+    assert sweep.keep_going, "one dry pass is ordinary luck on a shuffling list"
+    sweep.record(["a", "b", "c"])
+
+    assert sweep.converged
+    assert not sweep.keep_going
+    assert sweep.found == {"a", "b", "c"}
+
+
+def test_each_pass_reports_only_what_it_added():
+    sweep = Sweep()
+
+    first = sweep.record(["a", "b"])
+    second = sweep.record(["b", "c", "d"])
+
+    assert (first.number, first.seen, first.fresh) == (1, 2, 2)
+    assert (second.number, second.seen, second.fresh) == (2, 4, 2)
+    assert not second.dry
+
+
+def test_one_new_name_after_four_dry_passes_resets_the_streak():
+    """THE STREAK RESETS, IT NEVER DECREMENTS. A new contractor after four quiet
+    passes means the list is still moving underneath, and treating that as
+    "three quarters done" would stop a sweep that had just proved it should
+    not."""
+    sweep = Sweep(dry_passes_before_stopping=2, max_passes=20)
+    sweep.record(["a"])
+    for _ in range(4):
+        sweep.record(["a"])
+    assert sweep.converged
+
+    sweep.record(["a", "b"])
+
+    assert not sweep.converged
+    assert sweep.keep_going, "a fresh name did not restart the sweep"
+
+
+# ---- the two things that must never print the same word ----------------------
+
+def test_stopping_at_the_ceiling_is_not_converging():
+    """A run that stopped counting is not a run that finished."""
+    sweep = Sweep(dry_passes_before_stopping=2, max_passes=3)
+
+    for n in range(3):
+        sweep.record([f"pass{n}"])          # every pass still bringing names
+
+    assert not sweep.keep_going, "it ran past its own ceiling"
+    assert not sweep.converged, "a ceiling was reported as convergence"
+
+
+def test_the_summary_says_which_of_the_two_happened():
+    stopped = Sweep(dry_passes_before_stopping=2, max_passes=2)
+    stopped.record(["a"])
+    stopped.record(["b"])
+
+    said = stopped.summary()
+    assert "STOPPED AT THE CEILING, NOT CONVERGED" in said
+    assert "do not record this as complete" in said
+    assert "1 new names" in said or "1," in said
+
+
+def test_a_converged_summary_refuses_to_claim_the_directory_is_complete():
+    """THE OWNER'S OWN POINT. Re-crawling later will find contractors registered
+    since and changed data on ones already held — that is the directory living,
+    not the crawl failing, and the wording must not invite the opposite
+    reading."""
+    sweep = Sweep(dry_passes_before_stopping=2)
+    sweep.record(["a", "b"])
+    sweep.record(["a", "b"])
+    sweep.record(["a", "b"])
+
+    said = sweep.summary()
+    assert "stopped finding names it had not seen" in said
+    assert "not the directory being complete" in said
+    assert "registered since" in said
+
+
+def test_it_reports_what_each_pass_contributed_so_the_shape_is_visible():
+    """`11,059 + 900 + 40 + 0 + 0` tells you the crawl was converging.
+    `11,059 + 900 + 800 + 750` tells you it was not, and the total alone hides
+    which."""
+    sweep = Sweep(dry_passes_before_stopping=2)
+    sweep.record([str(n) for n in range(100)])
+    sweep.record([str(n) for n in range(110)])
+    sweep.record([str(n) for n in range(110)])
+    sweep.record([str(n) for n in range(110)])
+
+    assert "100 + 10 + 0 + 0" in sweep.summary()
+
+
+# ---- what it refuses to be built as ------------------------------------------
+
+def test_a_sweep_that_stops_before_a_dry_pass_is_refused():
+    with pytest.raises(ValueError, match="has not swept"):
+        Sweep(dry_passes_before_stopping=0)
+
+
+def test_a_sweep_of_no_passes_is_refused():
+    with pytest.raises(ValueError, match="reads nothing"):
+        Sweep(max_passes=0)
+
+
+def test_blank_ids_are_not_counted_as_names():
+    sweep = Sweep()
+
+    made = sweep.record(["a", "", None, "b"])
+
+    assert made.fresh == 2
+    assert sweep.found == {"a", "b"}
+
+
+def test_nothing_recorded_yet_says_so_rather_than_claiming_zero_contractors():
+    assert Sweep().summary() == "no passes made"


### PR DESCRIPTION
You asked for all three drift remedies built and compared. **Two of them were measured first and did not survive the measurement**, so only one is built — and the measurements are why.

## The defect

muqawil's listing is byte-stable for about **thirty seconds**, then exchanges **four of its twenty rows**.

A 2.8-hour crawl of 865 pages returned **17,275 rows and only 11,059 different contractors** — 6,216 slots on a row already seen.

And the repeats are the **visible half of an invisible loss**: a contractor sliding from page 42 to 41 is read twice; the one sliding from 41 to 42 is **never read at all**. All 4,556 repeats were byte-identical, so this is not bad data — it is one row read from two places, and the skipped rows left no trace.

## The two that died

| remedy | measured | verdict |
|---|---|---|
| **a stable sort** | `sort`, `order`, `order_by`, `orderby`, `sort_by`, `direction`, `sort_field` each tried live | **not one changed the order.** Nothing to build |
| **a slice** | `region_id` and `city_id` *are* honoured over GET; blind pagination works under them | a region is still **hundreds of pages** — a sliced pass does not finish inside the thirty-second window either. It narrows the problem without ending it |

So the sweep assumes **nothing** about ordering, which is the only assumption this site has not already broken.

## The design, and why each choice

**Two dry passes, not one** — and not out of caution. A single dry pass is ordinary luck on a list that reshuffles: the pass can revisit the same window twice and find nothing while a thousand contractors sit in a part of the ordering it never reached.

**The streak resets on any find and never decrements.** One new contractor after four quiet passes means the list is still moving underneath, and counting that as *"three quarters done"* would stop a sweep that had just proved it should not.

**The ceiling and convergence must never print the same word.** A run that stopped counting is not a run that finished, and the summary says so in capitals when it was the ceiling.

**The per-pass shape is reported, not just the total.** `11,059 + 900 + 40 + 0 + 0` tells you the crawl was converging. `11,059 + 900 + 800 + 750` tells you it was not — and the total alone hides which.

## What "dry" does not mean — your own point, built in

It does **not** mean the directory is complete. It means *this run* stopped finding names *it* had not seen.

A later run will legitimately find contractors registered since, and changed data on ones it already had. **That is the directory living, not the crawl failing** — so the converged summary says so in words and a test pins the wording. A report that claimed completeness would make normal growth read as a fault.

`generic_record.content_hash` and `generic_record_revision` are what carry change across runs; this module is only ever about one run's own convergence.

## A real bug the tests found

Ids were filtered with `if str(one)` — and `str(None)` is `"None"`, a perfectly non-empty string. A parser that failed to find an id would have contributed a contractor called `None` to every pass, **the same one each time**, so the sweep would have gone dry looking convergent.

## Verified — eleven tests, all six mutations caught

| mutation | verdict |
|---|---|
| one dry pass is enough | **CAUGHT** |
| the streak decrements instead of resetting | **CAUGHT** |
| hitting the ceiling is reported as convergence | **CAUGHT** |
| a converged sweep claims the directory is complete | **CAUGHT** |
| blank ids are counted as names | **CAUGHT** |
| the per-pass shape is hidden behind the total | **CAUGHT** |

No network, no clock: the sweep takes each pass's ids as data.

## Not in this PR

Nothing drives it yet. Wiring it to a real repeated crawl is the next step, and it is the step that will finally answer **how many contractors muqawil actually has** — the first pass said 11,059, and only a converged sweep can say what the real number is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)