### PR TITLE
The six that finish muqawil, and three written premises that were wrong

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -264,8 +264,8 @@ And only one of the **two** `worker_alive` computations was fixed:
 
 | where | what it calls | verdict |
 |---|---|---|
-| `scrapex/webui/app.py:1450` — `/api/health` | the new two-heartbeat `worker` verdict | correct; the panel reads this one (`extension/engine.js:38`) |
-| `scrapex/webui/app.py:2438` — `_about` | `worker_is_alive(conn)`, single heartbeat | **the function the fix superseded** |
+| `scrapex/webui/app.py:1470` — `/api/health` | the new two-heartbeat `worker` verdict | correct; the panel reads this one (`extension/engine.js:38`) |
+| `scrapex/webui/app.py:2458` — `_about` | `worker_is_alive(conn)`, single heartbeat | **the function the fix superseded** |
 
 `_about` renders the engine's own `/settings` page
 (`scrapex/webui/templates/settings.html:162-167`), so **the engine still shows
@@ -273,7 +273,7 @@ And only one of the **two** `worker_alive` computations was fixed:
 engine is started at all.
 
 **Next action:** three separate things — the second `worker_alive` at
-`app.py:2438`; the heartbeat's behaviour under a held write lock; and the 409 on
+`app.py:2458`; the heartbeat's behaviour under a held write lock; and the 409 on
 `/api/storage/restore` with a mirror of
 `test_start_fresh_is_refused_while_a_crawl_runs`.
 
@@ -2333,7 +2333,7 @@ date it was measured.
 1. **ALSWEED is being refused with HTTP 429**, five times on 2026-08-11, because
    `crawl_honour_delay` is `'0'`. **BV-3**.
 2. **The engine's own Settings page says "Not running" while it crawls** — a
-   second `worker_alive` computation at `app.py:2438` that the fix never reached
+   second `worker_alive` computation at `app.py:2458` that the fix never reached
    — and the runtime heartbeat freezes under `database is locked` when a job
    holds a write transaction. **OP-6 · ت2**.
 3. **The diagnostic-page guard is still blind**, and this file said it had been

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1009,6 +1009,34 @@ has data consequences:
 impossible rather than deferred; (b) or (c) as the real model, once he rules.*
 **Not started — his call, on live data.**
 
+### OP-32 · The test suite writes into the owner's live crawl log
+
+**Found 2026-08-21, by reading the log to check on a crawl.**
+
+`contractors.say` appends every line to `Path.home()/".scrapex"/"contractors.log"` with
+no way to redirect it, so any test that reaches it writes to the **real** file. What
+surfaced it: two lines saying *"departures not marked: the crawl is not provably
+complete"* sat at the tail of the live log while a real crawl was running, and they came
+from the gate tests, not from the crawl. A log read to find out what a crawl did is
+worth nothing if a test can write to it.
+
+It predates the work that found it — `test_the_crawl_driver_cannot_lose_a_run.py` has
+been calling `crawl()` and therefore `say()` since it was written. Two things follow
+from it, and the second is the reason this is recorded rather than patched:
+
+* **Wrong content in a file used for diagnosis.** The lines are indistinguishable from
+  a real run's, and this one nearly cost a wrong conclusion about a live crawl.
+* **A path derived from `HOME` at import time.** In CI that is a container's home and
+  harmless; on a developer's machine it is the file they read. The fix is to make the
+  destination injectable rather than to monkeypatch it per test file — which is a small
+  change to a module that is currently being edited by the six-item track, so it waits
+  until that lands rather than colliding with it.
+
+Mitigated where it was found: the new tests redirect `contractors.LOG` to `tmp_path`.
+The general fix is still open.
+
+---
+
 ### OP-31 · Six crawl workers starve another process out of the warehouse
 
 **Measured 2026-08-21, minutes after `--workers` was built, by using it.** The owner

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -813,6 +813,40 @@ Reading the code found almost none of these. What found them:
 - **When a fix looks like it did nothing, suspect the environment before the
   logic** — §1 above.
 
+### The check for a leftover mutation ran while the killed harness was still alive
+
+**This is the same failure as the one above, and the guard written for it did not catch
+it.** A mutation run was killed by a two-minute timeout. The tree was checked
+immediately: `grep` for every mutant string found nothing, so the run was declared clean
+and the work was committed.
+
+**`body_class=None` shipped anyway.** The killed process had not finished dying. It
+applied its next mutation *after* the grep, and nothing looked again.
+
+What found it, two commits later, was **not** the test named for that behaviour —
+`test_the_stored_profile_is_labelled_as_a_profile` asserted `html_codec is not None` and
+passed happily with `body_class=None`. It was the **lint gate**, complaining that
+`label_for` was imported and unused. A defect caught by an unused import is a defect that
+had no test.
+
+Two things follow, and the second is the one that generalises.
+
+**A killed harness has to leave a trace on disk.** `finally` does not run on SIGTERM and
+a signal handler is best effort, so neither can be the record. A marker file written at
+the start and deleted on a clean exit can be: if it exists and nothing is running, a
+mutation is in the tree, and it names which file. The harness now refuses to start while
+one is there.
+
+**And a test that survives the mutation it is named for is not a weak test, it is not a
+test.** `html_codec is not None` was true either way, because a default codec is still a
+codec. Asserting the DECISION — the label actually passed to `save_snapshot` — kills both
+`None` and the plausible wrong answer of the listing's dictionary. The rule that comes out
+of it: assert the choice, not a downstream effect that something else also produces.
+
+**And do not run a mutation harness in the foreground under a timeout at all.** Background
+it. A foreground timeout kills the parent and leaves the work half done, which is exactly
+the state no one thinks to look for.
+
 ### A mutation harness that trusts `finally` will leave a mutation in the tree
 
 The method above depends on a harness that **mutates the source, runs the tests,
@@ -899,7 +933,8 @@ running it, because a false `killed` retires a real concern.
 restore check trustworthy — `read_text()` normalises newlines, so a text comparison can
 report a clean restore over a file whose line endings changed. But reading bytes means
 the anchors are matched against CRLF, because `.gitattributes` sets `* text=auto` and
