### PR TITLE
A 404 storm must not buy speed, which is Scrapy's ratchet and we needed it more

### DIFF
--- a/scrapex/pacegovernor.py
+++ b/scrapex/pacegovernor.py
@@ -143,6 +143,25 @@ class PaceGovernor:
             self._ease(pace, strain, answer)
             return strain
 
+        # ONLY A 200 MAY BUY SPEED, and this is Scrapy's rule taken whole.
+        # `scrapy/extensions/throttle.py` ends `_adjust_delay` with a one-way
+        # ratchet — a non-200 response may only ever RAISE the delay — and its
+        # comment gives the reason: error pages and redirects are SMALL, so they
+        # come back fast, and a latency-driven controller reads an error storm as
+        # "the site just got quicker" and accelerates into it. A positive
+        # feedback loop, at the exact moment the site is failing.
+        #
+        # It bites us harder than it bites them, because `HttpFetcher` sends
+        # conditional requests: a re-crawl is mostly 304s, which carry NO BODY
+        # AT ALL and so are the fastest answers a server can give. Without this
+        # line every re-crawl would widen on its own emptiness.
+        #
+        # `!= 200` and not `< 400`, deliberately — 204, 206, 301, 302 and 304 are
+        # all real answers and none of them is a page. A neutral answer neither
+        # eases nor widens: it simply does not count.
+        if answer.status is not None and answer.status != 200:
+            return strain
+
         # LEARNED ONLY AT ONE IN FLIGHT. See the module docstring: a baseline
         # that moved with the load could never detect the load.
         if pace.concurrency == self._floor and answer.latency_s > 0:

--- a/tests/test_a_governor_that_learns_each_server.py
+++ b/tests/test_a_governor_that_learns_each_server.py
@@ -251,3 +251,96 @@ def test_every_easing_is_remembered_so_a_report_can_say_what_happened():
     governor.record(HOST, Answer(latency_s=1.0, status=429, retry_after_s=5.0))
 
     assert governor.pace_for(HOST).eased == [(8, 4, Strain.TOLD_TO_WAIT)]
+
+
+# ---- only a 200 may buy speed -----------------------------------------------
+#
+# Scrapy's ratchet, taken whole. `scrapy/extensions/throttle.py` ends
+# `_adjust_delay` by refusing to let a non-200 lower the delay, and its comment
+# gives the reason: error pages and redirects are SMALL, so they come back fast,
+# and a latency-driven controller reads an error storm as "the site got quicker"
+# and accelerates into it — at the exact moment the site is failing.
+
+@pytest.mark.parametrize("status", [404, 301, 302, 500, 204, 206])
+def test_a_fast_error_never_widens_the_crawl(status):
+    """A 404 page is a few hundred bytes and answers in milliseconds. Counted as
+    clean, a storm of them is the fastest the server has ever looked."""
+    governor = PaceGovernor(ceiling=8, clean_before_widening=2)
+    settle(governor, at=6.0)
+    was = governor.concurrency(HOST)
+
+    for _ in range(20):
+        governor.record(HOST, Answer(latency_s=0.05, status=status))
+
+    assert governor.concurrency(HOST) == was, (
+        f"twenty fast {status}s widened the crawl — the site is failing and we "
+        "sped up")
+
+
+def test_a_304_is_the_sharpest_case_because_it_carries_no_body_at_all():
+    """`HttpFetcher` sends conditional requests, so a RE-crawl is mostly 304s.
+    They are the fastest answer a server can give — nothing is sent. Without
+    the ratchet every re-crawl would widen on its own emptiness."""
+    governor = PaceGovernor(ceiling=8, clean_before_widening=2)
+    settle(governor, at=6.0)
+    was = governor.concurrency(HOST)
+
+    for _ in range(30):
+        governor.record(HOST, Answer(latency_s=0.01, status=304))
+
+    assert governor.concurrency(HOST) == was
+
+
+def test_a_fast_error_does_not_teach_the_baseline_either():
+    """The second half of the same defect. A baseline dragged down by empty
+    error pages makes the slowdown threshold far too tight, and the governor
+    then eases on ordinary healthy responses."""
+    governor = PaceGovernor(ceiling=8, clean_before_widening=99)
+    for _ in range(6):
+        governor.record(HOST, clean(6.0))
+    baseline = governor.pace_for(HOST).baseline_s
+
+    for _ in range(20):
+        governor.record(HOST, Answer(latency_s=0.02, status=404))
+
+    assert governor.pace_for(HOST).baseline_s == pytest.approx(baseline, rel=0.01), (
+        "empty error pages taught the governor that this server is fast")
+
+
+def test_an_error_is_neutral_and_not_a_reason_to_ease():
+    """It must not widen, and it must not narrow either. A 404 is a missing
+    page, not a server in distress — easing on one would shrink a crawl for
+    every dead link in a directory."""
+    governor = PaceGovernor(ceiling=8, clean_before_widening=2)
+    settle(governor, at=6.0)
+    was = governor.concurrency(HOST)
+
+    assert governor.record(HOST, Answer(latency_s=0.05, status=404)) is Strain.NONE
+    assert governor.concurrency(HOST) == was
+
+
+def test_a_real_200_still_buys_speed_after_a_run_of_errors():
+    """The ratchet must not JAM. It refuses to let an error buy speed; it must
+    not also refuse the 200 that comes after one."""
+    governor = PaceGovernor(ceiling=8, clean_before_widening=2)
+    governor.record(HOST, Answer(latency_s=1.0, status=429))     # eased to 1
+    for _ in range(20):
+        governor.record(HOST, Answer(latency_s=0.05, status=404))
+    was = governor.concurrency(HOST)
+    assert was == 1, "the errors themselves moved it"
+
+    settle(governor, at=6.0)
+
+    assert governor.concurrency(HOST) > was, "the ratchet jammed shut"
+
+
+def test_an_answer_with_no_status_is_still_read_as_clean():
+    """A fetcher that reports latency without a status — the governor's own
+    tests do — must keep working, or every existing caller silently stops
+    widening."""
+    governor = PaceGovernor(ceiling=4, clean_before_widening=2)
+
+    for _ in range(6):
+        governor.record(HOST, Answer(latency_s=6.0))
+
+    assert governor.concurrency(HOST) > 1


