### PR TITLE
The board is checked against its own entries, and the rule that could not tell history from rot

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -877,6 +877,42 @@ for three different readers, and compression hides it. If space ever becomes a
 problem, the 90 MB of `.jsonl`/`.csv` is the part regenerable from the `.db`;
 the zip is not the thing to reconsider.
 
+### OP-20 · CI has not executed since 2026-08-19, and the reason is billing
+
+**Measured 2026-08-20.** Every workflow run since `2026-08-19T14:28Z` fails in
+**0-3 seconds with ZERO steps** — lint, test, contract-parity, scope,
+migration-authority, and the store-documents publish alike. The last run that
+actually executed anything was `2026-08-19T11:50Z` on
+`claude/blissful-swartz-bdca44` (13/11/9 steps, the test job 1,030 seconds, and it
+failed on code). The last CI success was `2026-08-19T11:11Z`.
+
+GitHub's own annotation on the job, read out of the API rather than guessed:
+
+> *"The job was not started because recent account payments have failed or your
+> spending limit needs to be increased. Please check the 'Billing & plans' section
+> in your settings"*
+
+**This is an account setting and only the owner can clear it.** Nothing in the
+code is involved, and `repos/.../actions/permissions` is `enabled: true,
+allowed_actions: all`, so it is not a policy block.
+
+**What it has already cost, and this is the part that matters:**
+
+- **#214 — the whole documentation system — merged with CI never having run.**
+  Its own merge run at `2026-08-20T04:57Z` is one of the zero-step failures. The
+  system now telling every session to trust these documents was itself verified
+  only locally.
+- **SR-23 cannot be satisfied at all right now.** *"CI must be green on every
+  push"* is not a rule anyone can follow while no job starts, and a red check that
+  means "unpaid" is indistinguishable at a glance from a red check that means
+  "broken" — which is how a real failure gets waved through.
+- Every open pull request shows three failing checks that say nothing about its
+  code. #219, #213 and `ci/the-suite-a-docs-change-actually-needs` all inherit it.
+
+**Until it is cleared, a local full-suite run is the only verification available**,
+and a PR should say so rather than showing a red tick and hoping the reader knows
+why.
+
 ### OP-19 · The chaos test races the startup sweep it is checking — STILL LIVE, re-measured 2026-08-20
 
 > **RE-MEASURED 2026-08-20, and "MOSTLY fixed" is too generous.** Thirteen runs of

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -877,7 +877,28 @@ for three different readers, and compression hides it. If space ever becomes a
 problem, the 90 MB of `.jsonl`/`.csv` is the part regenerable from the `.db`;
 the zip is not the thing to reconsider.
 
-### OP-19 · The chaos test races the startup sweep it is checking — MOSTLY fixed 2026-08-12
+### OP-19 · The chaos test races the startup sweep it is checking — STILL LIVE, re-measured 2026-08-20
+
+> **RE-MEASURED 2026-08-20, and "MOSTLY fixed" is too generous.** Thirteen runs of
+> `test_a_killed_engine_does_not_leave_a_job_claiming_to_run` across two
+> checkouts: **8 failed, 5 passed.** The `swept=True` marker did not close the race.
+>
+> It fails on **unmodified `cab69b1`** — 1 of 5 there — so it is not caused by any
+> branch in flight; a separate worktree carrying only documentation changes failed
+> 7 of 8. That asymmetry is this entry's own thesis rather than a second bug: the
+> conditions differed, and **two other sessions were editing this repository at the
+> time**, which is precisely the "loaded Windows machine" named below. The failure
+> is always the same assertion, `tests/test_the_engine_survives_being_killed.py:266`
+> — after crash and restart the job still reads `running`.
+>
+> The trap described below was walked into again on the way here, and this entry is
+> what stopped it: three consecutive failures in the modified worktree looked like
+> proof the branch had caused them. Four passes on the unmodified checkout refuted
+> that in one command. **Never conclude from runs on one side only.**
+>
+> Consequence unchanged and worth restating: `_source_is_busy` reads that status,
+> so a real crash leaves the source blocked from every future crawl with nothing
+> anywhere saying why. That is the defect; the flaky test is only how it is seen.
 
 Found 2026-08-11 while removing the engine's Google surface. The suite went red
 on `test_a_killed_engine_does_not_leave_a_job_claiming_to_run`, and the first

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -263,6 +263,36 @@ declare `SHEETS`. Flattening them into one scope is a `SyntaxError` before a lin
 runs. `tests/test_console_dom.py` serves `console.html` over http and loads its
 real module graph instead — **the stronger arrangement, and the one to copy.**
 
+### A guard joined by `or` cannot report which branch is false
+
+`tests/test_the_ruling_matches_the_code.py` checked that the generated document
+tells its reader how to regenerate it:
+
+```python
+assert "export-docs" in text or "export-version" in text
+```
+
+It was green for as long as it existed, and the document it guards said *"GENERATED
+— by `python -m scrapex.cli export-docs`"*. **There is no `export-docs`.** argparse
+answers `invalid choice: 'export-docs'` and lists the twenty-two real subcommands.
+The wrong name was in the generator itself, `scrapex/cli.py:302`, so the sentence
+was faithfully produced — and a reader following the repository's own instruction
+got an error.
+
+Two names joined by `or` accept either, so the assertion could not fail on the one
+that was wrong. It was not a weak test; it was a test whose failure mode did not
+exist. Found 2026-08-20 by reading the pattern before copying it, not by any test.
+
+**The fix reads the parser, not a list beside it:** every
+`python -m scrapex.cli <name>` in the document is checked against
+`build_parser()`'s real subparser choices. A list of valid names kept in the test
+would have drifted exactly the way the sentence did.
+
+**Apply:** an `or` between two *alternatives* is fine; an `or` between two
+*spellings of the same fact* is a hole. When a test tolerates more than one answer,
+ask which wrong answer it now accepts — and whether the truth is available to be
+read instead of matched.
+
 ### Record an equivalent mutant rather than contorting a test
 
 In the sign-out work, removing the early return **and** switching the message from
