### PR TITLE
His ruling tested before it was built, and it survives the test

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1592,6 +1592,46 @@ with HTTP 429.
 
 Each is phrased as a question with its options. Nothing below can be answered by code.
 
+**Q-13 · R-19: child tables — as five bespoke tables, or as five child DATASETS
+referencing a taxonomy?**
+He asked for his own ruling to be tested before it was built — *«ادرس حكمى اولا هل هو
+صحيح ام هناك الافضل»*, captured as
+[REQ-23](REQUESTS.md#req-23--test-my-own-ruling-before-building-it-with-strict-review-criteria)
+— against strict criteria. Measured in
+[R19-CHILD-TABLES-MEASURED.md](R19-CHILD-TABLES-MEASURED.md): 11 criteria, 5 shapes,
+518,490 rows.
+
+**The ruling's substance is upheld.** JSON costs **1,168 ms** on the query R-19 names
+against **0.6 ms** for the best shape — 47x worse than even a bespoke table, and
+nothing in the measurements favours it.
+
+**What the ruling did not decide** is how the value itself is stored, and one
+criterion nobody had raised turns out to be the biggest gap in the table: when the
+site **relabels a category**, a shape holding the string per row rewrites **103,698
+rows in 5.9 s**; a shape holding it once rewrites **1 row in 0.1 ms** — about
+59,000x. A live directory relabels things.
+
+Options:
+**(a)** R-19 read literally — five bespoke SQL tables. Five migrations, five read
+paths, and bespoke work in the export, the API, the panel and the CLI, because none
+of them speak "bespoke table".
+**(b)** Five child **datasets** in `generic_record`, value as a `classification_node`
+reference. **Zero migrations**; `dataset_relationship` and `classification_node`
+already exist and hold **0 rows each**; provenance is *enforced* by
+`source_snapshot_id NOT NULL`; one export tab per dataset from machinery already
+built. Costs ~235 MB and ~28 s per full re-extraction.
+**(c)** `classification_node` + one bespoke link table — **4.7x less storage** and
+**7x faster to write** than (b), at the price of (a)'s bespoke work everywhere.
+*Recommended: (b). It wins or ties every operational criterion; (c) is the fallback if
+the storage figure is judged too high.*
+
+**Two things found on the way that need his eye regardless of the option chosen:**
+R-19's own sample reported the licensed-activities table as *"one row — the header
+only"*, and the committed fixture for a different contractor has **six** — so "empty"
+was never general. And `dataset_workbook_tables` returns exactly one tab, justified in
+its docstring by *"a contractor directory has one flat table"*, **which any of these
+options makes false**; no test anywhere references that function.
+
 **Q-6 · Topology: is the TypeScript engine still the plan?**
 You chose Topology A on 2026-07-18 and nothing has been built toward it since; the Python
 product has instead become the whole thing. Options:

--- a/docs/R19-CHILD-TABLES-MEASURED.md
+++ b/docs/R19-CHILD-TABLES-MEASURED.md
@@ -1,0 +1,209 @@
+# R-19 measured — five shapes for the multi-valued contractor groups
+
+**Written 2026-08-21, at the owner's instruction to test his own ruling before
+building it:** *«ادرس حكمى اولا هل هو صحيح ام هناك الافضل ضع معايير صارمة للمراجعة
+مثل الاداء والسرعة والاحترافية»* — study my ruling first, is it right or is there
+something better; set strict review criteria.
+
+**The verdict in one line: his ruling is right about the thing it decided, and it
+decided only half the question.**
+
+[R-19](RULINGS.md#r-19--the-five-multi-valued-contractor-groups-go-in-child-tables-not-json)
+chose child tables over JSON. Measured, JSON loses by 47× on the query he named. But
+"child tables" read literally means five bespoke SQL tables, and the measurements say
+the same intent is better served by machinery this warehouse **already contains and
+has never used**.
+
+R-19 also states its own evidence limit — *"The limit of this evidence, stated
+plainly: one contractor"* — which is why this document exists.
+
+---
+
+## 1 · What the data actually is
+
+Measured from the committed fixture `tests/fixtures/muqawil/profile-en.html`, not
+from memory. The licensed-activities table holds six data rows, and each value is
+**a two-level path, bilingual, in one cell**:
+
+```
+التشغيل والصيانة - مكافحة الآفات والتطهير البيئي
+        Operations and Maintenance Activities - Pest Control & Environmental Disinfection
+```
+
+Three properties drive every result below, and all three are visible in one profile:
+
+| property | consequence |
+|---|---|
+| **the parent repeats** — `التشغيل والصيانة` appears **3 times in one contractor's six activities** | a value repeating inside one row's data repeats across 17,283 of them |
+| **the value is long** — ~120 characters, carrying both levels and both locales | storing it per row, per contractor, is the dominant cost |
+| **the leaf name is not unique** — `الصرف الصحي` sits under more than one parent | an identity built from the leaf name **merges two different activities** |
+
+**And R-19's own sample disagrees with this one.** R-19 measured membership 10001274
+and reported the licensed-activities table as *"one row — the header only. Empty for
+this contractor."* The committed fixture is a different contractor with **six**. So
+"empty" was never general — exactly the limit R-19 flagged.
+
+---
+
+## 2 · The strict criteria
+
+Set before the measurements, so a shape cannot be judged on whichever number
+flattered it:
+
+| # | criterion | why it is on the list |
+|---|---|---|
+| C1 | **the named query** — "which contractors operate sewage networks" | R-19 names it as the thing JSON cannot do |
+| C2 | **the sheet row** — every value for one contractor | this is what the export and the profile screen need on every render |
+| C3 | **the analytic** — how many contractors per value | the question that turns a directory into a market view |
+| C4 | **the hierarchy roll-up** — everyone under a parent category, children included | the data is a tree; a shape that cannot walk it has lost information |
+| C5 | **storage** | the warehouse is already the subject of `DEC-9` |
+| C6 | **write cost** for one full load | re-extraction is from disk and will be re-run often |
+| C7 | **a value gets relabelled** by the site | a directory's taxonomy is not frozen, and this is where duplication is paid for |
+| C8 | **new tables and migrations** | every one is a permanent maintenance surface |
+| C9 | **provenance** — can a row say which snapshot it came from | the repository's founding rule, `GENERIC-FETCH-SEAM.md` |
+| C10 | **publishing** — how it reaches the Google Sheet | R-19 calls this *"the real work and it is not yet designed"* |
+| C11 | **identity correctness** — can two different values collide | measured: they can, see §1 |
+
+---
+
+## 3 · The five shapes
+
+| | where the rows live | how the value is stored |
+|---|---|---|
+| **A** | five bespoke SQL tables (R-19 read literally) | the published string, per row |
+| **C** | a JSON array inside the parent's `data_json` (the overruled design) | the published string, per element |
+| **D** | `classification_node` + a bespoke link table | a reference to a taxonomy node |
+| **E** | a child **dataset** in `generic_record` | the published string, per row |
+| **F** | a child **dataset** in `generic_record` | a reference to a taxonomy node |
+
+**R-19 framed the choice as A-versus-C.** But "where the rows live" and "how the
+value is stored" are independent axes, and the ruling only settled the first.
+
+### The machinery that already exists, and holds zero rows
+
+Measured against the live warehouse on 2026-08-21:
+
+| table | what it is | rows |
+|---|---|---|
+| `classification_node` | a **generic self-referencing taxonomy** — `parent_node_id`, `external_id`, `node_name`, `node_name_ar`, `level` | **0** |
+| `classification_scheme` | its owner, with `scheme_type = 'source'` for a site's own taxonomy | **0** |
+| `dataset_relationship` | **dataset-to-dataset** parent/child, with cardinality and a review status | **0** |
+| `relationship_field_pair` | field-to-field, ordered | **0** |
+| `generic_record` | any dataset, `data_json`, its own schema version, and **`source_snapshot_id NOT NULL`** | 1,172 (one dataset) |
+
+`classification_node` is the exact shape the hierarchical groups need, and nothing
+has ever used it. That is the finding that produced shapes D and F.
+
+---
+
+## 4 · The measurements
+
+518,490 value rows — 17,283 contractors × 30, which is R-19's own arithmetic. A
+240-leaf taxonomy, each contractor holding 30 of them, so the target value is held by
+**2,161 of 17,283 (12.5%)**: selective enough for an index to matter.
+
+| | A flat table | C JSON in parent | D taxonomy + link | E child dataset | **F child dataset + taxonomy** |
+|---|---|---|---|---|---|
+| **C1** the named query | 25.0 ms | **1,168.3 ms** | 20.2 ms | 1.0 ms | **0.6 ms** |
+| **C2** the sheet row | 0.2 ms | 0.2 ms | 0.3 ms | 0.3 ms | 0.4 ms |
+| **C3** the analytic | 8,990 ms | 9,490 ms | 5,679 ms | 4,946 ms | **2,373 ms** |
+| **C4** hierarchy roll-up | 612 ms, by `LIKE` | **impossible** | **543 ms, real tree** | needs `LIKE` | 1,320 ms, real tree |
+| **C5** storage | 269.9 MB | 203.5 MB | **43.3 MB** | 765.4 MB | 205.7 MB |
+| **C6** write, full load | 6.9 s | 4.9 s | **3.9 s** | 47.0 s | 27.5 s |
+| **C7** relabel a value | 5,906 ms, **103,698 rows** | — | **0.1 ms, 1 row** | 401 ms, 2,161 rows | **0.1 ms, 1 row** |
+| **C8** new tables | **5 + migrations** | 0 | 1 | **0** | **0** |
+| **C9** provenance | to be built | inherited | to be built | **enforced** | **enforced** |
+| **C10** publishing | new payload work | new payload work | new payload work | **one tab, exists** | **one tab, exists** |
+| **C11** identity | manual | n/a | node id | **collided in test** | **node id, cannot collide** |
+
+Three results are worth reading twice.
+
+**C1 vindicates the ruling and then overtakes it.** JSON costs 1,168 ms against
+25 ms — R-19 was right, and by a wider margin than it claimed. But the fastest shape
+is not a bespoke table: it is a **partial expression index** on a child dataset,
+`CREATE INDEX … ON generic_record(json_extract(data_json,'$.node_id')) WHERE
+dataset_definition_id = 2`, which SQLite plans as
+`SEARCH … USING INDEX ix_gr_child_node (<expr>=?)` — 0.6 ms. That is the same
+mechanism whose absence made `OP-27` cost 49.7 s, applied deliberately this time.
+
+**C7 is the criterion nobody had asked about, and it is the largest gap in the
+table.** When the site relabels a category, a shape that stores the string per row
+rewrites **103,698 rows in 5.9 seconds**; a shape that stores it once rewrites **one
+row in 0.1 ms**. That is ~59,000×, and a live directory relabels things.
+
+**C5 is where F pays.** 205.7 MB against the pure taxonomy's 43.3 MB, because
+`generic_record` requires `record_key`, `content_hash`, `source_locator`, two
+timestamps and a status on every row. **Stated honestly: production would be higher
+still** — `record_key` is a SHA-256 in production and a short key in this fixture, so
+add roughly 30 MB, call it ~235 MB.
+
+### Two defects in the measurement itself, recorded because they were mine
+
+**The first fixture had no selectivity.** It built a 30-leaf taxonomy and gave every
+contractor 30 values, so every contractor held every leaf and C1 answered "all
+17,283". What looked like a comparison of three queries was three ways of scanning a
+whole table — and a selective lookup is the entire reason an index exists. The
+storage and relabel figures survived it (they depend on row count and string length);
+the query figures did not, and were re-measured.
+
+**The identity collision was found by a crash.** Keying a child row on
+`contractor:leaf_name` was refused by `UNIQUE (dataset_definition_id, record_key)`,
+because leaf names repeat across branches. It failed loudly only because that
+`INSERT` is not `OR IGNORE`. Behind an `INSERT OR IGNORE` the same mistake **drops
+the row and reports success** — the trap `LESSONS.md` records three times over. This
+is `C11`, and it is why a node id beats a string as an identity.
+
+---
+
+## 5 · Publishing, which R-19 correctly called undesigned
+
+`scrapex/publish.py`'s `dataset_workbook_tables` returns **exactly one tab**, and its
+docstring justifies that in so many words: *"a contractor directory has one flat
+table and inventing three empty tabs beside it would be the empty tables written as
+a header nobody can use"*.
+
+**R-19 makes that sentence false.** Under any of A, D, E or F the contractor dataset
+is not one flat table, and the export has to grow tabs.
+
+Under **E or F this is nearly free**: `workbook_tables` already returns a list of
+tabs for the price path, and a child dataset is a dataset — one tab each, driven by
+the confirmed rows of `dataset_relationship`. Under **A or D** the export, the API,
+the panel and the CLI each need bespoke work, because none of them speak "bespoke
+table".
+
+And the blast radius is small: **no test anywhere references
+`dataset_workbook_tables`** (measured — `grep -rc` over `tests/` returns nothing).
+That is itself worth noting as test debt, not as convenience.
+
+---
+
+## 6 · Recommendation
+
+**Adopt F: a child dataset per group, whose value is a reference into
+`classification_node`.**
+
+This is a refinement of R-19, **not a reversal**. The ruling's substance — child
+tables, not JSON — is upheld by every measurement. What changes is the
+implementation:
+
+| R-19 as written | recommended |
+|---|---|
+| five bespoke SQL tables | five child **datasets** in `generic_record` — zero migrations |
+| the value is the published string | the value is a `classification_node` reference; the string is stored once |
+| the payload work is undesigned | one tab per dataset, from machinery already built |
+| — | `dataset_relationship` gets its first tenant after holding 0 rows |
+| — | provenance is **enforced** by `source_snapshot_id NOT NULL`, not remembered |
+
+**What it costs, stated plainly:** ~235 MB for the interests group at full scale, and
+~28 s for a full re-extraction. The pure taxonomy (D) is 4.7× smaller and 7× faster
+to write, and if either number is judged too high, D is the fallback — at the price
+of bespoke work in the export, the API, the panel and the CLI.
+
+**What is still unmeasured, and it is the same limit R-19 named:** one profile. The
+taxonomy's real size, and how many values a typical contractor holds, come from the
+profile crawl. **The recommendation does not depend on those numbers** — it depends
+on the parent repeating, which one profile already proves three times over — but the
+storage figures will move when they arrive.
+
+**Not built. Awaiting his ruling**, recorded as a question in
+[BACKLOG.md](BACKLOG.md).

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -78,6 +78,7 @@ IDs are stable and never reused, matching the convention BACKLOG.md already uses
 | [REQ-20](#req-20--the-database-rename-must-reach-every-user-not-just-this-machine) | The database rename must reach every user | **Captured** — measured; a release blocker under [R-24](RULINGS.md#r-24--a-database-is-upgraded-never-replaced--the-users-data-survives-the-schema) | 2026-08-20 |
 | [REQ-21](#req-21--the-nested-audit--a-subdivision-must-be-checked-against-its-parent) | The nested audit — a subdivision checked against its parent | **In flight** — the audit is built and guarded; no subdivision is wired to a site yet | 2026-08-21 |
 | [REQ-22](#req-22--what-happens-on-a-new-contractor-a-vanished-one-a-changed-one-and-on-update) | What happens on a new / vanished / changed contractor, and on "update" | **Captured** — answered by measurement; 3 of 4 are gaps ([OP-26](BACKLOG.md)) | 2026-08-21 |
+| [REQ-23](#req-23--test-my-own-ruling-before-building-it-with-strict-review-criteria) | Test my own ruling before building it, with strict review criteria | **Done** — [R19-CHILD-TABLES-MEASURED.md](R19-CHILD-TABLES-MEASURED.md); ruling upheld, a refinement proposed as `Q-13` | 2026-08-21 |
 
 ---
 
@@ -995,6 +996,38 @@ its evidence, resumes, and records every id seen. What is missing is everything 
 happens *after* the first crawl: disappearance is invisible, an unchanged row still
 writes history, there is no path from the product's own interface, and the schema
 question is open. Filed as [OP-26](BACKLOG.md).
+
+---
+
+## REQ-23 · Test my own ruling before building it, with strict review criteria
+**Captured 2026-08-21 · Done — measured; the ruling is upheld and a refinement is
+proposed for him to rule on**
+
+> «ادمج لما يخضر وابدأ R-19 (ادرس حكمى اولا هل هو صحيح ام هناك الافضل ضع معايير
+> صارمة للمراجعة مثل الاداء والسرعة والاحترافية الخ)»
+
+Said when `R-19` came up for building. It is the second time he has asked for a
+ruling of his own to be challenged rather than obeyed — `R-19` itself records
+«ربما يكون قرار خاطى» — and it is now clearly a standing preference rather than a
+one-off: **a ruling is a decision, not an instruction to stop measuring.**
+
+### What he asked for, and what it produced
+
+"Strict criteria" was taken literally: eleven of them, **set before any shape was
+measured** so that no shape could be judged on whichever number happened to flatter
+it. Five shapes, 518,490 rows.
+[R19-CHILD-TABLES-MEASURED.md](R19-CHILD-TABLES-MEASURED.md) is the study.
+
+| | |
+|---|---|
+| **his ruling is upheld** | JSON costs **1,168 ms** on the query `R-19` names, against **0.6 ms** for the best shape — 47x worse than even a bespoke table |
+| **and it decided only half the question** | *where* the child rows live was ruled; *how the value is stored* was never put to him |
+| **the criterion nobody had raised** | the site **relabels a category**: 103,698 rows rewritten in 5.9 s, against 1 row in 0.1 ms — about 59,000x |
+| **two errors in the ruling's own evidence** | the licensed-activities table is not generally empty (a different contractor has six rows), and the value is a two-level bilingual path, not a flat string |
+
+Recorded as **`Q-13`** in [BACKLOG.md](BACKLOG.md) with three options and a
+recommendation. **Nothing was built** — the choice is his, which is the whole point
+of the request.
 
 ---
 

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -492,6 +492,22 @@ values.
 handful more profiles, which the crawl study will produce. But the direction is
 unambiguous and nothing in it favours JSON.
 
+> **MEASURED 2026-08-21, at his instruction to test this ruling before building it.**
+> [R19-CHILD-TABLES-MEASURED.md](R19-CHILD-TABLES-MEASURED.md) puts 5 shapes against
+> 11 criteria at 518,490 rows. **This ruling is upheld and by a wider margin than it
+> claimed** — JSON costs 1,168 ms on the query named above against 0.6 ms for the
+> best shape.
+>
+> Two corrections to the evidence above, kept visible per **C4**: the
+> licensed-activities table is **not** generally empty — the committed fixture for a
+> different contractor has **six rows**, so "empty for this contractor" was exactly
+> that. And the value is not a flat string but a **two-level bilingual path** whose
+> parent repeats three times inside one contractor's six activities.
+>
+> The study proposes a refinement of *how* — child **datasets** referencing
+> `classification_node` rather than five bespoke tables — which is **his to rule on**,
+> recorded as `Q-13`. Nothing has been built.
+
 **What it costs.** Five tables and their migration; a read path per table; and the
 dataset payload has to carry them, which today it cannot. That last part is the real
 work and it is not yet designed — and it would have been needed for JSON too.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -146,6 +146,12 @@ broken under load (**T2**).
 
 ## Track 2 · The muqawil.org contractor directory
 
+> **The R-19 data-model study is [R19-CHILD-TABLES-MEASURED.md](R19-CHILD-TABLES-MEASURED.md)**
+> — 11 criteria against 5 shapes at 518,490 rows, written because the owner asked for
+> his own ruling to be tested before it was built. It upholds the ruling against JSON
+> (47x) and recommends a refinement of how it is implemented. **Not built — his call,
+> recorded as `Q-13` in [BACKLOG.md](BACKLOG.md).**
+
 **Design:** [CONTRACTOR-SOURCE.md](CONTRACTOR-SOURCE.md) · **Storage:**
 [STORAGE.md](STORAGE.md) — **the mechanism is built** (`scrapex/snapshotbody.py`,
 engine migration 0005), so nothing gates the crawl any more · **Seam:**


### PR DESCRIPTION
**Documentation only. Nothing is built, and that is deliberate** — the decision is his.

`REQ-23`. He asked for `R-19` to be studied rather than obeyed:

> «ادرس حكمى اولا هل هو صحيح ام هناك الافضل ضع معايير صارمة للمراجعة مثل الاداء
> والسرعة والاحترافية»

This is the **second** time he has asked for a ruling of his own to be challenged —
`R-19` itself carries «ربما يكون قرار خاطى» — which makes it a standing preference
rather than a one-off: **a ruling is a decision, not an instruction to stop
measuring.**

Eleven criteria, **fixed before any shape was measured** so that no shape could be
judged on whichever number happened to flatter it. Five shapes. 518,490 rows.
[docs/R19-CHILD-TABLES-MEASURED.md](docs/R19-CHILD-TABLES-MEASURED.md).

## His ruling is upheld, by a wider margin than it claimed

| the query `R-19` names | |
|---|---|
| JSON inside the parent | **1,168.3 ms** |
| a bespoke child table | 25.0 ms |
| a child dataset + taxonomy | **0.6 ms** |

47× worse than even a bespoke table, at realistic selectivity (2,161 of 17,283).
Nothing in eleven criteria favours JSON.

## And it decided only half the question

`R-19` framed the choice as *child tables versus JSON*. But there are **two
independent axes**, and only the first was ruled:

|  |  |
|---|---|
| **where do the child rows live?** | bespoke tables · a child **dataset** · JSON in the parent |
| **how is the value stored?** | the published string · a reference into a taxonomy |

**The criterion nobody had raised is the largest gap in the whole table.** When the
site relabels a category:

| | |
|---|---|
| the string held per row | **5,906 ms — 103,698 rows rewritten** |
| the string held once | **0.1 ms — 1 row** |

About **59,000×**, and a live directory relabels things.

## Three machines are already built for this, holding zero rows each

| table | what it is | rows |
|---|---|---|
| `classification_node` | a **generic self-referencing taxonomy** — `parent_node_id`, both locales, `level` | **0** |
| `dataset_relationship` | dataset-to-dataset parent/child, with cardinality and review status | **0** |
| `generic_record` | any dataset, `data_json`, **`source_snapshot_id NOT NULL`** — provenance *enforced*, not remembered | 1 dataset |

Five bespoke tables would build what is built, and stay invisible to every generic
mechanism the warehouse has.

## Two errors in the ruling's own evidence — kept visible, per C4

- `R-19` reported the licensed-activities table as *"one row — the header only"*. The
  committed fixture, a different contractor, has **six**. "Empty" was never general —
  which is the limit `R-19` itself flagged.
- The value is **not a flat string**. It is a two-level bilingual path whose parent
  repeats **three times inside one contractor's six activities**. That is what makes
  the taxonomy question real rather than theoretical.

## Two defects in my own measurement

- **The first fixture had no selectivity.** A 30-leaf taxonomy with 30 values each
  gave every contractor every leaf, so the named query answered "all 17,283" and what
  looked like a comparison of three queries was three ways of scanning a whole table.
  A selective lookup is the entire reason an index exists. Storage and relabel figures
  survived; the query figures were re-measured.
- **The identity collision was found by a crash.** Keying a child row on
  `contractor:leaf_name` was refused by `UNIQUE (dataset_definition_id, record_key)`,
  because a leaf name repeats across branches. It failed *loudly* only because that
  `INSERT` is not `OR IGNORE` — behind one it drops the row and reports success, the
  trap `LESSONS.md` records three times over.

## Also found

`dataset_workbook_tables` returns exactly one tab, justified in its docstring by *"a
contractor directory has one flat table"* — a sentence `R-19` makes **false** under
every option. And **no test anywhere references that function**.

## Recorded, not decided

`Q-13` in `BACKLOG.md`, three options, recommendation **(b)** — child datasets
referencing the taxonomy: zero migrations, publishing nearly free, identity that
cannot collide; ~235 MB and ~28 s per full re-extraction. **(c)** is the fallback if
that storage figure is judged too high.

Full suite green but for `OP-19`, the known load-dependent race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
