### PR TITLE
Branch protection is its own session, the state file was stating something false, and the branch count is measured

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -501,7 +501,47 @@ per-branch availability. All three need an extension session capture, not a conn
 change. `sources.yaml:131`, `:112`, memory `sika-trade-tier-price.md`.
 
 ### DEC-7 · Branch cleanup, which the owner asked to be reminded of
-**RE-MEASURED 2026-08-12: 148 local branches, 128 remote.** It has GROWN by 31
+**RE-MEASURED 2026-08-20, with the right test this time: 172 local, 125 remote.**
+
+Run over all 172 local refs with `git merge-tree --write-tree origin/main <branch>`
+compared against `git rev-parse origin/main^{tree}` — the test this entry itself
+prescribes, on `main` at `72f93a8` (#218):
+
+| | |
+|---|---|
+| fully contained in `main` — merging changes **nothing** | **60** |
+| merging would **conflict** | **110** |
+| merges cleanly and **adds** something | **2** |
+
+The shape has held across three measurements over eleven days: 47/68/1, then this.
+Local grew 148 → 172 while remote SHRANK 128 → 125, so someone is deleting remote
+branches and nothing is deleting local ones.
+
+**And both members of the `adds` bucket are instructive rather than a backlog.**
+
+- `docs/branch-protection-is-its-own-session` — in flight; this entry's own commit.
+- `feat/the-warehouse-travels-through-drive` — **THE TRAP, and it must not be
+  merged.** It reads as "adds something" because its content is genuinely absent
+  from `main`. But its commit *did* land, as `8ebb1f5` (#123), and
+  `scrapex/drive.py` was then **deliberately deleted** by `59d5910` (#164), "Drive
+  moves into the panel, and the engine stops holding a token it never needed".
+  Verified: `git cat-file -e origin/main:scrapex/drive.py` fails. Merging it
+  resurrects a module the owner had removed on purpose.
+
+  **So `adds` is not a synonym for `wanted`.** The bucket test answers *would
+  merging change main*, never *should it*. Any branch whose files `main` later
+  deleted lands in `adds` for ever, and this is the second time this entry has
+  had to warn about a bucket being read as an instruction.
+
+**A branch rots between measurements, which is the case for acting rather than
+re-measuring.** `claude/jolly-borg-a826ba` — the one branch the 2026-08-20 morning
+inventory found holding live work that merged **cleanly** — is now in the
+**conflict** bucket. #217 and #218 moved `extension/app.css`, `extension/console.css`
+and the three parallel `tokens.css` / `appearance.js` copies, which is exactly the
+surface it touches. It was mergeable in the morning and is not by the afternoon,
+and nothing about the branch changed.
+
+**Previous measurement, 2026-08-12: 148 local branches, 128 remote.** It has GROWN by 31
 local and 22 remote in three days — every session that opens a branch adds one,
 and nothing removes any. The 2026-08-09 figures (117 / 106) are kept below with
 the analysis that was done against them, because the *method* is the valuable

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -66,6 +66,7 @@ IDs are stable and never reused, matching the convention BACKLOG.md already uses
 | [REQ-08](#req-08--a-guard-against-the-documents-going-stale) | A guard against the documents going stale | **Done** | 2026-08-17 |
 | [REQ-09](#req-09--one-home-for-rulings-not-two) | One home for rulings, not two | **Done** | 2026-08-17 |
 | [REQ-10](#req-10--adversarially-review-the-fixes-then-execute) | Adversarially review the fixes, then execute | **Done** | 2026-08-20 |
+| [REQ-11](#req-11--branch-protection-for-main-in-a-session-of-its-own) | Branch protection for `main`, in a session of its own | **Captured** — deferred by him | 2026-08-20 |
 
 ---
 
@@ -294,6 +295,65 @@ withdrawn rule teaches more than one that was never tried: the same
 no-elapsed-duration rule over the registers' free prose flagged twelve lines and
 essentially all twelve were honest history. It lives on the parsed state fields
 instead. See [LESSONS.md](LESSONS.md).
+
+---
+
+## REQ-11 · Branch protection for `main`, in a session of its own
+
+**Captured 2026-08-20 · Deferred by him, deliberately**
+
+> «حماية فرع main» · then «حماية main اجعلها لجلسة مخصصة»
+
+He asked for it, was shown one trap that could lock him out of merging, and moved
+it to a session of its own rather than deciding at the end of a long one. That is
+the request: **not "protect main" but "protect main with its own attention".**
+
+### Why it matters more than it sounds
+
+**`main` has no protection at all today.** `gh api
+repos/muhammadbayoumi/ScrapeX/branches/main/protection` answers **404** — no
+required checks, no restriction on direct pushes, nothing. So
+[R-18](RULINGS.md#r-18--merge-it-when-it-is-green) is the *entire* gate, enforced
+by discipline alone.
+
+It has already failed once, and expensively. `ac3a5af` reached `main` **with no
+pull request**, so no CI ran before it landed; it carried a raw hex literal that
+`tests/test_vendor.py` forbids, and `main` stayed red from 2026-08-18 until #215
+reverted it. Every pull request opened in between inherited that red.
+
+### The trap that stopped it being done at once
+
+After #216 the suite runs in tiers: `test` and `migration-authority` are jobs
+gated on `needs: scope`. **A documentation-only change makes them `SKIPPED`** —
+observed, not theorised: #216's own run reported exactly that when `scope` failed.
+And a *required* check that is skipped does not read as satisfied by GitHub's
+merge gate — it can leave a pull request unmergeable for ever. That is the same
+silent-skip shape [R-18](RULINGS.md#r-18--merge-it-when-it-is-green) names as its
+third trap.
+
+### The two options, as they stood when he deferred
+
+**(a) The safe subset.** Require `lint`, `contract-parity` and `scope` — all three
+run on every change and finish in seconds. Forbid direct pushes to `main`, forbid
+deletion and force-push. **No** human-review requirement: there is no second
+reviewer, so requiring one locks him out. **No** enforcement on admins, so an
+escape hatch remains.
+
+**(b) Require everything, `test` and `migration-authority` included** — stronger,
+and it accepts that a docs-only pull request may hang until someone intervenes.
+
+*Recommended: **(a)**, and then measure.* The measurement that settles (b) is
+cheap and was offered rather than assumed: open a real documentation-only pull
+request and read what GitHub reports for a skipped required job, instead of
+trusting either reading of the API docs.
+
+### What the session should also settle
+
+- Whether **`migration-authority`** becomes required. #216 asked for this
+  explicitly: until it is, a migration-stream failure does not block a merge,
+  which is *weaker* than the inline environment variable it replaced.
+- Whether the repository being **public** since 2026-08-20 changes anything —
+  protection rules and the audit that was declined are related decisions.
 
 ---
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,8 +1,6 @@
 # State — where the work stands
 
-**Last updated: 2026-08-20.** `main` is at `cab69b1` — #214, the documentation
-system itself. Behind it: #215 (the revert, merged 2026-08-19) and one commit
-pushed straight to `main` on 2026-08-18 carrying no PR number.
+**Last updated: 2026-08-20.** `main` is at `72f93a8` (#218).
 
 This is the document that is **wrong the moment it is out of date**. Update it
 when a phase lands, a PR merges, or the owner rules — in the same pull request as
@@ -14,48 +12,50 @@ tracks *his requests* through Captured → Ruled → Planned → In flight → D
 
 ---
 
-## Open pull requests
+## Open pull requests — none
 
-> **Read no check status on this page as a verdict on code.** GitHub Actions has
-> not started a job since 2026-08-19T14:28Z — failed payment or a spending limit,
-> in GitHub's own words. Every open PR shows three red checks that never ran. See
-> [OP-20](BACKLOG.md) in the backlog; only the owner can clear it.
+**The board is empty for the first time in this file's short life.** Nine merged on
+2026-08-20, in this order, each on green CI under
+[R-18](RULINGS.md#r-18--merge-it-when-it-is-green):
 
-| PR | branch | state | what it is |
-|---|---|---|---|
-| **#213** | `the-data-page-port-is-a-port` | **CONFLICTING** — cannot be read until it is rebased | DEC-8: the engine's Data page is a port, not a rebuild, and the measurement says which |
-| *(unopened)* | `the-board-is-generated` | local, tests green | [REQ-10](REQUESTS.md#req-10--adversarially-review-the-fixes-then-execute): the request board is guarded against its own entries, and a generated document stops naming a command that does not exist |
+| | |
+|---|---|
+| `a683d70` | **#215** the profile background reverted, which unblocked `main` |
+| `bf2ae66` | **#220** the Arabic half was a column and not a value, and `/source/{key}` answered 404 for a dataset |
+| `a1d077f` | **#213** DEC-8: the engine's Data page is a port, not a rebuild |
+| `3d265cd` | **#216** the CI tiers, the docs gate, and two guards that had become silent skips |
+| `cb869f9` | **#222** R-18 itself — merge it when it is green |
+| `785533c` | **#221** the two generic flags lit, at `PARTIAL` |
+| `ce80886` | **#217** the Engine page is two screens, plus three defects an adversarial review confirmed |
+| `42dbf23` | **#223** a dataset exports a workbook and loads whole |
+| `72f93a8` | **#218** `main`'s padding is a token, and the two full-bleed screens finish #217's refactor |
 
-> **Two other sessions are working in this repository.** `scrapex/extract/muqawil.py`
-> and `tests/test_a_dataset_is_a_table_like_any_other.py` carry another session's
-> uncommitted work in the main checkout, which is why `the-board-is-generated` is a
-> separate worktree and why every commit on it stages explicit paths. SR-19 is the
-> rule, and it exists because this went wrong twice before.
+> **CI works again, and how it came back is worth knowing.** Every job from
+> 2026-08-19T14:28Z until 2026-08-20T06:34Z failed with *"the job was not started
+> because recent account payments have failed"* and **no step executed** — absent,
+> not red. It cleared because **the repository was made public**: private Actions
+> minutes on the free plan had run out, and public repositories get unlimited
+> standard-runner minutes. A ruling recording that, and recording that an exposure
+> audit was proposed and declined, is drafted but **not yet committed** — see the
+> uncommitted-work list under Named gaps.
 
-**#210, #211 and #212 have all merged** since this file last spoke. What used to
-stand here as "both green, both waiting on the owner" is now history, and the
-reason #210 mattered is kept under Track 2 where it belongs.
+### What `ac3a5af` cost, kept because REQ-11 exists for it
 
-`ac3a5af` is on `main` without a pull request — a single-parent commit, no review
-trail. **It broke `main`, and `main` has been red since 2026-08-18 because of it.**
-`extension/app.css:1166` reads `background: light-dark(#FFFFFF, var(--bg));`, and
+It reached `main` **with no pull request** — a single-parent commit, so no CI ran
+before it landed. It wrote a raw hex literal into `extension/app.css`, which
 `tests/test_vendor.py::test_ui_colour_literals_live_only_in_the_canonical_colour_system`
-forbids a raw hex literal outside the token system. Reproduced locally on
-2026-08-19. Every PR opened since inherits the red, #214 included. **This is what
-the missing pull request cost** — CI would have refused it before it reached
-`main`.
+forbids, and `main` was red from 2026-08-18 until #215 reverted it on 2026-08-19.
+Every pull request opened in between inherited that red, and I misread the outage's
+"failure" as a regression of my own once.
 
-**Fixed by #215, a full revert, merged 2026-08-19T10:37Z.** It landed eighteen hours BEFORE #214 — which was carrying this very sentence, so the sentence reached `main` already false. That is the shape of the drift this file keeps producing: a PR state hand-copied into prose while `gh` can answer it.
-
-What it did: He was offered the token expression
-`light-dark(var(--surface), var(--bg))` and chose to go back to the original
-instead — «الغى تعديلات الخلفية ورجعها للاصل». `extension/app.css` is
-byte-identical to `36dd91c` again. Two things the literal did, recorded because
-they are why the guard exists: under `data-color-mode="device"` it **discarded the
-owner's accent palette on that one page in silence**, and its own comment claimed
-the canvas was a brighter step back from the card when `--surface` is already pure
-white and the card uses it. Also learned: that guard **reads every line, comments
-included** — a comment that merely names a hex value fails it too.
+**`main` still has no branch protection at all** — `gh api
+.../branches/main/protection` answers 404. So R-18 is the entire gate, enforced by
+discipline. Captured as
+[REQ-11](REQUESTS.md#req-11--branch-protection-for-main-in-a-session-of-its-own),
+deferred by him to a session of its own, with the trap that stopped it being done
+at once: `test` and `migration-authority` are gated on `needs: scope`, a docs-only
+change makes them **`SKIPPED`**, and a required check that is skipped can leave a
+pull request unmergeable for ever.
 
 ---
 


### PR DESCRIPTION
The tail of the plan he asked about: *«هل تم الانتهاء… فكثير من الخطط توضع ولا
تستكمل الى النهاية»*. He was right — steps 1–5 had landed and 7 and 8 had not.
Three files.

## 1 · `REQ-11` — branch protection, deferred to its own session

> «حماية فرع main» — then, once shown the trap, «حماية main اجعلها لجلسة مخصصة»

**`main` has no protection at all today.** `gh api .../branches/main/protection`
answers **404** — no required checks, no restriction on direct pushes, nothing. So
[R-18](docs/RULINGS.md) is the entire gate, enforced by discipline.

That has already failed once, expensively: `ac3a5af` reached `main` **with no pull
request**, so no CI ran before it landed; it carried a hex literal
`tests/test_vendor.py` forbids, and `main` was red from 2026-08-18 until #215.

### The trap that stopped it being done at once — measured, not supposed

After #216 the suite runs in tiers: `test` and `migration-authority` are gated on
`needs: scope`. **A documentation-only change makes them `SKIPPED`** — observed on
#216's own run when `scope` failed. A *required* check that is skipped can leave a
pull request unmergeable for ever. Requiring the obvious set could lock him out of
merging his own documentation, which is worse than the failure protection prevents.

Both options are recorded with a recommendation and, more usefully, the **cheap
measurement that settles the open half**: open a real docs-only PR and read what
GitHub actually reports for a skipped required job.

## 2 · `STATE.md` was not merely stale, it was false

It was telling every reader:

> GitHub Actions has not started a job since 2026-08-19T14:28Z … Every open PR shows
> three red checks that never ran.

CI has worked since 06:34 that morning and there are now **zero** open pull requests.
The file whose own header says it is *"wrong the moment it is out of date"* was the
one thing on `main` saying something untrue. It also still listed #213 as
`CONFLICTING`, which merged as `a1d077f`.

Rewritten: `main` at `72f93a8`, the **nine** that merged on 2026-08-20 with their
commits and landing order, and the outage recorded as what it was — jobs that never
*started*, absent rather than red, which I misread once as a regression of my own.

**And how CI came back, because it is not a detail: the repository was made public.**
Free-plan private Actions minutes had run out; public repositories get unlimited
standard-runner minutes.

## 3 · `DEC-7` re-measured, with the test it prescribes

All **172** local refs through `git merge-tree --write-tree origin/main <branch>`
against `main`'s tree:

| | |
|---|---|
| contained in `main` — merging changes nothing | **60** |
| would conflict | **110** |
| merges cleanly and **adds** | **2** |

Local grew 148 → 172 since 2026-08-12 while remote **shrank** 128 → 125.

### Both members of `adds` are the point, not a backlog

- **`feat/the-warehouse-travels-through-drive` must not be merged.** It reads as
  "adds" because its content is genuinely absent — but its commit *did* land as
  `8ebb1f5` (#123), and `scrapex/drive.py` was then **deliberately deleted** by
  `59d5910` (#164). Verified: `git cat-file -e origin/main:scrapex/drive.py` fails.
  So `adds` answers *would merging change main*, never *should it*.
- The other is this branch.

### And a branch rots between measurements

`claude/jolly-borg-a826ba` — the one branch this morning's inventory found holding
live work that merged **cleanly** — is now in the **conflict** bucket. #217 and #218
moved `extension/app.css`, `extension/console.css` and the three parallel
`tokens.css`/`appearance.js` copies, which is exactly its surface. Mergeable in the
morning, not by the afternoon, and nothing about the branch changed. That is the
argument for acting on the count rather than re-taking it.

## Verification

**31 green** across `test_the_request_board_matches_its_entries.py` (the guard #219
added so the board and its entries cannot drift) and
`test_the_documents_cite_what_they_claim.py`. Files staged by name; whole cached diff
read, per `SR-19`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