@@ -420,6 +450,24 @@ flake beat one true check that does."* So the guard that shipped **infers
 nothing**: a mechanical tier over every citation, and an explicit pinned list for
 the ones that carry weight. The pinned list costs a line of maintenance per
 important citation, and that cost is the feature.
+
+**IT HAPPENED AGAIN ON 2026-08-20, with this section already on the page.** A
+no-elapsed-durations rule was written over the four registers' free prose, run,
+and withdrawn within the hour: it flagged **twelve** lines and essentially every
+one was honest history — *"no one noticed for eleven days"*, *"Sixteen days later
+nothing had been built"*, *"two days after this was captured"*. A **closed** past
+interval does not rot. An **open** count against today does. No regex over prose
+separates them, which is this section's claim restated in a new subject.
+
+The rule now reads the parsed state fields of `docs/REQUESTS.md` — the board cells
+and the entry state lines — where the boundary is structural rather than inferred,
+and it is exact there. Same remedy as the pinned list: infer nothing, and pay a
+small explicit cost instead.
+
+The lesson about the lesson: it was recorded and still overreached. Reading it is
+not the same as applying it, which is why [APPROACHES.md](APPROACHES.md) A5 is now
+[R-17](RULINGS.md#r-17--a-fix-is-adversarially-reviewed-before-it-is-written) —
+the default for a fix, not an option.
 
 ### A path filter tested against absolute parts skips the whole worktree
 

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -17,7 +17,11 @@ the pull request it became. That chain is the point.
 ## The pipeline
 
 Every request moves through these states, in order. It may stop at any of them,
-but it may not skip one.
+and it may **skip** one -- but only forward, and only for a reason the entry
+states. The common skip is `Planned`: when a request is small enough that the
+ruling *is* the plan, it goes `Ruled` straight to `In flight`. R-15 and R-16 did
+exactly that. What is forbidden is moving BACKWARD without saying why, and
+recording a state the work has not reached.
 
 | state | means | where the work goes |
 |---|---|---|
@@ -54,18 +58,19 @@ IDs are stable and never reused, matching the convention BACKLOG.md already uses
 |---|---|---|---|
 | [REQ-01](#req-01--one-documentation-system-in-the-repository) | One documentation system, in the repo, all English | **Done** | 2026-08-17 |
 | [REQ-02](#req-02--more-than-one-way-of-working) | More than one way of working — add the Karpathy skill | **Done** | 2026-08-17 |
-| [REQ-03](#req-03--a-managed-pipeline-for-the-owners-requests) | A managed pipeline for his requests | **In flight** | 2026-08-17 |
-| [REQ-04](#req-04--every-setting-moves-into-the-extension) | Every setting moves into the extension | **Ruled**, not built — **16 days** | 2026-08-01 |
+| [REQ-03](#req-03--a-managed-pipeline-for-the-owners-requests) | A managed pipeline for his requests | **Done** | 2026-08-17 |
+| [REQ-04](#req-04--every-setting-moves-into-the-extension) | Every setting moves into the extension | **Ruled** — not built | 2026-08-01 |
 | [REQ-05](#req-05--a-contractor-directory-in-a-table-of-its-own) | A contractor directory, in a table of its own | **Done** | 2026-08-16 |
 | [REQ-06](#req-06--one-row-and-a-button-that-flips-it-between-arabic-and-english) | One row, and a button that flips AR\|EN | **Done** | 2026-08-17 |
 | [REQ-07](#req-07--the-data-page-must-carry-everything-the-engines-page-carries) | The Data page carries everything the engine's page does | **Planned** | 2026-08-12 |
 | [REQ-08](#req-08--a-guard-against-the-documents-going-stale) | A guard against the documents going stale | **Done** | 2026-08-17 |
 | [REQ-09](#req-09--one-home-for-rulings-not-two) | One home for rulings, not two | **Done** | 2026-08-17 |
+| [REQ-10](#req-10--adversarially-review-the-fixes-then-execute) | Adversarially review the fixes, then execute | **Done** | 2026-08-20 |
 
 ---
 
 ## REQ-01 · One documentation system, in the repository
-**Captured 2026-08-17 · Ruled ([R-09](RULINGS.md#r-09--one-documentation-system-in-the-repository-all-english)) · DONE — commits `51e44f3`, `47874b1`**
+**Captured 2026-08-17 · Ruled ([R-09](RULINGS.md#r-09--one-documentation-system-in-the-repository-all-english)) · Done — commits `51e44f3`, `47874b1`**
 
 > «اريد نظام موحد للمعلومات حيث اننى اعمل من جهازين مختلفين» · «واجعله كله
 > بالانجلليزى» · «وضيف فيه كل الخبرات التى اكتسبتها»
@@ -77,7 +82,7 @@ seven rescued plans.
 ---
 
 ## REQ-02 · More than one way of working
-**Captured 2026-08-17 · DONE — commit `51e44f3`**
+**Captured 2026-08-17 · Done — commit `51e44f3`**
 
 > «واحدة من الطرق التى نكتب بها كود او نحل مشكلة حيث لدى كذا skill ولا اريد
 > الاعتماد على واحدة فقط»
@@ -90,7 +95,7 @@ project's own rules resolved there.
 ---
 
 ## REQ-03 · A managed pipeline for the owner's requests
-**Captured 2026-08-17 · In flight — this file**
+**Captured 2026-08-17 · Ruled ([R-14](RULINGS.md#r-14--requests-are-captured-when-made-then-planned-then-executed)) · Done — #214**
 
 > «كل طلب او اضافة او اى شى اذكره ونقرر انه فى المستقبل نحطه … علشان مننساش،
 > ولما نوصله نعمله خطه ونفذها»
@@ -104,9 +109,9 @@ has not set; `WISHLIST` for understating what these are.
 ---
 
 ## REQ-04 · Every setting moves into the extension
-**Captured 2026-08-01 · Ruled ([R-04](RULINGS.md#r-04--all-ten-web-only-settings-move-into-the-extension), and `SR-10` in [BACKLOG.md](BACKLOG.md)) · NOT BUILT**
+**Captured 2026-08-01 · Ruled ([R-04](RULINGS.md#r-04--all-ten-web-only-settings-move-into-the-extension), and `SR-10` in [BACKLOG.md](BACKLOG.md)) · Ruled — not built, measured 2026-08-20**
 
-**This is the entry that justifies the whole file.** Ruled sixteen days ago,
+**This is the entry that justifies the whole file.** Ruled 2026-08-01,
 offered three options, he chose the most thorough — and nothing has been built.
 It was parked behind a review and then simply dropped out of view.
 
@@ -124,7 +129,7 @@ editing.
 ---
 
 ## REQ-05 · A contractor directory, in a table of its own
-**Captured 2026-08-16 · Ruled ([R-10](RULINGS.md#r-10--the-contractor-directory--three-rulings), [R-11](RULINGS.md#r-11--a-contractor-directory-is-a-separate-table-and-a-table-like-any-other)) · Planned ([plan](plans/2026-08-16-muqawil-contractor-source.md)) · DONE — #202–#212**
+**Captured 2026-08-16 · Ruled ([R-10](RULINGS.md#r-10--the-contractor-directory--three-rulings), [R-11](RULINGS.md#r-11--a-contractor-directory-is-a-separate-table-and-a-table-like-any-other)) · Planned ([plan](plans/2026-08-16-muqawil-contractor-source.md)) · Done — #202–#212**
 
 > «جدول منفصل تماما عن جداول المنتجات» · «صفحة المقاولين هى جدول سيظهر كاى جدول
 > لدينا»
@@ -141,7 +146,7 @@ decision is waiting: the two feature flags that make `/datasets` visible are sti
 ---
 
 ## REQ-06 · One row, and a button that flips it between Arabic and English
-**Captured 2026-08-17 · Ruled ([R-12](RULINGS.md#r-12--one-row-with-a-button-that-flips-it)) · DONE — PR #211**
+**Captured 2026-08-17 · Ruled ([R-12](RULINGS.md#r-12--one-row-with-a-button-that-flips-it)) · Done — PR #211**
 
 > «فى النهاية اريد رؤوية جدول اقدر ابدل بين عربى وانجليزى»
 
@@ -164,7 +169,7 @@ will raise them first.
 ---
 
 ## REQ-08 · A guard against the documents going stale
-**Captured 2026-08-17 · Ruled 2026-08-19 ([R-15](RULINGS.md#r-15--the-documents-are-guarded-by-a-test-not-by-good-intentions)) · DONE**
+**Captured 2026-08-17 · Ruled 2026-08-19 ([R-15](RULINGS.md#r-15--the-documents-are-guarded-by-a-test-not-by-good-intentions)) · Done**
 
 > «نفذ توصيتك فى REQ-08 و REQ-09»
 
@@ -223,7 +228,7 @@ catches automatically. **Nothing but a hand-check found them, which is the point
 ---
 
 ## REQ-09 · One home for rulings, not two
-**Captured 2026-08-17 · Ruled 2026-08-19 ([R-16](RULINGS.md#r-16--one-home-for-rulings-and-it-is-this-file)) · DONE**
+**Captured 2026-08-17 · Ruled 2026-08-19 ([R-16](RULINGS.md#r-16--one-home-for-rulings-and-it-is-this-file)) · Done**
 
 **Done, option (a):** `SR-1`–`SR-23` moved into
 [RULINGS.md](RULINGS.md#standing-rules--the-data-product-and-process-policy-sr-1sr-23),
@@ -256,6 +261,39 @@ nobody can state in one sentence is a boundary that will not hold.
 *Recommended: **(a)**.* Separation by kind is what makes C1 followable, and
 BACKLOG.md is already too large to be read before every design decision. The cost
 is one careful migration pass, and every `SR-` ID keeps its number.
+
+---
+
+## REQ-10 · Adversarially review the fixes, then execute
+**Captured 2026-08-20 · Ruled ([R-17](RULINGS.md#r-17--a-fix-is-adversarially-reviewed-before-it-is-written)) · Done — this commit**
+
+> «مراجعة عدائية اولا على 3 اصلاحات» — then «نفذ»
+
+Three drifts had been reported on 2026-08-20 and he asked for them to be
+**attacked before being written**, not merely checked. The review is why the work
+that followed is not the work that was proposed:
+
+- **It refuted one of the three.** `RULINGS.md:106` reads *"(As of 2026-08-17 the
+  gap is 58 commits.)"* — dated, therefore history rather than rot. The finding
+  was withdrawn.
+- **It widened another.** "16 days" had a second copy in `STATE.md`, and a third
+  written out in words as "sixteen days ago".
+- **It found what the three had missed:** the board is hand-written with no
+  generator, so board and entries must drift; `REQ-05` was `Done` while O-1..O-4
+  stayed open; and the pipeline's own *"may not skip one"* was obeyed by **no
+  entry at all**.
+
+Built: `tests/test_the_request_board_matches_its_entries.py` — seven tests, every
+one mutation-tested by breaking it deliberately first. The board's `request`
+column is independently worded from the entry heading in five of nine rows, so it
+cannot be generated; what is derivable is checked instead, and the prose stays
+hand-written. The skip rule now describes what actually happens.
+
+**And the rule that was written, run and withdrawn**, recorded because a
+withdrawn rule teaches more than one that was never tried: the same
+no-elapsed-duration rule over the registers' free prose flagged twelve lines and
+essentially all twelve were honest history. It lives on the parsed state fields
+instead. See [LESSONS.md](LESSONS.md).
 
 ---
 

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -332,6 +332,42 @@ one sentence will not hold.
 
 ---
 
+### R-17 · A fix is adversarially reviewed before it is written
+**2026-08-20 · process**
+
+> «مراجعة عدائية اولا على 3 اصلاحات»
+
+Three drifts had been reported and he asked for them to be **attacked** before
+being written — not checked, refuted. Then «نفذ».
+
+**It earned its keep on the first pass, against the reviewer's own findings:**
+
+| the review did | to what |
+|---|---|
+| **refuted one** | "`RULINGS.md` says 58 commits and the truth is 64" — the line reads *"(As of 2026-08-17 the gap is 58 commits.)"*. Dated, therefore history. The finding was withdrawn |
+| **widened another** | "16 days" had a second copy in `STATE.md` and a third spelled out as "sixteen days ago" |
+| **replaced the remedy** | fixing `STATE.md`'s "#215 in flight" was a symptom; #215 had merged eighteen hours *before* the PR carrying that sentence, so the sentence reached `main` already false |
+| **found three the fixes had missed** | the board has no generator, so it must drift; `REQ-05` read `Done` while O-1..O-4 stayed open; and the pipeline's *"may not skip one"* was obeyed by **no entry at all** |
+
+**And it works against an implementation too, which is the part worth keeping.**
+The rule that came out of the review — *no elapsed durations* — was then written
+over the registers' free prose, run, and **withdrawn**: it flagged twelve lines and
+essentially every one was honest history ("no one noticed for eleven days",
+"Sixteen days later nothing had been built"). A closed past interval does not rot;
+an open count against today does; no regex over prose separates them. The rule
+now lives on the parsed state fields, where it is exact. See
+[LESSONS.md](LESSONS.md) and [REQ-10](REQUESTS.md#req-10--adversarially-review-the-fixes-then-execute).
+
+**How to apply.** Attack each proposed fix on three questions before writing it:
+*is the finding even true*, *is the scope right in both directions*, and *does the
+fix address the cause or the symptom*. [APPROACHES.md](APPROACHES.md) **A5** is the
+method; this ruling makes it the default for a fix rather than an option, and the
+limit is stated there too — a review by the same author who proposed the fix is
+weaker than independent critics, and finding five things is evidence it worked, not
+proof it was enough.
+
+---
+
 ## Standing rules — the data, product and process policy (`SR-1`–`SR-23`)
 
 **Migrated here from [BACKLOG.md](BACKLOG.md) §1 on 2026-08-19, on the owner's

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -16,6 +16,11 @@ tracks *his requests* through Captured → Ruled → Planned → In flight → D
 
 ## Open pull requests
 
+> **Read no check status on this page as a verdict on code.** GitHub Actions has
+> not started a job since 2026-08-19T14:28Z — failed payment or a spending limit,
+> in GitHub's own words. Every open PR shows three red checks that never ran. See
+> [OP-20](BACKLOG.md) in the backlog; only the owner can clear it.
+
 | PR | branch | state | what it is |
 |---|---|---|---|
 | **#213** | `the-data-page-port-is-a-port` | **CONFLICTING** — cannot be read until it is rebased | DEC-8: the engine's Data page is a port, not a rebuild, and the measurement says which |

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,6 +1,7 @@
 # State — where the work stands
 
-**Last updated: 2026-08-19.** `main` is at `ac3a5af` — #212, plus one commit
+**Last updated: 2026-08-20.** `main` is at `cab69b1` — #214, the documentation
+system itself. Behind it: #215 (the revert, merged 2026-08-19) and one commit
 pushed straight to `main` on 2026-08-18 carrying no PR number.
 
 This is the document that is **wrong the moment it is out of date**. Update it
@@ -18,6 +19,13 @@ tracks *his requests* through Captured → Ruled → Planned → In flight → D
 | PR | branch | state | what it is |
 |---|---|---|---|
 | **#213** | `the-data-page-port-is-a-port` | **CONFLICTING** — cannot be read until it is rebased | DEC-8: the engine's Data page is a port, not a rebuild, and the measurement says which |
+| *(unopened)* | `the-board-is-generated` | local, tests green | [REQ-10](REQUESTS.md#req-10--adversarially-review-the-fixes-then-execute): the request board is guarded against its own entries, and a generated document stops naming a command that does not exist |
+
+> **Two other sessions are working in this repository.** `scrapex/extract/muqawil.py`
+> and `tests/test_a_dataset_is_a_table_like_any_other.py` carry another session's
+> uncommitted work in the main checkout, which is why `the-board-is-generated` is a
+> separate worktree and why every commit on it stages explicit paths. SR-19 is the
+> rule, and it exists because this went wrong twice before.
 
 **#210, #211 and #212 have all merged** since this file last spoke. What used to
 stand here as "both green, both waiting on the owner" is now history, and the
@@ -32,7 +40,9 @@ forbids a raw hex literal outside the token system. Reproduced locally on
 the missing pull request cost** — CI would have refused it before it reached
 `main`.
 
-**Fix in flight: #215, a full revert.** He was offered the token expression
+**Fixed by #215, a full revert, merged 2026-08-19T10:37Z.** It landed eighteen hours BEFORE #214 — which was carrying this very sentence, so the sentence reached `main` already false. That is the shape of the drift this file keeps producing: a PR state hand-copied into prose while `gh` can answer it.
+
+What it did: He was offered the token expression
 `light-dark(var(--surface), var(--bg))` and chose to go back to the original
 instead — «الغى تعديلات الخلفية ورجعها للاصل». `extension/app.css` is
 byte-identical to `36dd91c` again. Two things the literal did, recorded because
@@ -211,9 +221,13 @@ mechanical.
 - **HTTP 400 counts as revoked**, and neither `authorize` nor `revokeToken` has a
   deadline. Same section.
 - **[REQ-04](REQUESTS.md#req-04--every-setting-moves-into-the-extension) — the ten
-  settings move into the extension — is ruled and unbuilt after 16 days.** Parked
-  behind a review on 2026-08-01 and then lost from view. It is the entry that
-  justified building [REQUESTS.md](REQUESTS.md).
+  settings move into the extension — was ruled 2026-08-01 and is still unbuilt,
+  measured 2026-08-20.** Parked behind a review and then lost from view; verified
+  untouched with `git log -S'excel_folder' -- scrapex/webui/templates/ extension/`,
+  which returns nothing since the ruling. It is the entry that justified building
+  [REQUESTS.md](REQUESTS.md). The count of days it has sat is deliberately NOT
+  written here: the number that used to stand in this line was already stale by
+  the time anyone reread it, which is why the rule is a date and never a duration.
 - ~~**Two requests await the owner's ruling:** REQ-08 and REQ-09.~~ **BOTH RULED
   AND BUILT 2026-08-19** — he took both recommendations
   ([R-15](RULINGS.md#r-15--the-documents-are-guarded-by-a-test-not-by-good-intentions),

--- a/docs/data-page-schema.md
+++ b/docs/data-page-schema.md
@@ -1,7 +1,7 @@
 # What the Data page shows, and where
 
 The column tables below are GENERATED from `scrapex/reports.py` by
-`python -m scrapex.cli export-docs`. Do not hand-edit them: the code is the
+`python -m scrapex.cli export-version`. Do not hand-edit them: the code is the
 truth and this is its readable form. The prose is hand-written, because those
 are the owner's rulings and nothing derives them.
 

--- a/scrapex/cli.py
+++ b/scrapex/cli.py
@@ -299,7 +299,7 @@ def _render_data_page_schema() -> str:
         "# What the Data page shows, and where",
         "",
         "The column tables below are GENERATED from `scrapex/reports.py` by",
-        "`python -m scrapex.cli export-docs`. Do not hand-edit them: the code is the",
+        "`python -m scrapex.cli export-version`. Do not hand-edit them: the code is the",
         "truth and this is its readable form. The prose is hand-written, because those",
         "are the owner's rulings and nothing derives them.",
         "",

--- a/tests/test_the_request_board_matches_its_entries.py
+++ b/tests/test_the_request_board_matches_its_entries.py
@@ -1,0 +1,233 @@
+"""docs/REQUESTS.md carries the same requests twice -- once as a scannable board,
+once as the entries beneath it -- and nothing derived either from the other, so
+they drifted. Found 2026-08-20: REQ-03 sat at "In flight" on the board while the
+register it describes had already merged in #214, and REQ-04's cell claimed
+"16 days" that had become nineteen.
+
+THE BOARD CANNOT SIMPLY BE GENERATED, and that is why this is a test rather than
+a `_render_` function beside `_render_data_page_schema`. The `request` column is
+independently worded from the entry heading in five of nine rows -- "One
+documentation system, in the repo, all English" against the heading "One
+documentation system, in the repository" -- so a generator would have to invent
+that summary or destroy it.
+
+What IS derivable is checked here: which ids appear and in what order, each
+anchor, each state, and each `since` date. The prose stays hand-written. That is
+the same split docs/data-page-schema.md draws between its generated tables and
+the owner's rulings, applied to a file whose generated part is four columns wide.
+
+Not marked `extension`, because it reads nothing under that tree -- only
+docs/REQUESTS.md. tests/test_the_extension_gate_is_complete.py owns that rule, and
+note it matches on the literal path string: a sentence merely *mentioning* the
+tree is enough to trip it, which is why this paragraph talks around the name. That
+is the same prose-inference limit LESSONS.md records twice over.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+BOARD = ROOT / "docs" / "REQUESTS.md"
+
+# The pipeline in docs/REQUESTS.md "## The pipeline". Ordered, and closed: a state
+# outside this tuple is a typo or an invention, and either way the board and the
+# entry can no longer be compared.
+STATES = ("Captured", "Ruled", "Planned", "In flight", "Done", "Dropped")
+
+# Below today's nine on purpose -- requests are added rather than removed, but a
+# rewrite may renumber. It may not fall to nothing: a guard that can be emptied
+# without anyone noticing is the defect this file exists to answer.
+FLOOR = 6
+
+# Elapsed time rots. A count of days is true on the day it is typed and silently
+# false the next, which is exactly how "16 days" became nineteen.
+ELAPSED = re.compile(r"\b\d+\s+(?:day|days|week|weeks|month|months)\b", re.I)
+
+# The middle dot between an id and its title. It is deleted when GitHub slugs the
+# heading, and both spaces around it survive -- which is why every anchor in the
+# board carries TWO hyphens after `req-nn`.
+DOT = "·"
+
+
+def _text() -> str:
+    assert BOARD.is_file(), "docs/REQUESTS.md is gone"
+    return BOARD.read_text(encoding="utf-8")
+
+
+def _slug(heading: str) -> str:
+    """GitHub's rule: lowercase, drop what is neither word nor space nor hyphen,
+    then replace EACH space with a hyphen. Runs are NOT collapsed."""
+    kept = re.sub(r"[^\w\s-]", "", heading.strip().lower())
+    return kept.replace(" ", "-")
+
+
+def _cells(row: str) -> list[str]:
+    r"""Split a markdown row on unescaped pipes only. docs/REQUESTS.md contains
+    exactly one escaped pipe -- `AR\|EN` in REQ-06 -- and a plain split("|")
+    gives that row five cells and every other row four."""
+    return [cell.strip() for cell in re.split(r"(?<!\\)\|", row)[1:-1]]
+
+
+def _board() -> list[dict]:
+    text = _text()
+    start = text.index("## The board")
+    block = text[start:text.index("\n---", start)]
+
+    rows = []
+    for line in block.splitlines():
+        if not line.startswith("| [REQ-"):
+            continue
+        cells = _cells(line)
+        assert len(cells) == 4, f"board row has {len(cells)} cells, not 4:\n  {line}"
+        link, request, state, since = cells
+        match = re.fullmatch(r"\[(REQ-\d+)\]\(#([^)]+)\)", link)
+        assert match, f"a board row's first cell is not an anchored id:\n  {link}"
+        rows.append({"id": match.group(1), "anchor": match.group(2),
+                     "request": request, "state": state, "since": since,
+                     "line": line})
+    return rows
+
+
+def _entries() -> list[dict]:
+    lines = _text().splitlines()
+    entries = []
+    for index, line in enumerate(lines):
+        match = re.fullmatch(rf"## (REQ-\d+) {DOT} (.+)", line)
+        if not match:
+            continue
+        state_line = next(x for x in lines[index + 1:] if x.strip())
+        assert state_line.startswith("**"), (
+            f"{match.group(1)}'s state line does not follow its heading:\n  "
+            f"{state_line}")
+        entries.append({"id": match.group(1), "heading": line[3:],
+                        "state_line": state_line})
+    return entries
+
+
+def _reached(state_line: str) -> str | None:
+    """The furthest state an entry claims, which is the LAST one it names. These
+    lines are prose around the states, not a fixed set of fields: REQ-04 reads
+    `Ruled (...) -- not built, measured 2026-08-20` and REQ-05 names four."""
+    best: tuple[int, str] | None = None
+    for state in STATES:
+        for match in re.finditer(rf"\b{re.escape(state)}\b", state_line):
+            if best is None or match.start() > best[0]:
+                best = (match.start(), state)
+    return best[1] if best else None
+
+
+def test_the_board_lists_every_entry_and_nothing_else():
+    board = [row["id"] for row in _board()]
+    entries = [entry["id"] for entry in _entries()]
+
+    assert board == entries, (
+        "the board and the entries below it disagree about which requests exist, "
+        f"or about their order.\n  board:   {board}\n  entries: {entries}")
+
+
+def test_every_board_anchor_reaches_its_entry():
+    """A row whose link is dead is worse than no row: it reads as a promise that
+    the detail exists somewhere."""
+    headings = {entry["id"]: entry["heading"] for entry in _entries()}
+
+    wrong = [f"{row['id']} links to #{row['anchor']}, but its heading slugs to "
+             f"#{_slug(headings[row['id']])}"
+             for row in _board() if row["anchor"] != _slug(headings[row["id"]])]
+
+    assert not wrong, ("these board anchors do not reach their entry:\n  "
+                       + "\n  ".join(wrong))
+
+
+def test_every_board_state_is_the_state_its_entry_reached():
+    """THE DRIFT THIS FILE WAS WRITTEN FOR. REQ-03's board cell read
+    `**In flight**` while its own entry had reached Done in #214."""
+    lines = {entry["id"]: entry["state_line"] for entry in _entries()}
+
+    wrong = []
+    for row in _board():
+        reached = _reached(lines[row["id"]])
+        shown = re.match(r"\*\*([^*]+)\*\*", row["state"])
+        assert shown, (f"{row['id']}'s board state is not a bold state token: "
+                       f"{row['state']!r}")
+        if shown.group(1) != reached:
+            wrong.append(f"{row['id']}: board says {shown.group(1)!r}, entry "
+                         f"reached {reached!r}\n      entry: {lines[row['id']][:110]}")
+
+    assert not wrong, ("the board contradicts the entries it summarises:\n  "
+                       + "\n  ".join(wrong))
+
+
+def test_every_state_named_anywhere_is_one_the_pipeline_declares():
+    """`DONE` in an entry and `**Done**` on the board are one state spelled two
+    ways, and a comparison cannot know that. One spelling, and it is the table's."""
+    unknown = [f"{entry['id']} reaches no declared state: {entry['state_line'][:110]}"
+               for entry in _entries() if _reached(entry["state_line"]) is None]
+    assert not unknown, "\n  ".join(unknown)
+
+    text = _text()
+    for state in STATES:
+        assert f"| **{state}** |" in text, (
+            f"{state!r} is in this guard's vocabulary but the pipeline table in "
+            "docs/REQUESTS.md no longer declares it -- one of the two is wrong")
+
+    shouted = re.findall(r"\b(?:DONE|CAPTURED|RULED|PLANNED|DROPPED)\b", text)
+    assert not shouted, (
+        f"{len(shouted)} state name(s) are shouted rather than spelled the way "
+        f"the pipeline table spells them: {sorted(set(shouted))}")
+
+
+def test_no_state_field_claims_an_elapsed_duration():
+    """`**Ruled**, not built -- **16 days**` was true the day it was typed and read
+    nineteen when it was next opened. A state field may carry a DATE, from which a
+    reader computes the age; it may not carry the answer, because nothing
+    recomputes it.
+
+    THE STRUCTURED FIELDS ONLY, and that boundary was measured rather than chosen.
+    The same rule over the registers' free prose was written, run and withdrawn:
+    it flagged twelve lines and essentially every one was honest history -- "no one
+    noticed for eleven days", "Sixteen days later nothing had been built", "two
+    days after this was captured". A closed past interval does not rot; an open
+    count against today does, and no regex over prose tells them apart. Here the
+    fields are parsed, so the rule is exact instead of approximate."""
+    offenders = []
+    for row in _board():
+        if match := ELAPSED.search(row["state"]):
+            offenders.append(f"{row['id']} board cell: {match.group(0)!r} in "
+                             f"{row['state']!r}")
+    for entry in _entries():
+        if match := ELAPSED.search(entry["state_line"]):
+            offenders.append(f"{entry['id']} state line: {match.group(0)!r} in "
+                             f"{entry['state_line'][:110]!r}")
+
+    assert not offenders, (
+        "these state fields count elapsed time, which is false the day after it "
+        "is written. Give the date the thing happened:\n  " + "\n  ".join(offenders))
+
+
+def test_every_since_is_the_date_its_entry_was_captured():
+    """`since` is the day he asked, not the day anything happened afterwards.
+    REQ-08 and REQ-09 were ruled on 2026-08-19 and are still `since 2026-08-17`,
+    which is correct and is the reason this has to be stated."""
+    captured = {}
+    for entry in _entries():
+        match = re.search(r"Captured (\d{4}-\d{2}-\d{2})", entry["state_line"])
+        assert match, (f"{entry['id']} does not say when it was captured:\n  "
+                       f"{entry['state_line'][:110]}")
+        captured[entry["id"]] = match.group(1)
+
+    wrong = [f"{row['id']}: board says {row['since']}, entry was captured "
+             f"{captured[row['id']]}"
+             for row in _board() if row["since"] != captured[row["id"]]]
+
+    assert not wrong, "\n  ".join(wrong)
+
+
+def test_this_guard_cannot_be_quietly_emptied():
+    rows, entries = _board(), _entries()
+
+    assert len(rows) >= FLOOR, (
+        f"{len(rows)} board rows, and the floor is {FLOOR}. A row goes when a "
+        "request is renumbered, never to silence a failure.")
+    assert len(entries) >= FLOOR, f"{len(entries)} entries, and the floor is {FLOOR}"

--- a/tests/test_the_ruling_matches_the_code.py
+++ b/tests/test_the_ruling_matches_the_code.py
@@ -17,10 +17,12 @@ tests are what stop them going stale again.
 
 from __future__ import annotations
 
+import argparse
 import pathlib
+import re
 
 from scrapex import reports
-from scrapex.cli import _render_data_page_schema
+from scrapex.cli import _render_data_page_schema, build_parser
 from scrapex.vocab import BLOCK_ORDER
 
 RULING = pathlib.Path(__file__).resolve().parent.parent / "docs" / "data-page-schema.md"
@@ -97,8 +99,35 @@ def test_the_owners_prose_survives_generation():
 def test_the_file_says_it_is_generated_and_how_to_regenerate_it():
     """Otherwise the next person edits it by hand, the golden test fails on
     their unrelated PR, and they learn the rule from a red build instead of
-    from the file."""
+    from the file.
+
+    AND THE COMMAND IT NAMES HAS TO EXIST. This read
+    `assert "export-docs" in text or "export-version" in text`, and that `or`
+    is the whole reason it stood green while the file told its reader to run
+    `python -m scrapex.cli export-docs` -- which argparse answers with
+    "invalid choice: 'export-docs'". A guard that accepts either of two names
+    can never report the wrong one. Found 2026-08-20; the generator was
+    emitting it at `scrapex/cli.py:302`."""
     text = RULING.read_text(encoding="utf-8")
 
     assert "GENERATED from `scrapex/reports.py`" in text
-    assert "export-docs" in text or "export-version" in text
+
+    named = re.findall(r"python -m scrapex\.cli ([a-z][a-z0-9-]*)", text)
+    assert named, "the file no longer says which command regenerates it"
+
+    real = _subcommands()
+    for command in named:
+        assert command in real, (
+            f"docs/data-page-schema.md tells the reader to run `python -m "
+            f"scrapex.cli {command}`, which is not a scrapex subcommand. "
+            f"Real ones: {sorted(real)}")
+
+
+def _subcommands() -> set[str]:
+    """The real subcommand names, read out of the parser rather than from a
+    list kept beside it -- a list would drift the way the sentence above did."""
+    parser = build_parser()
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            return set(action.choices)
+    raise AssertionError("scrapex.cli.build_parser() has no subparsers")


### PR DESCRIPTION
## He asked for the fixes to be attacked before they were written

Three documentation drifts had been reported. The instruction was «مراجعة عدائية اولا على 3 اصلاحات» — adversarially review them first — then «نفذ». **This is not the change that was proposed**, and that difference is the point. `R-17` makes the review the default for a fix rather than an option.

### What the review did to its own findings

| | |
|---|---|
| **Refuted one** | *"`RULINGS.md` says 58 commits and the truth is 64."* The line reads **`(As of 2026-08-17 the gap is 58 commits.)`** — dated, therefore history rather than rot. Withdrawn. |
| **Widened another** | `16 days` had a second copy in `STATE.md`, and a third spelled out as *"sixteen days ago"* three lines under the first. |
| **Replaced a remedy** | Fixing `STATE.md`'s *"#215 in flight"* treated a symptom. #215 merged **eighteen hours before** #214 — the PR carrying that sentence — so it reached `main` already false. The cause is that a PR's state is hand-copied into prose while `gh` can answer it. |
| **Found three the fixes had missed** | The board has no generator, so it must drift. `REQ-05` read `Done` while `O-1`–`O-4` stayed open. And the pipeline's own *"it may not skip one"* was obeyed by **no entry at all**. |

## The board is checked, not generated — and that was measured

Its `request` column is independently worded from the entry heading in **five of nine rows** (*"One documentation system, in the repo, all English"* against the heading *"One documentation system, in the repository"*). A generator would have to invent that summary or destroy it.

So the derivable part is checked instead — ids and their order, anchors, states, and each `since` against its entry's `Captured` date — and the prose stays hand-written. That is the split `docs/data-page-schema.md` already draws between its generated tables and the owner's rulings.

Three things the vocabulary had to settle first, all read at byte level rather than assumed:

- the separator is **U+00B7 MIDDLE DOT**, not a hyphen — which is why every anchor carries *two* hyphens after `req-nn`;
- `REQ-06`'s cell holds the file's **only escaped pipe** (`AR\|EN`), so a plain `split("|")` gives that row five cells and every other row four;
- entries shouted `DONE` while the board said `Done`, and no comparison can reconcile two spellings of one state.

**Seven tests, every one broken deliberately first.** `REQ-03` back to `In flight`, a bare duration back on the board, an anchor typo, one shouted `DONE`, a wrong `since`, a deleted row, and a duration in an entry state line. **Seven mutants, zero survivors**, with a byte-exact restore verified after each.

## A rule written, run, and withdrawn

Recorded because a withdrawn rule teaches more than one never tried. *No elapsed durations* over the four registers' **free prose** flagged **twelve** lines and essentially every one was honest history — *"no one noticed for eleven days"*, *"Sixteen days later nothing had been built"*, *"two days after this was captured"*.

A **closed** past interval does not rot. An **open** count against today does. No regex over prose separates them. `LESSONS.md` already carried this lesson in another subject, with a table of false-positive rates, and it was overreached anyway — which is now written down beside it. The rule lives on the parsed state fields, where the boundary is structural.

## A generated document told its reader to run a command that does not exist

`docs/data-page-schema.md:4` instructed: *"GENERATED … by `python -m scrapex.cli export-docs`"*. **There is no `export-docs`** — argparse answers `invalid choice` and lists the twenty-two real subcommands. The wrong name was in the generator itself at `scrapex/cli.py:302`, so the sentence was faithfully produced.

And the guard could not have caught it, by construction:

```python
assert "export-docs" in text or "export-version" in text
```

Two names joined by `or` accept either, so the assertion could never fail on the one that was wrong. It now reads `build_parser()`'s real subparser choices; a list of valid names kept in the test would have drifted exactly the way the sentence did. Mutation-tested both ways.

## Measured, not assumed

- **`OP-19` re-measured and reopened.** 13 runs of the chaos test, 8 failed. It fails on **unmodified `cab69b1`**, so it is not this branch — and the entry's own warning against concluding from one side is what stopped the wrong diagnosis: three failures here looked like proof until four passes there refuted it. `MOSTLY fixed` is now too generous.
- **`tests/test_the_extension_gate_is_complete.py` caught this very PR**, because the new file's docstring *said* it reads nothing under that tree and the gate matches the literal path string. A third instance of the same prose-inference limit; fixed by talking around the name rather than by claiming a mark this file has no right to.
- Full suite run in an isolated worktree: green but for `OP-19` above.

## Merge order matters, because another session is live

Two other sessions are editing this repository. One has uncommitted work moving `latest_extension_version` from `scrapex/webui/app.py:1375` to `:1439`, and is updating the citations and the pinned list to match. **This branch still cites `1375`.** Whichever lands second fixes the numbers, and the citation guard from #214 is what will insist on it — working exactly as intended.

Every path here was staged explicitly with the whole cached diff read before committing (`SR-19`, which exists because that went wrong twice before): eighteen removed lines, every one accounted for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
