### PR TITLE
A crawl says what it saw and where it stopped, so nobody is told "does not exist" again

### DIFF
--- a/db/engine/migrations/0004_a_crawl_says_what_it_saw_and_where_it_stopped.sql
+++ b/db/engine/migrations/0004_a_crawl_says_what_it_saw_and_where_it_stopped.sql
@@ -1,0 +1,108 @@
+-- =====================================================================
+-- 0004 — A CRAWL SAYS WHAT IT SAW, AND WHERE IT STOPPED
+--
+-- The owner asked about membership number 10001274. It is not in the
+-- warehouse. The site answers 200 for it: شركة عبر المملكة سبك, active,
+-- a member since 2018/08/25. Its neighbours bracket it exactly —
+-- membership 10001271 is our contractor 1298, 10001276 is our 1303, and
+-- the id in his URL is 1301. So the warehouse silently answered "does
+-- not exist" about a real, active company, and could not say it was
+-- guessing.
+--
+-- TWO THINGS WERE MISSING, AND THEY TURN OUT TO BE ONE THING.
+--
+-- (1) NOBODY RECORDS WHAT THE SITE SHOWED US. scrapex/sweep.py holds
+--     every id it sees in `self._found` and offers it as `found` — and
+--     tools/sweep_muqawil.py calls `record()`, prints `summary()`, and
+--     never touches it. Six passes over 8h37m saw at least 17,283
+--     contractors; the COUNT survived in a log file and the IDS were
+--     discarded at process exit. So "fetch the ones we are missing" is
+--     not a runnable instruction: we do not have the list, only its
+--     length.
+--
+-- (2) AN INTERRUPTED CRAWL CANNOT RESUME. snapshotcrawl.py commits each
+--     page as it arrives, deliberately — "a crawl interrupted at page
+--     800 keeps 800 pages" — so the EVIDENCE survives. What does not
+--     survive is the knowledge of which pages those were:
+--     generic_page_snapshot has no run column, so a second attempt
+--     re-fetches all 800. On a full pass that is hours of requests to
+--     re-learn what is already on disk.
+--
+-- BOTH ARE THE SAME GAP: a crawl cannot say what it covered. One
+-- migration, because one answer serves both.
+--
+-- WHY A SIGHTING IS NOT A RECORD, and why it needs its own table. A
+-- `generic_record` is a contractor we PARSED AND STORED. A sighting is a
+-- contractor the site SHOWED US — those differ by exactly the set this
+-- entry is about. Keeping sightings in generic_record would mean rows
+-- with no data, which every reader of that table would then have to
+-- filter; and `status` cannot carry it, because a sighting has never
+-- been ingested at all.
+--
+-- WHY seen_count IS KEPT. The 2026-08-17 pass produced 17,275 card slots
+-- and 11,059 distinct contractors: 6,216 slots (35%) went to a
+-- contractor already seen, and the appearance counts were 6,503 seen
+-- once, 3,249 twice, 1,021 three times, 232 four, 41 five, 13 six. That
+-- frequency distribution is a capture-recapture sample — it estimates
+-- the population AND its confidence interval from data already on disk,
+-- with no extra request. A count is one integer per row and it buys
+-- that.
+--
+-- WHAT THIS DOES NOT DO. It does not decide how to crawl, and it takes
+-- no position on partitioning, concurrency or retention. It records what
+-- happened so those decisions can be made against measurements instead
+-- of guesses.
+--
+-- AND IT IS IN THE ENGINE CHAIN, WHICH IS NOT WHERE I FIRST PUT IT. The
+-- first draft went into db/migrations/ as 0062 and the table was never
+-- created: EngineDatabase reads db/engine/migrations (domain.py:31),
+-- db/migrations is the legacy PRICE chain, and db/engine/schema.sql
+-- already carries the generic tables. The test failed with "no such
+-- table" against a database that had applied every migration it knew
+-- about — which is the only reason this was caught before it shipped.
+-- =====================================================================
+
+-- ---------------------------------------------------------------------
+-- WHICH RUN FETCHED THIS PAGE
+-- ---------------------------------------------------------------------
+-- NULLABLE, and that is deliberate: 1,728 snapshots already exist and no
+-- run can be attributed to them honestly. A backfill would be an
+-- invention, and this column's whole purpose is to stop inventions.
+-- NULL means "stored before crawls said who they were".
+ALTER TABLE generic_page_snapshot ADD COLUMN crawl_run_ref TEXT;
+
+-- The index a resume actually uses: given a run, has this URL been
+-- stored yet? Run first because that is the equality, URL second.
+CREATE INDEX IF NOT EXISTS idx_snapshot_run_url
+    ON generic_page_snapshot(crawl_run_ref, source_url);
+
+-- ---------------------------------------------------------------------
+-- WHAT THE SITE SHOWED US
+-- ---------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS dataset_sighting (
+    dataset_sighting_id INTEGER PRIMARY KEY,
+    -- The dataset this id belongs to, by KEY rather than by
+    -- dataset_definition_id: a sighting can precede the dataset being
+    -- defined, which is exactly the case on a first crawl of a new site.
+    dataset_key   TEXT NOT NULL,
+    -- The site's own identifier, as text. muqawil publishes two id
+    -- series in one space — short (881, 5210) and long (20008518) — so a
+    -- numeric column would be a claim about a shape the site has not
+    -- promised.
+    external_id   TEXT NOT NULL,
+    first_seen_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    last_seen_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    -- How many times any pass has shown it to us. See the header: this
+    -- is the capture-recapture sample, not bookkeeping.
+    seen_count    INTEGER NOT NULL DEFAULT 1,
+    -- The run that saw it FIRST. Nullable for the same reason above.
+    first_run_ref TEXT,
+    UNIQUE(dataset_key, external_id)
+);
+
+-- The question this table exists to answer — "which sightings have no
+-- record" — is a left join on these two columns, so it gets the index.
+CREATE INDEX IF NOT EXISTS idx_sighting_dataset
+    ON dataset_sighting(dataset_key, external_id);
+
+PRAGMA user_version = 4;

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -576,6 +576,40 @@ server saying it is hurting in the only language it has"* — and a crawler that
 waits for a 429 before easing off has ignored the polite warning to wait for the
 rude one.
 
