### PR TITLE
Six source briefs of his, and three of them say the append gate is keyed wrong

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,8 @@ the thing came from: **he asked** → `REQUESTS.md`; **we found it** →
 Other long-standing documents — `docs/MIGRATION-PLAN.md`,
 `docs/COMPATIBILITY.md`, `docs/PLATFORM-PLAN.md`, `docs/GENERIC-FETCH-SEAM.md`,
 `docs/CONTRACTOR-SOURCE.md`, `docs/STORAGE.md`, `docs/BALADY-ENG-OFFICES.md`,
-`docs/UAE-SOURCES.md` — are indexed from `docs/STATE.md`
+`docs/UAE-SOURCES.md`, `docs/GULF-EGYPT-SOURCES.md`, `docs/DIESEL-PRICES.md`,
+`docs/BITUMEN-PRICES.md` — are indexed from `docs/STATE.md`
 under the track they belong to.
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,8 @@ the thing came from: **he asked** → `REQUESTS.md`; **we found it** →
 
 Other long-standing documents — `docs/MIGRATION-PLAN.md`,
 `docs/COMPATIBILITY.md`, `docs/PLATFORM-PLAN.md`, `docs/GENERIC-FETCH-SEAM.md`,
-`docs/CONTRACTOR-SOURCE.md`, `docs/STORAGE.md` — are indexed from `docs/STATE.md`
+`docs/CONTRACTOR-SOURCE.md`, `docs/STORAGE.md`, `docs/BALADY-ENG-OFFICES.md`,
+`docs/UAE-SOURCES.md` — are indexed from `docs/STATE.md`
 under the track they belong to.
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,8 @@ Other long-standing documents — `docs/MIGRATION-PLAN.md`,
 `docs/COMPATIBILITY.md`, `docs/PLATFORM-PLAN.md`, `docs/GENERIC-FETCH-SEAM.md`,
 `docs/CONTRACTOR-SOURCE.md`, `docs/STORAGE.md`, `docs/BALADY-ENG-OFFICES.md`,
 `docs/UAE-SOURCES.md`, `docs/GULF-EGYPT-SOURCES.md`, `docs/DIESEL-PRICES.md`,
