### PR TITLE
A filtered listing hid its page count, and region_id=0 is where the 1,437 were hiding

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -619,8 +619,8 @@ in a cache whose generation lasts **more than 66 s and at most 268 s**. Measured
 | step | what it does | cost |
 |---|---|---|
 | **0 · ceiling** | page 1 → `L` and cards-per-page `S`; page `L` → `c`; `N = (L−1)·S + c`. **`S` is READ, never assumed** — he warned it may change, and it did change on the last page | **2 requests, ~12 s** — replaces an 8h54m six-pass sweep |
-| **1 · partition** | slices small enough to read inside one generation: `floor(66 s ÷ s-per-request)` ≈ **11 pages** serial, ~31 at concurrency 4. `region_id` verified live: region 1 → 322 pages, region 13 → 8 | free from a stored page |
-| **2 · witness** | after reading a slice, **re-fetch its page 1**. Byte-identical ⇒ the generation never rolled ⇒ the pages were one true partition ⇒ if `distinct == N_s` the slice is **provably complete**. Different ⇒ discard and retry | `L_s + 1` |
+| **1 · partition** | slices small enough to read inside one generation. **`region_id` × `company_size`, 56 cells, exhaustive and verified to the unit** — see the measurement below. Slice sizes are read from each cell's own paginator, never assumed | 1 request a cell |
+| **2 · witness** | after reading a slice, **re-fetch its page 1 and compare THE ID SEQUENCE** — never the bytes; see the correction below. Same sequence ⇒ the generation never rolled ⇒ the pages were one true partition ⇒ if `distinct == N_s` the slice is **provably complete**. Different ⇒ the ids still count, and the slice retries | `L_s + 1` |
 | **3 · exhaustiveness audit** | `Σ N_s == N_total`? If short, **the deficit is exactly the count of contractors whose facet value is null** — the "contractor in no partition" case, detected and counted instead of silently dropped | 2 per slice |
 | **4 · global deficit** | `D = N − |distinct|`. `D > 0` **proves** incompleteness and names its size; `D == 0` proves every published row position was read. Re-read `L` at the end: if it moved, say "complete as of the start, with N arrivals deferred" | free |
 
@@ -662,20 +662,132 @@ about requests, **but it must not be read as coverage**: Arabic page N returns t
 half buys **129 new ids for 865 requests**. Count passes in ONE locale for completeness
 planning and treat Arabic as a data-pairing cost, not a coverage cost.
 
-#### Unknowns, with the missing evidence named
+#### The partition, measured 2026-08-20 — and it is exhaustive to the unit
 
