### PR TITLE
A docstring quoting a Windows path says so, and the r-prefix is a guard now

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -849,7 +849,44 @@ debt on the board, and `say()` in particular is one parametrised test.
 
 ---
 
-### OP-29 · An invalid escape sequence in a test docstring is a future `SyntaxError`
+### OP-29 · ~~An invalid escape sequence in a test docstring is a future `SyntaxError`~~ — FIXED 2026-08-21
+
+> **CLOSED THE DAY AFTER IT WAS FILED, and the one character is a guard now rather
+> than a memory.** `tests/test_relaunch_log.py:85` opens `r"""`, so the Windows path
+> the docstring quotes is text rather than three escape sequences. Measured before
+> and after with one command:
+>
+> ```
+> PYTHONPATH=. python -m pytest tests/test_relaunch_log.py \
+>   tests/test_the_extension_gate_is_complete.py \
+>   tests/test_the_docs_gate_is_complete.py -p no:randomly -q -rw
+> ```
+>
+> **Before:** two entries in pytest's warnings summary — one against
+> `tests/test_relaunch_log.py:85` from importing the module, and one `<unknown>:85`
+> attributed to *both* gate tests at once, which is exactly the shape the diagnosis
+> below predicted. **After:** no warnings summary at all, 16 passed, exit 0.
+> The docstring's own text did not change — an invalid escape was already kept
+> verbatim, so nothing but the warning ever differed.
+>
+> **The sweep found nothing else, and that is a measurement rather than a glance.**
+> All **273** tracked `.py` files were compiled and every string literal classified:
+> **zero** invalid escapes remain; the only three non-raw literals holding a
+> valid-but-silent escape are deliberate byte constants (a UTF-8 BOM, a length
+> prefix, the PNG magic); and all **171** regex patterns in the repository are
+> already raw — so none of them holds a `\b` that would mean *backspace* where a
+> word boundary was meant, which is this defect's silent twin and would never warn.
+> `tests/test_gpp.py:496` reads like a fourth finding and is not: it is a `"""\`
+> line continuation, and it looked like backslash-CR only because the checkout is
+> CRLF — trap 2 of [../CLAUDE.md](../CLAUDE.md) biting the scan that was hunting
+> trap-shaped bugs.
+>
+> **Guarded, so a revert is loud.** The `r"""` is pinned in `PINNED` in
+> `tests/test_the_documents_cite_what_they_claim.py`, so deleting the `r` now fails
+> tier 2 of the citation guard instead of printing a warning nobody reads.
+
+**The diagnosis, kept as it was written on 2026-08-21 — the present tense below
+is that morning's, not today's.**
 
 Every full suite prints `<unknown>:85: SyntaxWarning: invalid escape sequence '\.'`,
 raised by both gate tests because they compile the suite's own sources to count it.

--- a/tests/test_relaunch_log.py
+++ b/tests/test_relaunch_log.py
@@ -82,7 +82,7 @@ def test_a_rotation_that_cannot_happen_never_stops_a_start(tmp_path: Path, monke
 
 
 def test_a_log_the_live_engine_is_holding_does_not_block_the_restart(tmp_path, monkeypatch):
-    """Reproduced on the owner's machine: the button answered 500 with
+    r"""Reproduced on the owner's machine: the button answered 500 with
     "could not start the helper ([Errno 13] Permission denied:
     ...\.scrapex\engine.log)".
 

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -159,6 +159,12 @@ PINNED = (
     # does not.
     ("docs/BACKLOG.md", "db/migrations/0058_a_unit_that_can_name_who_said_it.sql",
      90, "'legacy_unwitnessed'"),
+    # OP-29. The `r` IS the fix, and a docstring quoting a Windows path is the
+    # case that recurs -- so the prefix is pinned rather than remembered. Drop
+    # it and 3.12 warns on an invalid escape while a later Python refuses the
+    # file outright; this row turns that back into a failing test.
+    ("docs/BACKLOG.md", "tests/test_relaunch_log.py", 85,
+     'r"""Reproduced on the owner'),
 )
 
 # A guard that can be emptied without anyone noticing is the defect -- SR-23, and


### PR DESCRIPTION
Closes **OP-29**. One character of fix, one row of guard, and a sweep that proves nothing else in the repository has the same defect.