-`docs/BITUMEN-PRICES.md` — are indexed from `docs/STATE.md`
+`docs/BITUMEN-PRICES.md`, `docs/CONCRETE-MATERIALS.md` — are indexed from
+`docs/STATE.md`
 under the track they belong to.
 
 ---

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -582,6 +582,69 @@ than missing **(inferred from the titles; the check is a diff, not a title match
 **superseded, do not merge**. Two branches live in `~/.codex/worktrees/`, so
 `git worktree remove` comes before any deletion.
 
+### DEC-12 · The append gate's key is not the number, and three of his briefs prove it separately
+
+**FOUND 2026-08-20**, not from the code but from reading three price briefs he sent
+within an hour of each other. Each describes a different product, each was written
+independently, and **each breaks `SR-6` in a different place.** One case would be a
+quirk; three from three directions is a defect in the key.
+
+`SR-6` is right about what it was written for: a scraped shelf price where an
+unchanged number carries no new information, so the observation is **confirmed rather
+than appended**. That is what `_still_the_same_price` implements, and it is why the
+warehouse is not full of identical rows.
+
+**It is wrong about what "the same" means for an official published price.**
+
+| the brief | what carries the new fact | what `SR-6` sees |
+|---|---|---|
+| [DIESEL-PRICES.md](DIESEL-PRICES.md) §3 — *"never overwrite a previous price when a new month or quarter begins"* | **the period.** Oman published `0.258 OMR/litre` for August. If July was also `0.258`, the ministry setting it again for a named month **is** the fact | no change → writes nothing → **the August period never exists** |
+| [BITUMEN-PRICES.md](BITUMEN-PRICES.md) | **the commercial basis.** Two observations can be ex-refinery and delivered, taxed and untaxed, 25-tonne truck and sea — different facts at equal values | no change → collapses them → destroys the only thing that made either usable |
+| [CONCRETE-MATERIALS.md](CONCRETE-MATERIALS.md) §3 | **the source type.** Its table has a column headed *"Can it populate `price_amount`?"* and the answer is **No** for `official_price_index`, `official_approved_source` and `official_specification`. An index point and an absolute price are not comparable quantities | no change → treats an index value and a price as the same observation |
+
+> **So the key is not `(product, price)`. It is at least
+> `(product identity, period, commercial basis, source type)`** — and the concrete
+> brief goes further than a key: an index must not enter the price column **at all**,
+> which is a schema boundary rather than a gate condition. It gives
+> `price_index_observations` and `water_tariffs` their own tables for exactly that
+> reason.
+
+#### Why this is recorded now, before any of it is collected
+
+Because the failure is **silent and unrecoverable**. A dropped month is not a wrong
+row that a later fix corrects — it is a row that never existed, in a table whose whole
+purpose is history. By the time anyone notices August is missing, August is not
+re-fetchable: these are dated bulletins and expiring quotations, and the Qatar bitumen
+figure had **already expired** when he sent it.
+
+**And this shape has already happened here once.** A new `price_observation` column
+stayed NULL because the append gate never learned to notice it — the gate decides what
+history exists, and it only ever knew about the price. That is the same defect at a
+smaller scale, and it is the reason to believe this one.
+
+#### Water is the sharpest single example, and it is his
+
+The concrete brief §2.2 refuses to store one water price at all. The official network
+tariff is **one component** of the site cost, beside meter charges, wastewater
+charges, tanker filling, transport, storage and testing — and *"a potable-water tariff
+alone does not prove technical suitability"* for concrete mixing. **One number here
+would be false in both directions**: too low as a delivered cost, and not evidence of
+fitness for purpose. So the tariff and the delivered quotation are two tables, which
+is the same argument as the three rows above with the volume turned up.
+
+#### What this does NOT say
+
+It does not say `SR-6` should be removed. `SR-6` earned itself on the price sources
+this project already runs, and removing it would fill the warehouse with identical
+rows. **It says the gate needs to be told what "new" means per product class**, and
+that the three product classes he has now queued each answer differently.
+
+**Not built, and deliberately not designed here.** The evidence is recorded while it
+is fresh; the mechanism is a decision for when the first of these collections is
+actually scheduled, and it will need his ruling because it changes what `SR-6` means.
+
+---
+
 ### DEC-11 · How to crawl muqawil without missing anyone, and what it costs
 
 **STUDIED 2026-08-20 on his instruction** — «ازاى نزحف صح بدون ان نغفل شى» and «اريد

--- a/docs/BALADY-ENG-OFFICES.md
+++ b/docs/BALADY-ENG-OFFICES.md
@@ -1,0 +1,465 @@
+# Balady engineering offices — the owner's verification brief
+
+**QUEUED, NOT STARTED. Its own precondition is his:**
+
+> «ضيف هذا الملف ليكون المصدر التالى **بعد الانتهاء الكامل من مصدر مقاول**»
+> — 2026-08-20, [REQ-14](REQUESTS.md#req-14--balady-engineering-offices-as-the-next-source-after-muqawil)
+
+So nothing here is worked on until muqawil is finished, and "finished" is his
+definition: **«كلّ ما ينشره الموقع»** — every field the site publishes, both
+languages, detail pages included. [STATE.md](STATE.md) Track 2 carries where that
+stands.
+
+**The brief below is his, stored verbatim.** It is kept in the repository for one
+measured reason: he re-sent the muqawil column specification on 2026-08-20 because
+he could not tell whether it had survived — «هذا كان طلبى لمصدر مقاول … انا ارسلت
+الطلب مرة اخرى ليكون واضح هل كله مسجل ام لا … لان دراسته ربما تكون فقدت». It had
+survived, in `CONTRACTOR-SOURCE.md`. A specification that lives only in a
+conversation cannot be checked, and he should not have to ask twice.
+
+---
+
+## What this repository already knows that bears on it
+
+Recorded now, while it is cheap, so the work does not start by rediscovering it.
+
+**The brief's own guardrails match this project's, and one of them is a standing
+ruling.** It says: *"Do not bypass authentication, CAPTCHA, access controls, rate
+limits, or other technical restrictions."* `HttpFetcher` is built to that already —
+`SR-8` honours `Crawl-delay`, and the class docstring names user-agent rotation,
+proxy rotation, header spoofing and CAPTCHA handling as deliberately absent because
+*"those evade a decision the site has made"*. Nothing needs to change to comply.
+
+**Its deliverable 6 — "whether an official public API or downloadable open dataset
+exists" — should be answered FIRST**, before any schema work. It is the cheapest
+possible question and it can invalidate everything after it: `balady.gov.sa` is a
+government service, and if it publishes the directory as an open dataset then there
+is no crawl to design. Muqawil's equivalent question was answered late and the
+answer was no; here it may be yes, and it costs a handful of requests to find out.
+
+**Two of the brief's requirements are things muqawil taught us the hard way**, and
+the lessons transfer directly:
+
+| the brief asks | what muqawil already proved |
+|---|---|
+| *"Count total records and confirm how pagination affects the count"* | Read the paginator's own last-page link; never assume a page size. The count is live — muqawil's tail page held 15 cards, then 2, then 3 within four days. [DEC-11](BACKLOG.md) |
+| *"Do not treat an English interface label as proof that the underlying record is available in English"* | Exactly right, and stronger than it sounds: on muqawil the Arabic values are matched **by page-order index and never by label**, because the same label is spelled `رقم العضويه` with `ه` in one place. [LESSONS.md](LESSONS.md) |
+
+**And its bilingual rule is already this project's rule**, which is worth stating so
+nobody re-litigates it: base column English, `_ar` suffix for Arabic, no `_ar`
+duplicate for identifiers, numbers, URLs, coordinates, times or booleans. That is
+`R-12` and the shape of every column in `CONTRACTOR-SOURCE.md`.
+
+**One thing the brief asks for that muqawil has an open ruling on.** It proposes
+`office_working_hours`, `office_activities` and `office_locations` as child tables.
+He has already ruled that way for muqawil's five multi-valued groups —
+**«جداول أبناء للخمس كلّها»**, `R-19` — so the child-table shape here is consistent
+with a decision he has taken, not a new question.
+
+---
+
+*Everything below this line is the owner's brief as he sent it, unedited.*
+
+---
+
+# Balady Engineering Offices Database — Independent Verification Brief
+
+## 1. Objective
+
+Independently inspect and verify all publicly displayed information in the Saudi Balady Engineering Offices Inquiry service, then confirm or correct the proposed database schema in this document.
+
+Primary interactive source:
+
+- https://apps.balady.gov.sa/Eservices/Inquiries/InquiryEngOffices/Index
+
+Related official pages:
+
+- Arabic service description: https://balady.gov.sa/ar/services/الاستعلام-عن-المكاتب-الهندسية
+- English service description: https://balady.gov.sa/en/services/inquiry-about-engineering-offices
+- English user guide: https://balady.gov.sa/en/services/11114/guide
+
+Do not assume that any preliminary finding in this brief is correct. Verify it directly against the current live service and record evidence for every conclusion.
+
+## 2. Required Agent Deliverables
+
+Produce the following:
+
+1. A verified inventory of every search field, result-list field, detail-page field, filter, pagination control, and available display mode.
+2. A determination of which record values are available in Arabic, English, both languages, or neither.
+3. A corrected relational database schema using lowercase `snake_case` English column names.
+4. A data dictionary containing the source label, English column name, Arabic column name where applicable, data type, nullability, example value, and verification status.
+5. A list of discrepancies, duplicate fields, ambiguous values, missing values, and legacy formats.
+6. A technical feasibility assessment for collecting the public data, including pagination behavior, stable identifiers, request limits, and whether an official public API or downloadable open dataset exists.
+7. A compliance note covering the site's terms of use, robots policy, rate limits, and restrictions on automated collection or republication.
+8. A small verified sample covering different regions, classification grades, classified and unclassified establishments, old and new office-code formats, and records with incomplete data.
+9. Evidence for the conclusions, using direct official links and screenshots or captured page labels where useful.
+
+Do not bypass authentication, CAPTCHA, access controls, rate limits, or other technical restrictions. Do not infer unpublished personal data.
+
+## 3. Preliminary Findings to Re-verify
+
+### 3.1 Search inputs
+
+The inquiry page appears to provide these search inputs:
+
+- General search / establishment search
+- Activity name
+- Region
+- City
+- Search button
+
+Verify the exact matching behavior of each input, including partial matching, Arabic spelling variations, minimum character requirements, and whether filters can be combined.
+
+### 3.2 Result-list fields
+
+The result list appears to display:
+
+- Establishment logo
+- Office code
+- Establishment name
+- Mobile number
+- Establishment classification grade
+- View-details action
+
+Verify whether the mobile number and classification grade are frequently blank, whether sorting works for each column, and whether all display modes show the same data.
+
+### 3.3 Detail-page fields
+
+The detail page appears to contain these sections and fields:
+
+#### Establishment details
+
+- Establishment name
+- Office license number
+- Region
+- City
+- Establishment classification status
+- Establishment classification grade
+- Establishment logo
+
+#### Contact details
+
+- Mobile number
+- Phone number
+- Website
+- Email address
+- Fax number
+- Address
+
+#### Working hours
+
+For each day from Saturday through Friday:
+
+- Open 24 hours
+- Closed
+- First shift start time
+- First shift end time
+- Second shift start time
+- Second shift end time
+
+#### Geographic information
+
+- Location name
+- Region
+- City
+- Amanah/secretariat, if available
+- Municipality, if available
+- Address, if available
+- Latitude and longitude, if exposed
+- Map marker or map URL, if exposed
+- Location-level mobile number, phone number, and email address
+
+#### Service/activity information
+
+- Activity name
+- Minimum price per square metre
+- Maximum price per square metre
+
+Verify whether the price unit is always square metres, whether the currency is explicitly stated, and whether zero, blank, and unavailable prices have different meanings.
+
+## 4. Language Availability to Verify
+
+The following preliminary conclusion must be independently verified:
+
+- Balady has an English description page for the service.
+- The English description page appears to identify Arabic as the service-delivery language.
+- The live interactive directory appears to use an Arabic interface and return establishment names, addresses, and activities in Arabic.
+- The live directory does not appear to provide paired official English and Arabic record values.
+
+Test whether English record values become available through any official language selector, English route, query parameter, response field, application state, documented API, downloadable dataset, or other official Balady interface.
+
+Distinguish carefully between:
+
+1. An English translation of the service-description page.
+2. English translations of interface labels.
+3. Official English values for individual establishments and activities.
+
+Do not treat an English interface label as proof that the underlying record is available in English.
+
+## 5. Bilingual Column-Naming Rule
+
+Use the following convention:
+
+- The base column contains English content: `establishment_name`.
+- The same column name with the `_ar` suffix contains Arabic content: `establishment_name_ar`.
+- If no verified English value exists, keep the base English field `NULL` and retain the Arabic source value in the `_ar` field.
+- Never invent or automatically translate an official company name without recording that it is an unofficial translation.
+- Identifiers, numbers, URLs, email addresses, coordinates, prices, dates, times, and Boolean values do not need an `_ar` duplicate.
+
+Examples:
+
+| English content | Arabic content |
+|---|---|
+| `establishment_name` | `establishment_name_ar` |
+| `region` | `region_ar` |
+| `city` | `city_ar` |
+| `classification_status` | `classification_status_ar` |
+| `address` | `address_ar` |
+| `activity_name` | `activity_name_ar` |
+| `day_of_week` | `day_of_week_ar` |
+
+For any translated or externally sourced English value, verify whether provenance fields are needed, for example:
+
+- `english_translation_status`
+- `english_translation_source`
+- `english_translation_verified_at`
+
+## 6. Proposed Relational Schema
+
+### 6.1 `engineering_offices`
+
+```text
+office_id
+source_office_id
+office_code
+office_license_number
+
+establishment_name
+establishment_name_ar
+
+region
+region_ar
+city
+city_ar
+amanah
+amanah_ar
+municipality
+municipality_ar
+
+classification_status
+classification_status_ar
+classification_grade
+
+mobile_number
+phone_number
+email_address
+website_url
+fax_number
+
+address
+address_ar
+latitude
+longitude
+
+establishment_logo_url
+source_list_url
+source_detail_url
+collected_at
+last_verified_at
+```
+
+Recommended checks:
+
+- `office_id` should be an internal primary key.
+- `source_office_id` should preserve the source identifier used by the detail-page URL.
+- Store `office_code` and `office_license_number` as strings, not integers. Observed formats may contain leading zeros, slashes, or other legacy formatting.
+- Verify whether `office_code` and `office_license_number` are always identical. Do not merge them until this is proven across a representative sample.
+- Preserve phone and fax numbers as strings to avoid losing leading zeros.
+- Normalize website URLs without overwriting the original source value unless a separate raw field is retained.
+
+Suggested normalized values for `classification_status`:
+
+| `classification_status` | `classification_status_ar` |
+|---|---|
+| `classified` | `مصنف` |
+| `unclassified` | `غير مصنف` |
+| `unknown` | `غير متاح` |
+
+Verify the complete set of statuses before finalizing this controlled vocabulary.
+
+### 6.2 `office_working_hours`
+
+```text
+working_hours_id
+office_id
+
+day_of_week
+day_of_week_ar
+
+is_open_24_hours
+is_closed
+
+first_shift_start_time
+first_shift_end_time
+second_shift_start_time
+second_shift_end_time
+```
+
+Verification requirements:
+
+- Confirm that there is one row per office per day.
+- Confirm the meaning of checked and unchecked 24-hour and closed controls.
+- Determine whether `00:00` means midnight, missing data, or a default placeholder.
+- Check for logically conflicting states, such as 24-hour and closed being true simultaneously.
+- Confirm whether working times use Saudi local time and whether a `timezone` field should be stored.
+
+### 6.3 `office_activities`
+
+```text
+office_activity_id
+office_id
+activity_order
+
+activity_name
+activity_name_ar
+
+minimum_price_per_sqm
+maximum_price_per_sqm
+currency_code
+```
+
+Verification requirements:
+
+- Confirm whether one office can have multiple activities.
+- Confirm that `activity_order` is meaningful or only a display sequence.
+- Confirm the numeric format, decimal precision, unit, and currency.
+- Use `SAR` only if the source or applicable official context supports it.
+- Determine whether prices are mandatory, optional, estimates, or establishment-provided figures.
+
+### 6.4 `office_locations`
+
+Create this table only if the service exposes multiple locations or branches for one office.
+
+```text
+office_location_id
+office_id
+
+location_name
+location_name_ar
+
+region
+region_ar
+city
+city_ar
+amanah
+amanah_ar
+municipality
+municipality_ar
+
+address
+address_ar
+latitude
+longitude
+map_url
+
+mobile_number
+phone_number
+email_address
+
+is_main_location
+```
+
+If every establishment has exactly one location, determine whether these fields should remain in `engineering_offices` instead.
+
+## 7. Fields That Should Not Have an `_ar` Duplicate
+
+Unless the source demonstrates otherwise, do not create Arabic duplicates for:
+
+```text
+office_id
+source_office_id
+office_code
+office_license_number
+classification_grade
+mobile_number
+phone_number
+email_address
+website_url
+fax_number
+latitude
+longitude
+minimum_price_per_sqm
+maximum_price_per_sqm
+currency_code
+first_shift_start_time
+first_shift_end_time
+second_shift_start_time
+second_shift_end_time
+is_open_24_hours
+is_closed
+is_main_location
+source_list_url
+source_detail_url
+collected_at
+last_verified_at
+```
+
+## 8. Required Data-Quality Tests
+
+Perform at least the following checks:
+
+1. Count total records and confirm how pagination affects the count.
+2. Identify duplicate office codes, license numbers, names, contact details, and source IDs.
+3. Compare the result-list values with the corresponding detail-page values.
+4. Test old, short, long, slash-containing, and leading-zero code formats.
+5. Measure null rates for every field.
+6. Verify whether a classification grade can exist without a classified status, or vice versa.
+7. Check malformed mobile, phone, fax, email, and website values without silently correcting source data.
+8. Check whether region and city values use a controlled official list.
+9. Check whether activity names use a controlled official list.
+10. Determine whether geographic coordinates are actually available or only visually represented on a map.
+11. Confirm whether the same office can have more than one location, activity, or set of contact details.
+12. Check whether records include inactive, expired, historical, contractor, or non-consulting establishments.
+13. Verify whether blank values, zero values, and placeholder values are semantically different.
+14. Record the retrieval timestamp and the date on which each record was last independently verified.
+
+## 9. Sampling Plan
+
+Use a representative sample rather than validating only one or two records. Include, at minimum:
+
+- Multiple regions and cities.
+- Classified and unclassified establishments.
+- Several classification grades.
+- Records with complete and incomplete contact information.
+- Records with and without working hours.
+- Records with and without activities or prices.
+- Records with modern long numeric codes and legacy short or slash-containing codes.
+- At least one apparent duplicate-name case.
+- At least one establishment whose official website provides an English legal name, to test the English-name provenance rule.
+
+State the final sample size and explain why it is sufficient for each conclusion.
+
+## 10. Final Report Format
+
+Return the verification report in this order:
+
+1. Executive conclusion.
+2. Sources inspected and inspection date.
+3. Verified language-availability conclusion.
+4. Verified page-field inventory.
+5. Corrected database schema.
+6. Complete data dictionary.
+7. Sample records.
+8. Data-quality findings.
+9. Collection/API feasibility.
+10. Compliance and operational risks.
+11. Assumptions that remain unverified.
+12. Recommended next actions.
+
+Clearly label every statement as one of:
+
+- **Verified** — directly confirmed from an official source.
+- **Inferred** — supported by evidence but not explicitly documented.
+- **Unverified** — requires further evidence.
+- **Not available** — confirmed absent from the inspected official interfaces.
+

--- a/docs/BITUMEN-PRICES.md
+++ b/docs/BITUMEN-PRICES.md
@@ -1,0 +1,362 @@
+# Bitumen 60/70 price sources, seven countries — the owner's verification brief
+
+**QUEUED, NOT STARTED.**
+
+> «مصادر اخرى»
+> — 2026-08-20, [REQ-18](REQUESTS.md#req-18--bitumen-6070-prices--the-first-source-that-cannot-be-crawled)
+
+**The brief below is his, stored verbatim.**
+
+---
+
+## This is the first queued source that cannot be crawled at all, and it says so itself
+
+Every other source in the queue is a page to fetch. This one's own executive
+conclusion is that **for five of the seven countries there is no public official
+price to fetch**:
+
+| | |
+|---|---|
+| **`quote_required`** | Saudi Arabia, UAE, Oman, Bahrain, Kuwait — no current public 60/70 price located |
+| **a dated bulletin, not a live price** | Egypt — `EGP 21,542`/tonne, July 2026 |
+| **already expired** | Qatar — `2,925`/tonne, valid 22–31 July 2026, and **the page shows no currency label** |
+
+> **So its acquisition mode is correspondence, not crawling.** His own §"Suggested
+> written quotation request" is a letter to send to a producer. That is not something
+> this project has ever done, and it is not a gap to close — it is the shape of the
+> product. Bitumen 60/70 is bulk B2B: the payable price depends on quantity, customer
+> category, loading point, destination, hot-bulk versus packaged, tax, freight and
+> quote validity.
+
+**What ScrapeX can do for it is therefore narrower and more valuable than a crawl:**
+be the place where a dated, sourced, caveated observation is stored so it is never
+mistaken for a current market price. His `verification_status` vocabulary —
+`quote_required`, `latest_official_bulletin`, `expired_official_price` — is exactly
+that, and it is the most useful column in the design.
+
+## The instruction that matters most is a refusal to compare
+
+> *"Do not flatten these observations into one comparable price list."*
+
+Egypt's official Arabic label is **بيتومين مؤكسد على الساخن 70/60** — which may be a
+hot-applied **oxidized** product, not the internationally specified paving
+penetration grade at all. Qatar's row carries **no currency label**. Comparing them,
+or converting either, would manufacture a number that no official source published.
+
+**This is `SR-1` applied to a harder case.** The source of truth is what the
+publisher published; here what was published is *incomplete*, and the honest record
+has to carry the incompleteness rather than resolve it. His §11 says it plainly:
+**mark expired observations as expired even when they are the newest figures found.**
+
+## Where it agrees with what is already built, and where it does not
+
+**It agrees on the core shape, and independently.** His first design line is *"do not
+store a changing price directly on the supplier record; use a separate
+price-observation table so every value keeps its source, date range and commercial
+basis."* That is `price_observation` — the original spine of this warehouse — arrived
+at from the other direction.
+
+**And it collides with `SR-6` in the same way the diesel list does**, but harder.
+`SR-6` confirms rather than appends an unchanged price. Here two observations can
+carry the **same number and different commercial bases** — ex-refinery versus
+delivered, taxed versus not, 25-tonne truck versus sea. Those are **different facts
+with equal values**, so a gate that compares only the number would collapse them and
+lose the only thing that makes either usable. See [DIESEL-PRICES.md](DIESEL-PRICES.md)
+for the period-keyed version of the same problem.
+
+> **Together the two price briefs say the same thing about the append gate: the key
+> is not the number.** For diesel it is the period; for bitumen it is the commercial
+> basis. `SR-6` needs to be told what "new" means per product class, and this is the
+> second measured case for it.
+
+## And one thing here is a hard boundary rather than a task
+
+His §12: **reject any commercial figure that cannot be traced to an official
+producer, public authority, signed quote, tender award or official statistical
+publication.** Trader advertisements and price-aggregation sites are explicitly
+excluded. That is a rule about what may enter the warehouse at all, and it is
+stricter than anything currently enforced in code.
+
+---
+
+*Everything below this line is the owner's brief as he sent it, unedited.*
+
+---
+
+# Official Bitumen 60/70 Price Sources — Seven-Country Verification Brief
+
+**Countries:** Saudi Arabia, United Arab Emirates, Egypt, Oman, Qatar, Bahrain, and Kuwait  
+**Research cut-off:** 20 August 2026 (Asia/Riyadh)  
+**Product requested:** penetration-grade bitumen/asphalt 60/70  
+**Purpose:** provide an agent with official sources, the latest official figures found, and a verification workflow suitable for a price database.
+
+## Executive conclusion
+
+Bitumen 60/70 is normally a bulk business-to-business product, not a retail fuel with a single nationwide pump price. The actual payable price may depend on quantity, customer category, loading point, delivery destination, hot-bulk versus packaged supply, taxes, freight, and quote validity.
+
+As of the research cut-off:
+
+- No currently valid, nationwide, public official 60/70 price was confirmed for any of the seven countries.
+- Egypt and Qatar have official published figures that can be stored as dated observations, not as today's live market price.
+- Saudi Arabia, the UAE, Oman, Bahrain, and Kuwait should be recorded as `quote_required` until a dated written quotation is obtained from the official producer, marketer, or competent public authority.
+- Commercial marketplace prices, trader advertisements, and price-aggregation websites must not be labelled as official.
+
+## Latest official figures located
+
+| Country | Latest official figure found | Unit | Official reference period / validity | Status at 20 Aug 2026 | Scope and critical caveats |
+|---|---:|---|---|---|---|
+| Saudi Arabia | Not publicly located | — | — | `quote_required` | Aramco officially lists **Paving Asphalt**, but no public current 60/70 price table was found. Obtain a customer-specific quotation. |
+| United Arab Emirates | Not publicly located | — | — | `quote_required` | SCAD has historically published an item called **Bitumen / 60/70 / Ton** for Abu Dhabi, but no current 2026 item-level value was confirmed. Historical SCAD values must not be presented as current UAE prices. |
+| Egypt | **EGP 21,542** | tonne | July 2026 | `latest_official_bulletin`; not a live quote | The official Arabic label is **بيتومين مؤكسد على الساخن 70/60**. The bulletin states that prices come from some producers' lists before discounts, include taxes, and exclude transport. This wording may describe a hot-applied oxidized product rather than an internationally specified paving penetration grade; the specification must be verified before comparison. |
+| Oman | Not publicly located | — | — | `quote_required` | OQ confirms bitumen production and provides an official route for “Pricing & purchasing” and domestic refined-products enquiries, but no public current 60/70 price table was found. |
+| Qatar | **2,925** | tonne | 22 Jul 2026–31 Jul 2026 | `expired_official_price` | Ashghal's official raw-material price list identifies **Bitumen 60/70**. The page does not display a currency label beside the table. QAR is the expected local currency but must be confirmed before ingesting `currency_code = QAR`. The list's commercial/contractual scope must also be confirmed; it is not proof of a universal retail price. |
+| Bahrain | Not publicly located | — | — | `quote_required` | Bapco officially confirms Asphalt penetration grade 60/70 and states that it can be exported in 25-metric-tonne trucks or by sea. No public current price was found. |
+| Kuwait | Not publicly located | — | — | `quote_required` | KNPC officially lists bitumen as a specialty product mainly for local demand. A KNPC report confirms PEN 60/70 production, but no current public price was found. |
+
+### Do not flatten these observations into one comparable price list
+
+The Egyptian and Qatari entries have different product wording and commercial scope. Before comparing or converting them, verify all of the following:
+
+1. Penetration-grade paving bitumen versus oxidized/hot-applied bitumen.
+2. Bulk hot liquid versus drums, bags, or other packaging.
+3. Ex-refinery, ex-works, free-on-truck, delivered, FOB, CFR, or CIF basis.
+4. Tax/VAT inclusion.
+5. Freight, heating, loading, handling, and insurance inclusion.
+6. Minimum order quantity and customer eligibility.
+7. Product standard and certificate of analysis.
+8. Quote effective dates and price-adjustment mechanism.
+
+## Official sources and quote routes
+
+### 1. Saudi Arabia
+
+- **Official product confirmation:** Saudi Aramco lists **Paving Asphalt** in its product range.  
+  https://www.aramco.com/en/what-we-do/customers/products-and-facilities
+- **Official customer route:** the same page lists the in-Kingdom Customer Care Center and customer-account route. At the research cut-off it displayed the Saudi toll-free number `800 305 5555`.
+- **Official current public price found:** no.
+- **Required action:** request a written 60/70 quotation and ask for the loading terminal, price basis, VAT treatment, minimum volume, validity, and product specification.
+- **Language:** English and Arabic website navigation were visible. Verify that the relevant product/contact content is available in both languages before marking the record bilingual.
+
+### 2. United Arab Emirates
+
+- **Official statistical methodology:** Statistics Centre – Abu Dhabi (SCAD) states that its Building Materials Price statistics represent average transaction prices for materials in the Emirate of Abu Dhabi.  
+  https://www.scad.gov.ae/documents/20122/0/Building%2BMaterials%2BPrices%2BMethodology%2B%281%29.pdf/633becc4-8f63-a5a3-2dad-2b4fa8a4ef2f?t=1739265634403
+- **Historical official evidence:** older SCAD publications included **Bitumen / 60/70 / Ton**. These historical observations are useful for schema validation only and must not be treated as 2026 prices.
+- **Official refinery contact:** ADNOC Refining contact form and telephone. Product availability and 60/70 grade must be confirmed rather than assumed.  
+  https://adnoc.ae/en/adnoc-refining/contact-us/
+- **Official current public price found:** no.
+- **Required action:** first check the latest SCAD item-level Building Materials Prices release; if no current 60/70 value exists, obtain a written quote from an authorized producer/supplier and retain evidence of authorization.
+- **Language:** SCAD and ADNOC offer Arabic and English content, but each exact document/page must be checked individually.
+
+### 3. Egypt
+
+- **Official publication:** Ministry of Housing / affiliated official building-materials price bulletin, Roads and Bridges section.  
+  https://drso.gov.eg/drso/upload/BuildingMaterials/AttachmentA/62/%D8%A7%D9%84%D8%B7%D8%B1%D9%82%D9%88%D8%A7%D9%84%D9%83%D8%A8%D8%A7%D8%B1%D9%8A.pdf
+- **Latest figure located:** `21,542 EGP/tonne` for July 2026.
+- **Exact source label:** `بيتومين مؤكسد على الساخن 70/60`.
+- **Published basis:** some producers' list prices, before discounts; taxes included; transport excluded.
+- **Official current live quote found:** no. Store the figure as a July 2026 bulletin observation.
+- **Required action:** obtain the technical data sheet or certificate of analysis and confirm whether this item is equivalent to the penetration-grade paving bitumen required by the buyer.
+- **Language:** the bulletin is primarily Arabic; no complete official English edition was confirmed. Store a faithful English translation separately and retain the Arabic source label.
+
+### 4. Oman
+
+- **Official product confirmation:** OQ's refined-products page confirms a bitumen unit in the Sohar refinery complex.  
+  https://oq.com/en/our-business/our-products/refined-products
+- **Official pricing/contact route:** OQ's contact page includes “Pricing & purchasing” and “Domestic sales & refined products.” At the research cut-off it displayed `business.center@oq.com` and `+968 2214 3999`.  
+  https://oq.com/en/contact-us
+- **Official current public price found:** no.
+- **Required action:** request a written quotation specifying grade 60/70, bulk/packaging, loading point, quantity, incoterm, taxes, transport, and quote validity.
+- **Language:** English and Arabic versions of the contact pages were confirmed.
+
+### 5. Qatar
+
+- **Official price source:** Public Works Authority (Ashghal), Raw Materials Prices.  
+  https://www.ashghal.gov.qa/en/Services/Pages/PriceList.aspx?category=2
+- **Latest row located:** `Bitumen | Bitumen 60/70 | Tonne | 2925 | 22/07/2026 | 31/07/2026`.
+- **Currency warning:** the public table does not visibly label its currency. Do not infer and save `QAR` without an additional official confirmation.
+- **Official producer/distributor confirmation:** WOQOD states that it supplies bitumen for road asphalting and construction in Qatar.  
+  https://www.woqod.com/website/en/pages/our_story
+- **Official product data sheet:** WOQOD's Bitumen 60/70 PDS gives the product code, penetration range, test methods, and contact `bitumen@woqod.com.qa`.  
+  https://www.woqod.com/EN/Bitumen/Documents/BITUMEN%2060%2070%20PDS.pdf
+- **Current status:** the 2,925 observation expired on 31 July 2026. No August 2026 public row was located by the cut-off date.
+- **Required action:** email WOQOD for a current written quote and ask Ashghal to confirm the table currency and framework-price scope.
+- **Language:** the Ashghal English page and WOQOD English PDS were confirmed. An equivalent Arabic price row/PDS must be checked before marking the source bilingual.
+
+### 6. Bahrain
+
+- **Official product confirmation:** Bapco Refining states that its Asphalt has a penetration grade of 60/70 and is used for road construction, repairs, and waterproofing products.  
+  https://www.bapco.net/en/page/crude-and-petroleum-products
+- **Official logistics detail:** Bapco states that road export is in suitable 25-metric-tonne trucks and sea export is available in different cargo sizes.  
+  https://www.bapco.net/en/page/loading-facilities
+- **Official sales route:** Bapco International Markets manages refined-product sales including Asphalt.  
+  https://www.bapco.net/en/page/international-market
+- **Official contact:**  
+  https://www.bapco.net/en/page/contact-us
+- **Official current public price found:** no.
+- **Required action:** register or contact the appropriate Bapco sales channel for a written quote. Confirm whether the price is domestic or export, truck or sea, and whether heating/loading charges are included.
+- **Language:** English product pages were confirmed; verify the exact Arabic equivalents before setting bilingual availability.
+
+### 7. Kuwait
+
+- **Official product confirmation:** KNPC lists Bitumen as a specialty product, mainly for local demand.  
+  https://www.knpc.com/en/our-business/local-marketing/products-services
+- **Arabic official equivalent:**  
+  https://www.knpc.com/ar/our-business/local-marketing/products-services
+- **Grade evidence:** KNPC's official 2018/2019 annual report mentions production of `PEN 60/70` and `MC-70`. This confirms grade capability, not a current price.  
+  https://www.knpc.com/getmedia/50fea02f-88de-4244-9796-02eefd380360/annual-report-2018-2019-en.pdf?ext=.pdf
+- **Official local marketing route:** the KNPC directory lists the Local Marketing function; verify current personnel/telephone immediately before use.  
+  https://www.knpc.com/en/about-us/governance/knpc-directory
+- **Official contact form:**  
+  https://www.knpc.com/en/contact-us
+- **Official current public price found:** no.
+- **Required action:** request a dated written quotation from KNPC Local Marketing, including buyer eligibility, loading location, specifications, tax/subsidy treatment, transport, minimum volume, and validity.
+- **Language:** Arabic and English product pages were confirmed.
+
+## Recommended database design
+
+Do not store a changing price directly on the supplier/company record. Use a separate price-observation table so every value keeps its source, date range, and commercial basis.
+
+### `bitumen_suppliers`
+
+| Column | Type / example | Notes |
+|---|---|---|
+| `supplier_id` | UUID | Primary key. |
+| `country_code` | `SA`, `AE`, `EG`, `OM`, `QA`, `BH`, `KW` | ISO alpha-2 code; no Arabic duplicate required. |
+| `supplier_name` | text | Official English or Latin-script name. |
+| `supplier_name_ar` | text, nullable | Official Arabic name only when officially available. |
+| `supplier_type` | enum | `state_producer`, `state_marketer`, `government_authority`, `authorized_supplier`. |
+| `website_url` | URL | Official domain only. |
+| `sales_contact_url` | URL, nullable | Official quote/contact route. |
+| `sales_email` | text, nullable | Preserve only if officially published. |
+| `sales_phone` | text, nullable | Store in E.164-compatible form where possible. |
+| `source_languages` | array | Example: `["ar", "en"]`; verify exact page/document, not merely the site's language switcher. |
+| `last_verified_at` | datetime | UTC timestamp. |
+
+### `bitumen_products`
+
+| Column | Type / example | Notes |
+|---|---|---|
+| `product_id` | UUID | Primary key. |
+| `supplier_id` | UUID | Foreign key. |
+| `product_name` | `Bitumen 60/70` | Normalized English name. |
+| `product_name_ar` | `بيتومين 60/70` | Arabic normalized name. |
+| `official_product_label` | text | Exact official English label, if available. |
+| `official_product_label_ar` | text, nullable | Exact Arabic source label; do not overwrite with a translation. |
+| `grade` | `60/70` | Keep as text. |
+| `product_class` | enum | `penetration_grade`, `oxidized`, `cutback`, `emulsion`, `polymer_modified`, `unknown`. |
+| `penetration_min` | integer, nullable | Example: `60`. |
+| `penetration_max` | integer, nullable | Example: `70`. |
+| `test_standard` | text, nullable | Record exactly as published; do not infer a standard. |
+| `specification_url` | URL, nullable | Official PDS/COA/specification. |
+| `packaging_options` | array, nullable | Examples: `bulk_hot`, `drum`, `bag`, `tanker`, `vessel`. |
+| `equivalence_status` | enum | `confirmed`, `possible`, `not_equivalent`, `unverified`. Essential for the Egypt observation. |
+
+### `bitumen_price_observations`
+
+| Column | Type / example | Notes |
+|---|---|---|
+| `price_observation_id` | UUID | Primary key. |
+| `product_id` | UUID, nullable | Nullable until exact product equivalence is confirmed. |
+| `country_code` | text | Required. |
+| `price_amount` | decimal, nullable | Null when `quote_required`. |
+| `currency_code` | ISO 4217, nullable | Example: `EGP`; leave null if the official source does not state the currency. |
+| `currency_verification_status` | enum | `explicit`, `confirmed_separately`, `inferred`, `unknown`. |
+| `unit` | enum | Prefer `metric_tonne`; retain the source unit too. |
+| `source_unit_label` | text | Exact text such as `Tonne` or `طن`. |
+| `price_scope` | enum | `official_price_list`, `government_framework`, `official_statistical_average`, `producer_list`, `private_quote`, `general_market`, `unknown`. |
+| `price_basis` | text, nullable | Example: `producer list price before discounts`. |
+| `price_basis_ar` | text, nullable | Arabic content where available. |
+| `incoterm` | text, nullable | `EXW`, `FCA`, `FOB`, `CFR`, `CIF`, etc.; do not guess. |
+| `tax_included` | boolean, nullable | Use null when unstated. |
+| `transport_included` | boolean, nullable | Use null when unstated. |
+| `loading_heating_included` | boolean, nullable | Important for hot bulk bitumen. |
+| `minimum_order_quantity_mt` | decimal, nullable | Do not assume Bapco's 25-MT truck size is the commercial MOQ. |
+| `customer_category` | text, nullable | Government, contractor, industrial, export, etc. |
+| `effective_from` | date, nullable | Required for a valid comparison. |
+| `effective_to` | date, nullable | Required where published. |
+| `reference_month` | `YYYY-MM`, nullable | For statistical bulletins. |
+| `data_status` | enum | `current_quote`, `latest_official_bulletin`, `expired_official_price`, `historical_official`, `quote_required`, `unverified`. |
+| `source_title` | text | Official document/page title. |
+| `source_title_ar` | text, nullable | Arabic title if officially available. |
+| `source_url` | URL | Direct official page/document URL. |
+| `source_language` | `ar` or `en` | Language of the actual evidence. |
+| `retrieved_at` | datetime | UTC timestamp. |
+| `quote_reference` | text, nullable | Official quotation number or tender/framework reference. |
+| `evidence_file_hash` | text, nullable | Recommended for archived PDFs/quotes. |
+| `notes` | text, nullable | English notes. |
+| `notes_ar` | text, nullable | Arabic notes. |
+
+### Arabic-column rule
+
+Add the `_ar` suffix only to translatable text fields. Do **not** duplicate numbers, dates, currency codes, country codes, URLs, booleans, or identifiers into Arabic columns.
+
+Examples:
+
+- `supplier_name` and `supplier_name_ar`
+- `product_name` and `product_name_ar`
+- `official_product_label` and `official_product_label_ar`
+- `price_basis` and `price_basis_ar`
+- `notes` and `notes_ar`
+
+No duplicates are needed for `price_amount`, `currency_code`, `effective_from`, `effective_to`, or `source_url`.
+
+## Verification instructions for the agent
+
+For every country, the agent must:
+
+1. Re-open every official URL and record the retrieval timestamp.
+2. Check whether a newer publication or price row exists after the dates in this brief.
+3. Search the Arabic and English versions independently; do not assume translations contain identical rows.
+4. Preserve exact official product labels before translating or normalizing them.
+5. Confirm that `60/70` means penetration range and is not a reversed label, oxidized grade, or unrelated product code.
+6. Obtain or verify the PDS/COA and its standard, test methods, penetration, ductility, flash point, solubility, and source refinery.
+7. Confirm the currency from the official source. This is mandatory for the Qatar Ashghal row.
+8. Confirm whether a displayed figure is a framework price, statistical average, producer list price, tender price, subsidized local price, or customer-specific quote.
+9. Record the commercial basis: ex-refinery/ex-works/delivered/FOB/CFR/CIF, loading point, freight, heating, handling, tax, and insurance.
+10. Record minimum order, packaging, delivery location, customer category, quote number, effective dates, and payment terms.
+11. Mark expired observations as expired even if they are the newest official figures found.
+12. Reject any commercial figure that cannot be traced to an official producer, public authority, signed quote, tender award, or official statistical publication.
+
+## Suggested written quotation request
+
+> Please provide your current official quotation for penetration-grade Bitumen 60/70. State the currency and price per metric tonne; product specification and applicable standard; supply form (hot bulk/drum/bag); minimum order quantity; loading point and delivery destination; price basis or Incoterm; whether VAT/tax, heating, loading, transport, insurance, and handling are included; customer eligibility; payment terms; and the quote's effective-from and effective-to dates. Please include a quotation reference and current product data sheet/certificate of analysis.
+
+## Initial seed observations
+
+These are safe seed records only if all caveats are retained:
+
+```json
+[
+  {
+    "country_code": "EG",
+    "official_product_label_ar": "بيتومين مؤكسد على الساخن 70/60",
+    "product_class": "unverified",
+    "price_amount": 21542,
+    "currency_code": "EGP",
+    "currency_verification_status": "explicit",
+    "unit": "metric_tonne",
+    "price_scope": "producer_list",
+    "tax_included": true,
+    "transport_included": false,
+    "reference_month": "2026-07",
+    "data_status": "latest_official_bulletin",
+    "equivalence_status": "unverified"
+  },
+  {
+    "country_code": "QA",
+    "official_product_label": "Bitumen 60/70",
+    "product_class": "penetration_grade",
+    "price_amount": 2925,
+    "currency_code": null,
+    "currency_verification_status": "unknown",
+    "unit": "metric_tonne",
+    "price_scope": "official_price_list",
+    "effective_from": "2026-07-22",
+    "effective_to": "2026-07-31",
+    "data_status": "expired_official_price"
+  }
+]
+```
+
+For Saudi Arabia, the UAE, Oman, Bahrain, and Kuwait, create `quote_required` placeholders without a numeric `price_amount`. A missing official public price must remain null, not zero.

--- a/docs/CONCRETE-MATERIALS.md
+++ b/docs/CONCRETE-MATERIALS.md
@@ -1,0 +1,826 @@
+# Reinforced-concrete material prices, seven countries — the owner's brief
+
+**QUEUED, NOT STARTED — and he said so himself:**
+
+> «مصادر جديدة ضيفها للقائمة **سياتى دورها يوما ما**»
+> — 2026-08-20, [REQ-19](REQUESTS.md#req-19--reinforced-concrete-material-prices-its-turn-will-come)
+
+Cement, reinforcing steel, structural steel sections, sand, coarse aggregate and
+water, across Saudi Arabia, the UAE, Egypt, Oman, Qatar, Bahrain and Kuwait.
+**The brief below is his, stored verbatim.**
+
+---
+
+## This is the most carefully-typed of the price briefs, and its §3 is the reason
+
+Its source-type table has a column headed **"Can it populate `price_amount`?"**, and
+for three of the ten types the answer is **No**:
+
+| type | may it be a price? |
+|---|---|
+| `official_absolute_price`, `official_dated_price_list`, `official_historical_price` | **yes** |
+| `official_utility_tariff` | yes, **in its own table** |
+| `commercial_quote` | yes, **never labelled official** |
+| `official_price_index` | **no** — an index is not a price |
+| `official_approved_source`, `official_specification` | **no** — an approved-supplier list does not establish a market price |
+| `authenticated_portal` | only after the exact result is captured and archived |
+| `quote_required` | no, until a quotation exists |
+
+> **That is a provenance-typed price model**, and it is stricter than anything this
+> warehouse enforces. It is why his design gives `price_index_observations` and
+> `water_tariffs` tables of their own rather than a `kind` column on one table.
+
+## Water is the sharpest example in any of the briefs
+
+His §2.2 refuses to store a single water price. The official network tariff is **one
+component** of the site cost, beside meter charges, wastewater charges, tanker
+filling, transport, storage and testing — and *"a potable-water tariff alone does not
+prove technical suitability"* for concrete mixing or curing.
+
+**One number here would be false in both directions:** too low as a delivered cost,
+and not evidence of fitness for purpose. So the tariff and the delivered quotation
+are two records, and the technical suitability is a third thing again.
+
+## It completes a pattern across three of his briefs, now recorded as a finding
+
+With [DIESEL-PRICES.md](DIESEL-PRICES.md) and [BITUMEN-PRICES.md](BITUMEN-PRICES.md),
+this is the **third** independent case that `SR-6` — *an unchanged price is confirmed,
+not appended* — keys on the wrong thing:
+
+| brief | what carries the fact |
+|---|---|
+| diesel | the **period** |
+| bitumen | the **commercial basis** |
+| **this one** | the **source type** |
+
+Three products, three axes, three briefs written separately. [DEC-12](BACKLOG.md) is
+that finding, and it is recorded **before** any of these collections is scheduled,
+because the failure it describes is silent and the data is not re-fetchable: dated
+bulletins expire, and the Qatar bitumen figure had already expired when he sent it.
+
+## And one honest note about its own coverage
+
+Read its §12 before its §5. Its own bottom line is that **only Saudi Arabia, Egypt
+and Qatar have usable official absolute prices**; Oman and Kuwait offer **indices**,
+which by its own §3 are not prices; and Bahrain offers approval and specification
+evidence, which is not a price either. So for four of seven countries this is a
+`quote_required` source in the same sense the bitumen brief is.
+
+**Its §2.1 also flags a scope honesty point that is easy to lose:** structural steel
+sections are **not** constituents of reinforced concrete. They are in scope because he
+asked for them and they are procured in the same workflow — which is a reason to keep
+them a separate material, not to redefine the product.
+
+---
+
+*Everything below this line is the owner's brief as he sent it, unedited.*
+
+---
+
+# Official Sources for Reinforced-Concrete Material Prices in Seven Countries
+
+## Agent Research and Verification Brief
+
+**Countries:** Saudi Arabia, United Arab Emirates, Egypt, Oman, Qatar, Bahrain, and Kuwait  
+**Materials:** cement, reinforcing steel, structural steel sections, sand, coarse aggregate, and water  
+**Research cut-off:** 20 August 2026  
+**Required output language:** English field names, with Arabic content in matching fields suffixed `_ar`
+
+---
+
+## 1. Objective
+
+Build a verified, source-traceable database of official price observations and related official evidence for the listed materials in the seven countries.
+
+The agent must distinguish between:
+
+1. an official absolute price;
+2. an official dated price list;
+3. an official price index;
+4. an official utility tariff;
+5. an approved-product, approved-supplier, or specification source; and
+6. a commercial quotation.
+
+These are not interchangeable. An index value is not a price, and an approved supplier list does not establish a market price.
+
+---
+
+## 2. Important Scope Notes
+
+### 2.1 What counts as a reinforced-concrete constituent
+
+The primary constituents are cement, fine aggregate, coarse aggregate, water, and reinforcing steel. Admixtures and supplementary cementitious materials may also be used, but they are outside the present scope.
+
+Structural steel sections such as I-beams, H-beams, channels, and angles are **not** constituents of reinforced concrete. They are included because they were explicitly requested and are commonly procured in the same construction-material workflow.
+
+### 2.2 Water must be handled differently
+
+Public agencies normally publish a network-water tariff, not a construction-site “mixing water price.” The effective site cost may include:
+
+- utility tariff;
+- fixed or meter charges;
+- wastewater charges;
+- tanker filling price;
+- tanker transport and delivery;
+- storage; and
+- quality testing or treatment.
+
+Therefore, store a utility tariff separately from a delivered tanker quotation. Also verify that the water complies with the project specification for concrete mixing and curing. A potable-water tariff alone does not prove technical suitability.
+
+### 2.3 Current and historical sources
+
+A source may be official but outdated. Record the date actually shown by the source and never label a historical price as current. If no current official absolute price exists, mark the record `quote_required`; do not estimate or copy a commercial web price into an official-price table.
+
+---
+
+## 3. Source-Type Codes
+
+| Code | Meaning | Can it populate `price_amount`? |
+|---|---|---:|
+| `official_absolute_price` | A government statistical publication giving a currency amount per unit | Yes |
+| `official_dated_price_list` | A government or public-works price list with an explicit validity period | Yes, for that period only |
+| `official_historical_price` | An official absolute price whose validity period has ended | Yes, but only as historical data |
+| `official_price_index` | A WPI, PPI, CCI, or similar index | No; store in a separate index observation |
+| `official_utility_tariff` | A regulated water charge | Yes, in a separate water-tariff table |
+| `official_approved_source` | Approved manufacturer, supplier, product, or laboratory list | No |
+| `official_specification` | Technical requirements, test methods, or material standards | No |
+| `authenticated_portal` | Official data exists behind login or an interactive calculator | Only after the exact result is captured and archived |
+| `commercial_quote` | A written supplier or transporter quotation | Yes, but never label it official |
+| `quote_required` | No usable current official absolute price was located | No until a quotation is obtained |
+
+---
+
+## 4. Quick Availability Matrix
+
+The entries below describe the best verified public route located by the research cut-off. `Quote` means that a current project-specific quotation is still required.
+
+| Country | Cement | Rebar | Steel sections | Sand | Coarse aggregate | Water |
+|---|---|---|---|---|---|---|
+| Saudi Arabia | Official national absolute prices | Official national absolute prices by diameter | Index/Quote | Official national absolute prices | Partial absolute series/Quote for exact grading | Official tariff calculator + site-delivery check |
+| UAE | Historical official emirate-level prices; current quote | Historical official emirate-level prices; current quote | Coverage must be checked; current quote | Historical official emirate-level prices; current quote | Historical official emirate-level prices; current quote | Emirate-specific utility tariff + tanker quote |
+| Egypt | Official monthly bulletin | Official monthly bulletin | Official bulletin category | Official bulletin, including governorate tables in some releases | Official bulletin distinguishes `سن` and `زلط` | Utility/account tariff + tanker quote where applicable |
+| Oman | Official price index; Quote | Official price index; Quote | Official price index; Quote | Official price index; Quote | Official price index; Quote | Official non-residential network tariff |
+| Qatar | Official list exists, but latest row must be checked | Official dated Ashghal list | Quote | Official historical list; current row must be checked | Official historical gabbro list; current row must be checked | Official Kahramaa category/calculator + tanker check |
+| Bahrain | Approved-source/specification evidence; Quote | Approved-source/specification evidence; Quote | Approved-source/specification evidence; Quote | Approved-source/specification evidence; Quote | Approved-source/specification evidence; Quote | Official non-domestic network tariff |
+| Kuwait | Official WPI/PPI; Quote | Official WPI/PPI + quality-source directory; Quote | Official WPI/PPI; Quote | Official WPI/PPI; Quote | Official WPI/PPI; Quote | Official sector tariff per 1,000 imperial gallons |
+
+---
+
+## 5. Country Source Register
+
+## 5.1 Saudi Arabia
+
+### Primary absolute-price source
+
+**Authority:** General Authority for Statistics (GASTAT)  
+**Publication:** Average Prices of Goods and Services, July 2026, Arabic-English PDF  
+**Official URL:**
+
+<https://www.stats.gov.sa/documents/20117/2435267/Average%2BPrices%2Bof%2BGoods%2Band%2BServices%2BJul%2B2026-AR-EN%2B%281%29.pdf/e3a0c7cb-9318-003c-b51e-e6719f37f1cf?download=true&t=1786514996658&version=1.0>
+
+**Geographic scope:** national average  
+**Frequency:** monthly  
+**Language:** Arabic and English  
+**Source type:** `official_absolute_price`
+
+Verified material coverage includes:
+
+- black national cement, 50 kg;
+- white national cement, 50 kg;
+- reinforcing steel by diameter, per tonne;
+- soft white sand, per cubic metre;
+- red sand, per cubic metre;
+- mixed sand and pebble, per cubic metre; and
+- several ready-mix concrete classes.
+
+The July 2026 publication does not provide a clearly identified item-level series for fabricated structural steel sections such as I/H beams, channels, or angles. Obtain a written supplier quotation for the exact section and use an official construction, wholesale, or producer price index only as a movement benchmark.
+
+### Water source
+
+**Authority:** National Water Company (NWC)  
+**Source:** official tariff calculator referenced by NWC service guidance  
+**Tariff calculator:** <https://ebranch.nwc.com.sa/Arabic/Pages/TariffCalculator.aspx>  
+**Service guidance:** <https://sudpprod.nwc.com.sa/publicfiles/ServiceusermanualEn.pdf>  
+**Language:** Arabic; English guidance is available  
+**Source type:** `official_utility_tariff`
+
+The agent must save the selected customer category, consumption quantity, region if requested, calculation date, and calculator output. For tanker-supplied construction sites, obtain the filling and delivery price separately.
+
+### Saudi verification rules
+
+- Confirm that the first figure extracted is the current-month value, not the previous month or previous year.
+- Preserve the original diameter for every reinforcing-steel observation.
+- Do not map “mixed sand and pebble” to a specified coarse aggregate without checking the grading and intended use.
+- Record the actual national-average scope; do not claim that the value is a city-specific delivered price.
+
+---
+
+## 5.2 United Arab Emirates
+
+There is no single verified public federal table giving a current delivered price for every requested material. Price collection and utility tariffs are emirate-specific.
+
+### Abu Dhabi building-material source
+
+**Authority:** Statistics Centre – Abu Dhabi (SCAD)  
+**Source:** Building Materials Prices methodology  
+**Official URL:** <https://www.scad.gov.ae/documents/20122/0/Building%2BMaterials%2BPrices%2BMethodology%2B%281%29.pdf/633becc4-8f63-a5a3-2dad-2b4fa8a4ef2f?t=1739265634403>  
+**Publication catalogue:** <https://scad.gov.ae/web/guest/related-publications>  
+**Geographic scope:** Emirate of Abu Dhabi, not the whole UAE  
+**Frequency described by methodology:** monthly  
+**Language:** English publication and bilingual SCAD website  
+**Source type:** `official_absolute_price` when an item-level monthly release is available; otherwise `official_historical_price`
+
+SCAD groups include cement, aggregates and sand, concrete, and steel. The public catalogue must be checked for the most recent downloadable item-level release. The latest release located during this review was not current to August 2026, so the agent must not present it as a current UAE price.
+
+### Dubai building-material source
+
+**Authority:** Dubai Statistics Center / Digital Dubai  
+**Candidate official publication:** Average Building Material Prices 2025  
+**Official URL:** <https://www.dsc.gov.ae/Report/Avg-BMP-2025.pdf>  
+**Geographic scope:** Dubai only  
+**Source type:** `official_historical_price` until a newer official edition is verified
+
+The URL should be re-opened and the PDF archived. If access fails, do not infer its values from search snippets or third-party summaries.
+
+### Dubai water source
+
+**Authority:** Dubai Electricity and Water Authority (DEWA)  
+**English:** <https://www.dewa.gov.ae/en/consumer/billing/slab-tariff>  
+**Arabic:** <https://www.dewa.gov.ae/ar-AE/consumer/billing/slab-tariff>  
+**Geographic scope:** Dubai  
+**Language:** Arabic and English  
+**Source type:** `official_utility_tariff`
+
+The page gives category- and slab-dependent water tariffs, fuel surcharge information, and tax treatment. Store each component separately. Do not apply a Dubai tariff to Abu Dhabi or another emirate.
+
+### UAE verification rules
+
+- Store `emirate` as a mandatory field.
+- Verify whether “steel” means reinforcing bars, structural sections, steel mesh, or another product.
+- Record gabbro, crushed aggregate, and natural gravel as different product descriptions unless the official source explicitly combines them.
+- For an active project, request a delivered quotation for the exact emirate, quarry/source, grading, and site location.
+
+---
+
+## 5.3 Egypt
+
+### Primary building-material source
+
+**Authority:** Ministry of Housing, Utilities and Urban Communities — Central Administration for Building Materials  
+**Methodology:** <https://img.mhuc.gov.eg/images/1abdd0a9-a225-44b2-8d25-b386489ec545.pdf>  
+**2026 bulletin example:** <https://img.mhuc.gov.eg/images/7e3119c3-e31c-48e3-a9ef-e2f0749c3c8e.pdf>  
+**February 2026 bulletin cover/source:** <https://img.mhuc.gov.eg/images/e9f4bc7c-43e9-425d-b8bc-32652ec3ac48.pdf>  
+**Official roads-and-bridges material bulletin example, July 2026:** <https://drso.gov.eg/drso/upload/BuildingMaterials/AttachmentA/62/%D8%A7%D9%84%D8%B7%D8%B1%D9%82%D9%88%D8%A7%D9%84%D9%83%D8%A8%D8%A7%D8%B1%D9%8A.pdf>  
+**Language:** primarily Arabic  
+**Source type:** `official_absolute_price`
+
+Verified categories across the official bulletin system include:
+
+- reinforcing steel;
+- cement;
+- structural and metal sections;
+- ready-mix concrete;
+- sand;
+- crushed coarse aggregate, commonly `سن`;
+- natural gravel, commonly `زلط`; and
+- related road and bridge materials.
+
+The methodology indicates monthly collection around the middle of the month. Many market-price observations are scoped to Greater Cairo. Some basic-material tables provide governorate-by-governorate prices. Taxes and transport treatment must be captured from the note attached to the specific table; do not assume one note applies to the entire bulletin.
+
+### Historical governorate comparison source
+
+**Authority:** same ministry  
+**Official URL:** <https://img.mhuc.gov.eg/images/feb46b50-153d-4349-af33-100fb528fdf4.pdf>  
+**Use:** demonstrates official coverage of sand, `سن`, and `زلط` by governorate  
+**Source type:** `official_historical_price`
+
+This source is historical and must not be used as an August 2026 price.
+
+### Water sources
+
+**Authority:** Holding Company for Water and Wastewater (HCWW)  
+**Commercial sector:** <https://www.hcww.com.eg/%D8%A7%D9%84%D9%82%D8%B7%D8%A7%D8%B9-%D8%A7%D9%84%D8%AA%D8%AC%D8%A7%D8%B1%D9%8A/>  
+**Non-domestic water connection service:** <https://www.hcww.com.eg/%D8%AA%D9%88%D8%B5%D9%8A%D9%84-%D8%AE%D8%AF%D9%85%D8%A9-%D9%85%D9%8A%D8%A7%D9%87-%D8%A7%D9%84%D8%B4%D8%B1%D8%A8-%D8%B9%D8%AF%D8%A7%D8%AF-%D8%B1%D8%A6%D9%8A%D8%B3%D9%8A-%D8%A3%D9%88%D9%84-%D9%85-2/>  
+**Language:** Arabic  
+**Source type:** official service source; the current tariff must be verified for the local utility, governorate, and activity
+
+The agent must obtain the applicable tariff or actual bill from the local water company. If the construction site uses tanker water, record the tanker volume and delivered price separately.
+
+### Egypt verification rules
+
+- Do not merge `سن` and `زلط`. `سن` generally denotes crushed stone; `زلط` generally denotes natural gravel. Their grading and engineering use can differ.
+- Store the governorate or Greater Cairo scope for every record.
+- Record whether the price is a producer/company price or a market/consumer price.
+- Record minimum-quantity conditions, tax inclusion, and transport exclusion exactly as printed.
+
+---
+
+## 5.4 Oman
+
+### Primary official index source
+
+**Authority:** National Centre for Statistics and Information (NCSI)  
+**National statistics portal:** <https://www.ncsi.gov.om/NationalStatistics>  
+**Producer Price Index publication, first quarter 2026:** <https://api.ncsi.gov.om/uploads/keyindicators/real_estate_price_index_1782790856.pdf>  
+**Language:** Arabic and English  
+**Source type:** `official_price_index`
+
+The official index publication includes relevant groups such as:
+
+- stone, sand, and clay;
+- glass, cement, and marble products;
+- raw and manufactured iron, steel, or aluminium products;
+- fabricated iron, steel, or aluminium products; and
+- water.
+
+These are index series, not OMR-per-tonne or OMR-per-cubic-metre prices. Store them in an index table and obtain written commercial quotations for the exact cement, rebar, section, sand, and aggregate items.
+
+### Water sources
+
+**Authority:** Authority for Public Services Regulation (APSR)  
+**Official URL:** <https://apsr.om/pages/products/water-wastewater>  
+
+**Provider:** Nama Water Services  
+**Official tariff page:** <https://nws.nama.om/en-us/Services-and-Products/Services-Tariffs-and-Fees>  
+**Language:** Arabic and English  
+**Source type:** `official_utility_tariff`
+
+The public non-residential network-water tariff verified during this review was **OMR 1.320 per m³** for commercial and government customers. The agent must re-check the effective date before importing it and must store wastewater or other service charges separately. Tanker and delivery prices require their own quotations.
+
+### Oman verification rules
+
+- Never convert an index point into an absolute material price.
+- Require the quarry/source and grading for sand and aggregate quotations.
+- Identify whether steel observations refer to raw steel, fabricated products, rebar, or finished structural sections.
+
+---
+
+## 5.5 Qatar
+
+### Primary public-works material price list
+
+**Authority:** Public Works Authority (Ashghal)  
+**Source:** Raw Materials Price List  
+**Official URL:** <https://www.ashghal.gov.qa/en/Services/Pages/PriceList.aspx?category=2>  
+**Language:** English page; Arabic website interface is also available  
+**Source type:** `official_dated_price_list`
+
+The public list has included, depending on period:
+
+- reinforcing steel by diameter;
+- ordinary Portland and sulphate-resistant cement, bulk or bagged;
+- gabbro aggregate;
+- washed sand; and
+- bitumen.
+
+Coverage is not identical every month. In the 2026 records reviewed, reinforcement-steel entries were available, while current 2026 entries for every cement, sand, and aggregate subtype were not visible. Historical rows prove that a material was once listed, not that its price is current.
+
+Every extracted Ashghal record must include its displayed validity start and end dates. The agent must also verify the currency from an authoritative page or document before setting `currency`; do not infer it solely from context.
+
+No verified item-level structural-section price was located in the list. Obtain a quotation for the exact section profile, grade, length, finish, and delivery basis.
+
+### Official index source
+
+**Authority:** National Planning Council (NPC)  
+**Producer Price Index release:** <https://www.npc.qa/en/statistics/Pages/news/05022026.aspx>  
+**Language:** Arabic and English website  
+**Source type:** `official_price_index`
+
+Use the index only to monitor market movement in basic metals and cement/non-metallic mineral products.
+
+### Water sources
+
+**Authority:** Qatar General Electricity and Water Corporation (Kahramaa)  
+**Tariff categories:** <https://www.km.qa/CustomerService/pages/tariff.aspx>  
+**Tariff calculator:** <https://www.km.qa/CustomerService/pages/tariffCalculation.aspx>  
+**Laws and regulations:** <https://www.km.qa/Pages/LawsRegulations.aspx>  
+**Language:** Arabic and English  
+**Source type:** `authenticated_portal` or `official_utility_tariff`, depending on the captured result
+
+Kahramaa exposes different customer categories, including commercial, industrial, bulk industrial, and water tanker. Select the category that actually applies. Save the inputs, output, calculation date, and any tariff schedule that supports the result.
+
+### Qatar verification rules
+
+- Treat every Ashghal price as valid only for its stated date range.
+- Do not assume that gabbro of one nominal size is interchangeable with another.
+- For construction water, check whether the project is billed through a network meter, a bulk supply, or the water-tanker category.
+
+---
+
+## 5.6 Bahrain
+
+No verified public government table providing current absolute prices for all requested construction materials was located. Official Bahrain sources are useful for product approval, supplier qualification, testing, and technical compliance. Current prices still require written quotations.
+
+### Approved civil-material sources
+
+**Authority:** Ministry of Works  
+**Approved civil materials/products list, dated 31 October 2024:** <https://www.works.gov.bh/Arabic/Publications/ResearchandReports/DocLib/Pre-Qualification%20List%20for%20Civil%20Materials%20as%20of%2031%20October%202024.pdf>  
+**Approved independent testing laboratories, dated 31 January 2026:** <https://www.works.gov.bh/Arabic/Publications/DocLib/Approved%20Independent%20Materials%20Testing%20Laboratories%20as%20of%2031%20January%202026.pdf>  
+**Standard construction specifications:** <https://www.works.gov.bh/Arabic/Tenders/Pages/StandardConstruction.aspx>  
+**Concrete specification module:** <https://www.works.gov.bh/English/Publications/standards/Documents/APPROVED_Module%2002_Concrete_July%2009/files/6.html>  
+**Language:** Arabic and English pages/documents, depending on source  
+**Source types:** `official_approved_source` and `official_specification`
+
+These sources support verification of cement, aggregate, reinforcing steel, concrete, and water testing, but they do not establish a current market price. Obtain quotations only from currently qualified and technically acceptable sources, and verify expiry dates because an older approval may no longer be valid.
+
+### Water sources
+
+**Authority:** Electricity and Water Authority (EWA)  
+**English tariff page:** <https://www.ewa.bh/en/tariff>  
+**Arabic tariff page:** <https://www.ewa.bh/ar/tariff>  
+**Tariff information:** <https://www.ewa.bh/en/ewa-tariffs>  
+**Language:** Arabic and English  
+**Source type:** `official_utility_tariff`
+
+The non-domestic/commercial water tariff verified during this review was **775 fils per m³**, equivalent to **BHD 0.775 per m³**. Re-check the effective date and customer category before import. A delivered tanker price remains separate.
+
+### Bahrain verification rules
+
+- Mark all material price cells `quote_required` unless a new official absolute-price publication is found.
+- Use Ministry of Works lists for technical eligibility, not price.
+- Verify the current approved-product list rather than relying solely on the 2024 list linked above.
+
+---
+
+## 5.7 Kuwait
+
+### Official price-index sources
+
+**Authority:** Central Statistical Bureau (CSB)  
+**Wholesale Price Index, Arabic:** <https://www.csb.gov.kw/Pages/Statistics?ID=35&ParentCatID=3>  
+**Wholesale Price Index, English:** <https://www.csb.gov.kw/Pages/Statistics_en?ID=35&ParentCatID=3>  
+**Producer Price Index, Arabic:** <https://www.csb.gov.kw/Pages/Statistics?ID=62&ParentCatID=3>  
+**Producer Price Index, English:** <https://www.csb.gov.kw/Pages/Statistics_en?ID=62&ParentCatID=3>  
+**Latest releases located:** first quarter 2026  
+**Language:** Arabic and English  
+**Source type:** `official_price_index`
+
+The CSB publishes PDF and Excel releases. These are indices, not current KWD-per-bag, KWD-per-tonne, or KWD-per-cubic-metre prices. They may be used for escalation or market-movement analysis only after the exact item group, base period, and index value are verified.
+
+### Official industrial and quality sources
+
+**Authority:** Public Authority for Industry (PAI)  
+**Industrial Directory, seventh edition 2026:** <https://pai.gov.kw/industrial-directory>  
+**2026 directory announcement:** <https://pai.gov.kw/news-list/-/asset_publisher/zqcw/content/ann_may_2026_1>  
+**Imported-goods conformity page:** <https://ksm.pai.gov.kw/sites/cm/ar/Pages/ImportedConformity.aspx>  
+**Language:** Arabic; some English pages are available  
+**Source types:** `official_approved_source` and official manufacturer directory
+
+The conformity page identifies mandatory quality requirements for reinforcing steel and Portland cement. The directory can help identify manufacturers, but neither source should populate a price field.
+
+### Water sources
+
+**Authority:** Ministry of Electricity, Water and Renewable Energy (MEWRE)  
+**Arabic investor FAQ:** <https://investors.mew.gov.kw/ar/faq-s>  
+**English investor FAQ:** <https://investors.mew.gov.kw/en/faq-s>  
+**Bilingual tariff PDF:** <https://www.mew.gov.kw/media/ywtfjidr/water-2023.pdf>  
+**Language:** Arabic and English  
+**Source type:** `official_utility_tariff`
+
+The verified tariff schedule is expressed in KWD per **1,000 imperial gallons**, not per cubic metre. It lists different rates for government, investment/commercial, industrial/agricultural, productive industrial/agricultural, other, and water-filling-station categories.
+
+For example, the official schedule reviewed showed:
+
+| Category | Official tariff basis |
+|---|---:|
+| Government | KWD 4.000 per 1,000 imperial gallons |
+| Investment and commercial | KWD 2.000 per 1,000 imperial gallons |
+| Industrial and agricultural | KWD 1.250 per 1,000 imperial gallons |
+| Productive industrial and agricultural | KWD 0.750 per 1,000 imperial gallons |
+| Water filling stations | KWD 0.500 per 1,000 imperial gallons |
+
+Store the original unit and value before conversion. If converting, use **1 imperial gallon = 0.00454609 m³** and record the conversion factor. The filling-station tariff is not the same as the delivered tanker price.
+
+### Kuwait verification rules
+
+- Do not load CSB WPI or PPI numbers into `price_amount`.
+- Obtain commercial quotations for cement, rebar, structural sections, sand, and coarse aggregate.
+- Record the local term `صلبوخ` when it appears, but map it to a precise aggregate specification before comparison.
+- Check that cement and rebar manufacturers or imported products meet the current PAI quality requirements.
+
+---
+
+## 6. Local Terminology Map
+
+Local names are search aids, not guaranteed technical equivalents.
+
+| Country | Fine aggregate | Coarse aggregate search terms | Important warning |
+|---|---|---|---|
+| Saudi Arabia | `رمل`, soft white sand, red sand | `بحص`, `ركام خشن`, `حصى` | “Mixed sand and pebble” may not meet a specified concrete grading |
+| UAE | `رمل مغسول`, washed sand, dune sand, crushed sand | `ركام`, `بحص`, `gabbro`, crushed stone | Always store emirate and quarry/source |
+| Egypt | `رمل` | `سن`, `زلط`, `ركام خشن` | `سن` and `زلط` must remain separate products |
+| Oman | `رمل`, washed sand, crushed sand | `ركام`, `حصى`, crushed stone, gabbro | Verify quarry and grading |
+| Qatar | washed sand | gabbro aggregate, `ركام`, crushed stone | Nominal size and origin affect price |
+| Bahrain | washed sand, dune sand | aggregate, gabbro, crushed stone, `ركام`, `بحص` | Use Ministry of Works approval/specification status |
+| Kuwait | `رمل`, washed sand | `صلبوخ`, `بحص`, `ركام`, crushed aggregate | `صلبوخ` still needs size, grading, and source fields |
+
+---
+
+## 7. Required Database Design
+
+Use separate tables for price observations, index observations, water tariffs, sources, and approvals/specifications. This prevents unlike evidence from being mixed.
+
+## 7.1 `materials`
+
+| Column | Type | Notes |
+|---|---|---|
+| `material_id` | UUID/text | Internal stable identifier |
+| `material_class` | enum | `cement`, `rebar`, `structural_steel`, `fine_aggregate`, `coarse_aggregate`, `water` |
+| `material_name` | text | English normalized name |
+| `material_name_ar` | text | Arabic normalized name |
+| `local_name` | text | Local English/transliterated or source wording |
+| `local_name_ar` | text | Local Arabic wording |
+| `subtype` | text | OPC, SRC, washed sand, gabbro, natural gravel, etc. |
+| `subtype_ar` | text | Arabic subtype |
+| `grade_standard` | text | ASTM, EN, BS, GSO, national standard, or manufacturer grade |
+| `diameter_mm` | decimal | Rebar only |
+| `section_profile` | text | I, H, channel, angle, hollow section, etc. |
+| `section_dimensions` | text | Exact dimensions; do not translate numeric dimensions |
+| `aggregate_nominal_size_mm` | decimal/text | Preserve ranges such as 10–20 mm |
+| `aggregate_source_type` | text | Gabbro, limestone, natural gravel, recycled, etc. |
+| `water_supply_mode` | enum | `network`, `bulk`, `filling_station`, `tanker_delivered`, `other` |
+
+## 7.2 `material_price_observations`
+
+| Column | Type | Notes |
+|---|---|---|
+| `price_observation_id` | UUID/text | Primary key |
+| `material_id` | FK | Links to exact normalized item |
+| `country_code` | CHAR(2) | `SA`, `AE`, `EG`, `OM`, `QA`, `BH`, `KW` |
+| `admin_area` | text | Emirate, governorate, city, or national |
+| `admin_area_ar` | text | Arabic location |
+| `price_amount` | decimal | Never put an index value here |
+| `currency` | CHAR(3) | ISO 4217 code |
+| `unit` | text | `50_kg_bag`, `tonne`, `m3`, etc. |
+| `price_level` | enum | `producer`, `wholesale`, `retail`, `market`, `contract`, `quotation` |
+| `effective_from` | date | Exact displayed date |
+| `effective_to` | date | Exact displayed expiry, if any |
+| `reference_month` | YYYY-MM | Statistical reference month |
+| `tax_status` | enum | `included`, `excluded`, `unknown`, `not_applicable` |
+| `transport_status` | enum | `included`, `excluded`, `unknown` |
+| `minimum_quantity` | decimal/text | Preserve original condition |
+| `delivery_location` | text | Required for delivered quotations |
+| `delivery_location_ar` | text | Arabic location |
+| `source_id` | FK | Source register link |
+| `source_type` | enum | Use codes in Section 3 |
+| `is_current` | boolean | Derived from dates, not manually assumed |
+| `verification_status` | enum | `verified`, `partially_verified`, `unverified`, `rejected` |
+| `verification_note` | text | English explanation |
+| `verification_note_ar` | text | Arabic explanation if maintained bilingually |
+| `retrieved_at` | datetime | Store in UTC |
+
+## 7.3 `price_index_observations`
+
+| Column | Type | Notes |
+|---|---|---|
+| `index_observation_id` | UUID/text | Primary key |
+| `country_code` | CHAR(2) | Country |
+| `index_family` | enum | `PPI`, `WPI`, `CCI`, other |
+| `item_group` | text | English source label |
+| `item_group_ar` | text | Arabic source label |
+| `index_value` | decimal | Index points only |
+| `base_period` | text | Mandatory |
+| `reference_period` | text/date | Mandatory |
+| `change_mom_pct` | decimal | If officially published |
+| `change_yoy_pct` | decimal | If officially published |
+| `source_id` | FK | Source register link |
+| `retrieved_at` | datetime | UTC |
+
+## 7.4 `water_tariffs`
+
+| Column | Type | Notes |
+|---|---|---|
+| `water_tariff_id` | UUID/text | Primary key |
+| `country_code` | CHAR(2) | Country |
+| `admin_area` | text | Emirate/local utility where applicable |
+| `admin_area_ar` | text | Arabic area |
+| `provider_name` | text | English authority/provider name |
+| `provider_name_ar` | text | Arabic name |
+| `customer_category` | text | Commercial, industrial, tanker, etc. |
+| `customer_category_ar` | text | Arabic category |
+| `supply_mode` | enum | Network, bulk, filling station, tanker delivered |
+| `consumption_from` | decimal | Slab lower bound |
+| `consumption_to` | decimal | Slab upper bound |
+| `tariff_amount` | decimal | Base tariff only |
+| `currency` | CHAR(3) | Currency |
+| `tariff_unit` | text | Preserve original unit |
+| `fuel_surcharge` | decimal | Store separately where applicable |
+| `vat_rate_pct` | decimal | Store separately |
+| `wastewater_charge` | decimal | Store separately |
+| `effective_from` | date | Mandatory if published |
+| `effective_to` | date | If published |
+| `source_id` | FK | Official tariff source |
+| `retrieved_at` | datetime | UTC |
+
+## 7.5 `sources`
+
+| Column | Type | Notes |
+|---|---|---|
+| `source_id` | UUID/text | Primary key |
+| `source_title` | text | English title |
+| `source_title_ar` | text | Arabic title when available |
+| `authority_name` | text | English authority name |
+| `authority_name_ar` | text | Arabic authority name |
+| `official_domain` | text | Domain only |
+| `source_url` | text | Direct page or file URL |
+| `source_language` | array/enum | `ar`, `en`, `ar_en` |
+| `publication_date` | date | If shown |
+| `reference_period` | text | Period described by data |
+| `geographic_scope` | text | National/emirate/governorate/city |
+| `geographic_scope_ar` | text | Arabic scope |
+| `access_type` | enum | `public`, `interactive`, `login_required` |
+| `file_hash_sha256` | text | Required for downloaded files |
+| `archive_path` | text | Internal archive location |
+| `retrieved_at` | datetime | UTC |
+| `source_status` | enum | `active`, `superseded`, `expired`, `unreachable` |
+
+## 7.6 `material_approvals_and_specifications`
+
+| Column | Type | Notes |
+|---|---|---|
+| `approval_record_id` | UUID/text | Primary key |
+| `country_code` | CHAR(2) | Country |
+| `material_id` | FK | Material/product |
+| `manufacturer_name` | text | English/legal source name |
+| `manufacturer_name_ar` | text | Arabic legal name |
+| `product_name` | text | English product |
+| `product_name_ar` | text | Arabic product |
+| `approval_type` | enum | Product, manufacturer, lab, specification |
+| `approval_number` | text | If shown |
+| `valid_from` | date | If shown |
+| `valid_to` | date | If shown |
+| `standard_reference` | text | Standard or specification number |
+| `source_id` | FK | Official source |
+| `verification_status` | enum | Current, expired, unclear |
+
+### Bilingual naming rule
+
+Use `_ar` only for human-language text that can have an Arabic version. Do not duplicate numeric, date, boolean, code, currency, unit, URL, hash, or identifier fields with `_ar`.
+
+Examples:
+
+- `material_name` / `material_name_ar`
+- `authority_name` / `authority_name_ar`
+- `verification_note` / `verification_note_ar`
+
+Do **not** create fields such as `price_amount_ar`, `currency_ar`, `effective_from_ar`, or `source_url_ar`.
+
+---
+
+## 8. Extraction and Normalisation Rules
+
+### 8.1 Cement
+
+Capture at least:
+
+- cement type: OPC, SRC, white, blended, or other;
+- strength class or national designation;
+- bagged or bulk;
+- bag mass;
+- manufacturer if the official source identifies it;
+- ex-factory, market, or delivered basis; and
+- minimum quantity.
+
+Never compare a 50 kg bag price with a bulk-tonne price without retaining the original observation and documenting the conversion.
+
+### 8.2 Reinforcing steel
+
+Capture:
+
+- bar or coil;
+- plain or deformed;
+- diameter;
+- grade/standard;
+- domestic or imported status if stated;
+- unit; and
+- price basis.
+
+Do not average different diameters unless the official publication itself reports an aggregate and the aggregate is stored as a separate series.
+
+### 8.3 Structural steel sections
+
+Capture:
+
+- profile type;
+- exact dimensions and mass per metre;
+- steel grade;
+- standard;
+- length;
+- black, galvanized, painted, or fabricated condition;
+- fabrication scope; and
+- delivery basis.
+
+A generic “steel price” is not acceptable for structural sections.
+
+### 8.4 Sand
+
+Capture:
+
+- washed, natural, dune, crushed, red, or white;
+- grading/fineness where available;
+- source/quarry;
+- moisture basis if relevant; and
+- delivered or ex-source basis.
+
+### 8.5 Coarse aggregate
+
+Capture:
+
+- natural gravel, crushed stone, gabbro, limestone, or recycled aggregate;
+- nominal size/range;
+- grading;
+- source/quarry and country of origin;
+- density basis where the price is by weight; and
+- delivered or ex-quarry basis.
+
+### 8.6 Water
+
+Capture:
+
+- potable network, bulk, filling station, or delivered tanker;
+- customer category;
+- tariff slab;
+- original billing unit;
+- fixed charges, surcharges, tax, wastewater, and delivery as separate fields;
+- proof of water quality or project acceptance; and
+- tanker capacity where applicable.
+
+---
+
+## 9. Agent Verification Procedure
+
+For every country and material:
+
+1. Open the official landing page, not only a search result.
+2. Confirm that the domain belongs to the stated government authority.
+3. Find the latest publication available as of the research date.
+4. Record publication date and data reference period separately.
+5. Download the official PDF or spreadsheet where possible.
+6. Calculate and store a SHA-256 hash.
+7. Preserve the original-language item label before translating or normalising it.
+8. Classify the evidence using the codes in Section 3.
+9. Verify material specification, unit, currency, geographic scope, tax, transport, minimum quantity, and validity dates.
+10. Reject any row whose currency or unit cannot be established.
+11. Mark a past validity period as historical, even if the page is still live.
+12. Keep utility-water tariffs separate from delivered tanker quotations.
+13. Keep index observations separate from absolute prices.
+14. For quoted prices, save the dated quotation and supplier legal identity; never label the quote as an official price.
+15. Re-check all links at the end of the run and report unreachable or superseded sources.
+
+---
+
+## 10. Required Agent Deliverables
+
+The verification agent should return:
+
+1. `source_register.csv` — one row per official source;
+2. `material_price_observations.csv` — absolute or quoted prices only;
+3. `price_index_observations.csv` — official indices only;
+4. `water_tariffs.csv` — official tariffs and delivered-water quotes kept distinguishable;
+5. `material_approvals_and_specifications.csv` — approvals and standards;
+6. `unresolved_items.md` — missing current prices, inaccessible pages, ambiguous units, or missing currencies;
+7. `verification_report.md` — findings, exclusions, and exact reasons for every `quote_required` status; and
+8. an archive of downloaded official files with SHA-256 hashes.
+
+The report must explicitly state, for each country and material, one of:
+
+- `current_official_absolute_price_found`;
+- `official_historical_price_only`;
+- `official_index_only`;
+- `official_tariff_only`;
+- `official_approval_or_specification_only`;
+- `authenticated_or_interactive_source_requires_capture`;
+- `commercial_quote_required`; or
+- `not_found_after_verification`.
+
+---
+
+## 11. Final Quality Gates
+
+Do not approve the dataset unless all of the following are true:
+
+- Every numeric price has a currency, unit, source, and reference date.
+- Every price is clearly labelled official or commercial.
+- No index value appears in an absolute-price field.
+- No historical price is presented as current.
+- UAE observations identify the emirate.
+- Egypt observations identify Greater Cairo or the relevant governorate.
+- `سن` and `زلط` remain separate unless an official definition proves equivalence.
+- Rebar observations preserve diameter and grade.
+- Structural-section observations preserve profile and dimensions.
+- Aggregate observations preserve size and source/type.
+- Water observations distinguish utility tariff, filling-station price, and delivered tanker price.
+- Arabic content uses the matching English column name plus `_ar`.
+- Downloaded official evidence has a stored hash and retrieval timestamp.
+
+---
+
+## 12. Bottom-Line Research Assessment
+
+- **Saudi Arabia:** strongest verified national item-level statistical source among the seven for cement, rebar, and selected sand/aggregate descriptions.
+- **Egypt:** broad official monthly building-material bulletin system, but geography and table notes must be handled carefully.
+- **Qatar:** useful official public-works price list, but material coverage and validity are period-specific.
+- **UAE:** official emirate-level statistics exist; do not treat them as federal or automatically current.
+- **Oman and Kuwait:** official indices are useful for movement analysis, while current absolute project prices generally require quotations.
+- **Bahrain:** official approval and specification sources are strong for compliance, but current material prices generally require quotations.
+- **Water in every country:** the official tariff is only one component of site cost and must not be confused with a delivered concrete-mixing-water price.

--- a/docs/DIESEL-PRICES.md
+++ b/docs/DIESEL-PRICES.md
@@ -1,0 +1,238 @@
+# Official retail diesel prices, seven countries — the owner's source list
+
+**QUEUED, NOT STARTED.**
+
+> «مصادر اخرى لاسعار الديزل فقط مصادر منتجات ضيفها لقائمة المصادر»
+> — 2026-08-20, [REQ-17](REQUESTS.md#req-17--official-diesel-prices-a-product-source-not-a-firm-directory)
+
+**The list below is his, stored verbatim.**
+
+---
+
+## This one is not like the other four, and the difference is structural
+
+He named it himself — **«مصادر منتجات»**, product sources. The other four queued
+surveys are **firm directories**: they describe companies, and they land in
+`generic_record` through the generic-dataset seam that muqawil pioneered. This one
+describes **a product's price over time**, and that is the *original* spine of this
+project: `price_observation`, the `db/migrations/` PRICE chain, `SR-6`.
+
+> **So it is the first queued source that touches the half of the warehouse muqawil
+> never went near.** That is good news for scheduling and it is a warning about one
+> specific mechanism, below.
+
+## It is also, by a wide margin, the smallest thing in the queue
+
+| source | requests to collect once |
+|---|---|
+| muqawil, everything the site publishes | **36,548** |
+| the UAE, Egypt/Gulf surveys | 32+ sources, unmeasured |
+| **this** | **7 pages, ~14 with both locales** |
+
+**Roughly fourteen requests a month.** It does not compete with finishing muqawil in
+any meaningful sense — it is an afternoon, not a track. The order is his to set; this
+is recorded so the decision is made with the size in view rather than by position in
+a list.
+
+## The one mechanism that will silently drop his data, and it is measured
+
+His collection rule §3 is *"keep `effective_from` and `effective_to`; **never
+overwrite a previous price** when a new month or quarter begins."* That is exactly
+what `price_observation` is for. But `SR-6` says:
+
+> **an unchanged price is confirmed, not appended.**
+
+Those two rules disagree, and the disagreement is not theoretical. Oman published
+`0.258 OMR/litre` in August. If July was also `0.258`, the append gate sees no change
+and **writes nothing** — so the August *period* never exists, `effective_from` is
+never recorded for it, and his §3 is silently violated by a rule that is otherwise
+correct.
+
+> **A period-keyed price must key the append gate on the PERIOD, not only on the
+> value.** `SR-6` was written for a scraped shelf price where an unchanged number
+> carries no new information. A published official price for a *named month* carries
+> new information even when the number is identical: it says the ministry set it
+> again.
+
+This is the same shape as a defect already recorded here — a new
+`price_observation` column stays NULL because the append gate never learned to notice
+it. The gate decides what history exists, and it has to be told what "new" means for
+each kind of price. **Settle this before the first collection, not after a month is
+missing.**
+
+## Two more things in his list that need something we do not have
+
+**Bahrain publishes the price as an IMAGE.** His own note says an automated collector
+must preserve a screenshot or image hash and use OCR **only as a candidate
+extraction**, with manual verification against the dated committee announcement
+before publication. This project has **no OCR path at all**, and his instruction is
+the right one anyway: the image is the evidence, the number is a claim about it. So
+Bahrain is one source that cannot be fully automated on his own terms, and that is a
+property of the source rather than a gap in the plan.
+
+**Kuwait's page is stale in a way that would poison the dates.** He observed the
+correct diesel value beside an **out-of-date validity note**, and says explicitly not
+to derive the effective dates from the static product page. A collector that trusted
+the page would store a right price under wrong dates — the worst of the two failures,
+because it looks complete.
+
+## What is already settled and should not be re-decided
+
+| his rule | where it already lives |
+|---|---|
+| no USD conversion in the stored value; any conversion in a separate table with its rate source and date | `SR-1` — the source of truth is what the publisher published |
+| `_ar` only where the content is language-bearing; not for prices, currency codes, or dates | `R-12` |
+| store the official value and unit unchanged | the same rule his Gulf survey states as `source_registration_number_raw` |
+
+And his §4 — automotive retail diesel kept separate from marine, industrial bulk,
+subsidised fisheries and commercial-delivery prices — is a **product identity** rule.
+It is why his schema carries `fuel_type`, `fuel_grade` and `customer_category` in the
+record key, and it is the same reason Bahrain's general pump price and its supported
+fishermen category are two rows and not one.
+
+---
+
+*Everything below this line is the owner's list as he sent it, unedited.*
+
+---
+
+# Official Retail Diesel Prices — Seven Countries
+
+## Scope
+
+This list covers automotive retail diesel, also called `diesel`, `gas oil`, or `solar`, in Saudi Arabia, the United Arab Emirates, Egypt, Oman, Qatar, Bahrain, and Kuwait.
+
+Review date: **20 August 2026**.
+
+Prices are stated per litre in local currency. They are not converted to USD because exchange-rate conversion would make the stored value time-dependent and would no longer represent the official domestic pump price.
+
+## Current Price List
+
+| Country | ISO code | Official product name | Price per litre | Minor-unit equivalent | Effective period or observation date | Official publisher/source |
+|---|---|---|---:|---:|---|---|
+| Saudi Arabia | `SA` | Diesel | **SAR 1.79** | 179 halalas | August 2026 | Saudi Aramco retail-fuels page |
+| United Arab Emirates | `AE` | Diesel | **AED 3.80** | 380 fils | Current August 2026 price retrieved 20 August 2026 | ADNOC Distribution; price includes VAT |
+| Egypt | `EG` | Solar / Diesel | **EGP 20.50** | 2,050 piastres | Effective from 10 March 2026 | Ministry of Petroleum and Mineral Resources |
+| Oman | `OM` | Diesel | **OMR 0.258** | 258 baisa | August 2026 | Oman Oil Marketing Company retail-fuel page |
+| Qatar | `QA` | Diesel | **QAR 2.05** | 205 dirhams | 1–31 August 2026 | QatarEnergy announcement reported by Qatar News Agency |
+| Bahrain | `BH` | Diesel | **BHD 0.229** | 229 fils | Effective from 2 August 2026 | Fuel Price Determination and Monitoring Committee; official Ministry of Oil and Environment price page |
+| Kuwait | `KW` | Gas Oil / Diesel | **KWD 0.115** | 115 fils | 1 July–30 September 2026 | KNPC / state Subsidy Review Committee pricing |
+
+## Official Source Details
+
+### Saudi Arabia
+
+- Official Arabic source: https://www.aramco.com/ar/what-we-do/energy-products/retail-fuels
+- Official English source: https://www.aramco.com/en/what-we-do/energy-products/retail-fuels
+- Published value: `1.79 SAR/litre`
+- Published period: August 2026
+
+### United Arab Emirates
+
+- Official ADNOC Distribution retail-fuel page: https://www.adnocdistribution.ae/consumer-fuel
+- Published value retrieved on the review date: `3.80 AED/litre`
+- Tax note: The page states that the displayed price includes VAT.
+- Update frequency: Monthly. Store the applicable month and retrieve the page again after each monthly announcement.
+
+### Egypt
+
+- Official Ministry decision: https://www.petroleum.gov.eg/ar-eg/media-center/news/news-pages/Pages/mop_10032026_02.aspx
+- Official Ministry price display: https://www.petroleum.gov.eg/ar-eg/Pages/HomePage.aspx
+- Published value: `20.50 EGP/litre`
+- Effective from: 10 March 2026 at 03:00
+
+### Oman
+
+- Arabic retail-price source: https://oomco.om/ar/motorists/%D8%A7%D9%84%D9%88%D9%82%D9%88%D8%AF
+- English retail-price source: https://oomco.om/for-drivers/fuel
+- Ministry of Energy and Minerals FAQ directing users to the National Subsidy System for monthly prices: https://mem.gov.om/en-us/FAQ/PgrID/710/PageID/3
+- Published value: `258 baisa/litre`, equal to `0.258 OMR/litre`
+- Published period: August 2026
+
+### Qatar
+
+- Official Qatar News Agency announcement: https://qna.org.qa/en/news/news-details?date=31%2F07%2F2026&id=qatarenergy-sets-fuel-prices-for-august
+- QatarEnergy official fuel-price history PDF: https://www.qatarenergy.qa/en/Documents/Fuel%20Prices.pdf
+- Published value: `2.05 QAR/litre`
+- Published period: August 2026
+
+The QatarEnergy history PDF can lag the latest monthly announcement. Use the dated QatarEnergy announcement or the official QNA report for the new month, then use the PDF for historical backfilling after it is updated.
+
+### Bahrain
+
+- Official Ministry of Oil and Environment price page, Arabic: https://www.moo.gov.bh/moo/ar/GasolinePrices.aspx
+- Official Ministry of Oil and Environment price page, English: https://moo.gov.bh/moo/GasolinePrices.aspx
+- Published committee value for August 2026: `0.229 BHD/litre`
+- Effective from: 2 August 2026
+
+The Ministry page publishes the price table as an image, so an automated collector must preserve a screenshot or image hash and use OCR only as a candidate extraction. The number must be manually verified against the committee's dated announcement before publication.
+
+### Kuwait
+
+- Official KNPC products and fuel-prices page, Arabic: https://www.knpc.com/ar/our-business/local-marketing/products-services
+- Official KNPC products and fuel-prices page, English: https://www.knpc.com/en/our-business/local-marketing/products-services
+- Published value: `115 fils/litre`, equal to `0.115 KWD/litre`
+- Current confirmed period: 1 July–30 September 2026
+
+The KNPC product page displayed the correct diesel value during review but retained an old validity-period note. The collector must therefore save the dated quarterly KNPC or Subsidy Review Committee announcement as the period-specific evidence and must not derive the effective dates from the static product page alone.
+
+## Recommended Database Columns
+
+Use one record per country, product, price period, and customer category.
+
+```text
+fuel_price_id
+country_code
+country_name
+country_name_ar
+
+fuel_type
+fuel_type_ar
+fuel_grade
+fuel_grade_ar
+customer_category
+customer_category_ar
+
+price_per_liter
+currency_code
+minor_unit_name
+minor_unit_name_ar
+price_includes_tax
+
+effective_from
+effective_to
+announced_at
+retrieved_at
+
+publisher_name
+publisher_name_ar
+source_url
+source_language
+source_evidence_type
+verification_status
+notes
+notes_ar
+```
+
+## Collection Rules
+
+1. Store the decimal price in the major local currency, for example `0.258` OMR rather than only `258` baisa.
+2. Use ISO 4217 currency codes: `SAR`, `AED`, `EGP`, `OMR`, `QAR`, `BHD`, and `KWD`.
+3. Keep `effective_from` and `effective_to`; never overwrite a previous price when a new month or quarter begins.
+4. Store automotive retail diesel separately from marine diesel, industrial bulk diesel, subsidized fisheries diesel, and any commercial-delivery price.
+5. Treat a price shown on a live page without a visible month as a snapshot. Save `retrieved_at` and obtain a dated announcement where possible.
+6. Preserve the official source value and unit. Any USD conversion must be stored in a separate calculated table with the exchange-rate source and date.
+7. For Bahrain, keep the general pump price separate from the supported fishermen category.
+8. Recheck monthly sources on the first or second day of every month and Kuwait's quarterly source before each new quarter.
+
+## Verification Status
+
+| Country | Price verified from an official current page or dated official announcement | Follow-up needed |
+|---|---:|---|
+| Saudi Arabia | Yes | Recheck monthly page |
+| United Arab Emirates | Yes | Archive the monthly committee announcement in addition to the live distributor page |
+| Egypt | Yes | Monitor new Ministry pricing decisions |
+| Oman | Yes | Archive the National Subsidy System monthly evidence if accessible |
+| Qatar | Yes | Recheck QatarEnergy/QNA monthly announcement |
+| Bahrain | Official price page confirmed; record value requires dated image/announcement evidence | Archive the Ministry image and committee announcement |
+| Kuwait | Official KNPC price confirmed; static page validity note is stale | Archive the Q3 2026 KNPC/committee announcement and recheck Q4 |

--- a/docs/GULF-EGYPT-SOURCES.md
+++ b/docs/GULF-EGYPT-SOURCES.md
@@ -1,0 +1,1024 @@
+# Egypt, Oman, Qatar, Bahrain and Kuwait — the owner's source survey
+
+**QUEUED FOURTH, NOT STARTED.**
+
+> «المزيد من المصادر ضفها الى القائمة»
+> — 2026-08-20, [REQ-16](REQUESTS.md#req-16--egypt-oman-qatar-bahrain-and-kuwait-fourth-in-the-queue)
+
+He said *add them to the list*, without naming a position, so it is **appended in
+the order received** — after muqawil, [Balady](BALADY-ENG-OFFICES.md) and the
+[UAE](UAE-SOURCES.md). Nothing has started on any of the three queued surveys, so
+the order costs nothing to change; it is written down so there is one and not so it
+is fixed. [STATE.md](STATE.md) Track 5 carries the queue.
+
+**The survey below is his, stored verbatim**, for the same reason as the other two.
+
+---
+
+## The scale this adds, stated plainly
+
+This is the largest of the three by a wide margin: **five countries, 32 numbered
+sources, 933 lines.** Together the queue now reaches **eight countries** — Saudi
+Arabia twice over, the seven emirates, and these five.
+
+> **And its most useful content is where it says *no*.** Of the five countries, only
+> three have anything resembling a national public directory. Egypt and Kuwait do
+> not, and the survey says so in its own executive summary rather than leaving it to
+> be discovered.
+
+| country | its own verdict |
+|---|---|
+| **Oman** | ESNAD / Tender Board `Registered Companies` — *"the closest source found to the Saudi `muqawil.org` use case"* |
+| **Qatar** | Monaqasat classified-company profiles — a national-style public procurement directory |
+| **Bahrain** | Three separate official lists (Ministry of Works prequalified contractors, Benayat licensed engineering offices, Sijilat for registration) rather than one |
+| **Egypt** | **No complete combined directory confirmed.** EFCBC is authenticated; DRSO's consulting-office list is the best public discovery source and is Arabic-only |
+| **Kuwait** | **No complete current public list confirmed.** Registration and classification authorities exist; the public surface does not |
+
+**So this file's real instruction is "build federated datasets rather than claiming a
+single complete national directory"** — his §45 — and that is a schema requirement,
+not a crawl detail. It is why his `firms` table carries `source_system` and
+`regulatory_authority`, and why classifications, accreditations and contacts are
+separate child tables.
+
+## What this project has already learned that bears on it
+
+**1 · Two of these sources are bilingual at record level, and that is worth more
+than it sounds.** Oman's ESNAD and Qatar's Monaqasat each publish Arabic and English
+views joined by a stable identifier — PTLC/CR for Oman, the profile file number for
+Qatar. On muqawil the Arabic half costs a **second full crawl** (871 listing pages
+and 17,403 profiles again) and is matched **by page-order index, never by label**,
+because one field is spelled `رقم العضويه` with `ه`
+([LESSONS.md](LESSONS.md)). **A stable identifier joining two language views is
+strictly better than both** — half the requests of muqawil, and no index-matching
+risk at all. His §38.4 and §38.5 already require exactly that join.
+
+**2 · His §39.5 — check for an official API, CSV, Excel, JSON or open-data download
+before using browser automation — should gate every one of the 32 sources.** It is
+the cheapest question available and it can delete a crawl outright. muqawil's
+equivalent was answered late and the answer was no: the sitemap holds **20 static
+pages**, the map page carries **zero** contractor markers, and no sort parameter
+exists — three dead ends recorded in [DEC-11](BACKLOG.md) precisely so nobody spends
+those requests again.
+
+**3 · His §38.8 — "do not merge firms merely because their Arabic or English names
+look similar" — is a trap this project has already been bitten by.** The owner named
+contractor **10001274** and the warehouse said it did not exist; the answer turned
+out to be that a directory can show the same entity in ways a name-based identity
+cannot reconcile. `dataset_sighting` (#227) exists because of it, and it counts
+sightings separately from records for the same reason his §38.9 wants branches
+modelled separately.
+
+**4 · One of his rules here is stricter than ours and should be adopted.** §38.2 asks
+for `source_registration_number_raw` — the identifier **exactly as published**, kept
+beside any cleaned form. muqawil stores `card_membership_number` as published and
+that has held, but the rule is not written down anywhere as a rule. It should be,
+before eight countries' worth of identifiers arrive with slashes and leading zeros
+in them.
+
+## And his conventions here are already rulings
+
+| his rule | where it already lives |
+|---|---|
+| base column English, `_ar` for Arabic, never translate a legal name into an official field | `R-12`, and every column in [CONTRACTOR-SOURCE.md](CONTRACTOR-SOURCE.md) |
+| multi-value child tables for classifications, accreditations and contacts | `R-19` — **«جداول أبناء للخمس كلّها»** |
+| record nulls honestly; do not manufacture an English value when only Arabic is supplied | `SR-1`, and `LESSONS.md` on what a missing value means |
+
+---
+
+*Everything below this line is the owner's survey as he sent it, unedited.*
+
+---
+
+# Egypt, Oman, Qatar, Bahrain, and Kuwait Contractors and Engineering Consultants — Official Data Sources
+
+## Purpose
+
+This document identifies official or government-operated sources that can be used to build a database of contractors and engineering consultancy firms in Egypt, the Sultanate of Oman, Qatar, Bahrain, and Kuwait.
+
+It is written as a research and verification brief for another agent. The agent must recheck every live source, field, record count, access method, and reuse restriction before implementing automated collection.
+
+Review date: **20 August 2026**.
+
+## Executive Summary
+
+| Country | Best primary source | Contractors | Consultants | Public national-style directory | Record-level Arabic and English |
+|---|---|---:|---:|---:|---:|
+| Egypt | No single source; use the EFCBC for contractor authority and DRSO plus specialized official registers for consultants | Official registration authority exists, but a complete public browsable member directory was not confirmed | Several public lists exist, but coverage is fragmented | No complete combined directory confirmed | Generally Arabic only; official English record values must be verified source by source |
+| Oman | ESNAD / Tender Board `Registered Companies` | Yes | Yes | Yes, for companies registered with the government tender system | Strong: separate Arabic and English views use the same registration identifier |
+| Qatar | Ministry of Finance `Monaqasat` Classified Companies Profiles | Yes, within the government procurement classification system | Yes, through engineering-consultancy activity codes; professional licensing must be verified separately | Yes, for classified procurement companies | Strong separate Arabic and English views; the stable record join must be verified |
+| Bahrain | Ministry of Works prequalified contractors, Benayat licensed engineering offices, and Sijilat commercial-register verification | Yes, for Ministry of Works prequalified contractors | Yes, through the public licensed-engineering-offices list | Separate public directories rather than one combined list | Directory records are commonly English; official Arabic and English legal names can be sought in Sijilat |
+| Kuwait | CAPT/Kuwait Government Online, Kuwait Municipality, and Ministry of Public Works | Registration and classification authorities exist; a complete current public list was not confirmed | Registration and qualification workflows exist; a complete public office directory was not confirmed | No complete combined directory confirmed | Arabic is dominant; CAPT collects both names in some workflows, but public record-level pairing remains unconfirmed |
+
+The Oman ESNAD register is the closest source found to the Saudi `muqawil.org` use case. It is broader than construction because it also includes suppliers, services, IT, vehicle contractors, and other business types. A construction database must filter the registered category, subcategory, and activity instead of importing every record as a contractor or engineering consultant.
+
+Qatar's Monaqasat portal is also a strong national-style public procurement directory, but it is broader than construction and must be filtered by activity and classification. Bahrain provides unusually useful separate official lists for Ministry of Works contractors and licensed engineering offices, with Sijilat supporting commercial-registration verification.
+
+Egypt and Kuwait do not currently expose equally complete combined public directories. Their authoritative data is distributed across registration, qualification, professional-licensing, and sector-specific sources.
+
+---
+
+# Part I — Egypt
+
+## 1. Egyptian Federation for Construction and Building Contractors
+
+- Authority: Egyptian Federation for Construction and Building Contractors, commonly abbreviated EFCBC
+- Official portal: https://egypt-efcbc.org/
+- Related government explanation of the legal/registration framework: https://www.investinegypt.gov.eg/PublishingImages/Lists/ContentPageDetails/AllItems/Construction%2C%20Building%20and%20Contracting%20Activities.pdf
+- Coverage: Contractor registration and classification
+- Public access observed: The current portal is principally an authenticated/member portal
+- Database suitability: **Authoritative for verification, but poor for public bulk discovery unless a public directory, export, or authorized data-access route is confirmed**
+
+### Finding
+
+No complete, structured, publicly browsable list of all EFCBC members was confirmed during this review. The previous `tasheed.org` site was not reliably accessible during earlier checks and must not be treated as a current source without fresh verification.
+
+### Candidate fields to verify from an official membership record or certificate
+
+```text
+membership_number
+commercial_registration_number
+firm_name_ar
+contractor_classification
+contractor_classification_ar
+contractor_grade
+specialization
+specialization_ar
+registration_status
+registration_status_ar
+registration_issue_date
+registration_expiry_date
+```
+
+Do not populate these fields from assumptions or secondary directories. Confirm the exact field labels and definitions from an official EFCBC record, certificate, API, export, or authorized response.
+
+## 2. Ministry of Housing — Construction Research and Studies Fund/Agency
+
+- Official consulting-offices directory: https://drso.gov.eg/offices
+- Authority: Construction Research and Studies Fund/Agency under the Ministry of Housing, Utilities and Urban Communities
+- Coverage: Consulting offices shown by the Ministry of Housing source
+- Access type: Public searchable/list page
+- Database suitability: **Best initial public discovery source found for general engineering consulting offices in Egypt**
+
+### Fields observed
+
+```text
+firm_name_ar
+responsible_engineer_name_ar
+affiliation_ar
+address_ar
+source_detail_url
+```
+
+The page displayed office names, responsible engineers or persons, an affiliation such as the Engineers Syndicate, and addresses. The search control observed was based on address and list selection.
+
+### Limitations
+
+- The page is Arabic.
+- An official English legal name was not observed for each record.
+- The public page does not clearly state that it is the complete current register of every licensed consultancy office in Egypt.
+- The agent must confirm pagination, total records, detail-page fields, update date, and inclusion criteria.
+
+## 3. Egyptian Engineers Syndicate
+
+- Official website: https://eea.org.eg/
+- Consulting-engineers directory announcement: https://eea.org.eg/NewsDetails.aspx?ID=18629
+- Older announcement with more context: https://new.eea.org.eg/Content/%D9%8A%D8%AA%D9%88%D9%81%D8%B1-%D8%A7%D9%84%D8%A2%D9%86-%D8%A8%D9%85%D9%82%D8%B1-%D8%A7%D9%84%D9%86%D9%82%D8%A7%D8%A8%D8%A9-%D8%A7%D9%84%D8%B9%D8%A7%D9%85%D8%A9-%D9%84%D9%84%D9%85%D9%87%D9%86%D8%AF%D8%B3%D9%8A%D9%86?CID=6741&CtID=3&Dir=2&PN=0&PS=0&TId=1027
+- Coverage: Professional rules and licensing context for engineers, consulting engineers, consulting offices, multidisciplinary offices, and houses of expertise
+- Database suitability: **Regulatory and verification source; no current complete structured public office register was confirmed**
+
+The Syndicate has announced a directory of consulting engineers, but the available announcement is not itself a structured, current public database of engineering firms. Distinguish individual consulting engineers from licensed consulting offices and houses of expertise.
+
+## 4. Egyptian Environmental Affairs Agency — Accredited Practitioners
+
+- Official search: https://www.eeaa.gov.eg/Accreditations/index
+- Authority: Egyptian Environmental Affairs Agency
+- Coverage: Accredited environmental consultancy offices, consultants, and specialists
+- Access type: Public search and detail pages
+- Database suitability: **Very good for environmental consulting only**
+
+### Search fields observed
+
+```text
+accreditation_type
+registration_year
+field
+search_keywords
+```
+
+The search guidance states that keywords may search the name, the responsible manager for consulting offices, or the specialization for consultants and specialists. Clicking a name opens additional information.
+
+### Language status
+
+The reviewed interface and record-search guidance were Arabic. An English language selector exists, but official record-level English values were not confirmed. Store the source values in `_ar` fields and leave the base English fields `NULL` until verified.
+
+### Scope limitation
+
+This is a specialized environmental accreditation register, not a list of every engineering consultancy in Egypt.
+
+## 5. Industrial Development Authority — Accreditation Offices
+
+- Official list: https://www.ida.gov.eg/ar/accreditation-offices
+- Authority: Industrial Development Authority
+- Coverage: Engineering consulting offices and houses of expertise accredited to review technical matters and industrial licensing documents
+- Access type: Public structured list
+- Database suitability: **Excellent for the industrial-licensing consultancy subset**
+
+### Fields observed
+
+```text
+firm_name_ar
+address_ar
+contact_person_name_ar
+phone_number
+email_address
+```
+
+The page stated that **9 accreditation offices** were listed at the time of review. Treat this count as time-sensitive and recheck it before use.
+
+### Scope limitation
+
+These are offices accredited for the Industrial Development Authority workflow. The list is not a national register of all engineering consultants.
+
+## 6. Egyptian Survey Authority — Approved Companies and Engineering Offices
+
+- Official list: https://www.esa.gov.eg/certified_comp.aspx
+- Authority: Egyptian Survey Authority
+- Coverage: Companies and engineering offices approved to provide surveying services
+- Access type: Public list with detail links
+- Database suitability: **Good for surveying firms and offices**
+
+### Fields observed or to be verified on details
+
+```text
+firm_name_ar
+firm_type_ar
+surveying_accreditation_status
+surveying_accreditation_status_ar
+source_detail_url
+```
+
+The list includes both companies and engineering offices. It is specialized and should be modelled as an accreditation attached to a firm, not as proof that the firm represents every type of consultant or contractor.
+
+## 7. Government Procurement Portal and General Authority for Government Services
+
+- Government procurement portal: https://www.etenders.gov.eg/
+- General Authority for Government Services procurement role: https://www.gags.gov.eg/Home/Purchasesindex
+- Coverage: Registration of suppliers, contractors, consulting offices, and houses of expertise for government procurement
+- Database suitability: **Potential verification and procurement-participation source; no complete public directory was confirmed**
+
+The General Authority page states that it reviews registration applications from suppliers, contractors, consulting offices, and houses of expertise for the government contracting portal. The portal should not be assumed to be a complete public business directory unless an accessible register or authorized data export is identified.
+
+## 8. Egypt Source Priority
+
+1. Use EFCBC data or certificates as the authoritative contractor classification source when access is lawful and verifiable.
+2. Use the Ministry of Housing DRSO consulting-offices page for initial general consultant discovery.
+3. Add Industrial Development Authority accreditation as a specialized industrial credential.
+4. Add Egyptian Environmental Affairs Agency accreditation as a specialized environmental credential.
+5. Add Egyptian Survey Authority approval as a specialized surveying credential.
+6. Use the Engineers Syndicate and government procurement systems to verify professional or procurement status, not as complete directories unless further public data is confirmed.
+
+## 9. Egypt Language Assessment
+
+| Source | Arabic interface/data | English interface/data | Recommended handling |
+|---|---:|---:|---|
+| EFCBC portal | Yes | Not confirmed at record level | Verify membership/certificate values; do not invent English names |
+| DRSO consulting offices | Yes | No record-level English values confirmed | Populate `_ar`; keep English base fields `NULL` |
+| Engineers Syndicate | Yes | English branding exists, but a bilingual office register was not confirmed | Use only verified source values |
+| Environmental Affairs accreditation | Yes | English selector exists; bilingual records not confirmed | Populate `_ar` until individual English values are verified |
+| Industrial Development Authority accreditation offices | Yes | Page includes some English labels, but firm records are Arabic | Populate `_ar`; emails and phones remain language-neutral |
+| Egyptian Survey Authority approved firms | Yes | No record-level English values confirmed | Populate `_ar`; keep English base fields `NULL` |
+
+---
+
+# Part II — Sultanate of Oman
+
+## 10. ESNAD / Tender Board — Registered Companies
+
+- Authority: Projects, Tenders and Local Content Authority, using the Oman Tender Board eTendering/ESNAD system
+- English public directory: https://etendering.tenderboard.gov.om/product/ReportAction?CTRL_STRDIRECTION=LTR&PublicUrl=1&eventFlag=RegVendorPublic
+- Arabic public directory: https://etendering.tenderboard.gov.om/product/ReportAction?CTRL_STRDIRECTION=RTL&PublicUrl=1&eventFlag=RegVendorPublic
+- Coverage: Registered local, SME, international, and other company types across contracting, consulting, supplies, services, IT, and other categories
+- Access type: Public searchable and paginated directory
+- Database suitability: **Excellent and the primary Oman source**
+
+### Public filters observed
+
+```text
+category
+subcategory
+subcategory_grade
+company_name
+company_type
+ptlc_or_cr_number
+```
+
+### List fields observed
+
+```text
+sequence_number
+firm_name
+firm_name_ar
+ptlc_or_cr_number_raw
+address
+address_ar
+telephone_number
+fax_number
+registered_category
+registered_category_ar
+registration_expiry_date
+company_type
+company_type_ar
+source_detail_url
+```
+
+### Important bilingual finding
+
+The English and Arabic views display corresponding records with the same `PTLC / CR Number`. The English view supplies English firm names, categories, and company types, while the Arabic view supplies the Arabic equivalents.
+
+Match the two language versions using `ptlc_or_cr_number_raw` and other stable identifiers. Never join by row position or company name alone.
+
+Some addresses in the English view may remain Arabic or may be blank. Store an address in `address_ar` when its source value is Arabic, even if it was retrieved from the English interface. Leave `address` as `NULL` unless an official English address is present.
+
+### Coverage warning
+
+The register is broader than contractors and engineering consultants. The category `Consulting Offices` also includes non-engineering professions such as legal consulting. To produce a construction and engineering dataset:
+
+1. Filter contractor categories relevant to construction, maintenance, ports, roads, bridges, railways, dams, pipelines, wells, electromechanical work, and telecommunications.
+2. Filter `Consulting Offices` by subcategory and activity.
+3. Retain the exact category, subcategory, activity code, activity description, grade, and expiry date.
+4. Do not label every `Consulting Offices` record as an engineering consultant without validating its activity.
+
+### Multi-value modelling warning
+
+A firm can have several registered categories, with a different expiry date for each category. Do not store all categories in one comma-separated field. Use a child table such as `firm_registrations` or `firm_classifications`.
+
+## 11. Oman Registration and Classification Regulation
+
+- Official regulation PDF: https://www.ptlc.gov.om/en/Document/Guidline/%D8%AF%D9%84%D9%8A%D9%84%20%D8%AA%D8%B3%D8%AC%D9%8A%D9%84%20%D8%A7%D9%84%D8%B4%D8%B1%D9%83%D8%A7%D8%AA.pdf
+- Official tender-regulations page: https://www.ptlc.gov.om/ar/Pages/Tender-Regulations.aspx
+- Purpose: Defines classification and registration of suppliers, contractors, and consultancy offices in the central register
+- Database suitability: **Authoritative reference for the meaning and scope of registration**
+
+The regulation states that the classification and registration certificate enables the holder to compete for government project and procurement tenders. It applies to licensed entities in Oman, subject to the regulation's stated exceptions and treatment of foreign entities.
+
+Use this source to interpret the ESNAD register. Do not use it as a company list.
+
+## 12. Oman Category, Subcategory, and Activity Taxonomy
+
+- Official ESNAD classification PDF: https://etendering.tenderboard.gov.om/product/showTenderDocument?CTRL_STRDIRECTION=RTL&encparam=flag%2CfileName%2CviewPath%2CpublicUrl%2CCTRL_STRDIRECTION%2Crandomno&fileName=Categories_SubCategories_Activities_Classification_Updated_07092021.pdf&flag=viewgeneraldoc&hashval=ef6893018b14bee332d321b78a218998c2aac2ea8aec2133475936d709a0f3fe&publicUrl=1&viewPath=%2FLive%2FGeneralDocFiles
+- Coverage: Bilingual category, subcategory, and Ministry of Commerce activity descriptions and codes
+- Database suitability: **Excellent reference data, but the published file is dated 7 September 2021 and must be checked against the live taxonomy**
+
+### Fields available in the taxonomy
+
+```text
+category
+category_ar
+subcategory_number
+subcategory
+subcategory_ar
+activity_code
+activity
+activity_ar
+```
+
+The document confirms that `Consulting Offices` contains multiple types of consultancy, including engineering, IT, legal, and other fields. Use activity-level filtering to select engineering consultancies.
+
+## 13. Oman Business Platform — Commercial Registration Verification
+
+- Official platform: https://www.business.gov.om/
+- Ministry service directory: https://tejarah.gov.om/service-directory
+- Official government confirmation that commercial-register search is a platform service: https://omannews.gov.om/topics/en/80/show/117212
+- Authority: Ministry of Commerce, Industry and Investment Promotion
+- Coverage: Commercial registrations and business licensing
+- Database suitability: **Strong verification/enrichment source; not recommended as the primary bulk-discovery source**
+
+The service supports searching commercial registrations and is useful for confirming a company's legal registration. The live workflow may require CAPTCHA and interactive navigation.
+
+The agent must verify the current public output fields. Candidate fields that may be available include:
+
+```text
+commercial_registration_number
+firm_name
+firm_name_ar
+legal_form
+legal_form_ar
+commercial_registration_status
+commercial_registration_status_ar
+commercial_registration_expiry_date
+registered_activities
+registered_activities_ar
+```
+
+Do not bypass CAPTCHA or access controls. Prefer an official API, export, open-data source, or approved data-sharing route if systematic collection is required.
+
+## 14. Madayn eMassar — Providers Directory
+
+- Official public directory: https://ems.peie.om/newDir/ProvidersDir.aspx
+- Authority: Madayn / Public Establishment for Industrial Estates
+- Coverage: Providers registered in the eMassar ecosystem, including contractors, consultants, suppliers, and environmental consultancy companies
+- Access type: Public searchable directory
+- Database suitability: **Very good supplemental source for bilingual names, provider type, city, website, and phone**
+
+### Filters observed
+
+```text
+provider_type
+provider_name
+```
+
+### Fields observed
+
+```text
+provider_type
+provider_type_ar
+firm_name
+firm_name_ar
+website_url
+city
+city_ar
+phone_number
+```
+
+### Strengths
+
+- Arabic and English company names are displayed in paired columns.
+- Arabic and English city names are displayed in paired columns.
+- Provider type distinguishes contractors, consultants, suppliers, and environmental consultancy companies.
+
+### Limitations
+
+- This is a provider directory associated with Madayn/eMassar, not the national legal register of every Omani firm.
+- Duplicate names and multiple branches or city records may occur.
+- Data quality varies; websites, emails, spellings, or phone numbers may be inconsistent.
+- Use the ESNAD registration number or commercial registration number for identity resolution whenever available; do not deduplicate only by name.
+
+## 15. Sources Not Confirmed as Complete Public Directories in Oman
+
+### Oman Chamber of Commerce and Industry
+
+- E-services login: https://eservices.chamberoman.om/login
+
+A current complete public trade directory for contractors and consultants was not confirmed during this review. Do not treat old electoral-register PDFs or login-only member services as the primary live directory.
+
+### Ministry of Housing and Urban Planning
+
+- Official website: https://mohup.gov.om/
+
+The Ministry publishes regulatory, project, building-code, and engineering-sector material, but no complete public national list of all engineering consultancy offices was confirmed. Use it for policy and sector context unless a live approved-office register is subsequently found.
+
+## 16. Oman Source Priority
+
+1. ESNAD `Registered Companies` for primary discovery, classification, registration expiry, and bilingual names.
+2. ESNAD category/subcategory/activity taxonomy for normalization and engineering-only filtering.
+3. Oman Business Platform for commercial-registration verification and legal-status enrichment.
+4. Madayn eMassar Providers Directory for bilingual city, provider type, website, and phone enrichment.
+5. Sector regulators or utility/vendor lists only as additional accreditations, never as replacements for the central source.
+
+## 17. Oman Language Assessment
+
+| Source | Arabic data | English data | Record matching | Recommended handling |
+|---|---:|---:|---|---|
+| ESNAD Registered Companies | Yes | Yes | Use `PTLC / CR Number` | Populate both base English and `_ar` fields when the value is genuinely present in each interface |
+| ESNAD taxonomy PDF | Yes | Yes | Use category/subcategory/activity codes | Store official bilingual labels and stable codes |
+| Oman Business Platform | Search supports Arabic/English business names; live output must be rechecked | Search supports Arabic/English business names; live output must be rechecked | Use CR number | Use only values observed in the official result; never translate a legal name automatically |
+| Madayn eMassar Providers | Yes | Yes | No stable company ID was observed in the list; use additional identifiers | Store paired official names/cities; resolve duplicates carefully |
+
+---
+
+# Part III — Qatar
+
+## 18. Ministry of Finance Monaqasat — Classified Companies Profiles
+
+- Authority: Qatar Ministry of Finance, Government Procurement Regulation Department
+- Official portal: https://monaqasat.mof.gov.qa/
+- Public classified-companies directory: https://monaqasat.mof.gov.qa/ClassifiedCompaniesProfilesList/1
+- Contractor-classification service: https://monaqasat.mof.gov.qa/OnlineServices/ContractorClassification
+- Coverage: Companies classified or registered for government procurement, including contractors, suppliers, service providers, and consultancy activities
+- Access type: Public searchable and paginated directory
+- Database suitability: **Excellent primary discovery source, provided that construction and engineering records are selected at activity level**
+
+### Search and list fields observed
+
+```text
+company_profile_file_number
+company_type
+company_type_ar
+firm_name
+firm_name_ar
+commercial_registration_number
+trade_license_number
+legal_form
+legal_form_ar
+official_email_address
+company_size
+company_size_ar
+government_entity_rating
+activity_sector
+activity_sector_ar
+source_detail_url
+```
+
+The live search also exposed filters for company type, file number, company name, commercial registration number, trade-license number, legal form, company attribute, official email, activity sector, profile activity, company size, and activity classification grade. The verifying agent must capture the exact current labels and distinguish search-only fields from values returned in list or detail records.
+
+### Classification fields
+
+Contractor-classification records may expose:
+
+```text
+specialization
+specialization_ar
+classification_grade
+classification_grade_ar
+classification_expiry_date
+```
+
+Supplier and service-provider activities may expose:
+
+```text
+activity_code
+activity
+activity_ar
+classification_grade
+classification_grade_ar
+classification_expiry_date
+```
+
+Engineering-related activities observed during review included code `711010` for engineering and architectural consultancy offices, `71103` for civil-engineering offices, `711032` for several specialist engineering-office activities, and `711050` for surveying and quantity-services offices. These codes and their exact current labels must be rechecked in the live system before collection.
+
+### Bilingual handling
+
+The portal has separate Arabic and English views containing localized company and activity values. Match language versions using `company_profile_file_number` together with the commercial registration number. Do not match by page position or name alone, and verify that the record identifier remains stable across both interfaces.
+
+Monaqasat classification indicates procurement classification or registration. It must not automatically be treated as proof that an engineering office holds every professional or municipal licence required to practise.
+
+## 19. Ministry of Municipality — Engineering Offices Regulatory Framework
+
+- Official English classification/regulatory document: https://www.mm.gov.qa/static/cat_doc/pdf/eng_E_2-ver5-en.pdf
+- Official Arabic requirements and fees document: https://www.mm.gov.qa/static/cat_doc/pdf/fees.pdf
+- Official Arabic engineering-profession regulation: https://www.mme.gov.qa/static/cat_doc/pdf/org_eng_rule.pdf
+- Authority: Engineers and Engineering Consultancy Offices Accrediting and Classifying Committee, Ministry of Municipality
+- Coverage: Engineering disciplines, local office categories, foreign offices, classification conditions, required staffing, business volume, and registration rules
+- Database suitability: **Authoritative regulatory and taxonomy reference, not a confirmed complete public firm directory**
+
+Use these sources to interpret professional categories and licensing requirements and to design reference tables. No current complete public searchable list of every licensed engineering consultancy office was confirmed during this review.
+
+## 20. Qatar Source Priority
+
+1. Monaqasat Classified Companies Profiles for primary discovery, procurement classification, activities, grades, and expiry dates.
+2. Monaqasat activity codes for construction and engineering-only filtering.
+3. Ministry of Municipality engineering-office rules for professional classification and licensing interpretation.
+4. A Ministry of Municipality licence record, official API/export, or authorized data response for final professional-practice verification if available.
+
+## 21. Qatar Language Assessment
+
+| Source | Arabic data | English data | Recommended handling |
+|---|---:|---:|---|
+| Monaqasat Classified Companies | Yes | Yes | Join the language views by stable file/CR identifiers and store only official values |
+| Monaqasat activities and classifications | Yes | Yes | Store activity codes once and official labels in base and `_ar` fields |
+| Municipality engineering-office documents | Yes | Yes, in a separate official document | Use for regulatory taxonomy; do not infer that a bilingual rule creates bilingual company records |
+
+## 22. Qatar Coverage Conclusion
+
+Qatar has a strong public national-style procurement directory that can identify many contractors and engineering consultancy activities. The resulting database must explicitly distinguish procurement classification from professional engineering-office licensing. A claim that the dataset contains every licensed engineering office requires a separate completeness check with the Ministry of Municipality.
+
+---
+
+# Part IV — Bahrain
+
+## 23. Ministry of Works — Contractor Prequalification
+
+- Official service page: https://www.works.gov.bh/English/Services/cost/pages/cedapps2/Default.aspx
+- Public category-list example: https://www.works.gov.bh/English/Services/cost/Pages/CedApps2/Listing2.aspx?catId=3&glId=100
+- Public report-download example: https://www.works.gov.bh/English/Services/cost/Pages/CedApps2/DownloadReport.aspx?catId=1&glId=0
+- Coverage: Contractors currently prequalified by the Bahrain Ministry of Works, grouped by work category and grade
+- Access type: Public list and downloadable report views
+- Database suitability: **Excellent authoritative source for Ministry of Works prequalification; not a list of every contractor holding a commercial registration**
+
+### Fields observed
+
+```text
+firm_name
+commercial_registration_number
+po_box
+telephone_number
+fax_number
+email_address
+contractor_category
+contractor_category_ar
+contractor_grade
+contractor_grade_ar
+monetary_limit_or_capacity
+prequalification_expiry_date
+comments
+source_list_url
+```
+
+The records observed were largely English. An Arabic interface or Arabic page label does not prove that Arabic firm names are available. Keep `firm_name_ar` and other `_ar` values `NULL` unless the official record actually provides them.
+
+## 24. Benayat — Licensed Engineering Offices
+
+- English public directory: https://www.benayat.bh/building-permits/public/engineering-office?lang=en
+- Arabic public directory: https://www.benayat.bh/building-permits/public/engineering-office?lang=ar
+- About/licensing context: https://www.benayat.bh/building-permits/public/about?lang=ar
+- Supplemental official planning directory, English: https://www.planning.bh/liscensed-engineering-office.html
+- Supplemental official planning directory, Arabic: https://planning.bh/ar/liscensed-engineering-office.html
+- Coverage: Engineering offices licensed for Bahrain building-permit preparation
+- Licensing authority referenced by the service: Council for Regulating the Practice of Engineering Professions, or CRPEP
+- Database suitability: **Excellent primary public source for licensed building-permit engineering offices**
+
+### List and detail fields observed
+
+```text
+office_license_number
+office_category
+office_category_ar
+firm_name
+firm_name_ar
+engineering_disciplines
+engineering_disciplines_ar
+responsible_manager_name
+responsible_manager_name_ar
+commercial_registration_number
+address
+address_ar
+telephone_number
+fax_number
+email_address
+source_detail_url
+```
+
+The Arabic interface localizes interface labels, but the office names, disciplines, addresses, and manager names observed were commonly still English. Therefore, interface language must not be used as evidence of record-value language. Use CR number and office licence number for matching and deduplication.
+
+## 25. Sijilat — Commercial Registration Verification and Bilingual Enrichment
+
+- Public advanced search: https://www.sijilat.bh/public-search-cr/search-cr-2.aspx?advancedSearch=true
+- Ministry of Industry and Commerce service overview: https://www.moic.gov.bh/en/node/2724
+- Coverage: Bahrain commercial registrations and business activities
+- Database suitability: **Strong legal verification and official Arabic/English name-enrichment source**
+
+Search fields observed include CR number, English commercial name, Arabic commercial name, company type, status, CR type, registration dates, nationality, sector and business activities, partner names in English and Arabic, partner identifiers, address, and municipality.
+
+Use `commercial_registration_number` to link Ministry of Works or Benayat records to Sijilat. Retain source provenance so an official legal name from Sijilat is not misrepresented as a name published by the specialist directory.
+
+## 26. Bahrain Supporting and Specialized Sources
+
+- CRPEP official website: https://www.crpep.bh/
+- CRPEP executive regulation: https://www.crpep.bh/Executive_Regulation_Final_Version.pdf
+- Survey and Land Registration Bureau private survey companies: https://www.slrb.gov.bh/en/private-survey-companies
+- Bahrain Tender Board eTendering portal: https://etendering.tenderboard.gov.bh/
+
+CRPEP is the professional licensing authority, but its account portal was not confirmed as a better public bulk-discovery source than Benayat or the planning directory. The SLRB page is a useful specialist list for authorized private surveying companies and must be modelled as a separate accreditation. The Tender Board provides procurement-registration context, but a stable detailed public supplier list suitable for collection was not confirmed during this review.
+
+## 27. Bahrain Source Priority and Language Assessment
+
+1. Ministry of Works lists/reports for prequalified contractors.
+2. Benayat, cross-checked with the official planning directory, for licensed engineering offices.
+3. Sijilat for legal status, CR identity, activities, and official Arabic/English commercial names.
+4. CRPEP for professional-regulatory interpretation.
+5. SLRB and other sector lists as separate accreditations.
+
+| Source | Arabic record values | English record values | Recommended handling |
+|---|---:|---:|---|
+| Ministry of Works contractors | Not consistently observed | Yes | Populate English base fields; use `NULL` for unobserved Arabic values |
+| Benayat/planning engineering offices | Interface is Arabic-capable, but Arabic entity values were not consistently observed | Yes | Do not copy English values into `_ar` fields |
+| Sijilat commercial registry | Yes | Yes | Use CR number to obtain and preserve the two official commercial names |
+| SLRB survey companies | Not consistently observed | Yes | Treat as a specialist accreditation and preserve published values only |
+
+---
+
+# Part V — Kuwait
+
+## 28. Central Agency for Public Tenders and Company Qualification
+
+- CAPT Arabic portal: https://capt.gov.kw/ar/
+- CAPT English portal: https://capt.gov.kw/en/
+- Kuwait Government Online company-qualification service, English: https://e.gov.kw/sites/kgoenglish/Pages/eServices/CTC/RehabilatedTenderMain.aspx
+- Kuwait Government Online company-qualification service, Arabic: https://e.gov.kw/sites/kgoarabic/Pages/eServices/CTC/RehabilatedTenderMain.aspx
+- Official Public Tenders Law in English: https://capt.gov.kw/media/filer_public/ed/e8/ede8d640-d366-475a-8806-b3ea6dad59c8/law_no__________of_2016.pdf
+- Coverage: Registration and classification of contractors, suppliers, service providers, and consultancy-service providers for public procurement
+- Database suitability: **Authoritative, but public record-level directory access and exportability require live verification**
+
+The law provides for registers of suppliers, contractors, and service providers and for contractor classification. The current CAPT navigation includes contractor/supplier/service-provider registration and consultancy-service-provider registration. The Kuwait Government Online service states that users can access company-qualification information. However, this review did not confirm a complete, current, easily browsable public list of all classified contractors or registered consultancy providers.
+
+Candidate fields indicated by official registration workflows include:
+
+```text
+firm_name
+firm_name_ar
+commercial_registration_number
+address
+address_ar
+branch_details
+branch_details_ar
+telephone_number
+mobile_number
+fax_number
+official_email_address
+license_type
+license_type_ar
+license_expiry_date
+authorized_signatory_name
+authorized_signatory_name_ar
+owners
+owners_ar
+```
+
+These are candidate schema fields, not confirmation that every value is publicly returned. The agent must record which fields are actually visible without authentication and must not automate around access controls.
+
+## 29. Kuwait Municipality — Contractor and Engineering Office Systems
+
+- Contractor System, English: https://www.e.gov.kw/sites/kgoenglish/Pages/eServices/KM/ContractorsSystem.aspx
+- Contractor System, Arabic: https://e.gov.kw/sites/kgoarabic/Pages/eServices/KM/ContractorsSystem.aspx
+- Engineering Offices System, Arabic: https://e.gov.kw/sites/kgoarabic/Pages/eServices/KM/EngineerSystem.aspx
+- Coverage: Contractor registration, renewal, data updates, category changes, cancellation and related municipal workflows; engineering-office access to planning and building-permit services
+- Database suitability: **Authoritative workflow/status-verification source, but not a confirmed public directory**
+
+Do not treat a registration, login, renewal, or permit-service page as a company list. The agent must determine whether the systems expose a public inquiry, approved-office list, API, or official downloadable register.
+
+## 30. Ministry of Public Works — Contractor and Consultant Qualification
+
+- Companies and Contractors page: https://www.mpw.gov.kw/sites/ar/Pages/CompaniesAndContractors/CompaniesAndContractors.aspx
+- Kuwait Government Online consultancy-office service, English: https://www.e.gov.kw/sites/kgoenglish/Pages/eServices/MPW/RegistrationUpdateDataFromOfficeConsultant.aspx
+- Kuwait Government Online consultancy-office service, Arabic: https://e.gov.kw/sites/kgoArabic/Pages/Services/MPW/UpdateOfficeHouseDataConsultant.aspx
+- Coverage: Contractor and consultant qualification, supplier registration, and registration/update of engineering offices and consulting houses
+- Database suitability: **Authoritative for qualification workflows, but no complete public firm list was confirmed**
+
+The official service information indicates that engineering offices and consulting houses must maintain registration and meet relevant licensing or committee requirements. Model municipal professional licensing, Ministry of Public Works qualification, Ministry of Finance committee registration, and CAPT procurement classification as separate registrations unless an official rule proves they are the same status.
+
+## 31. Kuwait Specialized and Supporting Sources
+
+- Public Authority for Housing Welfare contractor requirements: https://www.pahw.gov.kw/Contractors_en
+- Public Authority for Industry registered consultant directory, English: https://www.pai.gov.kw/en/web/guest/registered-consultant-directory
+- Public Authority for Industry registered consultant directory, Arabic: https://www.pai.gov.kw/web/guest/registered-consultant-directory
+- Kuwait Direct Investment Promotion Authority listed consulting companies and offices: https://kdipa.gov.kw/investors-service-center/listed-companies-offices/
+- Ministry of Commerce and Industry e-services: https://moci.gov.kw/en/e-service/
+- Commercial Registry management, English: https://e.gov.kw/sites/kgoenglish/Pages/eServices/MOCI/CommercialRegistryManagement.aspx
+- Commercial Registry management, Arabic: https://e.gov.kw/sites/kgoarabic/Pages/eServices/MOCI/CommercialRegistryManagement.aspx
+
+PAHW publishes qualification requirements rather than a confirmed complete contractor list. PAI's directory is specialized for its own consultant purpose and showed no registered consulting offices at the review time. KDIPA lists firms accredited for investor-service applications and is not a general engineering-consultant directory. Ministry of Commerce sources are useful for legal-registration verification if a public inquiry or authorized extract is available, but no Bahrain-Sijilat-style complete public search was confirmed.
+
+## 32. Kuwait Source Priority, Language, and Coverage Conclusion
+
+1. Test the CAPT/Kuwait Government Online company-qualification service for lawful public discovery and stable identifiers.
+2. Use CAPT classification as a procurement status, not as a substitute for municipal or professional licensing.
+3. Use Kuwait Municipality and Ministry of Public Works sources to verify their distinct registration and qualification statuses.
+4. Use PAI, KDIPA, PAHW, utility, or other agency lists only as specialized accreditations with explicit coverage.
+5. Seek an official API, export, open-data dataset, or data-sharing agreement if a complete national database is required.
+
+| Source | Arabic data | English data | Recommended handling |
+|---|---:|---:|---|
+| CAPT and KGO | Strong Arabic support | English interface and some bilingual registration fields exist | Verify actual public record values; do not assume a form field is publicly downloadable |
+| Kuwait Municipality | Strong Arabic support | Some English service descriptions | Treat workflow language separately from record language |
+| Ministry of Public Works | Strong Arabic support | English service information exists | Keep statuses separate and populate only observed official values |
+| PAI/KDIPA specialized lists | Source-dependent | Source-dependent | Do not generalize specialized coverage to the whole market |
+
+No complete combined public directory of every Kuwait contractor and engineering consultancy office was confirmed. A defensible Kuwait dataset will probably require federation of multiple official sources or authorized data access, with provenance and coverage recorded for every row.
+
+---
+
+# Part VI — Recommended Database Design
+
+## 33. Bilingual Naming Rule
+
+Use lowercase English `snake_case` column names.
+
+- Base field: official English content, for example `firm_name`.
+- Arabic field: the same column name plus `_ar`, for example `firm_name_ar`.
+- If the official source provides only Arabic, store it in the `_ar` field and leave the English base field `NULL`.
+- Do not automatically translate or transliterate a legal company name and present it as official.
+- If machine translation is required for search, store it in a clearly separate field such as `firm_name_en_machine`, not `firm_name`.
+- Language-neutral values such as IDs, dates, phone numbers, email addresses, URLs, coordinates, and Boolean values must be stored only once.
+
+## 34. Recommended `firms` Table
+
+```text
+firm_id
+country_code
+
+firm_name
+firm_name_ar
+trade_name
+trade_name_ar
+firm_type
+firm_type_ar
+legal_form
+legal_form_ar
+company_type
+company_type_ar
+
+commercial_registration_number
+regulatory_registration_number
+membership_number
+company_profile_file_number
+trade_license_number
+office_license_number
+profession_license_number
+source_registration_number_raw
+
+commercial_registration_status
+commercial_registration_status_ar
+commercial_registration_issue_date
+commercial_registration_expiry_date
+
+address
+address_ar
+governorate
+governorate_ar
+city
+city_ar
+postal_code
+
+telephone_number
+mobile_number
+fax_number
+email_address
+website_url
+government_entity_rating
+government_entity_rating_ar
+
+source_system
+source_list_url
+source_detail_url
+first_collected_at
+last_collected_at
+last_verified_at
+```
+
+## 35. Recommended `firm_classifications` Table
+
+Use a child table because one firm can have many classifications, activities, grades, and expiry dates.
+
+```text
+firm_classification_id
+firm_id
+regulatory_authority
+regulatory_authority_ar
+
+category_code
+category
+category_ar
+subcategory_code
+subcategory
+subcategory_ar
+activity_code
+activity
+activity_ar
+
+classification_grade
+classification_grade_ar
+classification_status
+classification_status_ar
+classification_issue_date
+classification_expiry_date
+
+source_record_id
+source_url
+last_verified_at
+```
+
+## 36. Recommended `firm_accreditations` Table
+
+Use this for specialist approvals such as Egyptian environmental, industrial, or surveying accreditation.
+
+```text
+firm_accreditation_id
+firm_id
+accrediting_authority
+accrediting_authority_ar
+accreditation_type
+accreditation_type_ar
+accreditation_number
+accreditation_status
+accreditation_status_ar
+accreditation_field
+accreditation_field_ar
+issue_date
+expiry_date
+source_url
+last_verified_at
+```
+
+## 37. Recommended `firm_contacts` Table
+
+```text
+firm_contact_id
+firm_id
+contact_type
+contact_type_ar
+contact_name
+contact_name_ar
+job_title
+job_title_ar
+telephone_number
+mobile_number
+email_address
+is_primary
+source_url
+last_verified_at
+```
+
+## 38. Identity and Deduplication Rules
+
+1. Prefer national commercial registration numbers and regulator registration numbers over names.
+2. Preserve the source identifier exactly as published in `source_registration_number_raw`.
+3. Do not split a combined identifier such as Oman's `PTLC / CR Number` until its format has been validated for local, international, SME, and vehicle-contractor records.
+4. Match Oman's English and Arabic ESNAD views using the stable registration identifier.
+5. Match Qatar's Monaqasat language views by the company-profile file number and confirm with the commercial registration number.
+6. Use Bahrain's commercial registration number and professional office licence number to connect specialist directories with Sijilat.
+7. Keep Kuwait CAPT classification, municipal contractor or office registration, Ministry of Public Works qualification, and specialist accreditation as distinct source statuses.
+8. Do not merge firms merely because their Arabic or English names look similar.
+9. Model branches separately when the same legal firm appears in multiple cities or with multiple contacts.
+10. Store source values unchanged and put cleaned values in separate normalized columns where necessary.
+
+---
+
+# Part VII — Agent Verification Checklist
+
+## 39. Required Checks Before Collection
+
+The verifying agent must:
+
+1. Open every source listed above and record whether it is live on the verification date.
+2. Confirm which organization owns and operates the source.
+3. Confirm whether the source is a legal register, professional register, tender register, approved-provider list, accreditation list, or marketing/member directory.
+4. Record the exact filters, fields, page size, page count, total records, detail fields, and update date.
+5. Check for official API, CSV, Excel, JSON, XML, open-data download, or documented integration before using browser automation.
+6. Review terms of use, privacy notices, robots policy, rate limits, and republication restrictions.
+7. Do not bypass authentication, CAPTCHA, access controls, or technical safeguards.
+8. Verify whether personal contact data may lawfully be collected and republished.
+9. Capture one evidence sample for a contractor and one for an engineering consultant from each applicable source.
+10. For bilingual sources, confirm that the English and Arabic records refer to the same entity using a stable identifier.
+11. Record nulls honestly. Do not manufacture English values when only Arabic is supplied.
+12. Separate legal names, trade names, translated names, and machine-generated transliterations.
+13. Confirm whether classifications and grades are current and whether each has its own expiry date.
+14. Recheck all time-sensitive counts and dates before publication.
+
+## 40. Oman-Specific Verification Tasks
+
+1. Determine the exact live ESNAD category codes for construction contractors.
+2. Identify the engineering-consultancy subcategories and activities under `Consulting Offices`.
+3. Confirm whether `View Details` is public and list every additional field it exposes.
+4. Determine whether approved practical experience fields are public or visible only to government users.
+5. Validate all formats used in `PTLC / CR Number` before parsing it.
+6. Confirm whether the 2021 taxonomy PDF has been replaced by a newer official version.
+7. Test whether category expiry dates map one-to-one with categories when a firm has multiple registrations.
+8. Check whether ESNAD exposes an official data export or API.
+9. Confirm the live Oman Business Platform commercial-registration fields without bypassing CAPTCHA.
+10. Determine whether eMassar exposes a stable company identifier or only names and contact data.
+
+## 41. Egypt-Specific Verification Tasks
+
+1. Ask the EFCBC whether a public or licensed member directory, API, export, or data-sharing service exists.
+2. Obtain and verify the exact fields on an official current contractor registration/classification certificate.
+3. Confirm the scope, update date, total records, and inclusion criteria of the DRSO consulting-offices page.
+4. Confirm whether the Egyptian Engineers Syndicate offers a current electronic directory for consulting offices and houses of expertise, not only individual consulting engineers.
+5. Inspect the detail pages in the Environmental Affairs accreditation search and record all fields.
+6. Recheck the number and fields of Industrial Development Authority accreditation offices.
+7. Inspect every Egyptian Survey Authority detail link and distinguish companies, offices, and public utility information centers.
+8. Determine whether the government procurement portal exposes a lawful public supplier/contractor/consultant search or export.
+
+## 42. Qatar-Specific Verification Tasks
+
+1. Record the live Monaqasat result count, page size, pagination behaviour, and update date; treat every count as time-sensitive.
+2. Confirm that `company_profile_file_number` and commercial registration number are stable and identical across the Arabic and English views.
+3. Capture one contractor and one engineering-consultancy sample in both languages and list every field exposed on their detail/activity views.
+4. Recheck the exact engineering-office activity codes, labels, classification grades, and certificate-expiry semantics.
+5. Determine whether the Monaqasat classification is active, expired, suspended, or historical and how each state is exposed.
+6. Confirm whether an official API or export exists before considering browser automation.
+7. Ask the Ministry of Municipality whether it publishes a current complete directory or data service for licensed engineering consultancy offices.
+8. Document the legal distinction between procurement classification and professional engineering-office licensing.
+
+## 43. Bahrain-Specific Verification Tasks
+
+1. Enumerate every Ministry of Works contractor category and grade and verify which report URL parameters are stable.
+2. Record report generation dates, expired-record handling, monetary limits, and whether all contact fields are current.
+3. Compare Benayat and the official planning licensed-office directory for coverage, update timing, stable IDs, and conflicting records.
+4. Confirm with CRPEP whether the public licensed-office list is complete and whether suspended or expired licences are shown.
+5. Join contractor and consultant samples to Sijilat by CR number and verify the official English and Arabic commercial names.
+6. Do not interpret an Arabic interface as Arabic record data; record the actual script/language of every value.
+7. Determine whether the Tender Board exposes a stable public supplier list or export that materially adds to the specialist sources.
+8. Keep SLRB surveying authorization and other sector approvals as separate accreditations.
+
+## 44. Kuwait-Specific Verification Tasks
+
+1. Test the Kuwait Government Online Company Qualification service and record all publicly returned fields, filters, identifiers, pagination, and exports.
+2. Locate and verify any current CAPT public register of classified contractors and any public register of consultancy-service providers.
+3. Confirm whether CAPT exposes the four statutory contractor classes and each firm's current class, activities, issue date, expiry date, and status.
+4. Determine whether Kuwait Municipality provides a public approved-contractors list and a public licensed-engineering-offices list, rather than only application/login workflows.
+5. Determine whether the Ministry of Public Works provides a public qualified-contractors or registered-consultants list or an authorized export.
+6. Verify the distinct meanings and identifiers of CAPT classification, municipal licensing, Ministry of Public Works qualification, and Ministry of Finance consulting-house registration.
+7. Test whether official Arabic and English legal names are present at record level and identify the stable key used to join them.
+8. Confirm whether Ministry of Commerce offers public commercial-registration verification or whether an official extract/data-sharing route is required.
+9. Record the narrow scope of PAI, KDIPA, PAHW, and other entity-specific lists and never use them to claim national completeness.
+10. Do not bypass login, CAPTCHA, or access controls; request an official API, export, or data-sharing agreement when necessary.
+
+## 45. Final Recommendation
+
+For Oman, start with the ESNAD Registered Companies directory and join the English and Arabic interfaces through the PTLC/CR identifier. For Qatar, use Monaqasat as the primary discovery source, join its language views through stable identifiers, and verify engineering-office licensing separately from procurement classification.
+
+For Bahrain, combine the Ministry of Works prequalified-contractor reports with Benayat's licensed engineering offices and use Sijilat for commercial-registration status and official bilingual legal names.
+
+For Egypt and Kuwait, build federated datasets rather than claiming a single complete national directory. Keep each registration, qualification, licence, and sector accreditation as a separate sourced status with clearly documented coverage. Authorized official data access may be necessary for completeness.
+
+Across all five countries, use activity-level filtering, multi-value child tables, stable official identifiers, and explicit source provenance. Never translate or transliterate a legal name into an official English or Arabic field. All source status, counts, classifications, contacts, and expiry dates are time-sensitive and must be refreshed periodically.

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -69,6 +69,8 @@ IDs are stable and never reused, matching the convention BACKLOG.md already uses
 | [REQ-11](#req-11--branch-protection-for-main-in-a-session-of-its-own) | Branch protection for `main`, in a session of its own | **Captured** — deferred by him | 2026-08-20 |
 | [REQ-12](#req-12--justify-the-volume-not-compress-it) | Justify the volume, not compress it | **Captured** — study done, the ruling is his | 2026-08-20 |
 | [REQ-13](#req-13--crawl-muqawil-without-missing-anyone-and-know-the-cost-before-starting) | Crawl muqawil without missing anyone, and price it first | **Captured** — method proven, crawl not built | 2026-08-20 |
+| [REQ-14](#req-14--balady-engineering-offices-as-the-next-source-after-muqawil) | Balady engineering offices, the next source after muqawil | **Captured** — queued behind muqawil | 2026-08-20 |
+| [REQ-15](#req-15--the-uae-sources-third-in-the-queue) | The UAE sources, third in the queue | **Captured** — queued behind Balady | 2026-08-20 |
 
 ---
 
@@ -478,6 +480,91 @@ pages are not written under a retention policy that a later decision would rewri
 Five city×size cells stay above the safe slice size, worst ~212 pages, and no
 fourth exhaustive axis is fine enough. The witness makes attempting them safe
 rather than risky, so it is a cost question — but it is the open one.
+
+---
+
+## REQ-14 · Balady engineering offices, as the next source after muqawil
+
+**Captured 2026-08-20 · Queued behind muqawil, by his instruction**
+
+> «ضيف هذا الملف ليكون المصدر التالى بعد الانتهاء الكامل من مصدر مقاول وكمل شغل كما
+> انت»
+
+He attached a **verification brief** for the Saudi Balady Engineering Offices
+inquiry service — `apps.balady.gov.sa/Eservices/Inquiries/InquiryEngOffices/Index`
+— and set one precondition: **muqawil finished completely first.** "Finished" is his
+own definition, «كلّ ما ينشره الموقع».
+
+### Where it went
+
+[BALADY-ENG-OFFICES.md](BALADY-ENG-OFFICES.md), his brief stored **verbatim** under
+a preamble that records what this project already knows that bears on it. It is in
+the repository rather than in a conversation because he had to re-send the muqawil
+column specification once already, not knowing whether it had survived
+(«لان دراسته ربما تكون فقدت»).
+
+### What the brief is, and what it is not
+
+It is **not** a schema to implement. It is a brief to **verify** one, and it says so
+in its own words: *"Do not assume that any preliminary finding in this brief is
+correct."* Every field list in it is labelled *appears to* and carries a
+verification instruction. Nine deliverables, and the report format demands every
+statement be labelled **Verified / Inferred / Unverified / Not available**.
+
+**Its deliverable 6 should be answered first** — whether an official API or
+downloadable open dataset exists. It is the cheapest question in the brief and it
+can delete the crawl entirely. muqawil's equivalent was answered late and the answer
+was no, at the cost of the requests it took to find out.
+
+### Nothing about it needs a compliance change
+
+Its guardrail — *"Do not bypass authentication, CAPTCHA, access controls, rate
+limits"* — is what `HttpFetcher` already does. `SR-8` honours `Crawl-delay`, and the
+class names user-agent rotation, proxy rotation, header spoofing and CAPTCHA
+handling as deliberately absent because *"those evade a decision the site has
+made"*.
+
+---
+
+## REQ-15 · The UAE sources, third in the queue
+
+**Captured 2026-08-20 · Queued behind muqawil and Balady, by his instruction**
+
+> «ضيف هذا الملف ليكون المصادر التالية بعد الانتهاء الكامل من مصدر مقاول ومصدر
+> بلدية»
+
+A survey of official UAE government and municipal sources for engineering
+contractors and consultancy firms, with his own recommended priority order.
+
+### Where it went
+
+[UAE-SOURCES.md](UAE-SOURCES.md), verbatim under a preamble.
+
+### Why it is a different shape of work, and it matters for planning
+
+**It is not a source; it is a portfolio.** Its key finding is negative and is the
+most consequential line in it: **no single public federal directory covers every
+emirate.** Registration and classification are per-emirate, so the emirate and the
+regulatory authority are part of a record's **identity** — which is why his schema
+opens with `country`, `emirate`, `regulatory_authority`, `source_system`. Seven
+emirates, four of them with no confirmed public list at all.
+
+**One of them is better-shaped than muqawil, and by a measurable margin.** Abu Dhabi
+DMT publishes `firm_name` and `firm_name_ar` **in the same record**. On muqawil the
+Arabic half costs a second full crawl — 871 listing pages and 17,403 profiles again
+— and the values are matched by page-order index because the same label is spelled
+`رقم العضويه` with `ه` in one place. A bilingual record halves the requests and
+removes that risk entirely. If it holds up, DMT is the best-shaped source this
+project has been given.
+
+### Two of his rules here are already rulings, and one caution must not be lost
+
+The `_ar` convention is `R-12`; child tables for multi-valued groups is `R-19`
+(**«جداول أبناء للخمس كلّها»**). And his own caution about Ras Al Khaimah — a company
+listed once per project category must be modelled as a company-category
+relationship, **not** collapsed as duplicates — is the same trap as counting a
+muqawil contractor twice for appearing on two listing pages, which is why
+`dataset_sighting` counts sightings separately from records.
 
 ---
 

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -74,6 +74,7 @@ IDs are stable and never reused, matching the convention BACKLOG.md already uses
 | [REQ-16](#req-16--egypt-oman-qatar-bahrain-and-kuwait-fourth-in-the-queue) | Egypt, Oman, Qatar, Bahrain and Kuwait, fourth in the queue | **Captured** — appended in the order received | 2026-08-20 |
 | [REQ-17](#req-17--official-diesel-prices--a-product-source-not-a-firm-directory) | Official diesel prices — a product source, not a firm directory | **Captured** — the smallest item in the queue | 2026-08-20 |
 | [REQ-18](#req-18--bitumen-6070-prices--the-first-source-that-cannot-be-crawled) | Bitumen 60/70 prices — the first source that cannot be crawled | **Captured** — 5 of 7 need a written quotation | 2026-08-20 |
+| [REQ-19](#req-19--reinforced-concrete-material-prices--its-turn-will-come) | Reinforced-concrete material prices — its turn will come | **Captured** — a provenance-typed price model | 2026-08-20 |
 
 ---
 
@@ -755,6 +756,55 @@ His §12 rejects any figure not traceable to an official producer, public author
 signed quote, tender award or official statistical publication — trader
 advertisements and aggregator sites explicitly excluded. That is a rule about what
 may enter the warehouse at all, and it is stricter than anything code enforces today.
+
+---
+
+## REQ-19 · Reinforced-concrete material prices — its turn will come
+
+**Captured 2026-08-20 · Queued, in his own words**
+
+> «مصادر جديدة ضيفها للقائمة **سياتى دورها يوما ما**»
+
+Cement, reinforcing steel, structural steel sections, sand, coarse aggregate and
+water, across the same seven countries.
+
+### Where it went
+
+[CONCRETE-MATERIALS.md](CONCRETE-MATERIALS.md), verbatim under a preamble.
+
+### It is the most carefully-typed of his briefs, and that is its contribution
+
+Its §3 source-type table carries a column headed **"Can it populate `price_amount`?"**
+and answers **No** for `official_price_index`, `official_approved_source` and
+`official_specification`. An index is not a price; an approved-supplier list does not
+establish one. That is a **provenance-typed price model**, stricter than anything this
+warehouse enforces, and it is why his design gives `price_index_observations` and
+`water_tariffs` their own tables rather than a `kind` column on one.
+
+### Water is the sharpest example in any of the seven briefs
+
+His §2.2 refuses to store a single water price at all: the official network tariff is
+one component beside meter charges, wastewater, tanker filling, transport, storage and
+testing — and *"a potable-water tariff alone does not prove technical suitability"* for
+mixing or curing. **One number would be false in both directions** — too low as a
+delivered cost, and not evidence of fitness for purpose.
+
+### It completes a pattern, now recorded as [DEC-12](BACKLOG.md)
+
+Third independent case that `SR-6` keys on the wrong thing: diesel says the key is
+the **period**, bitumen the **commercial basis**, this one the **source type**. Three
+products, three axes, three briefs written separately — and recorded before any
+collection is scheduled, because the failure is silent and the data does not wait:
+dated bulletins expire, and the Qatar bitumen figure had already expired when he sent
+it.
+
+### And its own coverage is narrower than its length suggests
+
+Its §12 bottom line: only **Saudi Arabia, Egypt and Qatar** have usable official
+absolute prices. Oman and Kuwait offer **indices**, which its own §3 says are not
+prices. Bahrain offers approval and specification evidence, which is not a price
+either. So for four of seven countries this is a `quote_required` source in the same
+sense the bitumen brief is.
 
 ---
 

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -71,6 +71,9 @@ IDs are stable and never reused, matching the convention BACKLOG.md already uses
 | [REQ-13](#req-13--crawl-muqawil-without-missing-anyone-and-know-the-cost-before-starting) | Crawl muqawil without missing anyone, and price it first | **Captured** — method proven, crawl not built | 2026-08-20 |
 | [REQ-14](#req-14--balady-engineering-offices-as-the-next-source-after-muqawil) | Balady engineering offices, the next source after muqawil | **Captured** — queued behind muqawil | 2026-08-20 |
 | [REQ-15](#req-15--the-uae-sources-third-in-the-queue) | The UAE sources, third in the queue | **Captured** — queued behind Balady | 2026-08-20 |
+| [REQ-16](#req-16--egypt-oman-qatar-bahrain-and-kuwait-fourth-in-the-queue) | Egypt, Oman, Qatar, Bahrain and Kuwait, fourth in the queue | **Captured** — appended in the order received | 2026-08-20 |
+| [REQ-17](#req-17--official-diesel-prices--a-product-source-not-a-firm-directory) | Official diesel prices — a product source, not a firm directory | **Captured** — the smallest item in the queue | 2026-08-20 |
+| [REQ-18](#req-18--bitumen-6070-prices--the-first-source-that-cannot-be-crawled) | Bitumen 60/70 prices — the first source that cannot be crawled | **Captured** — 5 of 7 need a written quotation | 2026-08-20 |
 
 ---
 
@@ -565,6 +568,193 @@ listed once per project category must be modelled as a company-category
 relationship, **not** collapsed as duplicates — is the same trap as counting a
 muqawil contractor twice for appearing on two listing pages, which is why
 `dataset_sighting` counts sightings separately from records.
+
+---
+
+## REQ-16 · Egypt, Oman, Qatar, Bahrain and Kuwait, fourth in the queue
+
+**Captured 2026-08-20 · Appended to the queue in the order received**
+
+> «المزيد من المصادر ضفها الى القائمة»
+
+He said *add them to the list* without naming a position, so they are **appended
+after the UAE**. Nothing has started on any queued survey, so the order costs
+nothing to change — it is written down so there **is** one, not so it is fixed.
+
+### Where it went
+
+[GULF-EGYPT-SOURCES.md](GULF-EGYPT-SOURCES.md), verbatim under a preamble.
+
+### The scale, and where its value actually is
+
+The largest of the three surveys: **five countries, 32 numbered sources, 933
+lines.** With this the queue reaches **eight countries**.
+
+**Its most useful content is where it says no.** Only three of the five have
+anything resembling a national public directory:
+
+| | |
+|---|---|
+| **Oman** | ESNAD / Tender Board `Registered Companies` — his own words, *"the closest source found to the Saudi `muqawil.org` use case"* |
+| **Qatar** | Monaqasat classified-company profiles |
+| **Bahrain** | three separate official lists, not one |
+| **Egypt** | **no complete combined directory confirmed** — EFCBC is authenticated; DRSO's consulting-office list is Arabic-only |
+| **Kuwait** | **no complete current public list confirmed** |
+
+So its real instruction is his §45 — *"build federated datasets rather than claiming
+a single complete national directory"* — and that is a **schema** requirement rather
+than a crawl detail. It is why his `firms` table carries `source_system` and
+`regulatory_authority`, and why classifications, accreditations and contacts are
+separate child tables.
+
+### Two things in it that this project should take even before the work starts
+
+**A stable identifier joining two language views is better than anything muqawil
+has.** Oman's ESNAD and Qatar's Monaqasat both publish Arabic and English views
+joined by an identifier — PTLC/CR, and the profile file number. On muqawil the
+Arabic half is a **second full crawl** of 871 listing pages and 17,403 profiles,
+matched by **page-order index** because one label is spelled `رقم العضويه` with `ه`.
+His §38.4 and §38.5 already require the identifier join, and it removes that risk
+entirely.
+
+**His §38.2 is stricter than any rule we have written down**, and it should be
+adopted: keep `source_registration_number_raw` — the identifier **exactly as
+published** — beside any cleaned form. muqawil stores the membership number as
+published and it has held, but nothing records that as a rule. Eight countries of
+identifiers with slashes and leading zeros is the wrong time to find out.
+
+### What has not been done
+
+Nothing. It is queued, and its own §39 requires every one of the 32 sources to be
+re-opened and re-verified on the day the work starts, because *"all source status,
+counts, classifications, contacts and expiry dates are time-sensitive"*.
+
+---
+
+## REQ-17 · Official diesel prices — a product source, not a firm directory
+
+**Captured 2026-08-20 · Queued; and it is the smallest item in the queue by far**
+
+> «مصادر اخرى لاسعار الديزل فقط مصادر منتجات ضيفها لقائمة المصادر»
+
+Official retail diesel prices for Saudi Arabia, the UAE, Egypt, Oman, Qatar,
+Bahrain and Kuwait, with the publisher and the dated announcement for each.
+
+### Where it went
+
+[DIESEL-PRICES.md](DIESEL-PRICES.md), verbatim under a preamble.
+
+### He classified it himself, and the classification matters
+
+**«مصادر منتجات»** — product sources. The other four queued surveys are **firm
+directories** and land in `generic_record` through the generic-dataset seam muqawil
+pioneered. This describes **a product's price over time**, which is the *original*
+spine of this project: `price_observation`, the `db/migrations/` PRICE chain, `SR-6`.
+
+**It is the first queued source that touches the half of the warehouse muqawil never
+went near.**
+
+### And it is tiny, which he should know before deciding where it sits
+
+| | requests to collect once |
+|---|---|
+| muqawil, everything the site publishes | **36,548** |
+| this | **7 pages, ~14 with both locales** |
+
+About **fourteen requests a month**. It does not compete with finishing muqawil in
+any real sense — an afternoon, not a track. The order stays his; the size is recorded
+so the decision is made with it in view.
+
+### One mechanism will silently drop his data, and it is already measured
+
+His rule §3 is *"never overwrite a previous price when a new month or quarter
+begins."* `SR-6` says **an unchanged price is confirmed, not appended.** Those
+disagree, concretely: if Oman's July price was also `0.258`, the append gate sees no
+change and writes nothing, so the **August period never exists** and his §3 is
+violated by a rule that is otherwise right.
+
+> A period-keyed price must key the append gate on the **period**, not only the
+> value. `SR-6` was written for a shelf price, where an unchanged number carries no
+> information. An official price *for a named month* carries information even when
+> the number is identical — it says the ministry set it again.
+
+Same shape as a defect already on record: a new `price_observation` column stays NULL
+because the gate never learned to notice it. **Settle it before the first collection,
+not after a month is missing.**
+
+### Two sources need something this project does not have
+
+- **Bahrain publishes the price as an image.** His own instruction is to preserve the
+  screenshot or image hash and treat OCR as a *candidate* extraction only, verified
+  against the dated committee announcement. There is no OCR path here, and his rule
+  is the right one regardless: the image is the evidence, the number is a claim
+  about it.
+- **Kuwait's page is stale in the dates, not the price.** He observed a correct value
+  beside an out-of-date validity note and says not to derive the effective dates from
+  the static page. A collector that trusted it would store a right price under wrong
+  dates, which is the worse failure because it looks complete.
+
+---
+
+## REQ-18 · Bitumen 60/70 prices — the first source that cannot be crawled
+
+**Captured 2026-08-20 · Queued; and its acquisition mode is correspondence, not fetching**
+
+> «مصادر اخرى»
+
+Official bitumen 60/70 price sources for the same seven countries as the diesel
+list — and its conclusion is that, for five of them, **there is nothing public to
+fetch.**
+
+### Where it went
+
+[BITUMEN-PRICES.md](BITUMEN-PRICES.md), verbatim under a preamble.
+
+### Why it is unlike every other source in the queue
+
+| | |
+|---|---|
+| **`quote_required`** | Saudi Arabia, UAE, Oman, Bahrain, Kuwait |
+| **a dated bulletin, not a live price** | Egypt — `EGP 21,542`/tonne, July 2026 |
+| **already expired** | Qatar — `2,925`/tonne, 22–31 July 2026, **no currency label on the page** |
+
+Bitumen 60/70 is bulk B2B: the payable price depends on quantity, customer category,
+loading point, destination, hot-bulk versus packaged, tax, freight and quote
+validity. His brief therefore ends with **a letter to send a producer**, not a URL to
+crawl. That is the shape of the product, not a gap in the plan.
+
+**So what this project can do for it is narrower and more valuable than a crawl:** be
+the place a dated, sourced, caveated observation is stored so it is never mistaken
+for a current market price. His `verification_status` vocabulary —
+`quote_required`, `latest_official_bulletin`, `expired_official_price` — is the most
+useful column in his design.
+
+### Its most important instruction is a refusal to compare
+
+*"Do not flatten these observations into one comparable price list."* Egypt's official
+label is **بيتومين مؤكسد على الساخن 70/60**, possibly a hot-applied **oxidized**
+product rather than the paving penetration grade; Qatar's row shows no currency.
+Comparing or converting them would manufacture a number nobody published. That is
+`SR-1` on a harder case: what was published is *incomplete*, and the record must
+carry the incompleteness rather than resolve it.
+
+### And it is the second measured case against `SR-6`'s key
+
+`SR-6` confirms rather than appends an unchanged price. Here two observations can
+carry **the same number and different commercial bases** — ex-refinery versus
+delivered, taxed versus not. Different facts, equal values; a gate comparing only the
+number collapses them and destroys the only thing that makes either usable.
+
+> With [REQ-17](#req-17--official-diesel-prices--a-product-source-not-a-firm-directory)
+> this is two independent cases saying the same thing: **the append gate's key is not
+> the number.** For diesel it is the period; for bitumen it is the commercial basis.
+
+### One line in it is a hard boundary, not a task
+
+His §12 rejects any figure not traceable to an official producer, public authority,
+signed quote, tender award or official statistical publication — trader
+advertisements and aggregator sites explicitly excluded. That is a rule about what
+may enter the warehouse at all, and it is stricter than anything code enforces today.
 
 ---
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -232,6 +232,46 @@ with nothing stored for them. Their written conditions were measured, not quoted
 
 ---
 
+## Track 5 · The source queue — two more, in his order, neither started
+
+**He set the order himself on 2026-08-20**, and it is a precondition rather than a
+preference: each source waits for the previous one to be **finished completely**,
+where finished is his definition — «كلّ ما ينشره الموقع».
+
+| # | source | where the brief is | state |
+|---|---|---|---|
+| 1 | **muqawil.org** | [CONTRACTOR-SOURCE.md](CONTRACTOR-SOURCE.md) | Track 2 above — 11,059 of 17,403 rows, listing pages only, profiles never crawled |
+| 2 | **Balady engineering offices** | [BALADY-ENG-OFFICES.md](BALADY-ENG-OFFICES.md) | **Queued.** [REQ-14](REQUESTS.md#req-14--balady-engineering-offices-as-the-next-source-after-muqawil) |
+| 3 | **UAE contractors and consultants** | [UAE-SOURCES.md](UAE-SOURCES.md) | **Queued.** [REQ-15](REQUESTS.md#req-15--the-uae-sources-third-in-the-queue) |
+
+**Both briefs are his, stored verbatim**, and they are in the repository rather than
+in a conversation for a measured reason: he re-sent the muqawil column specification
+on 2026-08-20 because he could not tell whether it had survived. It had. He should
+not have to ask twice.
+
+**Neither is a schema to implement.** Balady's brief says so in its own words —
+*"Do not assume that any preliminary finding in this brief is correct"* — and demands
+every statement be labelled **Verified / Inferred / Unverified / Not available**. The
+UAE file is not even one source: its key finding is that **no single public federal
+directory covers every emirate**, so the emirate and the regulatory authority are
+part of a record's identity.
+
+**Two things worth knowing before either starts**, so the work does not open by
+rediscovering them:
+
+- **Ask for the open dataset first.** Both files require checking for an official
+  API or download **before** any browser automation. It is the cheapest question
+  available and it can delete the crawl. muqawil's equivalent was answered late, and
+  the answer was no — three dead ends recorded in [DEC-11](BACKLOG.md) so nobody
+  spends those requests again.
+- **Abu Dhabi DMT may be better-shaped than muqawil.** It publishes `firm_name` and
+  `firm_name_ar` **in one record**. On muqawil the Arabic half is a second full crawl
+  — 871 listing pages and 17,403 profiles again — matched by page-order index
+  because one label is spelled `رقم العضويه` with `ه`. A bilingual record halves
+  the requests and removes that risk.
+
+---
+
 ## Track 4 · What CI actually costs, and the tier a documentation change needed
 
 **Measured 2026-08-19**, because PR #214 was documentation only and took the two

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -232,19 +232,51 @@ with nothing stored for them. Their written conditions were measured, not quoted
 
 ---
 
-## Track 5 · The source queue — two more, in his order, neither started
+## Track 5 · The source queue — eight countries and two products, none started
 
-**He set the order himself on 2026-08-20**, and it is a precondition rather than a
-preference: each source waits for the previous one to be **finished completely**,
-where finished is his definition — «كلّ ما ينشره الموقع».
+**He set the order himself on 2026-08-20**, and for the first two it is a
+precondition rather than a preference: each waits for the previous one to be
+**finished completely**, where finished is his definition — «كلّ ما ينشره الموقع».
+The fourth he added with «المزيد من المصادر ضفها الى القائمة» and named no position,
+so it is appended in the order received.
 
 | # | source | where the brief is | state |
 |---|---|---|---|
 | 1 | **muqawil.org** | [CONTRACTOR-SOURCE.md](CONTRACTOR-SOURCE.md) | Track 2 above — 11,059 of 17,403 rows, listing pages only, profiles never crawled |
 | 2 | **Balady engineering offices** | [BALADY-ENG-OFFICES.md](BALADY-ENG-OFFICES.md) | **Queued.** [REQ-14](REQUESTS.md#req-14--balady-engineering-offices-as-the-next-source-after-muqawil) |
 | 3 | **UAE contractors and consultants** | [UAE-SOURCES.md](UAE-SOURCES.md) | **Queued.** [REQ-15](REQUESTS.md#req-15--the-uae-sources-third-in-the-queue) |
+| 4 | **Egypt, Oman, Qatar, Bahrain, Kuwait** | [GULF-EGYPT-SOURCES.md](GULF-EGYPT-SOURCES.md) | **Queued.** [REQ-16](REQUESTS.md#req-16--egypt-oman-qatar-bahrain-and-kuwait-fourth-in-the-queue) |
+| — | **Official diesel prices, 7 countries** — a PRODUCT source, not a firm directory | [DIESEL-PRICES.md](DIESEL-PRICES.md) | **Queued.** [REQ-17](REQUESTS.md#req-17--official-diesel-prices--a-product-source-not-a-firm-directory) |
+| — | **Bitumen 60/70 prices, 7 countries** — a product source that **cannot be crawled** | [BITUMEN-PRICES.md](BITUMEN-PRICES.md) | **Queued.** [REQ-18](REQUESTS.md#req-18--bitumen-6070-prices--the-first-source-that-cannot-be-crawled) |
 
-**Both briefs are his, stored verbatim**, and they are in the repository rather than
+> **Four briefs, 8 countries, and not one of them started.** Saudi Arabia twice
+> (muqawil and Balady), the seven emirates, then Egypt, Oman, Qatar, Bahrain and
+> Kuwait. The queue is a queue, not a plan: none of it competes with finishing
+> muqawil, which is what he said the priority is.
+
+**The diesel-price list is a different KIND of source and is listed without a
+position.** He classified it himself — **«مصادر منتجات»**, product sources. The
+other four describe *firms* and land in `generic_record`; this describes *a product's
+price over time* and lands in `price_observation` — the original spine of this
+project, which muqawil never touched. It is also **7 pages against muqawil's
+36,548**, about fourteen requests a month, so it is an afternoon rather than a track.
+
+> **And it collides with `SR-6`, which is worth knowing before it starts.** `SR-6`
+> says an unchanged price is confirmed, not appended. His rule §3 says never
+> overwrite a previous price when a new month begins. If Oman's July price equalled
+> August's, the gate writes nothing and the August **period** never exists. A
+> period-keyed price has to key the gate on the PERIOD, not only the value.
+> [DIESEL-PRICES.md](DIESEL-PRICES.md) carries the reasoning.
+
+**And the bitumen brief cannot be crawled at all** — by its own conclusion, five of
+its seven countries have no public official price, so its acquisition mode is a
+written quotation to a producer. What this project can do for it is store a dated,
+caveated observation that is never mistaken for a live market price. It is also the
+**second** independent case against `SR-6`'s key: for diesel the key is the period,
+for bitumen the commercial basis, because two observations can carry the same number
+and different bases. [BITUMEN-PRICES.md](BITUMEN-PRICES.md).
+
+**All three briefs are his, stored verbatim**, and they are in the repository rather than
 in a conversation for a measured reason: he re-sent the muqawil column specification
 on 2026-08-20 because he could not tell whether it had survived. It had. He should
 not have to ask twice.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -232,7 +232,7 @@ with nothing stored for them. Their written conditions were measured, not quoted
 
 ---
 
-## Track 5 · The source queue — eight countries and two products, none started
+## Track 5 · The source queue — eight countries and three product classes, none started
 
 **He set the order himself on 2026-08-20**, and for the first two it is a
 precondition rather than a preference: each waits for the previous one to be
@@ -248,6 +248,7 @@ so it is appended in the order received.
 | 4 | **Egypt, Oman, Qatar, Bahrain, Kuwait** | [GULF-EGYPT-SOURCES.md](GULF-EGYPT-SOURCES.md) | **Queued.** [REQ-16](REQUESTS.md#req-16--egypt-oman-qatar-bahrain-and-kuwait-fourth-in-the-queue) |
 | — | **Official diesel prices, 7 countries** — a PRODUCT source, not a firm directory | [DIESEL-PRICES.md](DIESEL-PRICES.md) | **Queued.** [REQ-17](REQUESTS.md#req-17--official-diesel-prices--a-product-source-not-a-firm-directory) |
 | — | **Bitumen 60/70 prices, 7 countries** — a product source that **cannot be crawled** | [BITUMEN-PRICES.md](BITUMEN-PRICES.md) | **Queued.** [REQ-18](REQUESTS.md#req-18--bitumen-6070-prices--the-first-source-that-cannot-be-crawled) |
+| — | **Reinforced-concrete materials, 7 countries** — cement, rebar, aggregate, water | [CONCRETE-MATERIALS.md](CONCRETE-MATERIALS.md) | **Queued.** [REQ-19](REQUESTS.md#req-19--reinforced-concrete-material-prices--its-turn-will-come) |
 
 > **Four briefs, 8 countries, and not one of them started.** Saudi Arabia twice
 > (muqawil and Balady), the seven emirates, then Egypt, Oman, Qatar, Bahrain and
@@ -275,6 +276,15 @@ caveated observation that is never mistaken for a live market price. It is also 
 **second** independent case against `SR-6`'s key: for diesel the key is the period,
 for bitumen the commercial basis, because two observations can carry the same number
 and different bases. [BITUMEN-PRICES.md](BITUMEN-PRICES.md).
+
+**A third price brief makes it a finding rather than an observation.** The
+reinforced-concrete materials brief types its sources explicitly and answers **No** to
+*"can it populate `price_amount`?"* for an index, an approved-supplier list and a
+specification. So: diesel says the append key is the **period**, bitumen the
+**commercial basis**, concrete the **source type** — three products, three axes, three
+briefs written separately. Recorded as [DEC-12](BACKLOG.md) before any of it is
+collected, because a dropped period is not a wrong row a later fix corrects; it is a
+row that never existed, in a table whose whole purpose is history.
 
 **All three briefs are his, stored verbatim**, and they are in the repository rather than
 in a conversation for a measured reason: he re-sent the muqawil column specification

--- a/docs/UAE-SOURCES.md
+++ b/docs/UAE-SOURCES.md
@@ -1,0 +1,445 @@
+# UAE contractors and engineering consultants — the owner's source survey
+
+**QUEUED THIRD, NOT STARTED. The order is his:**
+
+> «ضيف هذا الملف ليكون المصادر التالية **بعد الانتهاء الكامل من مصدر مقاول ومصدر
+> بلدية**»
+> — 2026-08-20, [REQ-15](REQUESTS.md#req-15--the-uae-sources-third-in-the-queue)
+
+So: muqawil, then [Balady](BALADY-ENG-OFFICES.md), then this. **The survey below is
+his, stored verbatim**, for the same reason as Balady's — a specification that lives
+only in a conversation cannot be checked, and he had to re-send the muqawil column
+spec once already because he could not tell whether it had survived.
+
+---
+
+## What is structurally different about this one
+
+**It is not a source. It is a portfolio of them**, and that changes the shape of the
+work rather than only its size.
+
+> **Its key finding is a negative one, and it is the most important line in the
+> file:** no single public federal directory covers every emirate. Registration and
+> classification are per-emirate, so **the emirate and the regulatory authority are
+> part of every record's identity**, not decoration.
+
+That is why his proposed schema opens with `country`, `emirate`,
+`regulatory_authority`, `source_system` — and why a "UAE contractors" table is not
+one crawl the way `contractors` was. His own priority order (§8) is the sequencing,
+and it is already sorted by suitability rather than by emirate.
+
+## Three things this project has already measured that bear on it
+
+Recorded now, while it is cheap, so the work does not open by rediscovering them.
+
+**1 · Abu Dhabi DMT publishes both languages in ONE record — and that is a
+materially cheaper source than muqawil.** His survey notes it as an advantage; it is
+worth naming exactly how much of one. On muqawil the Arabic half costs a **second
+full crawl** — 871 listing pages and 17,403 profiles again — and the values are
+matched **by page-order index, never by label**, because the same field is spelled
+`رقم العضويه` with `ه` in one place and a label-matched extractor breaks on it
+([LESSONS.md](LESSONS.md)). A record that carries `firm_name` and `firm_name_ar`
+together costs **half the requests and removes the index-matching risk entirely.**
+If DMT holds up, it is the best-shaped source this project has seen.
+
+**2 · His §11.2 — "check for an official API, open-data download, CSV, Excel, PDF or
+JSON source before using browser automation" — should gate everything else.** It is
+the cheapest question available and it can delete the crawl. On muqawil the
+equivalent question was answered late and the answer was no: `/sitemap.xml` holds
+**20 static pages**, the map page carries **zero** contractor markers, and no sort
+parameter exists — three dead ends recorded in [DEC-11](BACKLOG.md) so nobody spends
+the requests twice. These are government portals; here the answer may be yes.
+
+**3 · His §11.7 — "treat grades, ratings, classification categories and evaluation
+results as separate concepts" — is a lesson this repository learned by getting it
+wrong.** muqawil publishes `contractor_classification`,
+`contractor_classification_grade`, `customer_rating_score` and
+`customer_rating_count`, and collapsing any two would have lost information that is
+already stored. He is right, and the existing schema is the precedent.
+
+## And two of his rules here are already rulings
+
+Stated so nobody re-litigates them when the work starts:
+
+| his rule | where it already lives |
+|---|---|
+| base column English, `_ar` for Arabic, no `_ar` duplicate for identifiers, numbers, URLs, coordinates, dates, ratings or booleans | `R-12`, and the shape of every column in [CONTRACTOR-SOURCE.md](CONTRACTOR-SOURCE.md) |
+| separate relationship tables for activities, categories, branches, classifications and evaluations | `R-19` — **«جداول أبناء للخمس كلّها»**, his ruling for muqawil's five multi-valued groups |
+
+**One caution he raised himself and should not be lost**: Ras Al Khaimah lists a
+company once per project category, and he says explicitly that repeated appearances
+must be modelled as a company-category relationship **rather than treated
+automatically as duplicates**. That is the same trap as counting a muqawil
+contractor twice because they appear on two listing pages, and it is the reason
+`dataset_sighting` (#227) counts sightings separately from records.
+
+---
+
+*Everything below this line is the owner's survey as he sent it, unedited.*
+
+---
+
+# UAE Contractors and Engineering Consultants — Official Data Sources
+
+## Purpose
+
+This document lists official UAE government and municipal sources that publish, search, verify, register, or classify engineering contractors and engineering consultancy firms.
+
+The objective is to identify suitable sources for building a database similar to the Saudi `muqawil.org` contractor directory.
+
+## Key Finding
+
+No single public federal directory was identified that provides a complete list of all contractors and engineering consultants across every UAE emirate.
+
+Registration, licensing, and classification are generally managed at emirate or municipality level. A national database should therefore preserve the emirate and regulatory authority for every record.
+
+Recommended source fields:
+
+```text
+country
+emirate
+regulatory_authority
+firm_type
+source_system
+source_record_id
+source_list_url
+source_detail_url
+collected_at
+last_verified_at
+```
+
+## 1. Abu Dhabi
+
+### Engineering Firms with Valid Classification
+
+- Authority: Abu Dhabi Department of Municipalities and Transport — DMT
+- Official directory: https://pages.dmt.gov.ae/en/Engineering-Firms
+- Arabic directory: https://pages.dmt.gov.ae/ar/Engineering-Firms
+- Coverage: Engineering contracting companies and engineering consultancy offices with valid classifications
+- Access type: Public searchable directory
+- Database suitability: Excellent
+
+Observed fields:
+
+```text
+sequence_number
+economic_license_number
+firm_name
+firm_name_ar
+firm_type
+classification_category
+classification_expiry_date
+classification_status
+evaluation_result
+```
+
+Important advantages:
+
+- Official English and Arabic firm names appear in the same record.
+- Contractors and consultants are included in one structured directory.
+- Firm type distinguishes an `Engineering Contracting Company` from an `Engineering Consultancy Office`.
+- Classification category and expiry date are displayed.
+- The directory is the strongest initial source for a bilingual database.
+
+### Classification Certificate Inquiry
+
+- Official inquiry: https://pages.dmt.gov.ae/en/Engineering-Firms-Inquiry
+- Purpose: Verify the details of an engineering classification certificate
+- Access type: Search/inquiry
+- Database suitability: Useful for record verification
+
+### Engineering Excellence List
+
+- Official list: https://pages.dmt.gov.ae/en/Excellence-Listing
+- Coverage: Selected evaluated engineering contractors and consultants
+- Filters may include:
+  - Firm type
+  - Firm form
+  - Classification category
+  - Activity domain
+  - Activity
+  - Evaluation result
+- Database suitability: Useful as an enrichment and quality/evaluation source, but not a substitute for the full valid-classification directory
+
+### Classification System Information
+
+- DMT classification information: https://www.dmt.gov.ae/en/adm/Media-Centre/News/01Mar2024
+- Current framework update: https://www.dmt.gov.ae/en/Media-Centre/News/DMT-ADGM-Launch-Unified-Engineering-Classification-System-for-Abu-Dhabi
+
+The Abu Dhabi system covers engineering contracting companies, engineering consultancy offices, and licensed engineering professionals. Verify whether ADGM-licensed firms are fully represented in the public directory following the system integration.
+
+## 2. Dubai
+
+### Consultants, Contractors and Suppliers Data
+
+- Authority: Dubai Municipality
+- English information page: https://www.dm.gov.ae/municipality-business/consultants-contractors-and-suppliers-data/
+- Arabic information page: https://www.dm.gov.ae/التشريعات-والمعلومات/بيانات-الاستشاريين،-المقاولين-والمو/?lang=ar
+- Coverage:
+  - Registered engineering consultancy offices
+  - Registered contracting companies
+  - Approved building-material suppliers and manufacturers
+- Access type: Official information page linking to the register and Dubai BPS application
+- Database suitability: Very good, subject to confirming the available public fields and collection method
+
+Dubai Municipality identifies two relevant datasets:
+
+```text
+Database of Registered Engineering Consultancy Offices
+Database of Registered Contracting Companies
+```
+
+### Dubai Engineering Qualification Portal
+
+- Official portal: https://deqsmart.dm.gov.ae/EisPortal/faces/security/others/Corporate-practice-permit.xhtml
+- Purpose: Search or verify professional practice permits for engineering firms registered with Dubai Municipality
+- Access type: Interactive web portal
+- Database suitability: Requires technical inspection of search behavior, pagination, available fields, and public-access restrictions
+
+### Dubai Building Permits — Dubai BPS
+
+- Dubai Municipality announcement: https://www.dm.gov.ae/new-improved-building-permits-app-launched-for-streamlined-services/
+- Purpose: Building-permit services and search for contractors and consultants registered in Dubai
+- Reported search/enrichment information may include:
+  - Registration status
+  - Type of firm
+  - Number of active projects
+  - Consultant or contractor evaluation
+- Access type: Mobile application and connected municipal services
+- Database suitability: Potentially valuable for enrichment; verify current public availability and terms before collection
+
+### Licensing Standards
+
+- Official standards page: https://www.dm.gov.ae/municipality-business/consultants-and-contractors-licensing-standards/
+- Purpose: Understand classifications, permitted activities, qualification requirements, and professional-practice rules
+- Database suitability: Reference data for normalizing activity and classification fields
+
+## 3. Ras Al Khaimah
+
+### Approved Engineering Consultants
+
+- Authority: Ras Al Khaimah Municipality
+- Official list: https://sanad.mun.rak.ae/docs/en/approved-consultants
+- Coverage: Approved and classified engineering consultancy firms
+- Access type: Public list
+- Database suitability: Excellent for a public contact and classification dataset
+
+Observed fields:
+
+```text
+consultant_name
+grade
+establishment_date
+phone_number
+email_address
+rating
+project_or_building_category
+```
+
+The page is available through an English documentation interface, but many establishment names are displayed in Arabic. Do not assume that an official English legal name exists for every listed consultant.
+
+### Approved Contractors
+
+- Authority: Ras Al Khaimah Municipality
+- Official list: https://sanad.mun.rak.ae/rakm/docs/en/approved-contractors
+- Coverage: Approved and classified construction contractors
+- Access type: Public list
+- Database suitability: Excellent for a public contact and classification dataset
+
+Observed fields:
+
+```text
+contractor_name
+grade
+phone_number
+email_address
+rating
+project_or_building_category
+```
+
+Important data-quality considerations:
+
+- Phone-number formats are inconsistent.
+- Some email addresses may contain source-data errors or placeholders.
+- A company may appear under more than one project or building category.
+- Ratings and grades should be stored separately.
+- Repeated appearances should be modelled through a company-category relationship rather than treated automatically as duplicate companies.
+
+### General Approved Professionals Page
+
+- Official overview: https://sanad.mun.rak.ae/docs/en/approved-contractors-consultants-1
+- Purpose: Entry point for the municipality's approved contractor and consultant registers
+
+## 4. Sharjah
+
+### Contractor and Engineer Inquiry
+
+- Authority: Sharjah City Municipality
+- Official inquiry: https://portal.shjmun.gov.ae/en/eservices/Pages/QryPrjEngContractor.aspx
+- Coverage: Contractor and project-engineer verification
+- Search inputs observed:
+  - Engineer card number
+  - Contractor licence number
+- Access type: Record-specific inquiry rather than a complete browsable directory
+- Database suitability: Limited; useful for verification when identifiers are already known
+
+### Contractor and Consultant Classification Services
+
+- Service directory example: https://shjmun.gov.ae/servicedirectory/details/683d3a96ff3e1753c064e6de
+- Coverage: Classification-certificate services for contractors and consultants
+- Database suitability: Regulatory reference only unless a separate public list is identified
+
+### Star Rating Registration
+
+- Official service page: https://shjmun.gov.ae/servicedirectory/details/683d3a96ff3e1753c064e6d9
+- Purpose: Allows contractors and consultants to register in a star-rating program so their data can be shown to individual customers
+- Database suitability: Potential lead for an additional public directory or application; independently verify where the published rated-company list is displayed
+
+## 5. Ajman
+
+### Contractors and Consultants Classification
+
+- Authority: Ajman Municipality and Planning Department
+- Electronic services portal: https://online.am.gov.ae
+- 2024 English service guide: https://www.am.gov.ae/wp-content/uploads/2024/09/EN-دليل-الخدمات-2024.pdf
+- Coverage: Professional-practice accreditation and classification of contractors and engineering consultants
+- Access type: Registration and classification service
+- Database suitability: Regulatory reference; no comprehensive public list was confirmed during the initial review
+
+Relevant classified-service types include:
+
+- Professional practice accreditation for contractors and consultants
+- Raising the classification/ranking of a contractor or consultant
+- Temporary contractor or consultant permits
+
+Further verification is required to determine whether the online portal exposes a public search or approved-company list without authentication.
+
+## 6. Fujairah
+
+### Contractor and Consultant Classification Certificate
+
+- Authority: Fujairah Municipality
+- Official service: https://portal.fujmun.gov.ae/OnlineEservices/en/eService/ServicePages/service_information.aspx?serviceid=172
+- Coverage: Classification certificates for contractors and consultants
+- Access type: Application/service page
+- Database suitability: Regulatory reference; no comprehensive public list was confirmed during the initial review
+
+### Contractor Registration
+
+- Official service: https://portal.fujmun.gov.ae/OnlineEservices/en/eservice/ServicePages/service_information.aspx?serviceid=174
+- Coverage: Registration of local building and construction contractors
+- Access type: Application/service page
+- Database suitability: Regulatory reference only unless an approved-company inquiry or list is identified
+
+## 7. Umm Al Quwain
+
+No complete official public contractor-and-consultant directory was confirmed during the initial review.
+
+Further investigation should cover:
+
+- Umm Al Quwain Municipality public services
+- Contractor and consultant classification services
+- Building-permit portals
+- Open-data catalogues
+- Downloadable approved-company lists
+
+## 8. Recommended Source Priority
+
+For building the first version of the database, use this order:
+
+1. Abu Dhabi DMT Engineering Firms with Valid Classification
+2. Dubai Municipality Consultants, Contractors and Suppliers Data
+3. Ras Al Khaimah Approved Consultants
+4. Ras Al Khaimah Approved Contractors
+5. Sharjah verification and star-rating systems
+6. Ajman and Fujairah classification systems
+7. Umm Al Quwain municipal sources
+
+## 9. Recommended Core Database Fields
+
+```text
+firm_id
+source_record_id
+economic_license_number
+professional_license_number
+
+firm_name
+firm_name_ar
+firm_type
+firm_type_ar
+
+country
+country_ar
+emirate
+emirate_ar
+city
+city_ar
+
+classification_category
+classification_category_ar
+classification_status
+classification_status_ar
+classification_expiry_date
+
+rating_value
+evaluation_result
+
+phone_number
+mobile_number
+email_address
+website_url
+address
+address_ar
+
+regulatory_authority
+regulatory_authority_ar
+source_system
+source_list_url
+source_detail_url
+collected_at
+last_verified_at
+```
+
+Use separate relationship tables for activities, project/building categories, branches, classifications, and evaluations when one firm can have multiple values.
+
+## 10. Language Rule
+
+Use lowercase English `snake_case` column names.
+
+- Base field: English content, for example `firm_name`.
+- Arabic field: Same name with `_ar`, for example `firm_name_ar`.
+- Keep the English field `NULL` if no official or verified English value exists.
+- Do not automatically translate or transliterate a legal company name and present it as official.
+- Store language-independent values only once. Phone numbers, licence numbers, email addresses, URLs, coordinates, prices, dates, ratings, and Boolean values do not need an `_ar` duplicate.
+
+## 11. Verification and Compliance Requirements
+
+Before automated data collection:
+
+1. Confirm the current fields, pagination, filters, and record counts for each live source.
+2. Check for an official API, open-data download, CSV, Excel, PDF, or JSON source before using browser automation.
+3. Review the site's terms of use, robots policy, rate limits, and republication restrictions.
+4. Do not bypass authentication, CAPTCHA, access controls, or technical restrictions.
+5. Preserve the exact source value separately from cleaned or normalized values.
+6. Record the source URL and collection timestamp for every record.
+7. Treat grades, ratings, classification categories, and evaluation results as separate concepts.
+8. Test for duplicates across emirates using licence numbers and verified identifiers, not company names alone.
+9. Re-verify time-sensitive fields such as classification status and expiry dates periodically.
+
+## 12. Source Status Summary
+
+| Emirate | Contractors | Consultants | Public complete list confirmed | Arabic/English names | Initial suitability |
+|---|---:|---:|---:|---:|---|
+| Abu Dhabi | Yes | Yes | Yes | Both in the main directory | Excellent |
+| Dubai | Yes | Yes | Official registers confirmed; access requires further technical review | Interface available in both languages; record-level bilingual availability must be verified | Very good |
+| Ras Al Khaimah | Yes | Yes | Yes, separate lists | Names are frequently Arabic even on the English interface | Excellent |
+| Sharjah | Verification available | Classification services available | No complete list confirmed | Requires verification | Limited |
+| Ajman | Classification service | Classification service | No complete list confirmed | Requires verification | Regulatory reference |
+| Fujairah | Registration/classification service | Classification service | No complete list confirmed | Requires verification | Regulatory reference |
+| Umm Al Quwain | Not confirmed | Not confirmed | No | Not confirmed | Further research required |
+
+## 13. Verification Date
+
+Initial source review: 20 August 2026.
+
+All lists, classifications, ratings, and expiry dates are time-sensitive and must be rechecked against the current official source before publication or operational use.


### PR DESCRIPTION
Six source briefs he sent today, each with an instruction rather than a discussion:

| | his words | where it went |
|---|---|---|
| **REQ-14** | «ضيف هذا الملف ليكون المصدر التالى بعد الانتهاء الكامل من مصدر مقاول» | [BALADY-ENG-OFFICES.md](docs/BALADY-ENG-OFFICES.md) |
| **REQ-15** | «...بعد الانتهاء الكامل من مصدر مقاول ومصدر بلدية» | [UAE-SOURCES.md](docs/UAE-SOURCES.md) |
| **REQ-16** | «المزيد من المصادر ضفها الى القائمة» | [GULF-EGYPT-SOURCES.md](docs/GULF-EGYPT-SOURCES.md) |
| **REQ-17** | «مصادر اخرى لاسعار الديزل فقط مصادر منتجات» | [DIESEL-PRICES.md](docs/DIESEL-PRICES.md) |
| **REQ-18** | «مصادر اخرى» | [BITUMEN-PRICES.md](docs/BITUMEN-PRICES.md) |
| **REQ-19** | «مصادر جديدة ضيفها للقائمة سياتى دورها يوما ما» | [CONCRETE-MATERIALS.md](docs/CONCRETE-MATERIALS.md) |

**All stored verbatim under a preamble**, in the repository rather than in a conversation — he had to re-send the muqawil column specification earlier today not knowing whether it had survived («لان دراسته ربما تكون فقدت»). It had. He should not have to ask twice.

**Nothing is started.** `STATE.md` Track 5 is eight countries and three product classes, and says so.

## The firm directories

**Egypt/Oman/Qatar/Bahrain/Kuwait — 32 numbered sources, and the useful part is where it says no.** Only three of five have anything like a national public directory: Egypt's EFCBC is authenticated and its best public list is Arabic-only; Kuwait has no confirmed current public list at all. So its real instruction is a *schema* one — *"build federated datasets rather than claiming a single complete national directory"* — which is why his `firms` table opens with `source_system` and `regulatory_authority`.

**Two of these are better-shaped than muqawil, measurably.** Oman's ESNAD and Qatar's Monaqasat publish Arabic and English views joined by a stable identifier. On muqawil the Arabic half is a **second full crawl** — 871 listing pages and 17,403 profiles again — matched by **page-order index** because one label is spelled `رقم العضويه` with `ه`. An identifier join is strictly better than both.

## The price briefs are a different half of the warehouse — and they agree on a defect

He classified them himself: **«مصادر منتجات»**. The firm directories land in `generic_record`; these land in `price_observation`, the original spine muqawil never touched.

- **Diesel** is 7 pages against muqawil's 36,548 — about fourteen requests a month.
- **Bitumen cannot be crawled at all**: by its own conclusion five of seven countries have no public official price, so its acquisition mode is a written quotation, and its brief ends with a letter rather than a URL.
- **Concrete** types its sources explicitly, with a column headed *"Can it populate `price_amount`?"* answering **No** for an index, an approved-supplier list and a specification.

### And that is [DEC-12](docs/BACKLOG.md): the append gate's key is not the number

`SR-6` — an unchanged price is confirmed, not appended — is right about what it was written for and wrong about official published prices. Three briefs, written separately, break it in three different places:

| brief | what carries the new fact | what `SR-6` sees |
|---|---|---|
| diesel | the **period** — a ministry setting `0.258` again *for August* is the fact | no change → the August period never exists |
| bitumen | the **commercial basis** — ex-refinery vs delivered, taxed vs not | no change → collapses two different facts at equal values |
| concrete | the **source type** — an index point is not an absolute price | no change → treats an index and a price as one observation |

So the key is at least `(product identity, period, commercial basis, source type)` — and concrete goes further than a key: an index must not enter the price column **at all**.

**Recorded before any of it is collected, because the failure is silent and unrecoverable.** A dropped month is not a wrong row a later fix corrects; it is a row that never existed, in a table whose whole purpose is history. And it does not wait — the Qatar bitumen figure had **already expired** when he sent it. `DEC-12` also says what it does *not* say: `SR-6` earned itself and stays; the gate needs to be told what "new" means per product class, and that is his ruling to make.

## Two operational notes worth not rediscovering

- **Bahrain's diesel price is published as an image.** His own instruction: keep the screenshot, treat OCR as a *candidate* extraction, verify against the dated committee announcement. There is no OCR path here, and his rule is right regardless — the image is the evidence, the number is a claim about it.
- **Kuwait's page carries a correct price beside a stale validity note.** A collector that trusted it would store a right number under wrong dates, which is the worse failure because it looks complete.

## Verification

- Full suite under `SCRAPEX_FULL_MIGRATIONS=1`: **zero failures**, before this PR opened — `R-22`.
- Docs gates green, including the request-board guard added in #230 — which is what forced `REQ-14`…`REQ-19` to exist as board entries rather than as documents nobody indexes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
