### PR TITLE
A subdivision is checked against its parent, not against the whole listing

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -822,6 +822,48 @@ is fixed (it now hashes exactly as the write path does) and reverting the join f
 four tests — but a column named for what it actually holds would have made the mistake
 unavailable in the first place.
 
+---
+
+### OP-28 · The muqawil crawl driver has 306 lines and no tests at all
+
+Found 2026-08-21 while scoping what a Windows-only failure could hide.
+`tools/crawl_muqawil_listing.py` — the driver for `--plan`, `--crawl`, `--approve`,
+`--coverage`, `--only`, `--heavy-attempts`, `--not-seen-since` — is referenced by
+**zero tests**:
+
+```
+grep -rln "crawl_muqawil_listing" tests/   ->   no matches
+```
+
+It is also the file where the one Windows-only defect of this whole track lived: a
+`UnicodeEncodeError` on `→` in `say()` killed a run **after all 114 requests had
+succeeded**, because the console codepage is cp1252 and the arrow is not in it. The
+fix (a `say` that cannot raise) is guarded by nothing, and CI cannot catch a
+regression: CI is **ubuntu-only**, and `tools/` is not even in the linted path
+(`ruff check scrapex/`).
+
+So the exposure is specific rather than theoretical: **argument handling, resume
+selection and console output in the one file whose failure mode is invisible to CI.**
+Not urgent — it is a developer tool, not shipped code — but it is the cheapest test
+debt on the board, and `say()` in particular is one parametrised test.
+
+---
+
+### OP-29 · An invalid escape sequence in a test docstring is a future `SyntaxError`
+
+Every full suite prints `<unknown>:85: SyntaxWarning: invalid escape sequence '\.'`,
+raised by both gate tests because they compile the suite's own sources to count it.
+Traced 2026-08-21 to a **non-raw** docstring at `tests/test_relaunch_log.py:84`, which
+quotes a Windows path verbatim:
+
+    ...\.scrapex\engine.log
+
+`\.` and `\e` are not escape sequences. Python 3.12 warns; **a future Python makes
+this a `SyntaxError`**, and then the file stops importing. The fix is one character —
+`r"""` — and it is filed rather than folded into an unrelated pull request because a
+warning that has been printing for a while is not an emergency, and because a
+docstring quoting a path is exactly the case that will recur.
+
 ## 3. Decided, not yet built
 
 ### DEC-1 · Topology A — the TypeScript extension as the public product

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -813,6 +813,45 @@ Reading the code found almost none of these. What found them:
 - **When a fix looks like it did nothing, suspect the environment before the
   logic** — §1 above.
 
