### PR TITLE
OP-29's fix, rescued onto main — #240 was merged into a feature branch

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -873,7 +873,44 @@ Re-authored by line number, with the anchor lines asserted before anything is wr
 
 ---
 
-### OP-29 · An invalid escape sequence in a test docstring is a future `SyntaxError`
+### OP-29 · ~~An invalid escape sequence in a test docstring is a future `SyntaxError`~~ — FIXED 2026-08-21
+
+> **CLOSED THE DAY AFTER IT WAS FILED, and the one character is a guard now rather
+> than a memory.** `tests/test_relaunch_log.py:85` opens `r"""`, so the Windows path
+> the docstring quotes is text rather than three escape sequences. Measured before
+> and after with one command:
+>
+> ```
+> PYTHONPATH=. python -m pytest tests/test_relaunch_log.py \
+>   tests/test_the_extension_gate_is_complete.py \
+>   tests/test_the_docs_gate_is_complete.py -p no:randomly -q -rw
+> ```
+>
+> **Before:** two entries in pytest's warnings summary — one against
+> `tests/test_relaunch_log.py:85` from importing the module, and one `<unknown>:85`
+> attributed to *both* gate tests at once, which is exactly the shape the diagnosis
+> below predicted. **After:** no warnings summary at all, 16 passed, exit 0.
+> The docstring's own text did not change — an invalid escape was already kept
+> verbatim, so nothing but the warning ever differed.
+>
+> **The sweep found nothing else, and that is a measurement rather than a glance.**
+> All **273** tracked `.py` files were compiled and every string literal classified:
+> **zero** invalid escapes remain; the only three non-raw literals holding a
+> valid-but-silent escape are deliberate byte constants (a UTF-8 BOM, a length
+> prefix, the PNG magic); and all **171** regex patterns in the repository are
+> already raw — so none of them holds a `\b` that would mean *backspace* where a
+> word boundary was meant, which is this defect's silent twin and would never warn.
+> `tests/test_gpp.py:496` reads like a fourth finding and is not: it is a `"""\`
+> line continuation, and it looked like backslash-CR only because the checkout is
+> CRLF — trap 2 of [../CLAUDE.md](../CLAUDE.md) biting the scan that was hunting
+> trap-shaped bugs.
+>
+> **Guarded, so a revert is loud.** The `r"""` is pinned in `PINNED` in
+> `tests/test_the_documents_cite_what_they_claim.py`, so deleting the `r` now fails
+> tier 2 of the citation guard instead of printing a warning nobody reads.
+
+**The diagnosis, kept as it was written on 2026-08-21 — the present tense below
+is that morning's, not today's.**
 
 Every full suite prints `<unknown>:85: SyntaxWarning: invalid escape sequence '\.'`,
 raised by both gate tests because they compile the suite's own sources to count it.

--- a/tests/test_relaunch_log.py
+++ b/tests/test_relaunch_log.py
@@ -82,7 +82,7 @@ def test_a_rotation_that_cannot_happen_never_stops_a_start(tmp_path: Path, monke
 
 
 def test_a_log_the_live_engine_is_holding_does_not_block_the_restart(tmp_path, monkeypatch):
-    """Reproduced on the owner's machine: the button answered 500 with
+    r"""Reproduced on the owner's machine: the button answered 500 with
     "could not start the helper ([Errno 13] Permission denied:
     ...\.scrapex\engine.log)".
 

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -159,6 +159,12 @@ PINNED = (
     # does not.
     ("docs/BACKLOG.md", "db/migrations/0058_a_unit_that_can_name_who_said_it.sql",
      90, "'legacy_unwitnessed'"),
+    # OP-29. The `r` IS the fix, and a docstring quoting a Windows path is the
+    # case that recurs -- so the prefix is pinned rather than remembered. Drop
+    # it and 3.12 warns on an invalid escape while a later Python refuses the
+    # file outright; this row turns that back into a failing test.
+    ("docs/BACKLOG.md", "tests/test_relaunch_log.py", 85,
+     'r"""Reproduced on the owner'),
 )
 
 # A guard that can be emptied without anyone noticing is the defect -- SR-23, and


### PR DESCRIPTION
**Documentation and one character. This re-lands [#240](https://github.com/muhammadbayoumi/ScrapeX/pull/240), which never reached `main`.**

## What happened

#240 is genuinely merged — GitHub reports `state: MERGED`, `mergedAt:
2026-08-21T10:16:01Z`. Its **base was `claude/muqawil-nested-audit`**, a feature
branch that had already been squash-merged and abandoned. So the merge succeeded into
a dead branch and `main` never received a line of it.

```
gh pr view 240 --json baseRefName   ->  claude/muqawil-nested-audit
git log origin/main | grep '(#240)' ->  nothing
```

This is exactly what [`R-18`](docs/RULINGS.md) demands the grep for — *"a green tick
can belong to a different tree"* — and here a **merge** did. The tool said merged,
GitHub said merged, both were true, and the fix was nowhere. Cherry-picked onto
current `main` (`80bbaeb`); it applied with an auto-merge in `docs/BACKLOG.md` and no
conflict.

**The cause is worth recording, because it will recur.** A session spawned from this
one inherits whatever branch is checked out, and `gh pr create` defaults its base to
that branch rather than to `main`. Nothing warned, and the PR looked entirely normal.

## What the work itself is, verified independently

One character: `tests/test_relaunch_log.py:85` now opens `r"""`, so the Windows path
its docstring quotes is text rather than three escape sequences. Python 3.12 warned;
a later Python refuses the file outright.

I checked its central claim rather than trusting it — **compiled all 273 tracked
`.py` files with `SyntaxWarning` promoted to an error, on its own branch**:

```
tracked .py compiled: 273
invalid escapes / syntax warnings remaining: NONE
```

And the suite it touches runs green with `-rw`: **no warnings summary at all**.

Two things worth keeping from its own investigation:

- All **171** regex patterns in the repository are already raw — so none holds a `\b`
  meaning *backspace* where a word boundary was intended, which is this defect's
  silent twin and would never warn.
- `tests/test_gpp.py:496` looked like a fourth finding and was not: a `"""\` line
  continuation that read as backslash-CR **only because the checkout is CRLF** — trap
  2 of `CLAUDE.md` biting the scan that was hunting trap-shaped bugs.

The `r"""` is pinned in `PINNED`, so removing it fails the citation guard instead of
printing a warning nobody reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