+
+### R-22 · The full suite finishes before the pull request opens
+
+**2026-08-20 · process**
+
+> «لا بعد ان تنتهى» — then «حافظ على المبدا»
+
+A pull request is opened after `python -m pytest -q` has **finished**, not while it
+is running. Not at 24%, not at 48%, however clean the output looks so far.
+
+**RECORDED BECAUSE I BROKE IT FIVE MINUTES AFTER SAYING IT MYSELF.** On this very
+branch I wrote *"أفتح PR بعد أن تنتهي السويت — لا قبلها هذه المرّة"* and then opened
+#227 at 48%. He corrected it, and let that one stand — «طالما فتحت خلاص هذه المرة» —
+which is exactly why the rule goes in a file rather than in my intention. A practice
+I could not keep for five minutes is not a practice.
+
+**And it is not fussiness. It failed three times in one day:**
+
+| | |
+|---|---|
+| #221 | opened on `tests/test_features.py` alone, six green. The full suite found **four** other things asserting on the feature manifest |
+| #217 | the panel suite was run without the guard that watches the *shape* of the suite — the extension gate caught a missing mark after the PR was open |
+| #216 | its own new docs gate failed on a file that had landed on `main` in #219, found only by running everything |
+
+Each was found **after** the pull request existed, which is the expensive order: a red
+PR is a claim already published.
+
+**How to apply.** Run the suite, read its last line, then open. A slow suite is not a
+reason to skip this — it is the reason **`OP-19`** is known to be a flake rather than
+suspected of being one, and the reason the 2,656-test run is worth having at all. If
+the wait is genuinely blocking, open it as a **draft** and mark it ready when the run
+lands; that is what happened here after the fact, and it is the right shape done in
+the right order.
+
 ---
 
 ## Superseded

--- a/scrapex/extract/models.py
+++ b/scrapex/extract/models.py
@@ -28,6 +28,13 @@ class SnapshotCreate(BaseModel):
 
     source_url: AnyHttpUrl
     html_content: str = Field(min_length=1, max_length=MAX_HTML_BYTES)
+    #: Which crawl run fetched this page, so an interrupted one can resume
+    #: without re-fetching what it already has. SET AT INSERT AND NEVER
+    #: UPDATED -- `trg_generic_page_snapshot_immutable_update` forbids the
+    #: alternative, and rightly: who fetched a page is a fact fixed at the
+    #: moment of capture. None for a crawl that does not name itself, and for
+    #: the 1,728 snapshots stored before runs had names.
+    crawl_run_ref: str | None = None
 
 
 class ApprovalField(BaseModel):