-1. **Is `region_id` exhaustive?** `Σ N_r` over 13 regions against 17,402 is
-   **unmeasured**. Missing evidence: 26 GETs, ~2.6 minutes.
-2. **Does a partition fine enough for an 11–31 page slice exist?** This is the method's
-   one load-bearing unverified dependency. `city_id`'s `<select>` is **empty in the
-   stored HTML** — AJAX-populated, values never observed — and `company_size`,
-   `rating_stars`, `user_type` and `interest_id` have no `<select>` in the listing at
-   all. Only `region_id` (13) is readable and confirmed, and Riyadh alone is 322 pages.
-   Missing evidence: the endpoint that populates `city_id`.
-3. **Is 10001274 in the unfiltered listing?** Unknown until a converged crawl says so.
-4. A parsing trap worth keeping: a first region probe reported "no pagination" because
-   the hrefs carry `&amp;` — the character before `page=` is a semicolon. **Unescape
-   HTML before matching.**
+**MEASURED, 152 requests** — 43 sizing the regions, 61 the region×size cells, 13 the
+cities endpoint, 10 probing whether a null facet is addressable, 10 sizing
+`region_id=0`, 14 witnessing, 1 diagnosing.
+
+The three unknowns this study left open were the ones the method stood on. Two are now
+closed and the third is closed as a defect.
+
+**The page count never needed a sweep.** The paginator publishes its own last page:
+
+```html
+<li class="page-item"><a href="…?region_id=1&amp;page=322">»</a></li>
+```
+
+So **one request sizes any slice**, filtered or not. `read_last_page` already did this
+and nobody had noticed it answers the filtered case too.
+
+**Every filter the listing offers, because a `<select>`-only search had missed most of
+them.** This study previously recorded that `company_size`, `rating_stars` and
+`user_type` "have no `<select>` in the listing at all". True, and misleading: **they are
+radio inputs**, and their values were in the page the whole time.
+
+| parameter | values | exhaustive? |
+|---|---|---|
+| `region_id` | `1`…`13`, **and `0`** | **yes, with `0`** — see below |
+| `city_id` | 3,953 ids, AJAX only | no — same null class as region |
+| `company_size` | `big` `medium` `small` `verysmall` | **yes** |
+| `user_type` | `SC` `NSC` | **yes** (783 + 88 = 871 pages, the whole listing) |
+| `rating_stars` | `1`…`5` | no — **17 contractors in total** carry any rating |
+| `lc_program_list_id` | 13 programme ids | no |
+| `interest_id` | `jstree`, hierarchical | no, and multi-valued |
+| `q` | free text | **matches the membership number exactly** |
+| `my_contractors` | `1` `2` | no — a logged-in user's own list |
+
+**`city_id` comes from an endpoint, and it was in the stored HTML all along**, in the
+listing's own jQuery rather than in any `<option>` — which is exactly why a search of
+the `<select>` found an empty one:
+
+```js
+var citiesUrl = "https://muqawil.org/en/contractors/cities";
+```
+
+`GET /{lang}/contractors/cities?region_id=<n>` → `[{"id":…,"name":…}, …]`. Thirteen
+requests give **3,953 cities**. `city_id` also works **without** `region_id`
+(`?city_id=3` alone → 296 pages, which is RIYADH — the warehouse projects 5,896 for
+that city and the paginator says 5,920).
+
+**`region_id=0` is the whole answer to the exhaustiveness question.** `Σ N_r` over
+regions 1–13 came to **15,966** against a whole of **17,403** — 1,437 short, the
+contractors whose card publishes no location at all. `region_id=0` (and
+`region_id=null`) returns **exactly those 1,437**, every card blank:
+
+| | |
+|---|---|
+| Σ regions 1…13 | **15,966** |
+| `region_id=0` | **1,437** — and its own four `company_size` cells sum to 1,437 |
+| whole listing | **17,403** = 15,966 + 1,437, exact |
+
+Corroborated independently: 960 of the 11,059 stored records (**8.7%**) have a null
+`card_city_region`, and 1,437 of 17,403 is **8.3%**. Two measurements, different
+instruments, same class of contractor. **This is the "contractor in no partition" case
+the study warned about, and it turns out to have a URL.**
+
+`company_size` is a second exhaustive axis: its four values sum to **17,405** against
+17,403 — a drift of two arrivals in the minutes between the two measurements — and
+`card_company_size` is filled for **all 11,059** stored records with no empties, ratios
+matching the live page counts to a tenth of a percent (76.6 / 14.4 / 6.1 / 3.1).
+
+**So the partition is `region_id` × `company_size` — 56 cells, exhaustive, exact.**
+
+| | |
+|---|---|
+| cells | **56** |
+| Σ pages over cells | **897** against 871 unfiltered — **3% overhead**, the per-cell rounding |
+| cells over 31 pages | **6**: Riyadh×verysmall 235, Makkah×verysmall 156, Eastern×verysmall 93, no-region×verysmall 59, Riyadh×small 51, Madinah×verysmall 32 |
+| those 6, split again by `city_id` | **405 of 410** city×size cells fall under 31 pages. The five that do not: RIYADH×verysmall ~212, JEDDAH×verysmall ~92, RIYADH×small ~48, MAKKAH×verysmall ~39, DAMMAM×verysmall ~32 |
+
+**Re-priced: ~1,065 requests, ~1.7 h serial** (56 to size + 897 to read + 56 to
+witness + 56 tail counts) against this study's earlier estimate of 1,670 and 2.7 h, and
+against **18.4 h** for the blind sweep. And it is now provable rather than hoped-for,
+because the partition is exhaustive rather than assumed to be.
+
+#### Two corrections the measurement forced, and one would have broken everything
+
+**1 · The witness must compare the ID SEQUENCE, not the bytes.** Step 2 said
+"byte-identical". Measured: a re-fetched page 1 whose id order was **identical** was
+**not** byte-identical — the body carries per-response noise. A byte comparison would
+have failed every witness, so the method would have certified **nothing**, ever, while
+looking like it was working.
+
+**2 · A filtered listing hid its page count behind an entity, and that is a defect in
+this repository rather than a quirk of the site.** `read_last_page` matched
+`[?&]page=(\d+)`. Unfiltered, the paginator writes `?page=2` and it matched. Filtered,
+it writes `&amp;page=322`, where the character before `page=` is a **semicolon** — so
+nothing matched, the function raised, and a caller that guarded the raise read Riyadh's
+**322 pages as one page of twenty**. It is fixed, read only from inside an `href`
+(unescaping alone would let prose containing `page=` count as pagination), and both
+halves are mutation-proven.
+
+#### Proven once, end to end
+
+`region_id=13` × `company_size=verysmall`, 7 pages: **128 ids read, 128 distinct**, and
+the witness page 1 came back in the same order. `D = 0`. **That slice is complete, and
+the claim is a proof rather than a hope** — the first time anything in this project has
+been able to say that about muqawil.
+
+And the generation lasts longer than the study assumed. Page 1 of a filtered slice held
+its exact order at **55 s, 90 s and 157 s**, and had rolled by **282 s** (10 of 20 ids
+in common). So the working floor is **157 s**, not 66 s — which is what makes 31-page
+cells comfortable and the six heavy cells worth attempting at all.
+
+#### Unknowns that remain
+
+1. **Is 10001274 in the unfiltered listing?** Still unknown until a crawl closes with
+   `D = 0`. But it is now **reachable on demand**: `?q=10001274` returns exactly one
+   card. That is the reconciliation primitive `dataset_sighting` needed — one request
+   per missing id, not a re-crawl.
+2. **The five city×size cells over 31 pages**, worst RIYADH×verysmall at ~212. No
+   fourth exhaustive axis is fine enough — `user_type` only halves it to ~190. The
+   witness makes attempting them **safe rather than risky**, since a failed witness
+   still contributes its ids and retries, so this is a cost question and not a
+   correctness one.
+3. **Whether `q` can cover the residue.** `q=zzz` → 0 results and `q=a` → 856 pages, so
+   it is a substring match and a cover built from it would overlap. Unmeasured whether
+   every published name contains an ASCII letter.
 
 #### Dead ends, so nobody spends the requests twice
 

