### PR TITLE
A snapshot says how it is encoded, and 4.55 GB becomes about 90 MB

### DIFF
--- a/db/engine/migrations/0005_a_snapshot_says_how_it_is_encoded.sql
+++ b/db/engine/migrations/0005_a_snapshot_says_how_it_is_encoded.sql
@@ -27,6 +27,14 @@
 --
 -- 618 MB of listings becomes 3.3 MB; 3.95 GB of profiles becomes 87 MB.
 --
+-- THE CODEC IS THE `zstandard` WHEEL, NOT `compression.zstd`. The first draft
+-- of this used the 3.14 standard library module, and requires-python is
+-- ">=3.12" with CI on 3.12.14 -- where importing it stopped the package
+-- loading at all, not merely the tests. Same libzstd, identical on 3.12 through
+-- 3.14, which also means a page compressed on one of the owner's two machines
+-- can be read on the other. Re-measured through the wheel on the same 40 stored
+-- pages: 254x.
+--
 -- NOTHING EXISTING IS REWRITTEN, AND THAT IS NOT LAZINESS.
 -- `trg_generic_page_snapshot_immutable_update` aborts any UPDATE to this
 -- table, and it is right to: a stored page is evidence of what a site

--- a/db/engine/migrations/0005_a_snapshot_says_how_it_is_encoded.sql
+++ b/db/engine/migrations/0005_a_snapshot_says_how_it_is_encoded.sql
@@ -1,0 +1,98 @@
+-- =====================================================================
+-- 0005 — A SNAPSHOT SAYS HOW IT IS ENCODED
+--
+-- docs/STORAGE.md, on his instruction — «ليست الفكرة ضغط الملفات بل
+-- دراسة نشوف احنا بنسحب اى ولية وبنحتفظ باية ولية وما الفائدة». The study
+-- measured what the retention policy costs and what each option spends,
+-- and its recommendation needs exactly one thing from the schema: a
+-- snapshot has to be able to say how its body is encoded.
+--
+-- WHY NOT ZLIB, WHICH DEC-9 RECOMMENDED. Because its 15.6× is entirely
+-- intra-page. A listing page is 363 KB and its non-card skeleton is
+-- 121 KB, near-identical across all 871 pages; zlib's window is 32 KB, so
+-- by the time page 2 begins page 1 is out of view. Measured on the 40
+-- stored pages: ten skeletons concatenated cost 9.84× one skeleton, and
+-- all 40 pages compressed as a single zlib block came to 15.8× — no
+-- better than compressing them one at a time. The cross-page redundancy
+-- DEC-9 credited for its ratio was never captured at all.
+--
+-- WHY A DICTIONARY AND NOT A BLOCK. As one zstd block those same 40
+-- pages reach 219×, but a block is a CHAIN: row 700 cannot be read
+-- without row 699 still existing, which is not a property a database
+-- column may have. `zstd` with one real page as a RAW dictionary reaches
+-- 187× on listings and 46× on profiles at 3.5 ms a page, and every row
+-- stays independently decompressible — verified by round-trip, not
+-- assumed. That is why this migration stores dictionaries as rows rather
+-- than storing bodies as a stream.
+--
+-- 618 MB of listings becomes 3.3 MB; 3.95 GB of profiles becomes 87 MB.
+--
+-- NOTHING EXISTING IS REWRITTEN, AND THAT IS NOT LAZINESS.
+-- `trg_generic_page_snapshot_immutable_update` aborts any UPDATE to this
+-- table, and it is right to: a stored page is evidence of what a site
+-- published on a date. A backfill would have to drop that trigger, and
+-- the trigger is worth more than 600 MB. So `html_codec` defaults to
+-- 'plain' and the 1,728 rows already on disk keep working untouched,
+-- read by exactly the code path that reads them today. The 3.95 GB this
+-- is for has not been fetched yet, which is the whole reason the study
+-- gated the crawl.
+--
+-- WHY THE BODY COLUMN IS NOT CHANGED EITHER. `html_content` is declared
+-- TEXT and stays declared TEXT. SQLite column types are affinities, not
+-- constraints, and TEXT affinity explicitly does not convert a BLOB — so
+-- a compressed body is stored in the column it belongs in, NOT NULL is
+-- satisfied honestly, and no table rebuild puts 1,728 rows of evidence
+-- and four foreign keys at risk to add two columns.
+--
+-- `content_hash` KEEPS ITS MEANING: it is the SHA-256 of the DECODED
+-- page, so identity remains a fact about content and never about
+-- encoding. Two runs that fetch the same page agree on its hash whether
+-- one compressed it and the other did not.
+-- =====================================================================
+
+-- A dictionary is not derived data. Every body compressed against it is
+-- UNREADABLE without it, so it is stored here and guarded below rather
+-- than rebuilt on demand from whatever page happens to be handy.
+CREATE TABLE IF NOT EXISTS snapshot_dictionary (
+    dict_id    INTEGER PRIMARY KEY,
+    -- What this dictionary is FOR: host plus page kind, e.g.
+    -- `muqawil.org/listing`. Per kind and not per host, because the study
+    -- measured 187× on listings and 46× on profiles with a same-kind
+    -- dictionary; one dictionary for both would be worse than either.
+    label      TEXT NOT NULL UNIQUE,
+    -- One real page, exactly as it arrived. A raw dictionary rather than a
+    -- trained one: trained dictionaries were measured too and reached
+    -- 19.7× against the raw page's 187×.
+    body       BLOB NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+);
+
+-- IMMUTABLE FOR A HARDER REASON THAN THE SNAPSHOTS ARE. A changed
+-- snapshot loses one page; a changed dictionary loses every page
+-- compressed against it, silently, and the loss only surfaces when
+-- someone tries to read one. There is no repair — the plaintext is not
+-- stored anywhere else.
+CREATE TRIGGER IF NOT EXISTS trg_snapshot_dictionary_immutable_update
+BEFORE UPDATE ON snapshot_dictionary
+BEGIN
+    SELECT RAISE(ABORT, 'a compression dictionary is immutable: every stored page compressed against it would become unreadable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_snapshot_dictionary_immutable_delete
+BEFORE DELETE ON snapshot_dictionary
+BEGIN
+    SELECT RAISE(ABORT, 'a compression dictionary cannot be deleted: every stored page compressed against it would become unreadable');
+END;
+
+-- 'plain' means html_content is the page. Anything else names a codec the
+-- reader must apply. DEFAULT rather than nullable, so a row can never be
+-- ambiguous about how to read it -- including every row already on disk.
+ALTER TABLE generic_page_snapshot
+    ADD COLUMN html_codec TEXT NOT NULL DEFAULT 'plain';
+
+-- Which dictionary decodes this body. NULL for 'plain', and NULL for any
+-- future codec that needs none.
+ALTER TABLE generic_page_snapshot
+    ADD COLUMN html_dict_id INTEGER REFERENCES snapshot_dictionary(dict_id);
+
+PRAGMA user_version = 5;

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -893,8 +893,8 @@ and each of these looked promising enough to chase:
 > intra-page**. zlib's 32 KB window never sees across a 121 KB page, so the
 > cross-page redundancy this entry credits for the ratio was left on the table.
 > `zstd` with one real page as a raw dictionary gets **187×** on listings and
-> **46×** on profiles, is in the 3.14 standard library, and keeps every row
-> independently decompressible. Its *rule* — keep the snapshots — is upheld and
+> **46×** on profiles — **254×** re-measured through the `zstandard` wheel,
+> which is what shipped — and keeps every row independently decompressible. Its *rule* — keep the snapshots — is upheld and
 > strengthened. Its *encoding* is not.
 
 **MEASURED 2026-08-20, on the live database.** The contractors cost 342 MB, of which

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -400,9 +400,9 @@ does not exist:
 
 - The 6.4 GB was projected from **one** profile page at 168 KB. Thirteen real
   profiles average **119 KB**, so the complete corpus is **4.55 GB** raw, not 6.4.
-- `compression.zstd` entered the standard library in Python 3.14, and a raw page
-  used as a shared dictionary compresses listings **187×** and profiles **46×** with
-  every row still independently decompressible. `DEC-9`'s zlib gets 15.6× and 7.7×,
+- `zstandard` with a raw page used as a shared dictionary compresses listings
+  **187×** and profiles **46×** — **254×** re-measured through the wheel that
+  shipped — with every row still independently decompressible. `DEC-9`'s zlib gets 15.6× and 7.7×,
   because its 32 KB window cannot see across a 121 KB page — the cross-page
   redundancy it credited for its ratio was **left on the table**.
 - So everything the site publishes, both languages, evidence retained: **~90 MB of

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -109,7 +109,8 @@ broken under load (**T2**).
 ## Track 2 · The muqawil.org contractor directory
 
 **Design:** [CONTRACTOR-SOURCE.md](CONTRACTOR-SOURCE.md) · **Storage:**
-[STORAGE.md](STORAGE.md) · **Seam:**
+[STORAGE.md](STORAGE.md) — **the mechanism is built** (`scrapex/snapshotbody.py`,
+engine migration 0005), so nothing gates the crawl any more · **Seam:**
 [GENERIC-FETCH-SEAM.md](GENERIC-FETCH-SEAM.md) · **Plan:**
 [plans/2026-08-16-muqawil-contractor-source.md](plans/2026-08-16-muqawil-contractor-source.md)
 · **Rulings:** [R-10](RULINGS.md#r-10--the-contractor-directory--three-rulings),
@@ -186,6 +187,16 @@ snapshots and read one language only, deliberately (it needed ids, not values), 
 the ~6,344 known-missing contractors have **no evidence and no Arabic half** —
 closing that gap is a new bilingual crawl, and DEC-9 argues it should follow the
 compression migration rather than precede it.
+
+**The storage question that gated the crawl is answered and built.** `docs/STORAGE.md`
+measured what retention costs and what each option spends: the corpus is **4.55 GB**
+raw, not the 6.4 GB projected from one sample, and `zstd` against one real page of the
+same kind as a raw dictionary stores it in about **90 MB** — 187× on listings, 46× on
+profiles, every row independently decompressible. `scrapex/snapshotbody.py` and engine
+migration 0005 are that mechanism, and `snapshotcrawl` is its caller, so the pages the
+crawl writes arrive compressed. **The 1,728 rows already on disk were deliberately not
+rewritten**: `html_codec` defaults to `'plain'` rather than dropping an immutability
+trigger to backfill 607 MB.
 
 **And that crawl now has a method that can prove itself, measured 2026-08-20.**
 `region_id` × `company_size` is an **exhaustive 56-cell partition** of the

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -76,7 +76,7 @@ conversation about size that is not about snapshots is about the wrong thing.
 | 21% of a listing page is cards | **17.8%** |
 | a profile is **168 KB** *(one sample)* | **119 KB** (13 profiles, min 101, max 157) |
 | the full crawl is **~6.4 GB** raw | **4.55 GB** — 618 MB of listings, 3.95 GB of profiles |
-| compressed, ~660 MB | **~90 MB**, with a mechanism that is now in the standard library — §4 |
+| compressed, ~660 MB | **~90 MB**, with a shared-dictionary codec — §4 |
 | a profile compresses 9.4× | **7.7×** with zlib per row; **46×** with a shared dictionary |
 
 **And one claim of `DEC-9`'s was not merely imprecise but backwards**, which matters
@@ -158,10 +158,27 @@ comparison is real and not a mix of sources.
 | zstd-19, 20-page blocks | 170× | — | no — 20× read amplification |
 | zstd-19, all 40 as one block | 219× | 61× | **no** — a chain; row 700 needs row 699 |
 
-**`compression.zstd` is in the Python standard library as of 3.14** (this machine runs
-3.14.6), and `ZstdDict(..., is_raw=True)` accepts an ordinary page as the dictionary. So
-the constraint that made `DEC-9` choose zlib — *"no new dependency"* — is satisfied by
-the option that is **12× better**, and the cost is 3.5 ms a page.
+**This costs one dependency, and the first version of this study got that wrong.**
+`compression.zstd` is in the standard library as of Python **3.14**, and the machine
+this was measured on runs 3.14.6 — so the study concluded that the constraint which
+made `DEC-9` choose zlib, *"no new dependency"*, was satisfied for free. It is not.
+`pyproject.toml` declares `requires-python = ">=3.12"` and **CI runs 3.12.14**, where
+that module does not exist: importing it did not merely fail the tests, it stopped the
+package importing at all.
+
+**The fix is the `zstandard` wheel, and it is more portable than the thing it
+replaces.** Same libzstd underneath, identical behaviour on 3.12, 3.13 and 3.14 —
+where `compression.zstd` works on 3.14 alone. The owner works from two machines, and a
+compressed page that only one of them can read is a worse outcome than a dependency,
+because the plaintext is not stored anywhere else. Measured again through `zstandard`
+on the same 40 stored pages: **254×**, better than the 187× the stdlib module gave, at
+the same order of cost per page.
+
+So the honest form of `DEC-9`'s constraint is: it was a preference, the alternative
+costs **4.8× more disk** (stdlib-only `lzma` measured at 19.1× on these pages, and
+Python's `lzma` exposes no shared dictionary — prepending one is *worse*, 18.4×,
+because the dictionary is then paid for on every row), and the preference is not worth
+that.
 
 **The whole corpus, each way:**
 
@@ -223,7 +240,7 @@ Recommendation 3 is no longer a recommendation:
 
 | | |
 |---|---|
-| the codec | [`scrapex/snapshotbody.py`](../scrapex/snapshotbody.py) — `plain` and `zstd-raw-dict`, level 12 |
+| the codec | [`scrapex/snapshotbody.py`](../scrapex/snapshotbody.py) — `plain` and `zstd-raw-dict`, level 12, on the `zstandard` wheel |
 | the schema | `db/engine/migrations/0005_a_snapshot_says_how_it_is_encoded.sql` — `snapshot_dictionary`, plus `html_codec` and `html_dict_id` on the snapshots |
 | the production caller | `scrapex/snapshotcrawl.py` — the path the 36,548 pages arrive on, compressed against a dictionary of their own **kind** via `label_for(url, page.kind)` |
 | the guards | `tests/test_a_snapshot_says_how_it_is_encoded.py`, 13 tests, mutation-proven three ways |

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -217,13 +217,53 @@ it. It changes one row of the table above and no others: if evidence-over-time m
    evidence plus ~70 MB of rows and indexes — call it **160 MB** for everything the site
    publishes, against the **5 GB** the question was asked about.
 
-### What this does not decide, and what it needs from him
+### BUILT 2026-08-20, on his instruction «ابدأ آلية التخزين»
+
+Recommendation 3 is no longer a recommendation:
+
+| | |
+|---|---|
+| the codec | [`scrapex/snapshotbody.py`](../scrapex/snapshotbody.py) — `plain` and `zstd-raw-dict`, level 12 |
+| the schema | `db/engine/migrations/0005_a_snapshot_says_how_it_is_encoded.sql` — `snapshot_dictionary`, plus `html_codec` and `html_dict_id` on the snapshots |
+| the production caller | `scrapex/snapshotcrawl.py` — the path the 36,548 pages arrive on, compressed against a dictionary of their own **kind** via `label_for(url, page.kind)` |
+| the guards | `tests/test_a_snapshot_says_how_it_is_encoded.py`, 13 tests, mutation-proven three ways |
+
+**Nothing existing was rewritten, and that was a decision rather than a shortcut.**
+`trg_generic_page_snapshot_immutable_update` aborts any UPDATE to the snapshot table,
+and it is right to — a stored page is evidence of what a site published on a date. A
+backfill would have to drop that trigger; the trigger is worth more than the 607 MB.
+So `html_codec` carries a DEFAULT of `'plain'` and the 1,728 rows already on disk are
+read by exactly the path that reads a new one. **The 3.95 GB this is for has not been
+fetched yet, which is the whole reason the study gated the crawl.**
+
+Three things the build had to get right that the study did not have to say:
+
+- **`content_hash` stays the hash of the DECODED page.** Otherwise the day a codec
+  changes is the day every page becomes a different page, and every dedup and
+  revision decision downstream moves with it.
+- **`html_content` keeps its declared TEXT type and holds either.** SQLite column
+  types are affinities, and TEXT affinity explicitly does not convert a BLOB — so a
+  compressed body lives in the column it belongs in, `NOT NULL` is satisfied
+  honestly, and no table rebuild puts 1,728 rows of evidence and four foreign keys at
+  risk in order to add two columns.
+- **A page that would grow is stored plain.** A codec that is a pessimisation on some
+  rows and an optimisation on others is one nobody can reason about, so the
+  comparison is made on real bytes.
+
+**And the dictionary is guarded harder than the snapshots are.** A changed snapshot
+loses one page; a changed dictionary loses **every** page compressed against it,
+silently, and only when someone tries to read one — with no repair, because the
+plaintext is not stored anywhere else. `snapshot_dictionary` therefore forbids both
+UPDATE and DELETE.
+
+### What this still does not decide, and what it needs from him
 
 - **§5 — is a snapshot evidence, or only a parse cache?** His answer decides whether
-  profiles may ever be dropped for a re-fetch.
-- **The migration itself is not written.** He asked for a wider measurement first
-  («أريد قياساً أوسع أولاً»); this is that measurement. Writing the migration is a
-  separate decision with this in hand.
+  profiles may ever be dropped for a re-fetch. **It does not block the crawl**: the
+  recommendation is to retain everything, and §5 only decides whether a future
+  reduction is permitted.
+- **Backfilling the 1,728 existing rows** would save ~600 MB and requires dropping an
+  immutability trigger to do it. Not done, and not recommended without him saying so.
 - **`R-20` (revision on change only) is worth more than it looks here.** 34,550
   revisions for 11,059 records is 26.7 MB, and the distribution is exactly two revisions
   per appearance — the second recording no change. Under `R-20` that table is roughly

--- a/docs/plans/2026-08-20-finish-muqawil-then-the-source-queue.md
+++ b/docs/plans/2026-08-20-finish-muqawil-then-the-source-queue.md
@@ -1,0 +1,148 @@
+# Finish muqawil.org completely, then the source queue
+
+**LIVE. Written 2026-08-20, and written to be picked up on the other machine.**
+
+> «بعد الانتهاء من آلية التخزين اريد التوقف حتى استكمل من جهاز اخر تاكد من تسجيل كل شى»
+
+He works from two machines under two accounts. `~/.claude/plans/` is one machine and
+one account, which is why seven plans had to be rescued out of it on 2026-08-17 and
+why **`R-08` puts the plan in the repository**. This file is here so the other machine
+can start from it without asking anyone what happened.
+
+**His priority, in his words: «موقع مقاول بشكل كامل»** — finish muqawil.org
+completely — and complete means **«كلّ ما ينشره الموقع»**, every field the site
+publishes, both languages, detail pages included.
+
+---
+
+## Where it actually stands
+
+**The studying is finished. The building has started.** Every gate the previous plan
+set before the crawl has been cleared.
+
+| | |
+|---|---|
+| **Done** | the crawl study ([DEC-11](../BACKLOG.md), #228 · #229) · the sightings ledger and resume (#227) · the storage study ([STORAGE.md](../STORAGE.md), #230) · **the storage mechanism itself** (`scrapex/snapshotbody.py`, engine migration 0005) |
+| **Coverage today** | **11,059 of 17,403 contractors — 64%**, listing pages only, **zero** profile pages ever fetched |
+| **Columns today** | **22 of his ~70**, all from the listing card. The other 48 live on the profile page, which has never been crawled |
+
+### The four numbers that matter, all measured on 2026-08-20
+
+- The listing is **871 pages**, and `(L−1)×20 + c` with `c` **read** — it was 15 cards
+  on 2026-08-16, 2 that morning, 3 that afternoon. He warned the data is live before
+  any of this was measured.
+- `region_id` × `company_size` is an **exhaustive 56-cell partition**, exact to the
+  unit: 15,966 across regions 1–13 plus **1,437 under `region_id=0`** (the contractors
+  who publish no location) = 17,403.
+- A provable listing crawl is **~1,065 requests, ~1.7 h**, against 18.4 h for a blind
+  sweep that can never say "complete".
+- The whole corpus is **4.55 GB** raw and **~90 MB** stored, because the mechanism is
+  built.
+
+---
+
+## The build order, and why it is this order
+
+### 1 · The listing crawl — closes coverage to a *provable* 100%
+
+**~1,065 requests, ~1.7 hours.** Method in [DEC-11](../BACKLOG.md), §"The method:
+partition, then witness the partition":
+
+1. Size all 56 cells from their own paginators — one request each. `read_last_page`
+   already reads a filtered listing correctly (fixed in #229).
+2. Read each cell, then **re-fetch its page 1 and compare the ID SEQUENCE** — never
+   the bytes. A re-fetched page whose id order was identical was measured **not**
+   byte-identical; a byte comparison certifies nothing, ever, while appearing to work.
+3. `D = N_cell − |distinct|`. `D = 0` proves the cell complete. One cell is already
+   closed end to end: region 13 × verysmall, 7 pages, 128 ids, 128 distinct.
+4. Record every id seen through `scrapex/sightings.py` (`record_sightings`), so
+   "which contractors did the site show us that we did not store" is answerable
+   afterwards. That is what the 10001274 incident demanded.
+
+**Two things to expect.** The generation floor is **157 s** (measured: identical order
+at 55, 90 and 157 s; rolled by 282 s), so a cell above ~31 pages may fail its witness
+and retry — that is a cost, not a correctness problem. And **five city×size cells stay
+above the ceiling**, worst RIYADH×verysmall at ~212 pages, with no fourth exhaustive
+axis fine enough. `user_type` only halves it.
+
+### 2 · The profile parser — the 48 missing columns
+
+Nothing extracts a profile page today. `docs/CONTRACTOR-SOURCE.md` carries the full
+field table with his own labels and the addendum, and marks where each value comes
+from (`sc` search card, `pr` profile, `js` inline script, `u` built from the id).
+
+**One correction to carry forward:** `contract_request_url` is marked `u` in the design
+but has **no known URL pattern** and is not on the card. It cannot be built from the id.
+
+### 3 · The child tables — `R-19`, already ruled
+
+**«جداول أبناء للخمس كلّها»** — child tables for all five multi-valued groups
+(Interests, Licensed Activities, Qualification Programs, Balady Services, contractor
+relations), not JSON and not `Activity 1, 2, 3…`. A measured profile carried **30
+hierarchical interest values in 6 groups**, so this is ~500K rows and the decision is
+his and already taken.
+
+### 4 · The profile crawl — 34,806 pages, ~17.4 hours
+
+Both locales, because the Arabic values come only from the Arabic page and are matched
+**by page-order index, never by label** (one field is spelled `رقم العضويه` with `ه`).
+It writes 3.95 GB raw and ~87 MB stored. **This is the step the storage mechanism
+existed for**, so it must run with `body_class` set — `snapshotcrawl` already does it.
+
+### Cheap wins, an hour in total
+
+- **`DSN-05`**: split `card_city_region` (`"RIYADH - Riyadh"`) into City and Region.
+  His request to separate them is not met, and a column count calls it done.
+- **`DSN-04`**: the URL columns built from the id — minus `contract_request_url`
+  above.
+
+---
+
+## What is blocked, and on whom
+
+| | |
+|---|---|
+| **`DEC-10`** | *"fix the parser and re-run over the snapshots"* **does not work**: `approve_candidate` short-circuits on `(snapshot, locator)` plus `schema_hash`, so a corrected parser returns `recovered=True` for every page and writes nothing. 864 pages once reported re-approved changed not one row. Needs a row-aware idempotency key |
+| **`STORAGE.md` §5** | *Is a snapshot evidence, or only a parse cache?* **His.** It does not block the crawl — the recommendation is retain everything — it decides whether a future reduction is permitted |
+| **`DEC-12`** | The append gate's key is not the number. **His**, because it changes what `SR-6` means. Not needed for muqawil; needed before the first price collection |
+| **`O-2`, `O-5`** | Open contractor questions. `O-5` is explicitly held by him |
+| **`REQ-11`** | Branch protection — he deferred it to its own session. `main` still has **no protection at all** (the API answers 404) |
+
+---
+
+## Then, and only then: the source queue
+
+Six briefs of his, all stored **verbatim** in `docs/`, none started.
+[../STATE.md](../STATE.md) Track 5 is the board.
+
+| # | source | file | note |
+|---|---|---|---|
+| 2 | Balady engineering offices | [BALADY-ENG-OFFICES.md](../BALADY-ENG-OFFICES.md) | `REQ-14`. Its deliverable 6 — does an open dataset exist — should be answered **first** |
+| 3 | UAE, 7 emirates | [UAE-SOURCES.md](../UAE-SOURCES.md) | `REQ-15`. Abu Dhabi DMT publishes both languages **in one record** — better-shaped than muqawil |
+| 4 | Egypt, Oman, Qatar, Bahrain, Kuwait | [GULF-EGYPT-SOURCES.md](../GULF-EGYPT-SOURCES.md) | `REQ-16`. Only 3 of 5 have a national public directory |
+| — | diesel prices | [DIESEL-PRICES.md](../DIESEL-PRICES.md) | `REQ-17`. **7 pages**, ~14 requests a month — an afternoon, not a track |
+| — | bitumen 60/70 | [BITUMEN-PRICES.md](../BITUMEN-PRICES.md) | `REQ-18`. **Cannot be crawled**: 5 of 7 need a written quotation |
+| — | concrete materials | [CONCRETE-MATERIALS.md](../CONCRETE-MATERIALS.md) | `REQ-19`. A provenance-typed price model; an index is not a price |
+
+**All three price briefs break `SR-6` in different places** — period, commercial
+basis, source type — which is [DEC-12](../BACKLOG.md). Settle it before collecting,
+because a dropped period is not a wrong row a later fix corrects; it is a row that
+never existed, in a table whose whole purpose is history.
+
+---
+
+## Working rules that cost real time when forgotten
+
+- **`R-22`**: the full suite finishes before a PR opens. Two red PRs came from narrow
+  test runs.
+- **`R-18`**: merge when green — and **verify the merge landed**. A background waiter
+  once printed `MERGED` while GitHub had reported a conflict; check the command's exit
+  code *and* grep `origin/main` for `(#NNN)`.
+- **`SR-19`**: never `git add .`. It once swept 33 MB of `.vs/` into a commit.
+- **A guard is not trusted until it has been mutated.** Three guards written on
+  2026-08-20 passed under the very defect they were written for.
+- **`SCRAPEX_FULL_MIGRATIONS=1`** for the real migration path locally.
+- **One expected failure**, `OP-19`: `test_a_killed_engine_does_not_leave_a_job_claiming_to_run`
+  is a load-dependent race, demonstrated pass/FAIL/FAIL on an unchanged tree.
+- **The live DB is `~/.scrapex/engine/scrapex-engine.db`.** `~/.scrapex/marketlens/marketlens.db`
+  is the stale old path and carries none of the generic tables.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -22,6 +22,7 @@ of what was decided when. See
 
 | plan | date | status |
 |---|---|---|
+| [2026-08-20-finish-muqawil-then-the-source-queue.md](2026-08-20-finish-muqawil-then-the-source-queue.md) | 2026-08-20 | **LIVE.** Finish muqawil completely — «كلّ ما ينشره الموقع» — then the six queued sources. **Written to be picked up on his other machine**, per [R-08](../RULINGS.md#r-08--the-plan-and-the-state-live-in-the-repository): the studying is finished, the building has started, and the build order plus what is blocked on him is in one place. Coverage is 11,059 of 17,403 with **zero** profile pages fetched |
 | [2026-08-16-muqawil-contractor-source.md](2026-08-16-muqawil-contractor-source.md) | 2026-08-16 | **LIVE.** The contractor directory — the plan behind #202–#209 and PR #211. Holds the owner's three rulings ([R-10](../RULINGS.md#r-10--the-contractor-directory--three-rulings)), the four build steps, verification, and four open questions. Was `iterative-dreaming-prism.md` |
 | [../MIGRATION-PLAN.md](../MIGRATION-PLAN.md) | 2026-08-12 | **LIVE.** The Console, the migration, and the debt. Already in the repo (moved 2026-08-15, [R-08](../RULINGS.md#r-08--the-plan-and-the-state-live-in-the-repository)). Its living state is [HANDOFF-resume-the-migration.md](../HANDOFF-resume-the-migration.md) — and **two of its claims were measured false**; that table is in the handoff |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,17 @@ dependencies = [
     "beautifulsoup4>=4.12",
     "lxml>=5.2",
     "tzdata>=2024.1",   # Windows ships no system tz database (scheduler timezones)
+    # Snapshot bodies, compressed against a shared raw dictionary: 187x on
+    # listing pages and 46x on profiles, where zlib gets 15.6x and 7.7x --
+    # its 32 KB window never reaches across a 121 KB page skeleton. See
+    # docs/STORAGE.md and scrapex/snapshotbody.py.
+    #
+    # NOT `compression.zstd`, which is the same library in the 3.14 standard
+    # library: requires-python is >=3.12 and CI runs 3.12, so importing it
+    # broke the package outright. This wheel behaves the same on 3.12, 3.13
+    # and 3.14, which also means a page compressed on one of the owner's two
+    # machines can be read on the other.
+    "zstandard>=0.22",
 ]
 
 [project.optional-dependencies]

--- a/scrapex/extract/models.py
+++ b/scrapex/extract/models.py
@@ -35,6 +35,12 @@ class SnapshotCreate(BaseModel):
     #: moment of capture. None for a crawl that does not name itself, and for
     #: the 1,728 snapshots stored before runs had names.
     crawl_run_ref: str | None = None
+    #: Which compression dictionary this page belongs with -- `host/kind`, from
+    #: `snapshotbody.label_for`. None means STORE IT AS IT ARRIVED, and that is
+    #: the default on purpose: the engine's save-a-page endpoint saves one page
+    #: by hand, which has no class to share a dictionary with and nothing to
+    #: gain. A crawl of 36,548 pages has both. See docs/STORAGE.md.
+    body_class: str | None = None
 
 
 class ApprovalField(BaseModel):

--- a/scrapex/extract/service.py
+++ b/scrapex/extract/service.py
@@ -11,6 +11,7 @@ from urllib.parse import urlparse
 
 from .. import catalog
 from ..catalog_models import DatasetCreate, FieldCreate, SiteCreate
+from ..snapshotbody import decode, encode
 from .html_table import TableCandidate, candidate_by_index, detect_html_tables
 from .models import (
     DEFAULT_RECORD_PAGE_SIZE,
@@ -40,7 +41,8 @@ def _site_base_url(source_url: str) -> str:
 def _snapshot_row(conn: sqlite3.Connection, snapshot_id: int) -> sqlite3.Row:
     row = conn.execute(
         "SELECT page_snapshot_id, source_url, content_type, html_content, "
-        "content_hash, captured_at FROM generic_page_snapshot "
+        "content_hash, captured_at, html_codec, html_dict_id "
+        "FROM generic_page_snapshot "
         "WHERE page_snapshot_id = ? LIMIT 1",
         (snapshot_id,),
     ).fetchone()
@@ -70,11 +72,18 @@ def save_snapshot(conn: sqlite3.Connection, request: SnapshotCreate) -> dict[str
             "snapshot and try again."
         )
     source_url = str(request.source_url)
+    # THE HASH IS OF THE PAGE, NEVER OF ITS ENCODING. Two runs that fetch the
+    # same page must agree on its content_hash whether one compressed it and the
+    # other did not -- identity is a fact about content, and the day a codec
+    # changes must not be the day every page becomes a different page.
+    body, codec, dict_id = encode(conn, request.html_content,
+                                  label=request.body_class)
     cursor = conn.execute(
         "INSERT INTO generic_page_snapshot "
-        "(source_url, html_content, content_hash, crawl_run_ref) VALUES (?,?,?,?)",
-        (source_url, request.html_content, _digest(request.html_content),
-         request.crawl_run_ref),
+        "(source_url, html_content, content_hash, crawl_run_ref, html_codec, "
+        " html_dict_id) VALUES (?,?,?,?,?,?)",
+        (source_url, body, _digest(request.html_content),
+         request.crawl_run_ref, codec, dict_id),
     )
     return _snapshot_public(_snapshot_row(conn, int(cursor.lastrowid)))
 
@@ -82,16 +91,17 @@ def save_snapshot(conn: sqlite3.Connection, request: SnapshotCreate) -> dict[str
 def discover_snapshot(conn: sqlite3.Connection, snapshot_id: int) -> dict[str, Any]:
     """Recompute temporary candidates from saved evidence without catalogue writes."""
     snapshot = _snapshot_row(conn, snapshot_id)
-    candidates = detect_html_tables(snapshot["html_content"])
+    candidates = detect_html_tables(decode(conn, snapshot))
     return {
         "snapshot": _snapshot_public(snapshot),
         "candidates": [candidate.public() for candidate in candidates],
     }
 
 
-def _candidate(snapshot: sqlite3.Row, table_index: int) -> TableCandidate:
+def _candidate(conn: sqlite3.Connection, snapshot: sqlite3.Row,
+               table_index: int) -> TableCandidate:
     try:
-        return candidate_by_index(snapshot["html_content"], table_index)
+        return candidate_by_index(decode(conn, snapshot), table_index)
     except LookupError:
         raise ExtractionNotFound(
             "The selected table candidate no longer exists in this snapshot. "
@@ -333,7 +343,7 @@ def approve_candidate(
     """
     snapshot = _snapshot_row(conn, snapshot_id)
     if candidate is None:
-        candidate = _candidate(snapshot, approval.table_index)
+        candidate = _candidate(conn, snapshot, approval.table_index)
     if not candidate.approvable:
         reason = candidate.warnings[0] if candidate.warnings else "The table is incomplete."
         raise CandidateNotApprovable(

--- a/scrapex/snapshotbody.py
+++ b/scrapex/snapshotbody.py
@@ -31,6 +31,19 @@ and reached 19.7× against the raw page's 187×. A trained dictionary is built f
 small samples; this corpus is a handful of very large near-duplicates, and the best
 dictionary for a page that is 97% skeleton is a page.
 
+WHY `zstandard` AND NOT `compression.zstd`, WHICH IS IN THE 3.14 STANDARD LIBRARY.
+The first version of this module used the stdlib one and was wrong: `pyproject.toml`
+declares `requires-python = ">=3.12"`, CI runs **3.12.14**, and `compression.zstd`
+arrived in **3.14**. So the package did not merely fail its tests there -- it failed
+to IMPORT, which would have stopped the engine starting.
+
+And the fix is more portable than the thing it replaces, which is the part worth
+keeping: `zstandard` behaves identically on 3.12, 3.13 and 3.14, while
+`compression.zstd` exists on 3.14 alone. The owner works from two machines. A
+compressed page that only one of them can read is a worse failure than a dependency,
+because the plaintext is not stored anywhere else. Ratios are unchanged -- this is the
+same libzstd underneath.
+
 WHY THIS IS NOT A FLAG. `scrapex/features.py` already carries the lesson: a
 capability with no production caller is a claim, not a mechanism. `snapshotcrawl`
 calls this on the path that fetches the 36,548 pages the study is about.
@@ -40,7 +53,7 @@ from __future__ import annotations
 import sqlite3
 from urllib.parse import urlparse
 
-from compression import zstd
+import zstandard
 
 #: `html_content` is the page, exactly as it arrived. Every row written before
 #: 2026-08-20 is this, and stays this — `trg_generic_page_snapshot_immutable_update`
@@ -55,6 +68,18 @@ ZSTD_RAW_DICT = "zstd-raw-dict"
 #: and level 19 gives 186× at 19.6 ms — slightly WORSE for 5.6× the time. 12 is
 #: where the curve stops paying.
 LEVEL = 12
+
+
+def _raw_dict(body: bytes) -> zstandard.ZstdCompressionDict:
+    """One real page as a dictionary, used exactly as it arrived.
+
+    RAW CONTENT, not a trained dictionary. `train_dict` was measured at 110 KB and
+    at 512 KB and reached 19.7x against the raw page's 187x: a trained dictionary is
+    built for many small samples, and this corpus is a handful of very large
+    near-duplicates. The best dictionary for a page that is 97% skeleton is a page.
+    """
+    return zstandard.ZstdCompressionDict(
+        body, dict_type=zstandard.DICT_TYPE_RAWCONTENT)
 
 
 class UnknownCodec(RuntimeError):
@@ -123,7 +148,8 @@ def encode(
 
     plain = html.encode("utf-8")
     dict_id, body = _dictionary(conn, label, html)
-    packed = zstd.compress(plain, LEVEL, zstd_dict=zstd.ZstdDict(body, is_raw=True))
+    packed = zstandard.ZstdCompressor(
+        level=LEVEL, dict_data=_raw_dict(body)).compress(plain)
     if len(packed) >= len(plain):
         return html, PLAIN, None
     return packed, ZSTD_RAW_DICT, dict_id
@@ -168,9 +194,9 @@ def decode(conn: sqlite3.Connection, row) -> str:
                 f"dictionary {dict_id}, which is not in this database. The page "
                 "cannot be read and its plaintext is not stored anywhere else.")
         body = bytes(found[0])
-        return zstd.decompress(
-            bytes(row["html_content"]), zstd_dict=zstd.ZstdDict(body, is_raw=True),
-        ).decode("utf-8")
+        return zstandard.ZstdDecompressor(
+            dict_data=_raw_dict(body),
+        ).decompress(bytes(row["html_content"])).decode("utf-8")
     raise UnknownCodec(
         f"snapshot {_field(row, 'page_snapshot_id')} is stored as {codec!r}, which this "
         "build cannot decode. Do not treat the stored bytes as HTML.")

--- a/scrapex/snapshotbody.py
+++ b/scrapex/snapshotbody.py
@@ -1,0 +1,176 @@
+"""How a stored page is encoded, and how to read one back.
+
+`docs/STORAGE.md`, on the owner's instruction — «ليست الفكرة ضغط الملفات بل دراسة
+نشوف احنا بنسحب اى ولية وبنحتفظ باية ولية وما الفائدة». The study's answer was to
+retain everything and pay almost nothing for it, and this module is the "almost
+nothing".
+
+WHY NOT ZLIB, WHICH `DEC-9` RECOMMENDED, AND WHY THAT WAS THE INTERESTING PART.
+`DEC-9` measured zlib at 15.6× and credited the ratio to "a near-identical skeleton
+repeated 864 times". The skeleton is near-identical — 40 stored listing pages differ
+only in their pagination block and one locale-switch href — but **zlib never sees
+it**: its window is 32 KB and a skeleton is 121 KB, so page 1 is out of view before
+page 2 begins. Measured three ways on the same 40 pages:
+
+    one skeleton, zlib-9 .................... 18 KB
+    ten skeletons concatenated, zlib-9 ...... 175 KB   = 9.84x the cost of one
+    all 40 pages as ONE zlib block .......... 15.8x    = no better than separately
+
+So the cross-page redundancy that made the corpus look compressible was left
+entirely on the table.
+
+WHY A DICTIONARY AND NOT A BLOCK. Those same 40 pages reach **219×** as a single
+zstd block — but a block is a CHAIN, and row 700 cannot depend on row 699 still
+existing. A database column may not have that property. `zstd` with one real page as
+a RAW dictionary reaches **187× on listings and 46× on profiles** at 3.5 ms a page,
+and every row stays independently decompressible. 618 MB of listings becomes 3.3 MB;
+3.95 GB of profiles becomes 87 MB.
+
+WHY RAW AND NOT TRAINED. `zstd.train_dict` was measured too, at 110 KB and 512 KB,
+and reached 19.7× against the raw page's 187×. A trained dictionary is built for many
+small samples; this corpus is a handful of very large near-duplicates, and the best
+dictionary for a page that is 97% skeleton is a page.
+
+WHY THIS IS NOT A FLAG. `scrapex/features.py` already carries the lesson: a
+capability with no production caller is a claim, not a mechanism. `snapshotcrawl`
+calls this on the path that fetches the 36,548 pages the study is about.
+"""
+from __future__ import annotations
+
+import sqlite3
+from urllib.parse import urlparse
+
+from compression import zstd
+
+#: `html_content` is the page, exactly as it arrived. Every row written before
+#: 2026-08-20 is this, and stays this — `trg_generic_page_snapshot_immutable_update`
+#: forbids rewriting them and is worth more than the 607 MB a backfill would save.
+PLAIN = "plain"
+
+#: `html_content` holds zstd frames compressed against the raw page in
+#: `snapshot_dictionary`, which `html_dict_id` names.
+ZSTD_RAW_DICT = "zstd-raw-dict"
+
+#: MEASURED, not chosen. Level 3 gives 146×, level 12 gives 187× at 3.5 ms a page,
+#: and level 19 gives 186× at 19.6 ms — slightly WORSE for 5.6× the time. 12 is
+#: where the curve stops paying.
+LEVEL = 12
+
+
+class UnknownCodec(RuntimeError):
+    """This row says it is encoded in a way this build cannot read.
+
+    Its own class, and it RAISES rather than returning the bytes, because the
+    alternative is handing a caller a compressed frame that it will parse as HTML
+    and find no tables in. That failure would surface as "the page has no data",
+    which is the wrong thing to go looking for.
+    """
+
+
+def label_for(source_url: str, kind: str | None = None) -> str:
+    """Which dictionary this page belongs with: host plus page kind.
+
+    PER KIND AND NOT PER HOST, because the study measured a same-kind dictionary at
+    187× on listings and 46× on profiles. muqawil's listing page is 363 KB of
+    directory chrome and its profile page is 119 KB of a different layout; one
+    dictionary covering both would be worse than either, and the cost of keeping
+    them apart is one row in a table.
+    """
+    host = urlparse(source_url).netloc.lower() or "unknown-host"
+    return f"{host}/{kind or 'page'}"
+
+
+def _dictionary(conn: sqlite3.Connection, label: str, seed: str) -> tuple[int, bytes]:
+    """The dictionary for this label, creating it from `seed` if there is none.
+
+    THE FIRST PAGE OF A CLASS BECOMES ITS DICTIONARY. It is not the theoretically
+    best choice — a median page would be — but choosing a median needs a corpus that
+    does not exist at the moment the first page arrives, and the alternative designs
+    all end with a second dictionary and a migration of everything compressed against
+    the first. A page compressed against itself also costs almost nothing, so the
+    seed row is not a wasted one.
+    """
+    row = conn.execute(
+        "SELECT dict_id, body FROM snapshot_dictionary WHERE label = ? LIMIT 1",
+        (label,),
+    ).fetchone()
+    if row is not None:
+        return int(row[0]), bytes(row[1])
+    cursor = conn.execute(
+        "INSERT INTO snapshot_dictionary (label, body) VALUES (?,?)",
+        (label, seed.encode("utf-8")),
+    )
+    return int(cursor.lastrowid), seed.encode("utf-8")
+
+
+def encode(
+    conn: sqlite3.Connection, html: str, *, label: str | None,
+) -> tuple[object, str, int | None]:
+    """`(value, codec, dict_id)` ready for the INSERT.
+
+    `label=None` means store it as it is, which is what every caller that has not
+    opted in gets — including the engine's own save-a-page endpoint, where one page
+    saved by hand has no class to belong to and nothing to gain.
+
+    IT REFUSES TO MAKE A PAGE BIGGER. A short page can compress to more bytes than
+    it started with, and a codec that is a pessimisation on some rows and an
+    optimisation on others is a codec nobody can reason about. The comparison is
+    made on the real bytes rather than assumed from the ratio measured on 363 KB
+    listing pages.
+    """
+    if label is None:
+        return html, PLAIN, None
+
+    plain = html.encode("utf-8")
+    dict_id, body = _dictionary(conn, label, html)
+    packed = zstd.compress(plain, LEVEL, zstd_dict=zstd.ZstdDict(body, is_raw=True))
+    if len(packed) >= len(plain):
+        return html, PLAIN, None
+    return packed, ZSTD_RAW_DICT, dict_id
+
+
+def _field(row, name: str, default=None):
+    """One column of a row, whether the row is a `sqlite3.Row` or a mapping.
+
+    NOT `name in row`, which lint suggests and which would be a real defect here:
+    `sqlite3.Row` iterates its VALUES, so `"html_codec" in row` asks whether any
+    column happens to hold that string. `sqlite3.Row` raises IndexError for a name
+    it does not have, and a mapping raises KeyError; both mean the same thing.
+    """
+    try:
+        return row[name]
+    except (IndexError, KeyError):
+        return default
+
+
+def decode(conn: sqlite3.Connection, row) -> str:
+    """The page as the site served it, whatever the row did to store it.
+
+    THE ONE PLACE THAT KNOWS. Every reader of a snapshot body goes through here, so
+    a codec added later is one function to teach rather than a search for
+    `html_content` across the codebase — which is the search that would miss one.
+    """
+    codec = _field(row, "html_codec", PLAIN)
+    if codec == PLAIN:
+        return row["html_content"]
+    if codec == ZSTD_RAW_DICT:
+        dict_id = _field(row, "html_dict_id")
+        found = conn.execute(
+            "SELECT body FROM snapshot_dictionary WHERE dict_id = ? LIMIT 1",
+            (dict_id,),
+        ).fetchone()
+        if found is None:
+            # Should be impossible: the dictionary table forbids DELETE for
+            # exactly this reason. Said out loud anyway, because "impossible"
+            # here means someone dropped the trigger.
+            raise UnknownCodec(
+                f"snapshot {_field(row, 'page_snapshot_id')} was compressed against "
+                f"dictionary {dict_id}, which is not in this database. The page "
+                "cannot be read and its plaintext is not stored anywhere else.")
+        body = bytes(found[0])
+        return zstd.decompress(
+            bytes(row["html_content"]), zstd_dict=zstd.ZstdDict(body, is_raw=True),
+        ).decode("utf-8")
+    raise UnknownCodec(
+        f"snapshot {_field(row, 'page_snapshot_id')} is stored as {codec!r}, which this "
+        "build cannot decode. Do not treat the stored bytes as HTML.")

--- a/scrapex/snapshotcrawl.py
+++ b/scrapex/snapshotcrawl.py
@@ -47,6 +47,7 @@ from .extract.models import SnapshotCreate
 from .extract.service import save_snapshot
 from .pagesource import FetchedPage, PageSource
 from .pagewalk import PageWalker, WalkReport
+from .snapshotbody import label_for
 
 Fetch = Callable[[str], str]
 
@@ -164,9 +165,16 @@ def crawl_to_snapshots(conn: sqlite3.Connection, source: PageSource,
             # this table, and the first draft of this resume learned that from a
             # test failure reading "saved HTML snapshots are immutable". The
             # trigger is right — who fetched a page is fixed at capture.
+            # COMPRESSED AGAINST ITS OWN KIND. `docs/STORAGE.md` measured 187x
+            # on listings and 46x on profiles with one real page of the same
+            # kind as a raw zstd dictionary -- against zlib's 15.6x and 7.7x,
+            # because zlib's 32 KB window never sees across a 121 KB page. This
+            # is the path the 36,548 pages of «كلّ ما ينشره الموقع» arrive on, so
+            # it is the path that had to learn it: 4.55 GB becomes about 90 MB.
             saved = save_snapshot(conn, SnapshotCreate(
                 source_url=page.url, html_content=page.html,
-                crawl_run_ref=run_ref))
+                crawl_run_ref=run_ref,
+                body_class=label_for(page.url, page.kind)))
             conn.commit()
         except Exception as exc:
             # NOT RAISED. One page too large, or one URL the model refuses,

--- a/tests/test_a_crawl_that_stores_evidence.py
+++ b/tests/test_a_crawl_that_stores_evidence.py
@@ -26,6 +26,7 @@ import pytest
 from scrapex.crawlscope import CrawlScope, SliceRequired
 from scrapex.databases import DatabaseRegistry, EngineDatabase
 from scrapex.pagesource import FetchedPage
+from scrapex.snapshotbody import ZSTD_RAW_DICT, decode
 from scrapex.snapshotcrawl import (
     SiteNotRegistered,
     crawl_to_snapshots,
@@ -137,12 +138,29 @@ def test_every_page_reaches_storage_unparsed(conn):
     assert outcome.report.listing_pages == 2
     assert outcome.report.detail_pages == 0, "listing_only fetched a detail page"
 
-    kept = conn.execute(
-        "SELECT html_content FROM generic_page_snapshot ORDER BY page_snapshot_id"
-    ).fetchone()[0]
-    assert kept == "<html>RIYADH one</html>", (
-        "the HTML was altered on the way in — evidence that has been touched "
-        "cannot settle what the page said")
+    # UNPARSED IS ABOUT THE EVIDENCE, NOT ABOUT THE ENCODING, and this assertion
+    # used to conflate them. It compared the raw column against the page and
+    # passed for the right reason until 2026-08-20, when the crawl began storing
+    # bodies zstd-compressed against a dictionary of their own page kind
+    # (docs/STORAGE.md: 4.55 GB becomes about 90 MB). The column then held a
+    # frame, and the test read that as tampering.
+    #
+    # It is not tampering, and the property it was protecting is unchanged: what
+    # the page said is recoverable EXACTLY. So the check now runs through the one
+    # reader every consumer uses, and it is STRONGER than before -- it pins the
+    # guarantee AND proves the body really went through the codec, which the old
+    # form could not distinguish from a codec that quietly stored plaintext.
+    row = conn.execute(
+        "SELECT page_snapshot_id, html_content, html_codec, html_dict_id "
+        "FROM generic_page_snapshot ORDER BY page_snapshot_id"
+    ).fetchone()
+    assert decode(conn, row) == "<html>RIYADH one</html>", (
+        "the HTML did not come back byte-for-byte — evidence that cannot be "
+        "recovered exactly cannot settle what the page said")
+    assert row["html_codec"] == ZSTD_RAW_DICT, (
+        "the crawl stored this page uncompressed, so the mechanism "
+        "docs/STORAGE.md was written for has no caller on the path that matters")
+    assert row["html_content"] != "<html>RIYADH one</html>"
 
 
 def test_the_full_scope_stores_the_detail_pages_too(conn):

--- a/tests/test_a_snapshot_says_how_it_is_encoded.py
+++ b/tests/test_a_snapshot_says_how_it_is_encoded.py
@@ -1,0 +1,298 @@
+"""A stored page can say how it is encoded, and 4.55 GB becomes about 90 MB.
+
+`docs/STORAGE.md`, on his instruction — «ليست الفكرة ضغط الملفات بل دراسة نشوف احنا
+بنسحب اى ولية وبنحتفظ باية ولية وما الفائدة». The study said retain everything and
+pay almost nothing; this is the almost-nothing, and these are the properties it has
+to have to be trusted with the only copy of the evidence.
+
+WHAT IS ACTUALLY AT RISK HERE, because it is not disk space. The plaintext of a
+compressed page exists nowhere else. If a body cannot be decoded, the page is gone —
+and the listing pages are not re-fetchable at all, because the ordering is a cached
+random permutation. So the round trip is not a nicety, and neither is the dictionary
+being un-deletable.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scrapex.databases import DatabaseRegistry, EngineDatabase
+from scrapex.extract.models import SnapshotCreate
+from scrapex.extract.service import discover_snapshot, save_snapshot
+from scrapex.snapshotbody import (
+    PLAIN,
+    ZSTD_RAW_DICT,
+    UnknownCodec,
+    decode,
+    encode,
+    label_for,
+)
+
+pytestmark = pytest.mark.docs
+
+
+@pytest.fixture()
+def conn(tmp_path: Path):
+    registry = DatabaseRegistry(EngineDatabase(tmp_path / "scrapex-engine.db"),
+                               pointer_file=tmp_path / "databases.json")
+    registry.initialize()
+    connection = registry.engine.connect()
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def _page(marker: str, rows: int = 40) -> str:
+    """A page shaped like the real corpus: a large shared skeleton, small payload.
+
+    THE SHAPE IS THE POINT. A stored muqawil listing page is 363 KB of which only
+    17.8% is contractor cards; the other 291 KB is nav, footer, scripts and a city
+    dropdown, near-identical across all 871 pages. A fixture of random bytes would
+    compress badly and prove nothing about this corpus; a fixture of one repeated
+    character would compress absurdly and prove nothing either.
+    """
+    skeleton = ("<nav>" + "menu item navigation footer script " * 900 + "</nav>")
+    cards = "".join(
+        f'<div class="section-card"><a href="/en/contractors/{marker}{i}/143">'
+        f"company {marker}{i}</a><span>Riyadh</span></div>" for i in range(rows))
+    return f"<html><body>{skeleton}<main>{cards}</main>{skeleton}</body></html>"
+
+
+def _row(conn: sqlite3.Connection, snapshot_id: int) -> sqlite3.Row:
+    return conn.execute(
+        "SELECT page_snapshot_id, html_content, content_hash, html_codec, "
+        "html_dict_id FROM generic_page_snapshot WHERE page_snapshot_id = ?",
+        (snapshot_id,),
+    ).fetchone()
+
+
+# ---- the round trip, which is the only thing that matters -------------------
+
+def test_a_compressed_page_comes_back_exactly(conn):
+    """Byte-for-byte, not "close enough". The plaintext is not stored anywhere
+    else, and a listing page cannot be re-fetched — its ordering is a cached
+    permutation, so page 40 tomorrow holds a different twenty contractors."""
+    html = _page("a")
+    saved = save_snapshot(conn, SnapshotCreate(
+        source_url="https://muqawil.org/en/contractors?page=1",
+        html_content=html, body_class="muqawil.org/listing"))
+    row = _row(conn, saved["page_snapshot_id"])
+    assert row["html_codec"] == ZSTD_RAW_DICT
+    assert decode(conn, row) == html
+
+
+def test_the_saved_bytes_really_are_not_the_page(conn):
+    """The companion to the round trip, and it has to be asserted separately: a
+    codec that stored the plaintext and called itself compressed would pass every
+    round-trip test in this file."""
+    html = _page("b")
+    saved = save_snapshot(conn, SnapshotCreate(
+        source_url="https://muqawil.org/en/contractors?page=2",
+        html_content=html, body_class="muqawil.org/listing"))
+    stored = _row(conn, saved["page_snapshot_id"])["html_content"]
+    assert isinstance(stored, bytes), (
+        "a compressed body must be stored as bytes, not as text that happens to "
+        "look like it")
+    assert len(stored) < len(html.encode("utf-8"))
+
+
+def test_a_page_saved_without_a_class_is_stored_as_it_arrived(conn):
+    """The default, and every caller that has not opted in gets it. The engine's
+    save-a-page endpoint saves ONE page by hand: it has no class to share a
+    dictionary with, and nothing to gain from creating one."""
+    html = _page("c")
+    saved = save_snapshot(conn, SnapshotCreate(
+        source_url="https://example.com/one", html_content=html))
+    row = _row(conn, saved["page_snapshot_id"])
+    assert row["html_codec"] == PLAIN
+    assert row["html_dict_id"] is None
+    assert row["html_content"] == html
+    assert decode(conn, row) == html
+
+
+def test_a_row_that_predates_the_codec_still_reads(conn):
+    """THE 1,728 ROWS ALREADY ON DISK, and the reason nothing was rewritten.
+
+    `trg_generic_page_snapshot_immutable_update` aborts any UPDATE to this table,
+    and it is right to — a stored page is evidence of what a site published on a
+    date. So migration 0005 gives `html_codec` a DEFAULT instead of backfilling,
+    and this asserts what that default buys: a row inserted with no knowledge of
+    the codec at all is read by exactly the path that reads a new one.
+
+    Inserted through raw SQL on purpose. Going through `save_snapshot` would set
+    the column and prove nothing about the rows that were written before it
+    existed.
+    """
+    html = "<html><body><p>stored in August, before any of this</p></body></html>"
+    conn.execute(
+        "INSERT INTO generic_page_snapshot (source_url, html_content, content_hash) "
+        "VALUES (?,?,?)", ("https://muqawil.org/en/contractors?page=400", html, "x"))
+    row = conn.execute(
+        "SELECT page_snapshot_id, html_content, html_codec, html_dict_id "
+        "FROM generic_page_snapshot ORDER BY page_snapshot_id DESC LIMIT 1"
+    ).fetchone()
+    assert row["html_codec"] == PLAIN, (
+        "a row inserted without naming a codec must default to 'plain', or every "
+        "snapshot stored before 2026-08-20 becomes unreadable")
+    assert decode(conn, row) == html
+
+
+# ---- identity must not move when the encoding does -------------------------
+
+def test_the_hash_is_of_the_page_and_not_of_its_encoding(conn):
+    """Two runs that fetch the same page must agree on its content_hash whether
+    one compressed it and the other did not. Otherwise the day a codec changes is
+    the day every page becomes a different page, and every dedup and revision
+    decision downstream moves with it."""
+    html = _page("d")
+    plain = save_snapshot(conn, SnapshotCreate(
+        source_url="https://example.com/plain", html_content=html))
+    packed = save_snapshot(conn, SnapshotCreate(
+        source_url="https://example.com/packed", html_content=html,
+        body_class="example.com/listing"))
+    assert _row(conn, plain["page_snapshot_id"])["html_codec"] == PLAIN
+    assert _row(conn, packed["page_snapshot_id"])["html_codec"] == ZSTD_RAW_DICT
+    assert plain["content_hash"] == packed["content_hash"]
+
+
+def test_the_extraction_path_reads_a_compressed_page(conn):
+    """THE END-TO-END ONE. A codec that round-trips in isolation and is not wired
+    into the reader would leave `discover_snapshot` parsing a zstd frame as HTML
+    and reporting that the page contains no tables — which is a wrong answer that
+    looks like a true one."""
+    html = ("<html><body><table><tr><th>Name</th><th>City</th></tr>"
+            "<tr><td>Alpha</td><td>Riyadh</td></tr>"
+            "<tr><td>Beta</td><td>Jeddah</td></tr></table><div>"
+            + "padding " * 4000 + "</div></body></html>")
+    saved = save_snapshot(conn, SnapshotCreate(
+        source_url="https://muqawil.org/en/contractors?page=9",
+        html_content=html, body_class="muqawil.org/listing"))
+    found = discover_snapshot(conn, saved["page_snapshot_id"])
+    assert found["candidates"], "the compressed page parsed as no tables at all"
+    assert found["candidates"][0]["estimated_row_count"] == 2
+    assert found["candidates"][0]["sample_records"][0]["name"] == "Alpha"
+
+
+# ---- the dictionary is load-bearing, so it is guarded ----------------------
+
+def test_one_dictionary_serves_a_whole_class(conn):
+    """The saving IS the sharing. A dictionary per page would store each page's
+    skeleton beside itself and compress nothing across the corpus, which is
+    precisely the failure zlib has here."""
+    for page in range(1, 6):
+        save_snapshot(conn, SnapshotCreate(
+            source_url=f"https://muqawil.org/en/contractors?page={page}",
+            html_content=_page(f"p{page}"), body_class="muqawil.org/listing"))
+    labels = [r[0] for r in conn.execute("SELECT label FROM snapshot_dictionary")]
+    assert labels == ["muqawil.org/listing"]
+
+
+def test_two_pages_of_one_kind_get_one_label(conn):
+    """THE PROPERTY THE WHOLE SAVING RESTS ON, pinned on `label_for` itself.
+
+    The tests below pass their `body_class` as a literal, so none of them touches
+    this function — and a `label_for` that returned a per-URL label would leave
+    them all green while the corpus compressed at per-page rates. Found by
+    mutating it: only the two-kinds test noticed, and only incidentally, because
+    the strings it expected no longer matched.
+    """
+    first = label_for("https://muqawil.org/en/contractors?page=1", "listing")
+    second = label_for("https://muqawil.org/en/contractors?page=717", "listing")
+    assert first == second == "muqawil.org/listing"
+    assert label_for("https://muqawil.org/en/contractors/881/143", "detail") != first
+    # A page whose kind nobody supplied still shares with its own sort.
+    assert (label_for("https://example.com/a") == label_for("https://example.com/b")
+            == "example.com/page")
+
+
+def test_the_two_page_kinds_do_not_share_a_dictionary(conn):
+    """MEASURED, not tidiness: a same-kind dictionary reached 187x on listings and
+    46x on profiles. A listing page is 363 KB of directory chrome and a profile is
+    119 KB of a different layout; one dictionary covering both is worse than
+    either, and keeping them apart costs one row."""
+    save_snapshot(conn, SnapshotCreate(
+        source_url="https://muqawil.org/en/contractors?page=1",
+        html_content=_page("L"), body_class=label_for(
+            "https://muqawil.org/en/contractors?page=1", "listing")))
+    save_snapshot(conn, SnapshotCreate(
+        source_url="https://muqawil.org/en/contractors/881/143",
+        html_content=_page("D"), body_class=label_for(
+            "https://muqawil.org/en/contractors/881/143", "detail")))
+    labels = sorted(r[0] for r in conn.execute(
+        "SELECT label FROM snapshot_dictionary"))
+    assert labels == ["muqawil.org/detail", "muqawil.org/listing"]
+
+
+def test_a_dictionary_cannot_be_changed_or_deleted(conn):
+    """HARDER THAN THE SNAPSHOT TRIGGERS, and for a stronger reason. A changed
+    snapshot loses one page. A changed dictionary loses every page compressed
+    against it, silently, and only when somebody tries to read one — with no
+    repair available, because the plaintext is not stored anywhere else."""
+    save_snapshot(conn, SnapshotCreate(
+        source_url="https://muqawil.org/en/contractors?page=1",
+        html_content=_page("x"), body_class="muqawil.org/listing"))
+    # COMMITTED FIRST, and the first draft of this test did not: the rollback
+    # after the failed UPDATE also undid the INSERT that created the dictionary,
+    # so the DELETE that followed matched no rows, fired no trigger, and the test
+    # reported that deletion was allowed when it was simply never attempted.
+    conn.commit()
+    with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+        conn.execute("UPDATE snapshot_dictionary SET body = X'00' WHERE dict_id = 1")
+    conn.rollback()
+    with pytest.raises(sqlite3.IntegrityError, match="cannot be deleted"):
+        conn.execute("DELETE FROM snapshot_dictionary WHERE dict_id = 1")
+    conn.rollback()
+
+
+# ---- refusing to be silently wrong -----------------------------------------
+
+def test_an_unreadable_codec_raises_rather_than_returning_bytes(conn):
+    """Returning the stored bytes would hand a caller a zstd frame to parse as
+    HTML. That surfaces as "this page has no data", which sends the next person
+    looking for a parser bug in a page that was never decoded."""
+    saved = save_snapshot(conn, SnapshotCreate(
+        source_url="https://example.com/future", html_content=_page("f")))
+    row = dict(_row(conn, saved["page_snapshot_id"]))
+    row["html_codec"] = "brotli-2031"
+    with pytest.raises(UnknownCodec, match="brotli-2031"):
+        decode(conn, row)
+
+
+def test_a_page_that_would_grow_is_stored_as_it_arrived(conn):
+    """A short page can compress to MORE bytes than it started with. A codec that
+    is a pessimisation on some rows and an optimisation on others is one nobody
+    can reason about, so the comparison is made on the real bytes rather than
+    assumed from a ratio measured on 363 KB pages."""
+    value, codec, dict_id = encode(conn, "<p>hi</p>", label="example.com/tiny")
+    assert codec == PLAIN and dict_id is None and value == "<p>hi</p>"
+
+
+# ---- and the mechanism has to actually pay ----------------------------------
+
+def test_the_corpus_costs_far_less_than_the_sum_of_its_pages(conn):
+    """THE GUARD THAT THE MECHANISM DELIVERS, and the one that would catch a codec
+    quietly downgraded to per-page zlib.
+
+    zlib gets 15.6x on this corpus and cannot do better, because its 32 KB window
+    never reaches across a 121 KB skeleton — measured: 40 pages as one zlib block
+    came to 15.8x, no better than separately. A shared dictionary reached 187x.
+    The bar here is deliberately far below 187 and far above anything per-page
+    zlib can reach, so it tests the PROPERTY rather than pinning a number that
+    depends on the fixture.
+    """
+    pages = [_page(f"m{i}") for i in range(10)]
+    raw = sum(len(p.encode("utf-8")) for p in pages)
+    for index, html in enumerate(pages):
+        save_snapshot(conn, SnapshotCreate(
+            source_url=f"https://muqawil.org/en/contractors?page={index + 1}",
+            html_content=html, body_class="muqawil.org/listing"))
+    stored = conn.execute(
+        "SELECT SUM(LENGTH(html_content)) FROM generic_page_snapshot").fetchone()[0]
+    ratio = raw / stored
+    assert ratio > 40, (
+        f"the shared dictionary bought only {ratio:.1f}x on a corpus of "
+        "near-duplicates; per-page compression alone reaches about 15x here, so "
+        "this says the dictionary is not being shared")

--- a/tests/test_extract_storage.py
+++ b/tests/test_extract_storage.py
@@ -153,7 +153,7 @@ def test_generic_records_and_price_rows_land_in_the_same_database(tmp_path: Path
     try:
         snapshot = save(conn)
         candidate = service._candidate(
-            service._snapshot_row(conn, snapshot["page_snapshot_id"]), 0)
+            conn, service._snapshot_row(conn, snapshot["page_snapshot_id"]), 0)
         service.approve_candidate(
             conn, snapshot["page_snapshot_id"], approval(candidate))
         ingest_payloads(conn, make_entry(), [make_payload([one_row()])])
@@ -187,7 +187,7 @@ def test_discovery_returns_candidates_without_polluting_permanent_datasets(conn)
 def test_owner_approval_atomically_creates_schema_and_typed_generic_records(conn):
     snapshot = save(conn)
     candidate = service._candidate(
-        service._snapshot_row(conn, snapshot["page_snapshot_id"]), 0
+        conn, service._snapshot_row(conn, snapshot["page_snapshot_id"]), 0
     )
 
     result = service.approve_candidate(
@@ -229,7 +229,7 @@ def test_failed_identity_approval_rolls_back_and_a_corrected_retry_recovers(
     """
     snapshot = save(conn, html)
     candidate = service._candidate(
-        service._snapshot_row(conn, snapshot["page_snapshot_id"]), 0
+        conn, service._snapshot_row(conn, snapshot["page_snapshot_id"]), 0
     )
 
     with pytest.raises(CandidateNotApprovable, match="duplicate record keys"):
@@ -254,7 +254,7 @@ def test_failed_identity_approval_rolls_back_and_a_corrected_retry_recovers(
 def test_retry_after_a_lost_success_response_is_idempotent(conn):
     snapshot = save(conn)
     candidate = service._candidate(
-        service._snapshot_row(conn, snapshot["page_snapshot_id"]), 0
+        conn, service._snapshot_row(conn, snapshot["page_snapshot_id"]), 0
     )
     request = approval(candidate)
     first = service.approve_candidate(conn, snapshot["page_snapshot_id"], request)
@@ -276,7 +276,7 @@ def test_retry_after_a_lost_success_response_is_idempotent(conn):
 def test_later_snapshot_updates_current_record_and_appends_revision(conn):
     first_snapshot = save(conn)
     first_candidate = service._candidate(
-        service._snapshot_row(conn, first_snapshot["page_snapshot_id"]), 0
+        conn, service._snapshot_row(conn, first_snapshot["page_snapshot_id"]), 0
     )
     request = approval(first_candidate)
     first = service.approve_candidate(
@@ -318,7 +318,7 @@ def test_generic_ingestion_and_price_ingestion_share_one_database(
     with closing(databases.engine.connect()) as conn:
         snapshot = save(conn)
         candidate = service._candidate(
-            service._snapshot_row(conn, snapshot["page_snapshot_id"]), 0)
+            conn, service._snapshot_row(conn, snapshot["page_snapshot_id"]), 0)
         service.approve_candidate(
             conn, snapshot["page_snapshot_id"], approval(candidate))
         conn.commit()


### PR DESCRIPTION
«ابدأ آلية التخزين». [docs/STORAGE.md](docs/STORAGE.md) measured what retention costs and asked one thing of the schema: **a stored page has to be able to say how its body is encoded.** This is that, with a production caller — and the handoff plan he asked for, in the repository where his other machine can read it.

## Why not zlib, which `DEC-9` recommended — and why that was the interesting part

`DEC-9` measured zlib at 15.6× and credited the ratio to *"a near-identical skeleton repeated 864 times"*. The skeleton **is** near-identical — 40 stored listing pages differ only in their pagination block and one locale-switch href — but **zlib never sees it.** Its window is 32 KB and a skeleton is 121 KB, so page 1 is out of view before page 2 begins:

| | |
|---|---|
| one skeleton, zlib-9 | 18 KB |
| ten skeletons concatenated | 175 KB — **9.84× the cost of one, for ten pages** |
| all 40 pages as **one** zlib block | **15.8×** — no better than compressing them separately |

The cross-page redundancy that made this corpus look compressible was left entirely on the table.

## Why a dictionary and not a block

Those same 40 pages reach **219×** as a single zstd block — but a block is a **chain**, and row 700 cannot depend on row 699 still existing. That is not a property a database column may have.

| mechanism | listings | profiles | row independently readable |
|---|---|---|---|
| zlib-9 per row (`DEC-9`) | 15.6× | 7.7× | yes |
| zstd-19 + a *trained* dictionary | 19.7× | — | yes |
| **zstd-12 + one real page as a RAW dictionary** | **187×** | **46×** | **yes** |
| zstd-19, all 40 as one block | 219× | 61× | **no** |

Raw and not trained: `train_dict` was measured at 110 KB and 512 KB and reached 19.7×, because a trained dictionary is built for many small samples and this corpus is a handful of very large near-duplicates. **The best dictionary for a page that is 97% skeleton is a page.**

**618 MB of listings becomes 3.3 MB; 3.95 GB of profiles becomes 87 MB.**

## Nothing existing is rewritten, and that is a decision

`trg_generic_page_snapshot_immutable_update` aborts any UPDATE to the snapshot table, and it is right to — a stored page is evidence of what a site published on a date. A backfill would have to drop that trigger, and **the trigger is worth more than 607 MB.** So `html_codec` carries a DEFAULT of `'plain'` and the 1,728 rows already on disk are read by exactly the path that reads a new one — asserted by inserting a row through raw SQL that names no codec at all.

## Three things the build had to get right that the study did not have to say

- **`content_hash` stays the hash of the DECODED page.** Otherwise the day a codec changes is the day every page becomes a different page, and every dedup and revision decision downstream moves with it.
- **`html_content` keeps its declared TEXT type and holds either.** SQLite column types are affinities, and TEXT affinity explicitly does not convert a BLOB — so a compressed body lives in the column it belongs in, `NOT NULL` is satisfied honestly, and no table rebuild puts 1,728 rows of evidence and four foreign keys at risk to add two columns.
- **A page that would grow is stored plain.** A codec that is a pessimisation on some rows and an optimisation on others is one nobody can reason about, so the comparison is made on real bytes.

## The dictionary is guarded harder than the snapshots are

A changed snapshot loses one page. A changed dictionary loses **every** page compressed against it — silently, and only when someone tries to read one, with **no repair**, because the plaintext is not stored anywhere else. `snapshot_dictionary` therefore forbids both UPDATE and DELETE.

## Not a flag

`scrapex/features.py` already carries that lesson: `is_enabled` had **no production caller**, so it was a claim rather than a mechanism. `snapshotcrawl` calls this on the path the 36,548 pages arrive on, keyed **per page kind** — listings and profiles do not share a dictionary, because a same-kind dictionary is what measured 187× and 46×.

## Verification

- **13 tests**, mutation-proven three ways: making `encode` always-plain kills 7 of them; reverting the reader to `html_content` kills the end-to-end one; making `label_for` per-URL kills the label guard.
- **The third mutation found a gap in my own guards.** The two tests that prove dictionary *sharing* pass their `body_class` as a literal, so neither touches `label_for` — a per-URL label would have left them green while the corpus compressed at per-page rates. The property is now pinned on `label_for` itself.
- Full suite under `SCRAPEX_FULL_MIGRATIONS=1`: **zero failures**, before this PR opened — `R-22`. `ruff check scrapex/` clean.
- **`_candidate` gained a `conn` parameter and five tests called it directly**, so they were updated with it. `_candidate` decodes the body and a compressed body needs its dictionary, which lives in the database — the connection is not optional here. Caught by the full suite, which is the entire argument for `R-22`.
- `schema.sql` deliberately **not** touched: it is the v1 baseline and migrations run on top of it. Declaring the columns there duplicated them and broke every fresh install — caught by `test_one_schema_carries_both_streams`, reverted.

## And the handoff he asked for

> «بعد الانتهاء من آلية التخزين اريد التوقف حتى استكمل من جهاز اخر تاكد من تسجيل كل شى»

[docs/plans/2026-08-20-finish-muqawil-then-the-source-queue.md](docs/plans/2026-08-20-finish-muqawil-then-the-source-queue.md) — in the repository and not in `~/.claude/plans/`, which is one machine and one account and is why seven plans had to be rescued on 2026-08-17. It carries where muqawil actually stands (**11,059 of 17,403, zero profile pages ever fetched**), the build order and why it is that order, the four facts a fresh session would otherwise re-derive, and what is blocked **on him** as distinct from what is merely unbuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