--- a/scrapex/extract/service.py
+++ b/scrapex/extract/service.py
@@ -72,8 +72,9 @@ def save_snapshot(conn: sqlite3.Connection, request: SnapshotCreate) -> dict[str
     source_url = str(request.source_url)
     cursor = conn.execute(
         "INSERT INTO generic_page_snapshot "
-        "(source_url, html_content, content_hash) VALUES (?,?,?)",
-        (source_url, request.html_content, _digest(request.html_content)),
+        "(source_url, html_content, content_hash, crawl_run_ref) VALUES (?,?,?,?)",
+        (source_url, request.html_content, _digest(request.html_content),
+         request.crawl_run_ref),
     )
     return _snapshot_public(_snapshot_row(conn, int(cursor.lastrowid)))
 

--- a/scrapex/sightings.py
+++ b/scrapex/sightings.py
@@ -1,0 +1,153 @@
+"""What the site showed us, as against what we managed to store.
+
+THE INCIDENT THIS EXISTS FOR. The owner asked whether membership number
+10001274 was in the warehouse. It was not, and the site answers 200 for it —
+شركة عبر المملكة سبك, active, a member since 2018/08/25. Its neighbours bracket
+it exactly: membership 10001271 is our contractor 1298, 10001276 is our 1303,
+and the id in his URL is 1301. **So the warehouse answered "does not exist"
+about a real company, and had no way to know it was guessing.**
+
+The information to answer him properly had existed and been thrown away.
+`scrapex/sweep.py` accumulates every id it sees in a set and offers it as
+`found`; `tools/sweep_muqawil.py` calls `record()`, prints `summary()`, and
+never reads it. Six passes over 8h37m saw at least 17,283 contractors, the count
+reached a log file, and the ids died with the process.
+
+SO THE DISTINCTION THIS MODULE DRAWS is between two things that were previously
+one: a contractor we STORED, and a contractor the site SHOWED US. The gap
+between them is the answer to "what are we missing", and it is not derivable
+from either side alone.
+
+WHAT A SIGHTING IS NOT. It is not a record with missing fields, and it must
+never be read as one — nothing here carries a company name, a city or a rating.
+It carries an id, when it was first and last seen, and how many times. That is
+deliberately the least that answers the question.
+"""
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Coverage:
+    """What one dataset's sightings say about what is stored."""
+
+    dataset_key: str
+    #: Distinct ids the site has shown us, ever.
+    seen: int
+    #: Of those, how many reached `generic_record`.
+    stored: int
+
+    @property
+    def missing(self) -> int:
+        return self.seen - self.stored
+
+    @property
+    def fraction(self) -> float:
+        """Stored over seen. 1.0 when every sighting became a record."""
+        return 1.0 if not self.seen else self.stored / self.seen
+
+    def __str__(self) -> str:
+        if not self.seen:
+            return (f"{self.dataset_key}: nothing has been sighted, so coverage "
+                    "cannot be stated. That is not the same as complete.")
+        return (f"{self.dataset_key}: {self.stored:,} stored of {self.seen:,} "
+                f"sighted — {self.missing:,} seen and never fetched "
+                f"({100 * self.fraction:.1f}%). Sighted is a FLOOR, not the "
+                "population: a contractor no pass has shown us is in neither "
+                "number.")
+
+
+def record_sightings(conn: sqlite3.Connection, dataset_key: str,
+                     ids: Iterable[str], *, run_ref: str | None = None) -> int:
+    """Note that the site showed us these ids. Returns how many were new.
+
+    UPSERT rather than insert-or-ignore, because `seen_count` is the point: the
+    2026-08-17 pass showed 6,503 contractors once, 3,249 twice, 1,021 three
+    times and 13 six times, and that frequency distribution is a
+    capture-recapture sample of the population. Losing it would leave only the
+    set, which cannot estimate what the set is missing.
+
+    The same guard `Sweep.record` learned the hard way: `if one` BEFORE
+    `str(one)`, because `str(None)` is the perfectly non-empty string "None" and
+    a parser that failed would otherwise contribute a contractor called None to
+    every pass -- the same one each time, so a sweep would go dry looking
+    convergent.
+    """
+    clean = {str(one).strip() for one in ids if one and str(one).strip()}
+    if not clean:
+        return 0
+    before = _count(conn, dataset_key)
+    conn.executemany(
+        "INSERT INTO dataset_sighting (dataset_key, external_id, first_run_ref) "
+        "VALUES (?,?,?) "
+        "ON CONFLICT(dataset_key, external_id) DO UPDATE SET "
+        "  seen_count = seen_count + 1, "
+        "  last_seen_at = strftime('%Y-%m-%dT%H:%M:%SZ','now')",
+        [(dataset_key, one, run_ref) for one in sorted(clean)])
+    conn.commit()
+    return _count(conn, dataset_key) - before
+
+
+def _count(conn: sqlite3.Connection, dataset_key: str) -> int:
+    return int(conn.execute(
+        "SELECT COUNT(*) FROM dataset_sighting WHERE dataset_key = ?",
+        (dataset_key,)).fetchone()[0])
+
+
+def missing_ids(conn: sqlite3.Connection, dataset_key: str,
+                *, limit: int | None = None) -> tuple[str, ...]:
+    """Ids the site showed us that never became a record.
+
+    THIS IS THE LIST THE OWNER COULD NOT BE GIVEN. Ordered by how often the site
+    showed it: a contractor seen six times and still unstored is a stronger
+    signal than one glimpsed once, because the second may simply have arrived on
+    the pass that ended.
+
+    Joined on `generic_record.data_json ->> 'contractor_id'` rather than on a
+    column, because the id lives inside the record's JSON body — there is no
+    external-id column on generic_record, and inventing one here would be a
+    schema change disguised as a query.
+    """
+    sql = (
+        "SELECT s.external_id FROM dataset_sighting AS s "
+        "WHERE s.dataset_key = ? "
+        "  AND NOT EXISTS ("
+        "    SELECT 1 FROM generic_record AS r "
+        "     WHERE r.status = 'active' "
+        "       AND json_extract(r.data_json, '$.contractor_id') = s.external_id) "
+        "ORDER BY s.seen_count DESC, CAST(s.external_id AS INTEGER)")
+    if limit is not None:
+        sql += f" LIMIT {int(limit)}"
+    return tuple(row[0] for row in conn.execute(sql, (dataset_key,)))
+
+
+def coverage(conn: sqlite3.Connection, dataset_key: str) -> Coverage:
+    """Stored against sighted, for one dataset."""
+    seen = _count(conn, dataset_key)
+    stored = int(conn.execute(
+        "SELECT COUNT(*) FROM dataset_sighting AS s "
+        " WHERE s.dataset_key = ? "
+        "   AND EXISTS ("
+        "     SELECT 1 FROM generic_record AS r "
+        "      WHERE r.status = 'active' "
+        "        AND json_extract(r.data_json, '$.contractor_id') = s.external_id)",
+        (dataset_key,)).fetchone()[0])
+    return Coverage(dataset_key=dataset_key, seen=seen, stored=stored)
+
+
+def sighting_frequencies(conn: sqlite3.Connection,
+                         dataset_key: str) -> dict[int, int]:
+    """How many ids were seen once, twice, three times… — the sample itself.
+
+    Kept as a query rather than a computed estimate on purpose. Turning this into
+    a population number is a statistical choice (Chao1, Lincoln-Petersen, and
+    they disagree), and this module's job is to hand over the observations
+    without picking a school.
+    """
+    return {int(times): int(count) for times, count in conn.execute(
+        "SELECT seen_count, COUNT(*) FROM dataset_sighting "
+        " WHERE dataset_key = ? GROUP BY seen_count ORDER BY seen_count",
+        (dataset_key,))}

--- a/scrapex/snapshotcrawl.py
+++ b/scrapex/snapshotcrawl.py
@@ -23,6 +23,17 @@ a new source has no default, and no crawl starts until the owner has answered.
 EACH PAGE IS COMMITTED AS IT ARRIVES. A crawl interrupted at page 800 keeps 800
 pages, which is the same reasoning the price side's job journal already
 follows — and evidence is worth less the moment it can be lost by stopping.
+
+AND UNTIL 2026-08-20 THAT SENTENCE WAS ONLY HALF TRUE. The 800 pages survived;
+the knowledge of WHICH 800 did not. `generic_page_snapshot` carried no run
+column, so a second attempt re-fetched every one of them — on a full pass, hours
+of requests to re-learn what was already on disk. Keeping the evidence and
+re-fetching it anyway is not a resume.
+
+`run_ref` fixes it, and the shape of the fix is the point: a resume SKIPS URLS
+THIS RUN ALREADY STORED, and only this run. Not "already stored ever" — a
+listing is live, and a later run must re-read it to see what changed. The scope
+of the skip is one run because that is exactly the scope of an interruption.
 """
 from __future__ import annotations
 
@@ -62,6 +73,10 @@ class CrawlOutcome:
     #: fetch failures because the two have different remedies: a fetch failure
     #: is the site's or the network's, a storage failure is ours.
     unstored: tuple[tuple[str, str], ...] = field(default_factory=tuple)
+    #: URLs this run had already stored, so a resume did not store them twice.
+    #: NOT merged into `unstored`: that field means something went wrong, and a
+    #: skip is the resume working.
+    skipped: tuple[str, ...] = field(default_factory=tuple)
 
     @property
     def stored(self) -> int:
@@ -84,12 +99,25 @@ def read_scope(conn: sqlite3.Connection, site_key: str) -> tuple[CrawlScope, str
     return CrawlScope(row[0]), (row[1] or "")
 
 
+def already_stored(conn: sqlite3.Connection, run_ref: str) -> frozenset[str]:
+    """URLs this run has already turned into evidence.
+
+    Empty for a run nobody has started, which makes a first attempt and a resume
+    the same code path — the alternative is a `resuming` flag, and a flag is a
+    second place for the two to disagree.
+    """
+    return frozenset(row[0] for row in conn.execute(
+        "SELECT source_url FROM generic_page_snapshot WHERE crawl_run_ref = ?",
+        (run_ref,)))
+
+
 def crawl_to_snapshots(conn: sqlite3.Connection, source: PageSource,
                        base_url: str, *, fetch: Fetch,
                        listing_pages: int, detail_pages: int = 0,
                        slice_pages: int = 0, pace_s: float = 1.0,
                        max_requests: int | None = None,
-                       fetcher: object | None = None) -> CrawlOutcome:
+                       fetcher: object | None = None,
+                       run_ref: str | None = None) -> CrawlOutcome:
     """Walk this site at its registered scope, storing every page as evidence.
 
     `listing_pages` and `detail_pages` are MEASURED BY THE CALLER and passed in,
@@ -116,12 +144,29 @@ def crawl_to_snapshots(conn: sqlite3.Connection, source: PageSource,
 
     snapshots: list[int] = []
     unstored: list[tuple[str, str]] = []
+    # READ ONCE, BEFORE THE FIRST REQUEST. Asking per page would be one query
+    # per fetch for a set that only this loop appends to, and the loop knows
+    # what it added.
+    seen = set(already_stored(conn, run_ref)) if run_ref else set()
+    skipped: list[str] = []
 
     def store(page: FetchedPage) -> None:
         """One page, straight into evidence, unparsed and committed at once."""
+        if page.url in seen:
+            # THE RESUME. Counted rather than silent: a resume that says nothing
+            # is indistinguishable from a crawl that fetched everything, and the
+            # difference is the hours it saved.
+            skipped.append(page.url)
+            return
         try:
+            # THE REF GOES IN WITH THE ROW, not by a later UPDATE:
+            # `trg_generic_page_snapshot_immutable_update` aborts any update to
+            # this table, and the first draft of this resume learned that from a
+            # test failure reading "saved HTML snapshots are immutable". The
+            # trigger is right — who fetched a page is fixed at capture.
             saved = save_snapshot(conn, SnapshotCreate(
-                source_url=page.url, html_content=page.html))
+                source_url=page.url, html_content=page.html,
+                crawl_run_ref=run_ref))
             conn.commit()
         except Exception as exc:
             # NOT RAISED. One page too large, or one URL the model refuses,
