### PR TITLE
Merge it when it is green, recorded, because green had three meanings and two of them were false

### DIFF
--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -414,6 +414,40 @@ rule wastes a session.
 
 ---
 
+### R-18 · Merge it when it is green
+
+**2026-08-20 · process**
+
+> «ادمج لما يخضر»
+
+Said while four pull requests sat waiting on checks that had only just started
+working again. It ends a standing ambiguity: before this, green was reported to him
+and each merge waited for a separate instruction, which meant a ready pull request
+could sit for a day for no reason anyone could name.
+
+**Green means the checks that ran, not the checks that exist.** Three things had to
+be settled before this ruling could be safely obeyed, and all three are why it is
+written down rather than assumed:
+
+| trap | what it means for this rule |
+|---|---|
+| **`main` has no branch protection at all** — `gh api .../branches/main/protection` answers 404 | Nothing mechanical stops a red merge. This ruling is the whole gate, so it has to be read literally |
+| **A run that never started reports failure** | The 2026-08-19 outage failed every job with *"the job was not started because recent account payments have failed"* and no step executed. That is not red, it is absent — read the annotation before believing a failure |
+| **A green tick can belong to a different tree** | #217's `pull_request` run passed while its `push` run failed on the same commit: the merge ref carried `main`'s revert, the branch alone did not. A tick from before the last rebase is evidence about a tree nobody is merging |
+
+**How to apply.** When every check on a pull request has *concluded* and every
+conclusion is success, merge it — squash, and no further instruction needed. Do not
+merge while anything is `IN_PROGRESS`, `SKIPPED` or `QUEUED`; a skipped required
+check reads as satisfied, which is the silent-skip failure this repository has now
+recorded three times. If a check is red, establish whether it ran at all before
+touching the code. And if the branch has been rebased since the tick, wait for the
+new run — the old one described a tree that no longer exists.
+
+This does not override the ordering a stack imposes: a pull request whose premise is
+another's still waits for it, green or not.
+
+---
+
 ## Superseded
 
 Kept per **C4**. Do not follow these; they are here so the current rule can be


### PR DESCRIPTION
> «ادمج لما يخضر»

Said while four pull requests sat waiting on checks that had only just started
working again. One file, one ruling: **`R-18`** in
[docs/RULINGS.md](docs/RULINGS.md).

## Why it needed writing down rather than remembering

Before it, green was reported to the owner and every merge waited on a separate
word, so a ready pull request could sit for a day for no reason anyone could name.
**C3** says a decision is recorded here, not left in a conversation.

But the rule is unsafe to obey literally without the three traps measured today —
and **two of them caught me during this session**:

| trap | what it means for the rule |
|---|---|
| **`main` has no branch protection at all** — `gh api .../branches/main/protection` answers **404**, no required checks, nothing | Nothing mechanical stops a red merge. This ruling *is* the whole gate. It is also how `ac3a5af` reached `main` with no pull request and kept it red for a day |
| **A run that never started reports failure** | Through the 2026-08-19 outage every job failed with *"the job was not started because recent account payments have failed"* and **no step executed**. That is not red, it is absent — and I misread it once as a regression in my own branch |
| **A green tick can describe a tree nobody is merging** | #217's `pull_request` run passed while its `push` run failed on the **same commit**: the merge ref carried `main`'s revert of the colour literal, the branch alone still had it. A tick from before a rebase is evidence about a tree that no longer exists |

## The rule as written

Merge when every check has **concluded** and every conclusion is success. Squash, no
further instruction needed.

Not while anything is `IN_PROGRESS`, `QUEUED` or **`SKIPPED`** — a skipped required
check reads as satisfied, and that silent-skip shape is now recorded **three times**
in this repository. If a check is red, establish whether it *ran* before touching
code. If the branch has been rebased since the tick, wait for the new run.

A stack still imposes its order: a pull request whose premise is another's waits for
it, green or not.

## On the number

`R-18` is the next free id **in the repository**. An uncommitted `docs/RULINGS.md` in
another worktree also claims `R-18` — for the decision to make this repository
public, which is what restored CI — and **that draft will need to become `R-19`**
when it lands. The repository is the authority on what is taken; an uncommitted file
is not. That draft also cites `OP-21`, which exists in no ref, and will fail the
citation guard until it is fixed.

## Verification

**37 green** across `test_the_documents_cite_what_they_claim.py`,
`test_the_ruling_matches_the_code.py` and
`test_the_request_board_matches_its_entries.py` — all three read this file.

Committed on a branch rather than onto `main`, which is the practice whose absence
the first trap describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