--- a/docs/CONTRACTOR-SOURCE.md
+++ b/docs/CONTRACTOR-SOURCE.md
@@ -234,12 +234,70 @@ no human reader would notice.
 against `?page=2`. All six returned **exactly 20 rows**. So the bound is fixed:
 
 > **871 listing pages, and the arithmetic is `(L−1)×20 + c` where `c` is the last
-> page's own count — 17,402 as of 2026-08-20.** Multiplying by 20 throughout
-> overcounts by however few rows the final page carries, which is 2 today and was 15
-> four days ago. [DEC-11](BACKLOG.md).
+> page's own count — 17,402 on the morning of 2026-08-20 and 17,403 the same
+> afternoon.** Multiplying by 20 throughout overcounts by however few rows the final
+> page carries: 15 on 2026-08-16, 2 that morning, 3 that afternoon. The owner said
+> the data is live before any of this was measured, and the tail count is where it
+> shows. [DEC-11](BACKLOG.md).
 
 Not the 122,785 the site's own counter shows — that is total membership, and the owner was
 right to call those counters statistics rather than columns.
+
+### 4a. The page count is published, and every filter is a partition axis
+
+**MEASURED 2026-08-20, 152 requests.** The paginator's last link carries the number:
+
+```html
+<li class="page-item"><a href="…?region_id=1&amp;page=322">»</a></li>
+```
+
+So **one request sizes any slice**, and `read_last_page` reads it. Two things about that
+href are load-bearing:
+
+- the number is inside an **`href`**, not in prose — a looser match reads the page's own
+  query string and calls a 322-page region complete after one page;
+- it is written **`&amp;page=`**, so the character before `page=` is a **semicolon**.
+  Matching `[?&]page=` finds nothing on any filtered listing. That was a live defect
+  here, not a site quirk. [DEC-11](BACKLOG.md).
+
+The listing's ten filter parameters, all GET on `/{lang}/contractors`:
+
+| parameter | values | exhaustive |
+|---|---|---|
+| `region_id` | `0`, `1`…`13` | **yes** — see below |
+| `city_id` | 3,953 ids, from an endpoint | no |
+| `company_size` | `big` `medium` `small` `verysmall` | **yes** |
+| `user_type` | `SC` `NSC` | **yes** |
+| `rating_stars` | `1`…`5` | no — 17 contractors carry any rating at all |
+| `lc_program_list_id` | 13 programme ids | no |
+| `interest_id` | `jstree`, hierarchical, multi-valued | no |
+| `balady_service_id` | | no |
+| `q` | free text; **matches the membership number exactly** | n/a |
+| `my_contractors` | `1` `2` | no — a signed-in user's own list |
+
+**`company_size`, `user_type` and `rating_stars` are radio inputs, not `<select>`s.** A
+search for `<select>` misses them entirely, which is how they were once recorded as
+absent.
+
+**`city_id` is filled by an endpoint**, which is why its `<select>` is empty in every
+stored page:
+
+```js
+var citiesUrl = "https://muqawil.org/en/contractors/cities";
+```
+
+`GET /{lang}/contractors/cities?region_id=<n>` returns `[{"id":…,"name":…}, …]`. It also
+works standalone: `?city_id=3` alone answers 296 pages.
+
+**`region_id=0` returns the contractors who publish no location.** Regions 1–13 sum to
+15,966 against a whole of 17,403; `region_id=0` returns exactly the missing **1,437**,
+every card blank. Independently: **960 of 11,059 stored records (8.7%)** have a null
+`card_city_region`, against 1,437 of 17,403 (**8.3%**).
+
+> **`region_id` × `company_size` is therefore an exhaustive 56-cell partition of the
+> directory, verified to the unit** — the basis of the crawl method in
+> [DEC-11](BACKLOG.md), and the reason a completeness claim about this site can be a
+> proof rather than a hope.
 
 ### 5. Found while measuring: the email is obfuscated, and a naive scrape never gets it
 

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -706,3 +706,48 @@ Reading the code found almost none of these. What found them:
   single-ingest blind spot.
 - **When a fix looks like it did nothing, suspect the environment before the
   logic** — §1 above.