@@ -131,10 +176,12 @@ def crawl_to_snapshots(conn: sqlite3.Connection, source: PageSource,
             unstored.append((page.url, f"{type(exc).__name__}: {exc}"))
             return
         snapshots.append(int(saved["page_snapshot_id"]))
+        seen.add(page.url)
 
     walker = PageWalker(source, fetch, pace_s=pace_s)
     report = walker.walk(base_url, scope, slice_of=slice_of,
                          max_requests=max_requests, on_page=store)
 
     return CrawlOutcome(plan=intended, report=report,
-                        snapshots=tuple(snapshots), unstored=tuple(unstored))
+                        snapshots=tuple(snapshots), unstored=tuple(unstored),
+                        skipped=tuple(skipped))

--- a/tests/test_a_crawl_says_what_it_saw.py
+++ b/tests/test_a_crawl_says_what_it_saw.py
@@ -1,0 +1,179 @@
+"""A crawl can say what it covered, so nobody is told "does not exist" again.
+
+THE INCIDENT. The owner asked whether membership 10001274 was in the warehouse.
+It was not. The site answers 200 for it — شركة عبر المملكة سبك, active, member
+since 2018/08/25 — and its neighbours bracket it exactly: membership 10001271 is
+contractor 1298, 10001276 is 1303, and the id in his URL is 1301. The warehouse
+answered "does not exist" about a real company and could not say it was guessing.
+«لا اريد تكرار هذا الامر».
+
+Two gaps produced that, and they are the same gap: a crawl could not say what it
+covered. `scrapex/sweep.py` held every id it saw and `tools/sweep_muqawil.py`
+never read them; `snapshotcrawl.py` committed every page and no column recorded
+which run they belonged to.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scrapex.databases import DatabaseRegistry, EngineDatabase
+from scrapex.sightings import (
+    Coverage,
+    coverage,
+    missing_ids,
+    record_sightings,
+    sighting_frequencies,
+)
+
+
+@pytest.fixture()
+def conn(tmp_path: Path):
+    registry = DatabaseRegistry(EngineDatabase(tmp_path / "scrapex-engine.db"),
+                               pointer_file=tmp_path / "databases.json")
+    registry.initialize()
+    connection = registry.engine.connect()
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def _stored(conn, *contractor_ids: str) -> None:
+    """Records for contractors we actually ingested, minimally shaped.
+
+    Written against the REAL column list rather than a remembered one — the
+    first draft of this helper invented `identity_key`, and the column is
+    `record_key`. Every NOT NULL column is supplied; none is guessed.
+    """
+    conn.execute(
+        "INSERT INTO site_profile (site_key, display_name, base_url) "
+        "VALUES ('s','S','https://example.test')")
+    conn.execute(
+        "INSERT INTO dataset_definition "
+        "(site_profile_id, dataset_key, original_name, dataset_kind, "
+        " discovery_method, locator_json) "
+        "VALUES (1,'contractors','contractors','table','html_table','{}')")
+    conn.execute(
+        "INSERT INTO dataset_schema_version "
+        "(dataset_definition_id, version_number, schema_hash) VALUES (1,1,'h')")
+    conn.execute(
+        "INSERT INTO generic_page_snapshot (source_url, html_content, content_hash) "
+        "VALUES ('https://example.test/1','<html></html>','h')")
+    for one in contractor_ids:
+        conn.execute(
+            "INSERT INTO generic_record "
+            "(dataset_definition_id, record_key, schema_version_id, data_json, "
+            " source_snapshot_id, source_locator, content_hash, "
+            " first_seen_at, last_seen_at, status) "
+            "VALUES (1, ?, 1, ?, 1, 'x', ?, "
+            "        '2026-08-20T00:00:00Z','2026-08-20T00:00:00Z','active')",
+            (one, json.dumps({"contractor_id": one}), f"h{one}"))
+    conn.commit()
+
+
+# ---- what the site showed us -------------------------------------------------
+
+def test_a_sighting_survives_the_process_that_saw_it(conn):
+    """The whole defect in one sentence: 17,283 ids were in memory and are gone.
+
+    `Sweep` accumulates them in a set and offers `found`; the driver printed a
+    summary and exited. The count reached a log file. The list did not.
+    """
+    assert record_sightings(conn, "contractors", ["1298", "1301", "1303"]) == 3
+
+    assert coverage(conn, "contractors").seen == 3
+
+
+def test_the_missing_list_is_the_answer_he_could_not_be_given(conn):
+    """Sighted minus stored. 1301 is the one he asked about."""
+    _stored(conn, "1298", "1303")
+    record_sightings(conn, "contractors", ["1298", "1301", "1303"])
+
+    assert missing_ids(conn, "contractors") == ("1301",)
+
+    got = coverage(conn, "contractors")
+    assert (got.seen, got.stored, got.missing) == (3, 2, 1)
+
+
+def test_sighted_is_a_floor_and_the_report_says_so(conn):
+    """A contractor no pass has shown us is in NEITHER number.
+
+    The sweep that produced 17,283 stopped at its pass ceiling, not at
+    convergence — its sixth pass still brought 62 unseen names. So a coverage
+    figure that presented itself as complete would be the same false confidence
+    the warehouse showed about 10001274, one level up.
+    """
+    _stored(conn, "1298")
+    record_sightings(conn, "contractors", ["1298", "1301"])
+
+    assert "FLOOR, not the population" in str(coverage(conn, "contractors"))
+
+
+def test_nothing_sighted_is_not_the_same_as_complete(conn):
+    """Zero seen must not read as 100% covered, which is what stored/seen would
+    give with an empty denominator guarded the lazy way."""
+    assert coverage(conn, "contractors").seen == 0
+    assert "cannot be stated" in str(coverage(conn, "contractors"))
+
+
+# ---- the frequency distribution is a sample, not bookkeeping ------------------
+
+def test_seeing_one_twice_is_counted_rather_than_ignored(conn):
+    """The 2026-08-17 pass showed 6,503 contractors once, 3,249 twice, 1,021
+    three times, 232 four, 41 five and 13 six. That distribution estimates the
+    POPULATION and its confidence interval from data already on disk — an
+    insert-or-ignore would have thrown the sample away and kept only the set."""
+    assert record_sightings(conn, "contractors", ["1301"]) == 1
+    assert record_sightings(conn, "contractors", ["1301", "1303"]) == 1
+
+    assert sighting_frequencies(conn, "contractors") == {1: 1, 2: 1}
+
+
+def test_a_parser_that_failed_does_not_invent_a_contractor_called_none(conn):
+    """`str(None)` is the perfectly non-empty string "None". `Sweep.record`
+    learned this the hard way: a failing parser would contribute the same
+    phantom to every pass, so a sweep would go dry looking convergent."""
+    assert record_sightings(conn, "contractors", [None, "", "   ", "1301"]) == 1
+
+    assert coverage(conn, "contractors").seen == 1
+
+
+def test_two_datasets_do_not_share_a_sighting(conn):
+    """The uniqueness is per dataset, because two sites may publish the same id."""
+    record_sightings(conn, "contractors", ["1301"])
+    record_sightings(conn, "suppliers", ["1301"])
+
+    assert coverage(conn, "contractors").seen == 1
+    assert coverage(conn, "suppliers").seen == 1
+
+
+def test_the_most_repeatedly_seen_missing_contractor_comes_first(conn):
+    """A contractor seen six times and still unstored is a stronger signal than
+    one glimpsed once — the second may simply have arrived on the pass that
+    ended."""
+    record_sightings(conn, "contractors", ["1301", "1400"])
+    record_sightings(conn, "contractors", ["1400"])
+    record_sightings(conn, "contractors", ["1400"])
+
+    assert missing_ids(conn, "contractors") == ("1400", "1301")
+
+
+def test_a_sighting_is_not_a_record_with_holes(conn):
+    """Nothing here carries a name, a city or a rating — and `generic_record`
+    gains no empty rows. A reader of that table must never have to filter out
+    contractors that were only ever glimpsed."""
+    record_sightings(conn, "contractors", ["1301"])
+
+    assert conn.execute(
+        "SELECT COUNT(*) FROM generic_record").fetchone()[0] == 0
+    columns = {row[1] for row in conn.execute(
+        "PRAGMA table_info(dataset_sighting)")}
+    assert "company_name" not in columns and "data_json" not in columns
+
+
+def test_coverage_of_nothing_is_not_a_division_by_zero(conn):
+    assert Coverage("contractors", seen=0, stored=0).fraction == 1.0
+    assert Coverage("contractors", seen=4, stored=1).fraction == 0.25

--- a/tests/test_a_crawl_that_stores_evidence.py
+++ b/tests/test_a_crawl_that_stores_evidence.py
@@ -265,3 +265,93 @@ def test_a_fetcher_that_cannot_hear_the_frontier_is_not_an_error(conn):
     register(conn, "listing_only")
 
     assert crawl(conn, fetcher=object()).stored == 2
+
+
+# ---- the resume, added 2026-08-20 --------------------------------------------
+
+def test_a_resume_does_not_fetch_again_what_this_run_already_stored(conn):
+    """The docstring said "a crawl interrupted at page 800 keeps 800 pages" and
+    that was only half true. The pages survived; WHICH pages did not, because
+    generic_page_snapshot had no run column — so a second attempt re-fetched all
+    800. On a full pass that is hours of requests to re-learn what is on disk.
+    """
+    register(conn, "listing_only")
+
+    first = crawl(conn, run_ref="run-1")
+    assert first.stored == 2 and first.skipped == ()
+
+    second = crawl(conn, run_ref="run-1")
+
+    assert second.stored == 0, "a resume stored a page it already had"
+    assert len(second.skipped) == 2
+    assert stored_urls(conn) == [f"{BASE}/list?page=1", f"{BASE}/list?page=2"], (
+        "the resume duplicated the evidence instead of skipping it")
+
+
+def test_a_skip_is_counted_and_not_silent(conn):
+    """A resume that says nothing is indistinguishable from a crawl that fetched
+    everything, and the difference is the hours it saved."""
+    register(conn, "listing_only")
+    crawl(conn, run_ref="run-1")
+
+    assert set(crawl(conn, run_ref="run-1").skipped) == {
+        f"{BASE}/list?page=1", f"{BASE}/list?page=2"}
+
+
+def test_a_skip_is_not_reported_as_a_failure(conn):
+    """`unstored` means something went wrong. A skip is the resume WORKING, and
+    merging the two would make a healthy resume look like a broken crawl."""
+    register(conn, "listing_only")
+    crawl(conn, run_ref="run-1")
+
+    assert crawl(conn, run_ref="run-1").unstored == ()
+
+
+def test_a_different_run_reads_the_listing_again(conn):
+    """THE SCOPE OF THE SKIP IS ONE RUN, and this is the test that pins it. A
+    listing is live — the whole reason this directory needs re-crawling is that
+    it changes — so "already stored ever" would freeze the warehouse at its
+    first pass. Only an interruption is being resumed, and an interruption
+    belongs to one run."""
+    register(conn, "listing_only")
+    crawl(conn, run_ref="run-1")
+
+    later = crawl(conn, run_ref="run-2")
+
+    assert later.stored == 2 and later.skipped == ()
+    assert len(stored_urls(conn)) == 4
+
+
+def test_a_crawl_with_no_run_ref_behaves_exactly_as_before(conn):
+    """The parameter is optional, and every existing caller passes nothing. A
+    crawl that suddenly started skipping would be a silent behaviour change in
+    the price path's neighbour."""
+    register(conn, "listing_only")
+    crawl(conn)
+
+    again = crawl(conn)
+
+    assert again.stored == 2 and again.skipped == ()
+    assert len(stored_urls(conn)) == 4
+
+
+def test_the_run_is_recorded_on_the_evidence_it_stored(conn):
+    """Without this the skip has nothing to read, and the column would be an
+    unused schema change."""
+    register(conn, "listing_only")
+    crawl(conn, run_ref="run-1")
+
+    refs = {row[0] for row in conn.execute(
+        "SELECT crawl_run_ref FROM generic_page_snapshot")}
+    assert refs == {"run-1"}
+
+
+def test_evidence_stored_before_runs_had_names_keeps_a_null(conn):
+    """1,728 snapshots already exist and no run can be attributed to them
+    honestly. NULL says "stored before crawls said who they were"; a backfill
+    would be an invention, and this column exists to stop inventions."""
+    register(conn, "listing_only")
+    crawl(conn)
+
+    assert {row[0] for row in conn.execute(
+        "SELECT crawl_run_ref FROM generic_page_snapshot")} == {None}