### PR DESCRIPTION
## Read out of Scrapy, whole

`scrapy/extensions/throttle.py` ends `_adjust_delay` with a one-way ratchet:

```python
if response.status != 200 and new_delay <= slot.delay:
    return          # a non-200 may only ever RAISE the delay
```

Its comment gives the reason, and it is a hazard for **any** latency-driven controller: error pages and redirects are **small**, so they come back fast — and the controller reads an error storm as *"the site just got quicker"* and accelerates into it. A positive feedback loop, at the exact moment the site is failing.

**The governor merged in #206 had precisely that hole.** It handles 429, 503, `Retry-After` and a broken connection — but a 404, a 301 or a 500 fell through as `Strain.NONE`, fed the clean run, and widened the crawl.

## It bites us harder than it bites Scrapy

`HttpFetcher` sends conditional requests, by design and for good reason — an unchanged page answers **304 with no body at all**, which its own docstring calls *"the single biggest reason a large recurring crawl stays welcome."*

But that also makes a 304 **the fastest answer a server can possibly give**. Without this ratchet, every re-crawl would have widened on its own emptiness.

## `!= 200`, not `< 400`

Scrapy's exact test, and deliberately so. `204`, `206`, `301`, `302` and `304` are all real answers and **none of them is a page**. Only a full, real, successful 200 may buy speed.

## Neutral, not strain

An error must not widen **and must not narrow either**. A 404 is a missing page, not a server in distress — easing on one would shrink a crawl for every dead link in a directory.

So it simply does not count: not for the clean run, and not for the baseline. A baseline dragged down by empty error pages makes the slowdown threshold far too tight, and the governor would then ease on ordinary healthy responses.

And the ratchet must not **jam** — a 200 after a run of errors still buys speed.

## Verified

Six new tests, thirty in the suite:

| | |
|---|---|
| a fast error never widens the crawl | 404, 301, 302, 500, 204, 206 |
| a 304 is the sharpest case — no body at all | 30 of them, concurrency unmoved |
| a fast error does not teach the baseline either | |
| an error is neutral, not a reason to ease | |
| the ratchet does not jam | a 200 after 20 errors still widens |
| an answer with no status is still read as clean | existing callers keep working |

🤖 Generated with [Claude Code](https://claude.com/claude-code)