### PR TITLE
The Arabic half was a column and not a value, and the page serving it answered 404

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -542,6 +542,80 @@ than missing **(inferred from the titles; the check is a diff, not a title match
 **superseded, do not merge**. Two branches live in `~/.codex/worktrees/`, so
 `git worktree remove` comes before any deletion.
 
+### DEC-9 · Snapshots are stored uncompressed, and the full crawl is 6.4 GB of it
+**MEASURED 2026-08-20, on the live database.** The contractors cost 342 MB, of which
+**320 MB is HTML and 22 MB is data** — 94% of the price is the pages, not the rows.
+
+| | |
+|---|---|
+| the file on disk | 483 MB *(now 835 MB, with the Arabic half merged)* |
+| 864 snapshots | 320 MB, averaging **362 KB a page** |
+| 11,059 records | 8.7 MB |
+| 17,275 revisions | 13.6 MB |
+
+**Only 21% of a listing page is its contractor cards.** The other 291 KB is nav,
+footer, scripts and the city dropdown — a near-identical skeleton repeated 864
+times, which is exactly why it compresses so well:
+
+| | | |
+|---|---|---|
+| 25 pages raw | 9.3 MB | |
+| gzip level 6 | 0.6 MB | **15.1x** |
+| zlib level 9 | 0.6 MB | **15.6x** |
+| lzma | 0.5 MB | 19.1x |
+
+**320 MB would be 21 MB.** And the projection that makes it a decision — one real
+profile page was fetched and measured at **168 KB raw, 18 KB compressed (9.4x)**:
+
+| Stage B, 17,283 contractors x 2 languages = 34,566 pages | |
+|---|---|
+| raw | **~6.4 GB** |
+| compressed | **~660 MB** |
+
+**The recommendation is that the rule is right and the encoding is wrong.** "One page
+in, one snapshot out" earned itself on 2026-08-20: a defect in the bilingual merge was
+repaired from disk with **nothing re-fetched**, where a re-crawl is 2.8 hours. So the
+snapshots stay. They should be stored compressed — `zlib` is in the standard library
+and needs no new dependency.
+
+What was considered and is worse:
+- **Trimming to the cards (21%)** saves 4.8x where compression saves 15.6x — three
+  times worse, and it spends the ability to re-parse. The defect repaired that day was
+  *inside* the card; the next one may not be.
+- **Deleting snapshots after approval** spends exactly what saved the day.
+- **Keeping a hash and re-fetching on demand** cannot work: the listing reorders every
+  thirty seconds, so a page is not reproducible. What is not kept now is not gettable
+  later.
+- **A shared-dictionary compressor (trained zstd)** would beat 15.6x, since the
+  skeleton repeats 864 times — but it adds a dependency for a margin we do not need.
+
+**The cost, and why it is the owner's call:** `html_content` becomes a BLOB rather than
+TEXT. That is a migration plus every reader of the column.
+
+### DEC-10 · "Fix the parser and re-run over the snapshots" does not actually work
+The seam's stated product is that a wrong parse is re-run against stored snapshots with
+nothing re-fetched (`GENERIC-FETCH-SEAM.md`). **It was tried on 2026-08-20 and wrote
+nothing at all.**
+
+`approve_candidate` short-circuits on `_approved_ingestion(conn, snapshot_id,
+locator)` — same site, same dataset, same `schema_hash` means "already approved", and
+it returns `recovered=True` without touching a row. A **corrected parser produces the
+same schema and different values**, so all 864 pages came back recovered and the four
+empty columns stayed empty. Worse, the caller cannot tell: the return value looks like
+success, and the script that drove it reported 864 re-approvals that were 864 no-ops.
+
+The repair only landed because the ARABIC snapshots were merged in the same pass —
+a genuinely new `(snapshot, locator)` pair, so a genuinely new approval.
+
+**The gap is that the idempotency key does not include the ROWS.** A candidate hash
+alongside `schema_hash` would make a corrected parse a different request — replay of an
+identical request still short-circuits, so the tested behaviour is kept — and the
+re-ingestion would write revisions, which is what a repair should leave behind. Not
+built, because it changes the approval path's atomicity guarantee and that is a ruling.
+
+Until it is built, **re-parsing means approving against a snapshot that has never been
+approved**, and that has to be said out loud rather than discovered again.
+
 ---
 
 ## 4. Built, not yet verified

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -264,8 +264,8 @@ And only one of the **two** `worker_alive` computations was fixed:
 
 | where | what it calls | verdict |
 |---|---|---|
-| `scrapex/webui/app.py:1386` — `/api/health` | the new two-heartbeat `worker` verdict | correct; the panel reads this one (`extension/engine.js:38`) |
-| `scrapex/webui/app.py:2401` — `_about` | `worker_is_alive(conn)`, single heartbeat | **the function the fix superseded** |
+| `scrapex/webui/app.py:1450` — `/api/health` | the new two-heartbeat `worker` verdict | correct; the panel reads this one (`extension/engine.js:38`) |
+| `scrapex/webui/app.py:2438` — `_about` | `worker_is_alive(conn)`, single heartbeat | **the function the fix superseded** |
 
 `_about` renders the engine's own `/settings` page
 (`scrapex/webui/templates/settings.html:162-167`), so **the engine still shows
@@ -273,7 +273,7 @@ And only one of the **two** `worker_alive` computations was fixed:
 engine is started at all.
 
 **Next action:** three separate things — the second `worker_alive` at
-`app.py:2401`; the heartbeat's behaviour under a held write lock; and the 409 on
+`app.py:2438`; the heartbeat's behaviour under a held write lock; and the 409 on
 `/api/storage/restore` with a mirror of
 `test_start_fresh_is_refused_while_a_crawl_runs`.
 
@@ -1102,7 +1102,7 @@ date it was measured.
 1. **ALSWEED is being refused with HTTP 429**, five times on 2026-08-11, because
    `crawl_honour_delay` is `'0'`. **BV-3**.
 2. **The engine's own Settings page says "Not running" while it crawls** — a
-   second `worker_alive` computation at `app.py:2401` that the fix never reached
+   second `worker_alive` computation at `app.py:2438` that the fix never reached
    — and the runtime heartbeat freezes under `database is locked` when a job
    holds a write transaction. **OP-6 · ت2**.
 3. **The diagnostic-page guard is still blind**, and this file said it had been

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -303,6 +303,51 @@ only when handed a falsy token. Either mutation alone is caught.
 It is recorded rather than papered over. Contorting a test to kill an equivalent
 mutant would be the lie.
 
+### Presence is not arrival: asserting the column, not the value
+
+Four of the seven declared bilingual pairs on the contractor dataset shipped
+**NULL in all 11,059 rows**, and every check passed the whole way. The test read:
+
+```python
+for field in BILINGUAL_CARD_FIELDS:
+    assert all(f"{field}_ar" in row for row in without.rows)
+```
+
+That asserts the **column exists**. It was written to catch a real defect — a
+schema that changed per page — and it caught that one. It could never have caught
+an empty column, because an empty column is present.
+
+The cause was worth the lesson too. `read_listing` keys a card's boxes by
+`card_{_slug(label)}`, and `_slug` keeps `[a-z0-9]` only — so on the **Arabic**
+page every label filtered down to nothing, became `unnamed`, and seven boxes
+collapsed into one key the last of them won. The merge asked the Arabic page for
+English names. The module's own docstring had already stated the right rule for
+the profile path — *"the Arabic value is taken from the SAME INDEX … the Arabic
+labels are never matched against anything"* — and only the listing path was doing
+it by key.
+
+**A test on a bilingual column asserts a value that is non-empty, DIFFERENT from
+its partner, and in the right script.** Anything weaker passes on an empty table.
+
+### A success count is not a write count
+
+The seam's stated product is that a wrong parse is re-run over stored snapshots
+with nothing re-fetched. Re-running the corrected parser over all 864 snapshots
+reported **864 re-approved, 0 refused** — and changed nothing at all. Every
+column was exactly as empty afterwards, and `generic_record_revision` had not
+gained a single row.
+
+`approve_candidate` short-circuits on `_approved_ingestion(conn, snapshot_id,
+locator)`: same site, same dataset, same `schema_hash` means "already approved",
+and it returns `{"recovered": True}` **without touching a row**. A corrected
+parser produces the same schema with different values, so all 864 pages took that
+path. The driver counted the returns and called them writes.
+
+Two things follow. **Read the flag the function hands back** — `recovered` was
+right there and unexamined. And **verify a repair by measuring the data, not the
+run**: counting filled cells per column found it in one query, where the script's
+own report was confidently wrong. Recorded as DEC-10, because the fix is a ruling.
+
 ---
 
 ## 5 · The design system: a token has four homes

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -134,7 +134,7 @@ engine carries the extension.
 
 **The defect, found by trying the bump and reverting it the same day:**
 `version_report` sends `"latest_extension_version": VERSION`
-(`scrapex/version.py:477`, again in `scrapex/webui/app.py:1375`, drawn by
+(`scrapex/version.py:477`, again in `scrapex/webui/app.py:1439`, drawn by
 `extension/app.js:595` and `:629`). The moment the engine moves ahead of
 `extension/manifest.json`, the panel draws *"This ScrapeX extension is older than
 the engine it is talking to"*. Measured at 320×440: the profile page's legal line

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -179,7 +179,7 @@ written and 58 two days ago. It grows every time this is deferred.
 **The blocker, verified 2026-08-17 and still present:**
 `"latest_extension_version": VERSION` at
 [scrapex/version.py:477](../scrapex/version.py) and
-[scrapex/webui/app.py:1375](../scrapex/webui/app.py), drawn by
+[scrapex/webui/app.py:1439](../scrapex/webui/app.py), drawn by
 [extension/app.js:595](../extension/app.js) and `:629`.
 
 > **Re-verified 2026-08-19, and three of these citations had already drifted.**

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -120,10 +120,11 @@ off the page (#203) · a crawl whose output is evidence (#204) · the declared
 frontier was half the crawl (#205) · a per-server governor (#206) · cards become
 an approval candidate (#207) · the membership number is unique (#208) · names
 stop coming (#209) · a 404 storm must not buy speed (#210) · a dataset is a table
-like any other (#211) · the contractors appear among the datasets (#212).
+like any other (#211) · the contractors appear among the datasets (#212) · the
+Arabic half was a column and not a value (#220).
 
-**In flight: nothing. The track is waiting on one decision** — see the two
-feature flags below.
+**In flight: PR #220.** The track is otherwise waiting on decisions — the two
+feature flags below, and DEC-9/DEC-10 in [BACKLOG.md](BACKLOG.md).
 
 > **Why #210 mattered more than its size suggested.** `HttpFetcher` sends
 > conditional requests, so an unchanged page answers **304 with no body** — the
@@ -132,15 +133,56 @@ feature flags below.
 > `Strain.NONE` and feed the clean run.
 
 **The full `LISTING_ONLY` pass has run, and it is in the warehouse.** Verified
-against the live database on 2026-08-19, not taken from a conversation:
+against the live database on 2026-08-20, not taken from a conversation:
 
 ```
 generic_record            11,059 contractors
-generic_page_snapshot        864 pages, 864 of 864 approved, zero rejected
-generic_record_revision   17,275
-dataset_field                496
-engine db                    460 MB + 4 MB WAL
+generic_page_snapshot      1,728 pages — 864 English AND 864 Arabic
+generic_record_revision   34,550
+engine db                    796 MB + a 393 MB WAL   ← 2026-08-20 07:0x
 ```
+
+**Read the WAL as part of the size.** The figure above was `835 MB` when it was
+first written a few hours earlier, and the file has moved since — a bare total goes
+stale the same day. What matters is that **393 MB of it is an unmerged write-ahead
+log**: `~1.19 GB` on disk today, and a checkpoint will move most of that into the
+main file rather than reclaim it. That is the measurement `DEC-9` is arguing about.
+
+**The Arabic snapshots were merged on 2026-08-20**, and they carried the #220
+repair with them: four of the seven declared bilingual pairs had been NULL in
+all 11,059 rows. All seven now hold values —
+
+```
+company_name_ar 97.9% · contractor_classification_ar 98.0%
+card_company_size_ar 98.0% · card_status_ar 98.0%
+card_city_region_ar 89.5% · card_training_credit_hours_ar 98.0%
+membership_level_ar 0.2% (as its English half)
+```
+
+**And `/source/contractors` renders.** It answered 404 until #220 — #212's leak
+one layer up, the page asking the manifest where the API had learned to ask the
+catalogue too. Confirmed in a browser: 20 rows painted, 5,000 in the grid, and
+`grid.js`'s EN/AR switch flips all seven pairs.
+
+**HOW MANY CONTRACTORS EXIST, measured and not converged.** The sweep ran six
+passes over the English listing, 8h37m:
+
+| pass | new | total |
+|---|---|---|
+| 1 | +11,191 | 11,191 |
+| 2 | +3,960 | 15,151 |
+| 3 | +1,334 | 16,485 |
+| 4 | +547 | 17,032 |
+| 5 | +189 | 17,221 |
+| 6 | **+62** | **17,283** |
+
+It **stopped at its pass ceiling, not at convergence** — the sixth pass still
+brought 62 names never seen before, so an unknown number remain unseen. The
+warehouse therefore holds **11,059 of at least 17,283: about 64%**. The sweep
+stored no snapshots and read one language only, deliberately (it needed ids, not
+values), so the ~6,224 known-missing contractors have **no evidence and no Arabic
+half** — closing that gap is a new bilingual crawl, and DEC-9 argues it should
+follow the compression migration rather than precede it.
 
 **The live database is `~/.scrapex/engine/scrapex-engine.db`**, per
 `~/.scrapex/databases.json`. The older `~/.scrapex/marketlens/marketlens.db` is
@@ -149,9 +191,10 @@ opens it looking for this data.
 
 **Not in, and named so it is not mistaken for done:** the detail files
 (coordinates, email, licences, interests) — a second crawl of ~22,000 requests ·
-the Arabic half of the page snapshots (the English were stored; the Arabic values
-are **inside the rows**, but their evidence is not) · the sweep that says how many
-contractors the listing missed.
+the ~6,224 contractors the sweep counted and nothing has fetched · the
+compression migration DEC-9 asks for · the row-aware idempotency key DEC-10 asks
+for, without which a corrected parser cannot be re-run over stored snapshots at
+all.
 
 **One decision is open and it is the owner's:** both
 `FeatureKey.GENERIC_EXTRACTION` and `FeatureKey.GENERIC_DATASET_CATALOG` are still

--- a/scrapex/extract/muqawil.py
+++ b/scrapex/extract/muqawil.py
@@ -176,6 +176,41 @@ def _boxes(soup: BeautifulSoup) -> list[tuple[str, str]]:
     return pairs
 
 
+def _card_boxes(html: str) -> dict[str, tuple[tuple[str, str], ...]]:
+    """Per contractor, that card's boxes in PAGE ORDER, as `(field_key, value)`.
+
+    WHY THIS EXISTS, and it is the fourth leak's twin. `read_listing` keys a
+    card's boxes by `card_{_slug(label)}`, and `_slug` keeps `[a-z0-9]` only —
+    so on the ARABIC page every label filters down to nothing, becomes
+    `unnamed`, and all seven boxes collapse into ONE key that the last of them
+    wins. Merging the two languages BY KEY therefore asked the Arabic page for
+    names it does not have, and `card_city_region_ar`, `card_company_size_ar`,
+    `card_status_ar` and `card_training_credit_hours_ar` were empty in all
+    11,059 approved rows. The test that should have caught it asserted the
+    COLUMN was present rather than that a VALUE had arrived.
+
+    So the boxes come back positional and the module's existing rule applies:
+    the English label names the field, the Arabic page contributes a value at
+    the same index, and no Arabic label is ever matched against anything. That
+    is what `merge_locales` already does for profiles.
+
+    MEASURED BEFORE IT WAS RELIED ON. Across 120 real page pairs, 2,360 cards
+    appeared in both languages, and the box count agreed on 2,360 of them.
+
+    The last box is dropped because it is the classification, whose LABEL is its
+    data — `read_listing` takes that one by position for the same reason.
+    """
+    boxes: dict[str, tuple[tuple[str, str], ...]] = {}
+    for card in BeautifulSoup(html, "html.parser").select("div.section-card"):
+        link = card.find("a", href=_PROFILE_HREF)
+        if link is None:
+            continue
+        found = _PROFILE_HREF.search(link["href"])
+        boxes[found.group(1)] = tuple(
+            (f"card_{_slug(name)}", value) for name, value in _boxes(card)[:-1])
+    return boxes
+
+
 def read_profile(html: str) -> Reading:
     """One profile page, in whichever language it was fetched.
 
@@ -550,13 +585,18 @@ def bilingual_listing_candidate(english: str, arabic: str, *,
     toggle has nothing to flip, which is why an English-only approval produces a
     table with no language switch at all.
 
-    MERGED BY CONTRACTOR ID, NEVER BY POSITION. `en?page=5` and `ar?page=5` are
-    two separate requests against a listing that reorders every thirty seconds —
-    measured: 4,556 of 11,059 contractors turned up on more than one page in a
-    single pass. Zipping the two pages row by row would therefore attach one
-    company's Arabic name to another company's English one, and the result would
-    look perfectly reasonable. A contractor the Arabic page did not happen to
-    show simply keeps its English half.
+    CONTRACTORS ARE MATCHED BY ID, NEVER BY POSITION ON THE PAGE. `en?page=5`
+    and `ar?page=5` are two separate requests against a listing that reorders
+    every thirty seconds — measured: 4,556 of 11,059 contractors turned up on
+    more than one page in a single pass. Zipping the two pages row by row would
+    therefore attach one company's Arabic name to another company's English one,
+    and the result would look perfectly reasonable. A contractor the Arabic page
+    did not happen to show simply keeps its English half.
+
+    ONE CARD'S BOXES ARE THEN PAIRED BY POSITION WITHIN THAT MATCH, which is a
+    different question and the opposite answer — see `_card_boxes`. The order of
+    boxes inside a card is the site's template, not its data, and the Arabic
+    labels cannot be read as keys at all.
 
     AND A PAIR IS ONLY KEPT WHEN THE TWO DIFFER, which is the same rule
     `merge_locales` applies to profiles. `contractor_id`, the rating counts and
@@ -566,16 +606,29 @@ def bilingual_listing_candidate(english: str, arabic: str, *,
     """
     english_rows = read_listing(english)
     arabic_rows = {row["contractor_id"]: row for row in read_listing(arabic)}
+    english_boxes, arabic_boxes = _card_boxes(english), _card_boxes(arabic)
 
     merged: list[dict[str, str]] = []
     for row in english_rows:
         both = dict(row)
-        other = arabic_rows.get(row["contractor_id"], {})
+        contractor = row["contractor_id"]
+        other = arabic_rows.get(contractor, {})
+        mine = english_boxes.get(contractor, ())
+        theirs = arabic_boxes.get(contractor, ())
+        # ONLY WHEN BOTH LANGUAGES PUBLISHED THE SAME NUMBER OF BOXES. A
+        # positional pair drawn from lists of different lengths is a value on
+        # the wrong field, which is worse than no value; a card that fails this
+        # keeps its English half, exactly as an unpaired contractor does.
+        aligned = ({key: theirs[index][1] for index, (key, _) in enumerate(mine)}
+                   if len(mine) == len(theirs) else {})
         # EVERY declared pair, every row — present or not. See
         # BILINGUAL_CARD_FIELDS: a column that appears only when a value was
         # found is a column that appears only on some pages.
         for key in BILINGUAL_CARD_FIELDS:
-            value = other.get(key) or ""
+            # `aligned` answers for the card's boxes. `other` answers for the
+            # three fields read from fixed places in the markup, which never
+            # needed a label: the title, the membership badge, the grade.
+            value = aligned.get(key) or other.get(key) or ""
             both[f"{key}_ar"] = value if value != row.get(key) else ""
         merged.append(both)
     return _candidate_from(merged, table_index=table_index)

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -100,6 +100,7 @@ from ..reports import (
     BROWSE_COLUMNS,
     FILTERABLE,
     SORTABLE,
+    SourceSummary,
     browse_columns,
     browse_google_finance_rates,
     browse_observations,
@@ -593,6 +594,48 @@ def create_app(
             source.base_url = entry.base_url or source.base_url
         return sources
 
+    def _dataset_rows():
+        """Every approved dataset, in the shape a source listing already speaks.
+
+        ONE QUERY, TWO READERS, and the reason is a bug that shipped. `/api/sources`
+        learned about datasets in #212 and the PAGE did not — so
+        `/source/contractors` answered 404 while `/api/table/contractors` served
+        11,059 rows to nobody at all. Copying the query into the page would have
+        left the next widening to drift the same way.
+
+        `kind` MARKS THEM, and the panel needs it: the row menu offers Update,
+        Wipe and Rename, and every one of those is a price-path action that would
+        answer 400 or worse for a dataset. A button that cannot work is worse
+        than no button, so the panel hides them on this marker.
+        """
+        general = general_read_conn()
+        try:
+            return [{
+                "kind": "dataset",
+                "source_key": row["dataset_key"],
+                "source_name": row["display_name"] or row["original_name"],
+                "source_name_ar": "", "base_url": row["base_url"],
+                "family": "generic", "active": True, "implemented": True,
+                "supports_history": False,
+                # `observations` is what the Data screen filters on, and for a
+                # directory the honest number is its rows. `products` has no
+                # meaning for a company, so it carries the same count rather
+                # than a zero that would read as an empty dataset.
+                "observations": row["rows"], "products": row["rows"],
+                "last_success": None, "kept_pages": 0, "kept_at": None,
+            } for row in general.execute(
+                "SELECT d.dataset_key, d.display_name, d.original_name, "
+                "s.base_url, count(r.generic_record_id) AS rows "
+                "FROM dataset_definition AS d "
+                "JOIN site_profile AS s "
+                "ON s.site_profile_id = d.site_profile_id "
+                "LEFT JOIN generic_record AS r "
+                "ON r.dataset_definition_id = d.dataset_definition_id "
+                "AND r.status = 'active' "
+                "WHERE d.valid_to IS NULL GROUP BY d.dataset_definition_id")]
+        finally:
+            general.close()
+
     def _source_catalog(conn):
         """Every configured source, split by whether it has warehouse data."""
         sources = _display_sources(conn)
@@ -808,10 +851,31 @@ def create_app(
             rate_dataset = google_finance_status(conn)
             summary = next((source for source in sources
                             if source.source_key == source_key), None)
+            # A DATASET IS NOT IN THE MANIFEST, and this page asked the manifest
+            # alone: `/source/contractors` answered 404 for a table that
+            # `/api/table/contractors` was already serving in full. The price
+            # machinery below stays behind `is_dataset` because none of it means
+            # anything for a company — there is no availability, no offer and no
+            # price history to count. The GRID does not need any of it:
+            # `grid.js` fetches `/api/table/{key}` itself and builds the language
+            # switch from `payload.bilingual`, which is generic and not
+            # product-specific.
+            is_dataset = summary is None
+            if is_dataset:
+                dataset = next((row for row in _dataset_rows()
+                                if row["source_key"] == source_key), None)
+                if dataset is not None:
+                    summary = SourceSummary(
+                        source_key=dataset["source_key"],
+                        source_name=dataset["source_name"],
+                        source_name_ar=dataset["source_name_ar"],
+                        base_url=dataset["base_url"],
+                        products=dataset["products"],
+                        observations=dataset["observations"])
             page_data, fields, views, columns = None, [], [], []
             changes_by_offer, facets, watch_counts = {}, {}, {}
             absent_columns = []
-            if summary is not None:
+            if summary is not None and not is_dataset:
                 page_data = browse_observations(
                     conn, source_key, search=q or None, availability=availability or None,
                     sort=sort or None, direction=direction,
@@ -1478,34 +1542,7 @@ def create_app(
         # Wipe and Rename, and every one of those is a price-path action that
         # would answer 400 or worse for a dataset. A button that cannot work is
         # worse than no button, so the panel hides them on this marker.
-        general = general_read_conn()
-        try:
-            for row in general.execute(
-                    "SELECT d.dataset_key, d.display_name, d.original_name, "
-                    "s.base_url, count(r.generic_record_id) AS rows "
-                    "FROM dataset_definition AS d "
-                    "JOIN site_profile AS s "
-                    "ON s.site_profile_id = d.site_profile_id "
-                    "LEFT JOIN generic_record AS r "
-                    "ON r.dataset_definition_id = d.dataset_definition_id "
-                    "AND r.status = 'active' "
-                    "WHERE d.valid_to IS NULL GROUP BY d.dataset_definition_id"):
-                out.append({
-                    "kind": "dataset",
-                    "source_key": row["dataset_key"],
-                    "source_name": row["display_name"] or row["original_name"],
-                    "source_name_ar": "", "base_url": row["base_url"],
-                    "family": "generic", "active": True, "implemented": True,
-                    "supports_history": False,
-                    # `observations` is what the Data screen filters on, and for
-                    # a directory the honest number is its rows. `products` has
-                    # no meaning for a company, so it carries the same count
-                    # rather than a zero that would read as an empty dataset.
-                    "observations": row["rows"], "products": row["rows"],
-                    "last_success": None, "kept_pages": 0, "kept_at": None,
-                })
-        finally:
-            general.close()
+        out.extend(_dataset_rows())
         return {"sources": out}
 
     @app.get("/api/resolve")

--- a/tests/test_a_dataset_is_a_table_like_any_other.py
+++ b/tests/test_a_dataset_is_a_table_like_any_other.py
@@ -256,6 +256,96 @@ def test_every_declared_pair_is_on_every_row_present_or_not():
         assert all(f"{field}_ar" in row for row in without.rows)
 
 
+def test_a_declared_pair_carries_an_arabic_value_and_not_merely_a_column():
+    """THE FIFTH LEAK — and the fourth's own test was blind to it.
+
+    That test asserts `f"{field}_ar" in row`: that the COLUMN is there. Four of
+    the seven declared pairs then shipped EMPTY in all 11,059 approved rows —
+    `card_city_region_ar`, `card_company_size_ar`, `card_status_ar` and
+    `card_training_credit_hours_ar` — and every check passed the whole way.
+
+    `read_listing` keys a card's boxes by `card_{_slug(label)}`, and `_slug`
+    keeps `[a-z0-9]` only: on the Arabic page each label filtered down to
+    nothing, became `unnamed`, and seven boxes collapsed into one that the last
+    of them won. The merge was asking the Arabic page for English keys.
+
+    PRESENCE IS NOT ARRIVAL. This asserts arrival."""
+    from scrapex.extract.muqawil import (
+        BILINGUAL_CARD_FIELDS,
+        bilingual_listing_candidate,
+    )
+    arabic = (FIXTURES / "listing-ar.html").read_text(encoding="utf-8")
+
+    rows = bilingual_listing_candidate(LISTING, arabic).rows
+    assert rows, "the fixture stopped producing rows"
+
+    for field in BILINGUAL_CARD_FIELDS:
+        for row in rows:
+            value = row[f"{field}_ar"]
+            assert value, (
+                f"{field}_ar is an empty column on contractor "
+                f"{row['contractor_id']} — the column exists and nothing arrived")
+            assert value != row[field], (
+                f"{field}_ar merely repeats the English value")
+            # The site translates all seven. A value with no Arabic letter in it
+            # is an English string that reached an Arabic column, which is how a
+            # positional pairing goes wrong without looking wrong.
+            assert any("؀" <= character <= "ۿ" for character in value), (
+                f"{field}_ar holds {value!r}, which carries no Arabic letter")
+
+
+def test_a_card_whose_two_languages_disagree_on_box_count_keeps_its_english():
+    """The equal-length guard, which no real card has ever tripped.
+
+    Box counts agreed on 2,360 of 2,360 cards seen in both languages across 120
+    real page pairs — so this case has to be BUILT to be tested, and it is worth
+    building: a positional pair drawn from lists of different lengths puts one
+    field's value under another field's name, and nothing about the result looks
+    wrong. Training hours would read as a city.
+
+    The fallback is the one this function already promises an unpaired
+    contractor: keep the English half. Per CARD, not per page — the other
+    contractors on the same page are untouched."""
+    from bs4 import BeautifulSoup
+
+    from scrapex.extract.muqawil import (
+        _PROFILE_HREF,
+        bilingual_listing_candidate,
+    )
+    arabic = (FIXTURES / "listing-ar.html").read_text(encoding="utf-8")
+
+    soup = BeautifulSoup(arabic, "html.parser")
+    maimed = None
+    for card in soup.select("div.section-card"):
+        link = card.find("a", href=_PROFILE_HREF)
+        if link is None:
+            continue
+        maimed = _PROFILE_HREF.search(link["href"]).group(1)
+        card.select_one(".info-box").decompose()
+        break
+    assert maimed, "the fixture no longer holds a card to maim"
+
+    rows = {row["contractor_id"]: row
+            for row in bilingual_listing_candidate(LISTING, str(soup)).rows}
+
+    hurt = rows[maimed]
+    for field in ("card_city_region", "card_company_size", "card_status",
+                  "card_training_credit_hours"):
+        # Empty rather than `""`: `_candidate_from` normalises a blank to NULL,
+        # which is why the live table read `null` and not the empty string.
+        assert not hurt[f"{field}_ar"], (
+            f"{field}_ar took a value from a card whose boxes did not line up")
+    # The title and the badge are read from fixed places, not from the boxes,
+    # so they are unaffected — losing a box must not cost the whole row.
+    assert hurt["company_name_ar"], "a maimed card lost its Arabic name too"
+
+    others = [row for contractor, row in rows.items() if contractor != maimed]
+    assert others, "the fixture needs a second contractor to prove the scope"
+    for row in others:
+        assert row["card_city_region_ar"], (
+            "one bad card cost the whole page its Arabic half")
+
+
 def test_the_arabic_half_is_matched_by_contractor_id_and_never_by_position():
     """`en?page=5` and `ar?page=5` are two requests against a listing that
     reorders every thirty seconds — 4,556 of 11,059 contractors turned up on
@@ -318,6 +408,50 @@ def test_a_dataset_appears_among_the_sources_the_panel_lists(tmp_path):
     assert row["implemented"] is True, (
         "the panel disables a source it thinks has no connector")
     assert "muqawil.org" in row["base_url"]
+
+
+def test_the_source_page_renders_a_dataset_instead_of_answering_404(tmp_path):
+    """«اريد ظهور الجدول فى هذه الصفحة http://127.0.0.1:8000/source/contractors».
+
+    THE SAME LEAK AS `/api/sources`, ONE LAYER UP. That route learned about
+    datasets; the PAGE kept asking the manifest alone, and `source()` ends
+    `status_code=200 if summary is not None else 404` — so `/source/contractors`
+    answered 404 for a table `/api/table/contractors` was serving in full. A
+    grid nobody can reach.
+
+    The page needs nothing else: `grid.js` fetches `/api/table/{key}` itself and
+    builds the language switch from `payload.bilingual`, which is generic and
+    not product-specific. Verified in a browser — EN shows the seven English
+    columns, AR shows the seven Arabic ones."""
+    from fastapi.testclient import TestClient
+
+    from scrapex.databases import DatabaseRegistry, EngineDatabase
+    from scrapex.webui.app import create_app
+
+    registry = DatabaseRegistry(EngineDatabase(tmp_path / "scrapex-engine.db"),
+                               pointer_file=tmp_path / "databases.json")
+    registry.initialize()
+    conn = registry.engine.connect()
+    try:
+        stored(conn)
+        conn.commit()
+    finally:
+        conn.close()
+
+    client = TestClient(create_app(databases=registry))
+    page = client.get("/source/contractors")
+
+    assert page.status_code == 200, (
+        "the page 404s on a dataset whose rows /api/table already serves")
+    assert "Contractors" in page.text, "the page does not name the dataset"
+    assert "grid.js" in page.text, (
+        "without grid.js the page has no grid to fill")
+    # The price machinery must NOT have run: there is no availability, no offer
+    # and no price history for a company, and asking the warehouse for them is
+    # how this branch would raise instead of render.
+    missing = client.get("/source/no-such-thing-at-all")
+    assert missing.status_code == 404, (
+        "a key that is neither a source nor a dataset must still 404")
 
 
 def test_a_price_source_still_carries_no_kind(tmp_path):

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -104,10 +104,10 @@ PINNED = (
     # The version-gate blocker. Track 3 of STATE.md cannot be worked without
     # these three, and two of them are the citations that drifted.
     ("docs/STATE.md", "scrapex/version.py", 477, '"latest_extension_version": VERSION'),
-    ("docs/STATE.md", "scrapex/webui/app.py", 1375, '"latest_extension_version": VERSION'),
+    ("docs/STATE.md", "scrapex/webui/app.py", 1439, '"latest_extension_version": VERSION'),
     ("docs/STATE.md", "extension/app.js", 595, "latest_extension_version"),
     ("docs/STATE.md", "scrapex/version.py", 76, 'VERSION = "'),
-    ("docs/RULINGS.md", "scrapex/webui/app.py", 1375, '"latest_extension_version": VERSION'),
+    ("docs/RULINGS.md", "scrapex/webui/app.py", 1439, '"latest_extension_version": VERSION'),
     ("docs/RULINGS.md", "scrapex/version.py", 477, '"latest_extension_version": VERSION'),
     # The two flags whose condition is met and whose lighting is the owner's call.
     ("docs/STATE.md", "scrapex/features.py", 54, "False"),
@@ -125,8 +125,8 @@ PINNED = (
      'assert.equal(manifest.version, VECTORS.version)'),
     ("docs/RULINGS.md", "tests/test_version.py", 79, "pyproject"),
     # OP-2's two worker_alive computations, one of which the fix never reached.
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1386, '"worker_alive"'),
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2401, "def _about("),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1450, '"worker_alive"'),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2438, "def _about("),
     ("docs/BACKLOG.md", "scrapex/webui/templates/settings.html", 162, "about.worker_alive"),
     # BV-3's chain, end to end: the panel posts it, capture reads it.
     ("docs/BACKLOG.md", "extension/app.js", 836, "crawl_honour_delay:"),


### PR DESCRIPTION
## Four of seven bilingual pairs were empty in all 11,059 rows

`card_city_region_ar`, `card_company_size_ar`, `card_status_ar` and
`card_training_credit_hours_ar` shipped **empty in every approved contractor row**,
and every check passed the whole way.

`read_listing` keys a card's boxes by `card_{_slug(label)}`, and `_slug` keeps
`[a-z0-9]` only — so on the **Arabic** page each label filtered down to nothing,
became `unnamed`, and seven boxes collapsed into one key that the last of them won.
The merge was asking the Arabic page for English names it does not have.

**Proved from committed fixtures, no network:**

```
EN card keys : card_city_region, card_company_size, card_status, … (seven)
AR card keys : card_unnamed                                        (one)
```

`_card_boxes` now returns the boxes **in page order**, and the merge takes the Arabic
value from the same index, named by the English label. That is the rule this module's
docstring already stated and `merge_locales` already used for profiles — only the
listing path was doing it by key.

**Measured before it was relied on:** across 120 real page pairs, 2,360 cards appeared
in both languages and the box count agreed on **2,360 of 2,360**.

| after | |
|---|---|
| `company_name_ar` | 97.9% |
| `contractor_classification_ar` | 98.0% |
| `card_company_size_ar` | 98.0% |
| `card_status_ar` | 98.0% |
| `card_city_region_ar` | 89.5% |
| `card_training_credit_hours_ar` | 98.0% |
| `membership_level_ar` | 0.2% *(as its English half)* |

## Why the test did not catch it

It asserted `f"{field}_ar" in row` — that the **column** was there. **Presence is not
arrival.** The new test asserts a real Arabic value: non-empty, different from the
English, and carrying an Arabic letter.

A second test builds the case reality never produced — a card whose two languages
disagree on box count — and proves it keeps its English half **per card** rather than
costing the whole page its Arabic.

**Mutations run:** merge by key again (CAUGHT), shift the position by one (CAUGHT),
drop the equal-length guard (CAUGHT), take no boxes at all (CAUGHT), let the English
side name nothing (CAUGHT). One equivalent mutant survives — keeping the classification
box adds a key that is never in `BILINGUAL_CARD_FIELDS`, so nothing reads it.

## And `/source/{key}` answered 404 for a dataset

#212's leak one layer up. That commit taught `/api/sources` about datasets; the **page**
kept asking the manifest alone, and `source()` ends
`status_code=200 if summary is not None else 404` — so `/source/contractors` 404'd on a
table `/api/table/contractors` was serving in full.

The dataset query is now **one helper with two readers** rather than a second copy to
drift. The page needs nothing else: `grid.js` fetches `/api/table/{key}` itself and
builds the language switch from `payload.bilingual`, which is generic and not
product-specific.

**Verified in a browser, not asserted:** 20 rows painted, 5,000 in the grid, and the
switch works — EN shows the seven English columns, AR shows the seven Arabic ones, with
cells reading «الرياض - الرياض», «منشأة صغيرة», «الحساب مفعل», «96 س».

**Mutations run:** never look the dataset up (CAUGHT), look it up but build no summary
(CAUGHT), the dataset listing returns nothing (CAUGHT), the page keeps its old 404
(CAUGHT). One guard is unprovable — letting the price machinery run on a dataset makes
no observable difference, because every price query on a key that is not a source
returns empty. It stays as the defence it is.

## Two decisions recorded, not taken

**DEC-9 — snapshots are stored uncompressed.** The contractors cost 342 MB, of which
320 MB is HTML and 22 MB is data: 94% of the price is the pages. Only 21% of a listing
page is its cards; the other 291 KB is a skeleton repeated 864 times, which is why zlib
gets **15.6x** and 320 MB would be 21 MB. One real profile page was fetched to keep the
projection honest — 168 KB raw, 18 KB compressed — so Stage B's 34,566 pages are
**~6.4 GB raw against ~660 MB compressed**. The rule is right and the encoding is wrong.

**DEC-10 — "fix the parser and re-run over the snapshots" does not work today.**
`approve_candidate` short-circuits on `(snapshot, locator)` plus `schema_hash`, and a
corrected parser produces the **same** schema with **different** values — so 864 pages
came back `recovered=True` and the empty columns stayed empty, while the return value
looked like success. The idempotency key does not include the rows.

## Also

Four pinned citations moved with `app.py` and are repinned; #214's citation test is what
found them. Rebased onto #219 and its new board tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)