### PR TITLE
The file that starts every crawl had no tests, and CI cannot see it

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -824,7 +824,11 @@ unavailable in the first place.
 
 ---
 
-### OP-28 · The muqawil crawl driver has 306 lines and no tests at all
+### OP-28 · The muqawil crawl driver had 452 lines and no tests at all
+**Status: ADDRESSED 2026-08-21** — 19 tests in `tests/test_the_crawl_driver_cannot_lose_a_run.py`, eleven mutations killed.
+The account below is kept because the exposure it describes is the reason the tests are shaped the way they are.
+
+> **Corrected:** first written as *"306 lines"*, which was wrong — the number was read off a line in a traceback rather than off `wc -l`. It is **452**.
 
 Found 2026-08-21 while scoping what a Windows-only failure could hide.
 `tools/crawl_muqawil_listing.py` — the driver for `--plan`, `--crawl`, `--approve`,
@@ -844,8 +848,28 @@ regression: CI is **ubuntu-only**, and `tools/` is not even in the linted path
 
 So the exposure is specific rather than theoretical: **argument handling, resume
 selection and console output in the one file whose failure mode is invisible to CI.**
-Not urgent — it is a developer tool, not shipped code — but it is the cheapest test
-debt on the board, and `say()` in particular is one parametrised test.
+
+### What the tests cover, and what they found
+
+Nineteen tests, grouped by the way hours get lost rather than by function:
+
+| | |
+|---|---|
+| a log line kills the run | a real `cp1252` stream (`TextIOWrapper`, `errors="strict"`), not a mock — `say` must not raise, the **log must keep** the character the console could not show, and a line cp1252 *can* encode must not be degraded to ASCII |
+| a crawl into a warehouse that is not there | `open_engine` exits 2 and **the file is not created** (`R-24`) |
+| a mistyped `--only` | refused, and refused **before the connection is touched** — `conn=None` is passed deliberately, so a late refusal would raise the wrong error |
+| `--approve` reading another run's evidence | `_` is a `LIKE` wildcard: unescaped, `my_run-%` also matches `myXrun-…` |
+| the two locales of one page | paired on the URL with the locale removed, never on arrival order; and the **later** read wins for a page a retry stored twice |
+| an empty departure window | says *"Crawl first"* rather than reporting every contractor as departed |
+
+**And the mutation run found two defects in itself, which is the part worth keeping.**
+Three of the first twelve mutations printed `NOT APPLIED` — their literal source
+strings had their backslashes mangled passing through a shell heredoc — and they were
+the valuable three: the `LIKE` escaping, the last-read-wins ordering, and the log
+keeping an unshowable character. A fourth applied but was a **no-op** (a trailing comma
+added to a call), "survived", and meant nothing. **A mutation that does not apply is
+not a passing guard**, and reporting it beside real results is a harness lying quietly.
+Re-authored by line number, with the anchor lines asserted before anything is written.
 
 ---
 

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -852,6 +852,45 @@ handler is the belt; the background is the braces. And after any mutation run th
 did not print its own `restored: True`, **grep the tree for the mutations** rather
 than assuming — that check is what caught this one.
 
+### And `restored: True` can be true while the file on disk has changed
+
+The harness proves it restored by comparing what it wrote back:
+
+```python
+return SRC.read_text(encoding="utf-8") == original
+```
+
+That comparison **cannot see a line-ending change**, because `read_text` opens in
+text mode and universal newlines turns `
+` into `
+` on the way in. Both sides
+are normalised, so both sides match — while `write_text` has meanwhile translated
+every `
+` back to `
+` on Windows. A run that reports `restored: True` can
+therefore leave a file whose **452 lines all changed ending**.
+
+On this repository that surfaces as the confusing pair:
+
+```
+git status  ->  M tools/crawl_muqawil_listing.py
+git diff    ->  (nothing)
+```
+
+`.gitattributes` sets `* text=auto`, so `diff` normalises the endings away and shows
+an empty change, while `status` still reports the file modified. Nothing was wrong
+with the content — measured: identical after `b"
+" -> b"
+"` on both sides — and
+`git checkout --` on the file settles it.
+
+**This is CLAUDE.md's second trap seen from the other side.** That one says never hash
+a tracked file's raw bytes, because CRLF-vs-LF makes equal files look different. This
+is the same fact making *different* files look equal: **normalise when you are asking
+"is the content the same", and compare bytes when you are asking "did I put the file
+back".** The two questions have different right answers, and one function cannot serve
+both.
+
 ---
 
 ## 9 · A measurement is only as good as the instrument

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,6 +1,6 @@
 # State — where the work stands
 
