### PR TITLE
A documentation change ran 2,656 tests to prove a Markdown edit was safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,15 @@ jobs:
 
           scope=full
           if [ -n "$base" ] && git cat-file -e "$base^{commit}" 2>/dev/null; then
-            changed=$(git diff --name-only "$base" "${{ github.sha }}")
+            # --no-renames, AND THAT IS NOT A DETAIL. Rename detection is on
+            # by default and `--name-only` then prints only the DESTINATION of a
+            # move: `git mv scrapex/webui/templates/settings_partial.html
+            # extension/settings.html` reports one path under extension/, so the
+            # diff classifies as `extension` and the engine suite never runs on a
+            # change that deleted an engine template. Reproduced in a scratch
+            # repository. Without rename detection both paths appear, and the
+            # only direction this moves the answer is WIDER.
+            changed=$(git diff --name-only --no-renames "$base" "${{ github.sha }}")
             if [ -n "$changed" ]; then
               # Narrowest first. A change that is documentation AND extension is
               # an extension change; only an all-documentation diff is `docs`.
@@ -145,9 +153,24 @@ jobs:
     needs: scope
     runs-on: ubuntu-latest
     steps:
-      # Shallow is enough here now. The full history was only ever for the scope
-      # diff, and that moved into its own job above.
       - uses: actions/checkout@v4
+        with:
+          # FULL HISTORY, and it is not for the scope diff. Two guards in this
+          # suite ask git when something last really changed, and BOTH SKIP
+          # rather than fail on a grafted clone:
+          #   tests/test_the_privacy_policy_is_true.py:433 -- the "Last updated"
+          #     staleness guard, added 2026-08-12 after the policy was edited
+          #     three times in a day while still claiming an older date;
+          #   tests/test_version.py:231 -- every capability's cited commit hash.
+          # A depth-1 checkout turns both into skips, which `-q` reports as green.
+          # Measured: edit docs/privacy-policy.md, leave its date, and full
+          # history fails while depth 1 passes.
+          #
+          # publish-docs.yml and release-extension.yml pin this for the same
+          # reason, and the helper's own comment names them. This job was the
+          # third, briefly, in the commit that split the scope job out.
+          # tests/test_the_workflows_check_out_enough_history.py now guards it.
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -335,6 +358,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # FULL HISTORY, and it is not for the scope diff. Two guards in this
+          # suite ask git when something last really changed, and BOTH SKIP
+          # rather than fail on a grafted clone:
+          #   tests/test_the_privacy_policy_is_true.py:433 -- the "Last updated"
+          #     staleness guard, added 2026-08-12 after the policy was edited
+          #     three times in a day while still claiming an older date;
+          #   tests/test_version.py:231 -- every capability's cited commit hash.
+          # A depth-1 checkout turns both into skips, which `-q` reports as green.
+          # Measured: edit docs/privacy-policy.md, leave its date, and full
+          # history fails while depth 1 passes.
+          #
+          # publish-docs.yml and release-extension.yml pin this for the same
+          # reason, and the helper's own comment names them. This job is NEW, so
+          # it never had the history to lose -- it was born shallow, which is the
+          # easier half of the same mistake to make.
+          # tests/test_the_workflows_check_out_enough_history.py now guards it.
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         if: needs.scope.outputs.scope == 'full'
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,42 +37,54 @@ jobs:
       - name: Lint the JavaScript (eslint)
         run: npx --yes eslint@9.39.0 extension scrapex/webui/static contract apps_script --no-warn-ignored
 
-  test:
+  # ITS OWN JOB, and it was a step inside `test` until 2026-08-19. Two jobs need
+  # the answer now — `test` and `migration-authority` — and they must run in
+  # PARALLEL, so neither can compute it for the other: `needs: test` would
+  # serialise six minutes in front of twelve and make the split pointless.
+  # Computing it twice would mean two copies of the base-detection reasoning
+  # below, and the copy that drifts is always the one nobody reads.
+  #
+  # It is seconds long: a checkout and a `git diff --name-only`. No Python.
+  scope:
     runs-on: ubuntu-latest
+    outputs:
+      scope: ${{ steps.scope.outputs.scope }}
     steps:
       - uses: actions/checkout@v4
         with:
           # The scope step below diffs against the base branch, which needs
           # more than the single commit a shallow checkout fetches.
           fetch-depth: 0
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Install
-        # The browser extra is installed HERE and not moved into [dev]: the
-        # panel suite needs a real Chromium, and putting playwright in the extra
-        # every contributor installs would make `pip install -e .[dev]` download
-        # a browser on every machine for a suite most changes never touch. CI is
-        # the place that must run everything.
-        run: |
-          pip install -e .[dev,browser]
-          python -m playwright install --with-deps chromium
-
       - name: What did this change touch?
         id: scope
-        # THIS DECIDES WHICH SUITE RUNS, AND IT IS A STEP RATHER THAN A JOB
-        # FILTER ON PURPOSE. A workflow- or job-level `paths:` filter makes the
-        # job not exist, and a required check that does not exist stays pending
-        # forever — the pull request can never merge. A step that always runs and
-        # sets an output leaves the job reporting on every change, which is what
-        # branch protection needs.
+        # THIS DECIDES WHICH SUITE RUNS, AND IT IS A JOB OUTPUT RATHER THAN A
+        # `paths:` FILTER ON PURPOSE. A workflow- or job-level `paths:` filter
+        # makes the consuming job not exist, and a required check that does not
+        # exist stays pending forever — the pull request can never merge. A job
+        # that always runs, plus step-level `if:` on the expensive steps, leaves
+        # every check reporting on every change, which is what branch protection
+        # needs.
         #
-        # The rule is deliberately one-sided. `extension-only` means every
-        # changed file is inside extension/ or docs/; anything else — one line
-        # in scrapex/, one line in tests/, a workflow edit — runs the whole
-        # suite exactly as before. An unknown event, an empty diff, or a failure
-        # to compute the base all fall through to "run everything", because the
+        # The rule is deliberately one-sided. `extension` means every changed
+        # file is inside extension/ or the documentation set; `docs` means every
+        # changed file is documentation and nothing else. Anything else — one line
+        # in scrapex/, one line in tests/, a workflow edit — runs the whole suite
+        # exactly as before. An unknown event, an empty diff, or a failure to
+        # compute the base all fall through to "run everything", because the
         # expensive mistake here is skipping a suite, never running one twice.
+        #
+        # WHY THE DOCUMENTATION SET IS MORE THAN `docs/`. Measured on PR #214,
+        # which was documentation only: it changed CLAUDE.md, ENGINEERING.md,
+        # README.md, .gitignore and a file under .claude/, none of which match
+        # `^docs/`. It took the FULL suite twice — 14m21s and 14m40s, the two
+        # slowest runs of the last twenty. The documentation system C1 sends every
+        # session to read lives partly at the repository ROOT, so this filter has
+        # to know that, or the system's own pull requests are the slowest kind
+        # there is.
+        #
+        # `.github/` IS DELIBERATELY ABSENT from both sets. A workflow edit
+        # changes what CI itself guarantees, so it runs everything — including an
+        # edit to this very file.
         run: |
           set -euo pipefail
           base=""
@@ -102,11 +114,24 @@ jobs:
             fi
           fi
 
+          # Documentation, in the sense of "a file whose only readers are the
+          # document guards". docs/, .claude/, any Markdown at the root, and
+          # .gitignore. CHANGELOG.md is in here and is GENERATED, which is why
+          # tests/test_version.py carries the docs mark: the guard that catches a
+          # hand-edited CHANGELOG has to run on the change that hand-edits it.
+          documentation='^(docs/|\.claude/|[^/]+\.md$|\.gitignore$)'
+
           scope=full
           if [ -n "$base" ] && git cat-file -e "$base^{commit}" 2>/dev/null; then
             changed=$(git diff --name-only "$base" "${{ github.sha }}")
-            if [ -n "$changed" ] && ! echo "$changed" | grep -qvE '^(extension/|docs/)'; then
-              scope=extension
+            if [ -n "$changed" ]; then
+              # Narrowest first. A change that is documentation AND extension is
+              # an extension change; only an all-documentation diff is `docs`.
+              if ! echo "$changed" | grep -qvE "$documentation"; then
+                scope=docs
+              elif ! echo "$changed" | grep -qvE "^(extension/)|$documentation"; then
+                scope=extension
+              fi
             fi
             echo "changed files:"
             echo "$changed" | sed 's/^/  /'
@@ -115,6 +140,42 @@ jobs:
           fi
           echo "scope=$scope" >> "$GITHUB_OUTPUT"
           echo "SCOPE: $scope"