> ### ⚠ Stacked on #236 — read the base before merging
>
> OP-29 was **filed** in `52da8fd`, which is on `claude/muqawil-nested-audit` and **not on `main`** (`origin/main` is at `ec53b17` / #235 and tops out at OP-27). So this PR is based on that branch, not on `main`, and its diff is **one commit**. Basing it on `main` would have meant writing a *second* OP-29 into a register whose rule is that ids are never reused.
>
> **Merge #236 first.** GitHub will retarget this to `main` automatically when it does.

---

## The defect

`tests/test_relaunch_log.py:85` opened a **non-raw** docstring quoting a Windows path verbatim:

```
...\.scrapex\engine.log
```

`\.` and `\e` are not escape sequences. Python 3.12 warns; **a later Python makes it a `SyntaxError`** and the file stops importing. It surfaced on every full suite as `<unknown>:85` — `<unknown>` because both CI gate tests compile the suite's own sources to count tests, so the warning arrived with no filename attached.

## The fix

`"""` → `r"""`. The docstring's own text does **not** change: an invalid escape was already kept verbatim, so nothing but the warning ever differed.

## Measured, before and after, with one command

```
PYTHONPATH=. python -m pytest tests/test_relaunch_log.py \
  tests/test_the_extension_gate_is_complete.py \
  tests/test_the_docs_gate_is_complete.py -p no:randomly -q -rw
```

| | warnings summary | result |
|---|---|---|
| **before** | **2 entries** — one against `tests/test_relaunch_log.py:85` on import, one `<unknown>:85` attributed to *both* gate tests at once | 16 passed |
| **after** | **none** | 16 passed, exit 0 |

## The sweep found nothing else, and that is a measurement rather than a glance

All **273** tracked `.py` files were compiled and every string literal classified.

- **Zero** invalid escapes remain.
- The only **three** non-raw literals holding a *valid-but-silent* escape are deliberate byte constants — a UTF-8 BOM, a length prefix, the PNG magic.
- All **171** regex patterns in the repository are **already raw**, so none carries a `\b` meaning *backspace* where a word boundary was meant. That is this defect's silent twin: it never warns, and it would have survived a fix aimed only at the warning.

`tests/test_gpp.py:496` reads like a second finding and is not — it is a `"""\` line continuation, and it looked like backslash-CR only because the checkout is CRLF. Trap 2 of `CLAUDE.md` biting the scan that was hunting trap-shaped bugs.

## Pinned rather than remembered

`PINNED` in `tests/test_the_documents_cite_what_they_claim.py` now holds the `r`-prefix, so **deleting the `r` fails tier 2 of the citation guard** instead of printing a warning nobody reads. Verified by removing it — the guard failed with *"which is not within 3 lines of there. It is at nowhere in the file"* — then restored. One mutation, killed.

That row is also why this closure may carry a `file:line` citation at all: **C2** and [R-15](docs/RULINGS.md) both ask for it.

## Documentation travels with the work (C2)

`docs/BACKLOG.md` marks OP-29 **FIXED 2026-08-21** in place, matching OP-23's convention. The diagnosis is **kept as written** (**C4**), with one line saying its present tense belongs to the morning it was filed rather than to today.

## Full suite finished before this PR opened (R-22)

`2,520` collected on exactly this tree — **2,515 passed · 3 skipped · 1 xfailed · 1 failed**.

The single failure is `tests/test_the_engine_survives_being_killed.py::test_a_killed_engine_does_not_leave_a_job_claiming_to_run` — the load-dependent race recorded as **OP-19**, re-measured 2026-08-20 at **8 failed / 5 passed** over thirteen runs. It touches nothing this PR changes.

No `SyntaxWarning` anywhere in the run. The only warnings-summary entry left is a third-party `StarletteDeprecationWarning` out of fastapi's `TestClient`.

> An earlier full-suite run was **discarded and repeated**: `docs/BACKLOG.md` was still being edited while it was in flight, and doc-reading tests are *in* the suite, so that run would not have verified the tree being committed.

## Noticed, not fixed here

`docs/STATE.md` at this base says `main` is at `71d1d41` (#234); `origin/main` is `ec53b17` (#235). A **C2** staleness bug, left alone rather than folded into a one-character PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