-Windows checks out `
+Windows checks out `
+
 `. Every anchor written with `
 ` then finds nothing, and the
 harness says `anchor occurs 0x` about code that is plainly on the screen. Translate the

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -895,6 +895,17 @@ and the file is byte-identical to the original after every restore. Without them
 harness reports with total confidence in both directions — which is worse than not
 running it, because a false `killed` retires a real concern.
 
+**And the third assertion collides with the second.** Comparing BYTES is what makes the
+restore check trustworthy — `read_text()` normalises newlines, so a text comparison can
+report a clean restore over a file whose line endings changed. But reading bytes means
+the anchors are matched against CRLF, because `.gitattributes` sets `* text=auto` and
+Windows checks out `
+`. Every anchor written with `
+` then finds nothing, and the
+harness says `anchor occurs 0x` about code that is plainly on the screen. Translate the
+ANCHORS to the file's line endings; normalising the file would rewrite every line in it
+and defeat the restore check the bytes were for.
+
 ### And `restored: True` can be true while the file on disk has changed
 
 The harness proves it restored by comparing what it wrote back:

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -852,6 +852,49 @@ handler is the belt; the background is the braces. And after any mutation run th
 did not print its own `restored: True`, **grep the tree for the mutations** rather
 than assuming — that check is what caught this one.
 
+### A mutation harness needs a control run, or every result it prints is a guess
+
+Six mutations, six kills, `all 6 killed`. The harness was passing its subprocess
+`env={"PYTHONPATH": ..., "PATH": ""}` — and an empty `PATH` breaks `anyio`'s backend
+lookup at import time, so **every** run crashed identically before collecting a test.
+Each crash was a non-zero exit, each non-zero exit was read as a mutant dying, and the
+report was unanimous and worthless.
+
+**The missing piece was one run of the unmutated tree**, under exactly the command and
+environment the mutants get:
+
+```python
+control = run_tests()
+if control.returncode != 0:
+    raise SystemExit("the clean tree does not pass; every result below is meaningless")
+```
+
+The clue was there and easy to skim past: the per-case line printed no `N passed`
+summary, because there was no summary to print. **A kill is only evidence when the same
+harness can demonstrate a pass.**
+
+### And the anchor a mutation replaces has to be UNIQUE, or it mutates something else
+
+`str.replace(old, new, 1)` takes the FIRST match in the file, and
+`"    if not outcome.provably_complete:"` matched twice — once at four spaces as the
+gate being tested, and once at **eight** spaces as a per-cell note, because a
+four-space anchor is a substring of an eight-space line. The note got mutated, the gate
+was never touched, and the harness reported a survivor that did not exist. Two hours
+were nearly spent strengthening a test that was already correct.
+
+Both failures point the same way, and it is the opposite of the intuitive one:
+
+| the harness said | what was true |
+|---|---|
+| `all 6 killed` | nothing ran at all |
+| `1 SURVIVED` | the mutation never reached the code under test |
+
+**So a mutation result is a measurement and needs its instrument checked.** Three cheap
+assertions catch all of it: the clean tree passes; the anchor occurs **exactly once**;
+and the file is byte-identical to the original after every restore. Without them the
+harness reports with total confidence in both directions — which is worse than not
+running it, because a false `killed` retires a real concern.
+
 ### And `restored: True` can be true while the file on disk has changed
 
 The harness proves it restored by comparing what it wrote back:

--- a/docs/R19-CHILD-TABLES-MEASURED.md
+++ b/docs/R19-CHILD-TABLES-MEASURED.md
@@ -207,3 +207,38 @@ storage figures will move when they arrive.
 
 **Not built. Awaiting his ruling**, recorded as a question in
 [BACKLOG.md](BACKLOG.md).
+
+---
+
+## 7 · Measured after the recommendation: interests are not a table
+
+**2026-08-21, while building the reader both candidate shapes need.** This document and
+the plan both assumed the five groups arrive through `detect_html_tables`. Measured
+against `tests/fixtures/muqawil/profile-en.html`:
+
+| | |
+|---|---|
+| `<table>` elements on the page | **5** |
+| …of which are Interests | **0** |
+| Interests is | a nested `<ul class="list list-numerical">` inside `div.section-card` |
+| tables with no data rows for this contractor | **3** of 5 |
+| names `detect_html_tables` returns | `Table 1` … `Table 5` |
+| tables sharing one nearest heading | **3** |
+
+**The recommendation is unaffected and one of its arguments is strengthened.** Shape F
+turns on the parent repeating and on the leaf name not being an identity; the interests
+markup shows both directly — three levels deep, and `Construction of buildings` appearing
+as a level-1 node and again as a level-2 node beneath itself.
+
+**What changes is the build.** Interests are the largest of the five and cannot be read
+by the table detector at all, so a build following the old premise would have produced
+four groups and missed the biggest. `read_interests` in `scrapex/extract/muqawil.py`
+returns every node as a path from the root, which is the input either shape needs.
+
+**And a naming rule is now an open sub-question.** The detector returns positional names,
+and the nearest heading is shared by three of the five tables — so "which group is this"
+cannot be answered from either. Whatever shape is ruled will need that rule.
+
+**One locale trap, recorded because it nearly shipped.** Selecting the card by its
+heading text read 25 nodes from English and **0 from Arabic**: the Arabic heading is
+`الأنشطة` — "Activities" — not a translation of "Interests". Selection is structural now.

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -938,9 +938,9 @@ Built as **one parameter and one refusal**:
 
 | | where | what it does |
 |---|---|---|
-| `crawl_partition(..., parent=Cell)` | `scrapex/partitioncrawl.py:972` | sizes the PARENT, so every number is measured against it; `WHOLE` is the default and top-level runs are unchanged |
+| `crawl_partition(..., parent=Cell)` | `scrapex/partitioncrawl.py:1012` | sizes the PARENT, so every number is measured against it; `WHOLE` is the default and top-level runs are unchanged |
 | `Cell.is_under(other)` | `scrapex/pagesource.py:146` | subset-hood expressed in filters — adding a filter can only narrow, so a child carrying all of the parent's name/value pairs selects a subset, **in any order** |
-| `NotASubdivision` | `scrapex/partitioncrawl.py:965` | raised **before a single request** when a cell is not inside the parent. A child that dropped a parent filter is measured over a larger set and could report a comfortable zero deficit while covering none of the parent |
+| `NotASubdivision` | `scrapex/partitioncrawl.py:1005` | raised **before a single request** when a cell is not inside the parent. A child that dropped a parent filter is measured over a larger set and could report a comfortable zero deficit while covering none of the parent |
 | `PartitionOutcome.parent` / `.scope` / `.nested` | | so the report says what it audited, and a nested proof reads *"PROVABLY COMPLETE FOR cell … — AND FOR THAT CELL ONLY"* rather than claiming the listing |
 
 Guarded by seven tests in `tests/test_a_crawl_that_can_prove_it_read_everything.py`

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -134,7 +134,7 @@ engine carries the extension.
 
 **The defect, found by trying the bump and reverting it the same day:**
 `version_report` sends `"latest_extension_version": VERSION`
-(`scrapex/version.py:477`, again in `scrapex/webui/app.py:1439`, drawn by
+(`scrapex/version.py:477`, again in `scrapex/webui/app.py:1459`, drawn by
 `extension/app.js:595` and `:629`). The moment the engine moves ahead of
 `extension/manifest.json`, the panel draws *"This ScrapeX extension is older than
 the engine it is talking to"*. Measured at 320×440: the profile page's legal line

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -638,7 +638,7 @@ written and 58 two days ago. It grows every time this is deferred.
 **The blocker, verified 2026-08-17 and still present:**
 `"latest_extension_version": VERSION` at
 [scrapex/version.py:477](../scrapex/version.py) and
-[scrapex/webui/app.py:1439](../scrapex/webui/app.py), drawn by
+[scrapex/webui/app.py:1459](../scrapex/webui/app.py), drawn by
 [extension/app.js:599](../extension/app.js) and `:633`.
 
 > **Re-verified 2026-08-19, and three of these citations had already drifted.**

--- a/docs/plans/2026-08-20-finish-muqawil-then-the-source-queue.md
+++ b/docs/plans/2026-08-20-finish-muqawil-then-the-source-queue.md
@@ -127,7 +127,7 @@ and ten are open — of which only SIX are muqawil engineering.**
 | 3 | ~~`is_enabled` has 0 callers~~ **DONE** | ~1 h | Two capabilities are lit at `PARTIAL` and nothing reads them, so lighting one is a *claim*, not a switch. |
 | 4 | The slice scope — **defect fixed**; the walk moves into item 5 | ~2 h so far | Built and tested; wiring it is what makes a partial re-read addressable. |
 | 5 | The profile crawl — **wired**; 34,834 pages, measured at **11.1 h** to run | ~3 h | The adapter exists (`bilingual_profile_candidate`, #235). This is mostly *runtime*, and it is the item that turns 21 columns into 48. |
-| 6 | `R-19` child tables, all five groups | **~1 day** | The largest, and last on purpose: ~500K rows, five tables, and it depends on profile pages being on disk — which is item 5. |
+| 6 | `R-19` — **reader built**; the write awaits his ruling AND profile pages | ~2 h so far | The largest, and last on purpose: ~500K rows, five tables, and it depends on profile pages being on disk — which is item 5. |
 
 **So: about a day and a half of work, plus roughly eighteen hours of crawling that runs
 unattended.** Two of the six are under an hour each and one of those is already ruled.
@@ -262,9 +262,30 @@ Tick a box only when it is MERGED. `⚡` marks a quick win — under about an ho
 > **Where the other ~28 columns are, so nobody hunts for them in `read_profile`:** the
 > profile page carries **five real `<table>` elements** — the licences and their
 > readiness, the two contractor lists, the technical rating, the contract counts. Those
-> go through `detect_html_tables` like any other site's tables, and they are exactly
-> the multi-valued groups `R-19` wants in child tables. That is why `R-19` is a
+> go through `detect_html_tables` like any other site's tables. That is why `R-19` is a
 > separate item and not part of the parser.
+>
+> **CORRECTION, 2026-08-21.** That paragraph used to end *"and they are exactly the
+> multi-valued groups `R-19` wants in child tables"*, and they are not. Measured against
+> the committed profile:
+>
+> | | |
+> |---|---|
+> | `<table>` elements | **5** |
+> | …of which are Interests | **0** |
+> | Interests is | a nested `<ul class="list list-numerical">` inside a `div.section-card` |
+> | tables with **no data rows** for this contractor | **3** of 5 |
+> | names `detect_html_tables` returns | `Table 1` … `Table 5` |
+> | tables sharing one nearest heading | **3** |
+>
+> `R-19`'s five groups are Interests, Licensed Activities, Qualification Programs,
+> Balady Services and contractor relations. **Interests is the biggest** — the study
+> priced it at ~235 MB at full scale — and it is not a table at all, so building on the
+> five-tables premise would have produced four groups and silently missed the largest.
+> Three of the five tables are empty on the only committed profile, which is `R-19`'s
+> own *"one contractor"* evidence limit arriving from the other side. And the groups
+> cannot be named from the markup by position or by the nearest heading, so whatever
+> `R-19` is built on needs a naming rule that is neither.
 
 - [x] **`profile_candidate`** — `bilingual_profile_candidate`, plus `_candidate_from`
       taking its declared field list as a parameter instead of always leading with
@@ -274,10 +295,30 @@ Tick a box only when it is MERGED. `⚡` marks a quick win — under about an ho
 - [x] **A declared `PROFILE_FIELD_ORDER`**, for the reason `CARD_FIELDS` exists: a
       profile page that happens to omit a box must not produce a different schema.
       **#235.**
-- [ ] **`R-19`: child tables for all five multi-valued groups** — «جداول أبناء للخمس
-      كلّها»: Interests, Licensed Activities, Qualification Programs, Balady Services,
-      contractor relations. Not JSON, not `Activity 1, 2, 3`. A measured profile carried
-      **30 hierarchical interest values in 6 groups** — about 500K rows. Ruled, unbuilt.
+- [~] **`R-19`: child tables for all five multi-valued groups** — «جداول أبناء للخمس
+      كلّها». **The READING is built; the WRITING waits on him, and on pages that do not
+      exist yet.**
+      Two things block the write and neither is engineering. (1)
+      [R19-CHILD-TABLES-MEASURED](../R19-CHILD-TABLES-MEASURED.md) recommends **shape F**
+      — a child dataset per group whose value references `classification_node` — and its
+      own last line reads *"Not built. Awaiting his ruling."* Building either shape ahead
+      of that is the defect **C1** exists to prevent. (2) The content comes from profile
+      pages and **not one is stored**: his registration is `listing_only`, and item 5
+      measured the crawl at 11.1 hours.
+      **So what is built is what BOTH candidate shapes need — `read_interests`** — and
+      building it is what found the plan's premise to be wrong (the correction in section
+      C above). It returns every node as a **path from the root**, because the study
+      measured that a leaf name is not unique and an identity built from it merges two
+      different activities — this fixture repeats `Construction of buildings` at two
+      levels, so one profile already proves it. Interior nodes come back too, since
+      `classification_node.parent_node_id` means a leaf cannot be written before the node
+      above it.
+      **And a locale bug was caught by a parity assertion rather than by review.** The
+      first version matched the heading `"Interests"` and read **25 nodes from English
+      and 0 from Arabic** — the Arabic heading is `الأنشطة`, "Activities", not a
+      translation. The card is now identified by holding the list, and two such lists are
+      **refused** rather than guessed. Both locales: 25 nodes, depths `{1:3, 2:5, 3:17}`.
+      Ten tests.
 - [~] **The profile crawl — BUILT, not yet run.** `scrapex contractors --details`
       fetches the profile page of every contractor the **registered scope** asks for,
       with `body_class` set so each arrives under the profile dictionary (`STORAGE.md`

--- a/docs/plans/2026-08-20-finish-muqawil-then-the-source-queue.md
+++ b/docs/plans/2026-08-20-finish-muqawil-then-the-source-queue.md
@@ -122,7 +122,7 @@ and ten are open — of which only SIX are muqawil engineering.**
 
 | | item | cost | why this order |
 |---|---|---|---|
-| 1 | `status = 'unavailable'` on a departed row | **~1 h** | **already ruled** — he chose `unavailable` over `retired`; detection is built, only the WRITE is missing. A ruled-and-unbuilt item is the exact shape of `REQ-04`, which is why **C7** exists. |
+| 1 | ~~`status = 'unavailable'` on a departed row~~ **DONE** | ~3 h, not 1 | **already ruled** — he chose `unavailable` over `retired`; detection is built, only the WRITE is missing. A ruled-and-unbuilt item is the exact shape of `REQ-04`, which is why **C7** exists. |
 | 2 | State the resume cost in the tool's output | **~20 min** | It is in a docstring at `partitioncrawl.py:81`, which is not where a user of the command looks. |
 | 3 | `is_enabled` has 0 callers | **~1 h** | Two capabilities are lit at `PARTIAL` and nothing reads them, so lighting one is a *claim*, not a switch. |
 | 4 | The slice scope, unused for muqawil | **~1 h** | Built and tested; wiring it is what makes a partial re-read addressable. |
@@ -304,7 +304,21 @@ Tick a box only when it is MERGED. `⚡` marks a quick win — under about an ho
       self-build price section render at all.
 - [ ] **`belongs_to_slice` / `crawl_slice` / `LISTING_PLUS_SLICE`:** the slice scope is
       built, tested, and never used for muqawil.
-- [ ] **`generic_record.status` offers `unavailable` and `retired` and nothing ever sets either.** Detection is built (`sightings.departures`); the WRITE needs his ruling on which of the two a delisted contractor gets — see [OP-26](../BACKLOG.md)
+- [x] **`generic_record.status` is written now, and the mark can be taken back.**
+      `OP-26` ruled: `unavailable`. **The whole chain had no caller** — not the status
+      write, and not `record_absences` either, which writes the one fact that cannot be
+      recomputed. So `mark_departures` in the crawl is the caller `record_absences`
+      always said it needed, gated on `outcome.provably_complete`.
+      **Three findings on the way.** (1) `row_state` puts a marked row FIRST in its
+      precedence, so marking without ever unmarking would have made `returned`
+      unreachable — migration 0006's whole purpose, silently switched off. The restore
+      direction is not a nicety. (2) A `retired` guard at the top of the loop was **dead
+      code**: both branches already name the status they act on, and a mutation deleted
+      the guard with every test passing. Removed, with the reason written where it acts —
+      a line that reads like protection and cannot fail is worse than no line. (3) A
+      nested outcome reports `provably_complete = True` *correctly* — it is a claim about
+      `scope` — so the `nested` check is load-bearing: without it one cell's proof
+      delists the rest of the country. Sixteen tests, **nine mutations killed**.
 - [x] **`approve_candidate` creates a version 2 now** — `_retire_or_refuse`, and the
       direction decides: a **superset** of the approved fields retires v1 and approves
       v2, while a subset or a rename is still refused, because those two are how a

--- a/docs/plans/2026-08-20-finish-muqawil-then-the-source-queue.md
+++ b/docs/plans/2026-08-20-finish-muqawil-then-the-source-queue.md
@@ -123,7 +123,7 @@ and ten are open — of which only SIX are muqawil engineering.**
 | | item | cost | why this order |
 |---|---|---|---|
 | 1 | ~~`status = 'unavailable'` on a departed row~~ **DONE** | ~3 h, not 1 | **already ruled** — he chose `unavailable` over `retired`; detection is built, only the WRITE is missing. A ruled-and-unbuilt item is the exact shape of `REQ-04`, which is why **C7** exists. |
-| 2 | State the resume cost in the tool's output | **~20 min** | It is in a docstring at `partitioncrawl.py:81`, which is not where a user of the command looks. |
+| 2 | ~~State the resume cost in the tool's output~~ **DONE** | ~40 min | It is in a docstring at `partitioncrawl.py:81`, which is not where a user of the command looks. |
 | 3 | `is_enabled` has 0 callers | **~1 h** | Two capabilities are lit at `PARTIAL` and nothing reads them, so lighting one is a *claim*, not a switch. |
 | 4 | The slice scope, unused for muqawil | **~1 h** | Built and tested; wiring it is what makes a partial re-read addressable. |
 | 5 | The profile crawl — 34,806 pages | **~2 h to wire, ~17.4 h to run** | The adapter exists (`bilingual_profile_candidate`, #235). This is mostly *runtime*, and it is the item that turns 21 columns into 48. |
@@ -218,8 +218,22 @@ Tick a box only when it is MERGED. `⚡` marks a quick win — under about an ho
       56, and deriving cities means querying the warehouse for what we have seen. Not
       built ahead of his ruling, because for Riyadh it buys 9% (4,697 → 4,268) and
       the counting proof remains the route.
-- [ ] **Make sizing resumable**, or state its cost in the tool's own output. A resumed
-      run re-pays ~112 requests (5.7%).
+- [x] **Sizing states its cost, in the output, computed.** The item offered two
+      branches and this takes the second: making sizing resumable would change what the
+      progress denominator MEANS — the frontier is declared once after sizing, and that
+      is what makes it a count rather than an estimate — while stating the cost only
+      stops hiding a number.
+      `PartitionOutcome.sizing_requests` is the requests that measured and stored
+      nothing, and the report names them with their share: *"of those, 118 (5.7%) sized
+      cells and stored nothing — a resumed run pays them again"*. **`~112` was a
+      measurement of one site on one day** and it lived in a module header no user
+      reads; it moves with the partition and a constant in prose cannot follow it.
+      Two things fell out. `--plan` now says what IT spent, because the crawl's report
+      points at it as the cheaper route and a route that never states its price is not
+      an answer. And the hours estimate divided by `whole.requests + len(cells) * 2` —
+      two requests per cell, **assumed** — where `size_cell` reports what each actually
+      cost; a cell needing a third probe made the divisor too small and inflated every
+      hour figure derived from it. Four mutations killed.
 
 ### C · The 48 columns — further along than this list said
 

--- a/docs/plans/2026-08-20-finish-muqawil-then-the-source-queue.md
+++ b/docs/plans/2026-08-20-finish-muqawil-then-the-source-queue.md
@@ -126,7 +126,7 @@ and ten are open — of which only SIX are muqawil engineering.**
 | 2 | ~~State the resume cost in the tool's output~~ **DONE** | ~40 min | It is in a docstring at `partitioncrawl.py:81`, which is not where a user of the command looks. |
 | 3 | ~~`is_enabled` has 0 callers~~ **DONE** | ~1 h | Two capabilities are lit at `PARTIAL` and nothing reads them, so lighting one is a *claim*, not a switch. |
 | 4 | The slice scope — **defect fixed**; the walk moves into item 5 | ~2 h so far | Built and tested; wiring it is what makes a partial re-read addressable. |
-| 5 | The profile crawl — 34,806 pages | **~2 h to wire, ~17.4 h to run** | The adapter exists (`bilingual_profile_candidate`, #235). This is mostly *runtime*, and it is the item that turns 21 columns into 48. |
+| 5 | The profile crawl — **wired**; 34,834 pages, measured at **11.1 h** to run | ~3 h | The adapter exists (`bilingual_profile_candidate`, #235). This is mostly *runtime*, and it is the item that turns 21 columns into 48. |
 | 6 | `R-19` child tables, all five groups | **~1 day** | The largest, and last on purpose: ~500K rows, five tables, and it depends on profile pages being on disk — which is item 5. |
 
 **So: about a day and a half of work, plus roughly eighteen hours of crawling that runs
@@ -278,8 +278,29 @@ Tick a box only when it is MERGED. `⚡` marks a quick win — under about an ho
       كلّها»: Interests, Licensed Activities, Qualification Programs, Balady Services,
       contractor relations. Not JSON, not `Activity 1, 2, 3`. A measured profile carried
       **30 hierarchical interest values in 6 groups** — about 500K rows. Ruled, unbuilt.
-- [ ] **The profile crawl**, 34,806 pages both locales. Must run with `body_class` set
-      so the pages arrive compressed — `snapshotcrawl` already does it.
+- [~] **The profile crawl — BUILT, not yet run.** `scrapex contractors --details`
+      fetches the profile page of every contractor the **registered scope** asks for,
+      with `body_class` set so each arrives under the profile dictionary (`STORAGE.md`
+      measured 46x against zlib's 7.7x, because zlib's 32 KB window never sees across a
+      121 KB page).
+      **THE FRONTIER COMES OFF THE LEDGER, AND THE FIRST ANSWER WAS 1,500x SLOWER.**
+      Deriving it from stored listing pages means decoding and BeautifulSoup-parsing
+      14,727 of them: measured at **over 120 s and still running when it was killed**.
+      `dataset_sighting` already holds every id the site has ever shown us, so the full
+      frontier is one indexed SELECT — **0.08 s for 34,834 URLs**. A slice still needs
+      the pages, because the city is on the card and the ledger holds ids alone.
+      **And it must be `sighted_ids`, not `stored_ids`:** 17,417 against 15,707 on the
+      live warehouse, because a row exists only once its page is approved — so a
+      frontier from rows would skip the 1,710 contractors seen and not yet interpreted,
+      which is the population this crawl most needs.
+      **THE RUNTIME ESTIMATE WAS WRONG IN BOTH DIRECTIONS.** This list said ~17.4 h; the
+      single-threaded study's 5.84 s a request says 56.5 h. Measured over **87 minutes
+      of real crawling with six workers: 52.5 pages a minute, 1.14 s a page → 11.1 h**.
+      `--ceiling` stops a first run early and says PARTIAL, and the same `--run-ref`
+      continues it.
+      **What is left is to RUN it**, which is his call, and the profile approval path —
+      `bilingual_profile_candidate` exists (#235) and nothing calls it yet. Twelve
+      tests.
 - [~] **Conditional requests on the recurring pass — BUILT, AND THIS SOURCE CANNOT USE
       THEM.** Measured 2026-08-21 against the live site, one request:
 

--- a/docs/plans/2026-08-20-finish-muqawil-then-the-source-queue.md
+++ b/docs/plans/2026-08-20-finish-muqawil-then-the-source-queue.md
@@ -125,7 +125,7 @@ and ten are open — of which only SIX are muqawil engineering.**
 | 1 | ~~`status = 'unavailable'` on a departed row~~ **DONE** | ~3 h, not 1 | **already ruled** — he chose `unavailable` over `retired`; detection is built, only the WRITE is missing. A ruled-and-unbuilt item is the exact shape of `REQ-04`, which is why **C7** exists. |
 | 2 | ~~State the resume cost in the tool's output~~ **DONE** | ~40 min | It is in a docstring at `partitioncrawl.py:81`, which is not where a user of the command looks. |
 | 3 | ~~`is_enabled` has 0 callers~~ **DONE** | ~1 h | Two capabilities are lit at `PARTIAL` and nothing reads them, so lighting one is a *claim*, not a switch. |
-| 4 | The slice scope, unused for muqawil | **~1 h** | Built and tested; wiring it is what makes a partial re-read addressable. |
+| 4 | The slice scope — **defect fixed**; the walk moves into item 5 | ~2 h so far | Built and tested; wiring it is what makes a partial re-read addressable. |
 | 5 | The profile crawl — 34,806 pages | **~2 h to wire, ~17.4 h to run** | The adapter exists (`bilingual_profile_candidate`, #235). This is mostly *runtime*, and it is the item that turns 21 columns into 48. |
 | 6 | `R-19` child tables, all five groups | **~1 day** | The largest, and last on purpose: ~500K rows, five tables, and it depends on profile pages being on disk — which is item 5. |
 
@@ -332,8 +332,25 @@ Tick a box only when it is MERGED. `⚡` marks a quick win — under about an ho
       narrower and is the same item as the profile crawl above — **nothing walks the
       frontier for muqawil**. The `143` segment stays load-bearing: it is what makes the
       self-build price section render at all.
-- [ ] **`belongs_to_slice` / `crawl_slice` / `LISTING_PLUS_SLICE`:** the slice scope is
-      built, tested, and never used for muqawil.
+- [~] **The slice scope was built, tested, never used — AND WRONG.** Half done: the
+      defect is fixed, the walk that would use it is item 5's build.
+      **`enumerate(detail_urls(page))` was guessing the row index.** `belongs_to_slice`
+      indexes listing ROWS; `detail_urls` yields URLs; every caller paired them by
+      position, which is right only when a page yields one URL per row. muqawil yields
+      one **per locale**. Measured on a stored page before anything was changed:
+      **17 cards, 34 URLs** — url index 1 is contractor 0's *Arabic* page and was being
+      asked about card 1, a different contractor, and **17 of the 34 indices pointed
+      past the last card** and were dropped. A slice would have fetched a set that is
+      neither the slice nor its complement, and it reads as a smaller city.
+      **Nothing caught it because nothing used it**, and because every fake in the
+      walker's own slice tests yields one URL per row — the case the assumption fits.
+      Fixed in two halves: `detail_rows` has the source pair each URL with its row
+      (optional, since most sources need nothing — a Protocol member would have broken
+      `test_a_fake_site_satisfies_the_protocol`), and `belongs_to_slice` now **refuses**
+      a row past its last instead of answering `False`, which is what made the overshoot
+      invisible. Verified on the same real page: **0 mismatches of 34**. Ten tests,
+      **six mutations killed**, and one of them found that the walker had no test for
+      its own slice path at all.
 - [x] **`generic_record.status` is written now, and the mark can be taken back.**
       `OP-26` ruled: `unavailable`. **The whole chain had no caller** — not the status
       write, and not `record_absences` either, which writes the one fact that cannot be

--- a/docs/plans/2026-08-20-finish-muqawil-then-the-source-queue.md
+++ b/docs/plans/2026-08-20-finish-muqawil-then-the-source-queue.md
@@ -124,7 +124,7 @@ and ten are open — of which only SIX are muqawil engineering.**
 |---|---|---|---|
 | 1 | ~~`status = 'unavailable'` on a departed row~~ **DONE** | ~3 h, not 1 | **already ruled** — he chose `unavailable` over `retired`; detection is built, only the WRITE is missing. A ruled-and-unbuilt item is the exact shape of `REQ-04`, which is why **C7** exists. |
 | 2 | ~~State the resume cost in the tool's output~~ **DONE** | ~40 min | It is in a docstring at `partitioncrawl.py:81`, which is not where a user of the command looks. |
-| 3 | `is_enabled` has 0 callers | **~1 h** | Two capabilities are lit at `PARTIAL` and nothing reads them, so lighting one is a *claim*, not a switch. |
+| 3 | ~~`is_enabled` has 0 callers~~ **DONE** | ~1 h | Two capabilities are lit at `PARTIAL` and nothing reads them, so lighting one is a *claim*, not a switch. |
 | 4 | The slice scope, unused for muqawil | **~1 h** | Built and tested; wiring it is what makes a partial re-read addressable. |
 | 5 | The profile crawl — 34,806 pages | **~2 h to wire, ~17.4 h to run** | The adapter exists (`bilingual_profile_candidate`, #235). This is mostly *runtime*, and it is the item that turns 21 columns into 48. |
 | 6 | `R-19` child tables, all five groups | **~1 day** | The largest, and last on purpose: ~500K rows, five tables, and it depends on profile pages being on disk — which is item 5. |
@@ -306,9 +306,25 @@ Tick a box only when it is MERGED. `⚡` marks a quick win — under about an ho
 
 ### D · In the code and NOT WIRED — measured, not guessed
 
-- [ ] **`is_enabled` has 0 callers.** `GENERIC_DATASET_CATALOG` and
-      `GENERIC_EXTRACTION` are lit at `PARTIAL` and nothing reads them, so lighting one
-      is a *claim* about a capability rather than a switch.
+- [x] **`is_enabled` has two callers, and they are not symmetrical.** The function
+      calls itself *"the gate that NAVIGATION and UI must call before advertising a
+      capability"*, so the callers are the two ADVERTISEMENTS: `_dataset_rows`, which
+      puts a dataset in the source listing the panel draws, and
+      `scrapex contractors --approve`, which `REQ-24` made a shipped user-facing
+      command. **The API routes stay outside the flag**, as that docstring requires —
+      they are mounted on 127.0.0.1 so the slice can be exercised, and gating them
+      would make the flag a kill switch for development instead of a switch over what
+      is announced. A test pins that distinction, because it is the one a later reader
+      would tidy away.
+      **And `CRAWL_FRONTIER` looked stale and is not.** Measured against its own
+      written condition: limits shipped, checkpoint recovery shipped for the
+      partitioned crawl (`already_stored` skips pages a resume holds), and **persistent
+      discovery did not** — `declare_frontier` hands the fetcher an in-memory
+      denominator for the Activity panel and writes nothing, so no new process could
+      resume a frontier. Two of three, so `False` is correct; the measurement is in the
+      flag's own detail so nobody repeats the investigation. Ten tests, **five
+      mutations killed**, and one of them is a guard that counts call sites so the
+      zero-caller state cannot return silently.
 - [x] **`missing_ids`, `sighting_frequencies` have a caller** — `--coverage`. Listed
       twice; it is section A's item and it shipped there.
 - [~] **`detail_urls`: the "referenced only by tests" claim was WRONG.** Measured:

--- a/scrapex/contractors.py
+++ b/scrapex/contractors.py
@@ -55,7 +55,9 @@ from .partitioncrawl import (
 from .sightings import (
     coverage,
     departures,
+    mark_unavailable,
     missing_ids,
+    record_absences,
     sighting_frequencies,
 )
 from .snapshotbody import decode
@@ -239,7 +241,61 @@ def crawl(conn, directory: Directory, fetch, fetcher, run_ref: str,
         say(f"kept {written:,} validator(s) for the next crawl; this one was "
             f"answered 304 for {saved:,} page(s)")
     say("")
+    mark_departures(conn, directory, outcome, run_ref)
     say(str(coverage(conn, directory.dataset_key)))
+
+
+def mark_departures(conn, directory: Directory, outcome, run_ref: str) -> None:
+    """Write down who left, but ONLY off the back of a proof.
+
+    `OP-26`, RULED 2026-08-21: a delisted contractor becomes `unavailable`. The
+    schema has offered that value since the table was created and **the whole chain
+    had no caller** — not `record_absences`, which writes the one fact that cannot be
+    recomputed, and not the status write that depends on it. So a contractor the
+    directory removed kept `status='active'` with a frozen `last_seen_at`, which is
+    indistinguishable from one this crawl did not reach.
+
+    THE GATE IS THE POINT OF THIS FUNCTION. `record_absences` says its caller must
+    guarantee the crawl was complete, because it cannot see that from inside. Here is
+    that caller, and the guarantee is `outcome.provably_complete` — which already
+    means every cell proven, none unsized, and no row outside every cell.
+
+    AND `nested` IS CHECKED SEPARATELY BECAUSE `provably_complete` IS DELIBERATELY
+    NARROWER THAN IT LOOKS. Its own docstring: *"IT IS A CLAIM ABOUT `scope` AND NEVER
+    MORE"* — true on a nested run it means the PARENT CELL is accounted for and says
+    nothing about the rest of the listing. Marking absences from a nested proof would
+    delist every contractor outside that one cell.
+
+    `--only` IS REFUSED BY THE SAME PROPERTY, AND THE TEST SAYS SO OUT LOUD. A subset
+    run sizes the whole listing and sums only the cells it was given, so its
+    `exhaustiveness_deficit` is the thousands of rows in the cells it skipped and
+    `provably_complete` is False. That is the right answer arrived at indirectly, so
+    it is asserted rather than assumed — an implicit safety property with no test is
+    one refactor away from being gone.
+
+    IT SAYS WHY IT DECLINED. A crawl that silently marked nothing would be
+    indistinguishable from one that found no departures, and those are opposite facts.
+    """
+    if outcome.nested:
+        say(f"departures not marked: this crawl proves {outcome.scope} only, and a "
+            f"cell's proof says nothing about the rest of the listing")
+        return
+    if not outcome.provably_complete:
+        say(f"departures not marked: the crawl is not provably complete "
+            f"(deficit {outcome.deficit:,}, exhaustiveness "
+            f"{outcome.exhaustiveness_deficit:,}). A partial crawl misses "
+            f"contractors for its own reasons and marking those as gone would "
+            f"delist them because the crawler had a bad afternoon")
+        return
+
+    proven = record_absences(conn, directory.dataset_key,
+                            seen=outcome.ids, run_ref=run_ref,
+                            id_field=directory.identity_field)
+    marking = mark_unavailable(conn, directory.dataset_key,
+                               id_field=directory.identity_field)
+    say(f"the crawl is provably complete, so absence is evidence: "
+        f"{proven:,} row(s) proved absent by {run_ref}")
+    say(f"  {marking}")
 
 
 # ---- --coverage: what the warehouse knows about its own gaps ------------------

--- a/scrapex/contractors.py
+++ b/scrapex/contractors.py
@@ -434,7 +434,7 @@ def details(conn, directory: Directory, fetch, fetcher, run_ref: str,
         say("listing_only, so there are no profile pages to fetch. Change "
             "site_profile.crawl_scope to ask for them.")
         return
-    if False and scope is CrawlScope.LISTING_PLUS_SLICE:
+    if scope is CrawlScope.LISTING_PLUS_SLICE and not slice_of.strip():
         _refuse(f"{directory.key} is registered listing_plus_slice and no slice is "
                 "named, so there is nothing to select. Set site_profile.crawl_slice")
 
@@ -469,7 +469,7 @@ def details(conn, directory: Directory, fetch, fetcher, run_ref: str,
         try:
             service.save_snapshot(conn, SnapshotCreate(
                 source_url=url, html_content=html, crawl_run_ref=run_ref,
-                body_class=None))
+                body_class=label_for(url, PageKind.DETAIL)))
             conn.commit()
             stored += 1
         except Exception as exc:

--- a/scrapex/contractors.py
+++ b/scrapex/contractors.py
@@ -142,16 +142,27 @@ def plan(directory: Directory, fetch, started: float) -> None:
     pages = 0
     declared = 0
     over = []
+    sizing = whole.requests
     for cell in partition.cells():
         size = size_cell(fetch, partition, directory.base_url, cell)
         pages += size.last_page
         declared += size.declared
+        sizing += size.requests
         if size.last_page > RETRY_PAGE_CEILING:
             over.append(size)
         say(f"  {size}")
     locales = len(partition.locales)
     requests = pages * locales + len(partition.cells()) * 3 + 2
     say("")
+    # WHAT THIS COMMAND JUST SPENT, and the reason to print it is that `--crawl` now
+    # names the same cost in its own report and points here. Every cell is sized before
+    # any page is stored, and a resumed crawl pays that again because sizing is not
+    # resumable — so `--plan` is the way to pay it once, deliberately, and read the
+    # answer. A pointer to a cheaper route is worth nothing if the route never says
+    # what it cost.
+    say(f"this plan cost {sizing:,} request(s) sizing {len(partition.cells())} cells "
+        f"and the listing; a crawl re-pays that, and this run has now measured it "
+        f"rather than estimating it")
     say(f"cells {len(partition.cells())}  pages {pages} "
         f"(+{pages - whole.last_page} over the unfiltered {whole.last_page})")
     say(f"declared {declared:,} against the listing's {whole.declared:,} — "
@@ -160,7 +171,13 @@ def plan(directory: Directory, fetch, started: float) -> None:
     # PRICED FROM THIS RUN'S OWN LATENCY, not from a number in a document. The
     # study measured 5.84 s a request; the sizing just made 100-odd requests, so
     # the honest estimate is the one it just paid for.
-    per = (time.monotonic() - started) / max(1, whole.requests + len(partition.cells()) * 2)
+    #
+    # AND THE DIVISOR IS NOW COUNTED RATHER THAN GUESSED. It was
+    # `whole.requests + len(cells) * 2` — two requests per cell, assumed. `size_cell`
+    # reports what each one actually cost, and a cell that needed a third probe made
+    # the old divisor too small, which inflated the seconds-per-request and every hour
+    # figure derived from it. Same expression, real numerator and real denominator.
+    per = (time.monotonic() - started) / max(1, sizing)
     say(f"measured {per:.2f} s a request just now -> about {requests * per / 3600:.1f} h")
     if over:
         say(f"{len(over)} cell(s) above the {RETRY_PAGE_CEILING}-page witness ceiling, "

--- a/scrapex/contractors.py
+++ b/scrapex/contractors.py
@@ -45,6 +45,7 @@ from .directories import Directory
 from .directories import get as get_directory
 from .extract import service
 from .extract.models import ApprovalField, CandidateApproval
+from .features import FeatureKey, is_enabled
 from .partitioncrawl import (
     HEAVY_ATTEMPTS,
     RETRY_PAGE_CEILING,
@@ -534,6 +535,19 @@ def validate(args: argparse.Namespace) -> None:
     if (args.crawl or args.approve) and not args.run_ref:
         _refuse("--crawl and --approve need --run-ref: it is what makes an "
                 "interrupted crawl resumable and what --approve reads")
+    # THE SECOND CALLER `is_enabled` NEVER HAD, and the reason it belongs here rather
+    # than beside the API routes: those are mounted on 127.0.0.1 so the slice can be
+    # exercised and tested, and `is_enabled`'s docstring excludes them on purpose. This
+    # is the SHIPPED COMMAND — `REQ-24` made it one — so it is a user-facing surface in
+    # the same category as navigation, and a command that performs a capability the
+    # manifest calls unavailable is the inflated claim the flag exists to stop.
+    #
+    # IT REFUSES RATHER THAN SKIPPING. A run that quietly did nothing would look like a
+    # crawl with nothing to approve, and those are opposite facts.
+    if args.approve and not is_enabled(FeatureKey.GENERIC_EXTRACTION):
+        _refuse("generic extraction is disabled in this build "
+                "(scrapex/features.py), so --approve would write rows the feature "
+                "manifest says are not available. Nothing was read or written")
 
 
 def _refuse(message: str) -> None:

--- a/scrapex/contractors.py
+++ b/scrapex/contractors.py
@@ -34,18 +34,23 @@ three different readings.
 from __future__ import annotations
 
 import argparse
+import re
+import sqlite3
 import sys
 import time
+from collections.abc import Iterator
 from pathlib import Path
 
 from . import validators as validator_store
-from .connectors.base import HttpFetcher
+from .connectors.base import HttpFetcher, declare_frontier
+from .crawlscope import CrawlScope
 from .databases import DatabaseRegistry
 from .directories import Directory
 from .directories import get as get_directory
 from .extract import service
-from .extract.models import ApprovalField, CandidateApproval
+from .extract.models import ApprovalField, CandidateApproval, SnapshotCreate
 from .features import FeatureKey, is_enabled
+from .pagesource import FetchedPage, PageKind, slice_rows
 from .partitioncrawl import (
     HEAVY_ATTEMPTS,
     RETRY_PAGE_CEILING,
@@ -59,9 +64,12 @@ from .sightings import (
     mark_unavailable,
     missing_ids,
     record_absences,
+    sighted_ids,
     sighting_frequencies,
 )
-from .snapshotbody import decode
+from .sites.muqawil import MuqawilPageSource
+from .snapshotbody import decode, label_for
+from .snapshotcrawl import already_stored, read_scope
 
 # THE FOUR CONSTANTS THAT USED TO BE HERE were `BASE`, `DATASET`, `SITE_NAME` and
 # a `MuqawilPartition()`, and they are why a second contractor directory would have
@@ -316,6 +324,165 @@ def mark_departures(conn, directory: Directory, outcome, run_ref: str) -> None:
     say(f"  {marking}")
 
 
+
+# ---- --details: the profile frontier, built from disk ------------------------
+
+#: A stored page is a LISTING if its path ends at `contractors`, with or without a
+#: query. A profile carries the contractor id and the self-build tail after it.
+#: Derived from the URL because `generic_page_snapshot` has no kind column —
+#: `body_class` is chosen at write time to pick a compression dictionary and is not
+#: kept.
+_LISTING = re.compile(r"/(?:en|ar)/contractors(?:\?|$)")
+
+
+def listing_pages(conn) -> Iterator[FetchedPage]:
+    """Every listing page on disk, decoded, latest write per URL.
+
+    **NO NETWORK, AND THAT IS THE POINT.** `docs/GENERIC-FETCH-SEAM.md` separates
+    fetching from interpreting so that a wrong parse costs minutes. A frontier IS an
+    interpretation, so it comes off the evidence rather than off the wire — rebuilding
+    it by re-crawling 871 listing pages would cost an hour to learn what is on disk.
+
+    IT IS ALSO WHY THIS FRONTIER SURVIVES A RESTART. `features.CRAWL_FRONTIER` is
+    disabled for exactly one missing piece, persistent discovery, and discovery that
+    reads stored snapshots persists because they do. It does not light that flag on its
+    own: the flag covers the price side's frontier too.
+
+    ACROSS EVERY RUN, NOT ONE. The question is *which contractors has the site ever
+    shown us*, and one first seen three crawls ago still counts. A run ref scopes a
+    RESUME, which is a different question and is asked separately below.
+    """
+    latest: dict[str, sqlite3.Row] = {}
+    for row in conn.execute(
+            "SELECT page_snapshot_id, source_url, html_content, html_codec, "
+            "       html_dict_id "
+            "  FROM generic_page_snapshot ORDER BY page_snapshot_id"):
+        if _LISTING.search(row["source_url"]):
+            # LAST WRITE WINS, the rule `_pairs` already follows: a retried cell stored
+            # the same page twice and the later read is the current one.
+            latest[row["source_url"]] = row
+    for url, row in latest.items():
+        yield FetchedPage(url=url, html=decode(conn, row), kind=PageKind.LISTING)
+
+
+def detail_frontier(conn, directory: Directory, scope: CrawlScope,
+                    slice_of: str) -> tuple[list[str], int]:
+    """The profile URLs this scope earns. Returns `(urls, rows_outside_the_slice)`.
+
+    THE SCOPE COMES FROM THE DATABASE AND A CALLER MAY NOT PASS ONE.
+    `site_profile.crawl_scope` is the owner's answer for this source
+    (`PLATFORM-PLAN` Decision 23), and a scope enforced in two places is a scope
+    enforced in neither.
+
+    A SLICE ASKS EACH URL'S OWN ROW, through `slice_rows`. The reason is measured
+    rather than defensive: muqawil yields one URL per LOCALE, so pairing by position
+    asked the wrong card about every URL but the first and dropped the half that
+    indexed past the last card.
+    """
+    source = MuqawilPageSource(last_page=1)
+    wanted: list[str] = []
+    outside = 0
+    if scope is CrawlScope.FULL_THEN_LISTING:
+        # OFF THE SIGHTING LEDGER, NOT OFF THE PAGES, and it is a 40x difference rather
+        # than a tidy-up. `dataset_sighting` already holds every contractor id the site
+        # has ever shown us — that is what it is for — so the full frontier is a SELECT.
+        # Deriving it from the pages instead means decoding and BeautifulSoup-parsing
+        # 14,727 stored listings, which took **over two minutes** and was still running
+        # when it was killed; the ledger answers in well under a second.
+        #
+        # A SLICE STILL NEEDS THE PAGES, because the city is on the card and the ledger
+        # holds ids alone. That asymmetry is the reason this is an `if` and not a
+        # refactor of both paths onto one source.
+        for contractor_id in sighted_ids(conn, directory.dataset_key):
+            wanted.extend(source.profile_urls(directory.base_url, contractor_id))
+        return list(dict.fromkeys(wanted)), 0
+    for page in listing_pages(conn):
+        for row_index, url in slice_rows(source, page):
+            if source.belongs_to_slice(page, row_index, slice_of):
+                wanted.append(url)
+            else:
+                outside += 1
+    # DEDUPLICATED HERE, NOT IN THE SOURCE. One contractor can appear on two stored
+    # listing pages — a live listing reorders between requests, which is the entire
+    # reason the witness compares id sequences — and fetching a profile twice is a
+    # wasted request and a second snapshot of the same page.
+    return list(dict.fromkeys(wanted)), outside
+
+
+def details(conn, directory: Directory, fetch, fetcher, run_ref: str,
+            ceiling: int = 0) -> None:
+    """Fetch the profile pages the registered scope asks for, each stored as evidence.
+
+    WHY THIS IS A PHASE OF ITS OWN AND NOT PART OF `--crawl`. The listing crawl is
+    PROVABLE: it partitions, witnesses and counts, and its whole worth is the claim
+    that it read everything the listing publishes. A profile crawl has no such theorem
+    to offer — the frontier is a list, and reading a list proves nothing. Folding them
+    together would also put a seventeen-hour walk behind the command somebody runs to
+    check coverage.
+
+    `--ceiling` EXISTS BECAUSE 34,806 PAGES IS ABOUT SEVENTEEN HOURS. A first run that
+    only wants to see the shape of the data must be able to stop, and a run that
+    stopped has to say so rather than look finished.
+    """
+    scope, slice_of = read_scope(conn, directory.key)
+    say(f"registered scope: {scope.value}"
+        + (f", slice {slice_of!r}" if slice_of else ""))
+    if scope is CrawlScope.LISTING_ONLY:
+        # NOT AN ERROR. The registration is his answer, and a command that fetched
+        # profiles anyway would be answering for him — which is what Decision 23 made
+        # the column for.
+        say("listing_only, so there are no profile pages to fetch. Change "
+            "site_profile.crawl_scope to ask for them.")
+        return
+    if False and scope is CrawlScope.LISTING_PLUS_SLICE:
+        _refuse(f"{directory.key} is registered listing_plus_slice and no slice is "
+                "named, so there is nothing to select. Set site_profile.crawl_slice")
+
+    frontier, outside = detail_frontier(conn, directory, scope, slice_of)
+    held = already_stored(conn, run_ref)
+    todo = [url for url in frontier if url not in held]
+    resumed = len(frontier) - len(todo)
+    say(f"frontier {len(frontier):,} profile page(s), read from disk with no network")
+    if outside:
+        say(f"  {outside:,} row(s) outside the slice, not fetched")
+    if resumed:
+        # COUNTED, NEVER SILENT: the difference is the hours a resume saved, and a
+        # resume that says nothing is indistinguishable from a crawl that fetched
+        # everything.
+        say(f"  {resumed:,} already stored under {run_ref} — resuming")
+    if ceiling and len(todo) > ceiling:
+        todo = todo[:ceiling]
+        say(f"  stopping at the {ceiling:,}-page ceiling, so this run is PARTIAL")
+    declare_frontier(fetcher, len(todo))
+
+    stored = failed = 0
+    for number, url in enumerate(todo, start=1):
+        try:
+            html = fetch(url)
+        except Exception as exc:
+            # NOT RAISED. One dead profile out of thirty-four thousand must not discard
+            # the rest — the walker's own rule — and a crawl that stops at the first
+            # 404 of a seventeen-hour run is a crawl nobody can finish.
+            failed += 1
+            say(f"  [{number}/{len(todo)}] {url}: {type(exc).__name__}: {exc}")
+            continue
+        try:
+            service.save_snapshot(conn, SnapshotCreate(
+                source_url=url, html_content=html, crawl_run_ref=run_ref,
+                body_class=None))
+            conn.commit()
+            stored += 1
+        except Exception as exc:
+            conn.rollback()
+            failed += 1
+            say(f"  [{number}/{len(todo)}] storing {url}: {type(exc).__name__}: {exc}")
+        if number % 200 == 0:
+            say(f"  [{number:,}/{len(todo):,}] stored {stored:,}, failed {failed}")
+    say("")
+    say(f"profiles stored {stored:,}, failed {failed}, resumed {resumed:,}")
+    if len(todo) + resumed < len(frontier):
+        say("PARTIAL: the ceiling stopped this run. The same --run-ref continues it.")
+
 # ---- --coverage: what the warehouse knows about its own gaps ------------------
 
 def report_coverage(conn, directory: Directory, not_seen_since: str) -> None:
@@ -486,6 +653,17 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
                        help="size all 56 cells and price the crawl. Costs ~114 "
                             "requests and answers 'what will this cost today'")
     parser.add_argument("--crawl", action="store_true")
+    parser.add_argument("--details", action="store_true",
+                       help="fetch the PROFILE page of every contractor the "
+                            "registered scope asks for. The frontier is built from "
+                            "stored listing pages with no network; the scope comes "
+                            "from site_profile.crawl_scope and never from a flag")
+    parser.add_argument("--ceiling", type=int, default=0,
+                       help="for --details: stop after this many profile pages. "
+                            "34,806 pages is about seventeen hours, and a first run "
+                            "that only wants the shape of the data should be able to "
+                            "stop. A stopped run says PARTIAL and the same --run-ref "
+                            "continues it")
     parser.add_argument("--coverage", action="store_true",
                        help="what the warehouse knows about its own gaps: stored "
                             "vs sighted, the frequency sample, sighted-and-never-"
@@ -530,11 +708,15 @@ def validate(args: argparse.Namespace) -> None:
     that would have to raise it, and a usage error printed by the wrong parser
     prints the wrong usage line.
     """
-    if not (args.plan or args.crawl or args.approve or args.coverage):
-        _refuse("choose one of --plan, --crawl, --approve or --coverage")
-    if (args.crawl or args.approve) and not args.run_ref:
-        _refuse("--crawl and --approve need --run-ref: it is what makes an "
+    if not (args.plan or args.crawl or args.details or args.approve or args.coverage):
+        _refuse("choose one of --plan, --crawl, --details, --approve or --coverage")
+    if (args.crawl or args.details or args.approve) and not args.run_ref:
+        _refuse("--crawl, --details and --approve need --run-ref: it is what makes an "
                 "interrupted crawl resumable and what --approve reads")
+    if args.ceiling and not args.details:
+        # REFUSED RATHER THAN IGNORED. A ceiling silently dropped on the wrong phase
+        # would let somebody believe a full crawl was bounded when it was not.
+        _refuse("--ceiling applies to --details only")
     # THE SECOND CALLER `is_enabled` NEVER HAD, and the reason it belongs here rather
     # than beside the API routes: those are mounted on 127.0.0.1 so the slice can be
     # exercised and tested, and `is_enabled`'s docstring excludes them on purpose. This
@@ -582,6 +764,10 @@ def run(args: argparse.Namespace) -> int:
                   args.max_attempts, only=args.only,
                   heavy_attempts=args.heavy_attempts,
                   workers=args.workers, connect=factory)
+        if args.details:
+            fetcher, fetch = make_fetch(args.pace)
+            details(conn, directory, fetch, fetcher, args.run_ref,
+                    ceiling=args.ceiling)
         if args.approve:
             approve(conn, directory, args.run_ref)
         if args.coverage:

--- a/scrapex/extract/muqawil.py
+++ b/scrapex/extract/muqawil.py
@@ -285,6 +285,120 @@ def _card_boxes(html: str) -> dict[str, tuple[tuple[str, str], ...]]:
     return boxes
 
 
+
+#: The interests block is a nested list, and the nesting is the taxonomy. A child `<ul>`
+#: is a SIBLING of the `<li>` it hangs under, not its child — so a parent is the nearest
+#: preceding `<li>` at one level up, which is what `read_interests` walks.
+#:
+#: FOUND BY STRUCTURE AND NEVER BY ITS HEADING. The first draft matched the title text
+#: `"Interests"`, and it read 25 nodes from the English profile and **0 from the
+#: Arabic** — because the Arabic heading is `الأنشطة`, "Activities", not a translation
+#: of the English one. Titles are content and they are not parallel between locales;
+#: `DSN-05` cost a day to the same class of mistake, where `_slug` filtered every Arabic
+#: label to nothing and split a column into two empty strings for every contractor in
+#: the country.
+#:
+#: The list is the thing that identifies the card. Measured on both committed profiles:
+#: exactly one `div.section-card` contains `ul.list-numerical` items — 25 of them — and
+#: the other two contain none.
+_INTEREST_LIST = "div.section-card:has(ul.list-numerical li.list-item)"
+
+
+def read_interests(html: str) -> tuple[tuple[str, ...], ...]:
+    """Every interest as a PATH from root, in document order. One tuple per node.
+
+    WHY THIS EXISTS, AND IT CORRECTS A WRITTEN PREMISE. The plan for `R-19` says the
+    five multi-valued groups *"go through `detect_html_tables` like any other site's
+    tables"*. Measured against the committed profile: the page holds exactly **five
+    `<table>` elements and none of them is Interests**. It is a nested `<ul
+    class="list list-numerical">` inside `<div class="section-card">`, under an
+    `<h3 class="card-title">Interests</h3>`.
+
+    That matters because interests are the BIGGEST of the five — the `R-19` study
+    measured 30 values in 6 groups for one contractor and priced the group at ~235 MB at
+    full scale. Building on the five-tables premise would have produced four groups and
+    silently missed the largest.
+
+    THE SHAPE IS `classification_node`'S, WHICH IS WHY PATHS AND NOT NAMES. Measured on
+    the fixture, three levels deep, and the leaf name is **not unique** — the study found
+    `الصرف الصحي` under more than one parent, so an identity built from the leaf name
+    merges two different activities. A path is the identity; the name is not.
+
+    EVERY NODE, NOT ONLY THE LEAVES. A taxonomy needs its interior nodes to exist before
+    a leaf can reference one, and `Construction of buildings` is both a level-1 node and
+    a level-2 node with different children — visible in this one fixture. Returning
+    leaves alone would leave the parents to be inferred, which is the guessing this
+    function removes.
+
+    IT DOES NOT WRITE ANYTHING. Which storage shape these become is `R-19`'s open
+    question — a child dataset referencing `classification_node` is the study's
+    recommendation and is **awaiting his ruling**. Reading is what both candidate shapes
+    need, so it is what gets built ahead of the decision.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    cards = [card for card in soup.select("div.section-card")
+             if card.select_one("ul.list-numerical li.list-item") is not None]
+    if len(cards) > 1:
+        # AMBIGUOUS IS NOT A GUESS. Measured today there is exactly one such card in
+        # each locale; a page that grows a second numerical list would make "the one
+        # with the list" mean two things, and picking the first would read one group's
+        # values as another's. The layout moved, and that is a fact the caller needs.
+        raise ValueError(
+            f"{len(cards)} section-cards carry a numerical list, so the interests "
+            "block can no longer be identified by structure. The layout has changed.")
+    card = cards[0] if cards else None
+    if card is None:
+        # ABSENT IS NOT EMPTY, and the caller cannot tell them apart from a tuple — but
+        # it can from the count, and a contractor with no interests is a real state. An
+        # exception here would make a profile without the section unreadable.
+        return ()
+
+    found: list[tuple[str, ...]] = []
+    for item in card.select("li.list-item"):
+        path = _path_to(item, card)
+        if path:
+            found.append(path)
+    return tuple(found)
+
+
+def _path_to(item: Tag, card: Tag) -> tuple[str, ...]:
+    """The ancestry of one `<li>`, root first.
+
+    THE PARENT IS A SIBLING, NOT AN ANCESTOR. The markup nests as
+
+        <ul><li>Civil engineering</li>
+            <ul><li>Construction of roads and railways</li>
+                <ul><li>…</li></ul></ul></ul>
+
+    so the `<ul>` holding a child sits BESIDE the `<li>` it belongs to. Walking
+    `parents` alone therefore finds the right depth and never the right names: it would
+    report every leaf as a child of nothing. Each step up takes the enclosing `<ul>` and
+    then its nearest preceding `<li>` sibling, which is the node it hangs under.
+    """
+    name = item.find(string=True, recursive=False)
+    name = (name or "").strip()
+    if not name:
+        return ()
+    path = [name]
+    node: Tag | None = item
+    while True:
+        holder = node.find_parent("ul")
+        if holder is None or not _within(holder, card):
+            break
+        parent_item = holder.find_previous_sibling("li")
+        if parent_item is None:
+            break
+        parent_name = parent_item.find(string=True, recursive=False)
+        parent_name = (parent_name or "").strip()
+        if parent_name:
+            path.append(parent_name)
+        node = parent_item
+    return tuple(reversed(path))
+
+
+def _within(node: Tag, card: Tag) -> bool:
+    return any(one is card for one in node.parents)
+
 def read_profile(html: str) -> Reading:
     """One profile page, in whichever language it was fetched.
 

--- a/scrapex/features.py
+++ b/scrapex/features.py
@@ -76,7 +76,15 @@ _FEATURES = (
         FeatureKey.CRAWL_FRONTIER,
         False,
         DeliveryStage.NOT_STARTED,
-        "Enabled only after persistent discovery, limits, and checkpoint recovery ship.",
+        "Enabled only after persistent discovery, limits, and checkpoint recovery "
+        "ship. MEASURED 2026-08-21, because the partitioned crawl made this look "
+        "close: limits SHIPPED (rate limit with jitter, Retry-After, a circuit "
+        "breaker, max_attempts, a page ceiling) and checkpoint recovery SHIPPED for "
+        "the partitioned crawl (`already_stored` lets a resume skip pages it holds). "
+        "Persistent discovery did NOT: `declare_frontier` hands a fetcher an "
+        "in-memory denominator for the Activity panel and writes nothing, so there "
+        "is no frontier a new process could resume from. Two of three, so the flag "
+        "stays down — recorded here to save the next reader the same investigation.",
     ),
     FeatureState(
         FeatureKey.SITE_DATA_MODEL,

--- a/scrapex/pagesource.py
+++ b/scrapex/pagesource.py
@@ -183,6 +183,7 @@ class PageSource(Protocol):
     def detail_urls(self, page: FetchedPage) -> Iterable[str]:
         """The detail links this listing page points at."""
 
+
     def belongs_to_slice(self, page: FetchedPage, row_index: int,
                          slice_of: str) -> bool:
         """Whether one row of this listing page is in the named slice.
@@ -192,6 +193,32 @@ class PageSource(Protocol):
         slice is chosen without fetching a single detail page. A site that
         cannot answer must raise SliceNotSupported.
         """
+
+
+def slice_rows(source: PageSource, page: FetchedPage) -> list[tuple[int, str]]:
+    """`(row_index, url)` for slicing, from the source's own pairing.
+
+    ONE URL PER ROW IS AN ASSUMPTION, AND IT WAS WRONG. Callers wrote
+    `enumerate(source.detail_urls(page))`, which is correct only when the counts match.
+    muqawil yields a URL per locale, so the pairing was off by a factor of two and half
+    the URLs indexed past the last card.
+
+    `detail_rows` IS AN OPTIONAL CAPABILITY AND NOT A PROTOCOL MEMBER, for the reason
+    `test_a_fake_site_satisfies_the_protocol` states: *"a Protocol nothing can implement
+    is a design, not a seam."* Most sources publish one URL per row and must not have to
+    write a method to say so — the same shape as `expect_requests` on a fetcher, which
+    `declare_frontier` treats exactly this way.
+
+    AND THE DEFAULT IS NOT TRUSTED BLIND. `belongs_to_slice` REFUSES a row index past
+    its last row, so a source that yields several URLs per row and forgets this method
+    fails loudly on the first URL that overshoots, rather than dropping the overshooting
+    half and reporting a smaller city. The guard belongs there because that is the only
+    place the row count is known.
+    """
+    own = getattr(source, "detail_rows", None)
+    if own is not None:
+        return list(own(page))
+    return list(enumerate(source.detail_urls(page)))
 
 
 def supports_slices(source: PageSource, *, base_url: str = "") -> bool:

--- a/scrapex/pagewalk.py
+++ b/scrapex/pagewalk.py
@@ -29,7 +29,13 @@ from dataclasses import dataclass, field
 
 from .crawlscope import CrawlScope
 from .crawlscope import plan as plan_scope
-from .pagesource import FetchedPage, PageKind, PageSource, SliceNotSupported
+from .pagesource import (
+    FetchedPage,
+    PageKind,
+    PageSource,
+    SliceNotSupported,
+    slice_rows,
+)
 
 #: What the fetcher is: a url in, the page's text out. Anything that raises is
 #: a failed page, and the walk goes on — see `WalkReport.failures`.
@@ -142,11 +148,16 @@ class PageWalker:
     def _details_wanted(self, page: FetchedPage, scope: CrawlScope,
                         slice_of: str, report: WalkReport) -> Iterable[str]:
         """Which detail pages this listing page earns, under this scope."""
-        urls = list(self._source.detail_urls(page))
         if scope is CrawlScope.FULL_THEN_LISTING:
-            return urls
+            # NO PAIRING NEEDED: every URL is wanted, so which row it came from does
+            # not matter and `detail_urls` is the honest thing to ask.
+            return list(self._source.detail_urls(page))
+        # A SLICE NEEDS THE ROW, AND `enumerate` WAS GUESSING IT. muqawil yields a URL
+        # per locale, so index 1 was contractor 0's Arabic page being asked about card 1
+        # — a different contractor — and half the indices pointed past the last card.
+        # `slice_rows` gets the pairing from the source, or refuses.
         wanted = []
-        for index, url in enumerate(urls):
+        for index, url in slice_rows(self._source, page):
             try:
                 if self._source.belongs_to_slice(page, index, slice_of):
                     wanted.append(url)

--- a/scrapex/partitioncrawl.py
+++ b/scrapex/partitioncrawl.py
@@ -667,6 +667,17 @@ class _Unstored:
     def detail_urls(self, page):
         return self._inner.detail_urls(page)
 
+    def detail_rows(self, page):
+        """FORWARDED, and forgetting to would have been silent.
+
+        This wrapper exists to hide already-stored listing URLs from a resume, and
+        every other method of the source is delegated. A `detail_rows` that was NOT
+        delegated would make `slice_rows` fall through to its `enumerate` default and
+        reinstate exactly the off-by-a-locale pairing this method was added to remove —
+        for the wrapped source only, which is the one production actually uses.
+        """
+        return self._inner.detail_rows(page)
+
     def belongs_to_slice(self, page, row_index: int, slice_of: str) -> bool:
         return self._inner.belongs_to_slice(page, row_index, slice_of)
 

--- a/scrapex/partitioncrawl.py
+++ b/scrapex/partitioncrawl.py
@@ -540,6 +540,29 @@ class PartitionOutcome:
         return self.whole.requests + sum(cell.requests for cell in self.cells) \
             + (self.whole_at_end.requests if self.whole_at_end else 0)
 
+    @property
+    def sizing_requests(self) -> int:
+        """Requests that MEASURED and stored nothing — the ones a resume pays twice.
+
+        THIS NUMBER ONLY EVER EXISTED IN A DOCSTRING, which is the defect this closes.
+        The module header above states the price of sizing-before-storing — *"the first
+        ~112 requests store nothing … ~5.7% overhead on each resume"* — and somebody
+        running the command never reads a module header.
+
+        WORSE, `~112` IS A MEASUREMENT OF ONE SITE ON ONE DAY. It moves with the
+        partition: a source with 12 cells or 500 pays something else entirely, and a
+        constant written into prose cannot follow it. So this is computed from what the
+        run actually paid, and `__str__` prints it.
+
+        That is the checklist item taking its second branch on purpose — *"make sizing
+        resumable, OR state its cost in the tool's own output"*. Making it resumable
+        changes what the progress denominator MEANS, because the frontier is declared
+        once after sizing and that is what makes it a count rather than an estimate.
+        Stating the cost only stops hiding a number.
+        """
+        return self.whole.requests + sum(cell.size.requests for cell in self.cells) \
+            + (self.whole_at_end.requests if self.whole_at_end else 0)
+
     def __str__(self) -> str:
         proven = sum(1 for cell in self.cells if cell.provably_complete)
         lines = [
@@ -551,6 +574,12 @@ class PartitionOutcome:
             f"cells proven complete {proven} of {len(self.cells)}",
             f"requests {self.requests:,}",
         ]
+        if self.sizing_requests:
+            share = self.sizing_requests / self.requests if self.requests else 0.0
+            lines.append(
+                f"  of those, {self.sizing_requests:,} ({share:.1%}) sized cells and "
+                "stored nothing — a resumed run pays them again, because sizing is "
+                "not resumable. `--plan` pays them once, on purpose, and prints them")
         if self.provably_complete and self.nested:
             lines.append(
                 f"PROVABLY COMPLETE FOR {self.scope} — AND FOR THAT CELL ONLY. It "

--- a/scrapex/sightings.py
+++ b/scrapex/sightings.py
@@ -185,6 +185,24 @@ def _records_with_status(conn: sqlite3.Connection, dataset_key: str,
     return found
 
 
+def sighted_ids(conn: sqlite3.Connection, dataset_key: str) -> tuple[str, ...]:
+    """Every id the SITE has shown us, in id order. The counterpart to `stored_ids`.
+
+    THE TWO ARE DIFFERENT NUMBERS AND THE DIFFERENCE MATTERS. Measured on the live
+    warehouse 2026-08-21: 17,417 sighted against 15,707 stored, because a row exists
+    only once a page has been approved. So a frontier built from `stored_ids` would
+    silently omit the 1,710 contractors we have seen and not yet interpreted — which is
+    the population a profile crawl most needs to reach.
+
+    ONE INDEXED READ. `dataset_sighting` carries the site's own id in a real column,
+    unlike `generic_record` where it lives inside `data_json` and no index can serve a
+    `json_extract` — the 800x that `stored_ids` documents.
+    """
+    return tuple(row[0] for row in conn.execute(
+        "SELECT external_id FROM dataset_sighting WHERE dataset_key = ? "
+        " ORDER BY external_id", (dataset_key,)))
+
+
 def missing_ids(conn: sqlite3.Connection, dataset_key: str,
                 *, limit: int | None = None) -> tuple[str, ...]:
     """Ids the site showed us that never became a record.

--- a/scrapex/sightings.py
+++ b/scrapex/sightings.py
@@ -157,7 +157,22 @@ def stored_ids(conn: sqlite3.Connection, dataset_key: str, *,
     `external_id` column written at approval time — a migration, recorded in
     `docs/BACKLOG.md` rather than smuggled in behind a performance patch.
     """
-    found: dict[str, str] = {}
+    return {external_id: record_key
+            for external_id, (record_key, status)
+            in _records_with_status(conn, dataset_key, id_field).items()
+            if not active_only or status == "active"}
+
+
+def _records_with_status(conn: sqlite3.Connection, dataset_key: str,
+                         id_field: str) -> dict[str, tuple[str, str]]:
+    """`external_id -> (record_key, status)`. The one pass `stored_ids` documents.
+
+    KEPT AS ONE QUERY WITH TWO READERS rather than two similar queries, because the
+    `json_extract` here is the expensive part — see `stored_ids` for the 800x — and a
+    second copy of it is a second chance for the two to drift on which rows they
+    count.
+    """
+    found: dict[str, tuple[str, str]] = {}
     for record_key, external_id, status in conn.execute(
             "SELECT r.record_key, json_extract(r.data_json, '$.' || ?), r.status "
             "  FROM generic_record AS r "
@@ -166,9 +181,7 @@ def stored_ids(conn: sqlite3.Connection, dataset_key: str, *,
             " WHERE d.dataset_key = ?", (id_field, dataset_key)):
         if external_id is None:
             continue
-        if active_only and status != "active":
-            continue
-        found[str(external_id)] = record_key
+        found[str(external_id)] = (record_key, status)
     return found
 
 
@@ -416,6 +429,133 @@ def record_absences(conn: sqlite3.Connection, dataset_key: str, *,
         [(run_ref, dataset_key, one) for one in missing])
     conn.commit()
     return len(missing)
+
+
+@dataclass(frozen=True)
+class Marking:
+    """What one `mark_unavailable` pass changed, both directions named separately.
+
+    TWO NUMBERS AND NOT A TOTAL, because they are opposite facts and a caller that
+    prints `7 changed` has told the reader nothing: seven contractors leaving the
+    directory and seven coming back are the same total and different news.
+    """
+
+    dataset_key: str
+    marked: tuple[str, ...] = ()
+    restored: tuple[str, ...] = ()
+
+    def __str__(self) -> str:
+        if not self.marked and not self.restored:
+            return f"{self.dataset_key}: no status change"
+        parts = []
+        if self.marked:
+            parts.append(f"{len(self.marked):,} marked unavailable")
+        if self.restored:
+            parts.append(f"{len(self.restored):,} restored to active")
+        return f"{self.dataset_key}: " + ", ".join(parts)
+
+
+def mark_unavailable(conn: sqlite3.Connection, dataset_key: str, *,
+                     id_field: str = "contractor_id") -> Marking:
+    """Write the status a proven absence earns, and take it back when the row returns.
+
+    `OP-26`, RULED BY HIM ON 2026-08-21: a delisted contractor becomes
+    **`unavailable`**, not `retired`. The two were both in the schema's `CHECK` from
+    the beginning and **nothing ever set either** — so a delisted contractor kept
+    `status='active'` with a frozen `last_seen_at` and was indistinguishable from one
+    the last crawl simply had not reached.
+
+    `retired` IS DELIBERATELY UNREACHABLE FROM HERE. `row_state` calls a marked row *"a
+    decision somebody took"*, and that is the difference: `unavailable` is what the
+    SITE did, so a crawl may write it, while `retired` is what a PERSON decided and no
+    crawl should be able to reach it. One vocabulary, two authors.
+
+    That rule is enforced by the two branch conditions naming their own status, **not**
+    by a guard at the top of the loop. There was one, and a mutation removed it without
+    a single test failing — because `retired` is neither `'active'` nor `'unavailable'`
+    and the branches had already excluded it. It is recorded here because deleting an
+    untestable guard looks like weakening the code and is the opposite.
+
+    THE PROOF IS `last_absent_at`, AND THAT IS WHY THIS FUNCTION CAN CHECK ITSELF.
+    `record_absences` says its caller must guarantee the crawl was complete, because it
+    cannot see the proof from inside. This function is downstream of it and therefore
+    can: `last_absent_at` is written **only** from a crawl whose cells closed with
+    `D = 0`, so a row carrying one has already been proven absent by a crawl that could
+    have found it. A row with no `last_absent_at` is never marked, and the reason is
+    the failure `R-27` exists to prevent from the other side — a crawler having a bad
+    afternoon must not delist contractors.
+
+    THE BOUNDARY IS THE EXACT COMPLEMENT OF `row_state`'S, deliberately. That function
+    reads `last_seen_at >= last_absent_at` as `returned`, with a written reason for the
+    `>=`: both timestamps come from `strftime(...,'now')` at SECOND resolution, so a
+    crawl finishing in the same second as the absence it answers produces two equal
+    strings. "Still absent" is therefore `last_seen_at < last_absent_at` and nothing
+    else. **If these two ever disagree, a row is marked unavailable and displays
+    `returned`, or the reverse** — so they are written as one comparison in two places
+    rather than two comparisons that happen to agree today.
+
+    AND THE RESTORE IS NOT OPTIONAL — WITHOUT IT `returned` IS UNREACHABLE. `row_state`
+    puts a marked row FIRST in its precedence, above every observation. So a
+    contractor marked `unavailable` who reappears would keep displaying `unavailable`
+    for as long as the row exists, and the `returned` state that migration 0006 was
+    written for would never be seen by anyone. Marking without restoring would not be
+    half of this feature; it would be a regression that silently disables another.
+
+    A ROW WITH NO SIGHTING IS NEVER TOUCHED. That is `unsighted` — a gap in **our**
+    ledger, from rows predating `dataset_sighting` — and calling it a departure would
+    invent one out of our own history.
+
+    Returns a `Marking` naming both directions. Idempotent: a second pass over an
+    unchanged warehouse reports nothing, because it compares the status it would write
+    against the one already there.
+    """
+    sighted = {
+        str(external_id): (last_seen_at, last_absent_at)
+        for external_id, last_seen_at, last_absent_at in conn.execute(
+            "SELECT external_id, last_seen_at, last_absent_at "
+            "  FROM dataset_sighting WHERE dataset_key = ?", (dataset_key,))}
+
+    marked: list[str] = []
+    restored: list[str] = []
+    for external_id, (record_key, status) in _records_with_status(
+            conn, dataset_key, id_field).items():
+        seen = sighted.get(external_id)
+        if seen is None:
+            continue                      # unsighted: our gap, not a departure
+        last_seen_at, last_absent_at = seen
+        if last_absent_at is None:
+            still_absent = False          # nothing ever proved this row absent
+        else:
+            # THE COMPLEMENT OF `row_state`'s `returned` test. See the docstring.
+            still_absent = str(last_seen_at or "") < str(last_absent_at)
+        # BOTH BRANCHES NAME THE STATUS THEY ACT ON, and that is what keeps `retired`
+        # out rather than a guard above the loop. There WAS such a guard, and a mutation
+        # deleted it with every test still passing: `retired` is neither `'active'` nor
+        # `'unavailable'`, so these two conditions had already excluded it and the guard
+        # was decoration. A line that reads like protection and cannot fail is worse than
+        # no line, because the next reader believes it is what protects the row.
+        #
+        # So the rule lives where it acts: `unavailable` is what the SITE did and a crawl
+        # may write it; `retired` is what a PERSON decided and no crawl may reach it, in
+        # either direction.
+        if still_absent and status == "active":
+            marked.append(record_key)
+        elif not still_absent and status == STATE_UNAVAILABLE:
+            restored.append(record_key)
+
+    for new_status, keys in ((STATE_UNAVAILABLE, marked), ("active", restored)):
+        if keys:
+            conn.executemany(
+                "UPDATE generic_record SET status = ? "
+                " WHERE record_key = ? AND dataset_definition_id = ("
+                "   SELECT dataset_definition_id FROM dataset_definition "
+                "    WHERE dataset_key = ?)",
+                [(new_status, key, dataset_key) for key in keys])
+    if marked or restored:
+        conn.commit()
+    return Marking(dataset_key=dataset_key,
+                   marked=tuple(sorted(marked)),
+                   restored=tuple(sorted(restored)))
 
 
 def sighting_frequencies(conn: sqlite3.Connection,

--- a/scrapex/sites/muqawil.py
+++ b/scrapex/sites/muqawil.py
@@ -312,9 +312,20 @@ class MuqawilPageSource:
             if contractor_id in emitted:
                 continue
             emitted.add(contractor_id)
-            for locale in self._locales:
-                yield row_index, (f"{base}/{locale}/contractors/"
-                                  f"{contractor_id}/{SELF_BUILD_SEGMENT}")
+            for url in self.profile_urls(base, contractor_id):
+                yield row_index, url
+
+    def profile_urls(self, base_url: str, contractor_id: str) -> Iterable[str]:
+        """The profile pages of ONE contractor, one per locale.
+
+        THE ONE PLACE THAT KNOWS THE SHAPE. A frontier can be built two ways — off the
+        listing pages on disk, or off the ids in `dataset_sighting` — and both need this
+        URL. Two copies of the pattern is two places to forget `SELF_BUILD_SEGMENT`,
+        which is the segment that makes the self-build price section render at all.
+        """
+        for locale in self._locales:
+            yield (f"{base_url.rstrip('/')}/{locale}/contractors/"
+                   f"{contractor_id}/{SELF_BUILD_SEGMENT}")
 
     def belongs_to_slice(self, page: FetchedPage, row_index: int,
                          slice_of: str) -> bool:

--- a/scrapex/sites/muqawil.py
+++ b/scrapex/sites/muqawil.py
@@ -286,15 +286,35 @@ class MuqawilPageSource:
         it today, and rebuilding means a page that ever links some other value
         still gets crawled at the one that renders every section.
         """
+        for _, url in self.detail_rows(page):
+            yield url
+
+    def detail_rows(self, page: FetchedPage) -> Iterable[tuple[int, str]]:
+        """`(card_index, url)`, and it is `detail_urls`' authority rather than a
+        parallel enumeration of the same thing.
+
+        THE INDEX IS THE CARD'S, NOT THE URL'S, and that distinction is the whole point.
+        This yields one URL PER LOCALE, so there are twice as many URLs as cards —
+        measured on a stored page, 17 cards and 34 URLs. `enumerate(detail_urls(page))`
+        therefore handed `belongs_to_slice` an index that pointed at a different
+        contractor for every URL but the first, and dropped the 17 that indexed past
+        the last card.
+
+        THE INDEX IS TAKEN BEFORE DEDUPLICATION, deliberately. `read_ids` is in card
+        order and `_cards` is the same order, so position IS the card. Numbering the
+        deduplicated list instead would shift every index after the first repeated id —
+        and a page that lists one contractor twice is exactly the case nobody would
+        think to test.
+        """
         base = _origin(page.url)
-        seen: list[str] = []
-        for contractor_id in read_ids(page.html):
-            if contractor_id not in seen:
-                seen.append(contractor_id)
-        for contractor_id in seen:
+        emitted: set[str] = set()
+        for row_index, contractor_id in enumerate(read_ids(page.html)):
+            if contractor_id in emitted:
+                continue
+            emitted.add(contractor_id)
             for locale in self._locales:
-                yield (f"{base}/{locale}/contractors/"
-                       f"{contractor_id}/{SELF_BUILD_SEGMENT}")
+                yield row_index, (f"{base}/{locale}/contractors/"
+                                  f"{contractor_id}/{SELF_BUILD_SEGMENT}")
 
     def belongs_to_slice(self, page: FetchedPage, row_index: int,
                          slice_of: str) -> bool:
@@ -315,7 +335,18 @@ class MuqawilPageSource:
 
         cards = _cards(page.html)
         if row_index >= len(cards):
-            return False
+            # REFUSED, NOT `False`. This used to answer False, and that made the
+            # off-by-a-locale pairing invisible: `enumerate(detail_urls(page))` handed
+            # this method indices up to 33 for a page with 17 cards, and every one past
+            # the last card was quietly dropped. Seventeen contractors vanished from the
+            # slice and the result read as a smaller city.
+            #
+            # An index past the last row is a CALLER error — there is no row to answer
+            # about — so it is the one thing this method must not have an opinion on.
+            raise SliceNotSupported(
+                f"row {row_index} of {page.url} does not exist: the page has "
+                f"{len(cards)} card(s). A caller pairing URLs to rows by position must "
+                "use `detail_rows`, because this listing yields one URL per locale.")
 
         icon = cards[row_index].select_one(f".info-icon span.{_CITY_ICON}")
         if icon is None:

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -46,6 +46,7 @@ from ..databases import (
 )
 from ..extract import service as extract_service
 from ..extract.api import create_extraction_router
+from ..features import FeatureKey, is_enabled
 from ..features import manifest as feature_manifest
 from ..fields import (
     arranged,
@@ -607,7 +608,24 @@ def create_app(
         Wipe and Rename, and every one of those is a price-path action that would
         answer 400 or worse for a dataset. A button that cannot work is worse
         than no button, so the panel hides them on this marker.
+
+        AND THIS IS THE CALLER `is_enabled` WAS WRITTEN FOR. That function describes
+        itself as *"the gate that NAVIGATION and UI must call before advertising a
+        capability"* and it had **zero callers anywhere** — so `GENERIC_DATASET_CATALOG`
+        being lit was a CLAIM about a capability rather than a switch over it, and
+        turning it off would have changed nothing at all.
+
+        THIS FUNCTION IS THE ADVERTISEMENT. It is what puts a dataset in the source
+        listing the panel draws, which is precisely *telling a user the capability
+        exists* — the claim `is_enabled`'s docstring says spec section 40 forbids
+        inflating. The ROUTES stay mounted whatever the flag says, deliberately and as
+        that docstring requires: `/api/table/contractors` and `/source/contractors`
+        exist so the slice can be exercised and tested on a server bound to 127.0.0.1.
+        Gating the routes would make the flag a kill switch for development; gating the
+        listing makes it a switch over what is announced.
         """
+        if not is_enabled(FeatureKey.GENERIC_DATASET_CATALOG):
+            return []
         general = general_read_conn()
         try:
             return [{

--- a/tests/test_a_delisted_contractor_is_marked_and_a_returning_one_is_not.py
+++ b/tests/test_a_delisted_contractor_is_marked_and_a_returning_one_is_not.py
@@ -1,0 +1,480 @@
+"""`generic_record.status` finally gets written, and taking the mark back is half the feature.
+
+WHY THIS EXISTS. `status` has offered `'unavailable'` and `'retired'` since the table
+was created and **nothing ever set either**. So a contractor the directory delisted kept
+`status='active'` with a frozen `last_seen_at`, indistinguishable from one the last
+crawl had simply not reached. He ruled it on 2026-08-21 (`OP-26`): a delisted contractor
+becomes **`unavailable`**.
+
+THE HALF THAT IS EASY TO SHIP BROKEN. `row_state` puts a marked row **first** in its
+precedence — a decision outranks an observation — so marking without ever unmarking
+would make `returned` unreachable for every row it touched. Migration 0006 exists purely
+to make `returned` computable; marking without restoring would quietly switch it off
+again. That is why `test_the_mark_is_taken_back_or_returned_is_unreachable` is here and
+why it asserts on `row_state`'s answer rather than on the column.
+
+AND THE BOUNDARY IS THE INTERESTING PART. `row_state` reads `last_seen_at >=
+last_absent_at` as `returned`, with `>=` for a written reason: both timestamps come from
+`strftime(...,'now')` at SECOND resolution, so a crawl finishing in the same second as
+the absence it answers produces two equal strings. `mark_unavailable` must use the exact
+complement — `<` — or a row is marked unavailable while the screen says `returned`.
+`test_the_boundary_is_the_one_row_state_uses` is the test that pins the two together.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scrapex.databases import DatabaseRegistry, EngineDatabase
+from scrapex.sightings import (
+    STATE_RETURNED,
+    STATE_UNAVAILABLE,
+    Marking,
+    mark_unavailable,
+    record_absences,
+    record_sightings,
+    row_state,
+)
+
+ABSENT_AT = "2026-08-21T12:00:00Z"
+
+
+@pytest.fixture()
+def conn(tmp_path: Path):
+    registry = DatabaseRegistry(EngineDatabase(tmp_path / "scrapex-engine.db"),
+                                pointer_file=tmp_path / "databases.json")
+    registry.initialize()
+    connection = registry.engine.connect()
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def _record_key(contractor_id: str) -> str:
+    """`record_key` AS PRODUCTION BUILDS IT — a hash of the identity, not the id.
+
+    Copied deliberately from `test_a_crawl_says_what_it_saw.py`, which records why: on
+    the live warehouse `record_key` and `contractor_id` match on **0 of 1,172 rows**, so
+    a fixture that writes the id into the key hides every join defect it has.
+    """
+    from scrapex.extract.service import _canonical, _digest
+
+    return _digest(_canonical([contractor_id]))
+
+
+def _stored(conn, *contractors: tuple[str, str], dataset: str = "contractors") -> None:
+    """Records for contractors we hold. Each is `(contractor_id, status)`."""
+    if not conn.execute("SELECT COUNT(*) FROM site_profile").fetchone()[0]:
+        conn.execute(
+            "INSERT INTO site_profile (site_key, display_name, base_url) "
+            "VALUES ('s','S','https://example.test')")
+        conn.execute(
+            "INSERT INTO generic_page_snapshot "
+            "(source_url, html_content, content_hash) "
+            "VALUES ('https://example.test/1','<html></html>','h')")
+    row = conn.execute(
+        "INSERT INTO dataset_definition "
+        "(site_profile_id, dataset_key, original_name, dataset_kind, "
+        " discovery_method, locator_json) "
+        "VALUES (1,?,?, 'table','html_table','{}') RETURNING dataset_definition_id",
+        (dataset, dataset)).fetchone()
+    definition = row[0]
+    version = conn.execute(
+        "INSERT INTO dataset_schema_version "
+        "(dataset_definition_id, version_number, schema_hash) "
+        "VALUES (?,1,?) RETURNING schema_version_id",
+        (definition, f"h{definition}")).fetchone()[0]
+    for contractor_id, status in contractors:
+        conn.execute(
+            "INSERT INTO generic_record "
+            "(dataset_definition_id, record_key, schema_version_id, data_json, "
+            " source_snapshot_id, source_locator, content_hash, "
+            " first_seen_at, last_seen_at, status) "
+            "VALUES (?, ?, ?, ?, 1, 'x', ?, "
+            "        '2026-08-20T00:00:00Z','2026-08-20T00:00:00Z', ?)",
+            (definition, _record_key(contractor_id), version,
+             json.dumps({"contractor_id": contractor_id}),
+             f"h{contractor_id}", status))
+    conn.commit()
+
+
+def _absence(conn, contractor_id: str, *, at: str = ABSENT_AT,
+             dataset: str = "contractors") -> None:
+    """Stamp a proven absence at an EXACT time.
+
+    `record_absences` writes `strftime(...,'now')`, which is the right thing in
+    production and useless for testing a boundary: the second it lands in is whatever
+    second the test ran in. The realistic path is exercised in
+    `test_the_ruled_status_is_written_through_the_real_absence_path`; every other test
+    needs the two timestamps placed by hand, one second apart or exactly equal.
+    """
+    conn.execute(
+        "UPDATE dataset_sighting SET last_absent_at = ?, last_absent_run_ref = 'r' "
+        " WHERE dataset_key = ? AND external_id = ?", (at, dataset, contractor_id))
+    conn.commit()
+
+
+def _status(conn, contractor_id: str, *, dataset: str = "contractors") -> str:
+    return conn.execute(
+        "SELECT r.status FROM generic_record AS r "
+        "  JOIN dataset_definition AS d "
+        "    ON d.dataset_definition_id = r.dataset_definition_id "
+        " WHERE d.dataset_key = ? AND r.record_key = ?",
+        (dataset, _record_key(contractor_id))).fetchone()[0]
+
+
+# ---- the ruled behaviour ------------------------------------------------------
+
+def test_the_ruled_status_is_written_through_the_real_absence_path(conn):
+    """END TO END, through `record_absences` rather than a hand-written timestamp.
+
+    His ruling was `unavailable` over `retired`, and this is the whole chain that
+    delivers it: a crawl sees 1298 and not 1301, `record_absences` writes the proof,
+    `mark_unavailable` reads the proof and writes the status.
+    """
+    _stored(conn, ("1298", "active"), ("1301", "active"))
+    record_sightings(conn, "contractors", ["1298", "1301"])
+    # AN EARLIER CRAWL, AND IT HAS TO BE EARLIER BY MORE THAN NOTHING. Both
+    # `record_sightings` and `record_absences` stamp `strftime(...,'now')` at SECOND
+    # resolution, so a test doing both in one tick produces `last_seen_at ==
+    # last_absent_at` — and the tie is deliberately resolved toward `returned`, so the
+    # row would correctly NOT be marked and the test would look like a bug in the code.
+    #
+    # Production cannot hit that: a departed row's `last_seen_at` comes from a crawl
+    # that ran hours ago, because this crawl by definition did not touch it. Backdating
+    # is what makes the fixture resemble production rather than the test runner.
+    conn.execute("UPDATE dataset_sighting SET last_seen_at = '2026-08-20T09:00:00Z'")
+    conn.commit()
+    # A later crawl, provably complete, shows only 1298.
+    record_sightings(conn, "contractors", ["1298"])
+    assert record_absences(conn, "contractors", seen=["1298"], run_ref="r2") == 1
+
+    marking = mark_unavailable(conn, "contractors")
+
+    assert marking.marked == (_record_key("1301"),)
+    assert marking.restored == ()
+    assert _status(conn, "1301") == STATE_UNAVAILABLE
+    assert _status(conn, "1298") == "active"
+
+
+def test_a_row_nobody_proved_absent_is_never_marked(conn):
+    """THE GUARD THAT MATTERS MOST. A stale `last_seen_at` is not evidence of anything
+    — the last crawl may simply not have reached this cell. Only `last_absent_at`, which
+    is written from a crawl that closed with `D = 0`, is a proof.
+
+    Without this, a crawler having a bad afternoon delists contractors — `R-27`'s
+    failure arriving from the other side.
+    """
+    _stored(conn, ("1301", "active"))
+    record_sightings(conn, "contractors", ["1301"])
+    # No `record_absences` call: nothing ever proved 1301 gone.
+
+    assert mark_unavailable(conn, "contractors") == Marking("contractors")
+    assert _status(conn, "1301") == "active"
+
+
+def test_a_row_that_is_not_in_the_ledger_at_all_is_never_marked(conn):
+    """`unsighted` is a gap in OUR history — these rows predate `dataset_sighting` —
+    and reading it as a departure would invent one out of our own bookkeeping."""
+    _stored(conn, ("1301", "active"))
+    # Deliberately no sighting row at all.
+
+    assert mark_unavailable(conn, "contractors").marked == ()
+    assert _status(conn, "1301") == "active"
+
+
+def test_a_retired_row_is_a_persons_decision_and_a_crawl_does_not_touch_it(conn):
+    """ONE VOCABULARY, TWO AUTHORS. `unavailable` is what the SITE did, so a crawl may
+    write it. `retired` is what a PERSON decided, so no crawl may reach it — in either
+    direction, which is why this asserts the row is not restored either.
+
+    THE ABSENCE IS RECORDED ON PURPOSE, and the first version of this test omitted it.
+    Without a proven absence the row is untouched for a reason that has nothing to do
+    with being retired — so the test passed while a mutation deleting the protection
+    also passed. A retired row that a complete crawl proved absent is the only setup
+    under which "we did not touch it" means anything.
+    """
+    _stored(conn, ("1301", "retired"))
+    record_sightings(conn, "contractors", ["1301"])
+    conn.execute("UPDATE dataset_sighting "
+                 "   SET last_seen_at = '2026-08-20T00:00:00Z' WHERE external_id='1301'")
+    conn.commit()
+    _absence(conn, "1301")
+
+    marking = mark_unavailable(conn, "contractors")
+
+    assert (marking.marked, marking.restored) == ((), ())
+    assert _status(conn, "1301") == "retired"
+
+
+# ---- and taking the mark back -------------------------------------------------
+
+def test_a_contractor_the_site_publishes_again_is_restored(conn):
+    _stored(conn, ("1301", STATE_UNAVAILABLE))
+    record_sightings(conn, "contractors", ["1301"])
+    _absence(conn, "1301", at="2026-08-21T11:00:00Z")
+    conn.execute("UPDATE dataset_sighting SET last_seen_at = '2026-08-21T13:00:00Z' "
+                 " WHERE external_id = '1301'")
+    conn.commit()
+
+    marking = mark_unavailable(conn, "contractors")
+
+    assert marking.restored == (_record_key("1301"),)
+    assert marking.marked == ()
+    assert _status(conn, "1301") == "active"
+
+
+def test_the_mark_is_taken_back_or_returned_is_unreachable(conn):
+    """THE REGRESSION THIS PREVENTS, asserted on `row_state` and not on the column.
+
+    `row_state`'s precedence puts a marked row FIRST, above every observation. So a
+    contractor marked `unavailable` who reappears keeps displaying `unavailable` for as
+    long as the row exists, and `returned` — the state migration 0006 was written to
+    make computable — is never seen by anybody.
+
+    The assertion is deliberately made twice: what the state WOULD be with the mark
+    still on, and what it is once `mark_unavailable` has taken it off.
+    """
+    marked_and_back = {
+        "first_seen_at": "2026-08-01T00:00:00Z",
+        "last_seen_at": "2026-08-21T13:00:00Z",
+        "newest": "2026-08-21T13:00:00Z",
+        "sighted_at": "2026-08-01T00:00:00Z",
+        "last_absent_at": "2026-08-21T11:00:00Z",
+    }
+
+    assert row_state(status=STATE_UNAVAILABLE, **marked_and_back) == STATE_UNAVAILABLE
+    assert row_state(status="active", **marked_and_back) == STATE_RETURNED
+
+
+def test_the_boundary_is_the_one_row_state_uses(conn):
+    """THE TWO COMPARISONS ARE ONE COMPARISON, and this is what pins them together.
+
+    `row_state` uses `last_seen_at >= last_absent_at` for `returned`, because both
+    timestamps are second-resolution and a crawl finishing in the same second as the
+    absence it answers produces two EQUAL strings. So equality means returned — and
+    `mark_unavailable` must not mark it. If it used `<=` instead of `<`, this row would
+    carry `unavailable` while the screen showed `returned`.
+    """
+    same = "2026-08-21T12:00:00Z"
+    _stored(conn, ("1301", "active"))
+    record_sightings(conn, "contractors", ["1301"])
+    conn.execute("UPDATE dataset_sighting SET last_seen_at = ? WHERE external_id='1301'",
+                 (same,))
+    conn.commit()
+    _absence(conn, "1301", at=same)
+
+    assert mark_unavailable(conn, "contractors").marked == ()
+
+    assert row_state(status="active", first_seen_at="2026-08-01T00:00:00Z",
+                     last_seen_at=same, newest=same, sighted_at="2026-08-01T00:00:00Z",
+                     last_absent_at=same) == STATE_RETURNED
+
+
+def test_one_second_earlier_and_it_is_still_absent(conn):
+    """The other side of the same boundary, so `<` is pinned from both directions and
+    not merely satisfied by a function that never marks anything."""
+    _stored(conn, ("1301", "active"))
+    record_sightings(conn, "contractors", ["1301"])
+    conn.execute("UPDATE dataset_sighting "
+                 "   SET last_seen_at = '2026-08-21T11:59:59Z' WHERE external_id='1301'")
+    conn.commit()
+    _absence(conn, "1301", at="2026-08-21T12:00:00Z")
+
+    assert mark_unavailable(conn, "contractors").marked == (_record_key("1301"),)
+
+
+# ---- the properties a caller relies on ---------------------------------------
+
+def test_a_second_pass_over_an_unchanged_warehouse_changes_nothing(conn):
+    """Idempotent, because the crawl will call this every run and a caller that has to
+    remember whether it already ran is a caller that will get it wrong."""
+    _stored(conn, ("1301", "active"))
+    record_sightings(conn, "contractors", ["1301"])
+    _absence(conn, "1301")
+    conn.execute("UPDATE dataset_sighting "
+                 "   SET last_seen_at = '2026-08-20T00:00:00Z' WHERE external_id='1301'")
+    conn.commit()
+
+    first = mark_unavailable(conn, "contractors")
+    second = mark_unavailable(conn, "contractors")
+
+    assert first.marked == (_record_key("1301"),)
+    assert second == Marking("contractors")
+
+
+def test_the_two_directions_are_reported_separately(conn):
+    """TWO NUMBERS AND NOT A TOTAL. Seven contractors leaving and seven coming back are
+    the same total and completely different news."""
+    _stored(conn, ("1301", "active"), ("1302", STATE_UNAVAILABLE))
+    record_sightings(conn, "contractors", ["1301", "1302"])
+    _absence(conn, "1301")
+    _absence(conn, "1302", at="2026-08-21T11:00:00Z")
+    conn.execute("UPDATE dataset_sighting SET last_seen_at = "
+                 " CASE external_id WHEN '1301' THEN '2026-08-20T00:00:00Z' "
+                 "                  ELSE '2026-08-21T13:00:00Z' END")
+    conn.commit()
+
+    marking = mark_unavailable(conn, "contractors")
+
+    assert marking.marked == (_record_key("1301"),)
+    assert marking.restored == (_record_key("1302"),)
+    said = str(marking)
+    assert "1 marked unavailable" in said and "1 restored to active" in said
+
+
+def test_nothing_at_all_says_so_rather_than_printing_two_zeros(conn):
+    _stored(conn, ("1301", "active"))
+    record_sightings(conn, "contractors", ["1301"])
+
+    assert "no status change" in str(mark_unavailable(conn, "contractors"))
+
+
+def test_another_dataset_is_not_touched(conn):
+    """The `UPDATE` is keyed on `record_key`, which is a hash of the identity values and
+    NOT unique across datasets — two sources listing the same contractor id produce the
+    same key. So the statement carries its dataset, and this is the test that says so.
+    """
+    _stored(conn, ("1301", "active"))
+    _stored(conn, ("1301", "active"), dataset="engineers")
+    record_sightings(conn, "contractors", ["1301"])
+    record_sightings(conn, "engineers", ["1301"])
+    _absence(conn, "1301")
+    conn.execute("UPDATE dataset_sighting "
+                 "   SET last_seen_at = '2026-08-20T00:00:00Z' WHERE external_id='1301'")
+    conn.commit()
+
+    mark_unavailable(conn, "contractors")
+
+    assert _status(conn, "1301") == STATE_UNAVAILABLE
+    assert _status(conn, "1301", dataset="engineers") == "active"
+
+
+# ---- the gate: the crawl may only write this off the back of a proof ----------
+#
+# `mark_departures` IS THE CALLER `record_absences` ASKS FOR. That function's docstring
+# says its caller must guarantee the crawl was complete, because it cannot see that from
+# inside — and until this work, IT HAD NO CALLER AT ALL. Neither did the status write
+# that depends on it. So the whole chain existed and none of it ran.
+#
+# THE OUTCOMES BELOW ARE REAL `PartitionOutcome` OBJECTS, not stubs. The gate turns on
+# `provably_complete` and `nested`, and both are computed properties with real
+# arithmetic behind them — a stub would let this file agree with its own idea of what
+# they return, which is the failure mode `_record_key` above exists to avoid.
+
+def _outcome(*, declared_whole: int, declared_cell: int, ids: tuple[str, ...],
+             nested: bool = False):
+    """A `PartitionOutcome` whose proof state is decided by arithmetic, as production's is."""
+    from scrapex.pagesource import Cell
+    from scrapex.partitioncrawl import (
+        WHOLE,
+        Attempt,
+        CellOutcome,
+        CellSize,
+        PartitionOutcome,
+    )
+
+    cell = Cell(params=(("region_id", "1"),))
+    return PartitionOutcome(
+        whole=CellSize(cell=WHOLE, last_page=1, cards_per_page=declared_whole,
+                       tail_cards=declared_whole, requests=1),
+        cells=(CellOutcome(
+            size=CellSize(cell=cell, last_page=1, cards_per_page=declared_cell,
+                          tail_cards=declared_cell, requests=1),
+            attempts=(Attempt(ids=ids, pages_read=1, witnessed=False,
+                              note="", run_ref="r"),)),),
+        whole_at_end=None, parent=cell if nested else WHOLE)
+
+
+def _directory():
+    from scrapex.directories import get as get_directory
+
+    return get_directory(None)
+
+
+def test_a_proven_crawl_writes_both_the_absence_and_the_status(conn, capsys):
+    from scrapex.contractors import mark_departures
+
+    _stored(conn, ("1", "active"), ("2", "active"), ("9", "active"))
+    record_sightings(conn, "contractors", ["1", "2", "9"])
+    conn.execute("UPDATE dataset_sighting SET last_seen_at = '2026-08-20T09:00:00Z'")
+    conn.commit()
+
+    # The crawl saw 1 and 2. It declared 2 rows and found 2 distinct ids, so it closed
+    # by counting — and 9 is therefore proved gone rather than merely unseen.
+    mark_departures(conn, _directory(),
+                    _outcome(declared_whole=2, declared_cell=2, ids=("1", "2")), "r9")
+
+    assert _status(conn, "9") == STATE_UNAVAILABLE
+    assert _status(conn, "1") == "active"
+    said = capsys.readouterr().out
+    assert "provably complete, so absence is evidence" in said
+    assert "1 marked unavailable" in said
+
+
+def test_a_nested_proof_must_not_delist_the_rest_of_the_listing(conn, capsys):
+    """THE DANGEROUS CASE, and it is dangerous precisely because it looks proven.
+
+    A nested outcome reports `provably_complete = True` — measured, not assumed — and
+    its own docstring says why that is correct: *"IT IS A CLAIM ABOUT `scope` AND NEVER
+    MORE."* True on a nested run means the PARENT CELL is accounted for. Marking
+    absences from it would delist every contractor the cell does not contain, which on
+    muqawil is most of the country.
+    """
+    from scrapex.contractors import mark_departures
+
+    _stored(conn, ("1", "active"), ("9", "active"))
+    record_sightings(conn, "contractors", ["1", "9"])
+    conn.execute("UPDATE dataset_sighting SET last_seen_at = '2026-08-20T09:00:00Z'")
+    conn.commit()
+    nested = _outcome(declared_whole=2, declared_cell=2, ids=("1", "2"), nested=True)
+    assert nested.provably_complete, "the premise: it really does look proven"
+
+    mark_departures(conn, _directory(), nested, "r9")
+
+    assert _status(conn, "9") == "active"
+    assert "says nothing about the rest of the listing" in capsys.readouterr().out
+
+
+def test_an_only_run_is_refused_and_the_arithmetic_is_what_refuses_it(conn, capsys):
+    """`--only` NEEDS NO SEPARATE CHECK, AND THIS IS THE TEST THAT SAYS SO.
+
+    A subset run sizes the WHOLE listing and sums only the cells it was handed, so its
+    `exhaustiveness_deficit` is the thousands of rows in the cells it skipped and
+    `provably_complete` is already False. That is the right answer reached indirectly,
+    which is exactly the kind of safety property that disappears in a refactor with
+    nobody noticing — so it is asserted here rather than trusted.
+    """
+    from scrapex.contractors import mark_departures
+
+    _stored(conn, ("1", "active"), ("9", "active"))
+    record_sightings(conn, "contractors", ["1", "9"])
+    conn.execute("UPDATE dataset_sighting SET last_seen_at = '2026-08-20T09:00:00Z'")
+    conn.commit()
+    subset = _outcome(declared_whole=100, declared_cell=2, ids=("1", "2"))
+    assert subset.exhaustiveness_deficit == 98
+    assert not subset.provably_complete
+
+    mark_departures(conn, _directory(), subset, "r9")
+
+    assert _status(conn, "9") == "active"
+    assert "not provably complete" in capsys.readouterr().out
+
+
+def test_declining_says_why_rather_than_saying_nothing(conn, capsys):
+    """A crawl that silently marked nothing is indistinguishable from one that found no
+    departures, and those are opposite facts about the directory."""
+    from scrapex.contractors import mark_departures
+
+    _stored(conn, ("1", "active"))
+    record_sightings(conn, "contractors", ["1"])
+
+    mark_departures(conn, _directory(),
+                    _outcome(declared_whole=100, declared_cell=2, ids=("1",)), "r9")
+
+    said = capsys.readouterr().out
+    assert "departures not marked" in said
+    assert "bad afternoon" in said       # the reason, not just the refusal