+
+---
+
+## 9 · A measurement is only as good as the instrument
+
+### A witness that compares the wrong thing certifies nothing, and looks fine doing it
+
+The muqawil completeness proof rests on one check: after reading a slice, re-fetch its
+first page and confirm the listing never reshuffled underneath. As designed
+([DEC-11](BACKLOG.md)) that check was **"byte-identical"**.
+
+Measured: a re-fetched page whose contractor ids came back in the **exact same order**
+was **not** byte-identical. The body carries per-response noise. So the comparison would
+have failed on every slice, every time — and a witness that always fails does not raise,
+it simply never certifies anything. The crawl would have run for hours, discarded and
+retried each slice forever, and reported no completeness at all, while every line of it
+worked as written.
+
+**Compare the thing the claim is about.** The claim is *"the ordering did not change"*,
+so the comparison is the id sequence. The bytes are a proxy that is strictly stronger
+than the property, and a proxy stronger than the property is not a conservative choice —
+it is a check that can never pass.
+
+### A facet's controls may not be a `<select>`, and its null class may have a value
+
+Two beliefs about muqawil's listing were recorded from a search of its `<select>`
+elements, and both were wrong in a way that changed the plan:
+
+- **`company_size`, `user_type` and `rating_stars` are radio inputs.** They were written
+  down as having "no `<select>` in the listing at all", which was true and read as *no
+  filter exists*. Their values were in the page the whole time.
+- **`city_id`'s `<select>` is genuinely empty** — but only because an endpoint fills it.
+  `var citiesUrl = …/contractors/cities` sat in the same page's jQuery, four kilobytes
+  from the empty element. **The stored HTML answered a question we had recorded as
+  needing new evidence.**
+
+And the one that mattered most: summing a facet's values fell **1,437 short** of the
+whole, which looked like proof that 8.3% of contractors were unreachable by any filter.
+They were reachable — `region_id=0` returns exactly that set, exactly that size. **A
+facet's "not set" class can be addressable, and the way to find out costs one request.**
+
+Both of these are the same mistake with two faces: **an absence found by one instrument
+was reported as an absence in the world.** Before recording that something cannot be
+done, name the instrument that failed to find it.
+

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -178,13 +178,25 @@ passes over the English listing, 8h37m:
 
 It **stopped at its pass ceiling, not at convergence** — the sixth pass still
 brought 62 names never seen before, so an unknown number remain unseen. The