+### A mutation harness that trusts `finally` will leave a mutation in the tree
+
+The method above depends on a harness that **mutates the source, runs the tests,
+and puts the source back**. The putting-back is the dangerous half, and it has now
+failed twice on the same day, in two different disguises:
+
+| attempt | how the restore was written | what killed it | what it left behind |
+|---|---|---|---|
+| first | a `for` loop in **bash**, restoring after each mutation | the tool's two-minute timeout | a mutation in `scrapex/sightings.py` |
+| second | a **Python** script restoring in `finally` | the same timeout | `outside = []` in `scrapex/partitioncrawl.py` |
+
+The second is the instructive one, because `finally` *looks* like the fix for the
+first. It is not. **A timeout arrives as `SIGTERM`, and Python's default
+disposition for `SIGTERM` terminates the interpreter without unwinding the stack**
+— so no `finally` block runs, no `atexit` handler runs, and the file stays
+mutated. `try/finally` protects against exceptions, which is a different hazard
+from being killed.
+
+What it leaves behind is the worst possible artefact: **the check whose guard was
+under test, deleted**, in a working tree where every other test still passes. The
+next thing to run is a full suite that reports green on code with a hole in it, and
+`git diff` shows a one-line change that reads like something you meant.
+
+Two protections, and both are needed:
+
+```python
+def _on_signal(number, _frame):
+    print("restored:", restore())
+    sys.exit(128 + number)
+
+for _sig in (signal.SIGTERM, signal.SIGINT, signal.SIGBREAK):
+    signal.signal(_sig, _on_signal)
+```
+
+and **run the harness in the background**, where no timeout is counting. The
+handler is the belt; the background is the braces. And after any mutation run that
+did not print its own `restored: True`, **grep the tree for the mutations** rather
+than assuming — that check is what caught this one.
+
 ---
 
 ## 9 · A measurement is only as good as the instrument

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -76,7 +76,7 @@ IDs are stable and never reused, matching the convention BACKLOG.md already uses
 | [REQ-18](#req-18--bitumen-6070-prices--the-first-source-that-cannot-be-crawled) | Bitumen 60/70 prices — the first source that cannot be crawled | **Captured** — 5 of 7 need a written quotation | 2026-08-20 |
 | [REQ-19](#req-19--reinforced-concrete-material-prices--its-turn-will-come) | Reinforced-concrete material prices — its turn will come | **Captured** — a provenance-typed price model | 2026-08-20 |
 | [REQ-20](#req-20--the-database-rename-must-reach-every-user-not-just-this-machine) | The database rename must reach every user | **Captured** — measured; a release blocker under [R-24](RULINGS.md#r-24--a-database-is-upgraded-never-replaced--the-users-data-survives-the-schema) | 2026-08-20 |
-| [REQ-21](#req-21--the-nested-audit--a-subdivision-must-be-checked-against-its-parent) | The nested audit — a subdivision checked against its parent | **Captured** — measured (deficit 32 of 4,697); not built | 2026-08-21 |
+| [REQ-21](#req-21--the-nested-audit--a-subdivision-must-be-checked-against-its-parent) | The nested audit — a subdivision checked against its parent | **In flight** — the audit is built and guarded; no subdivision is wired to a site yet | 2026-08-21 |
 | [REQ-22](#req-22--what-happens-on-a-new-contractor-a-vanished-one-a-changed-one-and-on-update) | What happens on a new / vanished / changed contractor, and on "update" | **Captured** — answered by measurement; 3 of 4 are gaps ([OP-26](BACKLOG.md)) | 2026-08-21 |
 
 ---
@@ -885,7 +885,7 @@ exactly why a manual-only remedy looked finished.
 ---
 
 ## REQ-21 · The nested audit — a subdivision must be checked against its parent
-**Captured 2026-08-21 · Measured; not built**
+**Captured 2026-08-21 · In flight — the audit is built; the subdivision is not**
 
 > «اريد تسجيل التدقيق المتشعب ضمن الطلبات»
 
@@ -922,12 +922,44 @@ cities are few and contractors cluster in them: city coverage saturates far fast
 than contractor coverage. That is why choosing a subdivision from partial evidence
 works at all, and the audit is what makes relying on it safe.
 
-### What is missing, and it is a gap in my own plan
+### What was missing, and it was a gap in my own plan — now built
 
-**`crawl_partition`'s audit compares `Σ N_cell` against the WHOLE listing, not against
-a parent cell.** Running the 151 city cells as a partition today would compare them to
-17,417 and report a meaningless deficit. The nested comparison has to be built:
-a partition needs to know its parent, and the audit has to be relative to it.
+**`crawl_partition`'s audit compared `Σ N_cell` against the WHOLE listing, not against
+a parent cell.** Running the 151 city cells as a partition would have compared them to
+17,414 and reported a deficit of thirteen thousand rows that were never in scope — a
+number so wrong it would have to be ignored, which is how a check stops being one.
+
+Built as **one parameter and one refusal**:
+
+| | where | what it does |
+|---|---|---|
+| `crawl_partition(..., parent=Cell)` | `scrapex/partitioncrawl.py:811` | sizes the PARENT, so every number is measured against it; `WHOLE` is the default and top-level runs are unchanged |
+| `Cell.is_under(other)` | `scrapex/pagesource.py:146` | subset-hood expressed in filters — adding a filter can only narrow, so a child carrying all of the parent's name/value pairs selects a subset, **in any order** |
+| `NotASubdivision` | `scrapex/partitioncrawl.py:804` | raised **before a single request** when a cell is not inside the parent. A child that dropped a parent filter is measured over a larger set and could report a comfortable zero deficit while covering none of the parent |
+| `PartitionOutcome.parent` / `.scope` / `.nested` | | so the report says what it audited, and a nested proof reads *"PROVABLY COMPLETE FOR cell … — AND FOR THAT CELL ONLY"* rather than claiming the listing |
+
+Guarded by seven tests in `tests/test_a_crawl_that_can_prove_it_read_everything.py`
+and **eight mutations, all killed** — including the reversed subset test, the ordered
+comparison, and the nested proof claiming the listing.
+
+The re-size at the end follows the same scope, which is not cosmetic: a nested run
+that re-sized the whole listing would report the site's churn as the parent's, and a
+child ending one id short would then be excused by a departure that happened in
+another region entirely.
+
+**A nested crawl is runnable today, and that was worth checking rather than
+assuming.** Measured 2026-08-21: `listing_url` builds from `cell.query`
+generically, so a city cell is a URL like any other —
+`?region_id=1&company_size=verysmall&city_id=21&page=3` — and `in_cell` yields its
+pages in both locales. So `crawl_partition(cells=<city cells>, parent=<the cell>)`
+works end to end now.
+
+What is **not** built is a *published* city-cell generator: `cells()` still returns
+only the 56 `region_id x company_size` cells, and the 151 city cells were computed
+in a scratchpad from stored evidence. Deriving them inside the source module means
+querying the warehouse for what we have seen, which is a design decision — and the
+measurement below says it would buy 9% for the cell that motivated it, so it is not
+being built ahead of his ruling ([R-25](RULINGS.md#r-25--the-crawl-method-is-settled-first-the-schema-and-retention-questions-come-last)).
 
 ### And the subdivision turned out to be worth less than I claimed
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,6 +1,6 @@
 # State — where the work stands
 
-**Last updated: 2026-08-20 (evening).** `main` is at `2366d6d` (#232).
+**Last updated: 2026-08-21 (morning).** `main` is at `71d1d41` (#234).
 
 This is the document that is **wrong the moment it is out of date**. Update it
 when a phase lands, a PR merges, or the owner rules — in the same pull request as
@@ -14,10 +14,37 @@ tracks *his requests* through Captured → Ruled → Planned → In flight → D
 
 ## Open pull requests
 
-**One: the partitioned listing crawl** — `scrapex/partitioncrawl.py`, the `Cell`
-vocabulary, muqawil's facets, and the driver that had never existed. Verified
-against the live directory before it opened: 56 cells, 897 pages, an exhaustiveness
-deficit of **0**.
+**[#235](https://github.com/muhammadbayoumi/ScrapeX/pull/235) — a row says what
+state it is in.** The observation state as a column instead of something the reader
+infers from two dates: eight states, closed vocabulary, seven of them computed;
+engine migration `0006` for the eighth fact (`last_absent_at`, without which
+`returned` cannot exist); `R-27`, which stops a vanished row from leaving the sheet;
+`R-20`'s unchanged-means-no-revision, without which `last_changed` means nothing;
+the profile-page candidate adapter; and a **~1,600×** fix to `coverage()` /
+`missing_ids()` (49.7s → 0.03s each). All five CI jobs green including
+`migration-authority`. Ten mutations killed.
+
+**Next, on `claude/muqawil-nested-audit`** — REQ-21's nested audit: `crawl_partition`
+takes a `parent` cell and audits `Σ N_child` against **it** rather than the whole
+listing. Eight mutations killed.
+
+**Merged 2026-08-21:** [#233](https://github.com/muhammadbayoumi/ScrapeX/pull/233),
+[#234](https://github.com/muhammadbayoumi/ScrapeX/pull/234) — a proof that demanded
+more than it needed, and 823 pages refused by one column.
+
+### The crawl that is still running
+
+The residual crawl of the nine heavy cells is **live** and resumable
+([R-26](RULINGS.md#r-26)). As of 2026-08-21 08:06 it had stored **3,563 listing
+pages** across all 56 cells and the ledger held **15,273 distinct ids of the
+listing's 17,414 — 87.7%**. Stored *records* remain 1,172 because `OP-25`'s
+extraction route is deferred by `R-25`; the gap between the two numbers, 14,101, is
+exactly the question the sightings ledger exists to answer.
+
+**The listing crawl itself** — `scrapex/partitioncrawl.py`, the `Cell`
+vocabulary, muqawil's facets, and the driver that had never existed — merged as
+#227-#234. Verified against the live directory: 56 cells, 897 pages, an
+exhaustiveness deficit of **0**.
 
 Sixteen merged on 2026-08-20, the last nine in this order, each on green CI under
 [R-18](RULINGS.md#r-18--merge-it-when-it-is-green):

--- a/docs/plans/2026-08-20-finish-muqawil-then-the-source-queue.md
+++ b/docs/plans/2026-08-20-finish-muqawil-then-the-source-queue.md
@@ -160,10 +160,22 @@ Tick a box only when it is MERGED. `⚡` marks a quick win — under about an ho
       [R-26](../RULINGS.md#r-26--the-residual-crawl-runs-in-the-background-while-development-continues-and-must-be-stoppable).
       Three cells cannot be witnessed at any size — RIYADH twice, JEDDAH — and close by
       counting or report their deficit exactly.
-- [ ] **`REQ-21`: the nested audit.** `crawl_partition` audits against the WHOLE
-      listing, not against a parent cell, so the 151 city cells cannot be run as a
-      subdivision today. Measured: the city list from partial evidence accounts for
-      4,665 of 4,697 — a deficit of **32**, which the audit must name.
+- [x] **`REQ-21`: the nested audit** — `crawl_partition(..., parent=Cell)` audits
+      `Σ N_child` against the parent cell, `Cell.is_under` decides membership as a set
+      question so filter order cannot matter, and `NotASubdivision` refuses a child
+      that dropped one of the parent's filters **before a single request** — such a
+      child is measured over a larger set and could clear the parent's count while
+      covering none of it. A nested proof now reads *"AND FOR THAT CELL ONLY"* rather
+      than claiming the listing. Seven tests, **eight mutations killed**.
+      Measured target: the city list from partial evidence accounts for 4,665 of
+      4,697 — a deficit of **32** the audit now names instead of drowning in 17,414.
+      **A nested crawl runs today** — `listing_url` builds from `cell.query`
+      generically, so `?region_id=1&company_size=verysmall&city_id=21&page=3` is a URL
+      like any other and `in_cell` yields both locales; verified, not assumed. What is
+      missing is a **published** city-cell generator: `cells()` still returns only the
+      56, and deriving cities means querying the warehouse for what we have seen. Not
+      built ahead of his ruling, because for Riyadh it buys 9% (4,697 → 4,268) and
+      the counting proof remains the route.
 - [ ] **Make sizing resumable**, or state its cost in the tool's own output. A resumed
       run re-pays ~112 requests (5.7%).
 
@@ -178,7 +190,7 @@ Tick a box only when it is MERGED. `⚡` marks a quick win — under about an ho
 > | `read_email` | decodes Cloudflare's XOR'd `data-cfemail` ✓ |
 > | `read_coordinates` | returns `24.6717 / 46.3942` from the inline script ✓ |
 > | `merge_locales` | gives **20 merged keys** including both `_ar` halves ✓ |
-> | `profile_candidate` | **does not exist** ← the actual gap |
+> | `profile_candidate` | **built 2026-08-21** as `bilingual_profile_candidate` (#235) — it was the actual gap |
 > | `profile-en.html` / `profile-ar.html` | both committed ✓ |
 >
 > So the reading works end to end and what is missing is the **adapter** to a
@@ -198,10 +210,14 @@ Tick a box only when it is MERGED. `⚡` marks a quick win — under about an ho
 > the multi-valued groups `R-19` wants in child tables. That is why `R-19` is a
 > separate item and not part of the parser.
 
-- [ ] **`profile_candidate`** — the adapter, plus `_candidate_from` taking its declared
-      field list as a parameter instead of always leading with `CARD_FIELDS`.
-- [ ] **A declared `PROFILE_FIELD_ORDER`**, for the reason `CARD_FIELDS` exists: a
+- [x] **`profile_candidate`** — `bilingual_profile_candidate`, plus `_candidate_from`
+      taking its declared field list as a parameter instead of always leading with
+      `CARD_FIELDS`. Verified on the committed fixtures: 21 fields, approvable, one
+      row, no `card_*` leakage, identity `881`, coordinates `24.6717 / 46.3942`.
+      Five mutations killed. **#235.**
+- [x] **A declared `PROFILE_FIELD_ORDER`**, for the reason `CARD_FIELDS` exists: a
       profile page that happens to omit a box must not produce a different schema.
+      **#235.**
 - [ ] **`R-19`: child tables for all five multi-valued groups** — «جداول أبناء للخمس
       كلّها»: Interests, Licensed Activities, Qualification Programs, Balady Services,
       contractor relations. Not JSON, not `Activity 1, 2, 3`. A measured profile carried

--- a/scrapex/pagesource.py
+++ b/scrapex/pagesource.py
@@ -123,6 +123,28 @@ class Cell:
             return "whole"
         return "-".join(f"{name}_{value}" for name, value in self.params)
 
+    def is_under(self, other: Cell) -> bool:
+        """Is this cell entirely inside `other`?
+
+        A CELL IS A SET, AND THIS IS SUBSET-HOOD EXPRESSED IN FILTERS. Adding a
+        filter can only ever narrow, so a cell carrying every one of `other`'s
+        name/value pairs selects a subset of what `other` selects — whatever the
+        extra filters are and whatever order they are written in.
+
+        WHY THE AUDIT NEEDS IT. A nested crawl asks whether `Sum N_child` equals
+        `N_parent`, and that question is only meaningful when the children really
+        are inside the parent. Children that dropped one of the parent's filters
+        would answer it over a LARGER set and could report a comfortable zero
+        deficit while covering none of the parent — a false completeness claim,
+        which is the one kind of wrong answer this module exists to prevent.
+
+        THE EMPTY CELL IS UNDER EVERY CELL'S PARENT AND UNDER NONE OF ITS
+        CHILDREN, both of which fall out of the subset rule rather than being
+        special-cased: `WHOLE` carries no pairs, so every cell is under `WHOLE`
+        and `WHOLE` is under nothing but itself.
+        """
+        return set(other.params) <= set(self.params)
+
     def __str__(self) -> str:
         return self.label
 

--- a/scrapex/partitioncrawl.py
+++ b/scrapex/partitioncrawl.py
@@ -128,6 +128,19 @@ RETRY_PAGE_CEILING = 31
 HEAVY_ATTEMPTS = 10
 
 
+class NotASubdivision(ValueError):
+    """The cells handed in are not all inside the parent they claim to subdivide.
+
+    REFUSED RATHER THAN AUDITED, for the same reason `ScopeNotPartitionable`
+    refuses rather than narrowing. The nested audit's whole claim is
+    `Sum N_child == N_parent`, and a child that dropped one of the parent's
+    filters is measured over a different, larger set. Such a run could report a
+    zero deficit while covering none of the parent — a completeness claim that is
+    false rather than merely weak, and the one failure this module is built to
+    make impossible.
+    """
+
+
 class ScopeNotPartitionable(ValueError):
     """This site is registered for a scope a listing partition cannot honour.
 
@@ -377,11 +390,18 @@ class CellOutcome:
 class PartitionOutcome:
     """What the whole partition read, and what it can and cannot claim."""
 
-    #: The unfiltered listing, sized before the first cell.
+    #: THE SCOPE THIS RUN AUDITS AGAINST, sized before the first cell. The
+    #: unfiltered listing for a top-level run; the PARENT CELL for a nested one.
+    #: Named `whole` because it is the whole of whatever is being accounted for,
+    #: and `parent` below says which — read the two together, never this alone.
     whole: CellSize
     cells: tuple[CellOutcome, ...] = ()
-    #: The unfiltered listing, sized again at the end. `None` if it was not asked.
+    #: The scope, sized again at the end. `None` if it was not asked.
     whole_at_end: CellSize | None = None
+    #: The cell being subdivided. `WHOLE` for a top-level run, and then `whole`
+    #: above is the unfiltered listing and a completeness claim is site-wide.
+    #: Anything else means every claim here is ABOUT THAT CELL ONLY.
+    parent: Cell = WHOLE
     #: Ids recorded into `dataset_sighting`, cumulatively, as the run went.
     newly_sighted: int = 0
     #: Cells whose OWN PAGINATOR could not be read, with why. They were not read at
@@ -392,15 +412,34 @@ class PartitionOutcome:
     notes: tuple[str, ...] = ()
 
     @property
+    def nested(self) -> bool:
+        """Is this a subdivision of ONE cell rather than a run over the listing?"""
+        return bool(self.parent.params)
+
+    @property
+    def scope(self) -> str:
+        """What every number here is about, in words fit for a report line."""
+        return f"cell {self.parent.label}" if self.nested else "listing"
+
+    @property
     def declared_sum(self) -> int:
         return sum(cell.size.declared for cell in self.cells)
 
     @property
     def exhaustiveness_deficit(self) -> int:
-        """`N_whole − Σ N_cell`. Above zero means rows in NO cell — the case that
+        """`N_scope − Σ N_cell`. Above zero means rows in NO cell — the case that
         makes a partition method unsound, counted rather than assumed away. On
         muqawil it was 1,437 until `region_id=0` was found to address exactly
-        them."""
+        them.
+
+        NESTED, THIS IS THE WHOLE OF REQ-21: `Σ N_child` against `N_parent`, so a
+        subdivision chosen from incomplete evidence says by HOW MUCH it is
+        incomplete instead of being trusted. Measured on the worst cell, the 48
+        city cells derived from two thirds of the contractors declared 4,665
+        against the parent's 4,697 — a deficit of 32, which is 0.68% and is
+        NAMED rather than lost. A subdivision is an optimisation; the parent
+        remains the fallback and the counting proof on it needs no child list.
+        """
         return self.whole.declared - self.declared_sum
 
     @property
@@ -431,7 +470,12 @@ class PartitionOutcome:
 
     @property
     def provably_complete(self) -> bool:
-        """Every cell proven, and no row outside every cell.
+        """Every cell proven, and no row outside every cell — WITHIN `parent`.
+
+        IT IS A CLAIM ABOUT `scope` AND NEVER MORE. True on a nested run means
+        the parent cell is fully accounted for; it says nothing whatever about
+        the rest of the listing. `__str__` spells that out, because `True` read
+        off this property alone is the one way this method could mislead.
 
         BOTH HALVES ARE REQUIRED. Fifty-six proven cells that together declare
         fewer rows than the listing prove fifty-six things and not the one that
@@ -452,7 +496,7 @@ class PartitionOutcome:
     def __str__(self) -> str:
         proven = sum(1 for cell in self.cells if cell.provably_complete)
         lines = [
-            f"listing declared {self.whole.declared:,} rows over "
+            f"{self.scope} declared {self.whole.declared:,} rows over "
             f"{self.whole.last_page} pages",
             f"partition declared {self.declared_sum:,} over {len(self.cells)} cells "
             f"— exhaustiveness deficit {self.exhaustiveness_deficit:,}",
@@ -460,22 +504,29 @@ class PartitionOutcome:
             f"cells proven complete {proven} of {len(self.cells)}",
             f"requests {self.requests:,}",
         ]
-        if self.provably_complete:
+        if self.provably_complete and self.nested:
+            lines.append(
+                f"PROVABLY COMPLETE FOR {self.scope} — AND FOR THAT CELL ONLY. It "
+                "says nothing about the rest of the listing, which still needs its "
+                "own accounting; this run subdivided one cell and proved that cell.")
+        elif self.provably_complete:
             lines.append(
                 "PROVABLY COMPLETE for the listing as published. This is a claim "
                 "about what the listing PUBLISHES and never about every "
                 "contractor the site knows.")
         else:
             lines.append(
-                "NOT proven complete. The deficit above is a floor on what is "
-                "missing, not an estimate of it.")
+                f"NOT proven complete for {self.scope}. The deficit above is a "
+                "floor on what is missing, not an estimate of it.")
         if self.arrivals > 0:
             lines.append(
-                f"and the listing GREW by {self.arrivals:,} rows while this ran, so "
+                f"and the {self.scope} GREW by {self.arrivals:,} rows while this "
+                "ran, so "
                 "the claim is 'complete as of the start, with those deferred'")
         elif self.arrivals < 0:
             lines.append(
-                f"and the listing SHRANK by {-self.arrivals:,} rows while this ran "
+                f"and the {self.scope} SHRANK by {-self.arrivals:,} rows while "
+                f"this ran "
                 f"({self.whole.declared:,} -> {self.whole_at_end.declared:,}), so a "
                 "cell ending one or two short of its declared count may have lost a "
                 "contractor rather than missed one")
@@ -700,6 +751,7 @@ def _read_cell(conn: sqlite3.Connection, partition: PartitionedListing,
 def crawl_partition(conn: sqlite3.Connection, partition: PartitionedListing,
                     base_url: str, *, fetch: Fetch, run_ref: str,
                     dataset_key: str, cells: Sequence[Cell] | None = None,
+                    parent: Cell = WHOLE,
                     max_attempts: int = 2,
                     heavy_attempts: int = HEAVY_ATTEMPTS,
                     retry_page_ceiling: int = RETRY_PAGE_CEILING,
@@ -722,6 +774,17 @@ def crawl_partition(conn: sqlite3.Connection, partition: PartitionedListing,
 
     IT REFUSES A SCOPE IT CANNOT HONOUR rather than narrowing one. See
     `ScopeNotPartitionable`.
+
+    `parent` IS THE NESTED AUDIT, AND IT IS ONE SIZING REQUEST. Every number this
+    returns is measured against `parent`: pass `WHOLE` (the default) and the
+    accounting is against the unfiltered listing exactly as before; pass a cell
+    and `Σ N_child` is compared against THAT CELL's declared count instead.
+    Without it a subdivision could only be audited against the whole listing —
+    running the 151 city cells of one region would have compared them to 17,414
+    and reported a deficit of thirteen thousand rows that were never in scope, a
+    number so wrong it would have to be ignored, which is how a check stops being
+    one. The cells must actually lie inside `parent` or this raises
+    `NotASubdivision`.
     """
     scope, _slice = read_scope(conn, partition.site_key)
     if scope is not CrawlScope.LISTING_ONLY:
@@ -732,8 +795,20 @@ def crawl_partition(conn: sqlite3.Connection, partition: PartitionedListing,
             f"for. Register it as {CrawlScope.LISTING_ONLY.value!r} for this "
             "crawl, or run the detail crawl deliberately.")
 
-    whole = size_cell(fetch, partition, base_url)
     plan = tuple(cells) if cells is not None else partition.cells()
+
+    # CHECKED BEFORE A SINGLE REQUEST IS SPENT. The alternative is discovering it
+    # after hours of fetching, and the cost of the check is a set comparison.
+    outside = [cell.label for cell in plan if not cell.is_under(parent)]
+    if outside:
+        raise NotASubdivision(
+            f"{len(outside)} of {len(plan)} cell(s) are not inside "
+            f"{parent.label!r}, so `Σ N_child == N_parent` would be measured over "
+            f"a different set than the parent: {', '.join(outside[:6])}"
+            + (f" and {len(outside) - 6} more" if len(outside) > 6 else "")
+            + ". A subdividing cell must carry every one of the parent's filters.")
+
+    whole = size_cell(fetch, partition, base_url, parent)
 
     # ONE UNSIZEABLE CELL MUST NOT END A TWO-THOUSAND-REQUEST CRAWL. `size_cell`
     # raises when a cell's page 1 does not arrive or publishes no paginator, and
@@ -803,7 +878,11 @@ def crawl_partition(conn: sqlite3.Connection, partition: PartitionedListing,
         if on_cell is not None:
             on_cell(outcome)
 
-    at_end = size_cell(fetch, partition, base_url) if resize_at_end else None
+    # THE SAME SCOPE, so `arrivals` measures the movement of what was audited. A
+    # nested run re-sizing the whole listing would report the site's churn as the
+    # parent cell's, and then a child ending one short would be excused by a
+    # departure that happened somewhere else entirely.
+    at_end = size_cell(fetch, partition, base_url, parent) if resize_at_end else None
     notes: list[str] = []
     above = [size.cell.label for size in sizes if size.last_page > retry_page_ceiling]
     if above:
@@ -818,5 +897,6 @@ def crawl_partition(conn: sqlite3.Connection, partition: PartitionedListing,
             f"{len(unsized)} cell(s) could not be sized and were NOT READ: "
             + "; ".join(f"{label} ({why})" for label, why in unsized))
     return PartitionOutcome(whole=whole, cells=tuple(outcomes),
-                            whole_at_end=at_end, newly_sighted=newly_sighted,
+                            whole_at_end=at_end, parent=parent,
+                            newly_sighted=newly_sighted,
                             unsized=tuple(unsized), notes=tuple(notes))

--- a/tests/test_a_crawl_says_what_it_saw.py
+++ b/tests/test_a_crawl_says_what_it_saw.py
@@ -21,9 +21,9 @@ import pytest
 
 from scrapex.databases import DatabaseRegistry, EngineDatabase
 from scrapex.sightings import (
-    departures,
     Coverage,
     coverage,
+    departures,
     missing_ids,
     record_sightings,
     sighting_frequencies,
@@ -412,8 +412,8 @@ def test_a_changed_row_reads_updated_and_not_confirmed():
     from scrapex.sightings import STATE_CONFIRMED, STATE_UPDATED, row_state
 
     crawl = "2026-08-21T12:00:00Z"
-    common = dict(status="active", first_seen_at="2026-01-01T00:00:00Z",
-                  last_seen_at=crawl, newest=crawl, sighted_at=crawl)
+    common = {"status": "active", "first_seen_at": "2026-01-01T00:00:00Z",
+              "last_seen_at": crawl, "newest": crawl, "sighted_at": crawl}
 
     # A revision written by THAT crawl: the row changed.
     assert row_state(**common, changed_at=crawl) == STATE_UPDATED
@@ -428,7 +428,10 @@ def test_updated_outranks_confirmed_but_not_new_or_absent():
     changed on the crawl that introduced it is `new`; one that changed and is now
     missing is `absent`. Both matter more to a reader than the change."""
     from scrapex.sightings import (
-        STATE_ABSENT, STATE_NEW, STATE_UPDATED, row_state,
+        STATE_ABSENT,
+        STATE_NEW,
+        STATE_UPDATED,
+        row_state,
     )
 
     crawl = "2026-08-21T12:00:00Z"

--- a/tests/test_a_crawl_that_can_prove_it_read_everything.py
+++ b/tests/test_a_crawl_that_can_prove_it_read_everything.py
@@ -33,6 +33,7 @@ import pytest
 from scrapex.databases import DatabaseRegistry, EngineDatabase
 from scrapex.pagesource import WHOLE, Cell
 from scrapex.partitioncrawl import (
+    NotASubdivision,
     ScopeNotPartitionable,
     crawl_partition,
     size_cell,
@@ -928,3 +929,150 @@ def test_a_listing_that_shrank_says_shrank_and_not_grew_by_minus(conn):
     report = str(outcome)
     assert "SHRANK by 3 rows" in report
     assert "grew by -" not in report, "a negative growth is a shrinkage, in words"
+
+
+# ---- REQ-21 · a subdivision is audited against its parent ---------------------
+#
+# THE FIFTH WAY IT COULD LIE, and it is the one the owner named. A heavy cell can
+# only be subdivided by a value read off evidence we already have — muqawil's
+# `city_id`, chosen from the two thirds of contractors seen so far — and the site
+# is live, so «ماذا لو تم اضافة مقاول جديد بمدينة جديدة». A new city must cost
+# EFFICIENCY AND NEVER COVERAGE, which holds only if the shortfall is measured
+# against the PARENT. Audited against the whole listing instead, 151 city cells of
+# one region would be compared to 17,414 and report a deficit of thirteen thousand
+# rows that were never in scope — a number nobody can act on, which is a check that
+# has stopped being one.
+
+PARENT = cell(region_id=1, company_size="verysmall")
+
+
+def _nested(*, child_rows: dict[int, list[str]], parent_rows: list[str],
+            listing_rows: int = 100):
+    """A listing far bigger than the parent, so auditing the wrong one shows."""
+    cells = {"whole": [str(9000 + n) for n in range(listing_rows)],
+             PARENT.label: list(parent_rows)}
+    children = []
+    for city, rows in child_rows.items():
+        child = cell(region_id=1, company_size="verysmall", city_id=city)
+        cells[child.label] = list(rows)
+        children.append(child)
+    directory = Directory(cells)
+    return directory, Partition(directory, cells=tuple(children)), tuple(children)
+
+
+def test_a_subdivision_is_audited_against_its_parent_and_not_the_listing(conn):
+    """`Σ N_child == N_parent` is the claim, and the listing is not the yardstick."""
+    register(conn)
+    rows = [str(100 + n) for n in range(8)]
+    directory, partition, children = _nested(
+        child_rows={21: rows[:4], 22: rows[4:]}, parent_rows=rows)
+
+    outcome = run(conn, partition, directory, cells=children, parent=PARENT)
+
+    # The parent declares 8 and the children declare 8 between them.
+    assert outcome.whole.declared == 8
+    assert outcome.declared_sum == 8
+    assert outcome.exhaustiveness_deficit == 0
+    # Audited against the listing this would have been 100 - 8 = 92.
+    assert outcome.nested and outcome.scope == f"cell {PARENT.label}"
+    assert outcome.provably_complete
+
+
+def test_a_subdivision_short_of_its_parent_names_the_deficit_against_the_parent(conn):
+    """The 32-of-4,697 shape: a city the evidence never showed, counted."""
+    register(conn)
+    rows = [str(100 + n) for n in range(8)]
+    directory, partition, children = _nested(
+        child_rows={21: rows[:4], 22: rows[4:6]}, parent_rows=rows)
+
+    outcome = run(conn, partition, directory, cells=children, parent=PARENT)
+
+    assert outcome.declared_sum == 6
+    assert outcome.exhaustiveness_deficit == 2      # and NOT 94
+    assert outcome.deficit == 2
+    assert not outcome.provably_complete
+    assert f"NOT proven complete for cell {PARENT.label}" in str(outcome)
+
+
+def test_a_child_that_dropped_a_parents_filter_is_refused_before_any_request(conn):
+    """Refused on a set comparison, not discovered after hours of fetching."""
+    register(conn)
+    rows = [str(100 + n) for n in range(8)]
+    directory, partition, children = _nested(
+        child_rows={21: rows[:4], 22: rows[4:]}, parent_rows=rows)
+    # Carries `city_id` but has LOST `company_size`, so it selects more than the
+    # parent — and a sum over it could clear the parent's count while covering
+    # none of it.
+    wider = cell(region_id=1, city_id=21)
+
+    with pytest.raises(NotASubdivision) as raised:
+        run(conn, partition, directory, cells=(*children, wider), parent=PARENT)
+
+    assert wider.label in str(raised.value)
+    assert directory.fetched == []
+
+
+def test_a_nested_run_never_claims_the_listing_is_complete(conn):
+    """A proof about one cell must not read as a proof about the site."""
+    register(conn)
+    rows = [str(100 + n) for n in range(8)]
+    directory, partition, children = _nested(
+        child_rows={21: rows[:4], 22: rows[4:]}, parent_rows=rows)
+
+    said = str(run(conn, partition, directory, cells=children, parent=PARENT))
+
+    assert "AND FOR THAT CELL ONLY" in said
+    assert "PROVABLY COMPLETE for the listing as published" not in said
+
+
+def test_a_nested_run_never_sizes_the_unfiltered_listing(conn):
+    """So `arrivals` is the parent's movement and not the site's churn.
+
+    A nested run that re-sized the whole listing would excuse a child ending one
+    id short by a departure that happened in another region entirely.
+    """
+    register(conn)
+    rows = [str(100 + n) for n in range(8)]
+    directory, partition, children = _nested(
+        child_rows={21: rows[:4], 22: rows[4:]}, parent_rows=rows)
+
+    outcome = run(conn, partition, directory, cells=children, parent=PARENT)
+
+    assert all("region_id=1" in url for url in directory.fetched)
+    assert outcome.arrivals == 0
+
+
+def test_the_order_of_a_parents_filters_does_not_decide_what_is_under_it(conn):
+    """The params are ordered for the URL's sake; membership is a set question."""
+    register(conn)
+    rows = [str(100 + n) for n in range(4)]
+    child = cell(region_id=1, company_size="verysmall", city_id=21)
+    directory = Directory({"whole": [str(9000 + n) for n in range(100)],
+                           PARENT.label: list(rows),
+                           child.label: list(rows)})
+    partition = Partition(directory, cells=(child,))
+    reversed_parent = cell(company_size="verysmall", region_id=1)
+    assert reversed_parent.label != PARENT.label     # the URL really does differ
+
+    directory.roll(reversed_parent.label, list(rows))
+    outcome = run(conn, partition, directory, cells=(child,),
+                  parent=reversed_parent)
+
+    assert outcome.exhaustiveness_deficit == 0
+
+
+def test_a_top_level_run_still_audits_against_the_whole_listing(conn):
+    """The default has to be exactly what it was, or #229-#234 are undone."""
+    register(conn)
+    rows = [str(100 + n) for n in range(8)]
+    left, right = cell(region_id=1), cell(region_id=2)
+    directory = Directory({"whole": list(rows),
+                           left.label: rows[:4], right.label: rows[4:]})
+    partition = Partition(directory, cells=(left, right))
+
+    outcome = run(conn, partition, directory)
+
+    assert not outcome.nested and outcome.scope == "listing"
+    assert outcome.whole.declared == 8
+    assert outcome.exhaustiveness_deficit == 0
+    assert "PROVABLY COMPLETE for the listing as published" in str(outcome)

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -101,6 +101,14 @@ CITATION = re.compile(
 # EVERY ENTRY WAS READ OUT OF THE TARGET FILE, not copied from the document.
 WINDOW = 3
 PINNED = (
+    # REQ-21's nested audit. The whole request is that `Sum N_child` is compared
+    # against the PARENT, and these are the two lines that make it so -- one that
+    # sizes the parent, one that refuses cells outside it before a request is spent.
+    ("docs/REQUESTS.md", "scrapex/partitioncrawl.py", 811,
+     "whole = size_cell(fetch, partition, base_url, parent)"),
+    ("docs/REQUESTS.md", "scrapex/partitioncrawl.py", 804, "raise NotASubdivision("),
+    ("docs/REQUESTS.md", "scrapex/pagesource.py", 146,
+     "return set(other.params) <= set(self.params)"),
     # The version-gate blocker. Track 3 of STATE.md cannot be worked without
     # these three, and two of them are the citations that drifted.
     ("docs/STATE.md", "scrapex/version.py", 477, '"latest_extension_version": VERSION'),


### PR DESCRIPTION
**Stacked on [#235](https://github.com/muhammadbayoumi/ScrapeX/pull/235)** — its commit
is included until that merges, after which this diff is one commit.

`REQ-21`, which the owner asked for by name once the weak point of subdividing a heavy
cell was put to him. A subdivision can only be keyed on a value read off evidence we
already have — muqawil's `city_id`, derived from the two thirds of contractors seen so
far — and the site is live:

> «ماذا لو تم اضافة مقاول جديد بمدينة جديدة»

## The principle is his, and it is the durable half

**A subdivision is an optimisation, never a source of truth.** Correctness comes from
the parent cell, which always remains the fallback. So:

```
Σ N_child == N_parent   the child list is complete FOR THIS RUN
short by k              k rows live in children we do not know about, NAMED as a
                        deficit and closed by the counting proof on the PARENT,
                        which needs no child list at all
```

A new city therefore costs **efficiency, never coverage**, and it self-heals between
runs because the next run re-derives the child list from updated evidence.

## What was actually missing, and it was a gap in my own plan

`crawl_partition` sized the **unfiltered listing** and audited every partition against
it. Running one region's 151 city cells would have compared them to **17,414** and
reported a deficit of thirteen thousand rows that were never in scope — a number so
wrong it would have to be ignored, **which is how a check stops being one**.

| | | |
|---|---|---|
| `crawl_partition(..., parent=Cell)` | `partitioncrawl.py:811` | sizes the parent; `WHOLE` is the default and a top-level run is unchanged in every particular |
| `Cell.is_under(other)` | `pagesource.py:146` | membership as a **set** question — the params are ordered because the URL is the resume's identity, and that ordering must not decide what is inside what |
| `NotASubdivision` | `partitioncrawl.py:804` | refuses cells outside the parent **before one request is spent** |
| `.parent` / `.scope` / `.nested` | | so the report says what it audited |

Two of those exist to stop the feature being **worse than nothing**.

**A child that dropped one of the parent's filters is measured over a larger set** — and
a sum over such children could clear the parent's declared count while covering none of
the parent. That is a completeness claim which is *false*, not merely weak, and it is
the single failure this module exists to prevent. Refused up front, on a set
comparison, rather than discovered after hours of fetching.

**And a nested proof must not claim the site.** `provably_complete` is a statement about
`parent` and nothing more, so the report now reads

```
PROVABLY COMPLETE FOR cell region_id_1-company_size_verysmall — AND FOR THAT CELL
ONLY. It says nothing about the rest of the listing…
```

The end-of-run re-size follows the same scope, which is not cosmetic: a nested run
re-sizing the whole listing would report the **site's** churn as the parent's, and a
child ending one id short would then be excused by a departure that happened in another
region entirely.

## Verification

Seven tests, **eight mutations, all killed** — the subset test reversed; membership
compared as ordered tuples instead of sets; the parent ignored at sizing time; the
re-size falling back to the listing; the refusal deleted; the nested proof claiming the
listing; the outcome forgetting which scope it audited.

Three of those tests were **failing for the wrong reason first**, and it is worth saying
why: the fake directory's ids must match `href="/../row/(\d+)/143"`, and my `r0`/`w0`
ids matched nothing — so `declared` was `0`, `Σ N_child` was `0`, the deficit was
trivially `0`, and three assertions passed on emptiness. Fixed to digits; the numbers
mean something now.

Also **guarded citations**: three new `PINNED` rows, and I mutated one to confirm the row
is actually checked rather than a silent no-op.

## What this does NOT do, stated plainly

- **A nested crawl runs today** — checked rather than assumed. `listing_url` builds
  from `cell.query` generically, so `?region_id=1&company_size=verysmall&city_id=21&page=3`
  is a URL like any other and `in_cell` yields both locales. What is missing is a
  **published** city-cell generator: `cells()` still returns only the 56, and the 151
  city cells were computed in a scratchpad. Deriving them in the source module means
  querying the warehouse for what we have seen — a design decision, not a wiring job.
- **For the cell that motivated it, the subdivision is worth 9%.** `RIYADH × verysmall`
  alone is **4,268 of that cell's 4,697 rows**, so the counting proof remains the route
  for Riyadh and Jeddah — exactly as `DEC-11` said. What this buys is that any
  subdivision, here or at the next source, can be *relied* on, because it reports by how
  much it is incomplete.

## A lesson that cost the tree

A mutation harness that trusts `finally` **will** leave a mutation behind. The tool's
timeout arrives as `SIGTERM`, Python's default disposition does not unwind the stack, so
no `finally` and no `atexit` runs. This run left

```python
outside = []      # the check whose guard was under test, deleted
```

in the working tree, with every other test still green — the worst possible artefact,
and a one-line `git diff` that reads like something you meant. The harness has a signal
handler now and runs in the background where nothing counts minutes; and after any run
that did not print its own `restored: True`, **grep for the mutations** instead of
assuming. That grep is what caught this one. Written up in `LESSONS.md` §8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
