### PR TITLE
The volume that needed justifying does not exist, and three of his requests were off the board

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,8 +95,8 @@ the thing came from: **he asked** → `REQUESTS.md`; **we found it** →
 
 Other long-standing documents — `docs/MIGRATION-PLAN.md`,
 `docs/COMPATIBILITY.md`, `docs/PLATFORM-PLAN.md`, `docs/GENERIC-FETCH-SEAM.md`,
-`docs/CONTRACTOR-SOURCE.md` — are indexed from `docs/STATE.md` under the track
-they belong to.
+`docs/CONTRACTOR-SOURCE.md`, `docs/STORAGE.md` — are indexed from `docs/STATE.md`
+under the track they belong to.
 
 ---
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -817,6 +817,23 @@ and each of these looked promising enough to chase:
 ---
 
 ### DEC-9 · Snapshots are stored uncompressed, and the full crawl is 6.4 GB of it
+
+> **SUPERSEDED 2026-08-20 by [STORAGE.md](STORAGE.md), and kept in full per C4.**
+> It asked *how to store 6.4 GB more cheaply* and answered that well. The owner
+> asked *why we are storing 6.4 GB at all*, and five of the numbers below do not
+> survive being measured properly: a listing page is **17.8%** cards, not 21%; a
+> profile is **119 KB** across 13 samples, not 168 KB from one; the corpus is
+> **4.55 GB**, not 6.4; a profile compresses **7.7×** with zlib, not 9.4×; and the
+> compressed projection is **~90 MB**, not 660.
+>
+> The one that mattered is not a number but a cause: its 15.6× is **entirely
+> intra-page**. zlib's 32 KB window never sees across a 121 KB page, so the
+> cross-page redundancy this entry credits for the ratio was left on the table.
+> `zstd` with one real page as a raw dictionary gets **187×** on listings and
+> **46×** on profiles, is in the 3.14 standard library, and keeps every row
+> independently decompressible. Its *rule* — keep the snapshots — is upheld and
+> strengthened. Its *encoding* is not.
+
 **MEASURED 2026-08-20, on the live database.** The contractors cost 342 MB, of which
 **320 MB is HTML and 22 MB is data** — 94% of the price is the pages, not the rows.
 
@@ -895,6 +912,9 @@ approved**, and that has to be said out loud rather than discovered again.
 ---
 
 ### DEC-8 · The engine's Data page is a PORT, not a rebuild — measured 2026-08-16
