### PR TITLE
Revert the profile page background, which is what he asked for and what unblocks main

### DIFF
--- a/extension/app.css
+++ b/extension/app.css
@@ -1150,11 +1150,7 @@
      `min-height: auto` and refuses to shrink below its content, so without it a
      tall child grows the view instead of handing the overflow to the scroller
      inside it — which is the page-scrolls-instead-of-rows behaviour the chain
-     exists to remove.
-
-     The page canvas is white in light mode — a cleaner, brighter step back from
-     the card surface — while var(--bg) keeps dark mode intact. The card itself
-     keeps var(--surface). */
+     exists to remove. */
   #view-profile {
     display: flex;
     flex-direction: column;
@@ -1163,7 +1159,7 @@
     overflow: hidden;
     margin: calc(-1 * var(--sp-4));
     padding: var(--sp-4);
-    background: light-dark(#FFFFFF, var(--bg));
+    background: var(--bg);
   }
   .profile-stage {
     display: flex;


### PR DESCRIPTION
## What this is

> «الغى تعديلات الخلفية ورجعها للاصل»

A full revert of `ac3a5af`. `extension/app.css` is now **byte-identical to
`36dd91c`** — verified with `git diff` against that tree, not by eye.
`#view-profile` goes back to `background: var(--bg)` and the four comment lines
that commit added are gone. **One file, two hunks, nothing else touched.**

He was shown a token-based alternative —
`light-dark(var(--surface), var(--bg))` — and chose the revert. That is his page.

## It also unblocks `main`, which has been red since 2026-08-18

`ac3a5af` reached `main` **with no pull request** — a single-parent commit, so no
CI gate ran before it landed. It wrote a raw white hex literal into
`extension/app.css`, and
`test_ui_colour_literals_live_only_in_the_canonical_colour_system` forbids a colour
literal anywhere outside `tokens.css` and `appearance.js`.

`main` went red, and **every PR opened since inherited the failure — [#214](https://github.com/muhammadbayoumi/ScrapeX/pull/214) included.**
Reverting removes the literal, so the guard passes again with nothing else changed.

## Two things about that literal, found while trying the token fix first

- **It silently discarded the owner's palette.** Under `data-color-mode="device"`
  ([`extension/tokens.css`](extension/tokens.css)), `--surface` mixes the system
  accent into near-white. A hard white literal ignored that on this one page and
  reported nothing.
- **Its own comment did not match what it did.** The comment called the canvas *a
  cleaner, brighter step back from the card surface* — but `--surface` is already
  pure white in the default light palette and `.profile-card` uses it. Canvas and
  card became the same colour, separated only by the card's border and shadow.

And one property of the guard worth knowing, because it cost a retry: **it reads
every line, comments included.** An explanatory comment that merely *names* a hex
value fails it too. Anything describing a colour must do so in words.

## Verification

`tests/test_vendor.py` + `tests/test_ui_kit.py` — **68 green**, including the
literal guard that `main` currently fails. The eight profile tests in
`tests/test_panel_dom.py` green. `eslint` and `ruff` both clean. The whole cached
diff was read before committing, per `SR-19`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