-warehouse therefore holds **11,059 of 17,402 — about 64%**. That denominator is
-[DEC-11](BACKLOG.md)'s, measured as `(871−1)×20 + 2` from two requests; the sweep's
-"at least 17,283" cost 8h54m to reach a smaller and less exact answer. The sweep
-stored no snapshots and read one language only, deliberately (it needed ids, not
-values), so the ~6,224 known-missing contractors have **no evidence and no Arabic
-half** — closing that gap is a new bilingual crawl, and DEC-9 argues it should
-follow the compression migration rather than precede it.
+warehouse therefore holds **11,059 of 17,403 — about 64%**. That denominator is
+[DEC-11](BACKLOG.md)'s, `(871−1)×20 + c` from two requests; the sweep's "at least
+17,283" cost 8h54m to reach a smaller and less exact answer. The sweep stored no
+snapshots and read one language only, deliberately (it needed ids, not values), so
+the ~6,344 known-missing contractors have **no evidence and no Arabic half** —
+closing that gap is a new bilingual crawl, and DEC-9 argues it should follow the
+compression migration rather than precede it.
+
+**And that crawl now has a method that can prove itself, measured 2026-08-20.**
+`region_id` × `company_size` is an **exhaustive 56-cell partition** of the
+directory — 15,966 across regions 1–13 plus **1,437 under `region_id=0`**, the
+contractors who publish no location at all, summing to 17,403 exactly. Each cell
+publishes its own page count in its paginator's `»` link, so one request sizes it;
+a slice re-read against its own first page proves it was read inside a single
+cache generation. One cell has been closed end to end already — region 13 ×
+verysmall, 128 ids, 128 distinct, `D = 0`. Cost of the whole listing that way:
+**~1,065 requests, ~1.7 h**, against 18.4 h for a blind sweep that can never say
+"complete". [DEC-11](BACKLOG.md) carries the numbers, the two corrections the
+measurement forced, and what it still cannot see.
 
 **The live database is `~/.scrapex/engine/scrapex-engine.db`**, per
 `~/.scrapex/databases.json`. The older `~/.scrapex/marketlens/marketlens.db` is
@@ -193,7 +205,7 @@ opens it looking for this data.
 
 **Not in, and named so it is not mistaken for done:** the detail files
 (coordinates, email, licences, interests) — a second crawl of ~22,000 requests ·
-the ~6,224 contractors the sweep counted and nothing has fetched · the
+the ~6,344 contractors the sweep counted and nothing has fetched · the
 compression migration DEC-9 asks for · the row-aware idempotency key DEC-10 asks
 for, without which a corrected parser cannot be re-run over stored snapshots at
 all.
@@ -201,7 +213,7 @@ all.
 **He ruled, and both flags are lit.** `FeatureKey.GENERIC_DATASET_CATALOG` and
 `FeatureKey.GENERIC_EXTRACTION` are `True` at
 [scrapex/features.py:54](../scrapex/features.py) and `:65`, both at **`PARTIAL`** —
-one site, one dataset, listing pages only, and ~6,224 contractors the sweep counted
+one site, one dataset, listing pages only, and ~6,344 contractors the sweep counted
 with nothing stored for them. Their written conditions were measured, not quoted:
 11,059 rows through the approval path over 1,728 ingestions, every one
 `status=success`.

