### PR TITLE
A dataset exports a workbook and loads whole, because a prefix cannot be filtered

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ env/
 Thumbs.db
 .vscode/
 .idea/
+# Visual Studio's own workspace state: .vsidx indexes run to tens of megabytes
+# each and are per-machine. Untracked was not enough -- `git add -A` swept 33 MB
+# of them into a commit on 2026-08-20, which is the SR-19 failure the rule names.
+.vs/
 
 # screenshot harness scratch
 docs/screenshots/_tmp/

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -196,12 +196,21 @@ compression migration DEC-9 asks for · the row-aware idempotency key DEC-10 ask
 for, without which a corrected parser cannot be re-run over stored snapshots at
 all.
 
-**One decision is open and it is the owner's:** both
-`FeatureKey.GENERIC_EXTRACTION` and `FeatureKey.GENERIC_DATASET_CATALOG` are still
-`False` at [scrapex/features.py:54](../scrapex/features.py) and `:60`. Their own
-written condition — *"only after an approved non-product extraction reaches
-generic storage"* — is now met by the figures above. Lighting them is what makes
-`/datasets` appear in navigation and states the capability out loud.
+**He ruled, and both flags are lit.** `FeatureKey.GENERIC_DATASET_CATALOG` and
+`FeatureKey.GENERIC_EXTRACTION` are `True` at
+[scrapex/features.py:54](../scrapex/features.py) and `:65`, both at **`PARTIAL`** —
+one site, one dataset, listing pages only, and ~6,224 contractors the sweep counted
+with nothing stored for them. Their written conditions were measured, not quoted:
+11,059 rows through the approval path over 1,728 ingestions, every one
+`status=success`.
+
+> **And the reason given for lighting them was wrong, so it is corrected here
+> rather than deleted.** This file used to say lighting them "makes `/datasets`
+> appear in navigation". It does not. `is_enabled` has **no production caller** in
+> the engine or the panel, and there is no `/datasets` route — measured, not
+> assumed. What the flags govern is what `/api/features` **publishes**, so lighting
+> one is a *claim* about a capability rather than a switch that reveals it. The
+> capability itself already works without them: `/source/contractors` serves today.
 
 **Four questions are open and are his** — O-1 to O-4 in
 [RULINGS.md](RULINGS.md#open--awaiting-the-owners-ruling).

--- a/scrapex/extract/service.py
+++ b/scrapex/extract/service.py
@@ -528,7 +528,7 @@ def browse_records(
 
 
 def dataset_table_payload(conn: sqlite3.Connection, dataset_key: str,
-                          *, cap: int = 5_000) -> dict[str, Any] | None:
+                          *, cap: int | None = None) -> dict[str, Any] | None:
     """One generic dataset in the shape the grid already renders.
 
     THE PAGE NEEDS NO CHANGE, AND THAT IS THE WHOLE DESIGN. `grid.js` never asks
@@ -550,6 +550,24 @@ def dataset_table_payload(conn: sqlite3.Connection, dataset_key: str,
 
     Returns None when no dataset carries this key, so a caller can fall through
     to the price path rather than having to ask twice.
+
+    `cap=None` MEANS EVERY ROW, and that is the default on the owner's
+    instruction of 2026-08-20: «اريد تحميل كل الصفوف بلا حد». It used to default
+    to 5,000, so the page read "Loaded 5,000 of 11,059" and -- the part that
+    actually cost him something -- the grid's filters and its search only ever
+    saw the loaded prefix, so a search for a contractor in the other 6,059
+    found nothing and said so as if the contractor did not exist.
+
+    The number was also inconsistent with the docstring above it. A price table
+    loads reports.TABLE_ROW_CAP = 20,000 and a price EXPORT 40,000, so
+    "a table like any other table" was capped at a quarter of the smaller of
+    those, for no reason recorded anywhere.
+
+    MEASURED before removing it, because A8 asks for a bound and the honest
+    answer is what it costs: all 11,059 rows read and parsed in 0.09s for a
+    13.2 MB JSON payload, against 6.0 MB for the first 5,000. At the 17,283 the
+    sweep counted it is ~21 MB. A caller that needs a bound still passes one;
+    what changed is that the default no longer decides for him.
     """
     found = conn.execute(
         "SELECT d.dataset_definition_id AS id, d.display_name, d.original_name "
@@ -574,10 +592,13 @@ def dataset_table_payload(conn: sqlite3.Connection, dataset_key: str,
     total = conn.execute(
         "SELECT count(*) FROM generic_record WHERE dataset_definition_id = ? "
         "AND status = 'active'", (dataset_id,)).fetchone()[0]
+    # LIMIT only when a caller asked for one. `LIMIT -1` is SQLite's own idiom
+    # for no limit and is used rather than building two query strings, so the
+    # bounded and unbounded paths cannot drift apart.
     stored = conn.execute(
         "SELECT data_json FROM generic_record WHERE dataset_definition_id = ? "
         "AND status = 'active' ORDER BY generic_record_id LIMIT ?",
-        (dataset_id, cap)).fetchall()
+        (dataset_id, -1 if cap is None else int(cap))).fetchall()
     rows = [json.loads(row["data_json"]) for row in stored]
 
     keys = {row["field_key"] for row in fields}

--- a/scrapex/features.py
+++ b/scrapex/features.py
@@ -51,15 +51,26 @@ _FEATURES = (
     ),
     FeatureState(
         FeatureKey.GENERIC_DATASET_CATALOG,
-        False,
-        DeliveryStage.FOUNDATION,
-        "Definitions and API exist; enable only after generic rows and the catalogue UI ship.",
+        True,
+        DeliveryStage.PARTIAL,
+        "Enabled 2026-08-20 on the owner's instruction. One dataset is catalogued "
+        "and browsable: /api/sources reports `contractors` with kind=dataset among "
+        "thirteen entries (#212), /source/contractors renders it (#220), and "
+        "/api/table/contractors answers 22 columns over 11,059 rows. PARTIAL, not "
+        "production_ready: there is exactly one dataset, no dataset-only page, and "
+        "the relationship and promotion paths are untested for this kind.",
     ),
     FeatureState(
         FeatureKey.GENERIC_EXTRACTION,
-        False,
-        DeliveryStage.NOT_STARTED,
-        "Enabled only after an approved non-product extraction reaches generic storage.",
+        True,
+        DeliveryStage.PARTIAL,
+        "Enabled 2026-08-20 on the owner's instruction, its written condition met: "
+        "11,059 muqawil.org contractors reached generic storage through the approval "
+        "path over 1,728 ingestions -- 864 English pages and 864 Arabic -- every one "
+        "of them status=success with none refused, and all seven declared bilingual "
+        "pairs carry Arabic values (#202-#212, #220). PARTIAL: one site, "
+        "listing pages only, and the ~6,224 contractors the sweep counted have no "
+        "evidence stored.",
     ),
     FeatureState(
         FeatureKey.CRAWL_FRONTIER,

--- a/scrapex/publish.py
+++ b/scrapex/publish.py
@@ -71,9 +71,32 @@ def _sink_batch(sink: SheetSink, handle) -> AbstractContextManager[None]:
     return batch(handle) if batch is not None else nullcontext()
 
 
+def dataset_workbook_tables(payload: dict,
+                            tab: str | None = None
+                            ) -> list[tuple[str, list[str], list[list]]]:
+    """One generic dataset as workbook tabs. A pure function over the payload.
+
+    ONE TAB, and the reason is what a dataset IS. The price export carries four
+    because a price has a history, a detail block and a provenance sheet; a
+    contractor directory has one flat table and inventing three empty tabs
+    beside it would be the "empty tables written as a header nobody can use"
+    that workbook_tables already refuses.
+
+    The header is the DISPLAY labels, in the schema's own field order, and the
+    cells are read through the same key order — so a column cannot land under
+    another column's name if the payload's key order ever changes.
+    """
+    keys = [column["key"] for column in payload["columns"]]
+    header = [column["label"] or column["key"] for column in payload["columns"]]
+    rows = [[row.get(key, "") for key in keys] for row in payload["rows"]]
+    return [(tab or payload["source_key"], header, rows)]
+
+
 def workbook_tables(conn: sqlite3.Connection, source_key: str,
                     schema: str = ORIGINAL_SCHEMA,
-                    tab: str | None = None) -> list[tuple[str, list[str], list[list]]]:
+                    tab: str | None = None,
+                    general: sqlite3.Connection | None = None,
+                    ) -> list[tuple[str, list[str], list[list]]]:
     """EVERY tab one source's export is made of: [(tab, header, rows), ...].
 
     The one place that decides what a complete export CONTAINS, so a workbook
@@ -89,6 +112,30 @@ def workbook_tables(conn: sqlite3.Connection, source_key: str,
     nobody can use — except the price table, whose absence is an error, not an
     empty tab.
     """
+    # A GENERIC DATASET IS A TABLE LIKE ANY OTHER TABLE, and the catalogue is
+    # asked FIRST -- the same order and the same reason as /api/table and
+    # /source/{key}: a dataset key is lower-case with underscores and a source
+    # key is upper-case, so the two sets cannot collide, and asking the smaller
+    # table first costs nothing when it misses.
+    #
+    # THE BRANCH IS HERE RATHER THAN IN THE ROUTE, deliberately. This function
+    # is documented as the one place that decides what a complete export
+    # CONTAINS, and it has THREE consumers -- the .xlsx download, the Apps
+    # Script funnel (outputs.py) and the Google/local sink (publish_source).
+    # Fixing only the route would have left `export contractors` from the CLI
+    # and the Drive push still answering "nothing to publish", which is the
+    # defect this is, one layer down.
+    #
+    # `general` is separate because a two-database installation keeps the
+    # catalogue in the general database; it falls back to `conn`, which is the
+    # single-database case and the one the owner runs.
+    from .extract.service import dataset_table_payload
+
+    dataset = dataset_table_payload(general if general is not None else conn,
+                                    source_key)
+    if dataset is not None:
+        return dataset_workbook_tables(dataset, tab=tab)
+
     header, rows = export_source_table(conn, source_key)
     if not rows:
         raise ValueError(f"nothing to publish for {source_key} — crawl + ingest it first")

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -1119,11 +1119,13 @@ def create_app(
         cannot answer differently from another.
         """
         conn = read_conn()
+        general = general_read_conn()
         try:
-            tabs = workbook_tables(conn, source_key)
+            tabs = workbook_tables(conn, source_key, general=general)
         except ValueError as exc:      # nothing ingested for this source yet
             raise HTTPException(status_code=404, detail=str(exc)) from exc
         finally:
+            general.close()
             conn.close()
         try:
             body = workbook_bytes(tabs)

--- a/tests/test_a_dataset_is_a_table_like_any_other.py
+++ b/tests/test_a_dataset_is_a_table_like_any_other.py
@@ -473,3 +473,81 @@ def test_a_price_source_still_carries_no_kind(tmp_path):
 
     assert priced, "the manifest's own sources vanished from the list"
     assert all("kind" not in row for row in priced)
+
+
+# ---- what the owner reported on 2026-08-20 -----------------------------------
+
+def test_every_row_is_loaded_because_a_prefix_cannot_be_filtered(conn):
+    """«اريد تحميل كل الصفوف بلا حد» — and the cost of the cap was not the
+    count in the corner, it was the FILTERS.
+
+    The grid filters and searches what it was given. At a cap of 5,000 against
+    11,059 stored, a search for a contractor in the other 6,059 returned nothing
+    and said so exactly as it would for a contractor who did not exist. The page
+    even reported it honestly — "filters search only what is loaded" — which
+    makes it a documented wrong answer rather than a hidden one.
+
+    The default is now every row. A caller that wants a bound still passes one,
+    and `truncated` still tells the truth when it does.
+    """
+    payload = stored(conn)
+
+    assert payload["returned"] == payload["total"]
+    assert payload["truncated"] is False, (
+        "a dataset reports itself truncated while holding every row it has")
+
+    # AND THE DEFAULT ITSELF, because this fixture cannot reach the old cap.
+    # The listing holds ~20 rows, so restoring `cap=5_000` leaves every
+    # assertion above green — measured by mutation, and a guard that passes
+    # under the defect it was written for is the silent-skip shape this
+    # repository has recorded three times. The contract is what changed: the
+    # default no longer decides for the reader, so the default is what is
+    # asserted.
+    import inspect
+
+    default = inspect.signature(service.dataset_table_payload).parameters["cap"].default
+    assert default is None, (
+        f"dataset_table_payload defaults to cap={default!r}; a number here silently "
+        "truncates every dataset larger than it, and the grid can only filter what "
+        "it was given")
+
+    bounded = service.dataset_table_payload(conn, "contractors", cap=2)
+    assert bounded["returned"] == 2
+    assert bounded["truncated"] is True, (
+        "an explicit cap must still report the prefix as a prefix")
+    assert bounded["total"] == payload["total"], (
+        "the cap changed the total, so the reader cannot see what is missing")
+
+
+def test_a_dataset_exports_a_workbook_instead_of_refusing_one(conn):
+    """`/export/contractors.xlsx` answered 404 with "nothing to publish for
+    contractors — crawl + ingest it first", on 11,059 stored rows.
+
+    THE THIRD READER THAT DID NOT ASK THE CATALOGUE. #212 fixed /api/sources and
+    #220 fixed /source/{key}; `publish.workbook_tables` reads the price join, a
+    dataset has no row in it, and `if not rows` raises. The branch belongs in
+    workbook_tables rather than in the route because that function has THREE
+    consumers — the .xlsx download, the Apps Script funnel and the Google sink —
+    and fixing the route alone would leave the other two refusing.
+
+    ONE TAB, not four: a directory has no price history, no detail block and no
+    provenance sheet, and three empty tabs beside it is the failure
+    workbook_tables already refuses for the price path.
+    """
+    from scrapex.publish import workbook_tables
+
+    payload = stored(conn)
+    tabs = workbook_tables(conn, "contractors")
+
+    assert len(tabs) == 1, "a directory grew tabs it has no content for"
+    name, header, rows = tabs[0]
+    assert name == "contractors"
+    assert len(rows) == payload["total"], (
+        "the export carries fewer rows than the dataset holds")
+    assert header == [column["label"] or column["key"]
+                      for column in payload["columns"]], (
+        "the export's header is not the schema's own labels, in its own order")
+    assert len(rows[0]) == len(header), "a row and its header disagree in width"
+
+    with pytest.raises(ValueError, match="nothing to publish"):
+        workbook_tables(conn, "NOT_A_SOURCE_OR_DATASET")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -58,8 +58,16 @@ def test_feature_manifest_is_honest_about_the_generic_roadmap(client):
     assert response.status_code == 200
     features = {item["key"]: item for item in response.json()["features"]}
     assert features["price_tracking"]["enabled"] is True
-    assert features["generic_dataset_catalog"]["enabled"] is False
-    assert features["generic_extraction"]["stage"] == "not_started"
+    # LIT 2026-08-20 on the owner's instruction, and still PARTIAL. The honesty
+    # this test guards is no longer "not advertised" but "not oversold": a flag
+    # that reached production_ready on one site and one dataset would be the
+    # inflation scrapex/features.py exists to refuse.
+    assert features["generic_dataset_catalog"]["enabled"] is True
+    assert features["generic_dataset_catalog"]["stage"] == "partial"
+    assert features["generic_extraction"]["enabled"] is True
+    assert features["generic_extraction"]["stage"] == "partial"
+    assert features["crawl_frontier"]["enabled"] is False
+    assert features["site_data_model"]["enabled"] is False
 
 
 def test_sources_lists_manifest_with_counts(client):

--- a/tests/test_catalog_api.py
+++ b/tests/test_catalog_api.py
@@ -142,5 +142,8 @@ def test_feature_manifest_reports_foundation_without_enabling_the_ui(client):
         item["key"]: item for item in client.get("/api/features").json()["features"]
     }
     catalog_feature = features["generic_dataset_catalog"]
-    assert catalog_feature["stage"] == "foundation"
-    assert catalog_feature["enabled"] is False
+    # foundation -> partial, and enabled, on the owner's instruction 2026-08-20:
+    # one dataset is catalogued and browsable. `partial` is the assertion that
+    # matters now -- the UI it reports on serves one dataset, not a catalogue.
+    assert catalog_feature["stage"] == "partial"
+    assert catalog_feature["enabled"] is True

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -19,17 +19,33 @@ def test_price_tracking_is_the_enabled_compatibility_baseline():
     assert price["stage"] == DeliveryStage.PARTIAL.value
 
 
-def test_generic_catalogue_foundation_is_visible_but_not_enabled():
-    feature = next(
-        f for f in manifest()["features"] if f["key"] == "generic_dataset_catalog"
-    )
-    assert feature["stage"] == DeliveryStage.FOUNDATION.value
-    assert feature["enabled"] is False
+def test_the_two_generic_capabilities_the_owner_lit_are_partial_not_ready():
+    """Lit 2026-08-20, and the point of this manifest is that lighting one is a
+    CLAIM. Both are PARTIAL rather than production_ready: one site, one dataset,
+    listing pages only. A flag that jumped straight to production_ready would be
+    the overselling this file exists to prevent."""
+    for key in ("generic_dataset_catalog", "generic_extraction"):
+        feature = next(f for f in manifest()["features"] if f["key"] == key)
+        assert feature["enabled"] is True, key
+        assert feature["stage"] == DeliveryStage.PARTIAL.value, key
+        assert feature["stage"] != DeliveryStage.PRODUCTION_READY.value, key
+
+    assert is_enabled(FeatureKey.GENERIC_DATASET_CATALOG) is True
+    assert is_enabled(FeatureKey.GENERIC_EXTRACTION) is True
+
+
+def test_a_lit_flag_says_what_evidence_lit_it():
+    """The detail is the whole value of an honest manifest: `enabled: true` with
+    no evidence is indistinguishable from optimism. Both entries name the
+    measurement and the pull requests, and both name what is NOT done."""
+    for key in ("generic_dataset_catalog", "generic_extraction"):
+        detail = next(f for f in manifest()["features"] if f["key"] == key)["detail"]
+        assert "2026-08-20" in detail, key
+        assert "11,059" in detail, key
+        assert "PARTIAL" in detail, key
 
 
 @pytest.mark.parametrize("feature", [
-    FeatureKey.GENERIC_DATASET_CATALOG,
-    FeatureKey.GENERIC_EXTRACTION,
     FeatureKey.CRAWL_FRONTIER,
     FeatureKey.SITE_DATA_MODEL,
 ])

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -110,8 +110,8 @@ PINNED = (
     ("docs/RULINGS.md", "scrapex/webui/app.py", 1439, '"latest_extension_version": VERSION'),
     ("docs/RULINGS.md", "scrapex/version.py", 477, '"latest_extension_version": VERSION'),
     # The two flags whose condition is met and whose lighting is the owner's call.
-    ("docs/STATE.md", "scrapex/features.py", 54, "False"),
-    ("docs/STATE.md", "scrapex/features.py", 60, "False"),
+    ("docs/STATE.md", "scrapex/features.py", 54, "True"),
+    ("docs/STATE.md", "scrapex/features.py", 65, "True"),
     # B2 step 2 -- "do not write a second one". The instruction is to EXTRACT
     # these two, so a reader sent to the wrong line writes the duplicate instead.
     ("docs/STATE.md", "extension/app.js", 1590, "async function loadSourceColumns("),


### PR DESCRIPTION
Two things the owner reported on the contractor directory.

## 1 · `/export/contractors.xlsx` answered 404 on 11,059 stored rows

```json
{"detail":"nothing to publish for contractors — crawl + ingest it first"}
```

**The third reader that did not ask the catalogue**, and the class is now familiar:
**#212** fixed `/api/sources`, **#220** fixed `/source/{key}`, and this is
[`publish.workbook_tables`](scrapex/publish.py). It calls
`reports.export_source_table`, which reads the latest-per-offer **price** join; a
dataset has no row there, so `if not rows` raised and the route turned it into a 404.

### The branch goes in `workbook_tables`, not in the route

That is the design decision, not an implementation detail. The function documents
itself as *the one place that decides what a complete export contains*, and it has
**three consumers**:

| consumer | what it feeds |
|---|---|
| `webui/app.py` | the `.xlsx` download |
| `outputs.py:282` | the Apps Script funnel |
| `publish_source` | the Google / local sink |

Fixing the route alone would have left `export` from the CLI and the Drive push
**still refusing** — the same defect one layer down, which is exactly how this one
reached its third reader.

**One tab, not four.** A directory has no price history, no detail block and no
provenance sheet, and three empty tabs beside it is the *"header nobody can use"*
that `workbook_tables` already refuses for the price path. The header is the
schema's **display labels in its own field order**, and cells are read through the
same key order, so a column cannot land under another column's name if the payload's
key order ever changes.

`general` is a separate optional connection because a two-database installation keeps
the catalogue in the general database. It falls back to `conn` — the single-database
case, and the one he runs.

## 2 · The grid loaded 5,000 of 11,059 — and the count was not the cost

`dataset_table_payload` defaulted to `cap=5_000` and the caller passed nothing.

**The filters are what this cost him.** The grid filters and searches what it was
given, so a search for a contractor among the other **6,059** answered *"nothing"* —
in the same words it uses for a contractor who does not exist. The page even said so,
*"filters search only what is loaded"*, which makes it a **documented wrong answer**
rather than a hidden one.

The number was also inconsistent with the docstring directly above it:

| path | its cap |
|---|---|
| price table | `TABLE_ROW_CAP` = **20,000** |
| price export | **40,000** |
| **dataset** | **5,000** |

*"A table like any other table"* was capped at a quarter of the smaller, for no
reason recorded anywhere.

### Measured before removing it, because A8 asks for a bound

| | |
|---|---|
| all 11,059 rows, read + parsed | **0.09s** |
| JSON payload | **13.2 MB** (vs 6.0 MB for the first 5,000) |
| at the 17,283 the sweep counted | ~21 MB |

`cap=None` now means every row and is the default. A caller that needs a bound still
passes one, and `truncated` still reports a prefix as a prefix. `LIMIT -1` is
SQLite's own idiom for no limit, used rather than building two query strings so the
bounded and unbounded paths cannot drift apart.

## And my first guard for (2) was blind — found by mutation

I wrote the test, then restored `cap=5_000` to check it. **It passed.** The fixture
holds about twenty rows from one listing page, so a five-thousand cap truncates
nothing. **A guard that passes under the defect it was written for** is the
silent-skip shape this repository has recorded three times.

So the **contract** is asserted as well as the behaviour — the default parameter must
be `None` — with a comment saying why the fixture cannot reach it. Re-checked:

| mutation | result |
|---|---|
| `cap=5_000` | ❌ fails |
| `cap=20_000` | ❌ fails |
| restored | ✅ green |

The export guard caught its own branch being disabled on the first attempt.

## Verification

- `tests/test_a_dataset_is_a_table_like_any_other.py` — **22 green**
- `test_publish` + `test_outputs` + `test_localsheets` + `test_api` — **107 green**
  together, so the price path is untouched
- **A real workbook built from the live warehouse**: 22 columns, 11,059 rows,
  **1,502,378 bytes** of valid xlsx (starts `PK`)
- `ruff` clean on `scrapex/`
- Full suite running at commit time, 24% with no failures; CI is the gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