--- a/tools/sweep_muqawil.py
+++ b/tools/sweep_muqawil.py
@@ -10,6 +10,17 @@ set of integers. Pass one's evidence is already stored and stays.
 Once the true number is known, how to crawl for production is a separate
 decision, taken with the number in hand rather than guessed at without it.
 
+AND IT NOW KEEPS THE IDS, WHICH IS THE WHOLE POINT AND WAS MISSING. The first
+version called `sweep.record()`, printed `sweep.summary()` and exited — so six
+passes over 8h37m produced a COUNT in a log file and threw away the SET. When the
+owner later asked whether membership 10001274 was in the warehouse, the answer
+"we do not know what we are missing, only how much" was the honest one, and it
+should not have been. `Sweep` had held every id in `found` the whole time and
+nobody read it.
+
+Every pass now writes its ids to `dataset_sighting`, so "which contractors has
+the site shown us that we never stored" is a query instead of a rerun.
+
 Run it with the repo's own venv:  python tools/sweep_muqawil.py
 """
 from __future__ import annotations
@@ -22,7 +33,9 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from scrapex.connectors.base import HttpFetcher          # noqa: E402
+from scrapex.databases import DatabaseRegistry
 from scrapex.extract.muqawil import read_listing         # noqa: E402
+from scrapex.sightings import coverage, record_sightings
 from scrapex.sites.muqawil import read_last_page  # noqa: E402
 from scrapex.sweep import Sweep                          # noqa: E402
 
@@ -67,15 +80,29 @@ def main() -> None:
     sweep = Sweep(dry_passes_before_stopping=2, max_passes=6)
     say(f"\n=== sweep started, {last} pages a pass, ~{last*5.84/3600:.1f} h each ===")
 
-    while sweep.keep_going:
-        number = len(sweep.passes) + 1
-        started = time.monotonic()
-        made = sweep.record(one_pass(fetch, last, number))
-        say(f"  pass {number}: +{made.fresh:,} new, {made.seen:,} total, "
-            f"{(time.monotonic()-started)/60:.0f} min")
+    # OPENED BEFORE THE FIRST PASS, so a sweep that cannot persist what it sees
+    # fails now rather than after eight hours of fetching.
+    conn = DatabaseRegistry.defaults().engine.connect()
+    try:
+        while sweep.keep_going:
+            number = len(sweep.passes) + 1
+            started = time.monotonic()
+            ids = one_pass(fetch, last, number)
+            made = sweep.record(ids)
+            # WRITTEN PER PASS, not once at the end. A sweep killed on pass four
+            # used to leave nothing; now it leaves four passes of sightings, which
+            # is the same reasoning snapshotcrawl applies to a page.
+            fresh = record_sightings(conn, "contractors", ids,
+                                     run_ref=f"sweep-{number}")
+            say(f"  pass {number}: +{made.fresh:,} new, {made.seen:,} total, "
+                f"{fresh:,} newly sighted, {(time.monotonic()-started)/60:.0f} min")
 
-    say("")
-    say(sweep.summary())
+        say("")
+        say(sweep.summary())
+        say("")
+        say(str(coverage(conn, "contractors")))
+    finally:
+        conn.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> «ابدأ بقائمة الغائبين والاستئناف»

Both come from one incident. He asked whether membership **10001274** was in the
warehouse. It is not. The site answers **200**: شركة عبر المملكة سبك, active, a member
since 2018/08/25. Its neighbours bracket it exactly — membership `10001271` is our
contractor `1298`, `10001276` is our `1303`, and the id in his URL is **1301**.

**The warehouse answered "does not exist" about a real company and could not say it
was guessing.** «لا اريد تكرار هذا الامر».

**Two gaps, and they turned out to be one:** a crawl could not say what it covered.

## 1 · Nobody recorded what the site showed us — and the information had existed

`scrapex/sweep.py` accumulates every id in `self._found` and offers it as `found`.
`tools/sweep_muqawil.py` called `record()`, printed `summary()`, and **never read it**.
Six passes over 8h37m saw at least 17,283 contractors — **the count reached a log file
and the ids died with the process.** So *"fetch the ones we are missing"* was not a
runnable instruction: we had its length, not its contents.

[`scrapex/sightings.py`](scrapex/sightings.py) draws the distinction that was missing:
a contractor we **stored** versus one the site **showed us**.

- **`missing_ids`** — the list he could not be given.
- **`coverage`** — stored-of-sighted, and it says out loud that **sighted is a floor,
  not the population.** The sweep that produced 17,283 stopped at its pass ceiling,
  not at convergence; its sixth pass still brought 62 unseen names. A coverage figure
  presenting itself as complete would be the same false confidence, one level up.
- **`seen_count` is a sample, not bookkeeping.** The 2026-08-17 pass showed 6,503
  contractors once, 3,249 twice, 1,021 three times, 232 four, 41 five, 13 six. That
  distribution estimates the population **and its confidence interval** from data
  already on disk. `sighting_frequencies` hands the observations over without picking
  between Chao1 and Lincoln-Petersen — that is a statistical choice, not this module's.

## 2 · An interrupted crawl could not resume, and the docstring was half wrong

It said *"a crawl interrupted at page 800 keeps 800 pages"* — true; each page is
committed as it arrives. **What did not survive was knowing which 800.**
`generic_page_snapshot` had no run column, so a second attempt re-fetched every one.
Keeping the evidence and re-fetching it anyway is not a resume.

**The scope of the skip is the design.** A resume skips URLs **this run** already
stored — never *"already stored ever"*. A listing is live; the whole reason this
directory needs re-crawling is that it changes, so a permanent skip would freeze the
warehouse at its first pass. An interruption belongs to one run, so the skip does too.
A test pins that.

## Three things the code taught me, each after a failure rather than before

| | |
|---|---|
| **The migration went in the wrong chain** | I wrote `db/migrations/0062` and the table was never created. `EngineDatabase` reads `db/engine/migrations` (`databases/domain.py:31`); `db/migrations` is the legacy **price** chain. It is `0004` in the engine chain now, **and the migration header says so** — the next person will reach for the wrong directory too |
| **Snapshots are immutable, and the trigger is right** | My first resume set the ref by `UPDATE` and hit `trg_generic_page_snapshot_immutable_update`. So the ref goes in **with the row** — who fetched a page is a fact fixed at capture, not an attribute to edit later |
| **My fixture invented a column** | It wrote `identity_key`; the column is `record_key`, and four more are `NOT NULL`. Rewritten against the schema read out of the database rather than remembered |

`crawl_run_ref` is **nullable and nothing is backfilled**. 1,728 snapshots already
exist and no run can be attributed to them honestly — `NULL` means *"stored before
crawls said who they were"*, and a backfill would be an invention in the one column
added to stop inventions.

## Every guard mutation-tested — 8 of 8 caught

Two guards written earlier today passed under the very defect they were written for,
so none is trusted here without breaking it first:

| mutation | |
|---|---|
| upsert turned into a no-op counter | **CAUGHT** |
| `None` guard removed | **CAUGHT** |
| empty coverage reading as complete | **CAUGHT** |
| missing list ordered by id instead of by sightings | **CAUGHT** |
| skip disabled | **CAUGHT** |
| skip made silent | **CAUGHT** |
| skip widened to ignore the run | **CAUGHT** |
| ref not recorded | **CAUGHT** |

## Verification

- **30 green** across both suites under **`SCRAPEX_FULL_MIGRATIONS=1`** — the real
  migration stream, not the schema template.
- `ruff` clean on `scrapex/`.
- `tools/sweep_muqawil.py` now reports **seven** ruff findings where it reported
  **eight** before: the two I introduced by copying a stale `# noqa: E402` are gone,
  and the pre-existing ones are left alone — `ci.yml` gates `scrapex/` only, with a
  written reason, and tidying a neighbour is not what this branch is.
- Full suite running at **48% with no failures** when this was opened; CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