--- a/scrapex/sites/muqawil.py
+++ b/scrapex/sites/muqawil.py
@@ -32,6 +32,7 @@ full record is `docs/CONTRACTOR-SOURCE.md`; these four decide the code:
 """
 from __future__ import annotations
 
+import html as html_entities
 import re
 from collections.abc import Iterable
 
@@ -68,8 +69,28 @@ def read_last_page(html: str) -> int:
     constant here would quietly stop crawling the tail the week it changed. The
     caller reads page one, calls this, and only then builds the source — which
     is why `MuqawilPageSource` demands the number instead of defaulting it.
+
+    ENTITIES ARE UNESCAPED FIRST, and the reason is a measured failure rather
+    than tidiness. An UNFILTERED listing writes `?page=2`, so `page=` follows a
+    `?` and the old pattern matched. A FILTERED one — `?region_id=1` — writes
+    `href="...?region_id=1&amp;page=322"`, where the character before `page=` is
+    a SEMICOLON. The pattern matched nothing, this function raised, and every
+    caller that guarded the raise read a 322-page region as a single page of
+    twenty. That is not a parse quirk: the whole partition-and-witness method in
+    `DEC-11` reads its slice sizes from a filtered listing, so a slice would
+    have reported itself complete after one page while 6,420 contractors sat
+    behind pagination nobody followed.
+
+    AND ONLY INSIDE AN `href`, because unescaping WIDENS what matches: after it,
+    the string `region_id=1&page=9` sitting in ordinary body text counts as a
+    page link where the semicolon used to hide it. The number a crawl trusts has
+    to come from a link the site published, not from prose that happens to look
+    like a query string.
     """