-**Last updated: 2026-08-21 (morning).** `main` is at `71d1d41` (#234).
+**Last updated: 2026-08-21 (morning).** `main` is at `9e0610a` (#236).
 
 This is the document that is **wrong the moment it is out of date**. Update it
 when a phase lands, a PR merges, or the owner rules — in the same pull request as
@@ -14,6 +14,17 @@ tracks *his requests* through Captured → Ruled → Planned → In flight → D
 
 ## Open pull requests
 
+**None.** Next up is `OP-28` on `claude/the-crawl-driver-gets-tests`: the crawl
+driver had 452 lines and no tests, 19 now, eleven mutations killed.
+
+### Merged 2026-08-21
+
+**[#236](https://github.com/muhammadbayoumi/ScrapeX/pull/236) — a subdivision is
+checked against its parent.** `REQ-21`: `crawl_partition` takes a `parent` cell and
+audits `Σ N_child` against **it**, `Cell.is_under` settles membership as a set
+question, and `NotASubdivision` refuses a child that dropped a parent filter before a
+request is spent. Eight mutations killed.
+
 **[#235](https://github.com/muhammadbayoumi/ScrapeX/pull/235) — a row says what
 state it is in.** The observation state as a column instead of something the reader
 infers from two dates: eight states, closed vocabulary, seven of them computed;
@@ -24,20 +35,16 @@ the profile-page candidate adapter; and a **~1,600×** fix to `coverage()` /
 `missing_ids()` (49.7s → 0.03s each). All five CI jobs green including
 `migration-authority`. Ten mutations killed.
 
-**Next, on `claude/muqawil-nested-audit`** — REQ-21's nested audit: `crawl_partition`
-takes a `parent` cell and audits `Σ N_child` against **it** rather than the whole
-listing. Eight mutations killed.
-
-**Merged 2026-08-21:** [#233](https://github.com/muhammadbayoumi/ScrapeX/pull/233),
-[#234](https://github.com/muhammadbayoumi/ScrapeX/pull/234) — a proof that demanded
-more than it needed, and 823 pages refused by one column.
+Also merged 2026-08-21: [#233](https://github.com/muhammadbayoumi/ScrapeX/pull/233)
+and [#234](https://github.com/muhammadbayoumi/ScrapeX/pull/234) — a proof that
+demanded more than it needed, and 823 pages refused by one column.
 
 ### The crawl that is still running
 
 The residual crawl of the nine heavy cells is **live** and resumable
 ([R-26](RULINGS.md#r-26)). As of 2026-08-21 08:06 it had stored **3,563 listing
-pages** across all 56 cells and the ledger held **15,273 distinct ids of the
-listing's 17,414 — 87.7%**. Stored *records* remain 1,172 because `OP-25`'s
+pages** across all 56 cells; by 06:13 it was **4,561**, and the ledger held
+**15,273 distinct ids of the listing's 17,414 — 87.7%**. Stored *records* remain 1,172 because `OP-25`'s
 extraction route is deferred by `R-25`; the gap between the two numbers, 14,101, is
 exactly the question the sightings ledger exists to answer.
 

--- a/tests/test_the_crawl_driver_cannot_lose_a_run.py
+++ b/tests/test_the_crawl_driver_cannot_lose_a_run.py
@@ -1,0 +1,360 @@
+"""The driver that runs the listing crawl, and the ways it could throw hours away.
+
+WHY THIS FILE EXISTS. `tools/crawl_muqawil_listing.py` is 452 lines and had **zero
+tests** -- `grep -rln crawl_muqawil_listing tests/` returned nothing -- while being
+the only way the crawl is ever started. It is also the file where this track's single
+Windows-only defect lived, and CI cannot see it: CI is ubuntu-only and `tools/` is not
+even in the linted path. Recorded as `OP-28` in `docs/BACKLOG.md`.
+
+The four ways, each of which has happened or was one keystroke away:
+
+  * A LOG LINE KILLS THE RUN. `print("... -> ...")` raises `UnicodeEncodeError` on a
+    cp1252 console. The sizing pass completed all 114 requests and then died printing
+    its own summary. On the crawl itself that is hours of fetching thrown away.
+  * A CRAWL INTO A DATABASE THAT IS NOT THERE. `open_engine` refuses rather than
+    letting `connect()` create an empty warehouse beside the real one -- the mistake
+    `R-24` exists because of.
+  * A MISTYPED `--only` CRAWLS FEWER CELLS and reports success over the ones it did.
+  * `--approve` INTERPRETING ANOTHER RUN'S EVIDENCE, because `_` is a `LIKE`
+    wildcard and every cell ref is full of them.
+
+No network anywhere here, and nothing touches the live warehouse: `LOG` is redirected
+for every test by an autouse fixture, because `say` writes into `~/.scrapex/trial/`
+and a suite that writes to a real home is a suite that cannot be trusted twice.
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+from scrapex.databases import DatabaseRegistry, EngineDatabase
+from scrapex.sites.muqawil import MuqawilPartition
+
+DRIVER = Path(__file__).resolve().parent.parent / "tools" / "crawl_muqawil_listing.py"
+#: The exact shape of the line that killed a run: U+2192 is not in cp1252.
+ARROW = "sized 56 cells → about 1,065 requests"
+
+
+@pytest.fixture(scope="module")
+def driver():
+    """The tool, imported by path -- `tools/` is deliberately not a package."""
+    spec = importlib.util.spec_from_file_location("crawl_muqawil_listing", DRIVER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(autouse=True)
+def _log_goes_nowhere_real(driver, tmp_path, monkeypatch):
+    monkeypatch.setattr(driver, "LOG", tmp_path / "trial" / "listing.log")
+
+
+@pytest.fixture()
+def conn(tmp_path):
+    registry = DatabaseRegistry(EngineDatabase(tmp_path / "scrapex-engine.db"),
+                                pointer_file=tmp_path / "databases.json")
+    registry.initialize()
+    connection = registry.engine.connect()
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def snapshot(conn, url: str, body: str, run_ref: str) -> int:
+    """One stored page, with every NOT NULL column the real write path fills.
+
+    A fixture that omits one is silently dropped by `INSERT OR IGNORE` elsewhere in
+    this repository, which cost three separate hours on this track -- see
+    `LESSONS.md`. Written out in full rather than defaulted for that reason.
+    """
+    cursor = conn.execute(
+        "INSERT INTO generic_page_snapshot "
+        "  (source_url, content_type, html_content, content_hash, captured_at, "
+        "   crawl_run_ref, html_codec) "
+        "VALUES (?, 'text/html', ?, ?, '2026-08-21T00:00:00Z', ?, 'plain')",
+        (url, body, f"hash-of-{body}", run_ref))
+    conn.commit()
+    return int(cursor.lastrowid)
+
+
+# ---- a log line may not kill a crawl ----------------------------------------
+
+def _cp1252_console(monkeypatch):
+    """A console exactly as strict as the one that killed the run."""
+    raw = io.BytesIO()
+    console = io.TextIOWrapper(raw, encoding="cp1252", errors="strict",
+                               newline="", write_through=True)
+    monkeypatch.setattr(sys, "stdout", console)
+    return raw, console
+
+
+def test_say_does_not_raise_on_a_console_that_cannot_encode_the_line(driver,
+                                                                    monkeypatch):
+    """U+2192 is not in cp1252, and `print` raises rather than dropping it."""
+    raw, console = _cp1252_console(monkeypatch)
+
+    driver.say(ARROW)     # must not raise
+
+    console.flush()
+    shown = raw.getvalue().decode("cp1252")
+    assert "sized 56 cells" in shown
+    assert "→" not in shown          # it could not be shown, and was replaced
+
+
+def test_the_log_keeps_the_character_the_console_could_not_show(driver, monkeypatch):
+    """A log that cannot represent a character must lose the CHARACTER, not the run."""
+    _cp1252_console(monkeypatch)
+
+    driver.say(ARROW)
+
+    assert driver.LOG.read_text(encoding="utf-8").strip() == ARROW
+
+
+def test_a_line_cp1252_can_encode_is_not_mangled(driver, monkeypatch):
+    """The guard must not degrade every line to ASCII. Em-dash and guillemets ARE in
+    cp1252, and no reviewer can be expected to know which mark is safe."""
+    raw, console = _cp1252_console(monkeypatch)
+
+    driver.say("cells 56 — «all of them»")
+
+    console.flush()
+    assert raw.getvalue().decode("cp1252") == "cells 56 — «all of them»\n"
+
+
+# ---- a crawl into a warehouse that is not there ------------------------------
+
+def test_open_engine_refuses_a_database_that_does_not_exist(driver, tmp_path,
+                                                            monkeypatch):
+    """`R-24`: an absent file must not become an empty warehouse beside the real one.
+
+    `connect()` would CREATE it, the crawl would run for hours, and the rows would
+    land somewhere the panel never reads.
+    """
+    missing = tmp_path / "not-here" / "scrapex-engine.db"
+
+    class _Registry:
+        engine = type("_Engine", (), {"path": missing})()
+
+    monkeypatch.setattr(driver.DatabaseRegistry, "defaults",
+                        classmethod(lambda cls: _Registry()))
+
+    with pytest.raises(SystemExit) as raised:
+        driver.open_engine()
+
+    assert raised.value.code == 2
+    assert not missing.exists()
+    assert "does not exist" in driver.LOG.read_text(encoding="utf-8")
+
+
+# ---- a mistyped --only must not quietly crawl less ---------------------------
+
+class _Spy:
+    """Stands in for `crawl_partition`, recording what it was asked to crawl."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append(kwargs)
+        return "an outcome"
+
+
+def test_only_refuses_an_unknown_label_before_touching_the_database(driver,
+                                                                   monkeypatch):
+    """`conn` is None here on purpose: the refusal has to come first."""
+    spy = _Spy()
+    monkeypatch.setattr(driver, "crawl_partition", spy)
+
+    with pytest.raises(SystemExit) as raised:
+        driver.crawl(None, MuqawilPartition(), None, None, "run-1", 2,
+                     only="region_id_1-company_size_enormous")
+
+    assert "region_id_1-company_size_enormous" in str(raised.value)
+    assert spy.calls == []
+
+
+def test_only_passes_exactly_the_named_cells_and_no_others(driver, monkeypatch):
+    """47 of 56 cells were already proven; re-reading them is the cost this avoids.
+    Whitespace around a label is tolerated because these are pasted out of a log."""
+    spy = _Spy()
+    monkeypatch.setattr(driver, "crawl_partition", spy)
+    monkeypatch.setattr(driver, "coverage", lambda *a, **k: "coverage")
+
+    driver.crawl(None, MuqawilPartition(), None, None, "run-1", 2,
+                 only=" region_id_2-company_size_big ,region_id_5-company_size_small")
+
+    assert [one.label for one in spy.calls[0]["cells"]] == [
+        "region_id_2-company_size_big", "region_id_5-company_size_small"]
+
+
+def test_without_only_the_partition_decides_which_cells_to_crawl(driver, monkeypatch):
+    """`cells=None` is how `crawl_partition` is told to use the whole partition."""
+    spy = _Spy()
+    monkeypatch.setattr(driver, "crawl_partition", spy)
+    monkeypatch.setattr(driver, "coverage", lambda *a, **k: "coverage")
+
+    driver.crawl(None, MuqawilPartition(), None, None, "run-1", 2)
+
+    assert spy.calls[0]["cells"] is None
+
+
+# ---- --approve must read THIS run's evidence and no other run's --------------
+
+def test_pairs_does_not_gather_another_run_because_underscore_is_a_wildcard(driver,
+                                                                           conn):
+    """`LIKE 'my_run-%'` unescaped also matches `myXrun-...`, and the approval would
+    then write another run's pages under this run's name."""
+    snapshot(conn, "https://muqawil.org/en/contractors?page=1", "<html>mine</html>",
+             "my_run-region_id_1-a1")
+    snapshot(conn, "https://muqawil.org/en/contractors?page=2", "<html>theirs</html>",
+             "myXrun-region_id_1-a1")
+
+    found = driver._pairs(conn, "my_run")
+
+    assert list(found) == ["https://muqawil.org/contractors?page=1"]
+
+
+def test_pairs_puts_the_two_locales_of_the_same_page_together(driver, conn):
+    """Not by arrival order: the two locales are two requests against a listing that
+    reorders, so pairing by snapshot id marries page 7's English to whatever Arabic
+    page happened to be stored next."""
+    snapshot(conn, "https://muqawil.org/en/contractors?page=7", "<html>en7</html>",
+             "r-a1")
+    snapshot(conn, "https://muqawil.org/ar/contractors?page=3", "<html>ar3</html>",
+             "r-a1")
+    snapshot(conn, "https://muqawil.org/ar/contractors?page=7", "<html>ar7</html>",
+             "r-a1")
+
+    found = driver._pairs(conn, "r")
+
+    seven = found["https://muqawil.org/contractors?page=7"]
+    assert seven["en"][1] == "<html>en7</html>"
+    assert seven["ar"][1] == "<html>ar7</html>"
+    assert "en" not in found["https://muqawil.org/contractors?page=3"]
+
+
+def test_pairs_keeps_the_later_read_of_a_page_a_retry_stored_twice(driver, conn):
+    """A retried cell stored the same page in two generations, and the later read is
+    the one the crawl's own witness was computed against."""
+    url = "https://muqawil.org/en/contractors?page=4"
+    snapshot(conn, url, "<html>first generation</html>", "r-a1")
+    newer = snapshot(conn, url, "<html>second generation</html>", "r-a2")
+
+    found = driver._pairs(conn, "r")
+
+    assert found["https://muqawil.org/contractors?page=4"]["en"] == (
+        newer, "<html>second generation</html>")
+
+
+# ---- the approval the owner's answer stands for ------------------------------
+
+def _field(key: str, name: str):
+    return type("_Field", (), {"field_key": key, "source_name": name})()
+
+
+def test_every_field_is_text_and_only_contractor_id_is_the_identity(driver):
+    """Inference would guess `integer` for a rating reading `4.5` on the next page,
+    the schema hash would then differ per page, and every approval after the first is
+    refused. That is #234's 823 refusals in a different disguise."""
+    candidate = type("_Candidate", (), {
+        "fields": [_field("contractor_id", "ID"), _field("rating", "Rating")]})()
+
+    approval = driver._approval(candidate)
+
+    assert {one.field_key: one.data_type for one in approval.fields} == {
+        "contractor_id": "text", "rating": "text"}
+    assert [one.field_key for one in approval.fields if one.identity] == [
+        "contractor_id"]
+
+
+# ---- the command line itself -------------------------------------------------
+
+def test_choosing_no_mode_is_refused(driver, monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["crawl_muqawil_listing.py"])
+    with pytest.raises(SystemExit) as raised:
+        driver.main()
+    assert raised.value.code == 2
+
+
+@pytest.mark.parametrize("mode", ["--crawl", "--approve"])
+def test_a_crawl_or_an_approve_without_a_run_ref_is_refused(driver, monkeypatch, mode):
+    """The ref is what makes an interruption resumable and what `--approve` reads.
+    Without it a re-run re-fetches everything already on disk."""
+    monkeypatch.setattr(sys, "argv", ["crawl_muqawil_listing.py", mode])
+    with pytest.raises(SystemExit) as raised:
+        driver.main()
+    assert raised.value.code == 2
+
+
+def test_coverage_on_an_empty_ledger_says_to_crawl_rather_than_reporting_departures(
+        driver, conn, monkeypatch):
+    """The window defaults to the ledger's newest sighting. With no sightings that
+    default is empty, and an empty window would read as "every contractor departed"."""
+    called = []
+    monkeypatch.setattr(sys, "argv", ["crawl_muqawil_listing.py", "--coverage"])
+    monkeypatch.setattr(driver, "open_engine", lambda: conn)
+    monkeypatch.setattr(driver, "report_coverage", lambda *a, **k: called.append(a))
+
+    driver.main()
+
+    assert called == []
+    assert "Crawl first." in driver.LOG.read_text(encoding="utf-8")
+
+
+def _sight(conn, last_seen: str) -> None:
+    conn.execute(
+        "INSERT INTO dataset_sighting (dataset_key, external_id, first_seen_at, "
+        "  last_seen_at, seen_count) VALUES ('contractors','881',"
+        "  '2026-08-01T00:00:00Z',?,3)", (last_seen,))
+    conn.commit()
+
+
+def test_coverage_measures_against_the_newest_sighting_without_being_told(
+        driver, conn, monkeypatch):
+    """So running it straight after a crawl asks "who did THAT crawl not show us"
+    with nobody typing a timestamp -- a mistyped one reports everyone as departed."""
+    _sight(conn, "2026-08-20T09:00:00Z")
+    windows = []
+    monkeypatch.setattr(sys, "argv", ["crawl_muqawil_listing.py", "--coverage"])
+    monkeypatch.setattr(driver, "open_engine", lambda: conn)
+    monkeypatch.setattr(driver, "report_coverage",
+                        lambda _conn, since: windows.append(since))
+
+    driver.main()
+
+    assert windows == ["2026-08-20T09:00:00Z"]
+
+
+def test_an_explicit_window_overrides_the_ledgers_newest(driver, conn, monkeypatch):
+    _sight(conn, "2026-08-20T09:00:00Z")
+    windows = []
+    monkeypatch.setattr(sys, "argv", ["crawl_muqawil_listing.py", "--coverage",
+                                      "--not-seen-since", "2026-07-01T00:00:00Z"])
+    monkeypatch.setattr(driver, "open_engine", lambda: conn)
+    monkeypatch.setattr(driver, "report_coverage",
+                        lambda _conn, since: windows.append(since))
+
+    driver.main()
+
+    assert windows == ["2026-07-01T00:00:00Z"]
+
+
+# ---- the trap CLAUDE.md opens with -------------------------------------------
+
+def test_the_driver_puts_its_own_worktree_on_the_path(driver):
+    """`CLAUDE.md`'s first trap: `pip install -e` points at the MAIN checkout, so a
+    tool run from a worktree would import main's code and prove nothing about its own.
+    """
+    assert sys.path[0] == str(DRIVER.parent.parent)
+
+
+def test_pairs_can_read_a_row_by_column_name(conn):
+    """`_pairs` reads `row["source_url"]`. A tuple row factory would raise TypeError
+    on the first page, and only ever under `--approve`."""
+    assert conn.row_factory is sqlite3.Row


### PR DESCRIPTION
`OP-28`. `tools/crawl_muqawil_listing.py` is **452 lines** and
`grep -rln crawl_muqawil_listing tests/` returned **nothing**. It is the only way the
crawl is ever started, and two facts make that blind spot specific rather than
theoretical: **CI is ubuntu-only**, and `tools/` is **not in the linted path**
(`ruff check scrapex/`). It is also the file where this track's single Windows-only
defect lived.

**19 tests, grouped by the way hours get lost** rather than by function.

## A log line kills the run

`print` raises `UnicodeEncodeError` on U+2192 against a cp1252 console. The sizing
pass completed all **114 requests** and then died printing its own summary. On the
crawl itself that is hours of fetching thrown away by a log line.

Tested against a **real** `TextIOWrapper(encoding="cp1252", errors="strict")`, not a
mock — the failure belongs to the encoder, and a mock would only assert my model of
it. Three tests, because the guard has three ways to be wrong:

| | |
|---|---|
| `say` must not raise | the original defect |
| the **log** must keep the character the console could not show | a log that cannot represent a character must lose the character, never the run |
| a line cp1252 **can** encode must not be degraded to ASCII | em-dash and «guillemets» *are* in cp1252, and no reviewer can be expected to know which mark is safe |

## A crawl into a warehouse that is not there

`open_engine` exits 2 — and the test asserts **the file was not created**. `connect()`
would have made one, the crawl would have run for hours, and the rows would have
landed where the panel never reads. That is the mistake `R-24` exists because of.

## A mistyped `--only`

Refused, and refused **before the connection is touched** — pinned by passing
`conn=None` deliberately, so a late refusal raises the wrong error from the wrong
place. Without it a typo crawls fewer cells and reports success over the ones it did.

## `--approve` reading another run's evidence

`_` is a `LIKE` wildcard and every cell ref is full of them, so unescaped
`my_run-%` also gathers `myXrun`'s pages and approves them under this run's name.

## Three details only reading the code reveals

- the two locales are paired on the **URL with the locale removed**, never on arrival
  order — they are two requests against a listing that reorders, so pairing by
  snapshot id marries page 7's English to whatever Arabic page was stored next;
- the **later** read wins for a page a retry stored twice, because that is the read
  the witness was computed against;
- an empty `--coverage` window says *"Crawl first"* instead of reporting every
  contractor as departed.

## Eleven mutations killed — and the harness had two defects of its own

Three of the first twelve mutations printed `NOT APPLIED`: their literal source
strings had backslashes mangled passing through a shell heredoc, and they were **the
valuable three** — the `LIKE` escaping, the last-read-wins ordering, and the log
keeping an unshowable character. A fourth applied but was a **no-op** (a trailing
comma added to a call); it "survived" and meant nothing.

**A mutation that does not apply is not a passing guard**, and reporting it beside
real results is a harness lying quietly. Re-authored by line number, asserting every
anchor line before writing anything.

## And a second commit: `restored: True` can be true while the file changed

The harness proves it put the file back with `SRC.read_text() == original`. That
comparison **cannot see a line-ending change** — `read_text` normalises `\r\n` to
`\n` on the way in, so both sides match while `write_text` has translated every `\n`
back on Windows. It reported success having rewritten all **452 line endings**, which
surfaced as the confusing pair `git status` says modified / `git diff` shows nothing.

This is **CLAUDE.md's second trap from the other side**: that one says never hash a
tracked file's raw bytes because CRLF-vs-LF makes equal files look different; this is
the same fact making different files look *equal*. Normalise when asking "is the
content the same"; compare bytes when asking "did I put the file back". Written up in
`LESSONS.md`.

## Verification

- Full suite with `SCRAPEX_FULL_MIGRATIONS=1`: **one failure, `OP-19`**, the known
  load-dependent race.
- Eleven mutations killed; the driver verified untouched afterwards by `git diff`,
  not by trusting the harness's own message.
- `OP-28` corrected: it first said **306 lines**, a number read off a traceback
  rather than off `wc -l`. It is **452**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
