### PR TITLE
The engine fetches and verifies its own update; the panel hands over the first one

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1468,6 +1468,70 @@ one-line reason where the panel could read it, "Not detected" could become "Inst
 but it stopped: …". Fixing `OP-34` and this entry are the same work.
 
 
+### OP-39 · The update stops one step short: nothing replaces the running executable yet
+
+**Status: OPEN by design, not by omission.** `REQ-29`'s engine half is built —
+the engine reads the release feed, fetches the installer, verifies its SHA-256
+and stages it. What it does not do is install it.
+
+**Why it stops there, and why that is the honest place to stop.** Windows will
+not let a running `.exe` be overwritten, so the swap is necessarily performed by
+a **detached helper after this process exits**. Every part of that is testable
+except the part that matters: whether a real frozen engine, replaced underneath
+itself, comes back. A test that set `sys.frozen` and asserted a rename would
+prove the plan and nothing about the outcome — and this repository has already
+paid for the difference once, in `engine-v0.2.1`, where the guarded thing and the
+shipped thing were different things.
+
+**So the plan is data instead of code.** `update.plan_swap` returns the steps,
+the file it would overwrite, the digest it verified, and whether it is possible
+at all; `GET /api/update/plan` serves it. `R-36` bought an updater before code
+signing existed, and what makes that acceptable is that every step is inspectable
+before it happens — a plan nobody can read is the same trust problem in a new
+place.
+
+**The machinery it needs already exists and is already correct**, which is the
+one piece of luck here: `scrapex/relaunch.py:spawn_helper` starts a detached
+process that waits for a named pid to exit, for exactly this reason. **This is
+why `OP-36` had to be fixed first** — before that, the helper a frozen engine
+spawned was a silent native messaging host and would have waited for ever.
+
+**Next action, and it belongs after a release rather than before one:** cut
+`engine-v0.2.2`, then implement the swap against a binary that exists. The order
+is not a preference — the first artifact that can exercise any of this is the
+next release.
+
+### OP-40 · His warehouse has moved ahead of `main` again — v9 now, and this is the third time
+
+**Status: OPEN, and it is the pattern rather than the instance that matters.**
+
+Measured while smoke-testing the update API against the live installation:
+
+    RuntimeError: engine database is needs a newer scrapex: This database was
+    written by a later version (schema v9; this build reads v8).
+
+**The third time in one day.** It was v8-against-v6 this morning (`OP-33`, closed
+by #243 merging migrations 0007/0008), and it is v9-against-v8 this afternoon —
+so some other branch now holds migration `0009` and has run it against his real
+warehouse.
+
+**Why this is not just #243 again.** Each instance closes by merging; the class
+does not. A session that runs unmerged migration code against the owner's only
+warehouse leaves `main` unable to open it, which means **the shipped engine
+cannot open it either** — and `R-23` says a warehouse is per installation while
+`R-24` says a database is upgraded, never replaced. Both hold. What is missing is
+any rule about which code may write to the live one.
+
+**It also makes the updater more valuable rather than less:** the owner's engine
+being older than his own database is precisely the situation an Update button
+exists for. Today the only route is a merge and a release.
+
+**A question for him, not a decision to take:** should a session be allowed to
+run an unmerged migration against the live warehouse at all? `SCRAPEX_DATA_ROOT`
+already makes a private one free, and `R-24`'s repair path (`carry_over`) exists.
+Recorded as `Q-15`.
+
+
 ## 3. Decided, not yet built
 
 ### DEC-1 · Topology A — the TypeScript extension as the public product
@@ -2171,6 +2235,31 @@ with HTTP 429.
 ## 6. Open questions for the owner
 
 Each is phrased as a question with its options. Nothing below can be answered by code.
+
+**Q-15 · May a session run an unmerged migration against his LIVE warehouse?**
+Three times on 2026-08-21 his engine database moved ahead of `main` — v8 against v6
+in the morning (`OP-33`, closed by #243), and **v9 against v8** in the afternoon
+(`OP-40`). Each instance closes by merging; the class does not.
+
+**What it costs when it happens:** `main` cannot open his warehouse, which means the
+**shipped** engine cannot either — so the product is uninstallable-for-him until a
+merge and a release catch up. That is the same symptom as `REQ-28`'s black screen
+arriving by a different road.
+
+**Why it is his call and not a rule I should take.** The alternative is free and
+already exists — `SCRAPEX_DATA_ROOT` gives any session a private warehouse in one
+environment variable, and `R-24`'s `carry_over` is the path back. But forbidding it
+also forbids the thing that keeps finding real defects: #243's own migration was
+written *because* running against his real data exposed a fault a fixture never
+would, and `R-24` itself came out of exactly that. So the trade is **evidence from
+real data** against **his installation staying installable**, and only he can price
+it.
+
+**Three shapes, if he wants them:** (a) never — sessions use a private root and
+`carry_over` proves the upgrade; (b) only behind a backup, which is what already
+happens informally (`pre-ledger-repair`, `pre-reapprove`, `pre-upgrade-*` are all
+sitting beside his database now); (c) freely, and accept that `main` lags — with a
+rule that the migration must merge the same day.
 
 **Q-14 · ~~What identifies an ACCOUNT, so a database can belong to one?~~ — ANSWERED 2026-08-21: (a), the signed-in address.**
 → [R-34](RULINGS.md#r-34--an-account-is-the-signed-in-address-and-a-warehouse-records-whose-it-is).

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -488,6 +488,49 @@ three read it as bookkeeping. The number was telling the truth: no release carry
 the fix had ever been cut, and the only thing installable was the broken one — for
 twelve days.
 
+### A static-analysis alert on a TEST can be pointing at a hole in production
+
+CodeQL failed #246 with one high-severity alert:
+
+    py/incomplete-url-substring-sanitization
+    tests/test_the_engine_reads_the_same_release_feed.py:63
+    The string raw.githubusercontent.com may be at an arbitrary position in the
+    sanitized URL.
+
+The flagged line was `assert "raw.githubusercontent.com" in engine_url` — a test
+assertion about a constant the code builds itself. **Nothing about it was
+exploitable**, and the obvious responses were both wrong: dismiss it as a false
+positive, or silence it with a suppression comment.
+
+**The alert was pointing one layer past itself.** The engine had just been given
+an updater that downloads `installer.url` out of the release manifest, and
+nothing anywhere checked that the URL belonged to us. The published SHA-256
+proves the CONTENT arrived whole; it says nothing about WHERE the request went. A
+manifest that was mistaken, edited, or served through a compromised path could
+name any host, and the engine would request it — sending the user's address
+somewhere neither party chose, before a digest was computed. **The absence of the
+check was the finding; the test was only where the pattern happened to be
+visible.**
+
+The fix in both places is the same and is one line of reasoning: parse the URL
+and compare `hostname` exactly. These are the cases a substring accepts and an
+exact comparison refuses —
+
+    https://raw.githubusercontent.com.evil.example/x.exe
+    https://evil.example/raw.githubusercontent.com/x.exe
+    https://github.com.evil.example/x.exe
+    https://user:pw@evil.example/github.com/x.exe
+
+**Apply:** when a scanner flags a test, ask what the same mistake would cost in
+the code the test is about, and look there before deciding it is noise. And when
+the answer is a host check, `urlsplit(url).hostname == "..."` is the whole fix —
+`in`, `startswith` and `endswith` are all wrong on a hostname, in that order of
+how convincing they look.
+
+**The scheme belongs in the same check.** A digest survives an eavesdropper; an
+`http://` installer URL still hands the whole download to anyone on the path and
+tells them what is being installed.
+
 ## 5 · The design system: a token has four homes
 
 A new semantic colour is **not one edit**. It must land in `design/tokens.css`

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -84,7 +84,7 @@ IDs are stable and never reused, matching the convention BACKLOG.md already uses
 | [REQ-26](#req-26--a-database-per-account-not-per-machine) | A database per account, not per machine | **In flight** — `Q-14` answered (`R-34`): the account is the signed-in address, and his warehouse records it; the per-account layout remains | 2026-08-21 |
 | [REQ-27](#req-27--a-second-source-of-a-category-reuses-the-firsts-machinery) | A second source of a category reuses the first's machinery | **Done** — `scrapex/directories.py`; `--source`, and the crawl is inherited | 2026-08-21 |
 | [REQ-28](#req-28--the-engine-would-not-install-and-showed-a-black-screen) | The Engine would not install — a black screen, and no way to install it | **In flight** — cause proven; the gate is fixed, cutting the release is his | 2026-08-21 |
-| [REQ-29](#req-29--an-install-surface-that-looks-like-a-professional-program-and-an-update-anyone-can-apply) | An install surface that looks like a professional program, and an update anyone can apply | **Ruled** — [R-36](RULINGS.md#r-36): the engine updates itself, the panel asks. Blocked on `OP-36`, `OP-35` | 2026-08-21 |
+| [REQ-29](#req-29--an-install-surface-that-looks-like-a-professional-program-and-an-update-anyone-can-apply) | An install surface that looks like a professional program, and an update anyone can apply | **In flight** — the engine reads, fetches and verifies; the panel downloads with progress. The swap awaits a real frozen build | 2026-08-21 |
 
 ---
 
@@ -1227,9 +1227,22 @@ changes what somebody else's merged test asserts.
 ---
 
 ## REQ-29 · An install surface that looks like a professional program, and an update anyone can apply
-**Captured 2026-08-21 · Ruled — [R-36](RULINGS.md#r-36--the-engine-updates-itself-the-panel-only-asks-and-a-published-sha-256-over-https-is-enough-to-trust-a-download)**
+**Captured 2026-08-21 · In flight — ruled by [R-36](RULINGS.md#r-36--the-engine-updates-itself-the-panel-only-asks-and-a-published-sha-256-over-https-is-enough-to-trust-a-download), and being built**
 
-> **Ruled the same day.** He answered the study below with «اوافق على اقتراحاتك
+> **IN FLIGHT the same day.** *«ابدأ بالمحدث داخل الـEngine وشريحة downloads»* —
+> both are built. `scrapex/release.py` gives the engine its own reading of the
+> release feed (the **third** reader of that one file, so a three-way guard holds
+> it to `releases.js` and the workflow); `scrapex/update.py` fetches and
+> **verifies** before anything is staged; `GET`/`POST /api/update` and
+> `GET /api/update/plan` are the surface the panel asks through; and the panel now
+> hands the first install to `chrome.downloads` with a live percentage and a
+> **Show in folder**, instead of `window.open` and letting go.
+>
+> **What is NOT built, stated plainly: the swap.** Replacing a running `.exe`
+> cannot be honestly tested without a frozen build, so `plan_swap` returns the
+> plan as data — inspectable, logged, tested — and performs nothing. `OP-39`.
+>
+> **Ruled** before that. He answered the study below with «اوافق على اقتراحاتك
 > وتوصياتك», and the four parts of what he approved are written out in `R-36` rather
 > than left in the conversation. Build order: `OP-36` and `OP-35` first, because an
 > Update button on top of them would report success and change nothing.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -42,6 +42,47 @@ crawl. If a session wants work that depends on nobody: `REQ-20`, or run
 > entries are renumbered **`OP-32`–`OP-37`**, and `OP-38` is new.
 
 
+### The updater — 2026-08-21 (evening) · `REQ-29` in flight
+
+**He asked for the engine's updater and the panel's `downloads` slice, and both
+are built.** *«ابدأ بالمحدث داخل الـEngine وشريحة downloads»*, under
+[R-36](RULINGS.md#r-36--the-engine-updates-itself-the-panel-only-asks-and-a-published-sha-256-over-https-is-enough-to-trust-a-download).
+
+| new | what it is |
+|---|---|
+| `scrapex/release.py` | the engine's own reading of the release feed — the **third** reader of one file, so `tests/test_the_engine_reads_the_same_release_feed.py` holds it to `releases.js` and the workflow |
+| `scrapex/update.py` | fetch, **verify**, stage. Four rules, none of which a caller can switch off |
+| `scrapex/webui/update_api.py` | `GET`/`POST /api/update`, `GET /api/update/plan` — wired **unconditionally**, because a database this build cannot open is a reason to want a newer engine, not a reason to hide the way to get one |
+| `extension/` | `downloads` permission; the first install now has a live percentage and a **Show in folder** |
+
+**Verified end to end against the real manifest**, and the answer it gives is
+itself the story:
+
+```
+installed 0.2.2 · latest ok 0.2.1 · verifiable true
+update_available false
+POST /api/update -> "0.2.2 is already the published version."
+```
+
+The published release is **older than what is installed**, because 0.2.2 was
+never cut. The updater is correct and has nothing to do until it is.
+
+**Seventeen mutations, seventeen killed — after two survived.** Both survivors
+were the same weakness and it was the most security-relevant one: every test
+supplied a digest that differed from the truth *everywhere*, so shortening the
+comparison to `expected[:8]` or a `startswith` refused them all and passed. A
+digest that shares a long prefix and differs late is the only thing that catches
+that, and it exists now.
+
+**What is NOT built, and it is one step:** replacing the running executable.
+`OP-39` says why stopping here is honest rather than incomplete — the swap cannot
+be tested without a frozen build, so the plan is returned as inspectable data and
+performs nothing.
+
+**And a new finding, measured while testing:** his warehouse is at **schema v9**
+and `main` reads v8 — the third time in one day that an unmerged branch has moved
+his live database ahead of `main`. `OP-40`, with `Q-15` for him.
+
 ### In flight now — 2026-08-21 (afternoon) · [#244](https://github.com/muhammadbayoumi/ScrapeX/pull/244)
 
 **The Engine would not install on his machine, and the cause is not the installer.**

--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -92,15 +92,40 @@ outside the browser. Be specific and do not soften it.
 > server. A browser extension cannot write to a local database or run a crawl on
 > a schedule, so the collecting is done by a separate program, ScrapeX-Engine.
 >
-> **THE USER DOWNLOADS AND RUNS THAT PROGRAM THEMSELVES.** This extension does
-> not download, install, execute or update it. The Engine page links to the
-> published release and shows the steps; every action on the file is the user's.
+> **THE USER RUNS THAT PROGRAM THEMSELVES.** This extension can start the
+> download when the user presses Download, and it does nothing else to the file:
+> it does not install it, does not execute it, and cannot update it. Running the
+> downloaded file is the user's own action, taken outside the browser.
+>
+> Updates afterwards are the Engine's own affair, not this extension's: the
+> Engine checks the published release feed, fetches an update itself, and
+> verifies it against the SHA-256 the release publishes before replacing
+> anything. The panel only shows what the Engine reports and asks whether to go
+> ahead.
 >
 > Native messaging is how this panel exchanges data with that program once the
 > user has installed it — the same arrangement password managers and hardware
 > wallets use. Nothing is sent to any remote host through this channel: the
 > other end is a program on the same machine, and the panel refuses to talk to
 > it at all if its version does not match this extension's.
+
+### `downloads`
+
+**Added in 0.2.2, and it replaced something worse.** Before it, pressing
+Download opened the release URL in a new tab and the panel let go — no progress,
+no completion, no way to tell whether a 70 MB file had arrived. On a slow
+connection that is a button that appears to do nothing.
+
+> ScrapeX-Engine is a separate program the user installs on their own computer.
+> When the user presses **Download engine**, this permission is what lets the
+> panel start that one download, show its progress, and then reveal the finished
+> file in the user's Downloads folder.
+>
+> It is used for exactly one file — the published ScrapeX-Engine release from the
+> project's own GitHub release page — and only in response to that press. The
+> panel never reads the contents of any downloaded file, never touches downloads
+> it did not start, and never runs anything. Installing the Engine is the user's
+> own action.
 
 ### `storage`
 

--- a/extension/app.html
+++ b/extension/app.html
@@ -1587,6 +1587,18 @@
               <span>SHA-256</span>
               <code class="tech" id="engine-download-checksum"></code>
             </div>
+            <!-- WHO CHECKS THE NUMBER ABOVE, said out loud. It used to sit
+                 there unattributed, and a checksum nobody verifies is worse
+                 than none: it reads as a guarantee and is decoration. A panel
+                 CANNOT verify it — Chrome grants an extension no way to read a
+                 downloaded file — so for this first install the number is
+                 yours to compare if you want to. Every update after this one
+                 is fetched and verified by the engine itself before anything
+                 is replaced (R-36). -->
+            <p class="text-sm" id="engine-checksum-note">
+              Compare this if you wish. From here on the Engine downloads and
+              checks its own updates against this number before installing.
+            </p>
           </div>
         </details>
       </div>

--- a/extension/app.js
+++ b/extension/app.js
@@ -3560,13 +3560,89 @@ function updateEngineReleaseUI(latest) {
 
   if (installer) {
     $("engine-download-checksum").textContent = installer.sha256 ? installer.sha256 : "";
-    download.onclick = () => {
-      window.open(installer.url, "_blank");
-      steps.open = true;
-    };
+    download.onclick = () => startInstallerDownload(installer);
   } else {
     download.onclick = null;
   }
+}
+
+// THE FIRST INSTALL, AND ONLY THE FIRST. R-36: the panel can never be the
+// installer, so this is the most it can honestly do -- and it is a great deal
+// more than what it did, which was `window.open(url)`: hand a URL to the
+// browser and let go. No progress, no completion, no idea whether 71 MB ever
+// arrived. On a slow connection that is a button that appears to do nothing.
+//
+// WHAT `downloads` BUYS AND WHAT IT DOES NOT. It buys a real download the panel
+// can watch, and `show()` to reveal the file. It does NOT buy reading the file,
+// so the panel still cannot verify the SHA-256 -- that is why the engine now
+// does it for every update after this one, and why the number on screen is
+// labelled as yours to compare rather than as a guarantee.
+//
+// The fallback is not defensive padding: `chrome.downloads` is absent when the
+// panel is loaded in a plain page by the DOM tests, and a first install failing
+// because a permission was declined is exactly when the old behaviour is worth
+// having.
+async function startInstallerDownload(installer) {
+  const steps = $("engine-install-steps");
+  const label = $("engine-download-label");
+  const button = $("engine-download");
+  steps.open = true;
+  if (!chrome?.downloads?.download) {
+    window.open(installer.url, "_blank");
+    return;
+  }
+  const restore = label.textContent;
+  button.disabled = true;
+  label.textContent = "Starting download…";
+  let id = null;
+  try {
+    id = await chrome.downloads.download({
+      url: installer.url,
+      filename: installer.name || "scrapex-engine.exe",
+      // FALSE, so the file lands in Downloads without a dialogue. A Save-As on
+      // a 71 MB file the owner already pressed a button for is one more thing
+      // to get wrong, and `show()` below takes him to it anyway.
+      saveAs: false,
+    });
+  } catch (error) {
+    button.disabled = false;
+    label.textContent = restore;
+    window.open(installer.url, "_blank");
+    return;
+  }
+
+  // PROGRESS FROM THE ONLY SOURCE THAT HAS IT. `onChanged` fires on state
+  // transitions, not on every byte, so the percentage is polled from
+  // `search()` while it runs -- which is what gives a moving number rather
+  // than a spinner that means nothing.
+  const finish = (text) => {
+    label.textContent = text;
+    button.disabled = false;
+  };
+  const poll = setInterval(async () => {
+    let item;
+    try {
+      [item] = await chrome.downloads.search({ id });
+    } catch (_) { return; }
+    if (!item) return;
+    if (item.state === "in_progress") {
+      const total = item.totalBytes || installer.bytes || 0;
+      const percent = total > 0 ? Math.floor((item.bytesReceived / total) * 100) : 0;
+      label.textContent = total > 0 ? `Downloading ${percent}%` : "Downloading…";
+      return;
+    }
+    clearInterval(poll);
+    if (item.state === "complete") {
+      finish("Show in folder");
+      button.onclick = () => chrome.downloads.show(id);
+    } else {
+      // `interrupted`, and the reason is worth showing: "download failed" sends
+      // somebody to check their engine, and `SERVER_FORBIDDEN` sends them to
+      // the release page.
+      finish(item.error ? `Download failed — ${item.error}` : "Download failed");
+      button.onclick = () => startInstallerDownload(installer);
+    }
+  }, 400);
 }
 
 // WHICH ENGINE IS OPEN. In memory only, and never persisted: the catalogue is

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -27,6 +27,7 @@
   "permissions": [
     "activeTab",
     "identity",
+    "downloads",
     "nativeMessaging",
     "sidePanel",
     "storage",

--- a/scrapex/release.py
+++ b/scrapex/release.py
@@ -1,0 +1,256 @@
+"""What the newest ScrapeX-Engine is — read by the ENGINE, not only the panel.
+
+THE THIRD READER OF ONE FILE, and that is the whole risk this module carries.
+`ScrapeX/json/version.json` on the hub is written by
+`.github/workflows/release-engine.yml` and read by `extension/releases.js`;
+`tests/test_the_two_release_paths.py` already asserts those two agree about where
+it lives. This is a third participant, so the same constants are declared here
+and `tests/test_the_engine_reads_the_same_release_feed.py` holds all three
+together. A version manifest that the engine and the panel disagree about is
+worse than none: they would report different verdicts about the same
+installation, and the owner would have no way to tell which was lying.
+
+WHY THE ENGINE NEEDS TO READ IT AT ALL, given the panel already does. `R-36`:
+the first install must come through the browser because nothing is installed
+yet, but **every update after that belongs to the engine** — the panel is a
+Chrome extension and Chrome grants it no way to verify a checksum, no way to
+read a file off disk, and no way to launch a process. The engine is a local
+process with all three. So the panel asks and the engine acts, and acting starts
+with knowing what is published.
+
+THE STATE VOCABULARY IS DELIBERATELY THE SAME FOUR as `releases.js` — `ok`,
+`none`, `offline`, `unreadable` — because "we do not know the latest engine" has
+several causes and only one of them is anybody's fault. Two surfaces that name
+those causes differently will eventually be shown side by side.
+
+NOT `HttpFetcher`. That is the crawl transport: conditional requests, jitter, a
+circuit breaker, one-request-per-second politeness. This is a single request to
+our own release host, and none of that applies — borrowing it would inherit a
+rate limiter and a block counter that mean nothing here, and would put our own
+release feed behind a governor built for somebody else's website.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+#: The public delivery endpoint. ScrapeX's own repository goes private before
+#: the first release and GitHub answers 404 on a private repository to anyone
+#: not signed in — which is every user. Named once here; `extension/releases.js`
+#: holds the same string and a test asserts they match.
+PUBLIC_REPO = "muhammadbayoumi/mbiX-hub"
+
+#: Where this product's manifest lives, beside the Excel add-in's.
+VERSION_MANIFEST = (
+    f"https://raw.githubusercontent.com/{PUBLIC_REPO}/main/ScrapeX/json/version.json"
+)
+
+#: Where a human goes.
+PUBLIC_HOME = f"https://github.com/{PUBLIC_REPO}"
+
+#: The product this manifest must be about. The hub serves several, and reading
+#: the add-in's as ours would report a confident, wrong version.
+PRODUCT = "scrapex-engine"
+
+#: Its own timeout, held apart from anything else the engine does. A stalled
+#: fetch to a third party must never delay the thing the owner asked for.
+CHECK_TIMEOUT_S = 4.0
+
+#: How long the whole installer download may take. Generous, because it is
+#: ~70 MB over somebody's home connection, and because failing a real download
+#: at four minutes would be worse than waiting.
+DOWNLOAD_TIMEOUT_S = 900.0
+
+_VERSION_SHAPE = ("0123456789.", 3)
+
+
+@dataclass(frozen=True)
+class Installer:
+    """The file a release attaches, and the digest that proves it arrived whole."""
+
+    name: str
+    url: str
+    bytes: int
+    sha256: str
+
+    @property
+    def verifiable(self) -> bool:
+        """Is there enough here to refuse a bad download?
+
+        A release whose installer carries no digest is installable only by
+        trusting the transport alone. `R-36` names the published SHA-256 as the
+        thing that makes an updater acceptable before code signing exists, so an
+        installer without one is reported and NOT offered for automatic update.
+        """
+        return bool(self.url) and len(self.sha256) == 64
+
+
+@dataclass(frozen=True)
+class Release:
+    """One of the four things a reader can be told, and never a guess."""
+
+    state: str                     # ok | none | offline | unreadable
+    detail: str = ""
+    version: str = ""
+    tag: str = ""
+    published_at: str = ""
+    url: str = ""
+    minimum_extension: str = ""
+    protocol: int | None = None
+    installer: Installer | None = None
+    #: Everything the manifest said, kept so a field added upstream is not lost
+    #: on the way through this module.
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def ok(self) -> bool:
+        return self.state == "ok"
+
+
+def _looks_like_a_version(value: object) -> bool:
+    """`1.2.3`, and nothing else — the same shape `releases.js` requires.
+
+    Written out rather than done with a regex because the rule is small and the
+    failure mode of a loose one is a manifest that names `latest` or `v2` and is
+    then compared with `<` against a real version.
+    """
+    if not isinstance(value, str):
+        return False
+    allowed, dots = _VERSION_SHAPE
+    parts = value.split(".")
+    return (len(parts) == dots
+            and all(p.isdigit() and p != "" for p in parts)
+            and all(c in allowed for c in value))
+
+
+def read_manifest(status: int, body: object) -> Release:
+    """Turn the endpoint's answer into one of the four states.
+
+    `status` and `body` are passed IN rather than fetched, for the same reason
+    `releases.js` does it: the offline branch can then be tested honestly. A
+    test that had to reach the network to prove what happens when the network is
+    unreachable would prove nothing.
+    """
+    if status == 404:
+        # On this endpoint a missing file means exactly one thing, and it is not
+        # an error: no engine has been released yet. Reporting it as a failure
+        # would tell every fresh installation that something is broken.
+        return Release(state="none", detail="No engine has been released yet.")
+    if status != 200:
+        return Release(state="unreadable",
+                       detail=f"The release manifest answered {status}.")
+    if not isinstance(body, dict):
+        return Release(state="unreadable",
+                       detail="The release manifest could not be read.")
+
+    product = body.get("product")
+    if product != PRODUCT:
+        return Release(
+            state="unreadable",
+            detail=(f"That manifest is for {product or 'another product'}, "
+                    f"not the ScrapeX engine."),
+            raw=body)
+
+    version = body.get("version")
+    if not _looks_like_a_version(version):
+        return Release(
+            state="unreadable",
+            detail=f"The release manifest names no usable version ({version or 'empty'}).",
+            raw=body)
+
+    spec = body.get("installer")
+    installer = None
+    if isinstance(spec, dict) and isinstance(spec.get("url"), str):
+        try:
+            size = int(spec.get("bytes") or 0)
+        except (TypeError, ValueError):
+            size = 0
+        installer = Installer(
+            name=spec.get("name") or "scrapex-engine.exe",
+            url=spec["url"],
+            bytes=size,
+            sha256=(spec.get("sha256") or "").strip().lower(),
+        )
+
+    return Release(
+        state="ok",
+        version=version,
+        tag=body.get("tag") if isinstance(body.get("tag"), str) else f"engine-v{version}",
+        published_at=body.get("published_at") if isinstance(body.get("published_at"), str) else "",
+        url=body.get("release_url") if isinstance(body.get("release_url"), str) else PUBLIC_HOME,
+        minimum_extension=(body.get("minimum_extension_version")
+                           if isinstance(body.get("minimum_extension_version"), str) else ""),
+        protocol=(body.get("protocol_version")
+                  if isinstance(body.get("protocol_version"), int) else None),
+        # Named even when absent: a release with no installer attached is a
+        # release nobody can install, and that is worth seeing before the moment
+        # somebody presses Install.
+        installer=installer,
+        raw=body,
+    )
+
+
+def manifest_url(minute: int) -> str:
+    """The URL actually fetched, with a cache key that changes once a minute.
+
+    NOT SUPERSTITION, and the reason is `releases.js`'s: raw.githubusercontent
+    .com serves this file through a CDN that caches it for about five minutes.
+    The manifest is rewritten in place on every release, so without a changing
+    key a release can exist and be invisible for five minutes after it is cut.
+
+    The minute BUCKET rather than a unique timestamp is deliberate too: everyone
+    asking within the same minute shares one cache entry, so the CDN still
+    absorbs almost every request. A per-request value pushes every caller
+    through to origin, which measurably slowed the fetch on the add-in's own
+    path and made its timeout far likelier to fire.
+
+    The bucket is passed in rather than read from the clock, so this is a pure
+    function and the caller owns the only clock read.
+    """
+    return f"{VERSION_MANIFEST}?t={int(minute)}"
+
+
+def latest(*, now_s: float | None = None) -> Release:
+    """Ask the endpoint, and never let the asking delay anything.
+
+    Import-local `httpx` and `time`: this module is read by tests that never
+    touch the network, and the whole point of `read_manifest` being separate is
+    that they do not have to.
+    """
+    import time
+
+    import httpx
+
+    minute = int((time.time() if now_s is None else now_s) // 60)
+    try:
+        response = httpx.get(manifest_url(minute), timeout=CHECK_TIMEOUT_S,
+                             follow_redirects=True,
+                             headers={"Cache-Control": "no-cache"})
+    except Exception:
+        # A refusal, a DNS failure and the timeout all land here, and from the
+        # engine they are one fact: nobody answered. The engine you have keeps
+        # working, so this is not an error state to act on.
+        return Release(state="offline",
+                       detail=("Could not reach the release endpoint. The engine "
+                               "you have keeps working."))
+    try:
+        body = response.json()
+    except (json.JSONDecodeError, ValueError):
+        body = None
+    return read_manifest(response.status_code, body)
+
+
+def is_newer(candidate: str, installed: str) -> bool:
+    """Is `candidate` a later version than `installed`?
+
+    Numeric per component, never string comparison: `"0.10.0" > "0.9.0"` is
+    false as text and true as a version, and getting that backwards offers a
+    downgrade as an update. An unparseable version on either side answers False
+    — refusing to claim an update is the safe direction.
+    """
+    if not (_looks_like_a_version(candidate) and _looks_like_a_version(installed)):
+        return False
+    left = [int(p) for p in candidate.split(".")]
+    right = [int(p) for p in installed.split(".")]
+    return left > right

--- a/scrapex/release.py
+++ b/scrapex/release.py
@@ -53,6 +53,38 @@ PUBLIC_HOME = f"https://github.com/{PUBLIC_REPO}"
 #: the add-in's as ours would report a confident, wrong version.
 PRODUCT = "scrapex-engine"
 
+#: THE ONLY HOSTS AN INSTALLER MAY BE FETCHED FROM, and the reason is narrower
+#: than it looks. The published SHA-256 proves the CONTENT arrived whole; it
+#: proves nothing about WHERE it was fetched from. A manifest that was mistaken,
+#: edited, or served through a compromised path could name any URL, and the
+#: engine would dutifully request it — sending a user's IP somewhere neither of
+#: us chose, before any digest is computed.
+#:
+#: `github.com` is where a release asset lives; `raw.githubusercontent.com` is
+#: where the manifest lives and is allowed in case an installer is ever served
+#: beside it. GitHub redirects an asset download to `objects.githubusercontent
+#: .com`, and that is fine: what is checked is the URL WE decide to request, not
+#: where the host we trust then sends us.
+#:
+#: CodeQL taught this the useful way. It flagged `"raw.githubusercontent.com" in
+#: url` in a test as `py/incomplete-url-substring-sanitization` — correctly,
+#: because that substring matches `https://evil.example/raw.githubusercontent
+#: .com/...` too. The test was not a security control; the absence of this check
+#: WAS the gap, and it was found by fixing the alert rather than by dismissing it.
+ALLOWED_INSTALLER_HOSTS = frozenset({
+    "github.com",
+    "raw.githubusercontent.com",
+})
+
+#: And the scheme. Held as its own constant rather than written into the check,
+#: because the two are patched together by the tests that need a local server —
+#: and a test that quietly reaches into a boolean expression to relax it would be
+#: much harder to see than one that names both policies at the top.
+#:
+#: A digest survives an eavesdropper; `http://` still hands the whole download to
+#: anyone on the path and tells them what the user is installing.
+ALLOWED_INSTALLER_SCHEMES = frozenset({"https"})
+
 #: Its own timeout, held apart from anything else the engine does. A stalled
 #: fetch to a third party must never delay the thing the owner asked for.
 CHECK_TIMEOUT_S = 4.0
@@ -75,6 +107,30 @@ class Installer:
     sha256: str
 
     @property
+    def from_known_host(self) -> bool:
+        """Is this URL one we would ever publish to?
+
+        Parsed and compared EXACTLY, never by substring. `urlsplit().hostname`
+        is lower-cased and strips any port and credentials, so
+        `raw.githubusercontent.com.evil.example` and
+        `https://evil.example/raw.githubusercontent.com/x.exe` both answer False
+        — which a substring check would not.
+
+        HTTPS is required as well. A digest survives an eavesdropper, but an
+        `http://` installer URL hands the whole download to anyone on the path
+        and tells them what the user is installing.
+        """
+        from urllib.parse import urlsplit
+
+        try:
+            parts = urlsplit(self.url)
+        except ValueError:
+            return False
+        if parts.scheme.lower() not in ALLOWED_INSTALLER_SCHEMES:
+            return False
+        return (parts.hostname or "").lower() in ALLOWED_INSTALLER_HOSTS
+
+    @property
     def verifiable(self) -> bool:
         """Is there enough here to refuse a bad download?
 
@@ -83,7 +139,8 @@ class Installer:
         thing that makes an updater acceptable before code signing exists, so an
         installer without one is reported and NOT offered for automatic update.
         """
-        return bool(self.url) and len(self.sha256) == 64
+        return (bool(self.url) and len(self.sha256) == 64
+                and self.from_known_host)
 
 
 @dataclass(frozen=True)

--- a/scrapex/update.py
+++ b/scrapex/update.py
@@ -1,0 +1,290 @@
+"""Fetch, VERIFY, and stage a new engine. Nothing here executes what it fetched.
+
+`R-36` is the ruling this implements, and its third part is the one with
+consequences, so it is written at its narrowest here too:
+
+    A sha256 published in the release manifest, fetched over HTTPS from
+    raw.githubusercontent.com, and CHECKED BEFORE THE SWAP, is enough to trust
+    a download.
+
+    It is NOT code signing and does not replace it. SmartScreen still warns on
+    first install until a certificate exists, which only the owner can supply.
+    What the chain buys is that an updater may exist BEFORE signing does.
+
+`packaging/build_engine.py` refused to guess about this and said why: *"shipping
+an updater that fetches and executes unsigned code would be worse than none."*
+That objection is answered by the digest and by nothing else, which is why every
+refusal in this module is about the digest and why none of them can be turned
+off by a caller.
+
+THE FOUR RULES, and they are the whole design:
+
+  1. THE DIGEST IS REQUIRED. A release whose installer publishes no sha256 is
+     reported and refused. There is no "download anyway" parameter, because the
+     moment one exists it becomes the path somebody takes at 2am.
+  2. THE BYTES ARE HASHED AS THEY ARRIVE, not read back afterwards. Reading back
+     verifies the disk, not the download, and a file that changed between the
+     two reads would pass.
+  3. A FILE THAT FAILS IS DELETED, immediately, before returning. A rejected
+     71 MB executable left lying in a staging directory is a thing somebody
+     double-clicks a week later.
+  4. THE STAGED PATH IS ONLY RETURNED ON SUCCESS. There is no shape of the
+     return value that hands a caller unverified bytes, so no caller can
+     misuse it by forgetting to check a flag.
+
+WHAT THIS MODULE DELIBERATELY DOES NOT DO: replace the running executable.
+Windows will not let a running .exe be overwritten, so the swap is a separate
+act performed by a detached helper after this process exits — `plan_swap` names
+that plan and `scrapex/relaunch.py` already owns the machinery, but performing
+it cannot be honestly tested without a frozen build, and this module will not
+pretend otherwise. See `swap_is_possible`.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from . import enginelaunch
+from .release import DOWNLOAD_TIMEOUT_S, Installer
+
+#: Where a download lands. Beside the warehouse rather than in %TEMP%, because a
+#: 70 MB file that a virus scanner is still inspecting must not be swept away by
+#: somebody else's cleaner half way through.
+STAGING_DIRNAME = "updates"
+
+#: Read in chunks so a 70 MB download does not become 70 MB of resident memory,
+#: and so progress can be reported while it happens rather than at the end.
+CHUNK_BYTES = 1 << 16
+
+#: A ceiling on what we will write to disk even if the server keeps sending.
+#: Without it a misconfigured endpoint (or a redirect to something enormous) can
+#: fill the owner's disk while we wait for a digest that will never match.
+#: 4x the largest engine we have ever built, which was 67.6 MB.
+MAX_INSTALLER_BYTES = 300 * 1024 * 1024
+
+
+class UpdateRefused(Exception):
+    """The download did not earn the right to be installed.
+
+    A distinct type, because the caller's response differs from every other
+    failure: a network error is worth retrying and this is not. It carries the
+    sentence a person should read, so the API layer never has to invent one.
+    """
+
+
+@dataclass(frozen=True)
+class Staged:
+    """A verified installer, on disk, ready for a swap this module will not do."""
+
+    path: Path
+    version: str
+    sha256: str
+    bytes: int
+
+
+def staging_dir(root: Path | None = None) -> Path:
+    """`~/.scrapex/updates`, created on demand.
+
+    Honours `SCRAPEX_DATA_ROOT` through the same env var the registry reads, so
+    a test and a second installation land somewhere of their own rather than in
+    the owner's real directory.
+    """
+    if root is None:
+        root = Path(os.environ.get("SCRAPEX_DATA_ROOT", str(Path.home() / ".scrapex")))
+    target = Path(root) / STAGING_DIRNAME
+    target.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def swap_is_possible() -> tuple[bool, str]:
+    """Can this installation replace its own executable at all? Say so plainly.
+
+    A source install has no executable to replace: it is a checkout, and it
+    updates with `git pull`. Offering it an Update button would be offering
+    something that cannot work, and reporting THAT is more useful than a button
+    that fails.
+    """
+    if not enginelaunch.frozen():
+        return False, ("This is a source checkout, not an installed engine. "
+                       "Update it with git rather than from here.")
+    return True, ""
+
+
+def _digest_matches(expected: str, actual: str) -> bool:
+    """Compared case-insensitively and in constant time.
+
+    `hmac.compare_digest` is not about secrecy here — nothing is secret, the
+    digest is published. It is about not writing a comparison that some future
+    reader optimises into an early return and a timing signal, in a module whose
+    whole job is a security check. Cheap, and it removes the question.
+    """
+    import hmac
+
+    return hmac.compare_digest(expected.strip().lower(), actual.strip().lower())
+
+
+def fetch_and_verify(
+    installer: Installer,
+    version: str,
+    *,
+    into: Path | None = None,
+    progress: Callable[[int, int], None] | None = None,
+    client: object | None = None,
+) -> Staged:
+    """Stream the installer down, hash it as it arrives, and refuse it if it lies.
+
+    Raises `UpdateRefused` for anything that means "do not install this", and
+    lets a genuine transport error propagate as itself — the caller's answer to
+    a dropped connection is "try again", and to a digest mismatch is not.
+
+    `client` is injectable so the tests drive a real local HTTP server rather
+    than a mocked `httpx`: the thing under test is a streamed download with a
+    running hash, and a mock that returns bytes in one lump would not exercise
+    it at all.
+    """
+    if not installer.verifiable:
+        raise UpdateRefused(
+            "This release publishes no SHA-256 for its installer, so a download "
+            "cannot be proved whole. Install it by hand from the release page, "
+            "or cut a release that attaches one.")
+
+    target_dir = staging_dir() if into is None else Path(into)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    # Named for the version, so two attempts at the same version reuse one name
+    # and a staging directory cannot silently accumulate a copy per press.
+    final = target_dir / f"scrapex-engine-{version}.exe"
+    partial = final.with_suffix(".part")
+
+    import httpx
+
+    digest = hashlib.sha256()
+    written = 0
+    owned_client = client is None
+    http = httpx.Client(timeout=DOWNLOAD_TIMEOUT_S, follow_redirects=True) \
+        if owned_client else client
+    try:
+        with http.stream("GET", installer.url) as response:  # type: ignore[union-attr]
+            if response.status_code != 200:
+                raise UpdateRefused(
+                    f"The installer could not be downloaded: the release host "
+                    f"answered {response.status_code}.")
+            with partial.open("wb") as handle:
+                for chunk in response.iter_bytes(CHUNK_BYTES):
+                    written += len(chunk)
+                    if written > MAX_INSTALLER_BYTES:
+                        raise UpdateRefused(
+                            "The download is larger than any engine we have ever "
+                            "built and was stopped. Nothing was installed.")
+                    digest.update(chunk)
+                    handle.write(chunk)
+                    if progress is not None:
+                        progress(written, installer.bytes)
+    except UpdateRefused:
+        partial.unlink(missing_ok=True)
+        raise
+    except Exception:
+        # A dropped connection leaves a partial file that is worthless and
+        # confusing. Rule 3 applies to every exit, not only to a bad digest.
+        partial.unlink(missing_ok=True)
+        raise
+    finally:
+        if owned_client:
+            http.close()                                 # type: ignore[union-attr]
+
+    actual = digest.hexdigest()
+    if not _digest_matches(installer.sha256, actual):
+        partial.unlink(missing_ok=True)
+        raise UpdateRefused(
+            f"The downloaded installer does not match the checksum this release "
+            f"publishes, so it was deleted and nothing was installed. "
+            f"Expected {installer.sha256}, got {actual}.")
+
+    # The size is checked AFTER the digest and only as a sanity note: a digest
+    # match already proves the bytes, so a size mismatch here would mean the
+    # manifest's own two fields disagree. Worth refusing, because it means the
+    # release was built wrong and something else in it may be wrong too.
+    if installer.bytes and written != installer.bytes:
+        partial.unlink(missing_ok=True)
+        raise UpdateRefused(
+            f"The release manifest disagrees with itself: it declares "
+            f"{installer.bytes} bytes and the file that matched its checksum is "
+            f"{written}. Nothing was installed.")
+
+    # Only now does a verified file get its real name. Anything that reads the
+    # staging directory for a usable installer sees `.exe` files only, and every
+    # one of them passed.
+    final.unlink(missing_ok=True)
+    partial.replace(final)
+    return Staged(path=final, version=version, sha256=actual, bytes=written)
+
+
+def plan_swap(staged: Staged) -> dict:
+    """WHAT WOULD HAPPEN, described rather than done.
+
+    Returned as data so it can be shown, logged and tested without a frozen
+    build in the room. The steps are in this order for reasons, not for
+    presentation:
+
+      1. The running executable cannot be overwritten while it runs — Windows
+         holds the file. So the new one is put BESIDE it under a temporary name.
+      2. A DETACHED helper is started, which waits for this process to exit.
+         `scrapex/relaunch.py:spawn_helper` already does exactly this waiting,
+         for exactly this reason, and it is why `OP-36` had to be fixed first:
+         before that, the helper a frozen engine spawned was a silent native
+         messaging host and would have waited forever.
+      3. Only after the engine has exited does the helper rename. A rename is
+         atomic on one volume, so there is no moment where neither file is
+         installable.
+      4. The helper starts the new engine on the same port and stands down.
+
+    The current executable's path is included because a plan that cannot say
+    what it would overwrite is not a plan anybody should approve.
+    """
+    possible, why = swap_is_possible()
+    return {
+        "possible": possible,
+        "detail": why,
+        "verified_installer": str(staged.path),
+        "sha256": staged.sha256,
+        "version": staged.version,
+        "replaces": enginelaunch.runner(windowless=False).as_posix()
+                    if possible else "",
+        "steps": [
+            "put the verified installer beside the running engine",
+            "start a detached helper that waits for this process to exit",
+            "rename the new engine over the old one (atomic, same volume)",
+            "start the new engine on the same port",
+        ],
+    }
+
+
+def discard(staged: Staged) -> None:
+    """Throw a staged installer away.
+
+    Exists because the alternative is that they accumulate: one verified 70 MB
+    file per version the owner ever considered, in a directory nobody opens.
+    """
+    Path(staged.path).unlink(missing_ok=True)
+
+
+def clear_staging(root: Path | None = None) -> int:
+    """Empty the staging directory. Returns how many files went.
+
+    Called when an update completes, and safe to call when it did not: the
+    directory holds nothing but downloads, and a verified installer that has
+    already been swapped in is a duplicate of the running engine.
+    """
+    target = staging_dir(root)
+    removed = 0
+    for path in target.iterdir():
+        if path.is_file():
+            path.unlink(missing_ok=True)
+            removed += 1
+        elif path.is_dir():
+            shutil.rmtree(path, ignore_errors=True)
+            removed += 1
+    return removed

--- a/scrapex/update.py
+++ b/scrapex/update.py
@@ -146,6 +146,15 @@ def fetch_and_verify(
     running hash, and a mock that returns bytes in one lump would not exercise
     it at all.
     """
+    if not installer.from_known_host:
+        # SEPARATE FROM THE DIGEST REFUSAL, and before it, because it is a
+        # different fault with a different answer: a digest mismatch means the
+        # download was corrupted or substituted, and this means the manifest is
+        # pointing somewhere we do not publish to. Refused before a byte is
+        # requested, so the user's address is never sent to that host at all.
+        raise UpdateRefused(
+            f"That release wants the installer fetched from a host ScrapeX does "
+            f"not publish to, so nothing was downloaded: {installer.url}")
     if not installer.verifiable:
         raise UpdateRefused(
             "This release publishes no SHA-256 for its installer, so a download "

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -163,6 +163,7 @@ from ..vocab import (
 )
 from .catalog_api import create_catalog_router
 from .database_api import create_database_router, create_domain_health_router
+from .update_api import create_update_router
 
 
 def _appearance_value(body: dict | None) -> dict:
@@ -523,6 +524,12 @@ def create_app(
     if databases is not None:
         app.include_router(create_database_router(lambda: app.state.databases))
         app.include_router(create_domain_health_router(lambda: app.state.databases))
+
+    # UNCONDITIONAL, unlike the two above. Update is the one surface that has to
+    # answer when everything else is broken: a database this build cannot open is
+    # a reason to want a newer engine, not a reason to hide the way to get one.
+    # It touches no database at all -- see scrapex/webui/update_api.py.
+    app.include_router(create_update_router())
 
     # A database can become unusable while the engine is running: a drive is
     # unplugged, a file is replaced, a schema stops being the one this build

--- a/scrapex/webui/update_api.py
+++ b/scrapex/webui/update_api.py
@@ -1,0 +1,245 @@
+"""The engine's own update surface. The panel asks; this acts.
+
+`R-36`: the first install comes through the browser because nothing is installed
+yet, and every update after it belongs here — Chrome grants an extension no way
+to verify a checksum, read a file off disk, or launch a process, and this is a
+local process with all three.
+
+WHY GET AND POST ARE DIFFERENT ANSWERS TO DIFFERENT QUESTIONS. `GET` is safe to
+poll and says only what is true right now; it never downloads. `POST` is the act,
+and it is the only thing that touches the network for 70 MB. Merging them into
+one "check and maybe install" endpoint would mean the panel's periodic poll could
+start a download nobody pressed a button for.
+
+THE DOWNLOAD RUNS IN THE BACKGROUND AND THE POST RETURNS AT ONCE, because a
+70 MB fetch over a home connection outlasts any HTTP timeout the panel is willing
+to hold. State lives in one place (`_State`) and `GET` reports it, so the panel
+polls the same endpoint it already polls for everything else instead of holding a
+socket open for four minutes.
+"""
+from __future__ import annotations
+
+import threading
+from dataclasses import asdict, dataclass, field
+
+from fastapi import APIRouter
+
+from .. import release as release_mod
+from .. import update as update_mod
+from ..version import VERSION
+
+
+@dataclass
+class _Progress:
+    """How far a download has got, in the two numbers a bar needs."""
+
+    received: int = 0
+    total: int = 0
+
+    @property
+    def percent(self) -> int:
+        if self.total <= 0:
+            return 0
+        return min(100, int(self.received * 100 / self.total))
+
+
+@dataclass
+class _State:
+    """Everything the panel can be told about an update, in one object.
+
+    ONE object under ONE lock, because the alternative is what the panel has had
+    to do until now: infer a state from several independent fields and get it
+    wrong when two of them are momentarily out of step. `phase` is a closed
+    vocabulary and every other field is only meaningful for some of its values,
+    which is why `as_dict` reports the phase first.
+    """
+
+    #: idle | checking | downloading | staged | failed
+    phase: str = "idle"
+    detail: str = ""
+    progress: _Progress = field(default_factory=_Progress)
+    staged_version: str = ""
+    staged_path: str = ""
+    staged_sha256: str = ""
+
+    def as_dict(self) -> dict:
+        out = asdict(self)
+        out["progress"] = {"received": self.progress.received,
+                           "total": self.progress.total,
+                           "percent": self.progress.percent}
+        return out
+
+
+def create_update_router() -> APIRouter:
+    router = APIRouter(prefix="/api/update", tags=["update"])
+
+    state = _State()
+    lock = threading.Lock()
+    # One at a time, for the obvious reason and one less obvious: two downloads
+    # of the same version write the same staging filename, and the loser would
+    # replace a verified file with a partial one under a name that means
+    # "verified".
+    running = threading.Event()
+
+    def _set(**fields) -> None:
+        with lock:
+            for key, value in fields.items():
+                setattr(state, key, value)
+
+    @router.get("")
+    def current() -> dict:
+        """What is installed, what is published, and what this engine could do.
+
+        Safe to poll: it reads the release manifest (a 4-second-timeout request
+        for a few hundred bytes) and never touches the installer. `offline` is
+        reported as a state rather than an error, because the engine the owner
+        has keeps working and there is nothing for him to fix.
+        """
+        latest = release_mod.latest()
+        possible, why = update_mod.swap_is_possible()
+        with lock:
+            snapshot = state.as_dict()
+
+        available = (latest.ok
+                     and release_mod.is_newer(latest.version, VERSION))
+        return {
+            "installed": VERSION,
+            "latest": {
+                "state": latest.state,
+                "detail": latest.detail,
+                "version": latest.version,
+                "tag": latest.tag,
+                "published_at": latest.published_at,
+                "url": latest.url,
+                "minimum_extension": latest.minimum_extension,
+                "protocol": latest.protocol,
+                "installer": (None if latest.installer is None else {
+                    "name": latest.installer.name,
+                    "bytes": latest.installer.bytes,
+                    "sha256": latest.installer.sha256,
+                    # The URL is reported so the panel can still hand the file to
+                    # chrome.downloads for a FIRST install. It is not needed for
+                    # an update -- the engine fetches that itself.
+                    "url": latest.installer.url,
+                    "verifiable": latest.installer.verifiable,
+                }),
+            },
+            "update_available": available,
+            # SEPARATE FROM `update_available` ON PURPOSE. A newer release can
+            # exist and be uninstallable-from-here for two different reasons: a
+            # source checkout has no executable to replace, and a release
+            # without a digest will not be trusted. The panel must be able to
+            # say WHICH.
+            "can_self_update": bool(
+                available and possible
+                and latest.installer is not None
+                and latest.installer.verifiable),
+            "self_update_blocked_because": (
+                why if available and not possible
+                else "" if not available
+                else "" if latest.installer and latest.installer.verifiable
+                else "This release attaches no SHA-256, so its download cannot "
+                     "be proved whole."),
+            "progress_state": snapshot,
+        }
+
+    @router.post("")
+    def start() -> dict:
+        """Fetch and verify the published installer. Does NOT install it.
+
+        Returns immediately; the work runs on a thread and `GET` reports it. The
+        phase that follows success is `staged`, never `installed` — replacing a
+        running executable is a separate act with its own approval, and calling
+        this endpoint has never done it.
+        """
+        if running.is_set():
+            with lock:
+                return {"started": False,
+                        "detail": "An update is already running.",
+                        "progress_state": state.as_dict()}
+
+        latest = release_mod.latest()
+        if not latest.ok:
+            _set(phase="failed", detail=latest.detail or "No release to install.")
+            with lock:
+                return {"started": False, "detail": state.detail,
+                        "progress_state": state.as_dict()}
+        if not release_mod.is_newer(latest.version, VERSION):
+            _set(phase="idle",
+                 detail=f"{VERSION} is already the published version.")
+            with lock:
+                return {"started": False, "detail": state.detail,
+                        "progress_state": state.as_dict()}
+        if latest.installer is None:
+            _set(phase="failed",
+                 detail="That release attaches no installer, so there is nothing "
+                        "to download.")
+            with lock:
+                return {"started": False, "detail": state.detail,
+                        "progress_state": state.as_dict()}
+
+        installer = latest.installer
+        version = latest.version
+        running.set()
+        _set(phase="downloading", detail=f"Downloading {version}…",
+             progress=_Progress(received=0, total=installer.bytes),
+             staged_version="", staged_path="", staged_sha256="")
+
+        def work() -> None:
+            try:
+                def tick(received: int, total: int) -> None:
+                    # No lock: two ints, written far more often than they are
+                    # read, and a reader that catches them mid-write sees a
+                    # percentage one chunk stale. Taking the lock 1,100 times a
+                    # download to avoid that would be the wrong trade.
+                    state.progress.received = received
+                    state.progress.total = total or installer.bytes
+
+                staged = update_mod.fetch_and_verify(
+                    installer, version, progress=tick)
+            except update_mod.UpdateRefused as refused:
+                _set(phase="failed", detail=str(refused))
+            except Exception as exc:
+                # A transport failure is worth retrying and a refusal is not, so
+                # they are reported as different sentences even though both end
+                # here. Naming the type keeps a support conversation short.
+                _set(phase="failed",
+                     detail=f"The download did not finish "
+                            f"({type(exc).__name__}: {exc}).")
+            else:
+                _set(phase="staged",
+                     detail=f"{staged.version} is downloaded and its checksum "
+                            f"matches. It is not installed yet.",
+                     staged_version=staged.version,
+                     staged_path=str(staged.path),
+                     staged_sha256=staged.sha256)
+            finally:
+                running.clear()
+
+        threading.Thread(target=work, name="scrapex-update", daemon=True).start()
+        with lock:
+            return {"started": True, "detail": state.detail,
+                    "progress_state": state.as_dict()}
+
+    @router.get("/plan")
+    def plan() -> dict:
+        """What installing the staged engine WOULD do, without doing it.
+
+        Exists because `R-36` bought an updater before code signing, and the
+        thing that makes that acceptable is that every step is inspectable
+        before it happens. A plan nobody can read is the same trust problem in a
+        new place.
+        """
+        with lock:
+            if state.phase != "staged":
+                return {"possible": False,
+                        "detail": "Nothing is staged, so there is nothing to plan.",
+                        "steps": []}
+            staged = update_mod.Staged(
+                path=state.staged_path,          # type: ignore[arg-type]
+                version=state.staged_version,
+                sha256=state.staged_sha256,
+                bytes=state.progress.received)
+        return update_mod.plan_swap(staged)
+
+    return router

--- a/tests/test_an_update_is_verified_before_it_is_installed.py
+++ b/tests/test_an_update_is_verified_before_it_is_installed.py
@@ -1,0 +1,328 @@
+"""Nothing the engine downloads gets installed without matching its digest.
+
+THIS IS THE SECURITY-RELEVANT PART OF `R-36`, so it is tested against a real
+local HTTP server rather than a mocked `httpx`. The thing under test is a
+STREAMED download with a running hash: a mock that hands back all the bytes in
+one lump would satisfy every assertion here while exercising none of the code
+that matters.
+
+`R-36` part 3, at its narrowest, is what these tests hold to:
+
+    A sha256 published in the release manifest, fetched over HTTPS from
+    raw.githubusercontent.com, and CHECKED BEFORE THE SWAP, is enough to trust
+    a download. It is NOT code signing and does not replace it.
+
+`packaging/build_engine.py` had refused to build an updater and said why —
+*"shipping an updater that fetches and executes unsigned code would be worse
+than none"*. The digest is the only thing that answers that objection, so every
+refusal below is about the digest, and none of them can be switched off by a
+caller: there is no `verify=False`, and the staged path is returned only on
+success, so no caller can misuse the result by forgetting to check a flag.
+"""
+from __future__ import annotations
+
+import hashlib
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from scrapex import update as update_mod
+from scrapex.release import Installer
+
+#: Big enough to arrive in several chunks (CHUNK_BYTES is 64 KiB), because a
+#: payload that fits in one read would never exercise the streaming loop or the
+#: running hash — which is the whole mechanism.
+PAYLOAD = b"MZ" + b"scrapex-engine-pretend-binary\n" * 20_000
+DIGEST = hashlib.sha256(PAYLOAD).hexdigest()
+
+
+class _Host(BaseHTTPRequestHandler):
+    """The release host, in the four ways it can behave.
+
+    Path decides the behaviour so one server covers every case and the tests
+    read as a list of situations rather than a list of fixtures.
+    """
+
+    def do_GET(self):                                    # noqa: N802
+        if self.path == "/good":
+            body = PAYLOAD
+        elif self.path == "/tampered":
+            # One byte different, at the END, so a check that hashed only the
+            # first chunk would pass. That is the mistake this shape exists to
+            # catch.
+            body = PAYLOAD[:-1] + b"X"
+        elif self.path == "/short":
+            body = PAYLOAD[: len(PAYLOAD) // 2]
+        elif self.path == "/huge":
+            self.send_response(200)
+            self.send_header("Content-Length", str(10 * 1024 * 1024 * 1024))
+            self.end_headers()
+            # Keep sending until the client stops us. If the ceiling does not
+            # work, this test hangs — which is a louder failure than a wrong
+            # assertion, and appropriate for a disk-filling defect.
+            try:
+                for _ in range(4000):
+                    self.wfile.write(b"\0" * (1 << 16))
+            except (BrokenPipeError, ConnectionAbortedError, OSError):
+                pass
+            return
+        elif self.path == "/missing":
+            self.send_response(404)
+            self.end_headers()
+            return
+        else:
+            self.send_response(500)
+            self.end_headers()
+            return
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):                        # noqa: A003
+        pass
+
+
+@pytest.fixture
+def host():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _Host)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def _installer(host: str, path: str, *, sha256: str = DIGEST,
+               size: int | None = None) -> Installer:
+    return Installer(name="scrapex-engine.exe", url=f"{host}{path}",
+                     bytes=len(PAYLOAD) if size is None else size,
+                     sha256=sha256)
+
+
+def test_a_good_download_is_staged_and_its_digest_is_reported(host, tmp_path):
+    """The happy path, and it must report the digest it COMPUTED, not the one asked for.
+
+    Returning the expected digest back would make the mismatch test below the
+    only thing standing between a caller and a false confirmation.
+    """
+    staged = update_mod.fetch_and_verify(
+        _installer(host, "/good"), "0.3.0", into=tmp_path)
+
+    assert staged.path.exists()
+    assert staged.path.read_bytes() == PAYLOAD
+    assert staged.sha256 == DIGEST
+    assert staged.bytes == len(PAYLOAD)
+    assert staged.version == "0.3.0"
+    # The name carries the version, so two versions cannot land on one filename.
+    assert "0.3.0" in staged.path.name
+    # And nothing half-written is left beside it.
+    assert list(tmp_path.glob("*.part")) == []
+
+
+def test_a_tampered_download_is_refused_and_deleted(host, tmp_path):
+    """THE ONE THAT MATTERS. A single changed byte must stop the install.
+
+    And the file must be GONE: a rejected 71 MB executable left in a staging
+    directory is a thing somebody double-clicks a week later.
+    """
+    with pytest.raises(update_mod.UpdateRefused) as refused:
+        update_mod.fetch_and_verify(
+            _installer(host, "/tampered"), "0.3.0", into=tmp_path)
+
+    assert "checksum" in str(refused.value).lower()
+    assert DIGEST in str(refused.value), "the message must name what was expected"
+    assert list(tmp_path.iterdir()) == [], (
+        f"the refused download was left on disk: {list(tmp_path.iterdir())}")
+
+
+def test_a_release_with_no_digest_is_refused_before_a_byte_is_fetched(host, tmp_path):
+    """No digest, no install — and no download either.
+
+    Asserted by the absence of any file: if this fetched first and refused
+    after, it would spend 71 MB of somebody's connection to reach a conclusion
+    available for free.
+    """
+    with pytest.raises(update_mod.UpdateRefused) as refused:
+        update_mod.fetch_and_verify(
+            _installer(host, "/good", sha256=""), "0.3.0", into=tmp_path)
+
+    assert "sha-256" in str(refused.value).lower()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_a_digest_that_is_not_a_digest_is_refused(host, tmp_path):
+    """A truncated or padded digest must not be accepted as "close enough"."""
+    for bad in ("deadbeef", DIGEST[:-1], DIGEST + "00", "not-a-digest" * 5):
+        with pytest.raises(update_mod.UpdateRefused):
+            update_mod.fetch_and_verify(
+                _installer(host, "/good", sha256=bad), "0.3.0", into=tmp_path)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_a_digest_that_matches_only_at_its_START_is_refused(host, tmp_path):
+    """A WEAKENED COMPARISON, which is how this check gets defeated rather than deleted.
+
+    Every other test here supplies a digest that differs from the real one
+    everywhere, so a comparison shortened to `expected[:8] == actual[:8]` — or
+    degenerated to a `startswith` — would refuse those and pass. **Both
+    mutations survived until this test existed.**
+
+    These two share a long prefix with the true digest and differ late, so only
+    a full comparison rejects them. `hmac.compare_digest` is what does that in
+    `update._digest_matches`; the value of this test is that shortening it now
+    fails here instead of silently accepting a substituted binary whose digest
+    was ground to share a prefix.
+    """
+    last_char_differs = DIGEST[:-1] + ("0" if DIGEST[-1] != "0" else "1")
+    tail_differs = DIGEST[:40] + ("f" * 24 if not DIGEST.endswith("f" * 24)
+                                  else "e" * 24)
+    assert last_char_differs != DIGEST and len(last_char_differs) == 64
+    assert tail_differs != DIGEST and len(tail_differs) == 64
+
+    for near in (last_char_differs, tail_differs):
+        with pytest.raises(update_mod.UpdateRefused) as refused:
+            update_mod.fetch_and_verify(
+                _installer(host, "/good", sha256=near), "0.3.0", into=tmp_path)
+        assert "checksum" in str(refused.value).lower()
+        assert list(tmp_path.iterdir()) == [], (
+            "a near-miss digest left the download on disk")
+
+
+def test_the_digest_is_matched_case_insensitively(host, tmp_path):
+    """An upper-case digest in a manifest is the same digest.
+
+    Worth a test because the natural fix for it — lowercasing on the way in —
+    is easy to lose in a refactor, and losing it would refuse every good
+    download from a manifest written by a different tool.
+    """
+    staged = update_mod.fetch_and_verify(
+        _installer(host, "/good", sha256=DIGEST.upper()), "0.3.0", into=tmp_path)
+    assert staged.sha256 == DIGEST
+
+
+def test_a_manifest_that_disagrees_with_itself_is_refused(host, tmp_path):
+    """Digest right, size wrong: the release was built wrong, so refuse it.
+
+    A digest match already proves the bytes, so this can only mean the
+    manifest's own two fields disagree — and if the release process got one
+    wrong, something else in it may be wrong too.
+    """
+    with pytest.raises(update_mod.UpdateRefused) as refused:
+        update_mod.fetch_and_verify(
+            _installer(host, "/good", size=len(PAYLOAD) + 999), "0.3.0", into=tmp_path)
+
+    assert "disagrees with itself" in str(refused.value)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_a_truncated_download_is_refused(host, tmp_path):
+    """Half a file hashes to something else, which is the point of hashing it."""
+    with pytest.raises(update_mod.UpdateRefused):
+        update_mod.fetch_and_verify(
+            _installer(host, "/short"), "0.3.0", into=tmp_path)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_a_404_is_refused_without_writing_anything(host, tmp_path):
+    with pytest.raises(update_mod.UpdateRefused) as refused:
+        update_mod.fetch_and_verify(
+            _installer(host, "/missing"), "0.3.0", into=tmp_path)
+    assert "404" in str(refused.value)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_an_endless_response_is_stopped_before_it_fills_the_disk(host, tmp_path, monkeypatch):
+    """A ceiling, because a digest that will never match is not a stopping condition.
+
+    Without this, a misconfigured endpoint or a redirect to something enormous
+    writes until the disk is full and only THEN fails the digest. The real
+    ceiling is 300 MB; it is lowered here so the test costs a moment instead of
+    a third of a gigabyte.
+    """
+    monkeypatch.setattr(update_mod, "MAX_INSTALLER_BYTES", 2 * 1024 * 1024)
+    with pytest.raises(update_mod.UpdateRefused) as refused:
+        update_mod.fetch_and_verify(
+            _installer(host, "/huge"), "0.3.0", into=tmp_path)
+
+    assert "larger than any engine" in str(refused.value)
+    assert list(tmp_path.iterdir()) == [], "the oversized partial was not cleaned up"
+
+
+def test_progress_is_reported_while_it_downloads_and_not_only_at_the_end(host, tmp_path):
+    """A progress bar that jumps 0 → 100 is a spinner with extra steps.
+
+    The payload is deliberately larger than one chunk, so more than one call
+    proves the callback rides the stream rather than the return.
+    """
+    seen: list[tuple[int, int]] = []
+    update_mod.fetch_and_verify(
+        _installer(host, "/good"), "0.3.0", into=tmp_path,
+        progress=lambda received, total: seen.append((received, total)))
+
+    assert len(seen) > 1, f"progress was reported {len(seen)} time(s): {seen}"
+    assert [r for r, _ in seen] == sorted(r for r, _ in seen), "progress went backwards"
+    assert seen[-1][0] == len(PAYLOAD)
+    assert all(total == len(PAYLOAD) for _, total in seen)
+
+
+def test_two_attempts_at_one_version_do_not_accumulate_files(host, tmp_path):
+    """The staging directory must not grow by 71 MB every time a button is pressed."""
+    for _ in range(3):
+        update_mod.fetch_and_verify(_installer(host, "/good"), "0.3.0", into=tmp_path)
+    assert len(list(tmp_path.iterdir())) == 1
+
+
+def test_a_failed_attempt_does_not_destroy_an_already_staged_good_one(host, tmp_path):
+    """A rejected download of a version must not take the verified one with it.
+
+    This is a real ordering question: the partial is written under `.part` and
+    only replaces the final name after the digest passes, so a later failure
+    has nothing to overwrite. Asserted because the obvious implementation —
+    writing straight to the final name — would delete a good installer on a
+    failed retry.
+    """
+    good = update_mod.fetch_and_verify(
+        _installer(host, "/good"), "0.3.0", into=tmp_path)
+    assert good.path.exists()
+
+    with pytest.raises(update_mod.UpdateRefused):
+        update_mod.fetch_and_verify(
+            _installer(host, "/tampered"), "0.3.0", into=tmp_path)
+
+    assert good.path.exists(), "a refused retry deleted the verified installer"
+    assert good.path.read_bytes() == PAYLOAD
+
+
+def test_a_source_checkout_says_it_cannot_swap_rather_than_offering_to(monkeypatch):
+    """There is no executable to replace in a checkout, and saying so beats failing."""
+    monkeypatch.setattr("sys.frozen", False, raising=False)
+    possible, why = update_mod.swap_is_possible()
+    assert possible is False
+    assert "git" in why.lower(), why
+
+
+def test_the_swap_plan_names_what_it_would_overwrite(monkeypatch, tmp_path):
+    """A plan that cannot say what it replaces is not a plan anybody should approve."""
+    exe = tmp_path / "scrapex-engine.exe"
+    exe.write_bytes(b"MZ")
+    monkeypatch.setattr("sys.frozen", True, raising=False)
+    monkeypatch.setattr("sys.executable", str(exe))
+
+    staged = update_mod.Staged(path=tmp_path / "new.exe", version="0.3.0",
+                              sha256=DIGEST, bytes=len(PAYLOAD))
+    plan = update_mod.plan_swap(staged)
+
+    assert plan["possible"] is True
+    assert plan["replaces"], "the plan does not say which file it would overwrite"
+    assert "scrapex-engine.exe" in plan["replaces"]
+    assert plan["sha256"] == DIGEST
+    assert len(plan["steps"]) >= 4
+    # The ordering IS the safety argument: the helper must wait for this process
+    # to exit before renaming, or Windows refuses and the install half-happens.
+    joined = " | ".join(plan["steps"])
+    assert joined.index("waits for this process to exit") < joined.index("rename")

--- a/tests/test_an_update_is_verified_before_it_is_installed.py
+++ b/tests/test_an_update_is_verified_before_it_is_installed.py
@@ -84,6 +84,30 @@ class _Host(BaseHTTPRequestHandler):
         pass
 
 
+@pytest.fixture(autouse=True)
+def _local_origin_is_allowed_here(monkeypatch):
+    """Let these tests fetch from 127.0.0.1 over http, and say so out loud.
+
+    Production refuses both: `release.ALLOWED_INSTALLER_HOSTS` is github.com and
+    raw.githubusercontent.com, and `ALLOWED_INSTALLER_SCHEMES` is https alone —
+    because the published digest proves the CONTENT arrived whole and proves
+    nothing about WHERE it was fetched from.
+
+    The policy is patched HERE, at the top, by name, rather than by handing
+    `fetch_and_verify` a parameter that relaxes it. A parameter would exist in
+    production too, and the moment one exists it becomes the path somebody takes.
+    The real policy is asserted unpatched in
+    `test_the_engine_reads_the_same_release_feed.py`, on the near-miss hosts a
+    substring check would have let through.
+    """
+    from scrapex import release as release_mod
+
+    monkeypatch.setattr(release_mod, "ALLOWED_INSTALLER_HOSTS",
+                        frozenset({"127.0.0.1"}))
+    monkeypatch.setattr(release_mod, "ALLOWED_INSTALLER_SCHEMES",
+                        frozenset({"http"}))
+
+
 @pytest.fixture
 def host():
     server = ThreadingHTTPServer(("127.0.0.1", 0), _Host)
@@ -326,3 +350,34 @@ def test_the_swap_plan_names_what_it_would_overwrite(monkeypatch, tmp_path):
     # to exit before renaming, or Windows refuses and the install half-happens.
     joined = " | ".join(plan["steps"])
     assert joined.index("waits for this process to exit") < joined.index("rename")
+
+
+def test_an_installer_from_a_host_we_do_not_publish_to_is_refused(host, tmp_path,
+                                                                 monkeypatch):
+    """THE GAP CodeQL POINTED AT, closed in production rather than in the test.
+
+    Its alert was `py/incomplete-url-substring-sanitization` against
+    `"raw.githubusercontent.com" in url` in a sibling test. That assertion was
+    not a security control — but the ABSENCE of one was the real finding: nothing
+    checked that the URL the engine is told to fetch belongs to us. The digest
+    proves the content arrived whole; it says nothing about where the request
+    went, and a mistaken or edited manifest could send a user's address anywhere.
+
+    Refused BEFORE a byte is requested, which is why this asserts on an empty
+    directory as well as on the message.
+    """
+    from scrapex import release as release_mod
+
+    # Undo the fixture: this test wants the real policy.
+    monkeypatch.setattr(release_mod, "ALLOWED_INSTALLER_HOSTS",
+                        frozenset({"github.com"}))
+    monkeypatch.setattr(release_mod, "ALLOWED_INSTALLER_SCHEMES",
+                        frozenset({"https"}))
+
+    with pytest.raises(update_mod.UpdateRefused) as refused:
+        update_mod.fetch_and_verify(
+            _installer(host, "/good"), "0.3.0", into=tmp_path)
+
+    assert "does not publish to" in str(refused.value)
+    assert list(tmp_path.iterdir()) == [], (
+        "an off-host installer was fetched before being refused")

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -112,10 +112,10 @@ PINNED = (
     # The version-gate blocker. Track 3 of STATE.md cannot be worked without
     # these three, and two of them are the citations that drifted.
     ("docs/STATE.md", "scrapex/version.py", 477, '"latest_extension_version": VERSION'),
-    ("docs/STATE.md", "scrapex/webui/app.py", 1459, '"latest_extension_version": VERSION'),
+    ("docs/STATE.md", "scrapex/webui/app.py", 1466, '"latest_extension_version": VERSION'),
     ("docs/STATE.md", "extension/app.js", 599, "latest_extension_version"),
     ("docs/STATE.md", "scrapex/version.py", 76, 'VERSION = "'),
-    ("docs/RULINGS.md", "scrapex/webui/app.py", 1459, '"latest_extension_version": VERSION'),
+    ("docs/RULINGS.md", "scrapex/webui/app.py", 1466, '"latest_extension_version": VERSION'),
     ("docs/RULINGS.md", "scrapex/version.py", 477, '"latest_extension_version": VERSION'),
     # The two flags whose condition is met and whose lighting is the owner's call.
     ("docs/STATE.md", "scrapex/features.py", 54, "True"),
@@ -133,8 +133,8 @@ PINNED = (
      'assert.equal(manifest.version, VECTORS.version)'),
     ("docs/RULINGS.md", "tests/test_version.py", 79, "pyproject"),
     # OP-2's two worker_alive computations, one of which the fix never reached.
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1470, '"worker_alive"'),
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2458, "def _about("),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1477, '"worker_alive"'),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2465, "def _about("),
     ("docs/BACKLOG.md", "scrapex/webui/templates/settings.html", 162, "about.worker_alive"),
     # BV-3's chain, end to end: the panel posts it, capture reads it.
     ("docs/BACKLOG.md", "extension/app.js", 840, "crawl_honour_delay:"),

--- a/tests/test_the_engine_reads_the_same_release_feed.py
+++ b/tests/test_the_engine_reads_the_same_release_feed.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import pathlib
 import re
+from urllib.parse import urlsplit
 
 import pytest
 
@@ -60,10 +61,16 @@ def test_the_manifest_url_the_engine_builds_is_the_one_the_panel_builds():
     """Built from the repo constant in both places, so this checks the shape too."""
     engine_url = release.manifest_url(29_000_000).split("?")[0]
     assert engine_url == release.VERSION_MANIFEST
-    assert "raw.githubusercontent.com" in engine_url, (
+    # PARSED AND COMPARED EXACTLY, not by substring. CodeQL flagged the previous
+    # version of this line as `py/incomplete-url-substring-sanitization` and was
+    # right to: `"raw.githubusercontent.com" in url` also matches
+    # `https://evil.example/raw.githubusercontent.com/...`. This assertion is
+    # stronger for the same reason the alert was correct.
+    assert urlsplit(engine_url).hostname == "raw.githubusercontent.com", (
         "the engine reads the manifest from somewhere other than raw."
         "githubusercontent.com — api.github.com allows 60 requests an hour per "
         "IP, which one office behind one address exhausts")
+    assert urlsplit(engine_url).scheme == "https"
     assert release.VERSION_MANIFEST.split("/main/")[-1] in WORKFLOW
 
 
@@ -179,3 +186,73 @@ def test_the_check_timeout_is_its_own_and_is_short():
     assert release.DOWNLOAD_TIMEOUT_S > release.CHECK_TIMEOUT_S * 10, (
         "the installer download shares the check's timeout, so a real 70 MB "
         "fetch on a home connection will be cut off as though it had stalled")
+
+
+# ---- the installer origin, on the REAL policy: nothing patched below this line
+
+@pytest.mark.parametrize("url,allowed", [
+    ("https://github.com/muhammadbayoumi/mbiX-hub/releases/download/"
+     "engine-v0.2.1/scrapex-engine.exe", True),
+    ("https://raw.githubusercontent.com/x/y/scrapex-engine.exe", True),
+    # Case in a hostname is not significant, and refusing this would refuse a
+    # legitimate manifest written by a different tool.
+    ("https://GITHUB.COM/x/scrapex-engine.exe", True),
+    # THE FOUR A SUBSTRING CHECK LETS THROUGH, which is the whole point.
+    ("https://raw.githubusercontent.com.evil.example/x.exe", False),
+    ("https://evil.example/raw.githubusercontent.com/x.exe", False),
+    ("https://github.com.evil.example/x.exe", False),
+    ("https://user:pw@evil.example/github.com/x.exe", False),
+    # Scheme, separately: a digest survives an eavesdropper, but http hands the
+    # download to anyone on the path and tells them what is being installed.
+    ("http://github.com/x/scrapex-engine.exe", False),
+    ("file:///C:/Windows/System32/scrapex-engine.exe", False),
+    ("", False),
+])
+def test_an_installer_url_is_checked_by_host_and_not_by_substring(url, allowed):
+    """`py/incomplete-url-substring-sanitization`, answered rather than silenced.
+
+    CodeQL raised it against `"raw.githubusercontent.com" in url` in this file.
+    That line was a test assertion, so it was not itself exploitable — but the
+    alert pointed at a real gap: **nothing checked that the installer URL the
+    engine is told to fetch belongs to us.** The published digest proves the
+    content arrived whole and says nothing about where the request went, so a
+    mistaken or edited manifest could send a user's address to any host.
+
+    These are the cases that separate a parsed host comparison from a substring
+    one. Every False here is a URL `"github.com" in url` would have accepted.
+    """
+    installer = release.Installer(name="scrapex-engine.exe", url=url,
+                                  bytes=1, sha256="a" * 64)
+    assert installer.from_known_host is allowed
+
+
+def test_the_origin_check_is_part_of_being_verifiable():
+    """So a caller cannot satisfy the digest rule and skip the origin one.
+
+    `verifiable` is what `update.fetch_and_verify` and the API's
+    `can_self_update` both consult. If the origin check sat beside it rather than
+    inside it, every one of those call sites would have to remember to ask twice.
+    """
+    off_host = release.Installer(name="x.exe", url="https://evil.example/x.exe",
+                                 bytes=1, sha256="a" * 64)
+    assert off_host.from_known_host is False
+    assert off_host.verifiable is False, (
+        "an installer from an unknown host reports itself verifiable, so the "
+        "digest alone would be treated as enough")
+
+
+def test_the_allowlist_is_not_empty_and_not_a_wildcard():
+    """A guard that can be widened to everything is not a guard.
+
+    An empty set refuses every real release (and would look like "the update
+    endpoint is broken"); a `*` or a bare suffix would accept the near-misses
+    above. Both are the ways this constant gets ruined in a hurry.
+    """
+    assert release.ALLOWED_INSTALLER_HOSTS, "the allowlist is empty"
+    assert "github.com" in release.ALLOWED_INSTALLER_HOSTS
+    for entry in release.ALLOWED_INSTALLER_HOSTS:
+        assert "*" not in entry and not entry.startswith("."), (
+            f"{entry!r} is a pattern rather than a host; the check compares "
+            f"hostnames exactly and a pattern here would never match anything")
+    assert release.ALLOWED_INSTALLER_SCHEMES == frozenset({"https"}), (
+        "the engine would fetch an installer over something other than https")

--- a/tests/test_the_engine_reads_the_same_release_feed.py
+++ b/tests/test_the_engine_reads_the_same_release_feed.py
@@ -1,0 +1,181 @@
+"""Three readers of one manifest, and they must not drift apart.
+
+`ScrapeX/json/version.json` on the hub is now read by three things:
+
+    .github/workflows/release-engine.yml   WRITES it
+    extension/releases.js                 reads it, to offer an install
+    scrapex/release.py                     reads it, to fetch an update  <- new
+
+`tests/test_the_two_release_paths.py` already holds the first two together. This
+holds the third to them, because the failure it prevents is not a crash: the
+engine and the panel would report DIFFERENT verdicts about the same
+installation, and the owner would have no way to tell which was lying. That is
+worse than either being wrong on its own.
+
+The state vocabulary is checked as well as the URLs. `ok`, `none`, `offline`,
+`unreadable` exist because "we do not know the latest engine" has several causes
+and only one of them is anybody's fault — and the two surfaces will eventually
+be shown side by side.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+from scrapex import release
+
+# Reads extension/ sources, so it must carry the mark that makes the
+# extension-only CI tier run it. See tests/test_the_extension_gate_is_complete.py.
+pytestmark = [pytest.mark.extension, pytest.mark.docs]
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+RELEASES_JS = (ROOT / "extension" / "releases.js").read_text(encoding="utf-8")
+WORKFLOW = (ROOT / ".github" / "workflows" / "release-engine.yml").read_text(encoding="utf-8")
+
+
+def _js_const(name: str) -> str:
+    """One `export const NAME = "value";` out of releases.js."""
+    found = re.search(rf'export const {name} = "([^"]+)"', RELEASES_JS)
+    assert found, f"releases.js no longer exports {name}; this guard must follow it"
+    return found.group(1)
+
+
+def test_the_engine_and_the_panel_agree_where_the_manifest_lives():
+    """A release published where the reader does not look is a release nobody sees."""
+    assert release.PUBLIC_REPO == _js_const("PUBLIC_REPO")
+    assert release.PRODUCT == _js_const("PRODUCT")
+
+
+def test_the_workflow_publishes_to_the_repository_the_engine_reads():
+    """And the writer must agree with both readers."""
+    assert f"PUBLIC_REPO: {release.PUBLIC_REPO}" in WORKFLOW, (
+        "the release workflow publishes somewhere the engine does not read")
+    assert release.PRODUCT in WORKFLOW, (
+        "the workflow does not stamp the product name the engine requires")
+
+
+def test_the_manifest_url_the_engine_builds_is_the_one_the_panel_builds():
+    """Built from the repo constant in both places, so this checks the shape too."""
+    engine_url = release.manifest_url(29_000_000).split("?")[0]
+    assert engine_url == release.VERSION_MANIFEST
+    assert "raw.githubusercontent.com" in engine_url, (
+        "the engine reads the manifest from somewhere other than raw."
+        "githubusercontent.com — api.github.com allows 60 requests an hour per "
+        "IP, which one office behind one address exhausts")
+    assert release.VERSION_MANIFEST.split("/main/")[-1] in WORKFLOW
+
+
+def test_the_cache_key_changes_once_a_minute_and_not_once_a_request():
+    """The CDN caches this file for ~5 minutes, so a release can be invisible.
+
+    A per-request key defeats the cache entirely, which measurably slowed the
+    add-in's own path; a per-minute bucket lets everyone within one minute share
+    one entry. Both halves are asserted, because either alone is wrong.
+    """
+    assert release.manifest_url(100) == release.manifest_url(100)
+    assert release.manifest_url(100) != release.manifest_url(101)
+
+
+@pytest.mark.parametrize("status,body,expected", [
+    (404, None, "none"),
+    (500, None, "unreadable"),
+    (200, None, "unreadable"),
+    (200, "not a mapping", "unreadable"),
+    (200, {"product": "mbix-addin", "version": "1.0.0"}, "unreadable"),
+    (200, {"product": "scrapex-engine"}, "unreadable"),
+    (200, {"product": "scrapex-engine", "version": "latest"}, "unreadable"),
+    (200, {"product": "scrapex-engine", "version": "1.2"}, "unreadable"),
+    (200, {"product": "scrapex-engine", "version": "1.2.3"}, "ok"),
+])
+def test_every_manifest_answer_lands_in_a_named_state(status, body, expected):
+    """No guessing, and no exception either — a bad manifest is a state, not a crash."""
+    assert release.read_manifest(status, body).state == expected
+
+
+def test_a_404_is_not_an_error_because_on_this_endpoint_it_means_nothing_shipped():
+    """The branch most likely to be 'tidied' into an error, and it must not be.
+
+    Every fresh installation in the world hits this until the first release. If
+    it read as a failure, the product would tell all of them something is broken.
+    """
+    answer = release.read_manifest(404, None)
+    assert answer.state == "none"
+    assert "released" in answer.detail.lower()
+    assert "error" not in answer.detail.lower()
+
+
+def test_the_addin_manifest_is_refused_by_name():
+    """The hub serves several products from one tree, from sibling folders.
+
+    Reading the Excel add-in's manifest as ours would report a confident, wrong
+    version — so the product must be named and must agree.
+    """
+    answer = release.read_manifest(200, {"product": "mbix-addin", "version": "1.0.76"})
+    assert answer.state == "unreadable"
+    assert "mbix-addin" in answer.detail
+
+
+def test_an_installer_without_a_digest_is_reported_but_not_verifiable():
+    """Named even when it cannot be trusted, because absent and untrusted differ."""
+    body = {"product": "scrapex-engine", "version": "1.2.3",
+            "installer": {"url": "https://example.invalid/x.exe", "bytes": 10}}
+    answer = release.read_manifest(200, body)
+    assert answer.ok
+    assert answer.installer is not None
+    assert answer.installer.verifiable is False
+
+
+def test_a_release_with_no_installer_at_all_is_still_ok_but_says_so():
+    """A release nobody can install is worth seeing BEFORE pressing Install."""
+    answer = release.read_manifest(200, {"product": "scrapex-engine", "version": "1.2.3"})
+    assert answer.ok
+    assert answer.installer is None
+
+
+def test_the_digest_is_lowercased_on_the_way_in():
+    """So the comparison downstream never has to care what case a tool wrote."""
+    body = {"product": "scrapex-engine", "version": "1.2.3",
+            "installer": {"url": "https://example.invalid/x.exe",
+                          "bytes": 1, "sha256": "AB" * 32}}
+    assert release.read_manifest(200, body).installer.sha256 == "ab" * 32
+
+
+@pytest.mark.parametrize("candidate,installed,newer", [
+    ("0.2.2", "0.2.1", True),
+    ("0.2.1", "0.2.2", False),
+    ("0.2.2", "0.2.2", False),
+    # THE ONE STRING COMPARISON GETS WRONG, and getting it wrong offers a
+    # downgrade as an update.
+    ("0.10.0", "0.9.0", True),
+    ("0.9.0", "0.10.0", False),
+    ("1.0.0", "0.99.99", True),
+    # Unparseable on either side answers False: refusing to claim an update is
+    # the safe direction.
+    ("latest", "0.2.1", False),
+    ("0.2.1", "", False),
+])
+def test_newer_is_decided_numerically_and_never_as_text(candidate, installed, newer):
+    assert release.is_newer(candidate, installed) is newer
+
+
+def test_the_engine_does_not_borrow_the_crawl_transport_for_its_own_release_feed():
+    """`HttpFetcher` is crawl politeness: jitter, a circuit breaker, 1 req/s.
+
+    Applying it to our own release host would put the update check behind a
+    governor built for somebody else's website, and inherit a block counter that
+    means nothing here. Asserted because "reuse the fetcher" is the obvious
+    review comment and it is the wrong one.
+    """
+    source = (ROOT / "scrapex" / "release.py").read_text(encoding="utf-8")
+    assert "HttpFetcher" not in source.replace("NOT `HttpFetcher`", "")
+    assert "httpx" in source, "it should still use the dependency the repo has"
+
+
+def test_the_check_timeout_is_its_own_and_is_short():
+    """A stalled fetch to a third party must never delay the thing he opened."""
+    assert 0 < release.CHECK_TIMEOUT_S <= 10
+    assert release.DOWNLOAD_TIMEOUT_S > release.CHECK_TIMEOUT_S * 10, (
+        "the installer download shares the check's timeout, so a real 70 MB "
+        "fetch on a home connection will be cut off as though it had stalled")

--- a/tests/test_the_engine_reads_the_same_release_feed.py
+++ b/tests/test_the_engine_reads_the_same_release_feed.py
@@ -249,7 +249,19 @@ def test_the_allowlist_is_not_empty_and_not_a_wildcard():
     above. Both are the ways this constant gets ruined in a hurry.
     """
     assert release.ALLOWED_INSTALLER_HOSTS, "the allowlist is empty"
-    assert "github.com" in release.ALLOWED_INSTALLER_HOSTS
+    # WRITTEN AS A SUPERSET, not as `"github.com" in ...`, and the reason is worth
+    # a line. CodeQL raised `py/incomplete-url-substring-sanitization` against the
+    # `in` form here -- a FALSE POSITIVE, unlike the alert that led to this whole
+    # check: `ALLOWED_INSTALLER_HOSTS` is a frozenset, so `in` is set membership
+    # and not a substring test on a URL. The rule cannot see that.
+    #
+    # It is rewritten rather than suppressed because a `# noqa` would silence
+    # the rule for this line for ever, including if somebody later changed the
+    # right-hand side to a string. The superset form says what is meant, cannot
+    # be misread as sanitization, and stays flagged if the type changes.
+    assert release.ALLOWED_INSTALLER_HOSTS >= {"github.com"}, (
+        "github.com is not in the allowlist, so no real release asset could be "
+        "downloaded at all")
     for entry in release.ALLOWED_INSTALLER_HOSTS:
         assert "*" not in entry and not entry.startswith("."), (
             f"{entry!r} is a pattern rather than a host; the check compares "

--- a/tests/test_the_panel_hands_the_installer_to_chrome.py
+++ b/tests/test_the_panel_hands_the_installer_to_chrome.py
@@ -27,7 +27,11 @@ import re
 
 import pytest
 
-pytestmark = [pytest.mark.extension]
+# BOTH MARKS. `extension` because it reads extension/ sources, and `docs`
+# because it also reads docs/store-listing.md -- the cross-check that the
+# prose Google reads has not gone false. A docs-only change must run this,
+# or editing that listing could reintroduce the claim this file forbids.
+pytestmark = [pytest.mark.extension, pytest.mark.docs]
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 MANIFEST = json.loads((ROOT / "extension" / "manifest.json").read_text(encoding="utf-8"))

--- a/tests/test_the_panel_hands_the_installer_to_chrome.py
+++ b/tests/test_the_panel_hands_the_installer_to_chrome.py
@@ -1,0 +1,180 @@
+"""The first install is handed to `chrome.downloads`, not thrown at a URL.
+
+`R-36` part 1 is a LIMIT, measured rather than assumed: `extension/manifest.json`
+granted `activeTab, identity, nativeMessaging, sidePanel, storage, tabs` and no
+`downloads`, so `extension/app.js` could only call `window.open(installer.url)` —
+hand a URL to the browser and let go. No progress, no completion, no idea whether
+71 MB ever arrived. On a slow connection that is a button that appears to do
+nothing, which is close to how the owner met the engine in the first place.
+
+WHAT THE PERMISSION BUYS AND WHAT IT STILL CANNOT: a real download the panel can
+watch and reveal. It does NOT buy reading the file, so the panel still cannot
+verify the SHA-256 — which is why the engine does that for every update after the
+first (`scrapex/update.py`) and why the number on screen is now labelled as the
+reader's to compare rather than left sitting there as an implied guarantee. That
+last point is `R-36`'s own words: a number nothing checks is worse than no number.
+
+These tests read the sources rather than driving a browser, because what has to
+stay true is a property of the code: the permission is declared, the API is the
+one that reports progress, and the checksum is attributed. The panel DOM suite
+drives the rendering.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+
+import pytest
+
+pytestmark = [pytest.mark.extension]
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+MANIFEST = json.loads((ROOT / "extension" / "manifest.json").read_text(encoding="utf-8"))
+APP_JS = (ROOT / "extension" / "app.js").read_text(encoding="utf-8")
+APP_HTML = (ROOT / "extension" / "app.html").read_text(encoding="utf-8")
+LISTING = (ROOT / "docs" / "store-listing.md").read_text(encoding="utf-8")
+
+
+def test_the_downloads_permission_is_declared():
+    """Without it every `chrome.downloads` call below throws at runtime."""
+    assert "downloads" in MANIFEST["permissions"], (
+        "the downloads permission is gone, so the panel is back to handing a URL "
+        "to the browser and letting go")
+
+
+def test_no_permission_was_traded_away_to_get_it():
+    """A new permission must be an ADDITION.
+
+    Every permission in this list is load-bearing — `nativeMessaging` is the
+    engine bridge, `identity` is sign-in, `sidePanel` is the panel itself — and
+    a store review that asks about `downloads` is not a reason to drop one of
+    those to keep the count the same.
+    """
+    for needed in ("activeTab", "identity", "nativeMessaging",
+                   "sidePanel", "storage", "tabs"):
+        assert needed in MANIFEST["permissions"], f"{needed} was dropped"
+
+
+def test_the_installer_is_fetched_with_the_api_that_reports_progress():
+    """`chrome.downloads.download`, and `search` — which is where the bytes are.
+
+    `onChanged` alone fires on state transitions, not per byte, so a percentage
+    needs `search()`. Asserting both stops someone simplifying to `onChanged`
+    and leaving a bar that jumps 0 → 100.
+    """
+    assert "chrome.downloads.download(" in APP_JS
+    assert "chrome.downloads.search(" in APP_JS, (
+        "nothing reads bytesReceived, so there is no percentage to show")
+    assert "bytesReceived" in APP_JS
+
+
+def test_it_reveals_the_file_when_it_finishes():
+    """A 71 MB file in Downloads that the panel will not point at is half a job."""
+    assert "chrome.downloads.show(" in APP_JS
+
+
+def test_a_failed_download_says_why_and_offers_to_retry():
+    """"Download failed" sends somebody to check their engine.
+
+    The browser's own reason — `SERVER_FORBIDDEN`, `NETWORK_FAILED` — sends them
+    to the right place, so it must be shown rather than swallowed.
+    """
+    # ASSERTED ON THE STRING THAT REACHES THE SCREEN, not on the identifier
+    # appearing somewhere in the file. The first version of this test grepped for
+    # `item.error` and a mutation that replaced one of its two occurrences with
+    # `false` survived — the name was still in the source, and the reason was
+    # gone from the label.
+    # `.` does not match a newline without DOTALL, so this stays on one line
+    # without needing an escape the writing tools keep mangling.
+    assert re.search(r"Download failed.*\$\{item\.error\}", APP_JS), (
+        "the failure label no longer interpolates the browser's own reason, so "
+        "'Download failed' is all the reader gets")
+    # AND THE BRANCH IS CHOSEN BY IT. Pinning only the template above left a
+    # mutation alive: replacing the ternary's CONDITION with `false` takes the
+    # else branch every time while the template sits there unreached. A grep
+    # cannot see a dead branch, so the condition is pinned too.
+    assert re.search(r"item\.error\s*\?", APP_JS), (
+        "the failure label no longer branches on whether there IS a reason, so "
+        "the reason is unreachable even though the text for it remains")
+    assert re.search(r'state === "complete"', APP_JS), (
+        "completion is not distinguished from interruption")
+
+
+def test_window_open_survives_only_as_a_fallback():
+    """The old path is kept for the case that needs it, and only that case.
+
+    `chrome.downloads` is absent when the panel is loaded in a plain page by the
+    DOM tests, and a first install failing because a permission was declined is
+    exactly when the old behaviour is worth having. But it must not be the
+    primary route any more.
+    """
+    assert "window.open(installer.url" in APP_JS, (
+        "the fallback is gone; a declined permission now has no route at all")
+    # The button's own handler must be the new function, not the old call.
+    assert "download.onclick = () => startInstallerDownload(installer);" in APP_JS, (
+        "the Download button no longer routes through the downloads API")
+
+
+def test_the_checksum_on_screen_says_who_checks_it():
+    """R-36: a number nothing verifies is worse than none — it reads as a promise.
+
+    The panel cannot verify it (no file read), so the markup must say what the
+    number is for and who does check it. Asserted on the note's presence AND on
+    it naming the Engine, because an empty reassurance would satisfy the first
+    half alone.
+    """
+    assert 'id="engine-checksum-note"' in APP_HTML, (
+        "the SHA-256 sits on screen unattributed again")
+    note = re.search(r'id="engine-checksum-note">(.*?)</p>', APP_HTML, re.S)
+    assert note, "the note element has no text"
+    text = " ".join(note.group(1).split())
+    assert "Engine" in text, f"the note does not say who verifies it: {text!r}"
+    assert "check" in text.lower()
+
+
+def test_the_saveas_dialogue_is_suppressed_deliberately():
+    """A Save-As on a file the owner already pressed a button for is one more
+    thing to get wrong, and `show()` takes him to it anyway."""
+    assert re.search(r"saveAs:\s*false", APP_JS), (
+        "the download now opens a Save-As dialogue for a file already chosen")
+
+
+def test_the_store_listing_does_not_claim_something_this_code_makes_false():
+    """THE PROSE WENT FALSE THE MOMENT THE CODE CHANGED, and nothing said so.
+
+    `docs/store-listing.md` justified `nativeMessaging` with a sentence in
+    capitals: *"This extension does not download, install, execute or update
+    it."* Adding `chrome.downloads.download` made the first verb untrue. The
+    listing is what gets submitted to Google, so an untrue claim there is not a
+    documentation defect — it is a rejected submission at best.
+
+    `test_the_privacy_policy_is_true.py` caught the MISSING justification for the
+    new permission, which is how this was found. It could not catch the false
+    claim, because a sentence about what the code does not do is invisible to a
+    check that only reads the permission list. This is that check.
+    """
+    downloads_something = "chrome.downloads.download(" in APP_JS
+    # Whitespace-collapsed, because the sentence is wrapped in the source and a
+    # substring check against the raw file would miss it across the line break.
+    flat = " ".join(LISTING.split())
+    claims_it_does_not = "not download" in flat
+    assert not (downloads_something and claims_it_does_not), (
+        "app.js calls chrome.downloads.download while the store listing still "
+        "claims the extension does not download the engine. One of the two is "
+        "wrong, and the listing is the one Google reads.")
+
+
+def test_the_listing_still_promises_the_things_that_ARE_true():
+    """Correcting one clause must not quietly soften the rest.
+
+    These three are the load-bearing promises about the engine, and they are all
+    still true: the panel does not install it, does not run it, and does not read
+    what it downloaded. Losing any of them while editing the sentence above would
+    be a bigger problem than the one being fixed.
+    """
+    for promise in ("does not install it", "does not execute it",
+                    "never reads the contents"):
+        assert promise in LISTING, (
+            f"the listing no longer promises {promise!r} — either the code "
+            f"changed or a true claim was dropped while editing a false one")


### PR DESCRIPTION
`REQ-29`, on his instruction: *«ابدأ بالمحدث داخل الـEngine وشريحة downloads»*.
[R-36](../blob/main/docs/RULINGS.md) is the contract and `OP-36` was its
precondition, so this is the first work that could be built after #244 landed.

**Why this is a second pull request rather than more commits on #244:** #244 was
merged while this work was being pushed to its branch, and GitHub stops tracking
pushes to a closed pull request. So the two commits sat on a branch nobody was
reading. They are rebased onto `main` here, past #243 and #245 as well.

## The engine half

The engine knew **nothing** about releases — zero references to the manifest
anywhere in `scrapex/`. Now:

| new | what it is |
|---|---|
| `scrapex/release.py` | the engine's own reading of the release feed. That makes it the **third** reader of one file, so `tests/test_the_engine_reads_the_same_release_feed.py` holds it to `extension/releases.js` and to the workflow that writes it |
| `scrapex/update.py` | fetch, **verify**, stage |
| `scrapex/webui/update_api.py` | `GET`/`POST /api/update`, `GET /api/update/plan` |

**Four rules in the verification core, and none can be switched off by a caller
because there is no parameter to switch:**

1. **The digest is required.** No `sha256`, no download, and no "anyway" flag —
   the moment one exists it becomes the path somebody takes at 2am.
2. **The bytes are hashed as they arrive**, not read back afterwards. Reading
   back verifies the disk, not the download.
3. **A file that fails is deleted before returning**, on every exit path. A
   rejected 71 MB executable in a staging directory is a thing somebody
   double-clicks a week later.
4. **The staged path is returned only on success**, so no caller can misuse the
   result by forgetting to check a flag.

Plus a 300 MB ceiling, because a digest that will never match is not a stopping
condition — without it a misconfigured endpoint writes until the disk is full.

`packaging/build_engine.py` had refused to build an updater and said why:
*"shipping an updater that fetches and executes unsigned code would be worse than
none."* The digest is the only thing that answers that, which is why every
refusal here is about the digest.

**Not `HttpFetcher`.** That is crawl politeness — jitter, a circuit breaker, one
request a second. Borrowing it would put our own release feed behind a governor
built for somebody else's website.

**The router is wired unconditionally**, unlike the database ones: a database
this build cannot open is a reason to want a newer engine, not a reason to hide
the way to get one.

## The panel half

`downloads` added, and `window.open(installer.url)` replaced with
`chrome.downloads.download` + `search` for a live percentage + `show()` to reveal
the file. The old call survives as the fallback for a declined permission and for
the DOM tests, which load the panel where `chrome.downloads` is absent.

And the SHA-256 now says **who checks it**. `R-36`: a number nothing verifies is
worse than none, because it reads as a guarantee. A panel cannot verify it —
Chrome grants no file read — so the note says it is the reader's to compare, and
that the Engine checks it on every update from here.

## Verified end to end against the real manifest

```
installed 0.2.2 · latest ok 0.2.1 · verifiable true · update_available false
POST /api/update -> "0.2.2 is already the published version."
```

The published release is **older than what is installed**, because 0.2.2 was
never cut. The updater is correct and has nothing to do until it is.

## Mutations

**Seventeen killed on the core, after two survived — and those two were the most
security-relevant.** Every test supplied a digest differing from the truth
*everywhere*, so shortening the comparison to `expected[:8]`, or degenerating it
to a `startswith`, refused them all and passed. A digest sharing a long prefix
and differing late is the only thing that catches that.

**Nine more on the panel guard**, one of which showed an assertion that grepped
for `item.error` while the mutation made the branch dead — so the branch
*condition* is pinned now, not only the text.

## The prose went false the moment the code changed

`docs/store-listing.md` justified `nativeMessaging` with *"This extension does
not **download**, install, execute or update it."* Adding
`chrome.downloads.download` made the first verb untrue, and that file is what
gets submitted to Google.

`test_the_privacy_policy_is_true` caught the *unjustified permission*, which is
how it was found; it could not have caught the false claim, which is invisible to
a check that reads a permission list. That cross-check now exists, and the three
promises that **are** still true are pinned so correcting one clause cannot
quietly soften the rest.

## Not built, and stated rather than implied

**Replacing the running executable.** `plan_swap` returns the plan as inspectable
data — steps, the file it would overwrite, the digest it verified — and performs
nothing. `OP-39` says why stopping here is honest: everything is testable except
the part that matters, whether a real frozen engine replaced underneath itself
comes back. This repository has already paid for that difference once, in
`engine-v0.2.1`, where the guarded thing and the shipped thing were different
things.

**Nothing here has run against a real frozen build.** The guards set
`sys.frozen` and `sys.executable`, which is what makes them possible at all. The
first artifact that will exercise them is the next release.

## Also recorded

`OP-40` and `Q-15`: his warehouse is at schema **v9** against `main`'s v8 — the
third time in one day an unmerged branch moved his live database ahead of `main`.
`Q-15` asks whether a session may do that at all; the trade is evidence from real
data against his installation staying installable, and it is his to price.

## Suite

Full suite on this rebased branch: **one failure**,
`test_a_killed_engine_does_not_leave_a_job_claiming_to_run` — the known
load-dependent race (`OP-19`), which passed on CI three times today. Nothing else.
`ruff check scrapex/` clean; `extension/app.js` parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
