### PR TITLE
The contractors appear among the datasets, because servable is not the same as findable

### DIFF
--- a/extension/app.js
+++ b/extension/app.js
@@ -4346,6 +4346,14 @@ const SOURCE_ACTIONS = [
 ];
 
 function sourceMenu(source) {
+  // A GENERIC DATASET GETS NO MENU. Every action here — Update, Wipe, Rename —
+  // is a price-path action: they post to routes that read the manifest, and a
+  // dataset is not in it. Offering them would put three buttons on the card
+  // that answer 400, and a button that cannot work is worse than no button.
+  //
+  // Keyed on the engine's own marker rather than on the key's shape, so the
+  // panel is never the second place that decides what a dataset is.
+  if (source.kind === "dataset") return "";
   const options = SOURCE_ACTIONS.map((item) => `
     <button class="split-button-option" role="menuitem" type="button"
             data-split-action="${item.action}"${item.ready === false ? " disabled" : ""}

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -1466,6 +1466,46 @@ def create_app(
                 "kept_pages": kept["pages"],
                 "kept_at": kept["stopped_at"],
             })
+
+        # A GENERIC DATASET IS A SOURCE THE OWNER CAN OPEN, and until now it was
+        # invisible here: this route walked the manifest alone, so a
+        # `site_profile` row could never reach the panel however much data it
+        # held. The Data screen lists what this answers and opens it through
+        # /api/table/{key}, which already serves a dataset — so listing them is
+        # the whole of what was missing.
+        #
+        # `kind` MARKS THEM, and the panel needs it: the row menu offers Update,
+        # Wipe and Rename, and every one of those is a price-path action that
+        # would answer 400 or worse for a dataset. A button that cannot work is
+        # worse than no button, so the panel hides them on this marker.
+        general = general_read_conn()
+        try:
+            for row in general.execute(
+                    "SELECT d.dataset_key, d.display_name, d.original_name, "
+                    "s.base_url, count(r.generic_record_id) AS rows "
+                    "FROM dataset_definition AS d "
+                    "JOIN site_profile AS s "
+                    "ON s.site_profile_id = d.site_profile_id "
+                    "LEFT JOIN generic_record AS r "
+                    "ON r.dataset_definition_id = d.dataset_definition_id "
+                    "AND r.status = 'active' "
+                    "WHERE d.valid_to IS NULL GROUP BY d.dataset_definition_id"):
+                out.append({
+                    "kind": "dataset",
+                    "source_key": row["dataset_key"],
+                    "source_name": row["display_name"] or row["original_name"],
+                    "source_name_ar": "", "base_url": row["base_url"],
+                    "family": "generic", "active": True, "implemented": True,
+                    "supports_history": False,
+                    # `observations` is what the Data screen filters on, and for
+                    # a directory the honest number is its rows. `products` has
+                    # no meaning for a company, so it carries the same count
+                    # rather than a zero that would read as an empty dataset.
+                    "observations": row["rows"], "products": row["rows"],
+                    "last_success": None, "kept_pages": 0, "kept_at": None,
+                })
+        finally:
+            general.close()
         return {"sources": out}
 
     @app.get("/api/resolve")

--- a/tests/test_a_dataset_is_a_table_like_any_other.py
+++ b/tests/test_a_dataset_is_a_table_like_any_other.py
@@ -274,3 +274,68 @@ def test_the_arabic_half_is_matched_by_contractor_id_and_never_by_position():
         if paired and row["company_name"] != paired["company_name"]:
             assert paired["company_name_ar"] == row["company_name"], (
                 "an Arabic name landed on the wrong contractor")
+
+
+# ---- and it has to be FINDABLE, not merely servable --------------------------
+
+def test_a_dataset_appears_among_the_sources_the_panel_lists(tmp_path):
+    """«اريد ان ارى المصدر ضمن صفحة data فى extension حتى استطيع تصفح البيانات».
+
+    `/api/table/{key}` has served a dataset since the payload landed — but
+    `/api/sources` walked the manifest alone, so a `site_profile` row could
+    never reach the panel however much data it held. The Data screen lists what
+    that route answers, so a dataset that is servable and unlistable is a
+    dataset nobody can open.
+    """
+    from fastapi.testclient import TestClient
+
+    from scrapex.databases import DatabaseRegistry, EngineDatabase
+    from scrapex.webui.app import create_app
+
+    registry = DatabaseRegistry(EngineDatabase(tmp_path / "scrapex-engine.db"),
+                               pointer_file=tmp_path / "databases.json")
+    registry.initialize()
+    conn = registry.engine.connect()
+    try:
+        stored(conn)
+        # COMMITTED, because `approve_candidate` does not: the HTTP route owns
+        # the transaction (`_general_write`), and every other test in this file
+        # reads back through the SAME connection so it never noticed. Here a
+        # second connection asks, and an uncommitted dataset is an absent one.
+        conn.commit()
+    finally:
+        conn.close()
+
+    client = TestClient(create_app(databases=registry))
+    rows = client.get("/api/sources").json()["sources"]
+    mine = [row for row in rows if row["source_key"] == "contractors"]
+
+    assert mine, "the dataset is servable and unlistable, so nobody can open it"
+    row = mine[0]
+    assert row["kind"] == "dataset"
+    assert row["observations"] == 4, (
+        "the Data screen filters on `observations > 0`; a zero here hides it")
+    assert row["implemented"] is True, (
+        "the panel disables a source it thinks has no connector")
+    assert "muqawil.org" in row["base_url"]
+
+
+def test_a_price_source_still_carries_no_kind(tmp_path):
+    """The marker must be ABSENT on the price rows, not false — the panel reads
+    `source.kind === "dataset"`, and a shared key would make every source one
+    edit away from losing its menu."""
+    from fastapi.testclient import TestClient
+
+    from scrapex.databases import DatabaseRegistry, EngineDatabase
+    from scrapex.webui.app import create_app
+
+    registry = DatabaseRegistry(EngineDatabase(tmp_path / "scrapex-engine.db"),
+                               pointer_file=tmp_path / "databases.json")
+    registry.initialize()
+    client = TestClient(create_app(databases=registry))
+
+    rows = client.get("/api/sources").json()["sources"]
+    priced = [row for row in rows if row.get("kind") != "dataset"]
+
+    assert priced, "the manifest's own sources vanished from the list"
+    assert all("kind" not in row for row in priced)


### PR DESCRIPTION
> «اريد ان ارى المصدر ضمن صفحة data فى extension حتى استطيع تصفح البيانات»

`/api/table/{key}` has served a dataset since #211. But **`/api/sources` walked the manifest alone** — so a `site_profile` row could never reach the panel however much data it held, and the Data screen lists exactly what that route answers.

**A dataset that is servable and unlistable is a dataset nobody can open**, which is the state it has been in since the first row was written.

## What changed

The route now appends the catalogue's datasets to the manifest's sources, with the same keys the panel already reads.

| key | value | why |
|---|---|---|
| `observations` | the row count | the Data screen filters on `observations > 0`; a zero hides it |
| `products` | the same count | a company is not a product, and a zero would read as an empty dataset |
| `implemented` | `true` | the panel disables a source it thinks has no connector |
| `kind` | `"dataset"` | the marker below |

## The marker, and why the panel needs it

The row menu offers **Update**, **Wipe** and **Rename** — every one a price-path action posting to a route that reads the manifest, which a dataset is not in.

Three buttons that answer 400 is worse than no buttons, so `sourceMenu` returns nothing on the marker:

```js
if (source.kind === "dataset") return "";
```

Keyed on what the **engine** says rather than on the shape of the key, so the panel is never the second place that decides what a dataset is.

And the marker is **absent** on price rows rather than false — a test pins that. The panel reads `source.kind === "dataset"`, and a shared key would put every source one edit away from losing its menu.

## A bug in my own test helper, worth the note

`approve_candidate` does not commit — the HTTP route owns the transaction through `_general_write`. **Every other test in this file reads back through the same connection and so never noticed.** This one asks over HTTP, on a second connection, and an uncommitted dataset is an absent one.

## Verified

Seventeen tests, two of them new: that the dataset is listed with the keys the Data screen needs, and that a price source still carries no `kind`.

`ruff check scrapex/` clean, eslint clean, `test_panel_wiring` and the extract suites pass unchanged.

## What this completes

```
✅  knows its pages · reads a contractor · crawls · stores evidence
✅  reaches generic_record · renders as a table · flips between AR and EN
✅  and now: appears in the list, so it can be opened
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)