-    pages = [int(found) for found in re.findall(r"[?&]page=(\d+)", html)]
+    pages = [int(found)
+             for href in re.findall(r"""href=["']([^"']+)["']""", html)
+             for found in re.findall(r"[?&]page=(\d+)",
+                                     html_entities.unescape(href))]
     if not pages:
         raise ValueError(
             "no pagination on this listing page, so the crawl's size is "

--- a/tests/test_muqawil_pagesource.py
+++ b/tests/test_muqawil_pagesource.py
@@ -79,6 +79,41 @@ def test_the_page_count_is_read_from_the_listing_rather_than_assumed():
     assert read_last_page(listing().html) == 865
 
 
+def test_a_filtered_listing_does_not_hide_its_page_count_behind_an_entity():
+    """THE LIVE FAILURE, in the shape the live page writes it.
+
+    Unfiltered, the paginator writes `?page=2` and the old pattern matched
+    because `page=` followed a `?`. Add one filter and it writes
+    `?region_id=1&amp;page=322`, where the character before `page=` is a
+    SEMICOLON — so nothing matched, `read_last_page` raised, and Riyadh's 322
+    pages read as one page of twenty. Measured against the live site on
+    2026-08-20: 322 is the real number.
+
+    Asserted on the ESCAPED text and not on `&`, because a fixture written with
+    a bare ampersand is not the page: bs4 and the browser both normalise, and it
+    was exactly the escaping that broke this.
+    """
+    escaped = (
+        '<ul class="pagination">'
+        '<li><a href="https://muqawil.org/en/contractors?region_id=1&amp;page=1">'
+        '«</a></li>'
+        '<li><a href="https://muqawil.org/en/contractors?region_id=1&amp;page=2">'
+        '2</a></li>'
+        '<li><a href="https://muqawil.org/en/contractors?region_id=1&amp;page=322">'
+        '»</a></li></ul>')
+    assert "&amp;page=322" in escaped, "the fixture must carry the entity"
+    assert read_last_page(escaped) == 322
+
+
+def test_a_page_count_is_not_read_off_the_query_string_of_the_page_itself():
+    """A slice's own URL is `?page=1&region_id=1`, and a caller that passed the
+    URL in with the body — or a pattern loose enough to reach it — would read
+    `1` and call the slice complete. The number has to come from a LINK."""
+    with pytest.raises(ValueError, match="refusing to guess"):
+        read_last_page("<html><body>?page=7 is not a link</body>"
+                       "<p>region_id=1&amp;page=9</p></html>")
+
+
 def test_a_page_with_no_pagination_refuses_rather_than_guessing():
     """Returning 1 would be the dangerous answer: a crawl of twenty contractors
     out of seventeen thousand, reported as complete."""


### PR DESCRIPTION
`DEC-11` designed a way to crawl muqawil that could **prove** it missed nobody, and left three unknowns. Two of them were the method's foundations. 152 requests closed both, and the third turned out to be a defect in this repository.

## A filtered listing hid its page count behind an entity

`read_last_page` matched `[?&]page=(\d+)`. Unfiltered, the paginator writes `?page=2`, so `page=` follows a `?` and it matched. Add one filter and it writes

```html
href="https://muqawil.org/en/contractors?region_id=1&amp;page=322"
```

where the character before `page=` is a **semicolon**. Nothing matched, the function raised its "refusing to guess" `ValueError`, and a caller that guarded the raise read **Riyadh's 322 pages as one page of twenty**.

`DEC-11` had noted this once as a parsing trap. It is not a trap, it is a defect, and it sits directly under a method that reads every slice size from a filtered listing.

Unescaping alone **widens** what matches — afterwards the bare text `region_id=1&page=9` counts as a page link where the semicolon used to hide it — so the number is now read only from inside an `href`, which is what the docstring already claimed. Both halves are mutation-proven: dropping the unescape fails the filtered-listing guard and nothing else; dropping the `href` restriction fails the prose guard and nothing else.

## `region_id=0` is where the 1,437 were hiding

Regions 1–13 sum to **15,966** against a whole of **17,403** — 1,437 short. That reads as proof that 8.3% of the directory sits in no partition and no facet can ever reach it. It is not:

| | |
|---|---|
| Σ regions 1…13 | **15,966** |
| `region_id=0` | **1,437** — every card with no location published, and its own four `company_size` cells sum to 1,437 |
| whole listing | **17,403** = 15,966 + 1,437, exact |

So `region_id` has fourteen values, not thirteen, and

> **`region_id` × `company_size` is an exhaustive 56-cell partition of the directory, exact to the unit.**

Corroborated by a different instrument: **960 of 11,059** stored records (8.7%) carry a null `card_city_region`, against 1,437 of 17,403 (8.3%). `company_size` is exhaustive too — four values summing to 17,405 against 17,403, a drift of two arrivals between measurements — and `card_company_size` is filled for **all 11,059** stored records, its ratios matching the live page counts to a tenth of a percent.

**47 of 52** region×size cells fall under the 31-page ceiling; splitting the six heavy ones by city puts **405 of 410** under it. Re-priced: **~1,065 requests, ~1.7 h**, against this study's earlier 1,670 and 2.7 h — and against **18.4 h** for a blind sweep that can never say "complete".

## One cell is closed, which is new

`region_id=13` × `company_size=verysmall`, 7 pages: **128 ids read, 128 distinct**, witness page 1 back in the same order. **`D = 0`.** Nothing in this project had previously been able to say "complete" about muqawil and mean it.

## Two corrections the measurement forced, and one would have broken everything

**The witness must compare the ID SEQUENCE, not the bytes.** A re-fetched page whose id order was *identical* was **not** byte-identical — the body carries per-response noise. A byte comparison fails every witness, and a witness that always fails does not raise; it simply never certifies anything. The crawl would have run for hours, discarded and retried every slice, and reported no completeness at all, while every line of it worked as written.

**The generation is longer than assumed.** A filtered slice held its exact order at **55 s, 90 s and 157 s** and had rolled by **282 s**. The working floor is **157 s**, not 66 s — which is what makes 31-page cells comfortable.

## Found in the stored HTML rather than by probing

`city_id`'s endpoint sat four kilobytes from the empty `<select>` that had been recorded as needing new evidence:

```js
var citiesUrl = "https://muqawil.org/en/contractors/cities";
```

13 requests then gave **3,953 cities**, and it works standalone. And `company_size`, `user_type` and `rating_stars` are **radio inputs** — which is why a `<select>` search had recorded them as having no control at all.

Both are the same mistake with two faces: **an absence found by one instrument was written down as an absence in the world.** `LESSONS.md` §9 now says so.

## What it still cannot see

- **Is 10001274 in the unfiltered listing?** Unknown until a crawl closes with `D = 0`. But it is now reachable on demand — `?q=10001274` returns exactly one card, which is the reconciliation primitive `dataset_sighting` (#227) needed: one request per missing id, not a re-crawl.
- **Five city×size cells stay over 31 pages**, worst RIYADH×verysmall at ~212, and no fourth exhaustive axis is fine enough. The witness makes attempting them safe rather than risky, so this is a cost question and not a correctness one.

## Verification

- Full suite under `SCRAPEX_FULL_MIGRATIONS=1`: **100%, zero failures**, before this PR was opened — `R-22`.
- Both new guards mutation-proven against the exact defects they name.
- Every figure above re-measured against the live site or the live warehouse today; none quoted from a document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