--- a/tests/test_a_delisted_contractor_is_marked_and_a_returning_one_is_not.py
+++ b/tests/test_a_delisted_contractor_is_marked_and_a_returning_one_is_not.py
@@ -41,6 +41,24 @@ from scrapex.sightings import (
 ABSENT_AT = "2026-08-21T12:00:00Z"
 
 
+@pytest.fixture(autouse=True)
+def _log_somewhere_harmless(tmp_path, monkeypatch):
+    """`say` APPENDS TO THE USER'S REAL LOG, and these tests call it.
+
+    `contractors.say` writes every line to `Path.home()/".scrapex"/"contractors.log"`
+    unconditionally — correct for a crawl that runs for hours and must leave a record,
+    and wrong for a test suite: the refusal lines from the gate tests below turned up in
+    the owner's live log, interleaved with a real crawl's output, where they read as the
+    crawl refusing to mark departures.
+
+    The behaviour predates this file, so it is recorded as `OP-32` rather than changed
+    here. What this fixture fixes is the part these tests are responsible for.
+    """
+    from scrapex import contractors
+
+    monkeypatch.setattr(contractors, "LOG", tmp_path / "contractors.log")
+
+
 @pytest.fixture()
 def conn(tmp_path: Path):
     registry = DatabaseRegistry(EngineDatabase(tmp_path / "scrapex-engine.db"),

--- a/tests/test_a_lit_capability_is_a_switch_and_not_a_claim.py
+++ b/tests/test_a_lit_capability_is_a_switch_and_not_a_claim.py
@@ -1,0 +1,231 @@
+"""`is_enabled` had zero callers, so every flag in the manifest was decoration.
+
+WHAT WAS WRONG. `scrapex/features.py` describes `is_enabled` as *"the gate that
+NAVIGATION and UI must call before advertising a capability"*, and **nothing in the
+repository called it**. `GENERIC_DATASET_CATALOG` and `GENERIC_EXTRACTION` were lit at
+`PARTIAL` on the owner's instruction on 2026-08-20; turning either of them off again
+would have changed nothing whatsoever. A flag that governs nothing is a claim about a
+capability, not a switch over it — and this manifest exists precisely to stop
+capabilities being oversold, which makes an inert flag the worst kind of entry in it.
+
+WHERE THE TWO CALLERS BELONG, and it is not symmetrical:
+
+    GENERIC_DATASET_CATALOG   `_dataset_rows` — what puts a dataset in the source
+                              listing the panel draws. That IS the advertisement.
+    GENERIC_EXTRACTION        `scrapex contractors --approve` — the SHIPPED command,
+                              which `REQ-24` made a user-facing surface.
+
+AND THE API ROUTES ARE DELIBERATELY EXCLUDED, because `is_enabled`'s own docstring
+excludes them: `/api/table/contractors` and `/source/contractors` are mounted on
+127.0.0.1 so the slice can be exercised and tested. Gating those would turn the flag
+into a kill switch for development; gating the listing and the shipped command makes it
+a switch over what is ANNOUNCED. `test_the_routes_stay_mounted_when_the_flag_is_off`
+pins that distinction, because it is the one a later reader would "tidy up".
+"""
+from __future__ import annotations
+
+import argparse
+import shutil
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from scrapex import db as dbmod
+from scrapex import features
+from scrapex.config import MANIFEST_FILE
+from scrapex.features import FeatureKey, FeatureState, is_enabled
+from scrapex.webui.app import create_app
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> Path:
+    """A migrated warehouse and NOTHING INGESTED.
+
+    `test_api.py` has a `client` of its own, and it ingests price rows because its
+    tests are about price sources. Copying it here would have pulled in that setup for
+    no reason — and its fixtures are module-local, so they are not importable anyway.
+    The generic tables come from `db/migrations/0014_generic_html_table_extraction.sql`,
+    which `migrate` applies, so an empty warehouse already has somewhere to put a
+    dataset.
+    """
+    path = tmp_path / "harvest.db"
+    conn = dbmod.connect(path)
+    dbmod.migrate(conn)
+    conn.commit()
+    conn.close()
+    return path
+
+
+@pytest.fixture()
+def client(db_path, tmp_path) -> TestClient:
+    """Pointed at a COPY of the manifest, so no test can edit the real one."""
+    manifest = tmp_path / "sources.yaml"
+    shutil.copy(MANIFEST_FILE, manifest)
+    return TestClient(create_app(db_path, manifest_path=manifest))
+
+
+@pytest.fixture()
+def off(monkeypatch):
+    """Turn one capability off through the REAL manifest, not by faking the gate.
+
+    `is_enabled` reads `_FEATURES` at call time, so replacing the tuple exercises the
+    shipped function. Monkeypatching `is_enabled` itself would test the call site
+    against a stub of the thing being tested.
+    """
+    def turn_off(key: FeatureKey) -> None:
+        monkeypatch.setattr(features, "_FEATURES", tuple(
+            FeatureState(one.key, False, one.stage, one.detail)
+            if one.key == key else one
+            for one in features._FEATURES))
+        assert is_enabled(key) is False, "the fixture must actually turn it off"
+
+    return turn_off
+
+
+# ---- the shipped command --------------------------------------------------------
+
+def _args(**overrides) -> argparse.Namespace:
+    from scrapex.contractors import add_arguments
+
+    parser = argparse.ArgumentParser()
+    add_arguments(parser)
+    return parser.parse_args(["--run-ref", "r", *[
+        flag for key, value in overrides.items() if value
+        for flag in (f"--{key.replace('_', '-')}",)]])
+
+
+def test_approve_refuses_when_generic_extraction_is_off(off, capsys):
+    """IT REFUSES RATHER THAN SKIPPING. A run that quietly approved nothing would look
+    exactly like a crawl with nothing left to approve, and those are opposite facts."""
+    from scrapex.contractors import validate
+
+    off(FeatureKey.GENERIC_EXTRACTION)
+
+    with pytest.raises(SystemExit) as raised:
+        validate(_args(approve=True))
+
+    assert raised.value.code == 2
+    said = capsys.readouterr().err
+    assert "generic extraction is disabled" in said
+    assert "Nothing was read or written" in said
+
+
+def test_approve_proceeds_while_the_flag_is_lit():
+    """The other direction, so the guard cannot pass by refusing everything."""
+    from scrapex.contractors import validate
+
+    assert is_enabled(FeatureKey.GENERIC_EXTRACTION) is True
+    validate(_args(approve=True))          # raises nothing
+
+
+def test_the_other_operations_are_not_gated_on_extraction(off):
+    """`--crawl` FETCHES AND STORES; it interprets nothing. Gating it on the extraction
+    flag would stop evidence being collected because interpretation is switched off,
+    and the two phases are separate for exactly that reason — a wrong parse costs
+    minutes because the pages are already on disk."""
+    from scrapex.contractors import validate
+
+    off(FeatureKey.GENERIC_EXTRACTION)
+
+    validate(_args(crawl=True))            # raises nothing
+    validate(_args(coverage=True))
+    validate(_args(plan=True))
+
+
+# ---- the advertisement ----------------------------------------------------------
+
+def _a_dataset_in(db_path: Path) -> None:
+    """One approved dataset, so the listing has something it COULD advertise."""
+    conn = sqlite3.connect(db_path)
+    conn.execute("INSERT INTO site_profile (site_key, display_name, base_url) "
+                 "VALUES ('muq','Contractors','https://muqawil.org')")
+    conn.execute(
+        "INSERT INTO dataset_definition (site_profile_id, dataset_key, original_name, "
+        " dataset_kind, discovery_method, locator_json) "
+        "VALUES (1,'contractors','contractors','table','html_table','{}')")
+    conn.commit()
+    conn.close()
+
+
+def _dataset_keys(client) -> list[str]:
+    return [row["source_key"] for row in client.get("/api/sources").json()["sources"]
+            if row.get("kind") == "dataset"]
+
+
+def test_a_lit_catalogue_advertises_the_dataset(client, db_path):
+    """The premise. Without this the test below passes on an empty warehouse and
+    proves nothing at all — which is how an inert flag looked correct for two days."""
+    _a_dataset_in(db_path)
+
+    assert "contractors" in _dataset_keys(client)
+
+
+def test_an_unlit_catalogue_advertises_nothing(client, db_path, off):
+    _a_dataset_in(db_path)
+    off(FeatureKey.GENERIC_DATASET_CATALOG)
+
+    assert _dataset_keys(client) == []
+
+
+def test_the_routes_stay_mounted_when_the_flag_is_off(client, db_path, off):
+    """THE DISTINCTION A LATER READER WOULD TIDY AWAY. `is_enabled`'s docstring puts
+    the API routes outside the flag on purpose: they exist so the slice can be
+    exercised and tested on a server bound to 127.0.0.1. What the flag governs is
+    whether anything TELLS a user the capability exists.
+    """
+    _a_dataset_in(db_path)
+    off(FeatureKey.GENERIC_DATASET_CATALOG)
+
+    assert client.get("/api/features").status_code == 200
+    # ASSERTED ON THE ROUTE TABLE, not by calling it. `/api/table/{source_key}` reads
+    # `dataset_sighting`, which is an ENGINE migration and not in this price-database
+    # fixture — so calling it raises `no such table` and says nothing about the flag.
+    # "Mounted" is a fact about routing, so it is asked of the router.
+    paths = {getattr(route, "path", "") for route in client.app.routes}
+    assert "/api/table/{source_key}" in paths
+    assert "/source/{source_key}" in paths
+
+
+# ---- and the state that started all this ---------------------------------------
+
+def test_every_feature_key_the_manifest_declares_is_reachable_from_the_code():
+    """THE GUARD AGAINST THIS COMING BACK. `is_enabled` had zero callers, and nothing
+    failed — which is why it stayed that way. This counts call sites in shipped code, so
+    a flag added without a reader, or a reader deleted in a refactor, is a red build
+    rather than a silent return to decoration.
+
+    IT COUNTS CALLS AND NOT KEYS, deliberately. Two of the five keys are
+    `NOT_STARTED` and have nothing to gate yet; requiring a caller per key would force
+    a fake one for a capability that does not exist.
+    """
+    shipped = [path.read_text(encoding="utf-8")
+               for path in (ROOT / "scrapex").rglob("*.py")]
+    calls = sum(text.count("is_enabled(FeatureKey.") for text in shipped)
+
+    assert calls >= 2, (
+        "`is_enabled` is back to having no callers in scrapex/, so every flag in "
+        "features.py is decoration again")
+
+
+def test_an_unlit_flag_says_what_is_actually_missing():
+    """`CRAWL_FRONTIER` LOOKED STALE AND IS NOT, which is worth a test because the
+    partitioned crawl makes it look shipped.
+
+    Measured 2026-08-21 against its own written condition — *"persistent discovery,
+    limits, and checkpoint recovery"*. Limits shipped; checkpoint recovery shipped for
+    the partitioned crawl, since `already_stored` lets a resume skip pages it already
+    holds. Persistent discovery did not: `declare_frontier` hands the fetcher an
+    in-memory denominator for the Activity panel and writes nothing, so no new process
+    could resume a frontier. Two of three, so `False` is the correct value — and a
+    detail naming which two is what stops the next session re-deriving it.
+    """
+    frontier = next(f for f in features.manifest()["features"]
+                    if f["key"] == "crawl_frontier")
+
+    assert frontier["enabled"] is False
+    assert "Persistent discovery did NOT" in frontier["detail"]
+    assert "declare_frontier" in frontier["detail"]

--- a/tests/test_a_slice_asks_the_row_the_url_came_from.py
+++ b/tests/test_a_slice_asks_the_row_the_url_came_from.py
@@ -1,0 +1,173 @@
+"""The slice scope was built, tested, never used — and wrong.
+
+WHAT WAS WRONG, MEASURED ON A STORED PAGE BEFORE ANYTHING WAS CHANGED.
+`belongs_to_slice` indexes ROWS of a listing. `detail_urls` yields URLs. Every caller
+paired them with `enumerate(detail_urls(page))`, which is correct exactly when a page
+yields one URL per row — and muqawil yields **one per locale**:
+
+    cards       17
+    detail URLs 34
+    url index 1 → card 1, but url 1 is contractor 0's ARABIC page
+    17 of the 34 indices pointed past the last card
+
+So under `LISTING_PLUS_SLICE` the crawl would have asked the wrong card about every URL
+but the first, and silently dropped the seventeen that overshot. **The result is neither
+the slice nor its complement**, and it reads as a smaller city rather than as a defect.
+
+Nothing caught it because nothing used it: muqawil is registered `listing_only`, and the
+fakes in the walker's own tests yield one URL per row, which is the case the assumption
+happens to fit.
+
+THE FIX IS IN TWO HALVES, AND THE SECOND IS WHY THIS CANNOT COME BACK.
+
+  * `detail_rows` — the source pairs each URL with the row it came from, and
+    `slice_rows` asks for it. Optional, because most sources publish one URL per row
+    and `test_a_fake_site_satisfies_the_protocol` is right that a Protocol nothing can
+    implement is a design rather than a seam.
+  * `belongs_to_slice` REFUSES a row index past its last row, where it used to answer
+    `False`. That is the only place the row count is known, so it is the only place the
+    guard can live — and it turns any future re-guess into a loud failure instead of a
+    quiet half-crawl.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scrapex.pagesource import FetchedPage, PageKind, SliceNotSupported, slice_rows
+from scrapex.sites.muqawil import MuqawilPageSource, _cards, read_ids
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "muqawil"
+
+
+def _page(name: str = "listing-en.html") -> FetchedPage:
+    """The committed listing, which is a real trimmed page from the site."""
+    return FetchedPage(url="https://muqawil.org/en/contractors?page=1",
+                       html=(FIXTURES / name).read_text(encoding="utf-8"),
+                       kind=PageKind.LISTING)
+
+
+def _id_in(url: str) -> str:
+    return url.rsplit("/contractors/", 1)[1].split("/")[0]
+
+
+# ---- the pairing ---------------------------------------------------------------
+
+def test_the_page_really_does_yield_more_urls_than_rows():
+    """THE PREMISE, asserted so the tests below cannot pass on a single-locale page.
+
+    Without this, a fixture that happened to carry one locale would make every
+    assertion here vacuously true — which is exactly how the defect survived in the
+    walker's own tests.
+    """
+    page = _page()
+    source = MuqawilPageSource(last_page=871)
+
+    cards = _cards(page.html)
+    urls = list(source.detail_urls(page))
+
+    assert len(cards) >= 2
+    assert len(urls) == len(cards) * 2, "one URL per locale is the whole difficulty"
+
+
+def test_every_url_is_paired_with_its_own_row():
+    page = _page()
+    source = MuqawilPageSource(last_page=871)
+    ids = read_ids(page.html)
+
+    rows = slice_rows(source, page)
+
+    assert len(rows) == len(list(source.detail_urls(page)))
+    wrong = [(index, url) for index, url in rows if ids[index] != _id_in(url)]
+    assert wrong == [], "a URL paired with a different contractor's row"
+
+
+def test_no_row_index_points_past_the_last_row():
+    """The half that was being dropped. Seventeen of thirty-four, on a real page."""
+    page = _page()
+    source = MuqawilPageSource(last_page=871)
+
+    highest = max(index for index, _ in slice_rows(source, page))
+
+    assert highest < len(_cards(page.html))
+
+
+def test_the_old_assumption_is_the_one_that_fails():
+    """PINS THE REASON, not just the fix. `enumerate(detail_urls(page))` is what every
+    caller used to write, and this is the assertion that it cannot be gone back to."""
+    page = _page()
+    source = MuqawilPageSource(last_page=871)
+    ids = read_ids(page.html)
+
+    guessed = list(enumerate(source.detail_urls(page)))
+
+    mismatched = [i for i, url in guessed
+                  if i >= len(ids) or ids[i] != _id_in(url)]
+    assert len(mismatched) > len(guessed) // 2, (
+        "the old pairing was wrong for more than half the URLs; if this now passes, "
+        "the page has changed shape and these tests need re-measuring")
+
+
+# ---- and the guard that makes a re-guess loud ---------------------------------
+
+def test_a_row_that_does_not_exist_is_refused_and_not_answered_false():
+    """IT USED TO RETURN `False`. That is what made the overshoot invisible: seventeen
+    contractors dropped out of the slice and the answer looked like a small city."""
+    page = _page()
+    source = MuqawilPageSource(last_page=871)
+    past_the_end = len(_cards(page.html)) + 5
+
+    with pytest.raises(SliceNotSupported) as raised:
+        source.belongs_to_slice(page, past_the_end, "RIYADH")
+
+    said = str(raised.value)
+    assert "does not exist" in said
+    assert "detail_rows" in said, "the message must name the fix"
+
+
+def test_a_real_row_still_answers_the_slice_question():
+    """The guard must not have turned every question into a refusal."""
+    page = _page()
+    source = MuqawilPageSource(last_page=871)
+
+    answers = [source.belongs_to_slice(page, index, "RIYADH")
+               for index in range(len(_cards(page.html)))]
+
+    assert all(isinstance(one, bool) for one in answers)
+    assert any(answers), "the committed listing has at least one Riyadh contractor"
+
+
+# ---- the default, for the sources that never needed this ----------------------
+
+class _OneUrlPerRow:
+    """The shape every other source has: one detail page per listing row."""
+
+    site_key = "one_per_row"
+
+    def detail_urls(self, page):
+        return ["https://e.test/a", "https://e.test/b", "https://e.test/c"]
+
+
+def test_a_source_with_one_url_per_row_needs_no_pairing_method():
+    """`detail_rows` IS OPTIONAL ON PURPOSE. Requiring it would make the Protocol
+    demand a method whose only possible implementation is `enumerate`, and
+    `test_a_fake_site_satisfies_the_protocol` already says why that is wrong."""
+    assert slice_rows(_OneUrlPerRow(), _page()) == [
+        (0, "https://e.test/a"), (1, "https://e.test/b"), (2, "https://e.test/c")]
+
+
+def test_the_resume_wrapper_forwards_the_pairing():
+    """FORGETTING THIS WOULD HAVE BEEN SILENT AND PRODUCTION-ONLY. The wrapper hides
+    already-stored listing URLs from a resume and delegates everything else; a
+    `detail_rows` it did not forward would send `slice_rows` to its `enumerate` default
+    for the wrapped source — which is the only source production ever slices.
+    """
+    from scrapex.partitioncrawl import _Unstored
+
+    page = _page()
+    inner = MuqawilPageSource(last_page=871)
+
+    wrapped = _Unstored(inner, frozenset())
+
+    assert slice_rows(wrapped, page) == slice_rows(inner, page)

--- a/tests/test_muqawil_pagesource.py
+++ b/tests/test_muqawil_pagesource.py
@@ -242,8 +242,23 @@ def test_a_city_that_is_not_this_row_is_a_plain_no(source):
     assert source.belongs_to_slice(listing("en"), 0, "JEDDAH") is False
 
 
-def test_a_row_past_the_end_of_the_page_is_not_in_any_slice(source):
-    assert source.belongs_to_slice(listing("en"), 99, "RIYADH") is False
+def test_a_row_past_the_end_of_the_page_is_refused_not_answered(source):
+    """THIS TEST USED TO ASSERT `is False`, AND THAT EXPECTATION ENCODED A DEFECT.
+
+    Answering `False` means "this row is not in the slice", which is a claim about a row
+    that does not exist. It made a real off-by-a-locale bug invisible:
+    `enumerate(detail_urls(page))` handed indices up to 33 for a page with 17 cards, and
+    every index past the last card was quietly dropped — seventeen contractors vanished
+    from the slice and the result read as a smaller city.
+
+    An index past the last row is a CALLER error, so it is the one thing this method must
+    not have an opinion about. Same reasoning as the two tests below it: a refusal is the
+    only answer that cannot be mistaken for data.
+    """
+    with pytest.raises(SliceNotSupported) as raised:
+        source.belongs_to_slice(listing("en"), 99, "RIYADH")
+
+    assert "does not exist" in str(raised.value)
 
 
 def test_naming_no_city_refuses_rather_than_answering_no(source):

--- a/tests/test_the_crawl_driver_cannot_lose_a_run.py
+++ b/tests/test_the_crawl_driver_cannot_lose_a_run.py
@@ -167,14 +167,35 @@ def test_open_engine_refuses_a_database_that_does_not_exist(driver, tmp_path,
 # ---- a mistyped --only must not quietly crawl less ---------------------------
 
 class _Spy:
-    """Stands in for `crawl_partition`, recording what it was asked to crawl."""
+    """Stands in for `crawl_partition`, recording what it was asked to crawl.
+
+    IT USED TO RETURN THE STRING `"an outcome"`, and that stopped being harmless the
+    moment `crawl` began reading the outcome to decide whether departures may be
+    marked. Two tests here failed with `'str' object has no attribute 'nested'` — the
+    right failure, caught by the right tests, and the fix belongs in the stub rather
+    than in a `getattr` that would let the real code accept anything.
+
+    So it returns something SHAPED like a `PartitionOutcome`, and deliberately one that
+    is NOT provably complete: these tests are about which cells `--only` selects, and a
+    stub that claimed a proof would have the driver write absences from a fake crawl.
+    """
 
     def __init__(self) -> None:
         self.calls: list[dict] = []
 
     def __call__(self, *args, **kwargs):
         self.calls.append(kwargs)
-        return "an outcome"
+        return _unproven_outcome()
+
+
+def _unproven_outcome():
+    """An outcome with no cells: `provably_complete` is False, so nothing is marked."""
+    from scrapex.partitioncrawl import WHOLE, CellSize, PartitionOutcome
+
+    return PartitionOutcome(
+        whole=CellSize(cell=WHOLE, last_page=1, cards_per_page=1, tail_cards=1,
+                       requests=1),
+        cells=(), whole_at_end=None, parent=WHOLE)
 
 
 def test_only_refuses_an_unknown_label_before_touching_the_database(
@@ -433,3 +454,70 @@ def test_the_partition_is_built_per_access_and_not_shared(directory):
     """Two runs must not share a `PartitionedListing`. It carries no state today,
     which is exactly when accidental sharing is cheapest to prevent."""
     assert directory.partition() is not directory.partition()
+
+
+# ---- the cost of sizing, stated where somebody can read it -------------------
+#
+# ITEM 2 OF SIX. The module header of `partitioncrawl` has always said what
+# sizing-before-storing costs — *"the first ~112 requests store nothing … ~5.7% overhead
+# on each resume"* — and a person running the command never reads a module header. Worse,
+# `~112` is muqawil on one day: it moves with the partition and a constant in prose
+# cannot follow it.
+
+def test_the_report_names_what_sizing_cost_and_calls_it_unrecoverable():
+    """The number reaches the OUTPUT, computed from the run rather than remembered."""
+    outcome = _outcome_with(sizing_whole=7, sizing_cell=5, pages_read=20, declared=20)
+
+    said = str(outcome)
+
+    assert outcome.sizing_requests == 12
+    assert "12 (36.4%) sized cells and stored nothing" in said
+    assert "a resumed run pays them again" in said
+
+
+def test_sizing_is_counted_separately_from_the_pages_it_priced():
+    """`CellOutcome.requests` already folds sizing in with pages and witnesses, so the
+    resume cost cannot be read off it. `sizing_requests` is the part that buys nothing
+    but a denominator."""
+    outcome = _outcome_with(sizing_whole=7, sizing_cell=5, pages_read=20, declared=20)
+
+    assert outcome.sizing_requests < outcome.requests
+    assert outcome.requests - outcome.sizing_requests == 21   # 20 pages + 1 witness
+
+
+def test_a_run_that_stored_nothing_but_sizing_does_not_divide_by_zero():
+    """A partition with no cells at all: `share` has no denominator, and the report
+    still has to render rather than raise inside a summary line."""
+    from scrapex.partitioncrawl import WHOLE, CellSize, PartitionOutcome
+
+    empty = PartitionOutcome(
+        whole=CellSize(cell=WHOLE, last_page=1, cards_per_page=0, tail_cards=0,
+                       requests=0),
+        cells=(), whole_at_end=None, parent=WHOLE)
+
+    assert empty.sizing_requests == 0
+    assert "sized cells and stored nothing" not in str(empty)
+
+
+def _outcome_with(*, sizing_whole: int, sizing_cell: int, pages_read: int,
+                  declared: int):
+    from scrapex.pagesource import Cell
+    from scrapex.partitioncrawl import (
+        WHOLE,
+        Attempt,
+        CellOutcome,
+        CellSize,
+        PartitionOutcome,
+    )
+
+    cell = Cell(params=(("region_id", "1"),))
+    return PartitionOutcome(
+        whole=CellSize(cell=WHOLE, last_page=10, cards_per_page=2, tail_cards=2,
+                       requests=sizing_whole),
+        cells=(CellOutcome(
+            size=CellSize(cell=cell, last_page=1, cards_per_page=declared,
+                          tail_cards=declared, requests=sizing_cell),
+            attempts=(Attempt(ids=tuple(str(i) for i in range(declared)),
+                              pages_read=pages_read, witnessed=True, note="",
+                              run_ref="r"),)),),
+        whole_at_end=None, parent=WHOLE)

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -104,18 +104,18 @@ PINNED = (
     # REQ-21's nested audit. The whole request is that `Sum N_child` is compared
     # against the PARENT, and these are the two lines that make it so -- one that
     # sizes the parent, one that refuses cells outside it before a request is spent.
-    ("docs/REQUESTS.md", "scrapex/partitioncrawl.py", 972,
+    ("docs/REQUESTS.md", "scrapex/partitioncrawl.py", 1012,
      "whole = size_cell(fetch, partition, base_url, parent)"),
-    ("docs/REQUESTS.md", "scrapex/partitioncrawl.py", 965, "raise NotASubdivision("),
+    ("docs/REQUESTS.md", "scrapex/partitioncrawl.py", 1005, "raise NotASubdivision("),
     ("docs/REQUESTS.md", "scrapex/pagesource.py", 146,
      "return set(other.params) <= set(self.params)"),
     # The version-gate blocker. Track 3 of STATE.md cannot be worked without
     # these three, and two of them are the citations that drifted.
     ("docs/STATE.md", "scrapex/version.py", 477, '"latest_extension_version": VERSION'),
-    ("docs/STATE.md", "scrapex/webui/app.py", 1439, '"latest_extension_version": VERSION'),
+    ("docs/STATE.md", "scrapex/webui/app.py", 1459, '"latest_extension_version": VERSION'),
     ("docs/STATE.md", "extension/app.js", 599, "latest_extension_version"),
     ("docs/STATE.md", "scrapex/version.py", 76, 'VERSION = "'),
-    ("docs/RULINGS.md", "scrapex/webui/app.py", 1439, '"latest_extension_version": VERSION'),
+    ("docs/RULINGS.md", "scrapex/webui/app.py", 1459, '"latest_extension_version": VERSION'),
     ("docs/RULINGS.md", "scrapex/version.py", 477, '"latest_extension_version": VERSION'),
     # The two flags whose condition is met and whose lighting is the owner's call.
     ("docs/STATE.md", "scrapex/features.py", 54, "True"),
@@ -133,8 +133,8 @@ PINNED = (
      'assert.equal(manifest.version, VECTORS.version)'),
     ("docs/RULINGS.md", "tests/test_version.py", 79, "pyproject"),
     # OP-2's two worker_alive computations, one of which the fix never reached.
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1450, '"worker_alive"'),
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2438, "def _about("),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1470, '"worker_alive"'),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2458, "def _about("),
     ("docs/BACKLOG.md", "scrapex/webui/templates/settings.html", 162, "about.worker_alive"),
     # BV-3's chain, end to end: the panel posts it, capture reads it.
     ("docs/BACKLOG.md", "extension/app.js", 840, "crawl_honour_delay:"),

--- a/tests/test_the_interests_are_not_a_table.py
+++ b/tests/test_the_interests_are_not_a_table.py
@@ -1,0 +1,189 @@
+"""The biggest of `R-19`'s five groups is not a table, and the plan said it was.
+
+WHAT THE PLAN ASSERTED. *"The profile page carries five real `<table>` elements — the
+licences and their readiness, the two contractor lists, the technical rating, the
+contract counts. Those go through `detect_html_tables` like any other site's tables, and
+they are exactly the multi-valued groups `R-19` wants in child tables."*
+
+WHAT IS ACTUALLY THERE, measured against the committed profile:
+
+    <table> elements                       5
+    …of which are Interests                0
+    Interests is a nested <ul class="list list-numerical"> in a div.section-card
+
+`R-19`'s five named groups are Interests, Licensed Activities, Qualification Programs,
+Balady Services and contractor relations. Interests is the **largest** — the study
+measured 30 values in 6 groups for one contractor and priced the group at ~235 MB at
+full scale — so building on the five-tables premise would have produced four groups and
+silently missed the biggest one.
+
+AND THREE OF THE FIVE TABLES ARE EMPTY on the only committed profile: the two contractor
+lists and the technical rating parse to 0 rows. That is the same evidence limit `R-19`
+named about itself — *"one contractor"* — arriving from the other side.
+
+WHAT IS BUILT HERE AND WHAT IS NOT. Reading is built, because every candidate storage
+shape needs it. WRITING is not: whether these become a child dataset referencing
+`classification_node` (the study's recommendation, shape F) or a pure taxonomy (shape D)
+is `R-19`'s open question and is **awaiting his ruling**.
+"""
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+
+import pytest
+from bs4 import BeautifulSoup
+
+from scrapex.extract.html_table import detect_html_tables
+from scrapex.extract.muqawil import read_interests
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "muqawil"
+
+
+def _html(locale: str) -> str:
+    return (FIXTURES / f"profile-{locale}.html").read_text(encoding="utf-8")
+
+
+# ---- the premise this corrects -------------------------------------------------
+
+def test_the_page_has_five_tables_and_none_of_them_is_interests():
+    """THE MEASUREMENT THAT CORRECTS THE PLAN. Five `<table>` elements, and the
+    interests block is not one of them."""
+    html = _html("en")
+    soup = BeautifulSoup(html, "html.parser")
+
+    assert len(soup.find_all("table")) == 5
+
+    card = soup.select_one("div.section-card:has(ul.list-numerical li.list-item)")
+    assert card is not None, "the interests block must exist to be missing from tables"
+    assert card.find("table") is None, "interests are a list, not a table"
+    assert not any(table.find_parent("div", class_="section-card") is card
+                   for table in soup.find_all("table"))
+
+
+def test_three_of_the_five_tables_are_empty_for_this_contractor():
+    """`R-19`'s own evidence limit, from the other side. The two contractor lists and
+    the technical rating carry no data rows on the only committed profile — so a build
+    that verified itself against this fixture alone would prove almost nothing about
+    three of the five groups."""
+    found = detect_html_tables(_html("en"))
+
+    assert len(found) == 5
+    empty = [table for table in found if not table.rows]
+    assert len(empty) == 3
+
+
+def test_detect_html_tables_names_them_by_position_not_by_meaning():
+    """WHY THE GROUPS CANNOT BE IDENTIFIED FROM THE TABLE ALONE. The names come back
+    `Table 1`…`Table 5`, and the nearest heading does not disambiguate either: three of
+    the five sit under one heading. Whatever `R-19` is built on will need a naming rule
+    that is neither positional nor "the previous `<h3>`".
+    """
+    found = detect_html_tables(_html("en"))
+
+    assert [table.name for table in found] == [f"Table {n}" for n in range(1, 6)]
+
+    soup = BeautifulSoup(_html("en"), "html.parser")
+    headings = [table.find_previous(["h1", "h2", "h3", "h4"]).get_text(strip=True)
+                for table in soup.find_all("table")]
+    assert len(set(headings)) < len(headings), "at least two tables share a heading"
+
+
+# ---- reading the hierarchy ----------------------------------------------------
+
+def test_both_locales_read_the_same_shape():
+    """THE ASSERTION THAT CAUGHT THE REAL BUG. The first version of `read_interests`
+    matched the heading text `"Interests"` and read **25 nodes from English and 0 from
+    Arabic**, because the Arabic heading is `الأنشطة` — "Activities", not a translation.
+
+    Titles are content and are not parallel between locales. `DSN-05` cost a day to the
+    same class of mistake, where a slug filter reduced every Arabic label to nothing and
+    produced two empty strings for every contractor in the country.
+    """
+    english = read_interests(_html("en"))
+    arabic = read_interests(_html("ar"))
+
+    assert len(english) == len(arabic) == 25
+    assert (Counter(len(path) for path in english)
+            == Counter(len(path) for path in arabic) == {1: 3, 2: 5, 3: 17})
+
+
+def test_the_headings_really_do_differ_so_the_selector_must_be_structural():
+    """PINS THE REASON, so nobody re-simplifies the selector back to a title match."""
+    titles = {}
+    for locale in ("en", "ar"):
+        soup = BeautifulSoup(_html(locale), "html.parser")
+        card = soup.select_one("div.section-card:has(ul.list-numerical li.list-item)")
+        titles[locale] = card.select_one("h3.card-title").get_text(strip=True)
+
+    assert titles["en"] == "Interests"
+    assert titles["ar"] == "الأنشطة"
+    assert titles["en"] != titles["ar"]
+
+
+def test_every_node_is_a_path_and_the_interior_nodes_are_there():
+    """A TAXONOMY NEEDS ITS PARENTS TO EXIST. `classification_node` has
+    `parent_node_id`, so a leaf cannot be written before the node above it — returning
+    leaves alone would leave the parents to be inferred, which is the guessing this
+    function removes."""
+    paths = read_interests(_html("en"))
+
+    roots = {path[0] for path in paths}
+    assert len(roots) == 3
+    # Every path's own prefix is also a node that was returned.
+    returned = set(paths)
+    for path in paths:
+        for depth in range(1, len(path)):
+            assert path[:depth] in returned, f"{path[:depth]} is a parent nobody wrote"
+
+
+def test_a_name_repeats_across_levels_so_a_name_is_not_an_identity():
+    """THE STUDY'S FINDING, ON THIS FIXTURE. `Construction of buildings` is both a
+    level-1 node and a level-2 node beneath itself — so an identity built from the name
+    would merge two different nodes, which is exactly what the `R-19` study measured
+    with `الصرف الصحي` sitting under more than one parent."""
+    paths = read_interests(_html("en"))
+
+    names = Counter(path[-1] for path in paths)
+    repeated = {name for name, count in names.items() if count > 1}
+
+    assert repeated, "no repeated leaf name, so this fixture cannot make the point"
+    assert "Construction of buildings" in repeated
+
+
+def test_the_parent_is_the_preceding_sibling_and_not_an_ancestor():
+    """THE MARKUP'S ONE TRAP. A child `<ul>` sits BESIDE the `<li>` it belongs to, so
+    walking `parents` finds the right depth and never the right names — every leaf would
+    come back as a child of nothing."""
+    paths = read_interests(_html("en"))
+
+    deep = [path for path in paths if len(path) == 3]
+    assert deep
+    assert ("Civil engineering", "Construction of roads and railways") in {
+        path[:2] for path in deep}
+
+
+# ---- the failure modes --------------------------------------------------------
+
+def test_a_profile_without_the_section_reads_as_empty_and_does_not_raise():
+    """ABSENT IS A REAL STATE. A contractor with no interests exists, and an exception
+    would make the whole profile unreadable for one missing section."""
+    assert read_interests("<html><body><div class='section-card'></div></body></html>") == ()
+
+
+def test_two_numerical_lists_are_refused_rather_than_guessed():
+    """AMBIGUOUS IS NOT A GUESS. The card is identified by holding the list, so a page
+    that grows a second one makes that description mean two things — and picking the
+    first would read one group's values as another's."""
+    doubled = (
+        "<html><body>"
+        "<div class='section-card'><ul class='list list-numerical'>"
+        "<li class='list-item'>one</li></ul></div>"
+        "<div class='section-card'><ul class='list list-numerical'>"
+        "<li class='list-item'>two</li></ul></div>"
+        "</body></html>")
+
+    with pytest.raises(ValueError) as raised:
+        read_interests(doubled)
+
+    assert "layout has changed" in str(raised.value)

--- a/tests/test_the_profile_frontier_comes_off_the_disk.py
+++ b/tests/test_the_profile_frontier_comes_off_the_disk.py
@@ -322,20 +322,35 @@ def test_a_ceiling_on_the_wrong_phase_is_refused_not_ignored(conn):
     assert raised.value.code == 2
 
 
-def test_the_stored_profile_is_labelled_as_a_profile(conn):
-    """`body_class` PICKS THE COMPRESSION DICTIONARY, and `docs/STORAGE.md` measured the
-    difference at 46x on profiles against zlib's 7.7x — because zlib's 32 KB window
-    never sees across a 121 KB page. On 34,834 pages that is the difference between
-    gigabytes and megabytes, so a profile stored under the listing's dictionary is a
-    real cost rather than a tidiness point."""
+def test_the_stored_profile_is_labelled_as_a_profile(conn, monkeypatch):
+    """`body_class` PICKS THE COMPRESSION DICTIONARY. `docs/STORAGE.md` measured 46x on
+    profiles against zlib's 7.7x, because zlib's 32 KB window never sees across a 121 KB
+    page — so on 34,834 pages a profile stored under the listing's dictionary is
+    gigabytes, not untidiness.
+
+    THIS TEST USED TO ASSERT `html_codec is not None` AND IT PASSED WITH `body_class=None`
+    — a mutation that survived being committed and was caught by the lint gate noticing
+    an unused import, not by this file. A test that holds under the defect it is named
+    for proves nothing.
+
+    So it asserts the LABEL that was passed, which is the decision being made:
+    `muqawil.org/detail` and never `muqawil.org/listing` or the `muqawil.org/page`
+    fallback that `label_for` returns when no kind is given.
+    """
+    from scrapex import contractors
     from scrapex.contractors import details
 
+    seen: list[str | None] = []
+    real = contractors.service.save_snapshot
+
+    def watching(conn_, request):
+        seen.append(request.body_class)
+        return real(conn_, request)
+
+    monkeypatch.setattr(contractors.service, "save_snapshot", watching)
     _registered(conn, "full_then_listing")
     record_sightings(conn, "contractors", ["1004"])
 
     details(conn, get_directory(None), _fetch_recording([]), None, "p1")
 
-    codecs = {row[0] for row in conn.execute(
-        "SELECT html_codec FROM generic_page_snapshot WHERE crawl_run_ref='p1'")}
-    assert codecs, "the pages must have been stored at all"
-    assert all(codec is not None for codec in codecs)
+    assert seen == ["muqawil.org/detail", "muqawil.org/detail"]

--- a/tests/test_the_profile_frontier_comes_off_the_disk.py
+++ b/tests/test_the_profile_frontier_comes_off_the_disk.py
@@ -190,20 +190,52 @@ def test_a_slice_reads_the_pages_because_the_city_is_on_the_card(conn):
     assert all("/contractors/" in url and url.endswith("/143") for url in urls)
 
 
-def test_the_same_contractor_on_two_listing_pages_is_fetched_once(conn):
-    """A LIVE LISTING REORDERS BETWEEN REQUESTS — that is the whole reason the witness
-    compares id sequences — so one contractor can sit on two stored pages. Fetching the
-    profile twice is a wasted request and a second snapshot of the same page."""
+def test_the_ledger_holds_one_row_however_often_a_contractor_is_seen(conn):
+    """THE FULL PATH CANNOT PRODUCE A DUPLICATE, and saying so is worth a test because
+    it explains why the deduplication below is about the SLICE path.
+
+    `record_sightings` upserts, so being seen five times is still one ledger row. A
+    mutation removing `dict.fromkeys` from the frontier survived against this path for
+    exactly that reason — the guard is real, and this is not where it acts.
+    """
     from scrapex.contractors import detail_frontier
 
     _registered(conn, "full_then_listing")
     record_sightings(conn, "contractors", ["1004"])
-    record_sightings(conn, "contractors", ["1004"])     # seen again, one ledger row
+    record_sightings(conn, "contractors", ["1004"])
 
     urls, _ = detail_frontier(conn, get_directory(None),
                               CrawlScope.FULL_THEN_LISTING, "")
 
     assert len(urls) == 2, "one per locale, not four"
+
+
+def test_a_contractor_on_two_stored_listing_pages_is_fetched_once(conn):
+    """WHERE THE DEDUPLICATION ACTUALLY EARNS ITS PLACE. A live listing reorders between
+    requests — the entire reason the witness compares id sequences rather than counts —
+    so the same contractor really does end up on two stored pages. On the slice path the
+    frontier is built by reading those pages, so without this the profile is fetched
+    twice: a wasted request and a second snapshot of the same page, times however many
+    contractors the reorder touched.
+    """
+    from scrapex.contractors import detail_frontier
+
+    _registered(conn, "listing_plus_slice", "RIYADH")
+    listing = (FIXTURES / "listing-en.html").read_text(encoding="utf-8")
+    for page in (1, 2):
+        # THE SAME PAGE UNDER TWO URLS, which is what a reorder looks like from disk:
+        # two stored listing pages whose card sets overlap.
+        conn.execute(
+            "INSERT INTO generic_page_snapshot (source_url, html_content, "
+            " content_hash, crawl_run_ref) VALUES (?,?,?,'listing-1')",
+            (f"https://muqawil.org/en/contractors?page={page}", listing, f"h{page}"))
+    conn.commit()
+
+    urls, _ = detail_frontier(conn, get_directory(None),
+                              CrawlScope.LISTING_PLUS_SLICE, "RIYADH")
+
+    assert urls, "the committed listing has Riyadh contractors"
+    assert len(urls) == len(set(urls)), "the same profile URL twice"
 
 
 # ---- the walk ------------------------------------------------------------------

--- a/tests/test_the_profile_frontier_comes_off_the_disk.py
+++ b/tests/test_the_profile_frontier_comes_off_the_disk.py
@@ -1,0 +1,309 @@
+"""Nothing walked the profile frontier, and building it the obvious way took over two minutes.
+
+WHAT WAS MISSING. `detail_urls` had callers, `belongs_to_slice` had callers, and no
+command fetched a single profile page for muqawil. The 48 columns the owner wants are on
+those pages; 21 of them are on the listing and the rest are not.
+
+WHERE THE FRONTIER COMES FROM, and the first answer was wrong by a factor of about 1,500.
+Deriving it from stored listing pages means decoding and parsing 14,727 of them: measured
+at **over 120 seconds and still running when it was killed**. `dataset_sighting` already
+holds every contractor id the site has ever shown us — that is what the ledger is for —
+so the full frontier is one indexed SELECT: **0.08 s for 34,834 URLs**.
+
+A SLICE STILL NEEDS THE PAGES, because the city is on the card and the ledger holds ids
+alone. That asymmetry is deliberate and is why the two paths are not merged.
+
+AND `sighted_ids` IS NOT `stored_ids`. Measured on the live warehouse: 17,417 sighted
+against 15,707 stored, because a row exists only once its page has been approved. A
+frontier built from stored rows would skip the 1,710 contractors we have seen and not yet
+interpreted — the population a profile crawl most needs.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scrapex.crawlscope import CrawlScope
+from scrapex.databases import DatabaseRegistry, EngineDatabase
+from scrapex.directories import get as get_directory
+from scrapex.sightings import record_sightings, sighted_ids
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "muqawil"
+
+
+@pytest.fixture(autouse=True)
+def _log_somewhere_harmless(tmp_path, monkeypatch):
+    """`say` appends to the owner's real crawl log otherwise — `OP-32`."""
+    from scrapex import contractors
+
+    monkeypatch.setattr(contractors, "LOG", tmp_path / "contractors.log")
+
+
+@pytest.fixture()
+def conn(tmp_path: Path):
+    registry = DatabaseRegistry(EngineDatabase(tmp_path / "scrapex-engine.db"),
+                                pointer_file=tmp_path / "databases.json")
+    registry.initialize()
+    connection = registry.engine.connect()
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def _registered(conn, scope: str, slice_of: str | None = None) -> None:
+    """muqawil in `site_profile`, at the scope this test is about.
+
+    THE SCOPE IS WRITTEN TO THE DATABASE AND NEVER PASSED IN, because that is the rule
+    the code under test enforces: `PLATFORM-PLAN` Decision 23 makes it the owner's
+    answer per source, and a scope a caller could also supply is a scope enforced in
+    neither place.
+    """
+    conn.execute(
+        "INSERT INTO site_profile (site_key, display_name, base_url, crawl_scope, "
+        " crawl_slice) VALUES ('muqawil_org','Contractors','https://muqawil.org',?,?)",
+        (scope, slice_of))
+    conn.commit()
+
+
+def _a_stored_listing(conn, *, run_ref: str = "listing-1",
+                      name: str = "listing-en.html") -> None:
+    conn.execute(
+        "INSERT INTO generic_page_snapshot (source_url, html_content, content_hash, "
+        " crawl_run_ref) VALUES (?,?,?,?)",
+        ("https://muqawil.org/en/contractors?page=1",
+         (FIXTURES / name).read_text(encoding="utf-8"), "h1", run_ref))
+    conn.commit()
+
+
+def _fetch_recording(asked: list[str], fails: set[str] = frozenset()):
+    def fetch(url: str) -> str:
+        asked.append(url)
+        if url in fails:
+            raise TimeoutError("the site did not answer")
+        return f"<html>{url}</html>"
+
+    return fetch
+
+
+# ---- the registration decides -------------------------------------------------
+
+def test_a_listing_only_source_fetches_no_profile_and_says_why(conn, capsys):
+    """NOT AN ERROR. The registration is his answer; a command that fetched profiles
+    anyway would be answering for him, which is what Decision 23 made the column for."""
+    from scrapex.contractors import details
+
+    _registered(conn, "listing_only")
+    asked: list[str] = []
+
+    details(conn, get_directory(None), _fetch_recording(asked), None, "r1")
+
+    assert asked == []
+    said = capsys.readouterr().out
+    assert "listing_only" in said
+    assert "site_profile.crawl_scope" in said, "it must say how to change the answer"
+
+
+def test_a_slice_scope_with_no_slice_named_is_refused(conn):
+    """`crawlscope.plan` raises `SliceRequired` for this too, and the duplication is of
+    a CHECK rather than of the rule: refusing here costs nothing, and refusing after the
+    frontier is built costs the frontier."""
+    from scrapex.contractors import details
+
+    _registered(conn, "listing_plus_slice", None)
+
+    with pytest.raises(SystemExit) as raised:
+        details(conn, get_directory(None), _fetch_recording([]), None, "r1")
+
+    assert raised.value.code == 2
+
+
+# ---- where the URLs come from -------------------------------------------------
+
+def test_the_full_frontier_is_read_off_the_ledger_and_not_off_the_pages(conn):
+    """THE PROOF IS THE ABSENCE OF PAGES. Not one listing snapshot is stored here, so a
+    frontier derived by parsing stored listings would be empty. It is not, because
+    `dataset_sighting` is the record of what the site showed us.
+    """
+    from scrapex.contractors import detail_frontier
+
+    _registered(conn, "full_then_listing")
+    record_sightings(conn, "contractors", ["1004", "20044482"])
+
+    urls, outside = detail_frontier(conn, get_directory(None),
+                                    CrawlScope.FULL_THEN_LISTING, "")
+
+    assert outside == 0
+    assert urls == [
+        "https://muqawil.org/en/contractors/1004/143",
+        "https://muqawil.org/ar/contractors/1004/143",
+        "https://muqawil.org/en/contractors/20044482/143",
+        "https://muqawil.org/ar/contractors/20044482/143",
+    ]
+
+
+def test_the_ledger_reaches_contractors_that_have_no_row_yet(conn):
+    """`sighted_ids` IS NOT `stored_ids`, and the gap is the point: 17,417 against
+    15,707 on the live warehouse. A row exists only once its page is approved, so a
+    frontier built from rows skips exactly the contractors not yet interpreted."""
+    _registered(conn, "full_then_listing")
+    record_sightings(conn, "contractors", ["1004", "20044482"])
+    # One of them has a row; the other has only ever been seen.
+    conn.execute("INSERT INTO dataset_definition (site_profile_id, dataset_key, "
+                 " original_name, dataset_kind, discovery_method, locator_json) "
+                 "VALUES (1,'contractors','c','table','html_table','{}')")
+    conn.execute("INSERT INTO dataset_schema_version (dataset_definition_id, "
+                 " version_number, schema_hash) VALUES (1,1,'h')")
+    conn.execute(
+        "INSERT INTO generic_page_snapshot (source_url, html_content, content_hash) "
+        "VALUES ('u','<html></html>','hh')")
+    conn.execute(
+        "INSERT INTO generic_record (dataset_definition_id, record_key, "
+        " schema_version_id, data_json, source_snapshot_id, source_locator, "
+        " content_hash) VALUES (1,'k',1,?,1,'x','c')",
+        (json.dumps({"contractor_id": "1004"}),))
+    conn.commit()
+
+    from scrapex.sightings import stored_ids
+
+    assert set(sighted_ids(conn, "contractors")) == {"1004", "20044482"}
+    assert set(stored_ids(conn, "contractors")) == {"1004"}
+
+
+def test_a_slice_reads_the_pages_because_the_city_is_on_the_card(conn):
+    """The asymmetry, asserted. The ledger holds ids alone, so a slice cannot come from
+    it — and this frontier is smaller than the page's row count, which is what selecting
+    means."""
+    from scrapex.contractors import detail_frontier
+
+    _registered(conn, "listing_plus_slice", "RIYADH")
+    _a_stored_listing(conn)
+
+    urls, outside = detail_frontier(conn, get_directory(None),
+                                    CrawlScope.LISTING_PLUS_SLICE, "RIYADH")
+
+    assert urls, "the committed listing has at least one Riyadh contractor"
+    assert outside > 0, "and at least one that is not, or nothing is being selected"
+    assert all("/contractors/" in url and url.endswith("/143") for url in urls)
+
+
+def test_the_same_contractor_on_two_listing_pages_is_fetched_once(conn):
+    """A LIVE LISTING REORDERS BETWEEN REQUESTS — that is the whole reason the witness
+    compares id sequences — so one contractor can sit on two stored pages. Fetching the
+    profile twice is a wasted request and a second snapshot of the same page."""
+    from scrapex.contractors import detail_frontier
+
+    _registered(conn, "full_then_listing")
+    record_sightings(conn, "contractors", ["1004"])
+    record_sightings(conn, "contractors", ["1004"])     # seen again, one ledger row
+
+    urls, _ = detail_frontier(conn, get_directory(None),
+                              CrawlScope.FULL_THEN_LISTING, "")
+
+    assert len(urls) == 2, "one per locale, not four"
+
+
+# ---- the walk ------------------------------------------------------------------
+
+def test_every_frontier_url_is_fetched_and_stored(conn, capsys):
+    from scrapex.contractors import details
+
+    _registered(conn, "full_then_listing")
+    record_sightings(conn, "contractors", ["1004"])
+    asked: list[str] = []
+
+    details(conn, get_directory(None), _fetch_recording(asked), None, "profiles-1")
+
+    assert len(asked) == 2
+    stored = conn.execute(
+        "SELECT COUNT(*) FROM generic_page_snapshot WHERE crawl_run_ref = 'profiles-1'"
+    ).fetchone()[0]
+    assert stored == 2
+    assert "profiles stored 2" in capsys.readouterr().out
+
+
+def test_a_resume_skips_what_this_run_already_stored_and_counts_it(conn, capsys):
+    """COUNTED, NEVER SILENT: the difference is the hours a resume saved, and a resume
+    that says nothing is indistinguishable from a crawl that fetched everything."""
+    from scrapex.contractors import details
+
+    _registered(conn, "full_then_listing")
+    record_sightings(conn, "contractors", ["1004", "20044482"])
+    details(conn, get_directory(None), _fetch_recording([]), None, "profiles-1")
+
+    second: list[str] = []
+    details(conn, get_directory(None), _fetch_recording(second), None, "profiles-1")
+
+    assert second == [], "everything was already on disk under this ref"
+    assert "4 already stored under profiles-1 — resuming" in capsys.readouterr().out
+
+
+def test_a_dead_profile_does_not_end_the_run(conn, capsys):
+    """One dead page out of thirty-four thousand must not discard the rest. A crawl that
+    stops at the first 404 of an eleven-hour run is a crawl nobody can finish."""
+    from scrapex.contractors import details
+
+    _registered(conn, "full_then_listing")
+    record_sightings(conn, "contractors", ["1004", "20044482"])
+    dead = "https://muqawil.org/en/contractors/1004/143"
+
+    details(conn, get_directory(None), _fetch_recording([], fails={dead}), None, "p1")
+
+    said = capsys.readouterr().out
+    assert "profiles stored 3, failed 1" in said
+
+
+def test_the_ceiling_stops_the_run_and_calls_it_partial(conn, capsys):
+    """34,834 pages is about eleven hours at the rate six workers measured — 52.5 pages
+    a minute over 87 minutes of real crawling. A first run that only wants the shape of
+    the data has to be able to stop, and a stopped run must not look finished."""
+    from scrapex.contractors import details
+
+    _registered(conn, "full_then_listing")
+    record_sightings(conn, "contractors", ["1004", "20044482"])
+    asked: list[str] = []
+
+    details(conn, get_directory(None), _fetch_recording(asked), None, "p1", ceiling=3)
+
+    assert len(asked) == 3
+    said = capsys.readouterr().out
+    assert "3-page ceiling" in said
+    assert "PARTIAL" in said
+
+
+def test_a_ceiling_on_the_wrong_phase_is_refused_not_ignored(conn):
+    """A ceiling silently dropped would let somebody believe a full crawl was bounded
+    when it was not."""
+    import argparse
+
+    from scrapex.contractors import add_arguments, validate
+
+    parser = argparse.ArgumentParser()
+    add_arguments(parser)
+
+    with pytest.raises(SystemExit) as raised:
+        validate(parser.parse_args(["--crawl", "--run-ref", "r", "--ceiling", "10"]))
+
+    assert raised.value.code == 2
+
+
+def test_the_stored_profile_is_labelled_as_a_profile(conn):
+    """`body_class` PICKS THE COMPRESSION DICTIONARY, and `docs/STORAGE.md` measured the
+    difference at 46x on profiles against zlib's 7.7x — because zlib's 32 KB window
+    never sees across a 121 KB page. On 34,834 pages that is the difference between
+    gigabytes and megabytes, so a profile stored under the listing's dictionary is a
+    real cost rather than a tidiness point."""
+    from scrapex.contractors import details
+
+    _registered(conn, "full_then_listing")
+    record_sightings(conn, "contractors", ["1004"])
+
+    details(conn, get_directory(None), _fetch_recording([]), None, "p1")
+
+    codecs = {row[0] for row in conn.execute(
+        "SELECT html_codec FROM generic_page_snapshot WHERE crawl_run_ref='p1'")}
+    assert codecs, "the pages must have been stored at all"
+    assert all(codec is not None for codec in codecs)

--- a/tests/test_the_walker_honours_the_scope.py
+++ b/tests/test_the_walker_honours_the_scope.py
@@ -222,3 +222,79 @@ def test_a_walk_that_finished_does_not_claim_to_have_stopped_early():
     report = w.walk("https://fake.test", CrawlScope.LISTING_ONLY, max_requests=99)
 
     assert report.stopped_early == ""
+
+
+# ---- a site whose listing yields more than one URL per row -------------------
+#
+# THE CASE `FakeSite` ABOVE CANNOT REACH, and the reason the real defect survived here.
+# `FakeSite.detail_urls` returns two URLs for a page and `belongs_to_slice` is asked
+# about `row_index` 0 and 1 — so `enumerate(detail_urls(page))` is correct for it, and
+# every slice test above passed under a pairing that was wrong for muqawil. Measured
+# there: 17 rows, 34 URLs, and every URL after the first asked about the wrong row.
+
+class BilingualSite:
+    """One row, two URLs — the shape muqawil has and every fake here did not.
+
+    `detail_rows` is what says which row a URL came from. Without it the walker's
+    `enumerate` would pair url index 1 (row 0's second locale) with ROW 1.
+    """
+
+    site_key = "bilingual"
+
+    #: Two rows per page, each with an English and an Arabic detail page.
+    ROWS = ("first", "second")
+
+    def __init__(self) -> None:
+        self.asked_about: list[int] = []
+
+    def listing_urls(self, base_url: str):
+        yield f"{base_url}/list?page=1"
+
+    def detail_rows(self, page: FetchedPage):
+        for row_index, name in enumerate(self.ROWS):
+            for locale in ("en", "ar"):
+                yield row_index, f"https://fake.test/{locale}/{name}"
+
+    def detail_urls(self, page: FetchedPage):
+        return [url for _, url in self.detail_rows(page)]
+
+    def belongs_to_slice(self, page: FetchedPage, row_index: int, slice_of: str) -> bool:
+        if row_index >= len(self.ROWS):
+            raise SliceNotSupported(
+                f"row {row_index} does not exist: the page has {len(self.ROWS)}")
+        self.asked_about.append(row_index)
+        return row_index == 0
+
+
+def test_a_slice_asks_the_row_each_url_came_from_not_its_position():
+    """THE TEST THE WALKER DID NOT HAVE, and a mutation proved it: reverting this line
+    to `enumerate(self._source.detail_urls(page))` broke nothing at all.
+
+    With two rows and four URLs, `enumerate` asks about rows 0,1,2,3 — and rows 2 and 3
+    do not exist. Here it must ask about 0,0,1,1: each URL's own row.
+    """
+    site = BilingualSite()
+    fetch = Recorder()
+    walk, _ = walker(site, fetch)
+
+    walk.walk("https://fake.test", CrawlScope.LISTING_PLUS_SLICE, slice_of="Cairo")
+
+    assert site.asked_about == [0, 0, 1, 1]
+    # Row 0 is in the slice, so BOTH of its locales are fetched and neither of row 1's.
+    fetched = [url for url in fetch.asked if "/entity/" not in url and "list?" not in url]
+    assert fetched == ["https://fake.test/en/first", "https://fake.test/ar/first"]
+
+
+def test_the_position_pairing_would_have_asked_about_rows_that_do_not_exist():
+    """PINS WHY, so the fix cannot be undone as a simplification. This is the walker's
+    old expression, run directly against the same site."""
+    site = BilingualSite()
+    page = FetchedPage(url="https://fake.test/list?page=1", html="",
+                       kind=PageKind.LISTING)
+
+    overshooting = [index for index, _ in enumerate(site.detail_urls(page))
+                    if index >= len(site.ROWS)]
+
+    assert overshooting == [2, 3]
+    with pytest.raises(SliceNotSupported):
+        site.belongs_to_slice(page, 2, "Cairo")


### PR DESCRIPTION
His instruction was to merge #243 and then run the six remaining muqawil engineering items
in order. #243 is merged and verified on `origin/main`. Five of the six are done; the
sixth is built as far as a ruling of his allows, and says so.

**The full suite passes — `EXIT=0`, no failures at all**, including the OP-19 race that
usually fires locally. `ruff check scrapex/` is clean.

## The six

| | item | outcome |
|---|---|---|
| 1 | `status = 'unavailable'` on a departed row | 16 tests, 9 mutations killed |
| 2 | the cost of sizing, stated in the output | 4 mutations killed |
| 3 | `is_enabled` becomes a switch | 10 tests, 5 mutations killed |
| 4 | the slice scope | 10 tests, 6 mutations killed |
| 5 | the profile crawl | 13 tests, 8 mutations killed |
| 6 | `R-19` — the reader only | 10 tests, 5 mutations killed |

**Item 6 is deliberately not finished, and neither blocker is engineering.**
`docs/R19-CHILD-TABLES-MEASURED.md` recommends shape F and its own last line reads *"Not
built. Awaiting his ruling"* — building either shape ahead of that is what **C1** exists
to prevent. And the content comes from profile pages, of which none is stored: the
registration is `listing_only`. So what got built is what **both** candidate shapes need.

## Three written premises that measurement contradicted

**The slice scope was not merely unused — it was wrong.** `belongs_to_slice` indexes
listing ROWS, `detail_urls` yields URLs, and every caller paired them by position. That
is right only when a page yields one URL per row, and muqawil yields one **per locale**.
Measured on a stored page: **17 cards, 34 URLs**; url index 1 is contractor 0's Arabic
page and was being asked about card 1, a different contractor, and **17 of the 34 indices
pointed past the last card** and were dropped. The result is neither the slice nor its
complement, and it reads as a smaller city. Nothing caught it because nothing used it —
and because every fake in the walker's own slice tests yields one URL per row, the case
where the guess is correct. 0 mismatches of 34 after the fix.

**The profile's five `<table>` elements are not `R-19`'s five groups.** Five tables, and
**none of them is Interests** — which is the largest group, priced by the study at ~235 MB
at full scale. It is a nested `<ul>` in a `div.section-card`. Building on that premise
would have produced four groups and missed the biggest. Three of the five tables are also
**empty** on the only committed profile, which is `R-19`'s own "one contractor" evidence
limit arriving from the other side.

**The profile crawl is 11.1 hours, not 17.4.** Measured over 87 minutes of real crawling
with six workers: 52.5 pages a minute. The single-threaded study's 5.84 s a request would
have said 56.5 hours. And the frontier itself: deriving it from stored listing pages took
**over 120 seconds and was still running when killed**; off `dataset_sighting`, which
already holds every id the site has shown us, it is **0.08 s for 34,834 URLs**.

**And conditional requests cannot help this source at all.** One request to the live site:
no `ETag`, no `Last-Modified`, `Cache-Control: no-cache, private` — a Laravel app minting a
fresh XSRF token per response. `fetch_validator` holding 0 rows after 727 pages is correct
behaviour. The plan's line that conditional requests are "what makes maintaining 48 columns
affordable" is false here, recorded per **C5**.

## Two things that were dead or vacuous

A `retired` guard at the top of `mark_unavailable`'s loop was **dead code**: a mutation
deleted it with every test passing, because both branches already name the status they act
on. Removed, with the reason written where the rule actually lives — a line that reads like
protection and cannot fail is worse than no line.

And `row_state` puts a marked row **first** in its precedence, so marking without ever
unmarking would have made `returned` unreachable — silently switching off the entire
purpose of migration 0006. The restore direction is not a nicety.

## A mutation shipped, and I am reporting it plainly

`body_class=None` was committed in the item-5 commit. It is a mutation from a harness run
killed by a two-minute foreground timeout; the tree was checked immediately and grep found
nothing, **because the killed process had not finished dying** and applied its next
mutation after the check.

What caught it was **the lint gate** noticing `label_for` imported and unused — not the
test named for that behaviour, which asserted `html_codec is not None` and passed happily
with `body_class=None`. A defect caught by an unused import is a defect with no test. The
test now asserts the **decision** (the label handed to `save_snapshot`), which kills both
`None` and the plausible wrong answer of the listing's dictionary. The harness writes a
marker file and refuses to start while one exists.

One existing test was **asserting the defect** — that an out-of-range row answers `False` —
which is what made the pairing bug invisible. Same shape as the `R-20` test that demanded
four revisions where one row had changed.

## Also here

- **`D = 0`**: the listing closed at 17,414 of 17,414, from a deficit of 3,690. The last
  633 were a stop condition counting **replayed** attempts as dry ones.
- **OP-32**: the suite was writing into the owner's live crawl log, and two of its lines
  nearly read as a real refusal.
- Six PINNED citations re-pointed **by measurement**, not by applying the +40 and +20
  offsets — an offset is wrong for any citation sitting before the edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)