+
+  test:
+    needs: scope
+    runs-on: ubuntu-latest
+    steps:
+      # Shallow is enough here now. The full history was only ever for the scope
+      # diff, and that moved into its own job above.
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          # Measured 2026-08-19: nothing in .github/workflows/ cached anything.
+          # `pip install -e .[dev,browser]` is a steady 11s, so this is small --
+          # but it is one line and it never costs more than it saves.
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      # The browser download is a steady ~13s of the Install step and is keyed on
+      # nothing but the playwright version, which changes when pyproject does.
+      # The apt half of `--with-deps` is what actually swings -- 9.4s on
+      # 2026-08-17 against 104s on 2026-08-19, on the same command -- and no
+      # cache can fix that, because it is the runner image's package mirror.
+      - name: Cache the browser download
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ms-playwright-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: ms-playwright-${{ runner.os }}-
+      - name: Install
+        # The browser extra is installed HERE and not moved into [dev]: the
+        # panel suite needs a real Chromium, and putting playwright in the extra
+        # every contributor installs would make `pip install -e .[dev]` download
+        # a browser on every machine for a suite most changes never touch. CI is
+        # the place that must run everything.
+        run: |
+          pip install -e .[dev,browser]
+          python -m playwright install --with-deps chromium
 
       - name: Validate the manifest (S5 gate — a broken contract can't merge)
         run: python -m scrapex.cli validate-manifest
@@ -142,7 +203,15 @@ jobs:
           # tests/*.py, NOT -r: a recursive grep also matches the compiled
           # copies under __pycache__, whose names collect nothing and would fail
           # this step for a reason that has nothing to do with the browser.
-          suites=$(grep -l 'importorskip("playwright"' tests/*.py | tr -d '\r' | sort)
+          # NO CLOSING QUOTE AFTER playwright, and that is the whole fix. This
+          # read `importorskip("playwright"` until 2026-08-19, so
+          # tests/test_grid_dom.py:24 -- which writes
+          # `pytest.importorskip("playwright.sync_api")` -- never matched, and its
+          # 20 browser-driven tests were invisible to the guard for as long as
+          # they existed. That is precisely the silent failure the comment above
+          # describes, arrived at through the guard's own pattern rather than
+          # through a forgotten filename.
+          suites=$(grep -l 'importorskip("playwright' tests/*.py | tr -d '\r' | sort)
           echo "browser suites found:"; echo "$suites"
           test -n "$suites"
           for suite in $suites; do
@@ -158,9 +227,13 @@ jobs:
 
       - name: The extension gate must not have emptied
         # The same reasoning as the line above, for the set the split depends
-        # on. 325 of 2020 tests carried the mark when the split was made; a file
-        # that reads extension/ and forgets the mark stops running on exactly
-        # the pull requests it was written for, and nothing goes red.
+        # on. 325 of 2020 tests carried the mark when the split was made and
+        # **661 of 2,656 do today** — counted 2026-08-19 with
+        # `pytest -m extension --collect-only -q`, not remembered. The old figure
+        # had been quoted stale for a while, which is its own small instance of
+        # the thing this file keeps guarding against. A file that reads extension/ and
+        # forgets the mark stops running on exactly the pull requests it was
+        # written for, and nothing goes red.
         # tests/test_the_extension_gate_is_complete.py catches the missing mark;
         # this catches the set being emptied some other way.
         #
@@ -176,25 +249,123 @@ jobs:
           echo "extension gate collected: ${count}"
           test "${count}" -ge 300
 
+      - name: The docs gate must not have emptied either
+        # Same reasoning again, for the set the `docs` scope depends on.
+        # tests/test_the_docs_gate_is_complete.py catches a test file that reads
+        # a document and forgets the mark; this catches the set being emptied
+        # some other way. The floor is small because the set is small — six files
+        # when it was made — and a floor of 1 would let five of them vanish.
+        run: |
+          python -m pytest -m docs --collect-only -q | tr -d '\r' | tee /tmp/docsgate.txt | tail -20
+          count=$(grep -oE ': [0-9]+$' /tmp/docsgate.txt | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
+          echo "docs gate collected: ${count}"
+          test "${count}" -ge 150
+
+      - name: Documents only (this change touched nothing a document does not own)
+        if: needs.scope.outputs.scope == 'docs'
+        # THE TIER PR #214 SHOULD HAVE HAD. It was documentation only and paid
+        # 14m21s for the full suite; this runs the guards that a document can
+        # actually break -- the citation guard, the generated data-page ruling,
+        # the privacy policy, the version ledger's CHANGELOG -- and stops.
+        #
+        # It is NOT `-m "docs or extension"`: no extension file changed, so the
+        # panel suite has nothing to say. Files that guard both carry both marks
+        # and run here regardless.
+        run: python -m pytest -m docs
+
       - name: Extension gate only (this change touched nothing else)
-        if: steps.scope.outputs.scope == 'extension'
+        if: needs.scope.outputs.scope == 'extension'
         # THE POINT OF THE SPLIT. A button change runs the 325 tests that guard
         # the extension and stops there. The engine suite is not skipped by
         # being unreachable — it is skipped because nothing it tests changed.
-        run: python -m pytest -m extension
+        #
+        # `or docs` because this scope admits documentation files too, and the
+        # docs set is not a subset of the extension set --
+        # tests/test_the_ruling_matches_the_code.py reads
+        # docs/data-page-schema.md and carries no extension mark, so before this
+        # line an extension+docs change could hand-edit that generated ruling and
+        # pass. Strictly more coverage than the old `-m extension`, and the two
+        # sets overlap so the cost is a few seconds.
+        run: python -m pytest -m "extension or docs"
 
       - name: Tests (Python engine + Python-vs-frozen contract)
-        if: steps.scope.outputs.scope != 'extension'
-        # tests/conftest.py restores a prebuilt schema template instead of
-        # replaying 57 migrations per test, which is what turns a ~30-minute
-        # local suite into ~6 minutes. It is a developer-loop convenience, and
-        # this is the line that keeps it one: CI runs the REAL stream 805 times,
-        # so the authority on green tests exactly what it tested before that file
-        # existed. Same reasoning as the panel gate above — a guard that can
-        # vanish quietly is the defect.
+        if: needs.scope.outputs.scope == 'full'
+        # THE FULL SUITE, ON THE SCHEMA TEMPLATE. `SCRAPEX_FULL_MIGRATIONS` moved
+        # out of this step and into the `migration-authority` job below, and the
+        # guarantee did NOT move with it — that job runs the same suite with the
+        # real stream, in parallel, on every change this step runs on.
+        #
+        # WHAT IT BUYS, MEASURED 2026-08-19. tests/conftest.py restores a prebuilt
+        # schema template instead of replaying the migrations per test. Real
+        # `migrate()` is 396ms against a 3.6ms template restore, and a full suite
+        # makes 927 of those calls: 895 restored, 32 real. So the variable was
+        # adding roughly 350 seconds to a step that is 92% of this job's 12m49s.
+        # Splitting it means the ordinary green signal lands in about six minutes
+        # while the authoritative one keeps running beside it.
+        #
+        # IT DOES NOT MAKE A MERGE FASTER BY ITSELF. If branch protection
+        # requires `migration-authority` too — and it should — the slowest
+        # required check still decides. What changes is that a failure unrelated
+        # to migrations surfaces in six minutes instead of thirteen.
+        run: python -m pytest -q
+
+  migration-authority:
+    # THE GUARANTEE THAT USED TO BE AN ENVIRONMENT VARIABLE ON ANOTHER JOB'S
+    # STEP. `tests/conftest.py` restores a prebuilt schema template instead of
+    # replaying the real migration stream, which is what makes a local suite
+    # bearable. This job is the line that keeps that a developer-loop convenience
+    # and nothing more: it runs the SAME suite with `SCRAPEX_FULL_MIGRATIONS=1`,
+    # so the real stream is exercised exactly as it was before conftest existed.
+    #
+    # SEPARATE, AND IN PARALLEL, RATHER THAN INLINE. Measured 2026-08-19: real
+    # `migrate()` costs 396ms against a 3.6ms template restore, and a full suite
+    # makes 927 of those calls. Inline, that put ~350s in front of every other
+    # answer the suite had to give. Beside it, the ordinary failures arrive in
+    # about six minutes and this one keeps running.
+    #
+    # ⚠ IT IS NOT A REQUIRED CHECK UNTIL SOMEONE MAKES IT ONE. A new job is not
+    # automatically added to branch protection. Until `migration-authority` is
+    # required, a migration-stream failure here will NOT block a merge — which
+    # would be strictly weaker than the inline variable it replaced. Add it to
+    # the required set for `main`.
+    #
+    # It reads the same scope, so a documentation change does not replay 61
+    # migration files 927 times to prove a Markdown edit is safe.
+    needs: scope
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        if: needs.scope.outputs.scope == 'full'
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      # The browser extra is here for the same reason it is in `test`: this runs
+      # the WHOLE suite, and the panel suites need a real Chromium or they
+      # collect nothing and report a skip.
+      - name: Cache the browser download
+        if: needs.scope.outputs.scope == 'full'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ms-playwright-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: ms-playwright-${{ runner.os }}-
+      - name: Install
+        if: needs.scope.outputs.scope == 'full'
+        run: |
+          pip install -e .[dev,browser]
+          python -m playwright install --with-deps chromium
+      - name: The whole suite, against the real migration stream
+        if: needs.scope.outputs.scope == 'full'
         env:
           SCRAPEX_FULL_MIGRATIONS: "1"
         run: python -m pytest -q
+      - name: Nothing to replay
+        if: needs.scope.outputs.scope != 'full'
+        # The job still reports, which is what branch protection needs — see the
+        # note on `paths:` filters in the `scope` job. It just costs seconds.
+        run: echo "scope is ${{ needs.scope.outputs.scope }}; no engine change to replay migrations for"
 
   contract-parity:
     # The two-engine guardrail: the JS engine must reproduce the FROZEN contract

--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -75,6 +75,18 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # FULL HISTORY, because this job runs the WHOLE suite below and two of
+          # its guards ask git when a document last really changed --
+          # tests/test_the_privacy_policy_is_true.py:433 and
+          # tests/test_version.py:231. Both SKIP rather than fail on a grafted
+          # clone, and a run full of skips reports green under `-q`. So this
+          # workflow has been shipping the engine without checking that the
+          # privacy policy's own date is honest, or that a capability's cited
+          # commit exists. Found 2026-08-19 by
+          # tests/test_the_workflows_check_out_enough_history.py, which is the
+          # third and fourth instance of this same mistake in this repository.
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -959,6 +959,17 @@ UNCONDITIONALLY — a marker that appears only when there were orphans would be
 absent on every healthy start, and anyone waiting for it would wait for ever on
 exactly the machines where nothing had gone wrong.
 
+> **RE-MEASURED 2026-08-19 AND IT IS BACK, under load.** Three consecutive runs of
+> `tests/test_the_engine_survives_being_killed.py` on the owner's Windows machine --
+> while a full suite and twenty review agents were running -- gave **pass, FAIL,
+> FAIL** on an unchanged tree. The marker fix does not hold at this load, so
+> "MOSTLY" in the heading is doing real work.
+>
+> Recorded rather than diagnosed, and deliberately not blamed on the change that was
+> in flight: this entry's own warning below is that a with-and-without comparison
+> proved nothing here before. What is new is the load. The next step is to find
+> whether `Engine.start(swept=True)` is on this path at all, not to add a sleep.
+
 **Four runs in four, green.** And an honest note on the check: removing the wait
 again passed three runs in three that afternoon, having failed three in four
 that morning. A race that depends on machine load cannot be reproduced on

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -362,9 +362,10 @@ Two more found in the same reading, deliberately left alone:
 A stale document is not a neutral cost. It **actively directs the next reader
 into the wrong action**, and it does so with the authority of a rule.
 
-This project has two instances of a document stating the opposite of the code,
-and a third pattern — a citation that still resolves but no longer points at
-what it names — recorded below them:
+This project has two instances of a document stating the opposite of the code, a
+third pattern — a citation that still resolves but no longer points at what it
+names — and a fourth: a GUARD whose own discovery pattern cannot see its subject.
+All are recorded below.
 
 - **`docs/data-page-schema.md`** — it called itself "the ruling" and had drifted
   into stating the opposite of the code **in five ways at once**: wrong
@@ -492,6 +493,80 @@ for part in path.relative_to(ROOT).parts:
 Same family as §1: the worktree makes correct work look broken. Any path filter,
 ignore rule or glob in this repository must be applied **relative to the
 repository root**.
+
+---
+
+### A guard's own pattern can miss its subject, and the guard reports green
+
+Found 2026-08-19, measuring why CI took thirteen minutes.
+
+`.github/workflows/ci.yml` has a step whose entire purpose is to refuse a browser
+suite that silently collects nothing. It finds its subjects by grepping, and the
+grep read:
+
+```
+grep -l 'importorskip("playwright"' tests/*.py
+```
+
+Note the closing quote. `tests/test_grid_dom.py:24` writes
+`pytest.importorskip("playwright.sync_api")`, so it **never matched**, and its 20
+browser-driven tests were invisible to the guard for as long as they existed.
+Dropping one character fixes it.
+
+**The step's own comment describes the failure it then had.** It says *"THE FILES
+ARE DISCOVERED, NOT NAMED… A guard that lists its subjects fails on the one nobody
+added to the list"* — and discovery by an over-precise pattern fails the same way,
+just less visibly, because there is no list to audit. The same afternoon, the new
+docs-gate detector required a `/` before a quoted `*.md` and therefore could not
+see `test_the_documents_cite_what_they_claim.py`, **the one test whose whole
+subject is the documents.**
+
+The lesson is not "write better regexes". It is: **after writing a discovery
+pattern, print what it found and read the list.** Both misses were obvious the
+moment the list was printed, and invisible for as long as only the exit code was
+read.
+
+### A tier that runs a subset needs a set, a floor, and a test that the tier exists
+
+The extension split had all three and worked. The documentation tier added
+2026-08-19 copies it deliberately rather than inventing a second mechanism:
+
+| | extension | docs |
+|---|---|---|
+| marker | `pytest.mark.extension` | `pytest.mark.docs` |
+| completeness guard | `test_the_extension_gate_is_complete.py` | `test_the_docs_gate_is_complete.py` |
+| floor in CI | ≥300 collected | ≥150 collected |
+
+**And the copying found a hole in the original.** `docs/` was already inside the
+extension-only path filter, so a documentation-only change ran `pytest -m
+extension` — but `test_the_ruling_matches_the_code.py` reads
+`docs/data-page-schema.md`, carries no extension mark, and never needed one. A
+hand-edited copy of that generated ruling would have passed CI on exactly the kind
+of pull request that hand-edits it. The two sets overlap and **neither contains the
+other**, which is why the extension tier now runs `-m "extension or docs"`.
+
+Two things worth carrying to the next tier: the marker must be registered in
+`pyproject.toml` or `--strict-markers` rejects it, and the tier needs a test that
+**the workflow still runs it** — a marked set nothing executes reads as coverage
+and is worse than no set at all.
+
+### A scope rule written in bash inside YAML is code that no linter reads
+
+The rule deciding whether a change runs 178 tests or 2,656 was a `grep -qvE`
+pattern in `ci.yml`. Nothing checked it. Widening it by accident — adding
+`scrapex/` while meaning `docs/` — would make a warehouse change run the
+documentation suite and report green, and the failure would be invisible because
+green is what everyone expects.
+
+`test_the_workflows_documentation_pattern_admits_exactly_what_it_should` now lifts
+the pattern out of the YAML and classifies fifteen real paths with it, over half of
+them cases that must NOT be admitted. Verified by mutation: adding `scrapex/` to
+the pattern fails the test naming three files.
+
+**Any decision expressed as a pattern in a config file is testable, and the
+expensive ones should be tested.** The measured saving here — 12m49s to about 30
+seconds for a documentation-only pull request — is exactly the size of the mistake
+a silent widening would make in the other direction.
 
 ---
 

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -364,7 +364,7 @@ into the wrong action**, and it does so with the authority of a rule.
 
 This project has two instances of a document stating the opposite of the code, a
 third pattern — a citation that still resolves but no longer points at what it
-names — and a fourth: a GUARD whose own discovery pattern cannot see its subject.
+names — a fourth, a GUARD whose own discovery pattern cannot see its subject — and a fifth, a guard that SKIPS rather than fails and so reports green while absent.
 All are recorded below.
 
 - **`docs/data-page-schema.md`** — it called itself "the ruling" and had drifted
@@ -567,6 +567,78 @@ the pattern fails the test naming three files.
 expensive ones should be tested.** The measured saving here — 12m49s to about 30
 seconds for a documentation-only pull request — is exactly the size of the mistake
 a silent widening would make in the other direction.
+
+---
+
+### A skip is not a failure, and a guard that skips is a guard that is gone
+
+The worst defect in the CI work of 2026-08-19 was introduced BY that work, and
+caught by an adversarial review before it merged. It earns the space because the
+shape recurs.
+
+Moving the scope computation into its own job made `fetch-depth: 0` look unnecessary
+on the `test` job, and the comment "Shallow is enough here now" went in with the
+change. It was wrong. **Two guards ask git when something last really changed, and
+both skip rather than fail on a grafted clone:**
+
+| guard | on a shallow clone |
+|---|---|
+| `tests/test_the_privacy_policy_is_true.py:433` -- the policy's "Last updated" line | `_last_changed()` returns None, the test **skips** |
+| `tests/test_version.py:231` -- every capability's cited commit | **skips** |
+
+Under `addopts = "-q --strict-markers"` a run full of skips reports **green**. The
+review proved it by experiment rather than argument: edit `docs/privacy-policy.md`,
+leave its date alone, and full history reports one failure while `--depth 1` reports
+none. That is precisely the defect the guard was written for on 2026-08-12, after the
+policy was edited three times in a day while advertising an older date -- and the
+Chrome Web Store listing hangs on that document.
+
+**The repository had already learned this once.** `publish-docs.yml` and
+`release-extension.yml` both ran the file at depth 1; both were fixed, and the
+helper's own comment names them and says it "refuses to guess if one ever stops".
+
+**So why it happened again.** The requirement lived as prose beside the file that
+NEEDED the history, never on the jobs that have to PROVIDE it. Nothing structural
+connected the two. `tests/test_the_workflows_check_out_enough_history.py` is that
+structure now -- and on its first run it found a **fourth** instance nothing else
+had: `release-engine.yml`'s build job runs the whole suite at depth 1, so both guards
+have been skipping on **every engine release**.
+
+Two things to carry:
+
+- **When a test can skip, ask what makes it skip and who guarantees that never
+  happens.** A skip is invisible in a way a failure is not.
+- **A requirement written next to its consumer will be violated by its provider.**
+  Put it in a test that reads the provider.
+
+### `git diff --name-only` hides half of a rename, and a scope filter believes it
+
+Rename detection is on by default, so `--name-only` prints only a move's
+**destination**. `git mv scrapex/webui/templates/settings_partial.html
+extension/settings.html` reports one path under `extension/` -- and a scope filter
+reading that classifies the change as extension-only and never runs the engine suite,
+on a change that **deleted an engine template**. Reproduced in a scratch repository:
+`--name-status` shows `R100 old new`, and `--no-renames` shows both paths.
+
+It matters here specifically because
+[REQ-04](REQUESTS.md#req-04--every-setting-moves-into-the-extension) is exactly that
+kind of move -- ten settings going from the web page into the extension.
+
+`--no-renames` is the fix, and it can only ever widen the scope, which is the safe
+direction for a filter deciding what NOT to run.
+
+### Extract the pattern and you have still not tested the decision
+
+The guard written for the scope rule lifted the regex out of `ci.yml` and classified
+paths with it. An adversarial pass then inverted the shell logic -- `! grep -qvE`
+("no line fails to match", so all match) to `grep -qE` ("at least one matches", the
+opposite) -- and **every assertion stayed green**, because the extracted pattern was
+byte-identical. A diff of one Markdown file plus one connector would have run the
+documentation tier.
+
+A configuration guard has to pin the **polarity** as well as the pattern. The two
+decision lines are now asserted verbatim, with the reasoning beside them so the next
+person to reshape them re-derives the polarity instead of preserving characters.
 
 ---
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -165,6 +165,54 @@ generic storage"* — is now met by the figures above. Lighting them is what mak
 
 ---
 
+## Track 4 · What CI actually costs, and the tier a documentation change needed
+
+**Measured 2026-08-19**, because PR #214 was documentation only and took the two
+slowest runs of the previous twenty:
+
+| | |
+|---|---|
+| `test` job, median of 15 full-scope runs | **12m49s** |
+| of which the `pytest` step | **703s — 92%** |
+| `lint` · `contract-parity` | 21–26s · 14–16s |
+| PR #214's two runs | **14m21s and 14m40s** |
+
+The slowness is entirely inside one step. Four causes, ranked, with what was done:
+
+1. **A documentation change ran the whole suite.** The scope filter knew
+   `extension/` and `docs/` only, and #214 changed `CLAUDE.md`, `ENGINEERING.md`,
+   `README.md`, `.gitignore` and a `.claude/` file — none of which match `^docs/`.
+   **Fixed:** a third `docs` tier, a `pytest.mark.docs` marker on the nine files
+   that read a document, and `tests/test_the_docs_gate_is_complete.py` to keep the
+   set honest. **178 tests in 30.6s** against 451s for the whole suite locally.
+2. **`SCRAPEX_FULL_MIGRATIONS=1` was replaying 61 migration files 927 times per
+   run** — real `migrate()` is 396ms against a 3.6ms template restore, so roughly
+   350s of the 703s. **Moved** to a parallel `migration-authority` job. The
+   guarantee did not move: the same suite still runs against the real stream.
+   ⚠ **It is not a required check until someone makes it one** — until then a
+   migration-stream failure will not block a merge, which is weaker than the
+   inline variable it replaced.
+3. **Nothing was cached.** No `cache: pip`, nothing on `~/.cache/ms-playwright`.
+   **Both added.** Worth ~13s of steady browser download; the 104s apt spike seen
+   on 2026-08-19 is the runner's package mirror and no cache reaches it.
+4. **`tests/test_panel_dom.py` costs 236s of the 703**, about 120s of it literal
+   `wait_for_timeout(500)` on 164 panel opens. **Not touched** — the file's own
+   comment explains why some animation waits are load-bearing, and telling them
+   apart is its own task. Recorded here rather than done.
+
+**And a guard was blind.** The step that refuses a silently-skipping browser suite
+grepped `importorskip("playwright"` **with the closing quote**, so
+`tests/test_grid_dom.py:24` — which writes `importorskip("playwright.sync_api")` —
+never matched, and its 20 tests were invisible to it. One character. Fixed, and
+the guard now finds ten suites instead of nine.
+
+The scope rule itself is now tested:
+`test_the_workflows_documentation_pattern_admits_exactly_what_it_should` lifts the
+bash pattern out of the YAML and classifies fifteen paths with it, over half of
+them cases that must **not** be admitted.
+
+---
+
 ## Track 3 · The version debt
 
 **Ruling:** [R-06](RULINGS.md#r-06--version-moves-with-every-merged-pull-request)

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -208,8 +208,38 @@ the guard now finds ten suites instead of nine.
 
 The scope rule itself is now tested:
 `test_the_workflows_documentation_pattern_admits_exactly_what_it_should` lifts the
-bash pattern out of the YAML and classifies fifteen paths with it, over half of
-them cases that must **not** be admitted.
+bash pattern out of the YAML and classifies fifteen paths with it, over half of them
+cases that must **not** be admitted — and it pins the **polarity** of the two
+decision lines, because an adversarial pass inverted `! grep -qvE` to `grep -qE` and
+every assertion stayed green.
+
+### What an adversarial review caught before this merged, and the worst of it was mine
+
+Twenty agents over four lenses, sixteen refutation verdicts, **eight findings
+survived** — three of which had already been found and fixed by hand. The other
+three:
+
+1. **A blocker of my own making.** Moving the scope computation into its own job made
+   `fetch-depth: 0` look unnecessary and I wrote "Shallow is enough here now". It is
+   not: `tests/test_the_privacy_policy_is_true.py:433` and `tests/test_version.py:231`
+   both **skip** rather than fail on a grafted clone, and `-q` reports a run full of
+   skips as green. Proven by experiment — edit `docs/privacy-policy.md`, leave its
+   date, and full history fails while `--depth 1` passes. **The repository had already
+   learned this twice**, in `publish-docs.yml` and `release-extension.yml`.
+2. **`git diff --name-only` reports only a rename's destination**, so a file moved out
+   of `scrapex/` into `extension/` or `docs/` classified as the narrow scope.
+   `--no-renames` added; it can only widen.
+3. **The pattern guard could not see the logic inverted.** Now pinned.
+
+**And the structural fix found a fourth instance nothing else had.**
+`tests/test_the_workflows_check_out_enough_history.py` reads every workflow, finds
+every job that runs pytest, and requires full history — and it immediately failed on
+`release-engine.yml`'s build job, which runs the **whole suite** at depth 1. Both date
+guards have therefore been skipping on **every engine release**. Fixed here.
+
+Why the mistake recurred is the part worth keeping: the requirement lived as prose
+beside the file that *needed* the history, never on the jobs that had to *provide* it.
+See [LESSONS.md](LESSONS.md#7--a-document-can-drift-into-the-opposite-of-the-code).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,15 @@ markers = [
     # set. tests/test_the_extension_gate_is_complete.py is what keeps the set
     # honest: a new file that reads extension/ and forgets the mark fails.
     "extension: guards the Chrome extension; runs on an extension-only change",
+    # And a test file that READS A DOCUMENT is guarding the documentation system,
+    # so a documentation-only change must run it and need not run much else.
+    # Same discipline, same reason, a different set:
+    # tests/test_the_docs_gate_is_complete.py fails on a file that reads a
+    # document and forgets this mark. The two sets OVERLAP AND NEITHER CONTAINS
+    # THE OTHER -- test_the_ruling_matches_the_code.py reads
+    # docs/data-page-schema.md and touches no extension file at all, which is why
+    # the extension tier now runs `-m "extension or docs"`.
+    "docs: guards a document; runs on a documentation-only change",
 ]
 
 [tool.ruff]

--- a/tests/marks.py
+++ b/tests/marks.py
@@ -1,0 +1,79 @@
+"""What marks a test file actually DECLARES, read from its `pytestmark`.
+
+WHY THIS IS NOT A SUBSTRING SEARCH, and the answer was measured rather than
+guessed. Both gate files used to ask `"pytest.mark.extension" in source`, and both
+were wrong in the same way: a file that merely MENTIONS the name -- in a docstring,
+in an assertion message telling the reader to add the mark, in the gate's own
+detector -- counts as marked. Deleting
+
+    pytestmark = pytest.mark.docs
+
+from `tests/test_the_docs_gate_is_complete.py` left the string in four other places
+in that same file, so the guard went on reporting the file as a member of the set it
+had just left. The gate that exists to catch a missing mark could not catch its own.
+
+`ast`, not a regex, because `pytestmark` is written both ways here --
+`pytestmark = pytest.mark.extension` and
+`pytestmark = [pytest.mark.extension, pytest.mark.docs]` -- and a list may be
+wrapped across lines at any time without anyone thinking about this file.
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+
+
+def _named(node: ast.AST) -> str | None:
+    """`pytest.mark.docs` -> "docs". Anything else -> None."""
+    if (isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Attribute)
+            and node.value.attr == "mark"
+            and isinstance(node.value.value, ast.Name)
+            and node.value.value.id == "pytest"):
+        return node.attr
+    return None
+
+
+def declared_marks(source: str) -> frozenset[str]:
+    """Every mark this file puts on itself or on one of its tests.
+
+    BOTH PLACEMENTS COUNT, because the question a gate asks is *will anything in
+    this file run under `-m <mark>`*, and a decorator answers it as well as a
+    module-level assignment does.
+    `tests/test_the_lint_gate_cannot_be_quietly_widened.py` writes
+    `@pytest.mark.extension` on the single test that reads extension/ and says why
+    in a comment: only that one has to run on an extension-only change. A helper
+    that read `pytestmark` alone called that file unmarked, which is how this
+    second half came to be written.
+
+    A file that cannot be parsed returns nothing rather than raising: a syntax
+    error is the test run's failure to report, not this helper's, and a guard that
+    died here would hide it behind a traceback about marks.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return frozenset()
+
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and any(
+                isinstance(t, ast.Name) and t.id == "pytestmark"
+                for t in node.targets):
+            value = node.value
+            items = value.elts if isinstance(value, (ast.List, ast.Tuple)) else [value]
+            found.update(n for n in (_named(item) for item in items) if n)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            # A parametrised decorator -- `pytest.mark.skipif(...)` -- is a Call
+            # whose func carries the attribute chain, so both shapes are unwrapped.
+            for decorator in node.decorator_list:
+                target = decorator.func if isinstance(decorator, ast.Call) else decorator
+                name = _named(target)
+                if name:
+                    found.add(name)
+    return frozenset(found)
+
+
+def carries(path: pathlib.Path, mark: str) -> bool:
+    """Whether this test file declares `mark` at module level."""
+    return mark in declared_marks(path.read_text(encoding="utf-8"))

--- a/tests/test_signing_in_says_what_happened.py
+++ b/tests/test_signing_in_says_what_happened.py
@@ -24,7 +24,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.extension
+pytestmark = [pytest.mark.extension, pytest.mark.docs]
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "tools"))

--- a/tests/test_the_addin_contract_cannot_drift.py
+++ b/tests/test_the_addin_contract_cannot_drift.py
@@ -50,7 +50,7 @@ import pytest
 
 # Guards the extension: this reads extension/ sources, so a change there must
 # run it. See tests/test_the_extension_gate_is_complete.py.
-pytestmark = pytest.mark.extension
+pytestmark = [pytest.mark.extension, pytest.mark.docs]
 
 ROOT = Path(__file__).resolve().parent.parent
 CONTRACT = ROOT / "contract" / "addin-contract.json"

--- a/tests/test_the_docs_gate_is_complete.py
+++ b/tests/test_the_docs_gate_is_complete.py
@@ -36,7 +36,12 @@ import re
 
 import pytest
 
-pytestmark = pytest.mark.docs
+from tests.marks import carries
+
+# BOTH marks. This file reads a document, and its CLASSIFICATION table below names
+# `extension/app.js`, which is what the extension gate's own detector looks for --
+# so it belongs to both sets and says so rather than being admitted by accident.
+pytestmark = [pytest.mark.extension, pytest.mark.docs]
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 
@@ -75,7 +80,10 @@ def test_every_test_file_that_reads_a_document_carries_the_mark():
         source = path.read_text(encoding="utf-8")
         if not READS_A_DOCUMENT.search(source):
             continue
-        if "pytest.mark.docs" not in source:
+        # `carries`, not `in source`. A substring search counts this very file as
+        # marked on the strength of the line above and the message below -- see
+        # tests/marks.py, where that was measured.
+        if not carries(path, "docs"):
             unmarked.append(path.name)
 
     assert not unmarked, (
@@ -96,7 +104,14 @@ def test_the_mark_is_declared_so_a_typo_cannot_be_silent():
     """
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
 
-    assert "--strict-markers" in pyproject, (
+    # `addopts`, not the whole file -- the same trap the extension gate records
+    # hitting on its first attempt, and this file walked into it too. The flag is
+    # NAMED in the comment beside the marker declarations, so a plain substring
+    # search finds its own explanation and passes with the flag switched off.
+    # Confirmed by mutation: removing it from addopts left the old assertion green.
+    addopts = re.search(r'^addopts = "([^"]*)"', pyproject, re.MULTILINE)
+    assert addopts, "pyproject.toml no longer sets addopts"
+    assert "--strict-markers" in addopts.group(1), (
         "--strict-markers is gone from addopts; a misspelled mark is now a "
         "warning and a file can leave the docs set without failing anything")
     assert re.search(r'^\s*"docs:', pyproject, re.MULTILINE), (
@@ -108,8 +123,7 @@ def test_the_gate_still_collects_a_real_suite():
     """The count, not just the presence of a mark. A per-file 'at least one'
     would not notice 178 tests becoming 3 -- which is precisely how the panel
     suite went quiet."""
-    marked = [path for path in _test_files()
-              if "pytest.mark.docs" in path.read_text(encoding="utf-8")]
+    marked = [path for path in _test_files() if carries(path, "docs")]
 
     assert len(marked) >= 8, (
         f"only {len(marked)} test files carry the docs mark; nine did when the "
@@ -136,9 +150,14 @@ def test_the_workflow_actually_runs_the_docs_tier():
     leaving the markers behind, this is what says so."""
     workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
 
-    assert "pytest -m docs" in workflow, (
-        "ci.yml no longer runs `pytest -m docs`, so the docs mark selects a "
-        "suite that never executes")
+    # THE WHOLE `run:` LINE, not the substring. `pytest -m docs` also appears in
+    # the --collect-only floor step a few lines above, so the substring version
+    # passed with the step that actually RUNS the tier deleted. Confirmed by
+    # mutation before this line was written.
+    assert "run: python -m pytest -m docs\n" in workflow, (
+        "ci.yml has no step whose whole command is `python -m pytest -m docs`, so "
+        "the docs mark selects a suite that never executes. The --collect-only "
+        "gate step does not count: it collects and never runs.")
     assert 'scope=docs' in workflow, (
         "ci.yml no longer computes a `docs` scope, so the tier can never be "
         "chosen no matter what carries the mark")
@@ -185,6 +204,29 @@ def test_the_workflows_documentation_pattern_admits_exactly_what_it_should():
     and classifies real paths with it, so the rule is tested rather than trusted.
     """
     workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+    # THE POLARITY, BEFORE THE PATTERN. `! grep -qvE` means "no changed line
+    # FAILS to match", i.e. all of them match. Plain `grep -qE` means "at least
+    # one matches" -- the opposite -- and would classify a diff of one Markdown
+    # file plus one connector as documentation. Extracting the regex alone cannot
+    # see that: an adversarial pass inverted these two lines and every assertion
+    # in this file stayed green, so the lines are pinned verbatim.
+    for decision in (
+            'if ! echo "$changed" | grep -qvE "$documentation"; then',
+            'elif ! echo "$changed" | grep -qvE "^(extension/)|$documentation"; then'):
+        assert decision in workflow, (
+            f"the scope decision no longer reads {decision!r}. If the shape "
+            "changed, re-derive the polarity and update this list -- a `grep -qE` "
+            "where a `! grep -qvE` was means ANY file matching is enough, and a "
+            "code change would run the documentation tier.")
+
+    # And the diff must stay rename-blind: `--name-only` alone reports only a
+    # move's destination, so a file moved out of scrapex/ into docs/ would look
+    # like a documentation change. Reproduced before this was pinned.
+    assert 'git diff --name-only --no-renames' in workflow, (
+        "the scope diff lost --no-renames, so a file MOVED into docs/ or "
+        "extension/ reports only its destination and the engine suite is skipped "
+        "on a change that deleted an engine file")
 
     found = re.search(r"^\s*documentation='([^']+)'", workflow, re.MULTILINE)
     assert found, (

--- a/tests/test_the_docs_gate_is_complete.py
+++ b/tests/test_the_docs_gate_is_complete.py
@@ -1,0 +1,206 @@
+"""The set of tests that guard the documents must not shrink by accident.
+
+The sibling of tests/test_the_extension_gate_is_complete.py, and it exists for
+the same reason at a different seam. CI runs `pytest -m docs` when a change
+touches only documentation, so a Markdown edit stops dragging a 2,656-test engine
+suite behind it. The whole value of that depends on one thing: the marked set
+really being every test that reads a document.
+
+MEASURED when the tier was made, 2026-08-19: nine files under tests/ read a
+documentation file, carrying 178 tests that run in 30.6 seconds -- against 451
+seconds for the whole suite locally and 12m49s in CI. The largest by far is the
+privacy policy suite; the citation guard reads the eight documents in CLAUDE.md's
+map.
+
+WHY IT IS NOT ENOUGH TO REUSE THE EXTENSION MARK, and this was found rather than
+assumed. `tests/test_the_ruling_matches_the_code.py` reads
+`docs/data-page-schema.md` and asserts it equals what the generator produces. It
+carries no extension mark and never needed one -- it touches no extension file.
+But `docs/` was already inside the old extension-only path filter, so a
+documentation-only change ran `pytest -m extension` and DID NOT RUN IT. A
+hand-edited `docs/data-page-schema.md` would have passed CI on the very kind of
+pull request that hand-edits it. The two sets overlap and neither contains the
+other, which is why the extension tier now runs `-m "extension or docs"`.
+
+THE FAILURE THIS PREVENTS IS THE ONE THAT HAS HAPPENED TWICE HERE. The panel
+suite reported green for months while 48 tests skipped silently. The document
+guards are newer and more fragile in exactly the same way: write a test that reads
+CLAUDE.md, forget the mark, and it stops running on the pull requests it was
+written for. Nothing goes red. Nothing looks different.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+pytestmark = pytest.mark.docs
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+#: A file "reads a document" if it names one in a STRING, or joins a `docs` path
+#: segment. Deliberately broad in the same way READS_EXTENSION next door is: a
+#: false positive costs one marker, a false negative costs a guard nobody notices
+#: is gone.
+#:
+#: IT STARTED NARROWER AND THE NARROW VERSION MISSED THE MOST IMPORTANT FILE.
+#: The first pattern required a `/` before the quoted name -- `ROOT / "docs" /
+#: "data-page-schema.md"` -- and so did not see
+#: tests/test_the_documents_cite_what_they_claim.py, which holds its eight
+#: documents in a plain tuple of names and resolves them later. That is the
+#: citation guard: the one test whose entire subject is the documents. A guard
+#: whose detector cannot see the most important member of the set is not a guard,
+#: and matching any quoted `*.md` is what fixes it.
+READS_A_DOCUMENT = re.compile(
+    r'''"[\w.\-/]*\.md"'''
+    r'''|(?:ROOT|parents\[1\]|parent\.parent)\s*/\s*"docs"''')
+
+#: The floor, not the count -- same reasoning as LEAST_TESTS_IN_THE_GATE next
+#: door. 178 tests carried the mark when the tier was made. It is CHECKED because
+#: without it the set can be emptied one file at a time while CI keeps reporting
+#: a green docs gate over nothing.
+LEAST_TESTS_IN_THE_GATE = 150
+
+
+def _test_files() -> list[pathlib.Path]:
+    return sorted((ROOT / "tests").glob("test_*.py"))
+
+
+def test_every_test_file_that_reads_a_document_carries_the_mark():
+    """THE GUARD. Without it the docs tier is a promise rather than a mechanism."""
+    unmarked = []
+    for path in _test_files():
+        source = path.read_text(encoding="utf-8")
+        if not READS_A_DOCUMENT.search(source):
+            continue
+        if "pytest.mark.docs" not in source:
+            unmarked.append(path.name)
+
+    assert not unmarked, (
+        "these test files read a documentation file and would stop running on a "
+        "documentation-only change:\n  " + "\n  ".join(unmarked) + "\n\nAdd "
+        "`pytest.mark.docs` to the file's pytestmark. A file that guards both a "
+        "document and the extension carries both marks:\n"
+        "    pytestmark = [pytest.mark.extension, pytest.mark.docs]")
+
+
+def test_the_mark_is_declared_so_a_typo_cannot_be_silent():
+    """`--strict-markers` turns `pytest.mark.dcos` into an error.
+
+    Without it an unknown mark is a warning, the file quietly leaves the set, and
+    the gate keeps passing -- the same shape of failure as the one above, reached
+    by a different route. Asserted here as well as next door because either
+    marker could be removed from `pyproject.toml` on its own.
+    """
+    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+
+    assert "--strict-markers" in pyproject, (
+        "--strict-markers is gone from addopts; a misspelled mark is now a "
+        "warning and a file can leave the docs set without failing anything")
+    assert re.search(r'^\s*"docs:', pyproject, re.MULTILINE), (
+        "the `docs` marker is not registered in pyproject.toml, so "
+        "--strict-markers will reject every file that carries it")
+
+
+def test_the_gate_still_collects_a_real_suite():
+    """The count, not just the presence of a mark. A per-file 'at least one'
+    would not notice 178 tests becoming 3 -- which is precisely how the panel
+    suite went quiet."""
+    marked = [path for path in _test_files()
+              if "pytest.mark.docs" in path.read_text(encoding="utf-8")]
+
+    assert len(marked) >= 8, (
+        f"only {len(marked)} test files carry the docs mark; nine did when the "
+        "tier was built. A file leaves this set when its READS go, never to "
+        "quiet a failure.")
+
+    # `def test_` at the start of a line, which is how every test in this
+    # repository is written. Parametrised cases multiply this, so the real
+    # collected count is higher -- the safe direction for a floor. Same
+    # arithmetic as the extension gate next door, and the same slack.
+    functions = sum(
+        len(re.findall(r"^def test_", path.read_text(encoding="utf-8"), re.MULTILINE))
+        for path in marked)
+    assert functions >= LEAST_TESTS_IN_THE_GATE - 60, (
+        f"the docs gate is down to {functions} test functions; 178 collected "
+        "tests were measured when the tier was made")
+
+
+def test_the_workflow_actually_runs_the_docs_tier():
+    """A marked set nothing runs is worse than no set: it reads as coverage.
+
+    The extension gate has the same exposure and no test for it, so this asserts
+    for both -- if a future edit deletes either tier from the workflow while
+    leaving the markers behind, this is what says so."""
+    workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+    assert "pytest -m docs" in workflow, (
+        "ci.yml no longer runs `pytest -m docs`, so the docs mark selects a "
+        "suite that never executes")
+    assert 'scope=docs' in workflow, (
+        "ci.yml no longer computes a `docs` scope, so the tier can never be "
+        "chosen no matter what carries the mark")
+    assert 'pytest -m "extension or docs"' in workflow, (
+        "the extension tier stopped including the docs set. "
+        "tests/test_the_ruling_matches_the_code.py carries no extension mark, so "
+        "an extension+docs change would stop checking docs/data-page-schema.md")
+
+
+#: What the workflow's `documentation=` pattern must and must not admit. The left
+#: column is a changed-file path; True means "this alone is a documentation-only
+#: change and may run 178 tests instead of 2,656".
+CLASSIFICATION = (
+    ("docs/STATE.md", True),
+    ("docs/plans/2026-08-16-muqawil-contractor-source.md", True),
+    ("CLAUDE.md", True),
+    ("CHANGELOG.md", True),
+    (".gitignore", True),
+    (".claude/skills/karpathy-guidelines/SKILL.md", True),
+    # THE DANGEROUS DIRECTION. Every one of these must run the whole suite; a
+    # pattern that admits any of them turns a code change into a 30-second
+    # documentation run and says nothing.
+    ("scrapex/features.py", False),
+    ("scrapex/webui/templates/settings.html", False),
+    ("extension/app.js", False),
+    ("tests/test_vendor.py", False),
+    ("sources.yaml", False),
+    ("pyproject.toml", False),
+    # A workflow edit changes what CI itself guarantees -- including an edit to
+    # the very pattern this test reads.
+    (".github/workflows/ci.yml", False),
+    # docs/ is a prefix of nothing else, but a pattern written without the
+    # anchor would match this and quietly exempt a connector.
+    ("scrapex/connectors/docs/reader.py", False),
+)
+
+
+def test_the_workflows_documentation_pattern_admits_exactly_what_it_should():
+    """The scope rule is a bash regex inside YAML, which no linter reads.
+
+    A widened pattern is silent and expensive in the dangerous direction: add
+    `scrapex/` to it by accident and a change to the warehouse runs 178
+    documentation tests and reports green. This lifts the pattern out of ci.yml
+    and classifies real paths with it, so the rule is tested rather than trusted.
+    """
+    workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+    found = re.search(r"^\s*documentation='([^']+)'", workflow, re.MULTILINE)
+    assert found, (
+        "ci.yml no longer defines a `documentation=` pattern in the scope job, so "
+        "this test cannot check what the docs tier admits. If the rule moved, move "
+        "this test with it -- do not delete it.")
+
+    # ERE from the shell; Python's `re` is close enough for these paths, and the
+    # cases below are the ones the two dialects agree on.
+    pattern = re.compile(found.group(1))
+
+    wrong = [(path, expected) for path, expected in CLASSIFICATION
+             if bool(pattern.search(path)) is not expected]
+
+    assert not wrong, "\n".join(
+        ["the documentation pattern classifies these wrongly:"]
+        + [f"  {path!r} -> {'documentation' if not want else 'NOT documentation'}, "
+           f"expected {'documentation' if want else 'NOT documentation'}"
+           for path, want in wrong])

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -71,7 +71,7 @@ import pytest
 # on exactly the pull requests most likely to move them.
 # See tests/test_the_extension_gate_is_complete.py, which is the guard that
 # refuses an unmarked file reading extension/ sources.
-pytestmark = pytest.mark.extension
+pytestmark = [pytest.mark.extension, pytest.mark.docs]
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 

--- a/tests/test_the_extension_gate_is_complete.py
+++ b/tests/test_the_extension_gate_is_complete.py
@@ -32,6 +32,8 @@ import re
 
 import pytest
 
+from tests.marks import carries
+
 pytestmark = pytest.mark.extension
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -59,7 +61,10 @@ def test_every_test_file_that_reads_the_extension_carries_the_mark():
         source = path.read_text(encoding="utf-8")
         if not READS_EXTENSION.search(source):
             continue
-        if "pytest.mark.extension" not in source:
+        # `carries`, not `in source`: THIS FILE mentions the mark four times in
+        # its own prose and messages, so the substring version reported it as
+        # marked whether it was or not. Measured 2026-08-19 -- see tests/marks.py.
+        if not carries(path, "extension"):
             unmarked.append(path.name)
 
     assert not unmarked, (
@@ -80,12 +85,12 @@ def test_the_mark_is_declared_so_a_typo_cannot_be_silent():
     # `addopts`, not the file: the flag is named in the comment beside the
     # marker declaration, so a plain substring search finds its own explanation
     # and passes with the flag switched off — measured, on the first attempt.
-    addopts = re.search(r'^addopts = "([^"]*)"', pyproject, re.M)
+    addopts = re.search(r'^addopts = "([^"]*)"', pyproject, re.MULTILINE)
     assert addopts, "pyproject.toml no longer sets addopts"
     assert "--strict-markers" in addopts.group(1), (
         "an unknown marker is only a warning again, so a misspelt "
         "`pytest.mark.extension` silently removes a file from the gate")
-    assert re.search(r'^\s*"extension:', pyproject, re.M), (
+    assert re.search(r'^\s*"extension:', pyproject, re.MULTILINE), (
         "the extension marker is no longer declared in pyproject.toml")
 
 
@@ -96,8 +101,7 @@ def test_the_gate_still_holds_enough_tests_to_be_a_gate(pytestconfig):
     the number that matters is how many tests CARRY the mark, and that is a
     fact about the files.
     """
-    marked_files = [p for p in _test_files()
-                    if "pytest.mark.extension" in p.read_text(encoding="utf-8")]
+    marked_files = [p for p in _test_files() if carries(p, "extension")]
     assert len(marked_files) >= 10, (
         f"only {len(marked_files)} files are in the extension gate; eleven were "
         "measured when the split was made")
@@ -106,7 +110,7 @@ def test_the_gate_still_holds_enough_tests_to_be_a_gate(pytestconfig):
     # repository is written. Parametrised cases multiply this, so the real
     # collected count is higher — which is the safe direction for a floor.
     functions = sum(
-        len(re.findall(r"^def test_", p.read_text(encoding="utf-8"), re.M))
+        len(re.findall(r"^def test_", p.read_text(encoding="utf-8"), re.MULTILINE))
         for p in marked_files)
     assert functions >= LEAST_TESTS_IN_THE_GATE - 60, (
         f"the extension gate is down to {functions} test functions; it was "

--- a/tests/test_the_google_button_follows_googles_rules.py
+++ b/tests/test_the_google_button_follows_googles_rules.py
@@ -29,7 +29,7 @@ import re
 
 import pytest
 
-pytestmark = pytest.mark.extension
+pytestmark = [pytest.mark.extension, pytest.mark.docs]
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 TOKENS = (ROOT / "design" / "tokens.css").read_text(encoding="utf-8")

--- a/tests/test_the_privacy_policy_is_true.py
+++ b/tests/test_the_privacy_policy_is_true.py
@@ -18,7 +18,7 @@ import re
 import pytest
 from urllib.parse import urlparse
 
-pytestmark = pytest.mark.extension
+pytestmark = [pytest.mark.extension, pytest.mark.docs]
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 POLICY = ROOT / "docs" / "privacy-policy.md"

--- a/tests/test_the_request_board_matches_its_entries.py
+++ b/tests/test_the_request_board_matches_its_entries.py
@@ -21,12 +21,23 @@ docs/REQUESTS.md. tests/test_the_extension_gate_is_complete.py owns that rule, a
 note it matches on the literal path string: a sentence merely *mentioning* the
 tree is enough to trip it, which is why this paragraph talks around the name. That
 is the same prose-inference limit LESSONS.md records twice over.
+
+MARKED `docs`, and that mark is the whole reason this file has to carry one: it
+reads a document, and a change touching nothing but documents runs `pytest -m
+docs`. An unmarked file would simply stop running on exactly the pull requests
+that edit docs/REQUESTS.md -- which is every pull request that could break it.
+tests/test_the_docs_gate_is_complete.py is the guard that refuses the omission,
+and it caught this file the moment the two changes met.
 """
 
 from __future__ import annotations
 
 import pathlib
 import re
+
+import pytest
+
+pytestmark = pytest.mark.docs
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 BOARD = ROOT / "docs" / "REQUESTS.md"

--- a/tests/test_the_ruling_matches_the_code.py
+++ b/tests/test_the_ruling_matches_the_code.py
@@ -21,9 +21,21 @@ import argparse
 import pathlib
 import re
 
+import pytest
+
 from scrapex import reports
 from scrapex.cli import _render_data_page_schema, build_parser
 from scrapex.vocab import BLOCK_ORDER
+
+# THIS FILE IS WHY THE DOCS TIER EXISTS. It reads docs/data-page-schema.md and
+# asserts it equals what the generator produces -- and it carried no mark at all,
+# while `docs/` was already inside the extension-only path filter. So a
+# documentation-only change ran `pytest -m extension`, this file was not in that
+# set, and a hand-edited copy of the ruling would have passed CI on exactly the
+# kind of pull request that hand-edits it. No extension mark: it touches no
+# extension file, which is also why the extension tier now runs
+# `-m "extension or docs"` rather than `-m extension`.
+pytestmark = pytest.mark.docs
 
 RULING = pathlib.Path(__file__).resolve().parent.parent / "docs" / "data-page-schema.md"
 

--- a/tests/test_the_two_release_paths.py
+++ b/tests/test_the_two_release_paths.py
@@ -30,7 +30,7 @@ import pytest
 # Guards the extension: this file reads extension/ sources — the manifest the
 # store path packages, and the public repo the engine path publishes to. See
 # tests/test_the_extension_gate_is_complete.py.
-pytestmark = pytest.mark.extension
+pytestmark = [pytest.mark.extension, pytest.mark.docs]
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 WORKFLOWS = ROOT / ".github" / "workflows"

--- a/tests/test_the_workflows_check_out_enough_history.py
+++ b/tests/test_the_workflows_check_out_enough_history.py
@@ -1,0 +1,125 @@
+"""A job that runs pytest on a grafted clone turns two guards into silent skips.
+
+WHY THIS FILE EXISTS, and it is the third time the same mistake has been made here.
+
+Two tests in this suite ask git when something last really changed, and **both skip
+rather than fail** when the clone has no history to ask:
+
+  * `tests/test_the_privacy_policy_is_true.py:433` -- `_last_changed()` returns None
+    on a shallow repository, so the "Last updated" staleness test skips. That guard
+    was added on 2026-08-12 after the privacy policy was edited three times in one
+    day while still advertising an older date, and the Chrome Web Store listing
+    hangs on that document.
+  * `tests/test_version.py:231` -- every capability's cited commit hash goes
+    unchecked.
+
+A skip is not a failure. Under `addopts = "-q --strict-markers"` a run full of them
+reports **green**, so the loss is invisible in exactly the way a missing guard
+always is.
+
+THE HISTORY OF THIS MISTAKE:
+
+  1. `publish-docs.yml` and `release-extension.yml` both ran this file at depth 1.
+     Fixed, and the helper's own comment at
+     `tests/test_the_privacy_policy_is_true.py:430` names them and says it "refuses
+     to guess if one ever stops".
+  2. `ci.yml`'s `test` job carried `fetch-depth: 0` -- but only because the scope
+     diff needed it. When the scope computation moved into its own job on
+     2026-08-19, the comment "Shallow is enough here now" went in with it and the
+     history went away. An adversarial review caught it before it merged, by
+     experiment: edit `docs/privacy-policy.md`, leave its date alone, and full
+     history reports one failure while `--depth 1` reports green.
+
+Nothing structural stopped (2) from happening after (1) was fixed, because the
+reason lived in a comment on the file that NEEDED the history rather than on the
+jobs that have to PROVIDE it. This test is that structure: it reads every workflow,
+finds every job that runs pytest, and requires each one to fetch the whole history.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+pytestmark = pytest.mark.docs
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+
+def _runs_pytest(job: dict) -> bool:
+    return any("pytest" in str(step.get("run") or "")
+               for step in (job.get("steps") or []))
+
+
+def _checkout_depths(job: dict) -> list[object]:
+    """`fetch-depth` from every actions/checkout step in this job.
+
+    A job with no checkout has nothing to fetch and nothing to get wrong; a job
+    with two checkouts has to get both right, so every one is reported.
+    """
+    depths = []
+    for step in (job.get("steps") or []):
+        if str(step.get("uses") or "").startswith("actions/checkout"):
+            depths.append((step.get("with") or {}).get("fetch-depth", "<default>"))
+    return depths
+
+
+def _jobs():
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        parsed = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(parsed, dict):
+            continue
+        for name, job in (parsed.get("jobs") or {}).items():
+            if isinstance(job, dict):
+                yield path.name, name, job
+
+
+def test_every_job_that_runs_pytest_fetches_the_whole_history():
+    """THE GUARD. `fetch-depth: 0`, or the two date guards skip and say nothing."""
+    shallow = []
+    for workflow, name, job in _jobs():
+        if not _runs_pytest(job):
+            continue
+        for depth in _checkout_depths(job):
+            if depth != 0:
+                shallow.append(f"{workflow} :: {name} -- fetch-depth: {depth}")
+
+    assert not shallow, (
+        "these jobs run pytest on a clone with no history, so the guards at "
+        "tests/test_the_privacy_policy_is_true.py:433 and tests/test_version.py:231 "
+        "SKIP instead of running -- and a run full of skips reports green:\n  "
+        + "\n  ".join(shallow)
+        + "\n\nAdd to the checkout step:\n    with:\n      fetch-depth: 0")
+
+
+def test_the_guards_this_protects_still_consult_git():
+    """If they ever start FAILING on a shallow clone instead of skipping, this file
+    is no longer load-bearing and should be re-argued rather than kept out of habit.
+    If they stop consulting git at all, the same.
+
+    A source check rather than a real shallow clone: making one inside a test costs
+    seconds and a temp directory for a fact two lines of source state plainly.
+    """
+    for name in ("test_the_privacy_policy_is_true.py", "test_version.py"):
+        source = (ROOT / "tests" / name).read_text(encoding="utf-8")
+        assert "is-shallow-repository" in source, (
+            f"{name} no longer asks whether the clone is shallow. Either it stopped "
+            "consulting git history -- in which case this whole file can go -- or it "
+            "now trusts a grafted clone, which is worse than skipping.")
+
+
+def test_it_notices_a_job_that_runs_pytest_at_all():
+    """A parser that silently matches nothing makes the guard above vacuous -- the
+    failure mode this repository has hit more than once. `ci.yml` has jobs that run
+    pytest by construction; if this finds none, the reader changed shape."""
+    running = [f"{workflow}::{name}" for workflow, name, job in _jobs()
+               if _runs_pytest(job)]
+
+    assert len(running) >= 2, (
+        f"only {len(running)} workflow jobs look like they run pytest ({running}). "
+        "The step parser has probably stopped matching, which makes the guard above "
+        "pass over nothing.")

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -49,7 +49,7 @@ from scrapex.version import (
 
 # Guards the extension: this file reads extension/ sources, so a change to a
 # button must run it. See tests/test_the_extension_gate_is_complete.py.
-pytestmark = pytest.mark.extension
+pytestmark = [pytest.mark.extension, pytest.mark.docs]
 
 ROOT = Path(__file__).resolve().parent.parent
 CONTRACTS = ROOT / "contracts"


### PR DESCRIPTION
> **Stacks on [#214](https://github.com/muhammadbayoumi/ScrapeX/pull/214).** The docs
> tier needs the citation guard that #214 adds, so this branch is built on it and the
> list below shows #214's seven commits too. **The commit to review here is
> `c136ac4`.** Once #214 merges this reduces to one commit against `main`.

## Measured first, because the question was "why does CI take so long"

The answer is one step.

| | |
|---|---|
| `test` job, median of 15 full-scope runs | **12m49s** |
| of which the `pytest` step | **703s — 92%** |
| `lint` · `contract-parity` | 21–26s · 14–16s |
| PR #214's two runs | **14m21s and 14m40s** — the slowest of the previous twenty |

Nothing outside that one step matters. Four causes, ranked.

## 1 · A documentation change ran the whole suite

The scope filter knew `extension/` and `docs/` only. #214 changed `CLAUDE.md`,
`ENGINEERING.md`, `README.md`, `.gitignore` and a `.claude/` file — **none of which
match `^docs/`.** The documentation system C1 sends every session to read lives
partly at the repository root, so the filter could not see its own pull requests.

A third `docs` tier, built by **copying the extension split** rather than inventing
a second mechanism:

| | extension | docs |
|---|---|---|
| marker | `pytest.mark.extension` | `pytest.mark.docs` (registered in `pyproject.toml`) |
| completeness guard | `test_the_extension_gate_is_complete.py` | **`test_the_docs_gate_is_complete.py`** |
| floor in CI | ≥300 collected | ≥150 collected |

**Measured: 178 tests in 30.6s**, against 451s for the whole suite locally. #214's
exact file list now classifies as `docs`.

### And copying it found a hole in the original

`tests/test_the_ruling_matches_the_code.py` reads `docs/data-page-schema.md` and
asserts it equals what the generator produces. It carries **no extension mark** and
never needed one — it touches no extension file. But `docs/` was already inside the
extension-only filter, so a documentation-only change ran `pytest -m extension` and
**did not run it**. A hand-edited copy of that generated ruling would have passed CI
on exactly the kind of pull request that hand-edits it.

The two sets overlap and **neither contains the other**, so the extension tier now
runs `-m "extension or docs"` — strictly more coverage than before.

## 2 · `SCRAPEX_FULL_MIGRATIONS` replayed 61 files 927 times a run

Real `migrate()` is **396ms** against a **3.6ms** template restore, both measured
today, and a full suite makes **927** of those calls (895 restored, 32 real) —
roughly **350s of the 703**. Moved to a parallel `migration-authority` job.

**The guarantee did not move with it:** that job runs the same suite against the real
stream, on every change the full tier runs on.

> ### ⚠ It is not a required check until you make it one
> A new job is not added to branch protection automatically. **Until
> `migration-authority` is required for `main`, a migration-stream failure will not
> block a merge** — which is strictly weaker than the inline variable it replaced.
> This is the one action this PR needs from you.

And a correction to what I said earlier: splitting does **not** by itself make a merge
faster. If both are required, the slowest required check still decides. What changes
is that a failure unrelated to migrations surfaces in about six minutes instead of
thirteen.

## 3 · Nothing was cached

No `cache: pip`, nothing on `~/.cache/ms-playwright`. Both added. Worth ~13s of steady
browser download. The 104s apt spike measured on 2026-08-19 — against 9.4s on
2026-08-17, same command — is the runner's package mirror, and no cache reaches it.

## 4 · A guard was blind, and this is the finding rather than the optimisation

The step that refuses a silently-skipping browser suite grepped

```
importorskip("playwright"
```

**with the closing quote.** [`tests/test_grid_dom.py:24`](tests/test_grid_dom.py#L24)
writes `importorskip("playwright.sync_api")`, so it **never matched**, and its 20
browser-driven tests were invisible to that guard for as long as they existed. One
character. The step now finds ten suites instead of nine.

Its own comment says *a guard that lists its subjects fails on the one nobody added to
the list* — and discovery by an over-precise pattern fails the same way with no list to
audit. **The new docs detector made the identical mistake within the hour:** it
required a `/` before a quoted `*.md` and so could not see
`test_the_documents_cite_what_they_claim.py`, the one test whose whole subject is the
documents. Both were obvious the moment the matched list was printed.

## The scope rule is now tested

It is bash inside YAML and no linter reads it. Widening it by accident — adding
`scrapex/` while meaning `docs/` — would make a warehouse change run 178
documentation tests and report **green**, which is what everyone expects to see.

`test_the_workflows_documentation_pattern_admits_exactly_what_it_should` lifts the
pattern out of `ci.yml` and classifies fifteen real paths, **eight of them cases that
must not be admitted**. Verified by mutation: adding `scrapex/` fails it, naming three
files.

The scope computation also became **its own job**. Two jobs need the answer and must
run in parallel, so neither can compute it for the other — `needs: test` would
serialise six minutes in front of twelve — and computing it twice means two copies of
the base-detection reasoning, of which one drifts. `test` no longer needs
`fetch-depth: 0`.

## Measured and deliberately not done

`tests/test_panel_dom.py` is **236s of the 703**, about **120s of it literal
`wait_for_timeout(500)`** across 164 panel opens. The file's own comment explains why
some animation waits are load-bearing, and telling those apart from the blanket
post-`goto` sleep is its own task. Recorded in `STATE.md` Track 4 rather than
half-done here.

Two stale numbers in `ci.yml`'s own comments, corrected by counting rather than
remembering: the extension gate is **661 of 2,656** tests, not 325 of 2020.

## Verification

- **The whole suite on this branch: one failure** — `extension/app.css:1166`, which
  comes from `ac3a5af` on `main` and is reverted by
  [#215](https://github.com/muhammadbayoumi/ScrapeX/pull/215).
- Both gates plus the citation guard: **38 green**.
- `ruff` clean on every file this commit adds or edits.
- The YAML parses; its five jobs wire up as intended.
- The scope decision exercised on **twelve real file lists**, including #214's exact
  set → `docs`, and an empty diff → `full`.
- The whole cached diff was read before committing per `SR-19`, and it caught an unused
  constant and a count I had written from memory.

An adversarial review over four lenses — coverage loss, the shell logic, branch
protection, and whether the new guard can pass while broken — was still running when
this was opened. Anything it confirms will be pushed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