+
+**This answers [REQ-07](REQUESTS.md#req-07--the-data-page-must-carry-everything-the-engines-page-carries)**
+— his request on the board, which did not cite it in either direction.
 
 **The owner asked directly:** «هل يمكن نقل صفحة data الموجودة فى المحرك بكل مميزتها الى
 extension ام يلزم اعادة البناء كامل؟» Answered by measurement, not opinion, and the answer

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -67,6 +67,8 @@ IDs are stable and never reused, matching the convention BACKLOG.md already uses
 | [REQ-09](#req-09--one-home-for-rulings-not-two) | One home for rulings, not two | **Done** | 2026-08-17 |
 | [REQ-10](#req-10--adversarially-review-the-fixes-then-execute) | Adversarially review the fixes, then execute | **Done** | 2026-08-20 |
 | [REQ-11](#req-11--branch-protection-for-main-in-a-session-of-its-own) | Branch protection for `main`, in a session of its own | **Captured** — deferred by him | 2026-08-20 |
+| [REQ-12](#req-12--justify-the-volume-not-compress-it) | Justify the volume, not compress it | **Captured** — study done, the ruling is his | 2026-08-20 |
+| [REQ-13](#req-13--crawl-muqawil-without-missing-anyone-and-know-the-cost-before-starting) | Crawl muqawil without missing anyone, and price it first | **Captured** — method proven, crawl not built | 2026-08-20 |
 
 ---
 
@@ -157,7 +159,10 @@ reorders every thirty seconds.
 ---
 
 ## REQ-07 · The Data page must carry everything the engine's page carries
+
 **Captured 2026-08-12 (the migration plan is his) · Planned · Not started**
+
+**Answered by measurement:** [DEC-8](BACKLOG.md#dec-8--the-engines-data-page-is-a-port-not-a-rebuild--measured-2026-08-16) settled his direct question — «هل يمكن نقل صفحة data الموجودة فى المحرك بكل مميزتها الى extension ام يلزم اعادة البناء كامل؟» — by measuring rather than guessing, and the answer is **a port, not a rebuild**. The link was missing in both directions, so a reader of this board could not see the question had been answered at all.
 
 Four capabilities remain before the workbook link may be removed from the source
 card: the details drawer, Choose-Columns, saved views, and promotion. The order
@@ -354,6 +359,125 @@ trusting either reading of the API docs.
   which is *weaker* than the inline environment variable it replaced.
 - Whether the repository being **public** since 2026-08-20 changes anything —
   protection rules and the audit that was declined are related decisions.
+
+---
+
+## REQ-12 · Justify the volume, not compress it
+
+**Captured 2026-08-20 · The study is done; the ruling is his**
+
+> «انا لم استقر على طريقة خفض حجم المخزن … **ليست الفكرة ضغط الملفات** بل دراسة نشوف
+> احنا بنسحب اى ولية وبنحتفظ باية ولية وما الفائدة — دراسة تبرر الحجم الذى قيل انه
+> سيصل الى 5 جيجا من مصدر مقاول فقط»
+
+He had already been shown `DEC-9` and did not accept it as the answer, and he was
+right not to: `DEC-9` asked **how to store 6.4 GB more cheaply** and he is asking
+**why we are storing 6.4 GB at all.** Compression answers the first and cannot
+touch the second — a justified 660 MB and an unjustified 660 MB look identical on
+disk. He also asked for a wider measurement before any migration
+(«أريد قياساً أوسع أولاً»).
+
+### This entry is also a filing defect being repaired
+
+The request was **absent from this file entirely** — no hit for «مساحة», `storage`,
+`space`, `compress` or «حجم» — while the research it prompted sat in
+[BACKLOG.md](BACKLOG.md) as `DEC-9`. That is exactly the failure this file exists to
+prevent: `REQ-04` sat ruled and unbuilt for sixteen days after dropping out of view.
+Real work, correctly researched, invisible on the board that tracks what he asked
+for. `DEC-9`'s own filing was **correct** — it is a finding of ours; his *request*
+is what was missing.
+
+### Where it went
+
+[STORAGE.md](STORAGE.md), and the answer is that the volume he asked us to justify
+does not exist:
+
+- The 6.4 GB was projected from **one** profile page at 168 KB. Thirteen real
+  profiles average **119 KB**, so the complete corpus is **4.55 GB** raw, not 6.4.
+- `compression.zstd` entered the standard library in Python 3.14, and a raw page
+  used as a shared dictionary compresses listings **187×** and profiles **46×** with
+  every row still independently decompressible. `DEC-9`'s zlib gets 15.6× and 7.7×,
+  because its 32 KB window cannot see across a 121 KB page — the cross-page
+  redundancy it credited for its ratio was **left on the table**.
+- So everything the site publishes, both languages, evidence retained: **~90 MB of
+  pages plus ~70 MB of rows — about 160 MB**, against the 5 GB in the question.
+- And trimming is **strictly dominated**: keeping only the visible text of every
+  profile, uncompressed, costs **139 MB**; keeping the whole HTML compressed costs
+  **87 MB**. It is more expensive *and* it spends the ability to re-parse, which is
+  in active use while 48 of his ~70 columns remain unextracted.
+
+### What still needs him
+
+**Is a snapshot evidence, or only a parse cache?** `SR-1` makes the site the source
+of truth, so a stored page is a record of what it published on a date. If that
+matters to him, profiles may never be dropped for a re-fetch; if it does not, 87 MB
+is recoverable at the price of 17.4 hours. The study refuses to assume this
+([STORAGE.md §5](STORAGE.md)).
+
+**And the migration is not written.** He asked for the measurement first; this is
+the measurement.
+
+---
+
+## REQ-13 · Crawl muqawil without missing anyone, and know the cost before starting
+
+**Captured 2026-08-20 · The study is done and one slice is proven; the crawl is not built**
+
+> «عدد الصفح غير ثابت وفعدد المقاولين المسجلين على الموقع بالتاكيد يتغيروا مع الوقت شوف
+> طريقة ازاى نعرف عدد الصفح او ازاى نزحف صح بدون ان نغفل شى … ازاى نقدر عدد الطلبات قبل
+> بداية الزحف … **اريد منك فحص كل الحلول والحالات**»
+
+And the reason it was asked, in his words: **«لقد ذكرت لك اسم مقاول لم ياتى فى قاعدة
+البيانات — لا اريد تكرار هذا الامر»**. He named contractor **10001274**; the site
+answers 200 and the warehouse did not have it. He asked that it not happen again.
+
+He also set the two constraints the answer has to respect, both correcting an
+assumption of ours: **the page count is not fixed**, and **a page need not hold
+twenty cards** — «البيانات حية».
+
+### This entry is the third filing defect of the same kind, found by a rule
+
+`DEC-11` is 150 lines of measured research that exists **because he asked for it**,
+and it quotes his instruction twice. Nothing on this board recorded the request.
+[REQ-12](#req-12--justify-the-volume-not-compress-it) was the same failure and
+`DEC-8`/`REQ-07` was the same failure in the other direction. Three in one file is
+not an accident, so the signal is now a guard:
+`tests/test_a_request_of_his_reaches_the_board.py` fails when a finding quotes him
+in Arabic and no request cites it.
+
+### Where it went
+
+[DEC-11](BACKLOG.md#dec-11--how-to-crawl-muqawil-without-missing-anyone-and-what-it-costs),
+and each of his three questions has an answer:
+
+- **How do we know the page count?** The paginator publishes it — its `»` link
+  carries the last page. **One request**, filtered or not, and `read_last_page`
+  reads it. It also honours his warning: the last page carried 15 cards on
+  2026-08-16, 2 on the morning of 2026-08-20 and 3 that afternoon, so the count is
+  `(L−1)×20 + c` with `c` **read**, never assumed.
+- **How do we crawl without missing anyone?** `region_id` × `company_size` is an
+  exhaustive 56-cell partition, verified to the unit — 15,966 across regions 1–13
+  plus 1,437 under `region_id=0`, the contractors who publish no location, summing
+  to 17,403 exactly. A slice read inside one cache generation and witnessed against
+  its own first page is **provably** complete. One cell is closed already: region 13
+  × verysmall, 128 ids, 128 distinct, `D = 0`.
+- **How do we estimate the requests before starting?** 56 requests size every cell
+  before a single page is crawled. Total **~1,065 requests, ~1.7 h** — against
+  **18.4 h** for a blind sweep that can never say "complete".
+
+And **10001274 is reachable on demand**: `?q=10001274` returns exactly one card. So
+the specific thing he asked not to recur has a one-request answer, and
+`dataset_sighting` (#227) is the ledger that says which ids need it.
+
+### What is not done
+
+The crawl itself. The method is measured and proven on one slice; nothing runs it
+yet, and [STORAGE.md](STORAGE.md) was deliberately settled first so that 36,548
+pages are not written under a retention policy that a later decision would rewrite.
+
+Five city×size cells stay above the safe slice size, worst ~212 pages, and no
+fourth exhaustive axis is fine enough. The witness makes attempting them safe
+rather than risky, so it is a cost question — but it is the open one.
 
 ---
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -108,7 +108,8 @@ broken under load (**T2**).
 
 ## Track 2 · The muqawil.org contractor directory
 
-**Design:** [CONTRACTOR-SOURCE.md](CONTRACTOR-SOURCE.md) · **Seam:**
+**Design:** [CONTRACTOR-SOURCE.md](CONTRACTOR-SOURCE.md) · **Storage:**
+[STORAGE.md](STORAGE.md) · **Seam:**
 [GENERIC-FETCH-SEAM.md](GENERIC-FETCH-SEAM.md) · **Plan:**
 [plans/2026-08-16-muqawil-contractor-source.md](plans/2026-08-16-muqawil-contractor-source.md)
 · **Rulings:** [R-10](RULINGS.md#r-10--the-contractor-directory--three-rulings),

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -1,0 +1,251 @@
+# Storage — what we fetch, what we keep, and what each byte buys
+
+> «انا لم استقر على طريقة خفض حجم المخزن … **ليست الفكرة ضغط الملفات** بل دراسة نشوف
+> احنا بنسحب اى ولية وبنحتفظ باية ولية وما الفائدة — دراسة تبرر الحجم الذى قيل انه
+> سيصل الى 5 جيجا من مصدر مقاول فقط»
+> — the owner, 2026-08-20 ([REQ-12](REQUESTS.md#req-12--justify-the-volume-not-compress-it))
+
+He asked a question this project had not been asked before. `DEC-9` measured **how to
+store 6.4 GB more cheaply** and answered it well. He is asking **why we are storing 6.4
+GB at all** — justify each thing fetched, each thing retained, and say what each is
+worth. Compression answers the first question and does not touch the second: a justified
+660 MB and an unjustified 660 MB look identical on disk.
+
+**And the headline is that the volume he asked us to justify does not exist.** The
+number was measured from one sample and it was too high. Measured properly, and stored
+with a mechanism that was not available when `DEC-9` was written, **everything the site
+publishes in both languages fits in about 160 MB.**
+
+Every figure below is measured on the live warehouse or the live site on **2026-08-20**.
+None is quoted from a document, including this project's own.
+
+---
+
+## 1 · What we fetch, and why each fetch is necessary
+
+Four classes. The count of each is fixed by [DEC-11](BACKLOG.md)'s partition, not
+estimated.
+
+| class | pages | why it is fetched |
+|---|---|---|
+| listing EN | 871 | The **only** enumeration of who exists. There is no sitemap of contractors, no id-space that can be probed, and no stable sort — all three measured and recorded as dead ends in `DEC-11` |
+| listing AR | 871 | **Not redundant, and not for coverage.** Arabic page N returns the same 20 ids as English page N. It is fetched because Arabic values are matched **by page-order index and never by label** (`LESSONS.md`), so the Arabic page is the only source of the Arabic strings |
+| profile EN | 17,403 | 48 of the owner's ~70 columns exist **only** here — licences, interests, activities, coordinates, the obfuscated email, the self-build prices. The listing card carries 22 |
+| profile AR | 17,403 | Same reason as the Arabic listing: the `[ar]` half of every column |
+
+**Total: 36,548 fetches.** Each class is load-bearing and none is duplicated work. The
+Arabic halves are a **data-pairing cost, not a coverage cost** — a distinction `DEC-11`
+had to make once already, because counting Arabic passes as coverage doubles a
+completeness estimate for 129 new ids.
+
+**What we deliberately do NOT fetch**, so the list is a decision and not an omission:
+the map page (measured: zero contractor markers, its one coordinate is the map centre),
+`/api/rating-api` beyond what a profile renders, and the `my_contractors` filter, which
+is a signed-in user's private list.
+
+---
+
+## 2 · What we retain, and what it costs — measured, not projected
+
+**Today the warehouse keeps the entire HTML of every page it has ever fetched.**
+
+| | |
+|---|---|
+| `scrapex-engine.db` | **796 MB** + a 4 MB WAL |
+| `generic_page_snapshot` | 1,728 pages · **607 MB of `html_content`** — 76% of the whole file |
+| `generic_record` | 11,059 rows · 8.7 MB of `data_json` |
+| `generic_record_revision` | 34,550 rows · 26.7 MB |
+| accounted for | 643 MB of 796 MB; the remaining 153 MB is indexes and page overhead |
+
+So **the snapshots are the warehouse.** Everything else is a rounding error, and any
+conversation about size that is not about snapshots is about the wrong thing.
+
+### The composition of a page, per class
+
+| | listing | profile |
+|---|---|---|
+| average size | **363 KB** (min 312, max 373) | **119 KB** (min 101, max 157) |
+| the part that is data | **17.8%** — 20 cards, 64 KB | **3.5%** — 4.1 KB of visible text |
+| structure with scripts stripped | — | 27 KB (22%) |
+| samples | 5 pages, and 864 sized | **13 real profiles across the whole id range** |
+
+**Corrections to `DEC-9`, which measured this from one sample:**
+
+| `DEC-9` said | measured 2026-08-20 |
+|---|---|
+| 21% of a listing page is cards | **17.8%** |
+| a profile is **168 KB** *(one sample)* | **119 KB** (13 profiles, min 101, max 157) |
+| the full crawl is **~6.4 GB** raw | **4.55 GB** — 618 MB of listings, 3.95 GB of profiles |
+| compressed, ~660 MB | **~90 MB**, with a mechanism that is now in the standard library — §4 |
+| a profile compresses 9.4× | **7.7×** with zlib per row; **46×** with a shared dictionary |
+
+**And one claim of `DEC-9`'s was not merely imprecise but backwards**, which matters
+because the whole recommendation rested on it:
+
+> *"a near-identical skeleton repeated 864 times, which is exactly why it compresses so
+> well"*
+
+The skeleton **is** near-identical — 40 listing pages differ only in their pagination
+block and one locale-switch href. But **zlib captures none of that.** Its window is
+32 KB and a skeleton is 121 KB, so by the time page 2 begins, page 1 is out of view.
+Measured three ways:
+
+| | |
+|---|---|
+| one skeleton, zlib-9 | 18 KB |
+| ten skeletons **concatenated**, zlib-9 | 175 KB — **9.84× the cost of one, for ten pages** |
+| 40 whole pages as one zlib block | **15.8×** — no better than compressing them separately |
+
+So `DEC-9`'s 15.6× is **entirely intra-page redundancy**. The cross-page redundancy it
+credited for the ratio was real, large, and **left on the table**.
+
+---
+
+## 3 · What each retained byte buys, per class — and the classes differ
+
+This is the part `DEC-9` could not answer, because it is not a compression question.
+
+### Retention buys time — priced honestly
+
+| class | re-fetch cost |
+|---|---|
+| both listings | 1,742 requests × 5.84 s = **2.8 h** |
+| both profile sets | 34,806 requests × 1.8 s = **17.4 h** |
+| everything | **~20 hours** |
+
+Measured value of that policy so far: **one incident.** A defect in the bilingual merge
+on 2026-08-20 was repaired from disk with nothing re-fetched. That is the honest
+accounting — *hours saved per incident*, at one incident to date, not a principle.
+
+### But the two classes are not the same kind of thing, and only one is recoverable
+
+| | listing page | profile page |
+|---|---|---|
+| re-fetching page N returns the same content | **No.** The ordering is a cached random permutation with a generation of 157–282 s; across generations, page 40 holds a different 20 contractors | **Yes** — fetched twice, the visible text was identical (the bytes differ; a CSRF token moves) |
+| what it uniquely holds | the **set of ids published at a moment**, and the order they were in | that contractor's ~70 fields **as of that date** |
+| what re-fetching recovers | the union, eventually — never that page | everything, unless the contractor has since edited it |
+
+> **A listing page is not a document; it is a sample.** A profile page **is** a document.
+> That is the real per-class distinction, and it does not follow the size.
+
+### And the value of retention is highest exactly now
+
+A snapshot's re-parse value is a function of **how incomplete the extraction schema
+is.** Today 22 of the owner's ~70 columns are stored and 48 are not, so a retained
+profile page is 48 columns we can add without touching the network. When the schema is
+complete, that value drops toward zero and only the audit value remains.
+
+**So retention is not a permanent decision.** It is worth most during the period we are
+in, which is an argument for keeping everything **now** and revisiting when the schema
+closes — not for a rule that is meant to hold for ever.
+
+---
+
+## 4 · The options, per class, with what each costs in capability
+
+Measured on the same 40 stored listing pages and the same 13 real profiles, so the
+comparison is real and not a mix of sources.
+
+| mechanism | listings | profiles | keeps a row independently readable? |
+|---|---|---|---|
+| as stored today | 1× | 1× | yes |
+| **zlib-9 per row** — `DEC-9`'s answer | 15.6× | 7.7× | yes |
+| zstd-3 per row | 15.8× | — | yes |
+| zstd-19 per row | 18.8× | — | yes |
+| lzma per row | 19.1× | — | yes |
+| zstd-19 + a *trained* 512 KB dictionary | 19.7× | — | yes |
+| **zstd-12 + one real page as a RAW dictionary** | **187×** | **46×** | **yes — round-trip verified** |
+| zstd-19, 20-page blocks | 170× | — | no — 20× read amplification |
+| zstd-19, all 40 as one block | 219× | 61× | **no** — a chain; row 700 needs row 699 |
+
+**`compression.zstd` is in the Python standard library as of 3.14** (this machine runs
+3.14.6), and `ZstdDict(..., is_raw=True)` accepts an ordinary page as the dictionary. So
+the constraint that made `DEC-9` choose zlib — *"no new dependency"* — is satisfied by
+the option that is **12× better**, and the cost is 3.5 ms a page.
+
+**The whole corpus, each way:**
+
+| | listings | profiles | total |
+|---|---|---|---|
+| raw | 618 MB | 3,950 MB | **4.55 GB** |
+| zlib-9 per row (`DEC-9`) | 40 MB | 525 MB | **565 MB** |
+| **zstd-12 + raw page dictionary** | **3.3 MB** | **87 MB** | **90 MB** |
+
+### The options that cost capability, and why each loses
+
+| option | verdict |
+|---|---|
+| **keep only the extractable region** | **Strictly dominated, and this is the study's sharpest result.** Keeping *only the visible text* of every profile, uncompressed, costs **139 MB**. Keeping the **whole HTML** with a shared dictionary costs **87 MB**. Trimming is *more* expensive **and** spends the ability to re-parse — and 48 of the owner's columns are still unextracted, so that ability is in active use |
+| keep the skeleton once, pages as diffs | This is what the raw-dictionary row already does, without a custom format, without a chain, and without anything to maintain |
+| retain until the parse is verified, then reduce | Would have to be re-verified every time a column is added. With the schema 22 of 70 complete, "verified" is not a state this corpus is in |
+| tiered — newest N, or one per schema version | Spends history, which is not re-observable: a profile's fields change when the contractor edits them |
+| keep a hash and re-fetch | **Impossible for listings** — a listing page is a sample, not a document (§3). Viable for profiles, and it saves 87 MB at the price of 17.4 h and of losing what the page said on a date |
+| delete snapshots after approval | Spends exactly what repaired the 2026-08-20 defect |
+
+---
+
+## 5 · What the snapshots are FOR, beyond re-parsing — and this one is his call
+
+`SR-1` says the source of truth is what the site publishes. A stored page is **evidence
+of what it published on a date**, and that has uses that have nothing to do with parser
+bugs: a disputed row, a contractor whose classification changed, a claim about what the
+directory contained before an edit.
+
+**Only the owner can say whether that matters to him**, and the study should not assume
+it. It changes one row of the table above and no others: if evidence-over-time matters,
+"keep a hash and re-fetch" is out for profiles as well as listings.
+
+---
+
+## 6 · Recommendation
+
+**Retain everything, in both languages, and store it with a shared raw dictionary.**
+
+1. **The fetch list in §1 stands unchanged.** Every class is load-bearing; none is
+   duplicated. This is what «كلّ ما ينشره الموقع» costs, and it costs 36,548 requests.
+2. **Retain the whole HTML of every page.** Not because retention is a principle, but
+   because at 90 MB the alternative saves nothing worth the capability, and because the
+   extraction schema is 22 of 70 columns complete — the exact condition under which
+   re-parse value is at its highest.
+3. **Store it `zstd`-compressed against one real page per class as a raw dictionary.**
+   Stdlib, 3.5 ms a page, every row independently decompressible, 187× on listings and
+   46× on profiles. **This supersedes `DEC-9`'s zlib recommendation**, which is kept
+   below per **C4** — it was right that the rule was sound and the encoding wrong; it
+   had the wrong encoding.
+4. **Do not trim.** It is dominated on both axes.
+5. **Then the volume needs no justification, because there is no volume.** ~90 MB of
+   evidence plus ~70 MB of rows and indexes — call it **160 MB** for everything the site
+   publishes, against the **5 GB** the question was asked about.
+
+### What this does not decide, and what it needs from him
+
+- **§5 — is a snapshot evidence, or only a parse cache?** His answer decides whether
+  profiles may ever be dropped for a re-fetch.
+- **The migration itself is not written.** He asked for a wider measurement first
+  («أريد قياساً أوسع أولاً»); this is that measurement. Writing the migration is a
+  separate decision with this in hand.
+- **`R-20` (revision on change only) is worth more than it looks here.** 34,550
+  revisions for 11,059 records is 26.7 MB, and the distribution is exactly two revisions
+  per appearance — the second recording no change. Under `R-20` that table is roughly
+  halved, and it is the second-largest thing in the file.
+
+---
+
+## Appendix · how each number was obtained
+
+| number | how |
+|---|---|
+| 796 MB, 607 MB, 26.7 MB | `SUM(LENGTH(...))` over the live database, read-only |
+| 363 KB and 17.8% | 5 stored listing pages parsed with the production card selector; 864 sized |
+| 119 KB, 3.5% | 13 profiles fetched live, ids spread across the published range, **each checked not to be a redirect** |
+| every ratio in §4 | the same 40 stored pages and 13 profiles, one script, one run |
+| 157–282 s generation | page 1 of a filtered slice re-fetched at 55, 90, 157, 282 and 527 s |
+| 2.8 h and 17.4 h | 5.84 s a listing request (`DEC-11`, from a real 864-page pass) and 1.8 s a profile request (measured on 13) |
+
+**One measurement was thrown away rather than reported**, and it is recorded because it
+is the kind of error this study exists to avoid: the first profile sample fetched ids
+`2`, `5000`, `9000`, `12000` and `17000`, and all five returned **exactly 367 KB**.
+Those ids do not exist; the site redirects a missing profile to the contractor listing,
+the fetcher follows redirects, and a listing page is 367 KB. Averaged in, they put the
+profile figure at 250 KB and the projection at **8.3 GB** — off by 110%. Five identical
+sizes in a row is what gave it away.

--- a/tests/test_a_request_of_his_reaches_the_board.py
+++ b/tests/test_a_request_of_his_reaches_the_board.py
@@ -1,0 +1,113 @@
+"""A request of his, quoted inside a finding, must reach the request board.
+
+WHY THIS IS A GUARD AND NOT A CONVENTION. `docs/REQUESTS.md` exists because
+`REQ-04` sat ruled and unbuilt for sixteen days after dropping out of view, and it
+states the boundary itself: *"The owner asked for it -> this file, `REQ-nn`"*.
+`tests/test_the_request_board_matches_its_entries.py` already keeps that file
+honest against its own entries. **Nothing checked that a request of his was on the
+board at all**, and on 2026-08-20 three were not:
+
+  * `DEC-9` was 40 lines of storage research he had asked for, with no `REQ`.
+  * `DEC-8` answered a direct question of his and `REQ-07` -- that same question on
+    the board -- did not cite it, in either direction.
+  * `DEC-11` was 150 lines of crawl research quoting his instruction twice, with no
+    `REQ`.
+
+Three in one file is not an accident, and each was found by hand. This is the
+mechanical version.
+
+THE SIGNAL, and why it is this one. A quotation of his **in Arabic** inside a
+`BACKLOG.md` entry is the signature of a request rather than a finding: findings
+here are written in English, and the guillemets are reserved for his words. That
+makes it cheap and exact. `OP-6`, `BV-5` and `SEP-5` quote him too and are
+correctly in `BACKLOG.md` -- as review comments on things WE found -- which is why
+the rule is not "no Arabic in BACKLOG" but "something on the board must cite it".
+
+WHAT SATISFIES IT, either direction, because both are real links:
+  * the entry cites a `REQ-nn`, or
+  * `REQUESTS.md` names the entry.
+
+A guillemet with no Arabic inside it does not count: `DEC-11` writes
+*"as of «timestamp»"* as ordinary emphasis, and a guard that flagged that would be
+teaching people to avoid a punctuation mark.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+pytestmark = pytest.mark.docs
+
+DOCS = pathlib.Path(__file__).resolve().parent.parent / "docs"
+
+#: Any Arabic letter. Enough to tell his words from ours.
+ARABIC = re.compile(r"[؀-ۿ]")
+#: A guillemet quotation, which this repository reserves for what he said.
+QUOTED = re.compile(r"«([^»]*)»", re.DOTALL)
+#: The identifier at the head of a BACKLOG entry.
+ENTRY = re.compile(r"### ((?:OP|DEC|DEBT|BV|SEP|Q)-\d+)")
+
+
+def _entries() -> list[tuple[str, str]]:
+    """(identifier, body) for every `### `-headed entry in BACKLOG.md."""
+    text = (DOCS / "BACKLOG.md").read_text(encoding="utf-8")
+    found = []
+    for part in re.split(r"\n(?=### )", text):
+        if match := ENTRY.match(part):
+            found.append((match.group(1), part))
+    return found
+
+
+def _quotes_him(body: str) -> list[str]:
+    """His quoted words in this entry -- Arabic inside guillemets, nothing else."""
+    return [q.strip() for q in QUOTED.findall(body) if ARABIC.search(q)]
+
+
+def test_the_signal_still_finds_something():
+    """A vacuous guard is worse than none: it reports success for a corpus it can
+    no longer read. If the guillemets or the language ever change, this fails and
+    says so instead of passing silently for ever.
+
+    Asserted on the mechanism -- at least one entry quotes him -- and not on a
+    count, because the count is supposed to move."""
+    quoting = [ident for ident, body in _entries() if _quotes_him(body)]
+    assert quoting, (
+        "no BACKLOG entry quotes the owner in Arabic inside guillemets any more, so "
+        "this guard is checking nothing. Either the convention changed -- update "
+        "ARABIC/QUOTED here -- or the entries moved, and this file is now a "
+        "comment pretending to be a test")
+
+
+def test_every_finding_that_quotes_him_is_reachable_from_the_request_board():
+    """THE DEFECT THIS FILE WAS WRITTEN FOR, three times over in one afternoon.
+
+    Research he asked for, correctly recorded and invisible on the board that
+    tracks what he asked for. `REQUESTS.md` calls that out as the failure it exists
+    to prevent, and had it three times."""
+    requests = (DOCS / "REQUESTS.md").read_text(encoding="utf-8")
+
+    orphaned = []
+    for ident, body in _entries():
+        quotes = _quotes_him(body)
+        if not quotes:
+            continue
+        if re.search(r"REQ-\d+", body) or ident in requests:
+            continue
+        orphaned.append(
+            f"{ident} quotes him and nothing on the board cites it:\n"
+            f"      «{quotes[0][:90]}»")
+
+    assert not orphaned, (
+        "these findings carry a request of his that never reached "
+        "docs/REQUESTS.md. Capture it as a REQ-nn in his own words, or cite the "
+        "REQ it belongs to:\n  " + "\n  ".join(orphaned))
+
+
+def test_a_guillemet_without_arabic_is_not_treated_as_his_words():
+    """`DEC-11` writes *"complete as of «timestamp»"* as emphasis. A guard that
+    counted that would push people away from a punctuation mark to stay green,
+    which is how a guard starts shaping the prose instead of checking it."""
+    assert not _quotes_him("complete as of «timestamp», never before")
+    assert _quotes_him("he said «اريد كل ما ينشره الموقع» today")


### PR DESCRIPTION
He asked for a study and said plainly what it was not:

> «ليست الفكرة ضغط الملفات بل دراسة نشوف احنا بنسحب اى ولية وبنحتفظ باية ولية وما الفائدة — دراسة تبرر الحجم»

`DEC-9` asked **how to store 6.4 GB more cheaply** and answered that well. He asked **why we are storing 6.4 GB at all.** [docs/STORAGE.md](docs/STORAGE.md) answers his question, and the premise turns out to be wrong twice over.

## The number came from one sample

A profile page is **119 KB** across 13 real profiles spread over the whole published id range — not 168 KB from one. The complete corpus, both locales, listings and profiles, is **4.55 GB** raw, not 6.4. Five of `DEC-9`'s figures do not survive re-measurement, including "21% of a listing page is cards" (it is **17.8%**).

## And its 15.6× was entirely intra-page

`DEC-9` credited its ratio to *"a near-identical skeleton repeated 864 times"*. The skeleton **is** near-identical — 40 pages differ only in their pagination block — but **zlib captures none of it**: its window is 32 KB and a skeleton is 121 KB, so page 1 is gone by the time page 2 begins.

| | |
|---|---|
| one skeleton, zlib-9 | 18 KB |
| ten skeletons concatenated | 175 KB — **9.84× the cost of one, for ten pages** |
| 40 whole pages as one zlib block | **15.8×** — no better than compressing them separately |

`compression.zstd` is in the standard library as of **Python 3.14**, and `ZstdDict(..., is_raw=True)` takes an ordinary page as the dictionary:

| mechanism | listings | profiles | row stays independently readable |
|---|---|---|---|
| zlib-9 per row (`DEC-9`) | 15.6× | 7.7× | yes |
| zstd-19 + *trained* dictionary | 19.7× | — | yes |
| **zstd-12 + one real page as raw dictionary** | **187×** | **46×** | **yes — round-trip verified** |
| zstd-19, all 40 as one block | 219× | 61× | **no** — a chain |

So the constraint that made `DEC-9` choose zlib — *"no new dependency"* — is satisfied by the option that is **12× better**, at 3.5 ms a page.

**Everything the site publishes, evidence retained: ~90 MB of pages plus ~70 MB of rows — about 160 MB, against the 5 GB in his question.**

## The sharpest result: trimming is dominated

| | |
|---|---|
| keep **only the visible text** of every profile, uncompressed | **139 MB** |
| keep the **whole HTML**, zstd + shared dictionary | **87 MB** |

Trimming is *more* expensive **and** spends the ability to re-parse — which is in active use while **48 of his ~70 columns** are unextracted. Retention value is a function of how incomplete the schema is: highest now, falling later. That is an argument for keeping everything *today*, not for a rule meant to hold for ever.

## What the study leaves to him

**Is a snapshot evidence, or only a parse cache?** `SR-1` makes the site the source of truth, so a stored page records what it published on a date. If that matters, profiles may never be dropped for a re-fetch; if not, 87 MB is recoverable at the price of 17.4 h. §5 refuses to assume it.

## And three of his requests were not on his board

`REQUESTS.md` exists because `REQ-04` sat ruled and unbuilt for sixteen days after dropping out of view. Three requests had done the same thing:

| | |
|---|---|
| **REQ-12** | the storage study — researched as `DEC-9`, never captured |
| **REQ-13** | the crawl study — 150 lines as `DEC-11`, quoting his instruction twice |
| **REQ-07** | on the board, but never citing `DEC-8`, which answered it by measurement |

Three in one file is not an accident, so the signal is now a guard. `tests/test_a_request_of_his_reaches_the_board.py` fails when a `BACKLOG` entry quotes him in Arabic and nothing on the board cites it. **Mutation-proven**: removing `REQ-13` makes it name `DEC-11`. A guillemet with no Arabic inside does not count — `DEC-11` writes «timestamp» as emphasis, and a guard that flagged that would teach people to avoid a punctuation mark.

## Verification

- Full suite under `SCRAPEX_FULL_MIGRATIONS=1`: **zero failures**, run **after** the new guard was added and **before** this PR opened — `R-22`.
- `DEC-9` is kept in full with a supersede banner — **C4**. Its *rule* (keep the snapshots) is upheld and strengthened; its *encoding* is not.
- One measurement was **thrown away rather than reported**, and the appendix says so: the first profile sample hit five ids that do not exist, the site redirects a missing profile to the listing, and five identical 367 KB bodies averaged in put the projection at **8.3 GB** — off by 110%. Five identical sizes in a row is what gave it away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
