### PR TITLE
A proof that demanded more than it needed, and 823 pages refused by one column

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -634,6 +634,66 @@ under [R-24](RULINGS.md#r-24--a-database-is-upgraded-never-replaced--the-users-d
 it is a **release blocker** rather than debt — so it is his call whether it goes in its
 own session now or immediately after the crawl lands.
 
+### OP-25 · The partition made the crawl provable and broke the approval, for the SAME reason
+
+**MEASURED 2026-08-21 on the first partitioned crawl.** 897 stored page-pairs went
+through `--approve`. **74 approved, 823 refused** with
+`ExtractionConflict: This dataset already has a different approved schema.`
+
+**74 is not a round number and it is not random.** `region_id=0`'s four cells are
+`1 + 4 + 10 + 59 = 74` pages, and `region_id=0` **is** the 1,438 contractors who
+publish no location at all. Their cards carry no location box, so:
+
+| page | fields |
+|---|---|
+| `region_id=0 & company_size=big` | **21** — no `card_city_region` |
+| `region_id=1 & company_size=big` | **22** |
+
+Those 74 pages taught the dataset a 21-field schema, and every located contractor's
+page after them presented 22 and was refused.
+
+**The cause is the partition itself, which is what makes this worth writing down.**
+`_candidate_from` derives the field list from the union of THAT PAGE's cards. The old
+unfiltered crawl mixed every kind of contractor onto every page, so
+`card_city_region` was always in the union and the schema was stable — 864 pages
+approved into 11,059 records. The partition deliberately **groups like with like**, so
+the first cell is systematically unrepresentative. The same property that makes a cell
+provably complete makes its schema a bad sample.
+
+**The full card field set, measured across page 1 of every cell:** 15 fields, of which
+14 appear on every page that has any cards, and only `card_city_region` varies (58 of
+64 pages). The intersection reads 0 because one cell — `region_id=8 &
+company_size=big` — publishes **no contractors at all**, so its page contributes an
+empty set.
+
+**The fix is already written in the same file, for the same reason, applied to only
+half the problem.** `extract/muqawil.py` declares `BILINGUAL_CARD_FIELDS` and says why:
+
+> Emitting `_ar` only where an Arabic value happened to be found made the column list
+> depend on which contractors that page's Arabic half showed — and the listing
+> reorders, so 118 pages in 119 were refused as a different schema. Which fields the
+> SITE translates is a fact about the site, so it is declared here … and an absent
+> value is a NULL in a column that is always there.
+
+That argument is identical and covers the `_ar` half only. **The base card fields need
+the same declaration**: which boxes a card can carry is a fact about the site, not
+about which twenty contractors a page happened to show.
+
+**AND IT NEEDS A DECISION, because the 74 pages already landed.** A parser that always
+emits 22 fields produces a different `schema_hash`, so those 74 are refused too. Three
+ways out, and the choice has data consequences:
+
+- **(a) Wipe the `contractors` dataset and re-approve all 897 pages from disk.** ~20
+  minutes, **no re-fetching** — the snapshots are stored, which is the whole economics
+  of the seam. Cleanest, and destroys 1,172 rows that would be immediately rebuilt.
+- **(b) A new dataset key.** Keeps the 74 pages' dataset, and leaves two datasets
+  describing one directory — which `R-11` would not thank anyone for.
+- **(c) Schema-drift review support**, which the error message itself points at and
+  which does not exist. The largest option and the one that would help every future
+  source.
+
+*Recommended: (a), and it is only cheap because nothing has to be re-fetched.*
+
 ## 3. Decided, not yet built
 
 ### DEC-1 · Topology A — the TypeScript extension as the public product

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -835,6 +835,41 @@ so the comparison is the id sequence. The bytes are a proxy that is strictly str
 than the property, and a proxy stronger than the property is not a conservative choice —
 it is a check that can never pass.
 
+### A proof that demands more than it needs fails exactly where it is needed most
+
+2026-08-21. `partitioncrawl` had one completeness rule: a cell is complete when its
+witness held **and** its distinct ids equalled the declared count. The witness proves
+the pages were read inside one cache generation, so they were disjoint.
+
+**A cell above the generation's reach can never satisfy that, by construction.** The
+first real crawl measured six such cells — worst 236 pages against a 31-page ceiling —
+and reported a deficit of **3,690 with no route to close it**. Not a bug in the code;
+the rule itself had made those cells unprovable.
+
+**And the second proof was there the whole time.** A cell that declares `N` rows
+cannot show `N` DISTINCT ids unless it has shown all of them, and the ids may be
+accumulated over any number of reads. No generation, no witness, no single pass. Both
+proofs rest on the same assumption — that the paginator's `N` is true — so the witness
+adds no *completeness* the count does not.
+
+**What made it hard to see is worth more than the fix.** The module docstring stated
+the opposite as settled fact — *"the union can reach N by luck across two generations
+and that proves nothing"* — and a test was named
+`test_a_union_across_two_generations_is_not_a_proof` and asserted it. Nine guards and
+twenty-one killed mutations all agreed with each other, because they were all
+checking the same wrong rule. **Mutation testing cannot find a mistake in what you
+decided to prove**; it only checks that you still prove it. The error surfaced only
+when a live run produced a deficit and the question became "how would we ever close
+this?"
+
+**Apply:** when a check combines conditions with `and`, ask which of them the claim
+actually needs, and what class of input the extra condition excludes **permanently**.
+An over-strict proof reports false negatives, and a false negative on a completeness
+claim looks exactly like missing data — so it sends someone hunting for rows that were
+never lost. Both proofs are now computed, and the report says which one carried each
+cell (`[by witness]` / `[by count]`), because a claim whose grounds are invisible is a
+claim nobody can re-check.
+
 ### A facet's controls may not be a `<select>`, and its null class may have a value
 
 Two beliefs about muqawil's listing were recorded from a search of its `<select>`

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -706,6 +706,44 @@ mutations killed.
 
 ---
 
+### R-25 · The crawl method is settled first; the schema and retention questions come last
+
+**2026-08-21 · sequencing, and it decides what several open questions are waiting for**
+
+> «صعب حسم هذا الامر الان سنتركه النهاية بعد معالجة كل مشاكل مقاول والاستقرار على
+> افضل طرق ومسارت عمل crawl الخاصة به»
+
+**What he was asked.** Two decisions were put to him together: which route
+[OP-25](BACKLOG.md) should take (the parser's schema had refused 823 of 897 pages),
+and `STORAGE.md` §5 — is a snapshot evidence or only a parse cache. He declined to
+settle either **now**, and gave the order instead: finish muqawil's problems and
+settle **the best methods and work-paths for its crawl**, then decide these.
+
+**And the sequencing is right for a reason worth writing down.** Both deferred
+questions are about **interpreting** stored pages; neither changes what is on disk.
+`docs/GENERIC-FETCH-SEAM.md`'s central rule is that one page in gives one snapshot
+out, unparsed, so interpretation can be re-run against the evidence at any time. That
+was demonstrated twice on 2026-08-21: the 897 stored page-pairs were re-interpreted
+**from disk, twice, with not one network request** — a wrong schema cost 20 minutes
+where a re-crawl is two hours. So deferring an interpretation decision costs nothing,
+while deferring a **collection** decision costs a re-crawl. Collection first is the
+cheaper order, not merely the one he chose.
+
+**How to apply.** Until he settles them:
+
+- **Do not force either question to be answered by a default.** OP-25's three routes
+  and §5's two readings stay open and stay written down.
+- **Coverage stays at whatever the current schema admits** — 1,172 records tonight —
+  and that number must be reported as *"limited by an unresolved schema decision"*
+  rather than as the crawl's coverage. The crawl's own result is the **13,727 sighted
+  ids and 1,982 stored pages**, which is complete and independent of it.
+- **Work the crawl:** the 3,690 deficit, the counting proof, the `city_id`
+  subdivision, per-cell re-sizing. That is what "أفضل طرق ومسارات عمل crawl" names.
+- Anything needed by **all** routes may still be built — the `CARD_FIELDS`
+  declaration is, because none of the three routes works without it.
+
+---
+
 ## Superseded
 
 Kept per **C4**. Do not follow these; they are here so the current rule can be

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -250,7 +250,53 @@ until it has been mutated — including the two that would have made the method
 worthless while looking like it worked: a witness comparing **bytes**, and one
 comparing **sets** instead of sequences.
 
-**IT IS RUNNING, and getting there took two rulings of his and a fixed upgrade path.**
+**IT HAS RUN, and the result corrected the method. 115 minutes, 2,141 requests:**
+
+```
+listing declared 17,417 rows over 871 pages
+partition declared 17,417 over 56 cells — exhaustiveness deficit 0
+distinct ids seen 13,727 — D = 3,690
+cells proven complete 47 of 56          1,982 snapshots, all zstd-raw-dict
+```
+
+**The exhaustiveness audit came back 0 on live data** and 47 cells closed with `D=0`.
+The deficit is concentrated in the **6 cells above the 31-page witness ceiling**
+(D=3,680) plus three small cells short by 1, 1 and 8.
+
+**And the 3,690 was partly the method's own fault, which is the finding.**
+`provably_complete` required the witness AND the count — so a cell too large to hold
+one cache generation was unprovable **by construction**, and the six heavy cells had
+no route to closure at all. There are two independent proofs and only one was
+implemented:
+
+| | |
+|---|---|
+| **witness** | page 1 returns the same id sequence ⇒ one generation ⇒ pages disjoint |
+| **count** | `distinct == declared`. A cell holding `N` cannot show `N` distinct ids without showing all of them — **no generation needed** |
+
+Both now count, the report says which carried each cell (`[by witness]` / `[by count]`),
+and a heavy cell gets `HEAVY_ATTEMPTS = 10` reads to close by counting. Written up in
+[LESSONS](LESSONS.md) — *a proof that demands more than it needs fails exactly where it
+is needed most*, and twenty-one killed mutations all agreed with each other because
+they were all checking the same wrong rule.
+
+**Two more report defects the run exposed:** it said *"the listing grew by -25 rows"*
+(it **shrank**, 17,417 → 17,392 overnight), and a cell ending `235 of 236` could not be
+told from a cell that lost a contractor. Both fixed; short cells are now re-sized so a
+deficit inside the churn is named as churn.
+
+**And the approval path could not take the crawl.** 897 stored page-pairs, **74
+approved and 823 refused** — `region_id=0`'s four cells are exactly 74 pages, and they
+are the contractors with no location, so they taught the dataset a 21-field schema and
+every located contractor's page had 22. [OP-25](BACKLOG.md). The parser now declares
+`CARD_FIELDS` the way `BILINGUAL_CARD_FIELDS` was already declared, for the same
+stated reason; which of three routes reconciles the 74 pages already landed is
+deferred by [R-25](RULINGS.md#r-25--the-crawl-method-is-settled-first-the-schema-and-retention-questions-come-last).
+
+**Coverage is therefore 1,172 records — limited by an unresolved schema decision, not
+by the crawl.** The crawl's own result is 13,727 sighted ids and 1,982 stored pages.
+
+**Getting it a warehouse took two rulings of his and a fixed upgrade path.**
 Priced from its own measurement: **897 pages × 2 locales + 170 = ~1,964 requests**, and
 at the 2.51 s a request the sizing pass actually paid, about **1.4 hours**.
 

--- a/scrapex/extract/muqawil.py
+++ b/scrapex/extract/muqawil.py
@@ -64,6 +64,46 @@ BILINGUAL_CARD_FIELDS = (
     "card_training_credit_hours",
 )
 
+#: EVERY FIELD A LISTING CARD CAN CARRY, declared rather than derived — and the
+#: reason is the same one `BILINGUAL_CARD_FIELDS` above states for the `_ar` half,
+#: applied to the half it did not cover.
+#:
+#: THE FAILURE THAT FORCED IT, measured 2026-08-21 on the first partitioned crawl:
+#: 897 stored page-pairs went through the approval path and **74 were accepted and
+#: 823 refused** with `ExtractionConflict`. 74 is not a round number — it is
+#: `region_id=0`'s four cells, `1 + 4 + 10 + 59`. And `region_id=0` IS the 1,438
+#: contractors who publish no location, so their cards carry no location box:
+#:
+#:     region_id=0 & company_size=big   21 fields, no card_city_region
+#:     region_id=1 & company_size=big   22 fields
+#:
+#: Those 74 pages taught the dataset a 21-field schema and every located
+#: contractor's page after them was refused for having one more column.
+#:
+#: THE CAUSE IS THE PARTITION, WHICH IS WHY DERIVING THE LIST CANNOT WORK. The old
+#: unfiltered crawl mixed every kind of contractor onto every page, so the union of
+#: a page's cards always held every field and the schema was stable across 864
+#: pages. A partition **groups like with like** — that is exactly what makes a cell
+#: provably complete — so the first cell is systematically unrepresentative. The
+#: property that makes the crawl trustworthy makes a per-page field list wrong.
+#:
+#: MEASURED ACROSS PAGE 1 OF EVERY CELL: 15 fields, of which 14 appear wherever
+#: there is a card at all and only `card_city_region` varies (58 of 64 pages). One
+#: cell — `region_id=8 & company_size=big` — publishes no contractors whatsoever,
+#: so a derived list would be EMPTY there.
+#:
+#: An absent value is now a NULL in a column that is always there, which is what
+#: the bilingual note already says and what the owner's ~70 columns need: a column
+#: count that does not depend on which twenty contractors a page happened to show.
+CARD_FIELDS = (
+    "contractor_id", "company_name", "membership_level", "logo_url",
+    "customer_rating_score", "customer_rating_count",
+    "contractor_classification", "contractor_classification_grade",
+    "card_city_region", "card_company_size", "card_main_contractor",
+    "card_membership_number", "card_status", "card_sub_contractor",
+    "card_training_credit_hours",
+)
+
 #: `label -> field_key`, in the page's own order. English only, on purpose —
 #: see the module docstring. A label this map does not know is KEPT, under a
 #: slug of its own, rather than dropped: a field the site adds is news, and a
@@ -349,11 +389,14 @@ def _candidate_from(rows: list[dict[str, str]], *,
     # A fixed lead for the ones a reader looks for first, then sorted. Column
     # order on screen is `display_order`'s business and the owner's to set;
     # this only has to be the SAME every time.
-    lead = ["contractor_id", "company_name", "membership_level", "logo_url",
-            "customer_rating_score", "customer_rating_count",
-            "contractor_classification", "contractor_classification_grade"]
+    # DECLARED, NOT DERIVED. `CARD_FIELDS` is the list and its note carries the
+    # measurement that forced it: deriving `present` from this page's own cards made
+    # the schema depend on which twenty contractors the page showed, and a partition
+    # groups like with like — so 823 of 897 pages were refused. A field the site
+    # ADDS is still kept, appended after the declared ones, because a new column is
+    # news and a parser that silently drops it is how it stays news for a year.
     present = {key for row in rows for key in row}
-    names = [key for key in lead if key in present]
+    names = list(CARD_FIELDS)
     names += sorted(present - set(names))
 
     fields = tuple(

--- a/scrapex/partitioncrawl.py
+++ b/scrapex/partitioncrawl.py
@@ -40,11 +40,32 @@ THE METHOD, and `docs/BACKLOG.md` DEC-11 carries its measurements:
       and names its size; `D == 0` with a held witness proves every published row
       position was read.
 
-TWO NUMBERS PER CELL, BECAUSE THERE ARE TWO QUESTIONS. What we OBSERVED (the
-union of ids over every attempt) and what we can PROVE (one attempt whose witness
-held and whose own ids accounted for the cell). The union can reach N by luck
-across two generations and that proves nothing, so `provably_complete` is never
-computed from it.
+TWO PROOFS, AND THE SECOND ONE IS A CORRECTION OF THIS FILE'S FIRST CLAIM.
+
+  * THE WITNESS PROOF — page 1 returns the same id sequence after the read, so the
+    generation never rolled, so the pages were disjoint and one pass covered the
+    cell.
+  * THE COUNTING PROOF — `|distinct| == N`. A cell that declares N rows cannot show
+    N DISTINCT ids unless it has shown all of them, and the ids may be accumulated
+    over any number of reads.
+
+**This module originally said the union "can reach N by luck … and that proves
+nothing", and required the witness. That was wrong.** There is no luck in it: every
+id came off that cell's own filtered pages, so the cell contains at least the
+distinct ids seen, and it declares exactly N. Both proofs rest on the SAME
+assumption — that the paginator's N is true — and the witness adds no completeness
+that the count does not.
+
+The error was not free. It made the six cells measured above the 31-page ceiling
+unprovable **by construction** — no single read of them can hold one generation — so
+the first real run reported a 3,690 deficit with no route to close it. The counting
+proof is the route, and `HEAVY_ATTEMPTS` is how far it is pursued.
+
+WHAT THE WITNESS STILL EARNS. It says a cell was closed in ONE pass rather than
+several, which is the difference between 12 requests and 120; it detects the
+generation rolling, which is how a cell is known to be too big; and it is the only
+check that would notice a paginator declaring FEWER rows than the cell holds, since a
+too-small N makes the count agree for the wrong reason.
 
 WHAT THIS STILL CANNOT SEE, and it is the most important paragraph here. It
 proves it read every row the paginated listing PUBLISHES. It cannot prove the
@@ -92,6 +113,19 @@ Fetch = Callable[[str], str]
 #: contributes every id it read, so reading such a cell twice buys ids we already
 #: have. The verdict is reported honestly instead of bought expensively.
 RETRY_PAGE_CEILING = 31
+
+#: How many reads a cell ABOVE that ceiling is allowed, so the counting proof has a
+#: chance to close it. MODELLED, and the model is the one the blind sweep validated:
+#: a pass over a cell read across generations sees about `N(1 − 1/e)` of it, so the
+#: expected unseen after `k` passes is `N·e^(−k)`. It predicted 42.9 unseen after six
+#: passes where the sweep observed 38.
+#:
+#: Ten gives an expected unseen below 1 for the worst cell measured — `region_id=1 ×
+#: verysmall`, 4,704 rows: `4704·e^(−10) ≈ 0.2`. It also bounds the cost: ten reads of
+#: a 236-page cell is 2,360 requests, which is why this is a CEILING on effort and not
+#: a loop that runs until it succeeds. A cell that has not closed in ten reads reports
+#: its deficit, which is the honest outcome and the input to a finer partition.
+HEAVY_ATTEMPTS = 10
 
 
 class ScopeNotPartitionable(ValueError):
@@ -216,6 +250,16 @@ class CellOutcome:
 
     size: CellSize
     attempts: tuple[Attempt, ...] = ()
+    #: The cell, sized again after it was read. `None` when it was not asked.
+    #:
+    #: WHY A CELL NEEDS ITS OWN RE-SIZE AND NOT JUST THE LISTING'S. On the first real
+    #: run three cells finished one or two ids short — `235 of 236`, `148 of 149`,
+    #: `405 of 413` — and nothing could say whether a contractor had been MISSED or
+    #: had LEFT. The listing shrank by 25 rows that same night, so departure was the
+    #: likelier explanation and there was no way to prefer it. One request per cell
+    #: settles it, and a deficit that turns out to be churn is not a gap to go
+    #: hunting for.
+    size_at_end: CellSize | None = None
 
     @property
     def ids(self) -> frozenset[str]:
@@ -233,15 +277,67 @@ class CellOutcome:
 
     @property
     def proof(self) -> Attempt | None:
-        """The attempt that proves this cell complete, if one did."""
+        """The attempt that proves this cell complete by the WITNESS, if one did."""
         for attempt in self.attempts:
             if attempt.witnessed and attempt.distinct == self.size.declared:
                 return attempt
         return None
 
     @property
+    def departures(self) -> int:
+        """How many rows the cell LOST between being sized and being re-sized.
+
+        A deficit no larger than this is churn rather than a gap: the cell declared
+        `N` when it was measured and holds fewer now, so ids counted against the
+        original `N` were never all there to be read.
+        """
+        if self.size_at_end is None:
+            return 0
+        return max(0, self.size.declared - self.size_at_end.declared)
+
+    @property
+    def deficit_is_churn(self) -> bool:
+        """Whether this cell's shortfall is fully explained by rows leaving it."""
+        return (not self.provably_complete
+                and 0 < self.observed_deficit <= self.departures)
+
+    @property
+    def counted_complete(self) -> bool:
+        """THE SECOND PROOF, AND THE ONLY ONE AVAILABLE TO A HEAVY CELL.
+
+        A cell that declares `N` rows cannot show `N` DISTINCT ids unless it has
+        shown all of them. That is a complete proof of coverage and it needs no
+        generation, no witness, and no single pass — the ids may be accumulated
+        across any number of reads.
+
+        WHY THIS WAS MISSING, and it is a correction rather than an addition.
+        `provably_complete` originally required the witness AND the count, which is
+        stricter than the logic needs and is exactly the wrong constraint for the six
+        cells measured above the 31-page ceiling on 2026-08-21: those can never hold
+        one generation, so under the old rule they were unprovable **by
+        construction**, and the method reported a 3,690 deficit it had no route to
+        close. The counting proof is the route.
+
+        WHAT THE WITNESS STILL EARNS, so it is not now redundant: it proves the pages
+        were DISJOINT, which is what makes `distinct == declared` reachable in a
+        single pass instead of by repetition — and it is the only check that would
+        notice a paginator declaring fewer rows than the cell holds, because a
+        too-small `N` makes the count agree for the wrong reason.
+        """
+        return bool(self.attempts) and len(self.ids) == self.size.declared
+
+    @property
     def provably_complete(self) -> bool:
-        return self.proof is not None
+        """Either proof suffices, and the report says which one carried it."""
+        return self.proof is not None or self.counted_complete
+
+    @property
+    def proof_kind(self) -> str:
+        if self.proof is not None:
+            return "witness"
+        if self.counted_complete:
+            return "count"
+        return ""
 
     @property
     def requests(self) -> int:
@@ -263,10 +359,13 @@ class CellOutcome:
             # say so.
             verdict = "EMPTY — the site publishes no rows in this cell"
         elif self.provably_complete:
-            verdict = f"COMPLETE, D=0 over {self.size.declared:,}"
-        elif self.observed_deficit == 0:
-            verdict = (f"{len(self.ids):,} of {self.size.declared:,} seen and none "
-                       "missing, but no witness held — observed, not proven")
+            verdict = (f"COMPLETE, D=0 over {self.size.declared:,} "
+                       f"[by {self.proof_kind}]")
+        elif self.deficit_is_churn:
+            verdict = (f"{len(self.ids):,} of {self.size.declared:,}, "
+                       f"D={self.observed_deficit:,} — and the cell LOST "
+                       f"{self.departures:,} row(s) while it was read, which accounts "
+                       "for it: nothing was missed")
         else:
             verdict = (f"{len(self.ids):,} of {self.size.declared:,}, "
                        f"D={self.observed_deficit:,}")
@@ -316,7 +415,16 @@ class PartitionOutcome:
 
     @property
     def arrivals(self) -> int:
-        """How much the listing grew while the crawl ran. `0` if not re-sized."""
+        """How the listing's size MOVED while the crawl ran. `0` if not re-sized.
+
+        SIGNED, AND IT GOES BOTH WAYS — which the first real run proved and the first
+        wording denied. This was called "how much the listing grew", and the report
+        said *"the listing grew by -25 rows"*, because a directory can shrink: over
+        the night of 2026-08-20 it went 17,417 → 17,392 as twenty-five contractors
+        left. A number named for one direction hides the other, and a departure is
+        the more interesting event of the two — it is the reason a cell can end one
+        id short of its own declared count without anything having been missed.
+        """
         if self.whole_at_end is None:
             return 0
         return self.whole_at_end.declared - self.whole.declared
@@ -361,10 +469,16 @@ class PartitionOutcome:
             lines.append(
                 "NOT proven complete. The deficit above is a floor on what is "
                 "missing, not an estimate of it.")
-        if self.arrivals:
+        if self.arrivals > 0:
             lines.append(
-                f"and the listing grew by {self.arrivals:,} rows while this ran, so "
+                f"and the listing GREW by {self.arrivals:,} rows while this ran, so "
                 "the claim is 'complete as of the start, with those deferred'")
+        elif self.arrivals < 0:
+            lines.append(
+                f"and the listing SHRANK by {-self.arrivals:,} rows while this ran "
+                f"({self.whole.declared:,} -> {self.whole_at_end.declared:,}), so a "
+                "cell ending one or two short of its declared count may have lost a "
+                "contractor rather than missed one")
         lines.extend(self.notes)
         return "\n".join(lines)
 
@@ -587,9 +701,11 @@ def crawl_partition(conn: sqlite3.Connection, partition: PartitionedListing,
                     base_url: str, *, fetch: Fetch, run_ref: str,
                     dataset_key: str, cells: Sequence[Cell] | None = None,
                     max_attempts: int = 2,
+                    heavy_attempts: int = HEAVY_ATTEMPTS,
                     retry_page_ceiling: int = RETRY_PAGE_CEILING,
                     fetcher: object | None = None,
                     resize_at_end: bool = True,
+                    resize_cells: bool = True,
                     on_cell: Callable[[CellOutcome], None] | None = None,
                     ) -> PartitionOutcome:
     """Read every cell, witness each one, and report what can be proven.
@@ -644,9 +760,16 @@ def crawl_partition(conn: sqlite3.Connection, partition: PartitionedListing,
     newly_sighted = 0
     for size in sizes:
         attempts: list[Attempt] = []
-        # ONE ATTEMPT FOR A CELL TOO BIG TO WITNESS. See RETRY_PAGE_CEILING: a
-        # second read of a 235-page cell buys ids it already has and no proof.
-        allowed = 1 if size.last_page > retry_page_ceiling else max_attempts
+        # A HEAVY CELL GETS ITS RETRIES BACK, and that is the whole point of the
+        # counting proof. `RETRY_PAGE_CEILING` used to cut such a cell to ONE
+        # attempt, on the reasoning that a second read "buys ids it already has and
+        # no proof" — true of the witness, false of the count. Measured 2026-08-21:
+        # the six cells above the ceiling were read once each and left a deficit of
+        # 3,680 with no route to close it. Accumulating distinct ids IS the route,
+        # so the ceiling now decides how many reads a cell is ALLOWED, not whether
+        # it gets more than one.
+        allowed = (heavy_attempts if size.last_page > retry_page_ceiling
+                   else max_attempts)
         for number in range(1, allowed + 1):
             attempt = _read_cell(
                 conn, partition, base_url, size, fetch=fetch,
@@ -657,9 +780,25 @@ def crawl_partition(conn: sqlite3.Connection, partition: PartitionedListing,
             # crawl killed in cell forty leaves thirty-nine cells of sightings.
             newly_sighted += record_sightings(conn, dataset_key, attempt.ids,
                                               run_ref=attempt.run_ref)
+            # STOP ON EITHER PROOF. Witnessed-and-counted ends it in one pass; the
+            # union reaching the declared count ends it however many it took.
             if attempt.witnessed and attempt.distinct == size.declared:
                 break
-        outcome = CellOutcome(size=size, attempts=tuple(attempts))
+            if len({one for a in attempts for one in a.ids}) == size.declared:
+                break
+        # RE-SIZED ONLY WHEN IT MATTERS. One request a cell over 56 cells is 56
+        # requests spent to explain a deficit most cells do not have, so it is asked
+        # for exactly the cells that fell short.
+        seen_here = {one for a in attempts for one in a.ids}
+        at_end = None
+        if resize_cells and len(seen_here) != size.declared:
+            try:
+                at_end = size_cell(fetch, partition, base_url, size.cell)
+            except Exception:
+                # Failing to explain a deficit is not a reason to lose the cell.
+                at_end = None
+        outcome = CellOutcome(size=size, attempts=tuple(attempts),
+                              size_at_end=at_end)
         outcomes.append(outcome)
         if on_cell is not None:
             on_cell(outcome)
@@ -670,8 +809,10 @@ def crawl_partition(conn: sqlite3.Connection, partition: PartitionedListing,
     if above:
         notes.append(
             f"{len(above)} cell(s) were above the {retry_page_ceiling}-page witness "
-            f"ceiling and were read once without a retry: {', '.join(above)}. "
-            "Their ids count; their completeness is not claimed.")
+            f"ceiling, so no single read of them can hold one cache generation and "
+            f"the witness cannot carry them: {', '.join(above)}. They were read up to "
+            f"{heavy_attempts} times each and closed by COUNTING instead — "
+            "`distinct == declared` — or reported with the deficit they were left at.")
     if unsized:
         notes.append(
             f"{len(unsized)} cell(s) could not be sized and were NOT READ: "

--- a/tests/test_a_crawl_that_can_prove_it_read_everything.py
+++ b/tests/test_a_crawl_that_can_prove_it_read_everything.py
@@ -307,12 +307,16 @@ def test_a_rolled_generation_fails_the_witness_and_the_ids_still_count(conn):
                               run_ref="run-1", dataset_key="rows",
                               max_attempts=1)
     only = outcome.cells[0]
-    assert not only.provably_complete
+    assert not any(a.witnessed for a in only.attempts), "the generation rolled"
     assert len(only.ids) == 9, "the ids it read still count"
     assert only.observed_deficit == 0
-    assert "observed, not proven" in str(only)
-    assert not outcome.provably_complete
-    assert "NOT proven complete" in str(outcome)
+    # THE WITNESS FAILED AND THE CELL IS STILL COMPLETE, by the count. This test
+    # used to assert `not provably_complete` here, which was the wrong claim — see
+    # `test_a_union_across_two_generations_IS_a_proof`.
+    assert only.provably_complete
+    assert only.proof_kind == "count"
+    assert "[by count]" in str(only)
+    assert outcome.provably_complete
 
 
 def test_a_retry_after_a_rolled_generation_earns_the_proof(conn):
@@ -328,30 +332,46 @@ def test_a_retry_after_a_rolled_generation_earns_the_proof(conn):
     ids = [str(n) for n in range(1, 10)]
     directory = Directory({"whole": list(ids), "region_id_1": list(ids)})
     partition = Partition(directory, cells=(cell(region_id=1),))
+    # THE ROLL MUST LAND BEFORE THE LAST PAGE, not after it. Rolling after page 3
+    # left the first read holding all nine ids, so the COUNTING proof closed the cell
+    # on attempt one and there was no retry to observe. Rolling before page 2 makes
+    # the first read genuinely partial — 5 distinct of 9 — which is the case a retry
+    # exists for.
     hits: list[str] = []
 
     def rolling(url: str) -> str:
-        html = directory.fetch(url)
-        if url.endswith("region_id=1&page=3"):
+        if url.endswith("region_id=1&page=2"):
             hits.append(url)
-            if len(hits) == 2:
+            if len(hits) == 1:
                 directory.roll("region_id_1", list(reversed(ids)))
-        return html
+        return directory.fetch(url)
 
     outcome = crawl_partition(conn, partition, BASE, fetch=rolling,
                               run_ref="run-1", dataset_key="rows")
     only = outcome.cells[0]
     assert len(only.attempts) == 2
     assert not only.attempts[0].witnessed, "the first read straddled two generations"
+    assert only.attempts[0].distinct < only.size.declared, "and was partial"
     assert only.provably_complete
-    assert only.proof is only.attempts[1]
+    assert only.proof is only.attempts[1], "the second read held one generation"
+    assert only.proof_kind == "witness"
     assert outcome.provably_complete
 
 
-def test_a_union_across_two_generations_is_not_a_proof(conn):
-    """THE SWEEP'S ANSWER, REFUSED. Two reads that between them account for every
-    row prove nothing about either read. `provably_complete` must come from ONE
-    attempt whose witness held, never from the union."""
+def test_a_union_across_two_generations_IS_a_proof(conn):
+    """THIS TEST ASSERTED THE OPPOSITE AND THE ASSERTION WAS WRONG.
+
+    It was written as *"a union across two generations is NOT a proof"*, on the
+    reasoning that the union "can reach N by luck". There is no luck in it: every id
+    came off this cell's own filtered pages, so the cell contains at least the
+    distinct ids seen, and it declares exactly eight. Eight distinct of eight
+    declared IS complete, whether one read produced them or five did.
+
+    THE ERROR WAS NOT FREE, which is why it is corrected in place rather than
+    quietly. Requiring the witness made the six cells above the 31-page ceiling
+    unprovable BY CONSTRUCTION — no single read of them can hold one generation — and
+    the first real run reported a 3,690 deficit with no route to close it.
+    """
     register(conn)
     everyone = [str(n) for n in range(1, 9)]
     directory = Directory({"whole": list(everyone), "region_id_1": list(everyone)})
@@ -380,9 +400,20 @@ def test_a_union_across_two_generations_is_not_a_proof(conn):
                               run_ref="run-1", dataset_key="rows")
     only = outcome.cells[0]
     assert len(only.attempts) == 2, "a failed witness must earn the retry"
-    assert len(only.ids) == 8, "the union does account for every row"
+    assert len(only.ids) == 8, "the union accounts for every row"
     assert only.observed_deficit == 0
-    assert not only.provably_complete, "and that is not a proof"
+    # AND IT IS A PROOF, WHICH IS THE OPPOSITE OF WHAT THIS TEST FIRST ASSERTED.
+    # Neither read held a generation, so neither is witnessed — and it does not
+    # matter: eight distinct ids came off a cell that declares eight, so the cell
+    # contains exactly them. See `counted_complete`.
+    assert only.provably_complete
+    assert only.proof_kind == "count"
+    assert only.proof is None, "no single attempt accounted for the whole cell"
+    # AND EACH ATTEMPT'S OWN WITNESS HELD, which is what makes this the subtle case
+    # rather than an obvious one: both reads were internally consistent and neither
+    # covered the cell. The witness is not the thing that was missing.
+    assert all(a.witnessed for a in only.attempts)
+    assert all(a.distinct < only.size.declared for a in only.attempts)
 
 
 def test_a_retry_stores_its_own_evidence_rather_than_being_skipped(conn):
@@ -390,11 +421,15 @@ def test_a_retry_stores_its_own_evidence_rather_than_being_skipped(conn):
     run ref would let `already_stored` skip every page and the retry would witness
     the same stale ordering for ever."""
     register(conn)
-    ids = [str(n) for n in range(1, 5)]
+    # NINE IDS, NOT FOUR. A four-id cell is one page, so the first read closes it by
+    # counting and there is no second attempt whose evidence to check.
+    ids = [str(n) for n in range(1, 10)]
     directory = Directory({"whole": list(ids), "region_id_1": list(ids)})
     partition = Partition(directory, cells=(cell(region_id=1),))
 
     def rolling(url: str) -> str:
+        # Rolled on EVERY fetch, so no read can ever be complete or witnessed —
+        # which is what forces both attempts to happen and be observable.
         html = directory.fetch(url)
         directory.roll("region_id_1", list(reversed(directory._order["region_id_1"])))
         return html
@@ -557,7 +592,7 @@ def test_arrivals_during_the_crawl_are_reported_and_not_absorbed(conn):
     outcome = crawl_partition(conn, partition, BASE, fetch=arriving,
                               run_ref="run-1", dataset_key="rows")
     assert outcome.arrivals == 2
-    assert "grew by 2 rows" in str(outcome)
+    assert "GREW by 2 rows" in str(outcome)
 
 
 def test_a_parse_failure_is_not_reported_as_a_dead_page(conn):
@@ -748,6 +783,148 @@ def test_a_witness_that_cannot_be_read_is_a_verdict_and_not_an_end(conn):
     partition = Brittle(directory, cells=(cell(region_id=1),))
     outcome = run(conn, partition, directory, max_attempts=1, resize_at_end=False)
     only = outcome.cells[0]
-    assert not only.provably_complete
+    # THE POINT IS THAT NOTHING RAISED. An unguarded witness would have thrown out of
+    # `crawl_partition` and discarded every cell already read.
     assert "the witness could not be read" in only.attempts[0].note
+    assert not only.attempts[0].witnessed
     assert len(only.ids) == 4, "the pages it did read still count"
+    # And the cell is still complete — by COUNTING, which needs no witness at all.
+    # That is the correct outcome: the witness being unreadable costs the cheaper
+    # single-pass proof, not the coverage.
+    assert only.provably_complete
+    assert only.proof_kind == "count"
+
+
+# ---- the counting proof, and what it costs a heavy cell ----------------------
+
+def test_a_cell_too_big_to_witness_is_closed_by_counting(conn):
+    """THE 3,690 DEFICIT'S ROUTE OUT, and the reason the old rule was wrong.
+
+    Six cells were measured above the 31-page ceiling on 2026-08-21 — the worst 236
+    pages — so no single read of them can hold one cache generation and the witness
+    can never carry them. Under the old rule they were unprovable BY CONSTRUCTION.
+    Read repeatedly, their distinct ids accumulate to the declared count, and that is
+    a proof.
+    """
+    register(conn)
+    ids = [str(n) for n in range(1, 13)]
+    directory = Directory({"whole": list(ids), "region_id_1": list(ids)})
+    partition = Partition(directory, cells=(cell(region_id=1),))
+    # Rolled on every fetch, so no read is ever internally consistent — the exact
+    # condition of a cell larger than one generation.
+    def rolling(url: str) -> str:
+        html = directory.fetch(url)
+        order = directory._order["region_id_1"]
+        directory.roll("region_id_1", order[1:] + order[:1])
+        return html
+
+    outcome = crawl_partition(conn, partition, BASE, fetch=rolling, run_ref="run-1",
+                              dataset_key="rows", retry_page_ceiling=1,
+                              heavy_attempts=8, resize_at_end=False)
+    only = outcome.cells[0]
+    assert not any(a.witnessed for a in only.attempts), "no read held a generation"
+    assert only.provably_complete, "and the cell is complete anyway"
+    assert only.proof_kind == "count"
+    assert len(only.ids) == only.size.declared == 12
+    assert len(only.attempts) > 1, "it took more than one read"
+    assert "[by count]" in str(only)
+
+
+def test_a_heavy_cell_gets_more_than_one_read(conn):
+    """`RETRY_PAGE_CEILING` used to cut a heavy cell to a SINGLE attempt, on the
+    reasoning that a second read "buys ids it already has and no proof" — true of the
+    witness, false of the count. That one line is why the first real run left six
+    cells with a deficit and no way to close them."""
+    register(conn)
+    ids = [str(n) for n in range(1, 41)]
+    directory = Directory({"whole": list(ids), "region_id_1": list(ids)})
+    partition = Partition(directory, cells=(cell(region_id=1),))
+
+    def never_settles(url: str) -> str:
+        html = directory.fetch(url)
+        order = directory._order["region_id_1"]
+        directory.roll("region_id_1", order[3:] + order[:3])
+        return html
+
+    outcome = crawl_partition(conn, partition, BASE, fetch=never_settles,
+                              run_ref="run-1", dataset_key="rows",
+                              retry_page_ceiling=2, heavy_attempts=3,
+                              resize_at_end=False)
+    only = outcome.cells[0]
+    assert len(only.attempts) == 3, "a heavy cell must get its retries"
+    assert "closed by COUNTING" in str(outcome)
+    assert f"{2}-page witness ceiling" in str(outcome)
+
+
+# ---- a deficit that is churn, not a gap -------------------------------------
+
+def test_a_cell_that_lost_a_row_says_so_instead_of_reporting_a_gap(conn):
+    """THREE CELLS FINISHED ONE OR TWO SHORT on the first real run — `235 of 236`,
+    `148 of 149`, `405 of 413` — and nothing could say whether a contractor had been
+    missed or had LEFT. The listing shrank by 25 rows that same night, so departure
+    was the likelier reading and there was no way to prefer it. One request per short
+    cell settles it."""
+    register(conn)
+    ids = [str(n) for n in range(1, 10)]
+    directory = Directory({"whole": list(ids), "region_id_1": list(ids)})
+    partition = Partition(directory, cells=(cell(region_id=1),))
+    reads: list[str] = []
+
+    def losing_one(url: str) -> str:
+        html = directory.fetch(url)
+        reads.append(url)
+        # One contractor leaves the cell after it has been sized and read once, so
+        # the re-size finds 8 where the read was counted against 9.
+        if len(reads) == 4:
+            directory.roll("region_id_1", ids[:-1])
+        return html
+
+    outcome = crawl_partition(conn, partition, BASE, fetch=losing_one,
+                              run_ref="run-1", dataset_key="rows",
+                              max_attempts=1, resize_at_end=False)
+    only = outcome.cells[0]
+    assert only.size_at_end is not None, "a short cell must be re-sized"
+    assert only.departures >= 1
+    assert only.deficit_is_churn, (
+        f"D={only.observed_deficit} against {only.departures} departure(s) is churn")
+    assert "which accounts for it: nothing was missed" in str(only)
+
+
+def test_a_cell_that_closed_is_not_re_sized_at_all(conn):
+    """One request a cell over 56 cells is 56 requests spent explaining a deficit
+    that most cells do not have. It is asked for exactly the cells that fell short."""
+    register(conn)
+    ids = [str(n) for n in range(1, 10)]
+    directory = Directory({"whole": list(ids), "region_id_1": list(ids)})
+    partition = Partition(directory, cells=(cell(region_id=1),))
+
+    outcome = run(conn, partition, directory, resize_at_end=False)
+    only = outcome.cells[0]
+    assert only.provably_complete
+    assert only.size_at_end is None, "a complete cell must not cost a re-size"
+    assert only.departures == 0
+    assert not only.deficit_is_churn
+
+
+def test_a_listing_that_shrank_says_shrank_and_not_grew_by_minus(conn):
+    """THE REPORT SAID "the listing grew by -25 rows" ON THE FIRST REAL RUN, because
+    `arrivals` was named for one direction. A directory can shrink — that one did,
+    17,417 -> 17,392 overnight — and a departure is the more interesting event,
+    because it is why a cell can end short without anything being missed."""
+    register(conn)
+    ids = [str(n) for n in range(1, 9)]
+    directory = Directory({"whole": list(ids), "region_id_1": list(ids)})
+    partition = Partition(directory, cells=(cell(region_id=1),))
+
+    def leaving(url: str) -> str:
+        html = directory.fetch(url)
+        if url.endswith("region_id=1&page=1"):
+            directory.roll("whole", ids[:-3])
+        return html
+
+    outcome = crawl_partition(conn, partition, BASE, fetch=leaving, run_ref="run-1",
+                              dataset_key="rows")
+    assert outcome.arrivals == -3
+    report = str(outcome)
+    assert "SHRANK by 3 rows" in report
+    assert "grew by -" not in report, "a negative growth is a shrinkage, in words"

--- a/tests/test_a_dataset_is_a_table_like_any_other.py
+++ b/tests/test_a_dataset_is_a_table_like_any_other.py
@@ -551,3 +551,126 @@ def test_a_dataset_exports_a_workbook_instead_of_refusing_one(conn):
 
     with pytest.raises(ValueError, match="nothing to publish"):
         workbook_tables(conn, "NOT_A_SOURCE_OR_DATASET")
+
+
+# ---- the FIFTH leak, and the partition is what exposed it --------------------
+
+def _without_the_location_box(html: str) -> str:
+    """The same page as a `region_id=0` contractor publishes it: no location box.
+
+    Built by REMOVING the box that carries the location icon, which is what a card
+    with no location actually looks like — not by deleting the value and leaving an
+    empty cell. The distinction matters: `read_listing` names a field after the
+    box's label, so a missing box removes the FIELD, while an empty value would
+    leave the field present and blank.
+    """
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(html, "html.parser")
+    for icon in soup.select(".info-icon span.icon-locaion"):
+        box = icon.find_parent(class_="info-box")
+        if box is not None:
+            box.decompose()
+    return str(soup)
+
+
+def test_a_card_with_no_location_does_not_change_the_schema():
+    """THE DEFECT THAT REFUSED 823 OF 897 PAGES, measured 2026-08-21.
+
+    `region_id=0` is the 1,438 contractors who publish no location at all, and its
+    four cells are the first `1 + 4 + 10 + 59 = 74` pages a partitioned crawl reads.
+    Their cards carry no location box, so a field list derived from the page's own
+    cards had 21 entries; page 75 was `region_id=1` with 22, a different
+    `schema_hash`, and every page after it was refused.
+
+    AND THE PARTITION IS THE CAUSE, which is why this could never be a per-page
+    computation. The old unfiltered crawl mixed every kind of contractor onto every
+    page, so the union always held every field. A partition groups like with like —
+    the very property that makes a cell provably complete — so its first cell is
+    systematically unrepresentative.
+    """
+    stripped = _without_the_location_box(LISTING)
+    assert "icon-locaion" not in stripped, "the fixture must really lose the box"
+
+    from scrapex.extract.muqawil import read_listing
+    rows = read_listing(stripped)
+    assert rows, "the cards must still be cards"
+    assert not any("card_city_region" in row for row in rows), (
+        "no card in this fixture should publish a location any more")
+
+    assert _keys(stripped) == _keys(LISTING), (
+        "a page whose contractors publish no location declared a different schema, "
+        "so a partitioned crawl approves its first cell and refuses the rest")
+    assert "card_city_region" in _keys(stripped), (
+        "the column must still be THERE and simply be NULL — an absent value is a "
+        "null in a column that is always present")
+
+
+def test_the_declared_card_fields_are_what_a_real_page_publishes():
+    """A DECLARATION CAN GO STALE IN THE OTHER DIRECTION, so it is checked against
+    the committed fixture rather than trusted. Every field a real page publishes
+    must be declared; a field the site ADDS later is still kept, appended after the
+    declared ones, because a new column is news."""
+    from scrapex.extract.muqawil import CARD_FIELDS, read_listing
+
+    published = {key for row in read_listing(LISTING) for key in row}
+    undeclared = published - set(CARD_FIELDS)
+
+    assert not undeclared, (
+        f"a real listing page publishes {sorted(undeclared)}, which CARD_FIELDS "
+        "does not declare — so those columns move position from page to page")
+    assert len(CARD_FIELDS) == len(set(CARD_FIELDS)), "a field is declared twice"
+
+
+def test_an_empty_listing_page_still_declares_nothing_rather_than_a_short_schema():
+    """`region_id=8 & company_size=big` publishes ZERO contractors and still serves
+    a paginator. A derived field list is empty there; the candidate must refuse
+    rather than approve a schema of no columns."""
+    candidate = listing_candidate("<html><body>no cards at all</body></html>")
+
+    assert not candidate.approvable
+    assert candidate.fields == ()
+    assert "No contractor cards" in candidate.warnings[0]
+
+
+def test_a_field_the_site_adds_is_kept_and_not_silently_dropped():
+    """DECLARING THE LIST MUST NOT MAKE THE PARSER DEAF, and this guard exists
+    because a mutation proved it was missing. `CARD_FIELDS` was declared with a
+    comment promising that a new field is "appended after the declared ones", and
+    deleting the line that appends it left every test green — the claim had no guard
+    behind it at all, and the promise was the only thing holding it up.
+
+    The rule this protects is `PROFILE_FIELDS`' own: a label the map does not know
+    is KEPT under a slug of its own rather than dropped, because a field the site
+    adds is news, and a parser that discards what it was not told about is how it
+    stays news for a year.
+    """
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(LISTING, "html.parser")
+    card = soup.select_one("div.section-card")
+    assert card is not None, "the fixture must have a card to add a box to"
+    # A box shaped exactly like the site's own, carrying a label nothing knows.
+    box = soup.new_tag("div", attrs={"class": "info-box"})
+    name = soup.new_tag("div", attrs={"class": "info-name"})
+    name.string = "Green Building Points"
+    value = soup.new_tag("div", attrs={"class": "info-value"})
+    value.string = "42"
+    box.append(name)
+    box.append(value)
+    # NOT LAST. `read_listing` reads the classification from the FINAL box by
+    # position, so appending at the end would displace it and this test would be
+    # measuring the wrong thing.
+    existing = card.select_one(".info-box")
+    existing.insert_before(box)
+
+    keys = _keys(str(soup))
+    assert "card_green_building_points" in keys, (
+        f"the site added a field and the parser dropped it: {keys}")
+    assert list(keys[:len(CARD_FIELDS_FOR_TEST())]) == list(CARD_FIELDS_FOR_TEST()), (
+        "the declared fields must keep their positions; a new one is APPENDED")
+
+
+def CARD_FIELDS_FOR_TEST():
+    from scrapex.extract.muqawil import CARD_FIELDS
+    return CARD_FIELDS


### PR DESCRIPTION
Two corrections the first real crawl forced. Both were found by **running** it, not
by reading it, and one of them is a mistake in what I had decided to prove.

## 1 · The completeness rule demanded more than the claim needs

`provably_complete` required the witness **and** the count. A cell larger than one
cache generation can never satisfy the witness — so the six cells measured above the
31-page ceiling were unprovable **by construction**, and the run reported a **3,690
deficit with no route to close it**. That is a false negative on a completeness
claim, which looks exactly like missing data and sends someone hunting for rows that
were never lost.

There are two independent proofs and only one was implemented:

| | |
|---|---|
| **witness** | page 1 returns the same id sequence ⇒ one generation ⇒ pages disjoint |
| **count** | `distinct == declared`. A cell holding `N` cannot show `N` distinct ids without showing all of them — **no generation, no witness, no single pass** |

Both rest on the same assumption — that the paginator's `N` is true — so the witness
adds no *completeness* the count does not. It still earns its place, and the docstring
says how: it proves a cell closed in **one** pass rather than several (12 requests
against 120), it detects the generation rolling, and it is the only check that would
notice a paginator declaring *fewer* rows than a cell holds.

**What made this hard to see is worth more than the fix.** The module docstring
asserted the opposite as settled fact — *"the union can reach N by luck … and that
proves nothing"* — and a test was **named** `test_a_union_across_two_generations_is_not_a_proof`
and asserted it. Nine guards and twenty-one killed mutations all agreed with each
other, because they were all checking the same wrong rule. **Mutation testing cannot
find a mistake in what you decided to prove**; it only confirms you still prove it.
Written up in `LESSONS.md`.

Heavy cells therefore get their retries back — `HEAVY_ATTEMPTS = 10`, from the model
the blind sweep validated (`N·e^(−k)`; it predicted 42.9 unseen after six passes where
the sweep observed 38) — and the report now says which proof carried each cell,
`[by witness]` or `[by count]`.

## 2 · The schema refused 823 of 897 pages, and 74 is arithmetic

`region_id=0`'s four cells are `1 + 4 + 10 + 59 = 74` pages, and `region_id=0` **is**
the 1,438 contractors who publish no location. Their cards carry no location box:

```
region_id=0 & company_size=big   21 fields, no card_city_region
region_id=1 & company_size=big   22 fields
```

Those 74 pages taught the dataset a 21-field schema and every located contractor's
page after them was refused for having one more column.

**The partition is the cause**, which is why a per-page field list can never work. The
old unfiltered crawl mixed every kind of contractor onto every page, so the union
always held every field — 864 pages approved into 11,059 records. A partition
deliberately **groups like with like**; the very property that makes a cell provably
complete makes its first cell systematically unrepresentative.

`CARD_FIELDS` is now declared exactly as `BILINGUAL_CARD_FIELDS` already was, for the
reason that note already gives: *"which fields the SITE translates is a fact about the
site … and an absent value is a NULL in a column that is always there."* That argument
covered the `_ar` half only. Measured across page 1 of every cell: 15 fields, 14 on
every page with a card, and only `card_city_region` varying.

Which of three routes reconciles the 74 pages already landed is **deferred**, at his
instruction — [R-25](docs/RULINGS.md). Coverage therefore stays at 1,172 records,
limited by an unresolved schema decision and not by the crawl, whose own result is
13,727 sighted ids and 1,982 stored pages.

## Two more report defects, both from the run

- It said **"the listing grew by -25 rows"**. The listing had *shrunk*, 17,417 →
  17,392 overnight. `arrivals` was named for one direction and a directory goes both
  ways — and a departure is the more interesting event, because it is why a cell can
  end short without anything being missed.
- A cell ending **`235 of 236`** could not be told from one that lost a contractor.
  Short cells are now re-sized — only short ones, so 56 cells do not pay 56 requests
  to explain a deficit most of them do not have — and a deficit inside the churn is
  named as churn.

## Guards

Nine new tests, **twelve mutations killed**: the counting proof removed, a heavy cell
cut back to one attempt, the count stop-rule removed, departures never computed, a
complete cell re-sized anyway, shrinkage reported as negative growth, the field list
derived per page again, `card_city_region` dropped from the declaration, and a
site-added field silently discarded.

That last one exists **only because a mutation proved it was missing**: `CARD_FIELDS`
shipped with a comment promising a new field is "appended after the declared ones",
and deleting the line that appends it left every test green. The promise was the only
thing holding it up. My own mutation script had also reported that mutation as
*killed* when it survived — a false green I nearly accepted.

**R-22:** full suite locally with `SCRAPEX_FULL_MIGRATIONS=1` — **2,463 passed, 1
failed**, the failure being `OP-19`, proven 3 of 3 on untouched `main` at `2366d6d`.
`ruff check scrapex/` clean at CI's pinned 0.16.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
