### PR TITLE
main's padding is a token now, because two screens cancelled a value it no longer had

### DIFF
--- a/extension/app.css
+++ b/extension/app.css
@@ -7,7 +7,10 @@
      4px too far on each side at the narrowest panel — measured on the Engine
      screens at 320px: the pinned action bar sat at x -4 and lost 4px off its
      right edge into `overflow: hidden`. Same shape as --panel-rail-width, which
-     is named here for the same reason. */
+     And the two screens that actually cancel it are #view-profile and
+     #view-manage-account: when this was spelled `var(--sp-4)` in three
+     places, the 340px query moved only `main`'s and both of them pulled
+     4px too far. */
   --panel-pad: var(--sp-4);
   /* The extension behaves like a compact Android app: every primary touch
      target remains at least 48px even when the visual icon is smaller. */
@@ -1188,8 +1191,8 @@
     height: 100%;
     min-height: 0;
     overflow: hidden;
-    margin: calc(-1 * var(--sp-4));
-    padding: var(--sp-4);
+    margin: calc(-1 * var(--panel-pad));
+    padding: var(--panel-pad);
     background: var(--bg);
   }
   .profile-stage {
@@ -1950,7 +1953,7 @@
     height: 100%;
     min-height: 0;
     overflow: hidden;
-    margin: calc(-1 * var(--sp-4));
+    margin: calc(-1 * var(--panel-pad));
     background: var(--bg);
   }
   .manage-account-heading {

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -4616,6 +4616,64 @@ def test_the_engine_actions_stack_full_width_at_320px(open_panel):
     assert action_box["x"] == pytest.approx(0, abs=0.51), action_box["x"]
 
 
+def _bleeds_to_the_panel_edge(page, selector):
+    """The measurement a full-bleed screen has to pass: its box is `main`'s box.
+
+    Both edges, because the failure is one-sided. A screen that cancels `main`'s
+    padding with a negative margin LARGER than that padding starts left of the
+    panel and runs the same amount off the right, where `main`'s
+    `overflow: hidden` silently eats it — the left edge shows as a gap, the
+    right edge shows as nothing at all.
+    """
+    box = page.locator(selector).bounding_box()
+    main = page.locator("main").bounding_box()
+    assert box and main
+    return box, main
+
+
+def test_the_full_bleed_screens_still_bleed_exactly_at_320px(open_panel):
+    """Profile and Manage account cancel `main`'s padding to paint to the panel
+    edge, and `main`'s padding is not one number.
+
+    THE BUG THIS WOULD HAVE CAUGHT. `main` is padded `--panel-pad`, which the
+    340px query narrows from `--sp-4` to `--sp-3`. Both screens spelled their
+    cancelling margin `calc(-1 * var(--sp-4))` literally, so at 320px they
+    pulled 16px against a 12px padding: the box began at x -4 and the 4px it
+    gained on the right disappeared into `main`'s `overflow: hidden`. Nothing
+    measured it. `test_the_engine_actions_stack_full_width_at_320px` above is
+    the only 320px geometry guard on this file, and the Engine screen is not
+    full-bleed, so it could not see this.
+
+    Asserting against `main`'s own box rather than against 0 and 320 keeps the
+    test honest if the rail width or the padding is ever retuned: what must
+    hold is that the screen covers its container, whatever that measures.
+    """
+    page = open_panel(signed_in=ACCOUNT)
+    page.wait_for_selector("#welcome-signed-in:visible")
+    page.set_viewport_size({"width": 320, "height": 600})
+    page.wait_for_timeout(200)
+
+    box, main = _bleeds_to_the_panel_edge(page, "#view-profile")
+    assert abs(box["x"] - main["x"]) < 1, (
+        f"Profile starts at x {box['x']} but main starts at {main['x']}: its "
+        f"full-bleed margin no longer matches main's padding at 320px")
+    assert abs((box["x"] + box["width"]) - (main["x"] + main["width"])) < 1, (
+        f"Profile ends at x {box['x'] + box['width']} but main ends at "
+        f"{main['x'] + main['width']}: the overhang is clipped by main's "
+        f"overflow: hidden, so it is invisible rather than obviously wrong")
+
+    page.click("#manage-account")
+    page.wait_for_selector("#view-manage-account:visible")
+
+    box, main = _bleeds_to_the_panel_edge(page, "#view-manage-account")
+    assert abs(box["x"] - main["x"]) < 1, (
+        f"Manage account starts at x {box['x']} but main starts at "
+        f"{main['x']}: same defect, second screen")
+    assert abs((box["x"] + box["width"]) - (main["x"] + main["width"])) < 1, (
+        f"Manage account ends at x {box['x'] + box['width']} but main ends at "
+        f"{main['x'] + main['width']}")
+
+
 def _alpha_of(css_colour: str) -> float:
     """Alpha from any form Chrome serialises a computed colour in.
 


### PR DESCRIPTION
`main` is padded `--sp-4`, and the `@media (max-width: 340px)` query narrowed that
to `--sp-3`. `#view-profile` and `#view-manage-account` bleed to the panel edge by
cancelling that padding with a negative margin, and both spelled it
`calc(-1 * var(--sp-4))` literally. At 320px they pulled 16px against a 12px
padding: the section box began at x −4 and gained 4px on the right, where `main`'s
`overflow: hidden` ate it.

## The change

The padding is `--panel-pad` now. `main` reads it, the 340px query overrides the
**token** instead of `main`'s padding, and both screens cancel the token.

`#view-profile`'s adjacent `padding: var(--sp-4)` moves with it — it is the restore
half of the bleed/restore pair, and leaving it behind would have inset Profile's
content 16px at 320px while every other screen sits at 12px.

## What the owner actually saw

Measured at 320px rather than assumed, because the finding as written overstates it:

| | before | after |
|---|---|---|
| Profile card | `x 12 … 256` | `x 12 … 256` |
| Manage account back button | 12px from the edge | 16px |
| Manage account card gutters | 12px | 16px |
| Manage account section box | `−4 … 272`, clipped at 268 | `0 … 268` |

**On Profile: nothing.** The margin was 4px too large and the padding was 4px too
large, and they cancelled exactly.

**On Manage account:** the 4px the section overhung was padding and background, not
content. No text and no control was clipped. The screen was 4px out of step with
every other screen in the panel — felt rather than seen.

So the value here is the trap removed, not a complaint answered: the next
full-bleed screen, or the first control pinned to Manage account's right edge,
would have been clipped for real and in silence.

## Proof

`tools/style_snapshot.py` reports **no computed style changed on any element of any
page** — 24 pages, 22,715 elements. It snapshots the panel at 400px, where
`--panel-pad` *is* `--sp-4`, so a clean diff is the expected result and not evidence
about 320px. That is what the new test is for.

`test_the_full_bleed_screens_still_bleed_exactly_at_320px` asserts each view's box
against `main`'s **own** box, both edges, so retuning the rail width or the padding
cannot make it lie. Reverted `app.css` and re-ran it to prove it is not vacuous:

```
AssertionError: Profile starts at x -4 but main starts at 0
```

the predicted defect, measured. `test_the_engine_actions_stack_full_width_at_320px`
was this file's only 320px geometry guard, and the Engine screen is not full-bleed,
so it could not see this.

Green: `test_panel_dom.py`, `test_panel_startup.py`, `test_design_system.py`
(210 tests), plus `test_console_dom.py` and `test_grid_dom.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
