### PR TITLE
The register guard, the taxonomy on real data, and two warehouses that can become one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,18 @@ work predates this file, the commit that built it — evidence read out of
 record of what was done; this file answers a narrower question: which version
 has it.
 
+## 0.3.0
+
+Minimum supported extension: `0.2.2`.
+
+No new capabilities. Fixes and internal change only — an extension and an engine that spoke to each other before this version still do.
+
+
 ## 0.2.2
 
 Minimum supported extension: `0.2.2`.
 
-- **robots_per_source** — Read what a site's robots.txt asks of a crawler, then decide per source: follow the tool default, obey that site, or write a rule for it alone. _Runs in: panel, engine._
+- **robots_per_source** (adf31b2) — Read what a site's robots.txt asks of a crawler, then decide per source: follow the tool default, obey that site, or write a rule for it alone. _Runs in: panel, engine._
 
 ## 0.2.0
 

--- a/contracts/capability-baseline.json
+++ b/contracts/capability-baseline.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.2",
+  "version": "0.3.0",
   "minimum_extension_version": "0.2.2",
   "capabilities": {
     "crawl_pace": "0.2.0",

--- a/contracts/contract-baseline.json
+++ b/contracts/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.2",
+  "version": "0.3.0",
   "schema": [
     "0002_the_price_source_key_is_named_for_what_it_is.sql",
     "0003_a_source_says_how_deep_its_crawl_goes.sql",
@@ -7,7 +7,8 @@
     "0005_a_snapshot_says_how_it_is_encoded.sql",
     "0006_a_row_says_when_it_was_last_proved_absent.sql",
     "0007_a_taxonomy_says_which_site_it_belongs_to.sql",
-    "0008_a_page_remembers_how_to_ask_whether_it_changed.sql"
+    "0008_a_page_remembers_how_to_ask_whether_it_changed.sql",
+    "0009_a_contractor_points_at_a_taxonomy_instead_of_repeating_it.sql"
   ],
   "protocol": "1",
   "endpoints": [

--- a/contracts/version-vectors.json
+++ b/contracts/version-vectors.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.2",
+  "version": "0.3.0",
   "minimum_extension_version": "0.2.2",
   "capability_reporting_since": "0.2.0",
   "note": "Both copies of capabilityProblem must reproduce every `problem` string exactly. Python: scrapex/version.py. JavaScript: extension/version.js.",
@@ -7,8 +7,8 @@
     {
       "name": "in step — the engine deploys it and the extension is new enough",
       "key": "crawl_parallel_sources",
-      "extension_version": "0.2.2",
-      "engine_version": "0.2.2",
+      "extension_version": "0.3.0",
+      "engine_version": "0.3.0",
       "deployed": {
         "crawl_pace": {
           "since": "0.2.0",
@@ -50,7 +50,7 @@
       "name": "the extension is behind the engine",
       "key": "crawl_parallel_sources",
       "extension_version": "0.1.0",
-      "engine_version": "0.2.2",
+      "engine_version": "0.3.0",
       "deployed": {
         "crawl_pace": {
           "since": "0.2.0",
@@ -86,12 +86,12 @@
         }
       },
       "update_instructions": "Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards.",
-      "problem": "«Crawl several different sites at the same time. Two sources on the SAME site still take turns, so no site is asked for more than before.» needs ScrapeX extension 0.2.0; this extension is 0.1.0 and the engine is 0.2.2. Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards."
+      "problem": "«Crawl several different sites at the same time. Two sources on the SAME site still take turns, so no site is asked for more than before.» needs ScrapeX extension 0.2.0; this extension is 0.1.0 and the engine is 0.3.0. Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards."
     },
     {
       "name": "the engine is behind and says so",
       "key": "crawl_parallel_sources",
-      "extension_version": "0.2.2",
+      "extension_version": "0.3.0",
       "engine_version": "0.1.0",
       "deployed": {
         "crawl_pace": {
@@ -124,22 +124,22 @@
         }
       },
       "update_instructions": "Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards.",
-      "problem": "«crawl_parallel_sources» is not deployed by this ScrapeX engine (0.1.0); this extension is 0.2.2. Update the engine to 0.2.2 or newer."
+      "problem": "«crawl_parallel_sources» is not deployed by this ScrapeX engine (0.1.0); this extension is 0.3.0. Update the engine to 0.3.0 or newer."
     },
     {
       "name": "the engine is too old to say anything",
       "key": "crawl_parallel_sources",
-      "extension_version": "0.2.2",
+      "extension_version": "0.3.0",
       "engine_version": "0.1.0",
       "deployed": null,
       "update_instructions": "Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards.",
-      "problem": "«crawl_parallel_sources» cannot be confirmed: the ScrapeX engine reports version 0.1.0 and is too old to say which features it deploys. This extension is 0.2.2. Update the engine to 0.2.2."
+      "problem": "«crawl_parallel_sources» cannot be confirmed: the ScrapeX engine reports version 0.1.0 and is too old to say which features it deploys. This extension is 0.3.0. Update the engine to 0.3.0."
     },
     {
       "name": "an extension newer than the requirement is not refused for being newer",
       "key": "crawl_parallel_sources",
       "extension_version": "9.9.9",
-      "engine_version": "0.2.2",
+      "engine_version": "0.3.0",
       "deployed": {
         "crawl_pace": {
           "since": "0.2.0",

--- a/db/engine/migrations/0009_a_contractor_points_at_a_taxonomy_instead_of_repeating_it.sql
+++ b/db/engine/migrations/0009_a_contractor_points_at_a_taxonomy_instead_of_repeating_it.sql
@@ -1,7 +1,7 @@
 -- =====================================================================
 -- 0009 — A CONTRACTOR POINTS AT A TAXONOMY INSTEAD OF REPEATING IT
 --
--- `R-36`, his ruling of 2026-08-21: `R-19`'s five multi-valued groups are a
+-- `R-38`, his ruling of 2026-08-21: `R-19`'s five multi-valued groups are a
 -- TAXONOMY plus a link table — shape D — and not five child datasets inside
 -- `generic_record`, which was shape F and what the study recommended.
 --
@@ -46,7 +46,7 @@ CREATE TABLE IF NOT EXISTS generic_record_node (
     node_id            INTEGER NOT NULL
         REFERENCES classification_node(node_id),
 
-    -- `R-39`: the DECLARED name of the group this membership belongs to, from
+    -- `R-41`: the DECLARED name of the group this membership belongs to, from
     -- `MULTI_VALUED_GROUPS`. Never the table's position and never its heading —
     -- the detector returns `Table 1`…`Table 5`, three of the five tables share
     -- one heading, and two share a column signature while both being empty.
@@ -77,9 +77,9 @@ CREATE TABLE IF NOT EXISTS generic_record_node (
     -- extra read and no dependence on a clock.
     seen_count         INTEGER NOT NULL DEFAULT 1 CHECK (seen_count >= 1),
 
-    -- IDEMPOTENT BY CONSTRUCTION, which is `R-36`'s fourth reason for choosing
+    -- IDEMPOTENT BY CONSTRUCTION, which is `R-38`'s fourth reason for choosing
     -- D. Shape F would have written these through `approve_candidate` — the
-    -- function whose idempotency key `R-38` had to repair. Here a re-parse that
+    -- function whose idempotency key `R-40` had to repair. Here a re-parse that
     -- finds the same membership hits this key and updates `last_seen_at`; it
     -- cannot write a duplicate, and no later fix is needed to make that true.
     PRIMARY KEY (generic_record_id, node_id, group_key)

--- a/db/engine/migrations/0009_a_contractor_points_at_a_taxonomy_instead_of_repeating_it.sql
+++ b/db/engine/migrations/0009_a_contractor_points_at_a_taxonomy_instead_of_repeating_it.sql
@@ -1,0 +1,99 @@
+-- =====================================================================
+-- 0009 — A CONTRACTOR POINTS AT A TAXONOMY INSTEAD OF REPEATING IT
+--
+-- `R-36`, his ruling of 2026-08-21: `R-19`'s five multi-valued groups are a
+-- TAXONOMY plus a link table — shape D — and not five child datasets inside
+-- `generic_record`, which was shape F and what the study recommended.
+--
+-- HE OVERRULED THE RECOMMENDATION AND WAS RIGHT. F's headline argument was
+-- that it reuses machinery this warehouse already contains. Measured the
+-- same day: `classification_node`, `classification_scheme`,
+-- `dataset_relationship` and `relationship_field_pair` hold **zero rows
+-- between them**. Existing machinery that has never carried a row is not an
+-- asset — one session found `is_enabled` with no callers, `record_absences`
+-- with no callers, and a slice scope that was "built, tested, never used"
+-- and turned out to be WRONG.
+--
+-- AND F PAID A WHOLE RECORD FOR A TWO-INTEGER JOIN ROW. Measured on the live
+-- warehouse, each `generic_record` row carries `data_json` averaging 1,049
+-- bytes, a 64-character `record_key`, a 64-character `content_hash`, two
+-- timestamps, a status and four foreign keys. A membership fact — this
+-- contractor holds this node — is two integers. At the study's ~500K rows
+-- that is the measured 4.7x, and it is conservative.
+--
+-- WHY THE TAXONOMY HALF NEEDS NO TABLE. `classification_node` is already a
+-- generic self-referencing tree with `parent_node_id`, `node_name`,
+-- `node_name_ar` and `level`, and `ux_classification_node_name` makes
+-- `(scheme_id, ifnull(parent_node_id,0), node_name_ar)` its identity. That
+-- is exactly the shape the hierarchical groups need, which is the finding
+-- that produced shapes D and F in the first place. Only the LINK is new.
+--
+-- WHAT THIS CARRIES OVER FROM F, and it is the one advantage F really had:
+-- `source_snapshot_id NOT NULL`, so provenance is enforced by the schema
+-- rather than remembered. One column, one constraint.
+--
+-- AND WHY THE PRIMARY KEY INCLUDES `group_key`. The licensed-activities
+-- values look like the same two-level activity paths the interests tree
+-- publishes — measured, both are `parent - child` strings from the same
+-- vocabulary — so ONE node can legitimately be held by a contractor as an
+-- interest AND as a licensed activity. Keying on `(record, node)` alone
+-- would silently merge those two facts into one.
+-- =====================================================================
+
+CREATE TABLE IF NOT EXISTS generic_record_node (
+    generic_record_id  INTEGER NOT NULL
+        REFERENCES generic_record(generic_record_id) ON DELETE CASCADE,
+    node_id            INTEGER NOT NULL
+        REFERENCES classification_node(node_id),
+
+    -- `R-39`: the DECLARED name of the group this membership belongs to, from
+    -- `MULTI_VALUED_GROUPS`. Never the table's position and never its heading —
+    -- the detector returns `Table 1`…`Table 5`, three of the five tables share
+    -- one heading, and two share a column signature while both being empty.
+    group_key          TEXT NOT NULL,
+
+    -- ENFORCED, NOT REMEMBERED. This is F's one real advantage carried across:
+    -- every membership names the stored page it was read from, so "why does this
+    -- contractor hold this node" is answerable from the warehouse and not from a
+    -- log. NOT NULL is the whole point of the column.
+    source_snapshot_id INTEGER NOT NULL
+        REFERENCES generic_page_snapshot(page_snapshot_id),
+
+    first_seen_at      TEXT NOT NULL
+        DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+    last_seen_at       TEXT NOT NULL
+        DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+
+    -- HOW MANY TIMES THIS MEMBERSHIP HAS BEEN READ, and it exists because the
+    -- timestamps cannot answer "was this new" — both come from
+    -- `strftime(...,'now')` at SECOND resolution, so a first write and its
+    -- confirmation in the same second produce `first_seen_at = last_seen_at` and
+    -- the caller cannot tell them apart. Measured: a second identical pass over
+    -- one profile reported all 25 memberships as new.
+    --
+    -- `dataset_sighting` already carries a `seen_count` for the same reason, so
+    -- this is the schema's existing answer rather than a new idea. The upsert
+    -- increments it and returns it, so `= 1` means "written just now" with no
+    -- extra read and no dependence on a clock.
+    seen_count         INTEGER NOT NULL DEFAULT 1 CHECK (seen_count >= 1),
+
+    -- IDEMPOTENT BY CONSTRUCTION, which is `R-36`'s fourth reason for choosing
+    -- D. Shape F would have written these through `approve_candidate` — the
+    -- function whose idempotency key `R-38` had to repair. Here a re-parse that
+    -- finds the same membership hits this key and updates `last_seen_at`; it
+    -- cannot write a duplicate, and no later fix is needed to make that true.
+    PRIMARY KEY (generic_record_id, node_id, group_key)
+) WITHOUT ROWID;
+
+-- "Everything in this group for this contractor" is the read the panel and the
+-- export will both make, and the primary key already serves it left-to-right.
+-- This is the OTHER direction: "every contractor holding this node", which is
+-- the query `R-19` was ruled on — «كل المقاولين فى نشاط معيّن».
+CREATE INDEX IF NOT EXISTS ix_record_node_by_node
+    ON generic_record_node(node_id, group_key);
+
+-- A DELETED CONTRACTOR TAKES ITS MEMBERSHIPS WITH IT, which is why the foreign
+-- key above cascades. `OP-25` was settled on 2026-08-21 by wiping
+-- `generic_record` and re-approving from disk — 1,172 rows became 13,892 with
+-- zero network — so deletion is a route this warehouse actually takes, and
+-- links that survived it would be orphans pointing at nothing.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1178,7 +1178,7 @@ then the only engine that runs on this machine is that worktree's.
 **Status: OPEN, filed not fixed, per `R-01`.** Found while looking for the black
 window's trace and finding none.
 
-`_bind_log_streams` (`scrapex/cli.py:940`) says it plainly: *"run it from a terminal
+`_bind_log_streams` (`scrapex/cli.py:976`) says it plainly: *"run it from a terminal
 and this does nothing at all."* It exists for the `pythonw` autostart path, which
 has no streams. A double-click **does** get a console, so the redirect no-ops and
 the failure goes to a window that is closing. `~/.scrapex/engine.log` is dated

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1009,7 +1009,7 @@ has data consequences:
 impossible rather than deferred; (b) or (c) as the real model, once he rules.*
 **Not started — his call, on live data.**
 
-### OP-39 · The test suite writes into the owner's live crawl log
+### OP-41 · The test suite writes into the owner's live crawl log
 
 **Found 2026-08-21, by reading the log to check on a crawl.**
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1597,7 +1597,7 @@ TEXT. That is a migration plus every reader of the column.
 
 ### DEC-10 · "Fix the parser and re-run over the snapshots" does not actually work
 
-> **RULED 2026-08-21 — [R-38](RULINGS.md#r-38--dec-10-is-built-before-the-profile-crawl-not-after-it):
+> **RULED 2026-08-21 — [R-40](RULINGS.md#r-40--dec-10-is-built-before-the-profile-crawl-not-after-it):
 > built BEFORE the profile crawl.** On 34,834 profile pages a parser defect found
 > afterwards costs 11 hours of re-fetching to fix what should be minutes of
 > re-parsing, which is a direct contradiction of why the seam exists. Kept here

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1596,6 +1596,12 @@ What was considered and is worse:
 TEXT. That is a migration plus every reader of the column.
 
 ### DEC-10 · "Fix the parser and re-run over the snapshots" does not actually work
+
+> **RULED 2026-08-21 — [R-38](RULINGS.md#r-38--dec-10-is-built-before-the-profile-crawl-not-after-it):
+> built BEFORE the profile crawl.** On 34,834 profile pages a parser defect found
+> afterwards costs 11 hours of re-fetching to fix what should be minutes of
+> re-parsing, which is a direct contradiction of why the seam exists. Kept here
+> rather than deleted, because the measurement below is what produced the ruling.
 The seam's stated product is that a wrong parse is re-run against stored snapshots with
 nothing re-fetched (`GENERIC-FETCH-SEAM.md`). **It was tried on 2026-08-20 and wrote
 nothing at all.**

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -272,7 +272,7 @@ Options:
 **(a)** Migrate `SR-1..SR-23` into `RULINGS.md`; BACKLOG.md §1 becomes a pointer.
 One home, with the C4 supersession discipline applied to all of them. BACKLOG.md
 keeps what it is genuinely best at — `OP`, `DEC`, `DEBT`, `Q`.
-**(b)** Fold `R-01..R-13` back into BACKLOG.md §1 as `SR-24..SR-36`, delete
+**(b)** Fold `R-01..R-13` back into BACKLOG.md §1 as `SR-24..SR-38`, delete
 `RULINGS.md`. Fewer files; but the rulings then live inside a 1,151-line document
 that **C1** tells every session to read before designing anything.
 **(c)** Keep both with a documented split by subject. Rejected — a boundary

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -1044,6 +1044,69 @@ It works and it destroys history every time, which is what a row-aware key repla
 
 ---
 
+### R-43 · Drive is the single source of truth for DATA; the repository stays it for CODE
+
+**2026-08-22 · two machines · extends `CLAUDE.md`'s founding rule to the warehouse**
+
+> «الفكرة انى اريد توحيد او دمج قواعد البيانات … افضل طريقة هى حفظها على drive وقبل
+> التطوير فى الجهاز الاخر ينزلها ويدمجها معه من ثم يحفظها … وعند العودة لك مرة اخرى
+> سيكون هناك مصدر واحد للحقيقة هو drive»
+
+`CLAUDE.md` exists because everything saying *where the work stood* lived under one
+machine's home directory. It fixed that for code, decisions and state — **and said nothing
+about the data**, which is the half that cannot be committed. This is that half.
+
+**BOTH MACHINES HAVE DEVELOPED muqawil**, which is what rules out the obvious answer:
+neither file may be copied over the other, because each holds work the other does not.
+`R-24` already says upgrade rather than replace; this is the same rule between two
+machines instead of two versions.
+
+### What made it buildable, and it was not obvious
+
+*"Merge them"* is not an operation on two SQLite files. Every primary key is an
+autoincrement, so **both machines hold a `page_snapshot_id = 1` for a different page** —
+merging naively means remapping every key and every foreign key pointing at one, which is
+[OP-30](BACKLOG.md) at a far larger scale. Measured 2026-08-22, three natural keys exist and
+that is what changes the answer:
+
+| table | natural key | measured |
+|---|---|---|
+| `generic_page_snapshot` | `(source_url, content_hash)` | 20,379 rows, **20,379 distinct** |
+| `dataset_sighting` | `(dataset_key, external_id)` | UNIQUE in the schema |
+| `generic_record` | `(dataset_definition_id, record_key)` | UNIQUE in the schema |
+
+**ONLY THE EVIDENCE TRAVELS, AND THAT IS THE WHOLE DESIGN.** A snapshot is a page as it was
+fetched and a sighting is what the site showed and when — neither can be recomputed.
+Everything else is rebuilt by `--approve` with **no network**: records, revisions,
+ingestions, the taxonomy and its 15,559 memberships. So nothing that carries a primary key
+ever crosses, and no id is ever remapped.
+
+**EVERY COLUMN MERGES WITH `min` OR `max` AND NONE WITH `+`.** The first implementation
+summed `seen_count`, and three merges of the same file took one id from **4 to 8 to 12 to
+16** while the module's own docstring called the operation idempotent — caught because a
+test looked at the value instead of the row count. Summing is wrong on the *first* merge
+too: two machines crawling the same listing observe the same site state, so their counts are
+two observations of one fact.
+
+### The lock, which his plan was missing
+
+Download → work → upload has nothing stopping both machines doing it on the same day, and
+**the second upload silently wins**; Drive keeps versions but cannot merge them. That is
+`R-37`'s parallel-session problem one level down, and worse, because no CI sees it.
+
+So a warehouse records which machine holds it — `scrapex_meta.checkout_holder`, beside the
+`account_owner` that `R-34` already put there, so no migration — and `scrapex
+merge-warehouse` refuses to write into a copy somebody else holds. Re-claiming your own is
+allowed, because a session that died mid-merge has to pick the same copy back up.
+
+**A SHIPPED COMMAND, NOT A SCRIPT.** `scrapex merge-warehouse --status / --machine /
+--release / --from`. `contractors.py` exists because every piece of the first warehouse's
+pipeline was committed with no invocation, so the other machine could read how it worked
+and could not run it. Seventeen tests, and the one that matters most asserts that merging
+three times changes no VALUE.
+
+---
+
 ### R-42 · One PRIMARY session merges; every other session is SECONDARY and asks
 
 **2026-08-21 · process · supersedes [R-37](#r-37--the-agent-does-not-merge-the-main-programmer-does)**

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -813,7 +813,7 @@ changed.
 
 ---
 
-### R-36 · `R-19`'s five groups are a TAXONOMY plus a link table, not five datasets — shape D
+### R-38 · `R-19`'s five groups are a TAXONOMY plus a link table, not five datasets — shape D
 
 **2026-08-21 · data model · refines [R-19](#r-19--the-five-multi-valued-contractor-groups-go-in-child-tables-not-json), and overrules the study's own recommendation**
 
@@ -856,7 +856,7 @@ A membership fact — *this contractor holds this node* — is two integers. At 
 The contractor dataset has no retention today. F would have added five more datasets to
 that same gap rather than inheriting a solution.
 
-**A fourth reason, which crosses [R-38](#r-38--dec-10-is-built-before-the-profile-crawl-not-after-it):**
+**A fourth reason, which crosses [R-40](#r-40--dec-10-is-built-before-the-profile-crawl-not-after-it):**
 F routes five groups through `approve_candidate`, the function that answers
 `recovered=True` and writes nothing. D writes directly, so idempotency is one constraint
 — `UNIQUE (contractor, node)` — correct by construction instead of by later repair.
@@ -873,7 +873,7 @@ all, is parked by him, so the export half of that cost is not owed yet.
 
 ---
 
-### R-37 · muqawil is registered `listing_plus_slice`, and one city is crawled before eleven hours are spent
+### R-39 · muqawil is registered `listing_plus_slice`, and one city is crawled before eleven hours are spent
 
 **2026-08-21 · crawl scope · answers the registration `PLATFORM-PLAN` Decision 23 left to him**
 
@@ -912,7 +912,7 @@ the report says which.
 
 ---
 
-### R-38 · DEC-10 is built BEFORE the profile crawl, not after it
+### R-40 · DEC-10 is built BEFORE the profile crawl, not after it
 
 **2026-08-21 · idempotency · closes [DEC-10](BACKLOG.md) as a decision**
 
@@ -930,7 +930,7 @@ wrong parse costs minutes; an idempotency key that refuses to rewrite a correcte
 hands the cost straight back.
 
 **It is also the one open item that changes the COST of the remaining work rather than
-its scope**, which is why building it first is not sequencing preference. `R-36`'s link
+its scope**, which is why building it first is not sequencing preference. `R-38`'s link
 table depends on it twice over: the five groups are parsed from the same profile pages,
 and a first parse of a five-level taxonomy is unlikely to be the last.
 
@@ -940,13 +940,13 @@ It works and it destroys history every time, which is what a row-aware key repla
 
 ---
 
-### R-39 · A multi-valued group is named by a DECLARED per-site map, never by position or by its heading
+### R-41 · A multi-valued group is named by a DECLARED per-site map, never by position or by its heading
 
 **2026-08-21 · extraction · answers a question the measurement raised**
 
 > «كيف تُسمّى المجموعات الخمس؟» → **«خريطة مُعلَنة لكل موقع»**
 
-`R-36` needs to know which group a row belongs to, and neither obvious answer works.
+`R-38` needs to know which group a row belongs to, and neither obvious answer works.
 Measured against the committed profile:
 
 | candidate rule | why it fails |

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -150,6 +150,22 @@ Decision 21 unwelded (PR #112), whose "Done when" is *"the other number
 untouched"*. The two ship down separate paths — Google reviews the extension,
 nobody reviews the engine.
 
+> **PARTLY BUILT 2026-08-22, AND THE DELAY COST THE SAME 54px TWICE.** This ruling was
+> given on 2026-08-16 and the advert stayed in the code. On 2026-08-22 a schema change
+> moved `VERSION` to 0.3.0 for a legitimate reason under
+> [R-35](#r-35--the-engines-version-moves-on-a-contract-change-the-extensions-on-a-user-visible-one),
+> and **three panel layout tests failed with the identical 54px this ruling had already
+> measured** — because `version_report` still read
+> `bool(missing) or is_older(extension_version, VERSION)`, two questions welded into one
+> verdict. The `is_older` half is gone: the GATE ("this extension lacks a capability it
+> needs", a fact the engine owns) stays, and the ADVERT ("a newer extension exists",
+> which is Chrome's answer) does not. Two tests pin the distinction from both sides.
+>
+> **STILL OWED, so it does not go missing for another six days:**
+> `latest_extension_version`, `LATEST_SOURCE` and `UPDATE_INSTRUCTIONS` are named above as
+> also going, and each needs a coordinated change in `extension/app.js`, which reads them.
+> They were not smuggled in behind a one-line fix to the harm.
+
 **Apply:** its own pull request, with a guard that fails if the engine ever
 answers for the extension's head again.
 

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -416,7 +416,15 @@ rule wastes a session.
 
 ### R-37 · The agent does not merge. The main programmer does
 
-**2026-08-21 · process · supersedes [R-18](#r-18--merge-it-when-it-is-green)**
+**2026-08-21 · process · ~~active~~ SUPERSEDED the same day by [R-42](#r-42--one-primary-session-merges-every-other-session-is-secondary-and-asks)**
+
+> **Kept in full because its DIAGNOSIS is what R-42 is built on.** Merge order
+> across parallel sessions really is invisible to a single session. What R-42
+> changes is the remedy: name the one session that can see it, rather than
+> blinding all of them. Everything below about what a report must say still
+> governs a SECONDARY session.
+
+**supersedes [R-18](#r-18--merge-it-when-it-is-green)**
 
 > «واترك الدمج للمبرمج الرئيسيى»
 
@@ -1033,6 +1041,64 @@ and a first parse of a five-level taxonomy is unlikely to be the last.
 The route already proven on live data — wipe and re-approve from disk, which took
 `generic_record` from 1,172 to 13,892 with zero network on 2026-08-21 — stays available.
 It works and it destroys history every time, which is what a row-aware key replaces.
+
+---
+
+### R-42 · One PRIMARY session merges; every other session is SECONDARY and asks
+
+**2026-08-21 · process · supersedes [R-37](#r-37--the-agent-does-not-merge-the-main-programmer-does)**
+
+> «اريد تعديل القاعدة بحيث ان هناك جلسة اساسية وجلسات فرعية · الجلسة الاساسية هى الجلسة
+> التى تستطيع الدمج بينما الجلسات الفرعية لا · يمكن ان تسالنى اذا كنت جلسة اساسية ام
+> فرعية لتحدد هذا الامر»
+
+`R-37` removed the merge from every session because **merge order across parallel
+sessions is not a thing any single session can see**. That diagnosis was right and
+nothing here contradicts it. What it got wrong is the remedy: it solved a problem of
+COORDINATION by removing a CAPABILITY, so the cost R-18 was written against came
+straight back — a green branch idles until he happens to be at a keyboard.
+
+**THE FIX IS TO NAME WHO COORDINATES.** Exactly one session is PRIMARY and may merge.
+Every other session is SECONDARY: it builds, pushes, reports, and stops. The blindness
+`R-37` identified is real, so it is answered by making one session the one that can see
+— not by blinding all of them.
+
+### How a session knows, and it is the whole of the rule
+
+**IT ASKS. IT NEVER INFERS, AND IT NEVER ASSUMES.** He named the mechanism himself:
+*«يمكن ان تسالنى اذا كنت جلسة اساسية ام فرعية»*. There is no other source — being
+first, being busy, holding the open pull request, or having merged earlier in the same
+session prove nothing about which session he is treating as primary right now.
+
+**AND THE DEFAULT IS SECONDARY.** Until he answers, a session is secondary. That is the
+only safe direction: a secondary session that was really primary costs one message,
+while a primary session that was really secondary is the bad merge `R-37` was written
+about — and `main` has no branch protection, so nothing downstream would catch it.
+
+**ONE, NOT "AT MOST ONE PER MACHINE".** He works from two machines and two accounts
+(`CLAUDE.md`), and two primaries on two machines is exactly the parallel-merge problem
+under a new name.
+
+**THE ANSWER IS PER SESSION AND IS NOT A REPOSITORY FACT.** It cannot be committed —
+which session is primary changes with the day and is not true of the code. So it is
+asked in the session that needs it, and it does not carry to the next one. A session
+resuming from a summary that does not record the answer asks again.
+
+### What does not change
+
+`R-37`'s reading of the report stands in full for a secondary session: name every check,
+every failure, and **whether each failure ran at all**. `R-18`'s reading of *green*
+stands for the primary one — a `SKIPPED` required check is not satisfied, an absent run
+is not a red one, and a tick from before the last push describes a tree nobody is
+merging. `R-22` still requires the full suite before a pull request opens.
+
+**AND THE GUARD MATTERS MORE NOW, NOT LESS.** Returning the merge to a session returns
+its judgement to the gate, so the failures a person should not have to hunt for must be
+mechanical. `tests/test_the_registers_cannot_collide.py` was built the same day and
+immediately caught two real collisions between `#244` and the branch beside it — `R-36`
+and `R-37` claimed twice, and `OP-32` claimed twice — every one of them green,
+mergeable, and invisible to git. Branch protection on `main` is still absent and still
+his to switch on.
 
 ---
 

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -813,6 +813,163 @@ changed.
 
 ---
 
+### R-36 · `R-19`'s five groups are a TAXONOMY plus a link table, not five datasets — shape D
+
+**2026-08-21 · data model · refines [R-19](#r-19--the-five-multi-valued-contractor-groups-go-in-child-tables-not-json), and overrules the study's own recommendation**
+
+> «شكل تخزين مجموعات R-19 الخمس … أيّها؟» → **«D — تصنيف خالص + جدول ربط مخصَّص»**
+
+`R-19` ruled child tables over JSON and every measurement upheld it. What it did not
+settle was *how* — [the study](R19-CHILD-TABLES-MEASURED.md) put five shapes side by side
+and recommended **F**, a child dataset per group inside `generic_record` whose value
+references `classification_node`. **He chose D**: the taxonomy plus a bespoke link table.
+
+**He is right, and the recommendation was wrong for a reason worth writing down.** F's
+headline argument was that it reuses machinery the warehouse already contains. Measured
+on the live warehouse the same day:
+
+| the machinery F would be the first tenant of | rows |
+|---|---|
+| `classification_node` | **0** |
+| `classification_scheme` | **0** |
+| `dataset_relationship` | **0** |
+| `relationship_field_pair` | **0** |
+
+**Existing machinery that has never carried a row is not an asset.** This one session
+proved that three times: `is_enabled` called itself *"the gate navigation must call"* and
+had zero callers; `record_absences` had zero callers; and the slice scope was *"built,
+tested, and never used"* and turned out to be **wrong** — 17 cards paired against 34
+URLs. The recommendation weighed whether the machinery EXISTED. What matters is whether
+it RUNS.
+
+**And F pays a full record's overhead for a two-integer join row.** Measured per row of
+`generic_record`: `data_json` averages **1,049 bytes**, `record_key` is a 64-character
+SHA-256, `content_hash` another 64, plus two timestamps, a status and four foreign keys.
+A membership fact — *this contractor holds this node* — is two integers. At the study's
+~500K rows that is the measured 4.7×, and it is conservative.
+
+**"It inherits the lifecycle" was not true either:**
+
+    retention.py     16 references to price_observation, 0 to generic_record
+    compaction.py     7 references to price_observation, 0 to generic_record
+
+The contractor dataset has no retention today. F would have added five more datasets to
+that same gap rather than inheriting a solution.
+
+**A fourth reason, which crosses [R-38](#r-38--dec-10-is-built-before-the-profile-crawl-not-after-it):**
+F routes five groups through `approve_candidate`, the function that answers
+`recovered=True` and writes nothing. D writes directly, so idempotency is one constraint
+— `UNIQUE (contractor, node)` — correct by construction instead of by later repair.
+
+**WHAT D MUST NOT LOSE, and it is one line.** F's one surviving advantage was that
+`generic_record.source_snapshot_id NOT NULL` makes provenance **enforced by the schema**
+rather than remembered. The link table carries the same column under the same constraint.
+Then D is 4.7× smaller *and* provenance is still enforced.
+
+**What D genuinely costs:** bespoke work in the export, the API, the panel and the CLI,
+because a link table is not a dataset and nothing reads it for free. Noted rather than
+discounted — and `O-2`, whether the contractor entity belongs in the mbiX workbook at
+all, is parked by him, so the export half of that cost is not owed yet.
+
+---
+
+### R-37 · muqawil is registered `listing_plus_slice`, and one city is crawled before eleven hours are spent
+
+**2026-08-21 · crawl scope · answers the registration `PLATFORM-PLAN` Decision 23 left to him**
+
+> «نطاق زحف مقاول مسجَّل listing_only … ماذا أُسجِّل؟» → **«listing_plus_slice لمدينة واحدة أوّلاً»**
+
+The profile pages carry the ~28 columns the listing does not, and the full crawl is
+**34,834 pages — 11.1 hours**, measured over 87 minutes of real six-worker crawling at
+52.5 pages a minute. He chose to see one city first.
+
+**The city is read off the listing card, so a slice costs nothing to select.** Measured
+from the live warehouse, the cities that a first slice could be:
+
+| city | contractors | profile pages | at 1.14 s a page |
+|---|---|---|---|
+| RIYADH | 5,406 | 10,812 | ~3.4 h |
+| JEDDAH | 2,206 | 4,412 | ~1.4 h |
+| DAMMAM | 739 | 1,478 | ~28 min |
+| AL MADINAH AL MUNAWWARAH | 499 | 998 | ~19 min |
+| TABUK | 191 | 382 | ~7 min |
+
+**A DEFECT THIS RULING EXPOSED BEFORE IT WAS IMPLEMENTED.** A slice is named in the
+language of the page — `MuqawilPageSource.belongs_to_slice` says so — and measured
+against the committed fixtures:
+
+    en page, slice 'RIYADH'  → 3 of 4 cards match
+    en page, slice 'الرياض'  → 0 of 4
+    ar page, slice 'RIYADH'  → 0 of 4
+    ar page, slice 'الرياض'  → 3 of 4
+
+So a single `crawl_slice` value matches **one locale's pages only**. The frontier still
+comes out correct, because `detail_rows` yields both locales' profile URLs for a matched
+row — but every Arabic listing row is counted as *outside the slice*, which makes the
+report a lie, and the whole slice would depend on the English pages happening to be on
+disk. The frontier scan is therefore restricted to the locale the slice is named in, and
+the report says which.
+
+---
+
+### R-38 · DEC-10 is built BEFORE the profile crawl, not after it
+
+**2026-08-21 · idempotency · closes [DEC-10](BACKLOG.md) as a decision**
+
+> «هل نبنيه قبل زحفة الملفّات؟» → **«نعم، قبل الزحفة»**
+
+`approve_candidate`'s idempotency key is `(snapshot, locator)` plus the schema hash, so a
+**corrected** parser re-run over stored pages returns `recovered=True` and changes not one
+row. On the listing that was survivable — the pages are cheap to re-read. On 34,834
+profile pages it is not: a parser defect found after the crawl costs **11 hours of
+re-fetching** to fix what should be minutes of re-parsing.
+
+**That is a direct contradiction of why the seam exists.**
+`docs/GENERIC-FETCH-SEAM.md` separates fetching from interpreting precisely so that a
+wrong parse costs minutes; an idempotency key that refuses to rewrite a corrected row
+hands the cost straight back.
+
+**It is also the one open item that changes the COST of the remaining work rather than
+its scope**, which is why building it first is not sequencing preference. `R-36`'s link
+table depends on it twice over: the five groups are parsed from the same profile pages,
+and a first parse of a five-level taxonomy is unlikely to be the last.
+
+The route already proven on live data — wipe and re-approve from disk, which took
+`generic_record` from 1,172 to 13,892 with zero network on 2026-08-21 — stays available.
+It works and it destroys history every time, which is what a row-aware key replaces.
+
+---
+
+### R-39 · A multi-valued group is named by a DECLARED per-site map, never by position or by its heading
+
+**2026-08-21 · extraction · answers a question the measurement raised**
+
+> «كيف تُسمّى المجموعات الخمس؟» → **«خريطة مُعلَنة لكل موقع»**
+
+`R-36` needs to know which group a row belongs to, and neither obvious answer works.
+Measured against the committed profile:
+
+| candidate rule | why it fails |
+|---|---|
+| the detector's own name | it returns `Table 1` … `Table 5` — position, which moves when a section does |
+| the nearest heading | **three of the five tables sit under one heading** |
+| the column signature | two tables carry the same `الإسم / القيمة` pair, and three are **empty** for this contractor, so there are no columns to read |
+
+So each site declares it, the way `CARD_FIELDS` and `PROFILE_FIELD_ORDER` already declare
+what a listing and a profile publish. Explicit, tested against a committed fixture, and
+unchanged when the site moves a section.
+
+**And the heading rule fails for a second reason that would have been worse.** The
+interests card is titled `Interests` in English and **`الأنشطة`** — "Activities" — in
+Arabic. Not a translation. A heading-based rule read 25 nodes from the English profile and
+**0 from the Arabic**, which is `DSN-05`'s failure again: a locale-dependent selector that
+silently produces nothing for half the data.
+
+**The price, stated:** one declaration per group per site. That is the cost of a rule that
+cannot drift, and this file already records what the alternative costs.
+
+---
+
 ### R-35 · The engine's version moves on a CONTRACT change; the extension's on a USER-VISIBLE one
 
 **2026-08-21 · release · settles the trigger R-05 lost and R-07 left open**

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -134,7 +134,7 @@ engine carries the extension.
 
 **The defect, found by trying the bump and reverting it the same day:**
 `version_report` sends `"latest_extension_version": VERSION`
-(`scrapex/version.py:477`, again in `scrapex/webui/app.py:1459`, drawn by
+(`scrapex/version.py:483`, again in `scrapex/webui/app.py:1459`, drawn by
 `extension/app.js:595` and `:629`). The moment the engine moves ahead of
 `extension/manifest.json`, the panel draws *"This ScrapeX extension is older than
 the engine it is talking to"*. Measured at 320×440: the profile page's legal line

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -453,11 +453,52 @@ with nothing stored for them. Their written conditions were measured, not quoted
 
 > **And the reason given for lighting them was wrong, so it is corrected here
 > rather than deleted.** This file used to say lighting them "makes `/datasets`
-> appear in navigation". It does not. `is_enabled` has **no production caller** in
-> the engine or the panel, and there is no `/datasets` route — measured, not
-> assumed. What the flags govern is what `/api/features` **publishes**, so lighting
-> one is a *claim* about a capability rather than a switch that reveals it. The
-> capability itself already works without them: `/source/contractors` serves today.
+> appear in navigation". It does not, and there is no `/datasets` route — measured,
+> not assumed.
+>
+> **SUPERSEDED 2026-08-21 (#245): they are switches now.** The paragraph above went
+> on to say `is_enabled` has *"no production caller"*, which was true and is the
+> defect item 3 of the six closed. The two callers are the two ADVERTISEMENTS, and
+> they are not symmetrical: `_dataset_rows` puts a dataset in the source listing the
+> panel draws, and `scrapex contractors --approve` is a shipped user-facing command
+> since `REQ-24`. **The API routes stay outside the flags on purpose** — they are
+> mounted on 127.0.0.1 so the slice can be exercised, and gating them would make a
+> flag a kill switch for development instead of a switch over what is announced. A
+> test asserts that distinction on the route table, because it is the line a later
+> reader would tidy away.
+
+### The six that finish muqawil, merged 2026-08-21 (#245)
+
+His instruction after #243: run the six remaining muqawil engineering items in order.
+Five are done. The sixth is built as far as a ruling of his allows.
+
+| | item | outcome |
+|---|---|---|
+| 1 | `status = 'unavailable'` on a departed row | **done** — the whole chain had no caller, not even `record_absences` |
+| 2 | the cost of sizing, in the output | **done** — computed, not the `~112` a module header remembered |
+| 3 | `is_enabled` becomes a switch | **done** — two callers, and the routes stay outside |
+| 4 | the slice scope | **the defect is fixed**; the walk moved into item 5 |
+| 5 | the profile crawl | **wired, not run** — 34,834 pages, measured at **11.1 h** |
+| 6 | `R-19` child tables | **the reader only** — the write is his to rule |
+
+**Item 6's two blockers are not engineering.**
+[R19-CHILD-TABLES-MEASURED](R19-CHILD-TABLES-MEASURED.md) recommends shape F and its own
+last line says *"Not built. Awaiting his ruling"*; and the content comes from profile
+pages, of which **none is stored**, because the registration is `listing_only`.
+
+**Three written premises that measurement contradicted, all recorded where they were
+written:**
+
+| the premise | what was measured |
+|---|---|
+| the slice scope is "built, tested, never used" | it was also **wrong** — 17 cards paired against 34 URLs, and 17 indices pointed past the last card |
+| the profile's five `<table>`s "are exactly" `R-19`'s five groups | five tables, **none of them Interests** — which is the biggest group, and not a table at all |
+| the profile crawl is ~17.4 h | **11.1 h**, over 87 minutes of real six-worker crawling |
+
+**And a new sub-question of his to answer:** how are the five groups NAMED? The table
+detector returns `Table 1`…`Table 5`, and three of the five share one nearest heading —
+so neither position nor the heading above them answers it. Whichever shape is ruled needs
+that rule, and it does not exist.
 
 **Four questions are open and are his** — O-1 to O-4 in
 [RULINGS.md](RULINGS.md#open--awaiting-the-owners-ruling).

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -678,7 +678,7 @@ written and 58 two days ago. It grows every time this is deferred.
 
 **The blocker, verified 2026-08-17 and still present:**
 `"latest_extension_version": VERSION` at
-[scrapex/version.py:477](../scrapex/version.py) and
+[scrapex/version.py:483](../scrapex/version.py) and
 [scrapex/webui/app.py:1459](../scrapex/webui/app.py), drawn by
 [extension/app.js:599](../extension/app.js) and `:633`.
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -98,6 +98,18 @@ times changes no VALUE — the first implementation summed `seen_count` and took
 <downloaded.db>` → `contractors --approve --run-ref <ref>` for each run whose pages
 arrived → work → upload → `--release`.
 
+**AND THE UPLOAD IS THE PANEL'S, NOT THE CLI'S** — his ruling of 2026-08-11 removed
+`scrapex/gdrive.py` and gave every Google operation to the extension. `scrapex/bundle.py`
+builds a bundle containing `warehouse.db`, taken through sqlite3's own backup API;
+`extension/drive.js` uploads it resumably to a `ScrapeX backups` folder with a
+`latest.json` pointer and three kept. The panel button is **`drive-backup`**.
+
+> **DO NOT PRESS `drive-restore` ON THE OTHER MACHINE.** Restore REPLACES the live
+> warehouse — `registry.engine.restore` displaces it and says so — so it would lose the
+> muqawil and products work that machine has and this one does not. It sits beside
+> `drive-backup` in the same card. **Backup here, download there, MERGE.** That distinction
+> is the whole of `R-43`, and the destructive path is one button away from it.
+
 **For what the owner has asked for and where each request stands, see
 [REQUESTS.md](REQUESTS.md).** This file tracks the *work in flight*; that one
 tracks *his requests* through Captured → Ruled → Planned → In flight → Done.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,10 +1,102 @@
 # State — where the work stands
 
-**Last updated: 2026-08-21 (morning).** `main` is at `e5af340` (#238).
+**Last updated: 2026-08-22.** `main` is at `afb8648` (#244). #243, #245 and #244 are
+merged.
 
 This is the document that is **wrong the moment it is out of date**. Update it
 when a phase lands, a PR merges, or the owner rules — in the same pull request as
 the work it describes (**C2**, [../CLAUDE.md](../CLAUDE.md)).
+
+---
+
+## RESUME HERE — written for the other machine, 2026-08-22
+
+He works from two machines and asked to continue from the other one, which has neither
+this session's context nor this warehouse. Everything below is the whole handover.
+
+### The code and the decisions are in the repository. The DATA is not.
+
+**Merged and done:** the six muqawil engineering items (#245), four rulings of his
+executed (`R-38`…`R-41`), and the engine release gate (#244).
+
+**His warehouse on THIS machine, measured after the profile approval:**
+
+| | |
+|---|---|
+| the listing | **17,417 sighted of 17,414 declared — `D = 0`**, complete |
+| `generic_record` | **16,411** — 15,707 listing rows + 704 profiles |
+| `generic_page_snapshot` | **20,379** (~203 MB of bodies), 1,424 of them Dammam profiles |
+| `classification_node` | **214** nodes, depths `{1: 8, 2: 20, 3: 186}` |
+| `generic_record_node` | **15,559** memberships — `R-38` proved on real data |
+| datasets | `contractors` and `contractor_profiles` |
+| schema | **v9** (`0009` = the link table) |
+
+**That ratio is the whole of `R-38`:** 15,559 memberships share 214 nodes. Shape A would
+have stored 15,559 repeated strings; the study measured that at 4.7x and it is
+conservative.
+
+### What the other machine can do with NO database at all
+
+Two of the four next steps need nothing but this repository — the tests run on committed
+fixtures, never on his warehouse:
+
+1. **Workers for `--details`.** Measured: the Dammam profile crawl ran at **9.03 s a
+   page** single-threaded, so the full 34,834-page crawl is **87 hours**. The listing
+   crawl measured 1.14 s a page with six workers. Adding workers here is the difference
+   between 87 hours and about 14, and it is the same work already done for
+   `crawl_partition`. **`R-39` records 11.1 h and that figure is WRONG** — it was measured
+   with six workers and applied to a single-threaded command.
+2. **Branch protection on `main`.** Measured: `protected: False`, 404 on the protection
+   endpoint. Require the check suite, require branches up to date, forbid direct pushes.
+   His to switch on, and it is what makes `ac3a5af` — which left `main` red for two days
+   with no pull request — impossible rather than merely regretted.
+
+### What needs the data, and his plan for moving it
+
+3. **The full profile crawl** — 34,834 pages. Belongs on whichever machine holds the
+   warehouse.
+4. **The remaining four groups of `R-19`.** Only `interests` is wired, and
+   `contractors.write_groups` records why for each of the others: licensed activities
+   carry both languages in one unseparated string and one of six rows is already truncated
+   on the site's side; the two contractor lists are relations rather than classifications
+   and are empty on every page measured; contract counts are two scalars that belong in
+   the flat row.
+
+**HIS RULING ON THE TWO WAREHOUSES, 2026-08-22.** Both machines have developed muqawil, so
+the databases must be **merged**, with Drive as the single source of truth for DATA while
+the repository stays the single source of truth for CODE. **Do not copy either file over
+the other** — each holds work the other does not, and `R-24` says upgrade rather than
+replace.
+
+The merge is defined, and it is defined because the natural keys exist — measured
+2026-08-22:
+
+    generic_page_snapshot   20,379 rows, 20,379 distinct (source_url, content_hash)
+    dataset_sighting        UNIQUE (dataset_key, external_id) in the schema
+    generic_record          UNIQUE (dataset_definition_id, record_key) in the schema
+
+So: dedupe snapshots on their natural key; merge sightings taking min `first_seen_at`, max
+`last_seen_at`, **summed** `seen_count`, max `last_absent_at`; and **delete and rebuild
+everything derived** with `--approve` rather than merging it. That last clause is what
+makes the whole thing tractable — no primary key is ever remapped, and the operation is
+commutative and idempotent, so it does not matter which machine runs it or how often.
+
+**BUILT 2026-08-22 — `scrapex merge-warehouse`** ([R-43](RULINGS.md#r-43--drive-is-the-single-source-of-truth-for-data-the-repository-stays-it-for-code)).
+
+    scrapex merge-warehouse --status                      # who holds it
+    scrapex merge-warehouse --machine work-laptop         # take it
+    scrapex merge-warehouse --machine work-laptop --from <downloaded.db>
+    scrapex merge-warehouse --release                     # hand it back
+
+The lock lives in `scrapex_meta.checkout_holder`, beside the `account_owner` that `R-34`
+already put there, so it needs no migration and an older warehouse answers "nobody" rather
+than failing to open. Seventeen tests, and the one that matters asserts that merging three
+times changes no VALUE — the first implementation summed `seen_count` and took one id from
+4 to 8 to 12 to 16 while claiming to be idempotent.
+
+**The order on the other machine:** download from Drive → `--machine <name> --from
+<downloaded.db>` → `contractors --approve --run-ref <ref>` for each run whose pages
+arrived → work → upload → `--release`.
 
 **For what the owner has asked for and where each request stands, see
 [REQUESTS.md](REQUESTS.md).** This file tracks the *work in flight*; that one

--- a/docs/plans/2026-08-20-finish-muqawil-then-the-source-queue.md
+++ b/docs/plans/2026-08-20-finish-muqawil-then-the-source-queue.md
@@ -459,8 +459,11 @@ Tick a box only when it is MERGED. `⚡` marks a quick win — under about an ho
       not 363 KB**, 0.91 GB → 19.4 MB.
 - [ ] **`O-2`** — does the contractor entity belong in the mbiX workbook, or stay
       engine-only until it has proved itself?
-- [ ] **`DEC-10`** — the row-aware idempotency key. Without it a corrected parser
-      re-run over stored snapshots returns `recovered=True` and writes nothing.
+- [x] **`DEC-10` — RULED 2026-08-21, [R-38](../RULINGS.md#r-38--dec-10-is-built-before-the-profile-crawl-not-after-it):
+      built BEFORE the profile crawl.** It is the one open item that changed the COST of
+      the remaining work rather than its scope: on 34,834 pages a parser defect found
+      after the crawl costs 11 hours of re-fetching to repair what should be minutes of
+      re-parsing — which hands back exactly what the seam exists to save.
 
 ---
 

--- a/docs/plans/2026-08-20-finish-muqawil-then-the-source-queue.md
+++ b/docs/plans/2026-08-20-finish-muqawil-then-the-source-queue.md
@@ -297,7 +297,7 @@ Tick a box only when it is MERGED. `⚡` marks a quick win — under about an ho
       **#235.**
 - [x] **`R-19`: child tables for all five groups — BUILT, as shape D** — «جداول أبناء
       للخمس كلّها».
-      **RULED 2026-08-21, [R-36](../RULINGS.md#r-36--r-19s-five-groups-are-a-taxonomy-plus-a-link-table--not-five-datasets--shape-d).**
+      **RULED 2026-08-21, [R-38](../RULINGS.md#r-38--r-19s-five-groups-are-a-taxonomy-plus-a-link-table--not-five-datasets--shape-d).**
       He chose **D** — a taxonomy plus a link table — over the study's recommended F, and
       the recommendation was wrong: F's argument was that it reuses machinery this
       warehouse already contains, and `classification_node`, `classification_scheme`,
@@ -480,7 +480,7 @@ Tick a box only when it is MERGED. `⚡` marks a quick win — under about an ho
       not 363 KB**, 0.91 GB → 19.4 MB.
 - [ ] **`O-2`** — does the contractor entity belong in the mbiX workbook, or stay
       engine-only until it has proved itself?
-- [x] **`DEC-10` — RULED 2026-08-21, [R-38](../RULINGS.md#r-38--dec-10-is-built-before-the-profile-crawl-not-after-it):
+- [x] **`DEC-10` — RULED 2026-08-21, [R-40](../RULINGS.md#r-40--dec-10-is-built-before-the-profile-crawl-not-after-it):
       built BEFORE the profile crawl.** It is the one open item that changed the COST of
       the remaining work rather than its scope: on 34,834 pages a parser defect found
       after the crawl costs 11 hours of re-fetching to repair what should be minutes of

--- a/docs/plans/2026-08-20-finish-muqawil-then-the-source-queue.md
+++ b/docs/plans/2026-08-20-finish-muqawil-then-the-source-queue.md
@@ -127,7 +127,7 @@ and ten are open — of which only SIX are muqawil engineering.**
 | 3 | ~~`is_enabled` has 0 callers~~ **DONE** | ~1 h | Two capabilities are lit at `PARTIAL` and nothing reads them, so lighting one is a *claim*, not a switch. |
 | 4 | The slice scope — **defect fixed**; the walk moves into item 5 | ~2 h so far | Built and tested; wiring it is what makes a partial re-read addressable. |
 | 5 | The profile crawl — **wired**; 34,834 pages, measured at **11.1 h** to run | ~3 h | The adapter exists (`bilingual_profile_candidate`, #235). This is mostly *runtime*, and it is the item that turns 21 columns into 48. |
-| 6 | `R-19` — **reader built**; the write awaits his ruling AND profile pages | ~2 h so far | The largest, and last on purpose: ~500K rows, five tables, and it depends on profile pages being on disk — which is item 5. |
+| 6 | ~~`R-19`~~ **DONE as shape D** — reader, taxonomy, link table | ~5 h | The largest, and last on purpose: ~500K rows, five tables, and it depends on profile pages being on disk — which is item 5. |
 
 **So: about a day and a half of work, plus roughly eighteen hours of crawling that runs
 unattended.** Two of the six are under an hour each and one of those is already ruled.
@@ -295,10 +295,31 @@ Tick a box only when it is MERGED. `⚡` marks a quick win — under about an ho
 - [x] **A declared `PROFILE_FIELD_ORDER`**, for the reason `CARD_FIELDS` exists: a
       profile page that happens to omit a box must not produce a different schema.
       **#235.**
-- [~] **`R-19`: child tables for all five multi-valued groups** — «جداول أبناء للخمس
-      كلّها». **The READING is built; the WRITING waits on him, and on pages that do not
-      exist yet.**
-      Two things block the write and neither is engineering. (1)
+- [x] **`R-19`: child tables for all five groups — BUILT, as shape D** — «جداول أبناء
+      للخمس كلّها».
+      **RULED 2026-08-21, [R-36](../RULINGS.md#r-36--r-19s-five-groups-are-a-taxonomy-plus-a-link-table--not-five-datasets--shape-d).**
+      He chose **D** — a taxonomy plus a link table — over the study's recommended F, and
+      the recommendation was wrong: F's argument was that it reuses machinery this
+      warehouse already contains, and `classification_node`, `classification_scheme`,
+      `dataset_relationship` and `relationship_field_pair` hold **zero rows between
+      them**. Machinery that has never carried a row is not an asset.
+      Migration 0009 adds `generic_record_node` — `WITHOUT ROWID`, keyed
+      `(record, node, group_key)` so idempotency is a constraint and not a later repair,
+      with `source_snapshot_id NOT NULL` carrying across F's one real advantage.
+      `scrapex/taxonomy.py` is `ensure_scheme` / `ensure_path` / `link` / `memberships`.
+      **Proved on the committed profile:** 25 memberships over 25 nodes, depths
+      `{1:3, 2:5, 3:17}`; a second contractor holding the same activities adds **not one
+      node**; a second identical pass writes nothing. Thirteen tests, **seven mutations
+      killed**.
+      **`group_key` IS IN THE PRIMARY KEY** because the licensed-activities values come
+      from the same activity vocabulary as the interests tree, so one node can be held as
+      both — and a key without it would merge two different facts silently.
+      **And "is it new" is answered by a counter, not a clock.** The first `link` compared
+      `first_seen_at = last_seen_at`; both are second-resolution, so a second identical
+      pass reported all 25 as new. `seen_count` — which `dataset_sighting` already carries
+      for the same reason — is returned by the upsert instead.
+
+      *Kept because it is why this shape and not another:* (1)
       [R19-CHILD-TABLES-MEASURED](../R19-CHILD-TABLES-MEASURED.md) recommends **shape F**
       — a child dataset per group whose value references `classification_node` — and its
       own last line reads *"Not built. Awaiting his ruling."* Building either shape ahead

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "scrapex"
 # A MIRROR of scrapex/version.py:VERSION — setuptools cannot import the package
 # to ask. tests/test_version.py reads this line back and fails when they drift.
-version = "0.2.2"
+version = "0.3.0"
 description = "ScrapeX ecosystem: contract-driven web data collection into a SQLite warehouse. Categories: products, contractors"
 requires-python = ">=3.12"
 dependencies = [

--- a/scrapex/cli.py
+++ b/scrapex/cli.py
@@ -111,6 +111,42 @@ def _cmd_database_status(args: argparse.Namespace) -> int:
     return 0 if all(item["ok"] for item in health.values()) else 1
 
 
+def _cmd_merge_warehouse(args) -> int:
+    """`R-42`-era plumbing for his two machines: one warehouse, one holder at a time.
+
+    A SHIPPED COMMAND AND NOT A SCRIPT, which is the lesson `contractors.py` was written
+    to fix — every piece of the pipeline that built the first warehouse was committed and
+    none of it had an invocation, so the other machine could read how it worked and could
+    not run it. That is the exact failure this command exists to end.
+    """
+    from .warehousemerge import claim, holder, merge, release
+
+    registry = DatabaseRegistry.defaults() if not args.registry else         DatabaseRegistry.from_pointer(Path(args.registry))
+    conn = registry.engine.connect()
+    try:
+        if args.status:
+            who = holder(conn)
+            print(f"{registry.engine.path}")
+            print(f"held by: {who!r}" if who else "held by: nobody")
+            return 0
+        if args.release:
+            release(conn)
+            print("released — the other machine may claim it now")
+            return 0
+        if not args.machine:
+            print("--machine names which machine is taking the warehouse; a claim with "
+                  "no name holds nothing", file=sys.stderr)
+            return 2
+        claim(conn, args.machine)
+        if not args.source:
+            print(f"claimed by {args.machine!r}")
+            return 0
+        print(merge(conn, args.source, machine=args.machine))
+        return 0
+    finally:
+        conn.close()
+
+
 def _cmd_backup_databases(args: argparse.Namespace) -> int:
     registry = DatabaseRegistry.read(Path(args.registry) if args.registry else REGISTRY_FILE)
     result = registry.backup_bundle(Path(args.folder))
@@ -1094,6 +1130,20 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("database-status", help="show the database's health")
     p.add_argument("--registry", help="database registry path")
     p.set_defaults(func=_cmd_database_status)
+
+    p = sub.add_parser(
+        "merge-warehouse",
+        help="merge another machine's engine database into this one (evidence only)")
+    p.add_argument("--from", dest="source",
+                   help="the other machine's database file, downloaded from Drive")
+    p.add_argument("--machine", help="which machine is taking the warehouse")
+    p.add_argument("--claim", action="store_true",
+                   help="take the warehouse without merging anything")
+    p.add_argument("--release", action="store_true",
+                   help="hand it back so the other machine may claim it")
+    p.add_argument("--status", action="store_true", help="say who holds it")
+    p.add_argument("--registry", help="database registry path")
+    p.set_defaults(func=_cmd_merge_warehouse)
 
     p = sub.add_parser("backup-databases", help="back up the engine database")
     p.add_argument("--folder", required=True, help="folder that will receive the backup")

--- a/scrapex/cli.py
+++ b/scrapex/cli.py
@@ -1133,7 +1133,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     p = sub.add_parser(
         "merge-warehouse",
-        help="merge another machine's engine database into this one (evidence only)")
+        help="merge another machine's engine database into this one (evidence only). Use THIS and never restore-database for a second machine: restore replaces, this adds")
     p.add_argument("--from", dest="source",
                    help="the other machine's database file, downloaded from Drive")
     p.add_argument("--machine", help="which machine is taking the warehouse")

--- a/scrapex/contractors.py
+++ b/scrapex/contractors.py
@@ -416,7 +416,7 @@ def detail_frontier(conn, directory: Directory, scope: CrawlScope,
     #
     # So scanning every stored page against one slice value counts every row of the other
     # locale as *outside the slice* — a report that is simply false — and makes the whole
-    # frontier depend on that locale's pages happening to be on disk. `R-37` records the
+    # frontier depend on that locale's pages happening to be on disk. `R-39` records the
     # measurement; this is the code it asked for.
     #
     # ONE PASS AND NOT TWO, because the scan is the expensive half: a slice must parse
@@ -684,7 +684,7 @@ def approve(conn, directory: Directory, run_ref: str) -> None:
         conn.commit()
         made += 1
         if result.get("recovered"):
-            # ALREADY APPROVED AND IDENTICAL, so it wrote nothing — and since `R-38`
+            # ALREADY APPROVED AND IDENTICAL, so it wrote nothing — and since `R-40`
             # that is a claim about the ROWS and not just the request. The digest of
             # what the parser produced is compared against the digest the previous
             # ingestion stored, so this count now means "nothing had changed" rather
@@ -696,7 +696,7 @@ def approve(conn, directory: Directory, run_ref: str) -> None:
             # line above and wrote nothing at all.
             reparsed += 1
     say(f"approved {made} page(s): {recovered} unchanged and wrote nothing, "
-        f"{reparsed} re-parsed with new values (DEC-10 / R-38); "
+        f"{reparsed} re-parsed with new values (DEC-10 / R-40); "
         f"{lonely} page(s) missing a locale half")
     for key, why in refused[:20]:
         say(f"  refused {key}: {why}")

--- a/scrapex/contractors.py
+++ b/scrapex/contractors.py
@@ -41,6 +41,7 @@ import time
 from collections.abc import Iterator
 from pathlib import Path
 
+from . import taxonomy
 from . import validators as validator_store
 from .connectors.base import HttpFetcher, declare_frontier
 from .crawlscope import CrawlScope
@@ -48,7 +49,8 @@ from .databases import DatabaseRegistry
 from .directories import Directory
 from .directories import get as get_directory
 from .extract import service
-from .extract.models import ApprovalField, CandidateApproval, SnapshotCreate
+from .extract.models import ApprovalField, CandidateApproval
+from .extract.service import SnapshotCreate, _canonical, _digest
 from .features import FeatureKey, is_enabled
 from .pagesource import FetchedPage, PageKind, slice_rows
 from .partitioncrawl import (
@@ -608,13 +610,20 @@ def _pairs(conn, run_ref: str) -> dict[str, dict[str, tuple[int, str]]]:
     # `region_id_1-company_size_big` — and a run ref of the owner's choosing may
     # too. Unescaped, `--run-ref my_run` would also gather `myXrun`'s pages and
     # approve another run's evidence under this one's name.
-    pattern = (run_ref.replace("\\", "\\\\").replace("%", "\\%")
-               .replace("_", "\\_")) + "-%"
+    escaped = (run_ref.replace("\\", "\\\\").replace("%", "\\%")
+               .replace("_", "\\_"))
+    # BOTH SHAPES, BECAUSE THE TWO CRAWLS WRITE DIFFERENT ONES. A partitioned listing
+    # crawl stores `<ref>-<cell>-<attempt>`, so it needs the wildcard. `--details` stores
+    # the ref BARE — measured, `dammam-2026-08-21` holds 1,424 pages — and the wildcard
+    # alone matched **zero** of them, so `--approve` over a profile run reported an empty
+    # disk while 1,424 pages sat on it.
+    pattern = escaped + "-%"
     found: dict[str, dict[str, tuple[int, str]]] = {}
     rows = conn.execute(
         "SELECT page_snapshot_id, source_url, html_content, html_codec, html_dict_id "
-        "  FROM generic_page_snapshot WHERE crawl_run_ref LIKE ? ESCAPE '\\' "
-        " ORDER BY page_snapshot_id", (pattern,))
+        "  FROM generic_page_snapshot "
+        " WHERE (crawl_run_ref LIKE ? ESCAPE '\\' OR crawl_run_ref = ?) "
+        " ORDER BY page_snapshot_id", (pattern, run_ref))
     for row in rows:
         url = row["source_url"]
         for locale in ("en", "ar"):
@@ -630,7 +639,8 @@ def _pairs(conn, run_ref: str) -> dict[str, dict[str, tuple[int, str]]]:
     return found
 
 
-def _approval(directory: Directory, candidate) -> CandidateApproval:
+def _approval(directory: Directory, candidate, *,
+              profile: bool = False) -> CandidateApproval:
     """The owner's answer, every field text-typed, the directory's id the identity.
 
     TEXT FOR EVERYTHING, and it is not laziness: type inference over twenty rows
@@ -638,16 +648,109 @@ def _approval(directory: Directory, candidate) -> CandidateApproval:
     and the schema hash then differs per page and every approval after the first
     is refused. `listing_candidate` already declines to guess for the same reason.
     """
+    # A PROFILE IS ITS OWN DATASET. Two documents with two declared field sets — 21
+    # against 28 — cannot share one approved schema: every profile would read as a subset
+    # of the listing's and `R-31` refuses a subset, on purpose, because that is what a
+    # broken parser looks like. See `ProfileReader.dataset_key`.
+    into = directory.profiles.dataset_key if profile and directory.profiles else         directory.dataset_key
+    named = directory.profiles.dataset_name if profile and directory.profiles else         directory.display_name
     return CandidateApproval(
         table_index=0, site_key=directory.key,
         site_display_name=directory.display_name,
-        dataset_key=directory.dataset_key,
-        dataset_name=directory.display_name,
+        dataset_key=into,
+        dataset_name=named,
         fields=[ApprovalField(field_key=one.field_key, display_name=one.source_name,
                               data_type="text",
                               identity=(one.field_key
                                         == directory.identity_field))
                 for one in candidate.fields])
+
+
+#: A DETAIL page, by the shape of its URL. `/contractors/1005/143` against
+#: `/contractors?region_id=0&page=1` — and `_pairs` has already taken the locale out, so
+#: this sees `/contractors/1005/143` either way.
+_PROFILE_URL = re.compile(r"/contractors/(\d+)/\d+")
+
+
+def _contractor_of(key: str) -> str | None:
+    """The contractor id in a profile URL, or `None` for a listing URL."""
+    found = _PROFILE_URL.search(key)
+    return found.group(1) if found else None
+
+
+def write_groups(conn, directory: Directory, snapshot_id: int, *,
+                 english: str, arabic: str, contractor_id: str) -> tuple[int, int]:
+    """`R-38`'s memberships for one contractor. Returns `(written, already there)`.
+
+    ONLY `interests` IS WIRED, AND THE MEASUREMENT IS WHY. Read off the committed
+    profile on 2026-08-21, the five declared groups are not five of the same thing:
+
+        interests            a nested list, 25 nodes per locale, cleanly localised
+                             -> a taxonomy membership, which is what this writes
+        licensed_activities  6 rows whose activity cell carries BOTH languages in one
+                             string with no separator — `تشييد المباني … Construction of
+                             Buildings – All Types` — and whose readiness cell is
+                             `أساسي | Basic`. Splitting the first needs a script-boundary
+                             rule, and one of the six already has a TRUNCATED English half
+                             on the site's side (`Civil Engineering -`). Six samples, one
+                             malformed, is not enough to declare that rule on.
+        main_contractors     `# / name`, and EMPTY on every page measured. These are
+        sub_contractors      contractor-to-contractor RELATIONS, not classifications, so
+                             they do not belong in a taxonomy at all.
+        contract_counts      one row of two numbers, `455 / 64`. Two scalars — they belong
+                             in the flat row, and putting them in a link table would make
+                             a membership out of a count.
+
+    `R-19`'s own limit is the reason this stops here rather than guessing: the study says
+    it measured ONE profile, and three of these five are empty on every profile we hold.
+    The snapshots keep the evidence, so each of the four can be derived later with no
+    network the moment its shape is decided.
+    """
+    reader = directory.profiles
+    if reader is None:
+        return 0, 0
+    site = conn.execute("SELECT site_profile_id FROM site_profile WHERE site_key = ?",
+                        (directory.key,)).fetchone()
+    if site is None:
+        return 0, 0
+    record = conn.execute(
+        "SELECT r.generic_record_id FROM generic_record AS r "
+        "  JOIN dataset_definition AS d "
+        "    ON d.dataset_definition_id = r.dataset_definition_id "
+        " WHERE d.dataset_key = ? AND r.record_key = ?",
+        (reader.dataset_key, _digest(_canonical([contractor_id])))).fetchone()
+    if record is None:
+        # THE ROW MUST EXIST FIRST, because the link table's foreign key says so. A
+        # membership without its contractor is the orphan `ON DELETE CASCADE` exists to
+        # prevent, arriving from the other direction.
+        return 0, 0
+
+    scheme = taxonomy.ensure_scheme(conn, int(site["site_profile_id"]),
+                                    name=reader.scheme_name,
+                                    name_ar=reader.scheme_name_ar)
+    from .extract.muqawil import read_interests
+
+    paths_en = read_interests(english)
+    paths_ar = read_interests(arabic) if arabic else paths_en
+    if len(paths_en) != len(paths_ar):
+        # PAIRED BY POSITION, LIKE `merge_locales`, AND REFUSED THE SAME WAY. Measured:
+        # both locales publish 25 nodes in the same order. A count that differs means
+        # position no longer describes the same node, and writing anyway would attach an
+        # English name to a different Arabic one.
+        raise taxonomy.CannotPairLocales(
+            f"contractor {contractor_id} published {len(paths_en)} interests in English "
+            f"and {len(paths_ar)} in Arabic")
+
+    written = repeated = 0
+    for path, path_ar in zip(paths_en, paths_ar, strict=True):
+        node = taxonomy.ensure_path(conn, scheme, path=path, path_ar=path_ar)
+        if taxonomy.link(conn, generic_record_id=int(record["generic_record_id"]),
+                         node_id=node, group_key="interests",
+                         source_snapshot_id=snapshot_id):
+            written += 1
+        else:
+            repeated += 1
+    return written, repeated
 
 
 def approve(conn, directory: Directory, run_ref: str) -> None:
@@ -657,6 +760,8 @@ def approve(conn, directory: Directory, run_ref: str) -> None:
     recovered = 0
     reparsed = 0
     lonely = 0
+    linked = 0
+    relinked = 0
     refused: list[tuple[str, str]] = []
     for key, halves in sorted(pairs.items()):
         english = halves.get("en")
@@ -669,14 +774,44 @@ def approve(conn, directory: Directory, run_ref: str) -> None:
             continue
         if arabic is None:
             lonely += 1
-        candidate = directory.candidate(english[1], arabic[1] if arabic else "")
+        # WHICH DOCUMENT IS THIS. A listing card and a profile page publish two
+        # different declared field sets — `CARD_FIELDS` against `PROFILE_FIELD_ORDER` —
+        # so one candidate builder cannot serve both. Until this branch existed,
+        # `--approve` put profile pages through the LISTING parser, which is why running
+        # it over 712 stored profiles would have refused every one of them.
+        contractor = _contractor_of(key) if directory.profiles is not None else None
+        try:
+            if contractor is not None:
+                candidate = directory.profiles.candidate(
+                    english[1], arabic[1] if arabic else "", contractor_id=contractor)
+            else:
+                candidate = directory.candidate(english[1], arabic[1] if arabic else "")
+        except Exception as exc:
+            # BUILDING THE CANDIDATE CAN REFUSE, and it must not end the run. The listing
+            # path returns an unapprovable candidate with warnings; the profile path
+            # RAISES — `merge_locales` refuses a pair whose two locales publish different
+            # box counts, which is correct and happens on 8 of 712 real profiles. With
+            # this outside the guard, the first of those eight killed all 712.
+            refused.append((key, f"{type(exc).__name__}: {exc}"))
+            continue
         if not candidate.approvable:
             refused.append((key, candidate.warnings[0] if candidate.warnings else "?"))
             continue
         try:
             result = service.approve_candidate(
-                conn, english[0], _approval(directory, candidate),
+                conn, english[0],
+                _approval(directory, candidate, profile=contractor is not None),
                 candidate=candidate)
+            if contractor is not None:
+                # `R-38`'s MEMBERSHIPS, IN THE SAME TRANSACTION AS THE ROW THEY HANG OFF.
+                # The link table's foreign key requires the record to exist, and rolling
+                # back a failed membership write must not leave a row whose groups were
+                # half stored — so both commit together or neither does.
+                fresh, again = write_groups(
+                    conn, directory, english[0], english=english[1],
+                    arabic=arabic[1] if arabic else "", contractor_id=contractor)
+                linked += fresh
+                relinked += again
         except Exception as exc:
             conn.rollback()
             refused.append((key, f"{type(exc).__name__}: {exc}"))
@@ -698,6 +833,12 @@ def approve(conn, directory: Directory, run_ref: str) -> None:
     say(f"approved {made} page(s): {recovered} unchanged and wrote nothing, "
         f"{reparsed} re-parsed with new values (DEC-10 / R-40); "
         f"{lonely} page(s) missing a locale half")
+    if linked or relinked:
+        # BOTH NUMBERS, for the reason `Marking` gives: a run that wrote 17,000
+        # memberships and one that confirmed 17,000 are the same total and different news.
+        say(f"  taxonomy (R-38): {linked:,} membership(s) written, "
+            f"{relinked:,} already held — interests only, see `write_groups` for the "
+            f"four groups the measurement says are not memberships")
     for key, why in refused[:20]:
         say(f"  refused {key}: {why}")
     if len(refused) > 20:

--- a/scrapex/contractors.py
+++ b/scrapex/contractors.py
@@ -365,6 +365,19 @@ def listing_pages(conn) -> Iterator[FetchedPage]:
         yield FetchedPage(url=url, html=decode(conn, row), kind=PageKind.LISTING)
 
 
+def _locale_of(url: str) -> str:
+    """`en` or `ar`, from the path. The only two muqawil publishes.
+
+    READ FROM THE URL because that is where the fact is: the crawl fetches
+    `/en/contractors` and `/ar/contractors` as separate pages, so the locale is part of
+    the identity of a stored snapshot rather than something to infer from its content.
+    """
+    for locale in ("en", "ar"):
+        if f"/{locale}/" in url:
+            return locale
+    return "?"
+
+
 def detail_frontier(conn, directory: Directory, scope: CrawlScope,
                     slice_of: str) -> tuple[list[str], int]:
     """The profile URLs this scope earns. Returns `(urls, rows_outside_the_slice)`.
@@ -396,12 +409,61 @@ def detail_frontier(conn, directory: Directory, scope: CrawlScope,
         for contractor_id in sighted_ids(conn, directory.dataset_key):
             wanted.extend(source.profile_urls(directory.base_url, contractor_id))
         return list(dict.fromkeys(wanted)), 0
+    # ONE PASS, KEPT PER LOCALE, AND THE LOCALE DECIDED AT THE END. A slice is named in
+    # the language of the page — `MuqawilPageSource.belongs_to_slice` says so, and
+    # measured against the committed fixtures: `RIYADH` matches 3 of 4 cards on the
+    # English listing and **0 of 4** on the Arabic, and `الرياض` the reverse.
+    #
+    # So scanning every stored page against one slice value counts every row of the other
+    # locale as *outside the slice* — a report that is simply false — and makes the whole
+    # frontier depend on that locale's pages happening to be on disk. `R-37` records the
+    # measurement; this is the code it asked for.
+    #
+    # ONE PASS AND NOT TWO, because the scan is the expensive half: a slice must parse
+    # stored listing pages, and doing it twice to choose a locale first would double the
+    # cost of the only frontier that cannot come off the ledger.
+    per_locale: dict[str, tuple[list[str], int]] = {}
     for page in listing_pages(conn):
+        locale = _locale_of(page.url)
+        matched, missed = per_locale.setdefault(locale, ([], 0))
+        # GROUPED BY ROW BEFORE ASKING, for two reasons that both matter.
+        #
+        # THE COUNT IS ABOUT ROWS. `slice_rows` yields one entry per URL and muqawil
+        # publishes one URL per LOCALE, so asking per entry counted two skips for one
+        # card — measured, a four-card page reported eight rows examined. "Rows outside
+        # the slice" then meant nothing a reader could compare with the page.
+        #
+        # AND `belongs_to_slice` RE-PARSES THE PAGE EVERY CALL: it runs `_cards(html)`
+        # from scratch, so asking twice per card is two full BeautifulSoup parses of the
+        # same page for one answer. On the stored listing that doubling is the difference
+        # this frontier already had to route around once.
+        by_row: dict[int, list[str]] = {}
         for row_index, url in slice_rows(source, page):
+            by_row.setdefault(row_index, []).append(url)
+        for row_index, urls in by_row.items():
             if source.belongs_to_slice(page, row_index, slice_of):
-                wanted.append(url)
+                matched.extend(urls)
             else:
-                outside += 1
+                missed += 1
+        per_locale[locale] = (matched, missed)
+
+    answered = {locale: pair for locale, pair in per_locale.items() if pair[0]}
+    if len(answered) > 1:
+        # A SLICE VALUE THAT MATCHES IN TWO LANGUAGES is either a name that happens to be
+        # written the same way in both, or a marker that has moved. Either way the counts
+        # below would be the sum of two different questions, so it is refused rather than
+        # added up.
+        raise ValueError(
+            f"the slice {slice_of!r} matched rows in more than one locale "
+            f"({sorted(answered)}), so 'outside the slice' has two different meanings. "
+            "Name the slice in one language.")
+    if not answered:
+        # NOT AN ERROR, AND NOT SILENT EITHER. A city with no contractors is a real
+        # answer; so is a slice named in the wrong language, and the caller's report says
+        # how many rows were examined so the two can be told apart.
+        return [], sum(missed for _, missed in per_locale.values())
+    matched, outside = next(iter(answered.values()))
+    wanted.extend(matched)
     # DEDUPLICATED HERE, NOT IN THE SOURCE. One contractor can appear on two stored
     # listing pages — a live listing reorders between requests, which is the entire
     # reason the witness compares id sequences — and fetching a profile twice is a
@@ -593,6 +655,7 @@ def approve(conn, directory: Directory, run_ref: str) -> None:
     say(f"approve {run_ref}: {len(pairs)} page(s) on disk")
     made = 0
     recovered = 0
+    reparsed = 0
     lonely = 0
     refused: list[tuple[str, str]] = []
     for key, halves in sorted(pairs.items()):
@@ -621,14 +684,20 @@ def approve(conn, directory: Directory, run_ref: str) -> None:
         conn.commit()
         made += 1
         if result.get("recovered"):
-            # ALREADY APPROVED, AND IT WROTE NOTHING. `DEC-10`: the idempotency
-            # key is `(snapshot, locator)` plus the schema hash, so a corrected
-            # parser re-run over stored pages returns `recovered=True` and
-            # changes not one row. Counted out loud so a re-run that repaired
-            # nothing cannot be mistaken for one that did.
+            # ALREADY APPROVED AND IDENTICAL, so it wrote nothing — and since `R-38`
+            # that is a claim about the ROWS and not just the request. The digest of
+            # what the parser produced is compared against the digest the previous
+            # ingestion stored, so this count now means "nothing had changed" rather
+            # than the old "we did not look".
             recovered += 1
-    say(f"approved {made} page(s), of which {recovered} were already approved and "
-        f"wrote nothing (DEC-10); {lonely} page(s) missing a locale half")
+        elif result.get("reparsed"):
+            # THE CASE DEC-10 EXISTED FOR. Same page, same schema, DIFFERENT values —
+            # a parser that was corrected. It used to be indistinguishable from the
+            # line above and wrote nothing at all.
+            reparsed += 1
+    say(f"approved {made} page(s): {recovered} unchanged and wrote nothing, "
+        f"{reparsed} re-parsed with new values (DEC-10 / R-38); "
+        f"{lonely} page(s) missing a locale half")
     for key, why in refused[:20]:
         say(f"  refused {key}: {why}")
     if len(refused) > 20:

--- a/scrapex/directories.py
+++ b/scrapex/directories.py
@@ -67,16 +67,60 @@ class Directory:
     candidate: Callable[..., Any]
     #: `() -> PartitionedListing`.
     partition_factory: Callable[[], Any] = field(repr=False)
+    #: How this directory's DETAIL pages are read, or `None` for a directory whose
+    #: detail pages nothing interprets yet. Separate from `candidate` because a listing
+    #: card and a profile page are two different documents with two different declared
+    #: field sets — `CARD_FIELDS` against `PROFILE_FIELD_ORDER` — and one callable
+    #: taking both would have to guess which it was handed.
+    profiles: ProfileReader | None = None
 
     def partition(self) -> Any:
         return self.partition_factory()
+
+
+@dataclass(frozen=True)
+class ProfileReader:
+    """Everything needed to turn one directory's DETAIL pages into rows and memberships.
+
+    THREE CALLABLES AND A NAME, and they are grouped because they are useless apart: the
+    candidate produces the flat row, the groups say what repeats, and the locator finds
+    each group on the page. `R-41` put the declaration in the site's own module, so this
+    carries references to it rather than copies of it.
+
+    THE SCHEME NAME IS HERE AND NOT IN `taxonomy.py` because it is the SITE's vocabulary
+    — `classification_scheme.scheme_type='source'` says so — and the module that stores
+    trees has no business naming one site's.
+    """
+
+    #: `(english_html, arabic_html, *, contractor_id) -> TableCandidate`.
+    candidate: Callable[..., Any]
+    #: The declared multi-valued groups, from `R-41`'s map.
+    groups: tuple[Any, ...]
+    #: `(html, group_key) -> element | None`.
+    locate: Callable[..., Any]
+    #: What the site calls its own vocabulary, in both languages.
+    scheme_name: str
+    scheme_name_ar: str
+    #: ITS OWN DATASET, AND THIS IS NOT A DETAIL. A profile publishes 21 declared fields
+    #: and a listing card 28, so putting both under one `dataset_key` makes every profile
+    #: look like a SUBSET of the approved listing schema — which `R-31` correctly refuses,
+    #: or worse would retire the listing's live version and drop columns the site still
+    #: publishes. `Directory.dataset_key`'s own comment already said a site can publish
+    #: more than one dataset; this is that sentence being true.
+    dataset_key: str = "contractor_profiles"
+    dataset_name: str = "Contractor profiles"
 
 
 def _muqawil() -> Directory:
     # Imported inside the function so a `directories` import does not drag the whole
     # muqawil parser in. It matters for the CLI: `cli.py` builds its parser on every
     # invocation, and `scrapex status` should not pay for a parser it never uses.
-    from .extract.muqawil import bilingual_listing_candidate
+    from .extract.muqawil import (
+        MULTI_VALUED_GROUPS,
+        bilingual_listing_candidate,
+        bilingual_profile_candidate,
+        locate_group,
+    )
     from .sites.muqawil import MuqawilPartition
 
     return Directory(
@@ -87,6 +131,17 @@ def _muqawil() -> Directory:
         identity_field="contractor_id",
         candidate=bilingual_listing_candidate,
         partition_factory=MuqawilPartition,
+        profiles=ProfileReader(
+            candidate=bilingual_profile_candidate,
+            groups=MULTI_VALUED_GROUPS,
+            locate=locate_group,
+            # THE SITE'S OWN WORDS. `Interests` in English and `الأنشطة` in Arabic,
+            # which `R-41` measured are not translations of each other — so both are
+            # recorded rather than one being derived from the other.
+            scheme_name="Interests",
+            scheme_name_ar="الأنشطة",
+            dataset_key="contractor_profiles",
+            dataset_name="Contractor profiles"),
     )
 
 

--- a/scrapex/extract/muqawil.py
+++ b/scrapex/extract/muqawil.py
@@ -291,7 +291,7 @@ def _card_boxes(html: str) -> dict[str, tuple[tuple[str, str], ...]]:
 class MultiValuedGroup:
     """One of `R-19`'s repeating groups, and how to find it on a profile page.
 
-    `R-39`: a group is named by a DECLARED map, never by position and never by its
+    `R-41`: a group is named by a DECLARED map, never by position and never by its
     heading. The alternatives were measured and all three fail —
 
         the detector's own name    `Table 1` … `Table 5`, which is position
@@ -401,7 +401,7 @@ def locate_group(html: str, key: str) -> Tag | None:
 
     MORE THAN ONE MATCH IS REFUSED, though, because a selector that has stopped being
     unique has stopped being a declaration — and picking the first would read one
-    group's values as another's, which is the failure `R-39` exists to prevent.
+    group's values as another's, which is the failure `R-41` exists to prevent.
     """
     group = next((one for one in MULTI_VALUED_GROUPS if one.key == key), None)
     if group is None:

--- a/scrapex/extract/muqawil.py
+++ b/scrapex/extract/muqawil.py
@@ -286,6 +286,136 @@ def _card_boxes(html: str) -> dict[str, tuple[tuple[str, str], ...]]:
 
 
 
+
+@dataclass(frozen=True)
+class MultiValuedGroup:
+    """One of `R-19`'s repeating groups, and how to find it on a profile page.
+
+    `R-39`: a group is named by a DECLARED map, never by position and never by its
+    heading. The alternatives were measured and all three fail —
+
+        the detector's own name    `Table 1` … `Table 5`, which is position
+        the nearest heading        three of the five tables share one, and for two of
+                                   them the nearest heading is a TAB BUTTON that
+                                   belongs to a different section entirely
+        the column signature       two tables carry the same `# / الإسم` pair
+
+    THE SELECTOR IS THE DECLARATION, and it is chosen for stability rather than for
+    brevity. Where the page gives an id, the id is used: `#contractor-tab2` and
+    `#contractor-tab3` are the only thing that separates two tables with identical
+    headers and no rows. Where it does not, a header the site does not translate is
+    used — see `published_as` below for why that is safe here and would not be
+    elsewhere.
+    """
+
+    #: Our stable name. Not the site's — the site's is `published_as`.
+    key: str
+    #: `table` goes through `detect_html_tables`; `tree` is a nested list and does not.
+    kind: str
+    #: A CSS selector locating the container, resolved with soupsieve.
+    selector: str
+    #: What the SITE calls it, kept for the record and for a reader comparing with the
+    #: page. **Arabic even on the English profile** — measured: every table header and
+    #: every contractor tab label is identical in both locales, so a selector built on
+    #: this text is locale-stable. That is a property of THIS site and not a rule: the
+    #: interests card IS translated (`Interests` / `الأنشطة`), which is why that one is
+    #: located structurally instead.
+    published_as: str
+
+
+#: The groups `R-19` asks for, as they are actually published. Measured against
+#: `tests/fixtures/muqawil/profile-{en,ar}.html` on 2026-08-21.
+MULTI_VALUED_GROUPS: tuple[MultiValuedGroup, ...] = (
+    MultiValuedGroup(
+        key="interests",
+        kind="tree",
+        # STRUCTURAL, BECAUSE THIS CARD'S TITLE *IS* TRANSLATED — `Interests` in English
+        # and `الأنشطة` in Arabic, which is not even a translation of it. A title-based
+        # selector read 25 nodes from one locale and 0 from the other. The card is the
+        # one holding the nested list, and `read_interests` refuses if two ever do.
+        selector="div.section-card:has(ul.list-numerical li.list-item)",
+        published_as="Interests / الأنشطة"),
+    MultiValuedGroup(
+        key="licensed_activities",
+        kind="table",
+        selector='table:has(th:-soup-contains("الأنشطة المرخصة"))',
+        published_as="الأنشطة المرخصة"),
+    MultiValuedGroup(
+        key="sub_contractors",
+        kind="table",
+        # THE ID IS THE ONLY THING THAT WORKS HERE. This table and `main_contractors`
+        # have the same two headers, `# / الإسم`, and both are EMPTY for the committed
+        # contractor — so neither a signature nor a row can tell them apart. The tab
+        # button naming this pane reads `المقاولين بالباطن`.
+        selector="div#contractor-tab2 table",
+        published_as="المقاولين بالباطن"),
+    MultiValuedGroup(
+        key="main_contractors",
+        kind="table",
+        selector="div#contractor-tab3 table",
+        published_as="المقاولين الرئيسيين"),
+    MultiValuedGroup(
+        key="contract_counts",
+        kind="table",
+        selector='table:has(th:-soup-contains("عدد العقود النموذجية"))',
+        published_as="عدد العقود النموذجية / عدد العقود المسجلة"),
+)
+
+#: WHAT `R-19` NAMES AND THE PROFILE DOES NOT PUBLISH, recorded rather than guessed at.
+#:
+#: `R-19` lists *"Interests, Licensed Activities, Qualification Programs, Balady
+#: Services, contractor relations"*. Measured against the committed profile, two of
+#: those five are not on the page at all, and one is two:
+#:
+#:   * **Qualification Programs** and **Balady Services** appear as LISTING FILTER
+#:     axes — `lc_program_list_id` (13 values) and `balady_service_id` (8) — and not as
+#:     profile sections. They may be a facet of the search rather than a property of a
+#:     contractor, or they may render only for contractors that hold one. One profile
+#:     cannot tell those apart, which is `R-19`'s own stated evidence limit.
+#:   * **contractor relations** is TWO groups on the page: main contractors and sub
+#:     contractors, in separate tabs.
+#:   * And the **technical rating** — `contractor-tab4`, `التقييم الفني` — is a tab with
+#:     **no table in it** on this profile, so there is nothing to declare a selector for.
+#:
+#: Kept as a declaration so that "we could not find it" is a recorded fact rather than a
+#: silently shorter list, which is how a build ends up covering four of five groups and
+#: reporting success.
+GROUPS_NOT_LOCATED: tuple[tuple[str, str], ...] = (
+    ("qualification_programs",
+     "a listing filter axis (lc_program_list_id, 13 values), not a profile section on "
+     "the committed contractor"),
+    ("balady_services",
+     "a listing filter axis (balady_service_id, 8 values), not a profile section on the "
+     "committed contractor"),
+    ("technical_rating",
+     "tab contractor-tab4 (التقييم الفني) carries no table for this contractor"),
+)
+
+
+def locate_group(html: str, key: str) -> Tag | None:
+    """The element one declared group lives in, or `None` if this page has not got it.
+
+    `None` IS AN ANSWER AND NOT A FAILURE. Three of the five declared groups are empty
+    for the committed contractor and two of those render no rows at all, so a profile
+    without a section is the common case rather than the exception.
+
+    MORE THAN ONE MATCH IS REFUSED, though, because a selector that has stopped being
+    unique has stopped being a declaration — and picking the first would read one
+    group's values as another's, which is the failure `R-39` exists to prevent.
+    """
+    group = next((one for one in MULTI_VALUED_GROUPS if one.key == key), None)
+    if group is None:
+        raise KeyError(
+            f"{key!r} is not a declared group. Declared: "
+            f"{[one.key for one in MULTI_VALUED_GROUPS]}. Groups R-19 names that this "
+            f"profile does not publish: {[name for name, _ in GROUPS_NOT_LOCATED]}")
+    found = BeautifulSoup(html, "html.parser").select(group.selector)
+    if len(found) > 1:
+        raise ValueError(
+            f"{key!r} matched {len(found)} elements, so its selector is no longer a "
+            f"declaration: {group.selector}. The layout has changed.")
+    return found[0] if found else None
+
 #: The interests block is a nested list, and the nesting is the taxonomy. A child `<ul>`
 #: is a SIBLING of the `<li>` it hangs under, not its child — so a parent is the nearest
 #: preceding `<li>` at one level up, which is what `read_interests` walks.

--- a/scrapex/extract/muqawil.py
+++ b/scrapex/extract/muqawil.py
@@ -33,6 +33,7 @@ and a parser keyed on it breaks on a difference no reader would ever notice.
 """
 from __future__ import annotations
 
+import hashlib
 import re
 from collections.abc import Iterable
 from dataclasses import dataclass, field
@@ -238,7 +239,31 @@ def _text(node: Tag | None) -> str:
 
 
 def _slug(label: str) -> str:
-    return re.sub(r"[^a-z0-9]+", "_", label.lower()).strip("_") or "unnamed"
+    """A key from a label, and it must not collapse two labels into one.
+
+    `[a-z0-9]` ONLY, WHICH IS RIGHT FOR AN ENGLISH LABEL AND EMPTY FOR AN ARABIC ONE.
+    That emptiness used to fall back to the constant `"unnamed"`, so every Arabic label
+    produced the SAME key — measured 2026-08-21 on a real profile: **ten Arabic labels
+    collapsed into two keys**, losing eight of them to a silent dict collision.
+
+    Nothing consumes that today, because `merge_locales` pairs the two readings BY INDEX
+    and never reads an Arabic label — its docstring says so and that is why the merge is
+    correct. But a public attribute that silently drops eight of ten entries is a loaded
+    gun for the next caller, and this repository has already paid for exactly this once:
+    `DSN-05`, where `_slug` filtering every Arabic label to nothing made
+    `card_city_region` absent on the Arabic side and split it into two empty strings for
+    every contractor in the country.
+
+    SO A LABEL WITH NO ASCII LEFT GETS A DIGEST OF ITSELF. Stable for the same label,
+    distinct for different ones, and not pretending to be readable — a positional
+    fallback would shift the moment the site adds a box.
+    """
+    ascii_only = re.sub(r"[^a-z0-9]+", "_", label.lower()).strip("_")
+    if ascii_only:
+        return ascii_only
+    if not label.strip():
+        return "unnamed"
+    return "u" + hashlib.sha256(label.strip().encode("utf-8")).hexdigest()[:10]
 
 
 def _boxes(soup: BeautifulSoup) -> list[tuple[str, str]]:
@@ -985,7 +1010,18 @@ def merge_locales(english: Reading, arabic: Reading) -> dict[str, str]:
         merged["is_saudi_contractor"] = str(
             "non" not in membership.lower()).lower()
 
-    if english.latitude is not None:
+    # A ZERO IN EITHER HALF IS THE SITE'S "NO PIN", NOT A PLACE. Measured 2026-08-21 on
+    # two of 712 Dammam profiles, the page itself publishes
+    # `var latlang = { lat: 24.4493518, lng: 0 }` — and both carried the SAME latitude,
+    # which is what an unset default looks like. `read_coordinates` is right to report it
+    # faithfully; promoting it to a coordinate column is not, because latitude 24.45 with
+    # longitude 0 is a point in the Atlantic about 4,000 km from Dammam.
+    #
+    # ABSENT RATHER THAN CORRECTED, because there is nothing to correct it to. A missing
+    # coordinate says "this contractor never placed a pin"; a zero says "this contractor
+    # is in the Gulf of Guinea", and a table whose purpose is to be believed cannot say
+    # the second.
+    if english.latitude is not None and english.latitude and english.longitude:
         merged["latitude"] = str(english.latitude)
         merged["longitude"] = str(english.longitude)
     return merged

--- a/scrapex/extract/service.py
+++ b/scrapex/extract/service.py
@@ -255,6 +255,38 @@ def _approved_ingestion(
     ).fetchone()
 
 
+def _rows_unchanged(conn: sqlite3.Connection, dataset_id: int,
+                   rows: list[dict], record_keys: list[str]) -> bool:
+    """Would writing these rows change anything? Read from what is already stored.
+
+    THE SAME COMPARISON THE WRITE PATH MAKES, and deliberately the same expression:
+    `already.get(record_key) == content_hash`, where `content_hash` is
+    `_digest(_canonical(row))`. Two ways of deciding "unchanged" is one way of deciding
+    it and one liability, and this one runs BEFORE the upsert for the reason that path
+    already records — once the row is written, `content_hash` holds the new value and
+    the question can no longer be asked.
+
+    A ROW THIS DATASET HAS NEVER SEEN COUNTS AS CHANGED, and it needs no extra check to
+    say so: `stored.get(key)` is `None` for a key that was never written, and `None`
+    never equals a digest. A `len(stored) != len(record_keys)` guard was written here
+    first and a mutation deleted it with every test still passing — the second line today
+    that read like protection and could not fail. The comparison below is what protects
+    this, and it is the only thing that does.
+    """
+    if not record_keys:
+        return True
+    holes = ",".join("?" * len(record_keys))
+    stored = {
+        found["record_key"]: found["content_hash"]
+        for found in conn.execute(
+            "SELECT record_key, content_hash FROM generic_record "
+            f" WHERE dataset_definition_id = ? AND record_key IN ({holes})",
+            (dataset_id, *record_keys))
+    }
+    return all(stored.get(key) == _digest(_canonical(row))
+               for row, key in zip(rows, record_keys, strict=True))
+
+
 def _retire_or_refuse(conn: sqlite3.Connection, active_version_id: int,
                       approval: CandidateApproval) -> None:
     """A GROWN schema opens a new version; a SHRUNK one is still refused.
@@ -454,13 +486,28 @@ def approve_candidate(
                 "This table candidate was already approved with a different identity "
                 "or schema. Open the existing dataset instead of approving it again."
             )
-        result = _dataset_public(conn, int(recovered["dataset_definition_id"]))
-        result.update({
-            "schema_version_id": int(recovered["schema_version_id"]),
-            "generic_ingestion_id": int(recovered["generic_ingestion_id"]),
-            "recovered": True,
-        })
-        return result
+        # DEC-10 / `R-38`: SAME REQUEST IS NOT SAME ROWS. Everything checked above is
+        # about identity and shape, and none of it moves when a parser is CORRECTED — so
+        # a fixed parse of the same page matched here, answered `recovered=True` and
+        # wrote nothing. On 34,834 profile pages that would cost a re-crawl to repair
+        # what should be a re-parse, which is precisely what the fetch/interpret seam
+        # exists to prevent.
+        #
+        # ASKED OF THE ROWS THEMSELVES, AND NO COLUMN WAS ADDED FOR IT. The first
+        # attempt put a `rows_hash` on `generic_ingestion` and that table is
+        # append-only in BOTH directions and UNIQUE on `(snapshot, locator)` — so the
+        # digest would have been unwritable after the first insert, and there can never
+        # be a second ingestion for one page. `generic_record.content_hash` already
+        # holds exactly this fact per row, and the write path below already reads it.
+        if _rows_unchanged(conn, int(recovered["dataset_definition_id"]),
+                           rows, record_keys):
+            result = _dataset_public(conn, int(recovered["dataset_definition_id"]))
+            result.update({
+                "schema_version_id": int(recovered["schema_version_id"]),
+                "generic_ingestion_id": int(recovered["generic_ingestion_id"]),
+                "recovered": True,
+            })
+            return result
 
     site = catalog.register_site(
         conn,
@@ -559,18 +606,32 @@ def approve_candidate(
                 "content_hash) VALUES (?,?,?,?,?)",
                 (record_id, schema_version_id, snapshot_id, data_json, content_hash),
             )
-    ingestion = conn.execute(
-        "INSERT INTO generic_ingestion "
-        "(dataset_definition_id, schema_version_id, source_snapshot_id, "
-        "source_locator, record_count) VALUES (?,?,?,?,?)",
-        (dataset_id, schema_version_id, snapshot_id, candidate.locator, len(rows)),
-    )
+    if recovered is None:
+        ingestion_id = int(conn.execute(
+            "INSERT INTO generic_ingestion "
+            "(dataset_definition_id, schema_version_id, source_snapshot_id, "
+            "source_locator, record_count) VALUES (?,?,?,?,?)",
+            (dataset_id, schema_version_id, snapshot_id, candidate.locator,
+             len(rows)),
+        ).lastrowid)
+    else:
+        # NO SECOND INGESTION, AND THE SCHEMA IS WHAT SAYS SO: `generic_ingestion` is
+        # UNIQUE on `(source_snapshot_id, source_locator)` and append-only in both
+        # directions. That is right — "this page was ingested" happened once and is not
+        # revisable. A re-parse changes the ROWS, and their history lives in
+        # `generic_record_revision`, which is where a changed value belongs.
+        ingestion_id = int(recovered["generic_ingestion_id"])
     result = _dataset_public(conn, dataset_id)
     result.update({
         "site_profile_id": int(site["site_profile_id"]),
         "schema_version_id": schema_version_id,
-        "generic_ingestion_id": int(ingestion.lastrowid),
+        "generic_ingestion_id": ingestion_id,
         "recovered": False,
+        # NAMED SEPARATELY FROM `recovered`, because a caller counting re-parses and a
+        # caller counting no-ops are asking different questions. `scrapex contractors
+        # --approve` prints the recovered count out loud so a run that repaired nothing
+        # cannot be mistaken for one that did; this is the other half of that report.
+        "reparsed": recovered is not None,
     })
     return result
 

--- a/scrapex/extract/service.py
+++ b/scrapex/extract/service.py
@@ -486,7 +486,7 @@ def approve_candidate(
                 "This table candidate was already approved with a different identity "
                 "or schema. Open the existing dataset instead of approving it again."
             )
-        # DEC-10 / `R-38`: SAME REQUEST IS NOT SAME ROWS. Everything checked above is
+        # DEC-10 / `R-40`: SAME REQUEST IS NOT SAME ROWS. Everything checked above is
         # about identity and shape, and none of it moves when a parser is CORRECTED — so
         # a fixed parse of the same page matched here, answered `recovered=True` and
         # wrote nothing. On 34,834 profile pages that would cost a re-crawl to repair

--- a/scrapex/pagewalk.py
+++ b/scrapex/pagewalk.py
@@ -85,12 +85,20 @@ class PageWalker:
         self._fetched_any = False
 
     def walk(self, base_url: str, scope: CrawlScope, *, slice_of: str = "",
-             max_requests: int | None = None, on_page: OnPage | None = None) -> WalkReport:
+             max_requests: int | None = None, on_page: OnPage | None = None,
+             listing_phase_only: bool = False) -> WalkReport:
         """Fetch what the scope allows, and no more.
 
         `max_requests` is a ceiling the caller sets, not a default: a walk that
         silently stopped at some built-in number would report a partial crawl as
         a complete one. When it bites, `stopped_early` says so.
+
+        `listing_phase_only` IS NOT A SECOND SCOPE, and the distinction is the whole
+        reason it can exist without breaking `snapshotcrawl`'s rule that the scope comes
+        from the database and nowhere else. The scope says how deep a crawl of the SOURCE
+        may go. This says which PHASE is running — and the partitioned listing crawl is
+        the listing phase by construction: it partitions, witnesses and counts listing
+        pages, and no detail page takes part in any of its proofs.
         """
         # REFUSED BEFORE THE FIRST REQUEST. `plan_scope` raises SliceRequired
         # for a slice scope with no slice named, and asking it here means the
@@ -109,7 +117,14 @@ class PageWalker:
             if on_page is not None:
                 on_page(page)
 
-            if scope is CrawlScope.LISTING_ONLY:
+            if scope is CrawlScope.LISTING_ONLY or listing_phase_only:
+                # `listing_phase_only` STOPPED A REAL CRAWL FROM BEING BROKEN BY A
+                # CONFIGURATION CHANGE. On 2026-08-21 `site_profile.crawl_scope` was set
+                # to `listing_plus_slice` while a partitioned listing crawl was running —
+                # the scope is read per cell, not once per run — so cell five began
+                # asking `belongs_to_slice` about listing rows it had no interest in, and
+                # a single card without a city ended the run after four cells had closed
+                # with D=0.
                 continue
             for detail in self._details_wanted(page, scope, slice_of, report):
                 if self._over(report, max_requests):

--- a/scrapex/partitioncrawl.py
+++ b/scrapex/partitioncrawl.py
@@ -805,7 +805,14 @@ def _read_cell(conn: sqlite3.Connection, partition: PartitionedListing,
         # PACED BY THE FETCHER AND NOWHERE ELSE — see the module docstring. And
         # `fetcher=None` so the frontier is declared ONCE for the whole
         # partition rather than reset fifty-six times.
-        pace_s=0, fetcher=None, run_ref=run_ref)
+        pace_s=0, fetcher=None, run_ref=run_ref,
+        # THE LISTING PHASE, DECLARED. This crawl's whole product is a proof about the
+        # LISTING — the witness compares id sequences and the count compares distinct
+        # against declared — and a detail page takes part in neither. Without saying so,
+        # a registered `listing_plus_slice` made the walker ask `belongs_to_slice` about
+        # listing rows mid-run: measured 2026-08-21, four cells closed with D=0 and the
+        # fifth ended on one card that publishes no city.
+        listing_phase_only=True)
 
     # BOTH SETS, and they should not overlap. `_Unstored` removes a page before it
     # is fetched; `outcome.skipped` is a page the walker fetched and the store

--- a/scrapex/sites/muqawil.py
+++ b/scrapex/sites/muqawil.py
@@ -360,29 +360,28 @@ class MuqawilPageSource:
                 "use `detail_rows`, because this listing yields one URL per locale.")
 
         icon = cards[row_index].select_one(f".info-icon span.{_CITY_ICON}")
-        if icon is None and any(
-                card.select_one(f".info-icon span.{_CITY_ICON}") is not None
-                for card in cards):
-            # A REAL ABSENCE, NOT A MOVED MARKER, and telling them apart is what this
-            # page can answer for itself. Measured 2026-08-21 on a stored listing:
-            # `region_id=1&company_size=verysmall&page=11` has **20 cards, 19 with the
-            # city icon and one without** — so that contractor publishes no city, and it
-            # is in no named city. It is not in this slice.
-            #
-            # THE REFUSAL BELOW STOPPED A CRAWL BECAUSE IT COULD NOT TELL. Conflating the
-            # two states made one contractor without a city fatal to the whole run — and
-            # the reasoning the refusal was written for is still right: a marker that has
-            # moved must not read as a smaller city. The difference is measurable, so it
-            # is measured: if NO card on the page has the icon, the layout moved.
-            return False
         if icon is None:
-            # The card carries no city. NOT an answer of False, which would
-            # quietly drop a contractor from every slice and read as a smaller
-            # city rather than as a layout that moved.
-            raise SliceNotSupported(
-                f"no {_CITY_ICON} on card {row_index} of {page.url} — the "
-                "listing's city marker has moved, and a slice cannot be "
-                "chosen from a page that no longer publishes one")
+            # A CARD WITH NO CITY IS IN NO NAMED CITY. Not an exception, and the two
+            # versions of this that raised were both wrong on real pages.
+            #
+            # IT RAISED ON ANY MISSING ICON FIRST, on the reasoning that a moved marker
+            # must not read as a smaller city — sound, but unable to tell a moved marker
+            # from a contractor that publishes no location. One such card ended a crawl
+            # that had already closed four cells with `D = 0`.
+            #
+            # THEN IT RAISED ONLY WHEN NO CARD ON THE PAGE HAD ONE, which looked like the
+            # measurable distinction and is not. `region_id=0` is muqawil's
+            # no-location partition — the same fact `#234` recorded when its 74 pages
+            # taught a schema of 21 fields against a declared 22 — and measured
+            # 2026-08-21: `region_id=0` pages carry **17 and 20 cards with ZERO city
+            # icons**, while `region_id=1` pages carry 20 of 20. A whole page without a
+            # city is a legitimate state on this site.
+            #
+            # SO THE MOVED-MARKER SIGNAL DOES NOT LIVE HERE. It cannot be seen from one
+            # card or from one page; it is "the slice matched nothing anywhere", and
+            # `detail_frontier` already reports exactly that — the rows it examined
+            # against the rows it matched.
+            return False
 
         box = icon.find_parent(class_="info-box")
         value = box.select_one(".info-value") if box else None

--- a/scrapex/sites/muqawil.py
+++ b/scrapex/sites/muqawil.py
@@ -360,6 +360,21 @@ class MuqawilPageSource:
                 "use `detail_rows`, because this listing yields one URL per locale.")
 
         icon = cards[row_index].select_one(f".info-icon span.{_CITY_ICON}")
+        if icon is None and any(
+                card.select_one(f".info-icon span.{_CITY_ICON}") is not None
+                for card in cards):
+            # A REAL ABSENCE, NOT A MOVED MARKER, and telling them apart is what this
+            # page can answer for itself. Measured 2026-08-21 on a stored listing:
+            # `region_id=1&company_size=verysmall&page=11` has **20 cards, 19 with the
+            # city icon and one without** — so that contractor publishes no city, and it
+            # is in no named city. It is not in this slice.
+            #
+            # THE REFUSAL BELOW STOPPED A CRAWL BECAUSE IT COULD NOT TELL. Conflating the
+            # two states made one contractor without a city fatal to the whole run — and
+            # the reasoning the refusal was written for is still right: a marker that has
+            # moved must not read as a smaller city. The difference is measurable, so it
+            # is measured: if NO card on the page has the icon, the layout moved.
+            return False
         if icon is None:
             # The card carries no city. NOT an answer of False, which would
             # quietly drop a contractor from every slice and read as a smaller

--- a/scrapex/snapshotcrawl.py
+++ b/scrapex/snapshotcrawl.py
@@ -118,7 +118,8 @@ def crawl_to_snapshots(conn: sqlite3.Connection, source: PageSource,
                        slice_pages: int = 0, pace_s: float = 1.0,
                        max_requests: int | None = None,
                        fetcher: object | None = None,
-                       run_ref: str | None = None) -> CrawlOutcome:
+                       run_ref: str | None = None,
+                       listing_phase_only: bool = False) -> CrawlOutcome:
     """Walk this site at its registered scope, storing every page as evidence.
 
     `listing_pages` and `detail_pages` are MEASURED BY THE CALLER and passed in,
@@ -130,6 +131,13 @@ def crawl_to_snapshots(conn: sqlite3.Connection, source: PageSource,
     passed through `declare_frontier`, which tolerates a fetcher that cannot
     hear it: reaching for `expect_requests` directly once turned a progress
     display into an AttributeError that failed real crawls.
+
+    `listing_phase_only` IS NOT A SECOND SCOPE, which is what lets it exist beside the
+    rule above. The scope still comes from the database and only from there; this says
+    which PHASE the caller is running. The partitioned listing crawl is the listing phase
+    by construction — it partitions, witnesses and counts listing pages, and no detail
+    page enters any of its proofs — and on 2026-08-21 the absence of this distinction let
+    a live change to `crawl_scope` break a crawl that was already four cells in.
     """
     scope, slice_of = read_scope(conn, source.site_key)
 
@@ -188,7 +196,8 @@ def crawl_to_snapshots(conn: sqlite3.Connection, source: PageSource,
 
     walker = PageWalker(source, fetch, pace_s=pace_s)
     report = walker.walk(base_url, scope, slice_of=slice_of,
-                         max_requests=max_requests, on_page=store)
+                         max_requests=max_requests, on_page=store,
+                         listing_phase_only=listing_phase_only)
 
     return CrawlOutcome(plan=intended, report=report,
                         snapshots=tuple(snapshots), unstored=tuple(unstored),

--- a/scrapex/taxonomy.py
+++ b/scrapex/taxonomy.py
@@ -1,6 +1,6 @@
 """A site's own vocabulary, stored once, and the contractors that point at it.
 
-`R-36`. `R-19` ruled that the five multi-valued contractor groups go in child tables
+`R-38`. `R-19` ruled that the five multi-valued contractor groups go in child tables
 rather than JSON, and every measurement upheld it. What it left open was *how*, and he
 settled it: a **taxonomy plus a link table** — shape D — not five child datasets inside
 `generic_record`, which was the study's recommendation.
@@ -18,7 +18,7 @@ alongside it — which means the two locales' readings have to be PAIRED before 
 is written, and `ensure_path` refuses a pair it cannot align.
 
 WHAT IS DELIBERATELY NOT HERE. Nothing decides which groups exist or where they are on
-a page — that is `R-39`'s declared map in `extract/muqawil.py`. Nothing decides what a
+a page — that is `R-41`'s declared map in `extract/muqawil.py`. Nothing decides what a
 group's values MEAN. This module stores a tree and the memberships in it, for any site.
 """
 from __future__ import annotations
@@ -129,8 +129,8 @@ def link(conn: sqlite3.Connection, *, generic_record_id: int, node_id: int,
 
     IDEMPOTENT BY THE PRIMARY KEY, not by a check here — `(generic_record_id, node_id,
     group_key)` is the table's key, so a repeat cannot be written even by a caller that
-    forgot to look. `R-36` chose shape D partly for this: shape F would have written
-    these through `approve_candidate`, the function whose idempotency key `R-38` had to
+    forgot to look. `R-38` chose shape D partly for this: shape F would have written
+    these through `approve_candidate`, the function whose idempotency key `R-40` had to
     repair.
 
     `last_seen_at` MOVES ON A REPEAT AND `first_seen_at` DOES NOT, which is the same

--- a/scrapex/taxonomy.py
+++ b/scrapex/taxonomy.py
@@ -1,0 +1,202 @@
+"""A site's own vocabulary, stored once, and the contractors that point at it.
+
+`R-36`. `R-19` ruled that the five multi-valued contractor groups go in child tables
+rather than JSON, and every measurement upheld it. What it left open was *how*, and he
+settled it: a **taxonomy plus a link table** — shape D — not five child datasets inside
+`generic_record`, which was the study's recommendation.
+
+WHY THIS MODULE IS SMALL. Half of shape D already existed and had never been used:
+`classification_scheme` and `classification_node` are a generic self-referencing tree
+with `parent_node_id`, `node_name`, `node_name_ar` and `level`, and
+`ux_classification_node_name` makes `(scheme_id, ifnull(parent_node_id,0),
+node_name_ar)` its identity. Only the link was new, and that is migration 0009.
+
+THE IDENTITY IS THE ARABIC NAME, and that is the schema's choice rather than this
+module's: `node_name_ar` is `NOT NULL` and carries the unique index, while `node_name`
+is nullable. So a path is matched on its Arabic form and the English is written
+alongside it — which means the two locales' readings have to be PAIRED before anything
+is written, and `ensure_path` refuses a pair it cannot align.
+
+WHAT IS DELIBERATELY NOT HERE. Nothing decides which groups exist or where they are on
+a page — that is `R-39`'s declared map in `extract/muqawil.py`. Nothing decides what a
+group's values MEAN. This module stores a tree and the memberships in it, for any site.
+"""
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+
+
+class CannotPairLocales(ValueError):
+    """Two locales' readings of one group do not line up, so nothing is written.
+
+    THE ALTERNATIVE IS SILENT AND WRONG. The two readings are paired BY POSITION —
+    measured on the committed profile, both locales publish 25 interest nodes with the
+    same depths in the same document order — so a count that differs means the position
+    of one no longer describes the other, and writing anyway would attach an English
+    name to a different Arabic node.
+
+    `DSN-05` is the same failure one level up: a locale-blind alignment produced two
+    empty strings for every contractor in the country and nothing raised.
+    """
+
+
+@dataclass(frozen=True)
+class Membership:
+    """One row of `generic_record_node`, in the shape a reader wants it."""
+
+    group_key: str
+    node_id: int
+    path: tuple[str, ...]
+    path_ar: tuple[str, ...]
+
+
+def ensure_scheme(conn: sqlite3.Connection, site_profile_id: int, *,
+                  name: str, name_ar: str) -> int:
+    """The site's own vocabulary, created once.
+
+    `scheme_type='source'` because this is the SITE's taxonomy and not one we invented
+    — the column's own `CHECK` already names the three kinds, and `'internal'` would
+    claim we authored a vocabulary we are only reading.
+
+    `scheme_name_ar` IS UNIQUE IN THE SCHEMA, so it is what the lookup keys on. That is
+    the same choice `classification_node` makes for its own identity and for the same
+    reason: the Arabic name is the one the schema requires to exist.
+    """
+    found = conn.execute(
+        "SELECT scheme_id FROM classification_scheme WHERE scheme_name_ar = ?",
+        (name_ar,)).fetchone()
+    if found is not None:
+        return int(found[0])
+    cursor = conn.execute(
+        "INSERT INTO classification_scheme "
+        "(scheme_name_ar, scheme_name, scheme_type, site_profile_id) "
+        "VALUES (?,?,'source',?)", (name_ar, name, site_profile_id))
+    return int(cursor.lastrowid)
+
+
+def ensure_path(conn: sqlite3.Connection, scheme_id: int, *,
+                path: tuple[str, ...], path_ar: tuple[str, ...]) -> int:
+    """Every node on one root-to-leaf path, created as needed. Returns the LEAF's id.
+
+    EVERY LEVEL, BECAUSE A CHILD CANNOT EXIST WITHOUT ITS PARENT. `parent_node_id`
+    references this same table, so writing a leaf means writing the nodes above it —
+    which is why `read_interests` returns paths rather than leaf names.
+
+    IDEMPOTENT ON `(scheme, parent, node_name_ar)`, which is the unique index the schema
+    already declares. Running an identical parse twice creates nothing and returns the
+    same ids, so a re-parse is free.
+
+    THE ENGLISH NAME IS FILLED IN BUT NEVER MATCHED ON. A node first seen on an Arabic
+    page has no English name yet; the next English page supplies it. Matching on it would
+    make the same node two nodes depending on which locale arrived first.
+    """
+    if len(path) != len(path_ar):
+        raise CannotPairLocales(
+            f"a path of {len(path)} names cannot be paired with one of {len(path_ar)}: "
+            f"{path!r} against {path_ar!r}")
+    if not path:
+        raise CannotPairLocales("an empty path names no node")
+
+    parent: int | None = None
+    for level, (name, name_ar) in enumerate(zip(path, path_ar, strict=True), start=1):
+        found = conn.execute(
+            "SELECT node_id, node_name FROM classification_node "
+            " WHERE scheme_id = ? AND ifnull(parent_node_id, 0) = ? "
+            "   AND node_name_ar = ?",
+            (scheme_id, parent or 0, name_ar)).fetchone()
+        if found is None:
+            cursor = conn.execute(
+                "INSERT INTO classification_node "
+                "(scheme_id, parent_node_id, node_name_ar, node_name, level) "
+                "VALUES (?,?,?,?,?)", (scheme_id, parent, name_ar, name, level))
+            parent = int(cursor.lastrowid)
+            continue
+        parent = int(found["node_id"])
+        if not found["node_name"] and name:
+            # THE OTHER LOCALE ARRIVING SECOND. A node first written from an Arabic page
+            # has no English name; this is where it gets one, and it is an UPDATE rather
+            # than a second node because the Arabic name is the identity.
+            conn.execute(
+                "UPDATE classification_node SET node_name = ? WHERE node_id = ?",
+                (name, parent))
+    return int(parent)
+
+
+def link(conn: sqlite3.Connection, *, generic_record_id: int, node_id: int,
+         group_key: str, source_snapshot_id: int) -> bool:
+    """This contractor holds this node, in this group. `True` if it is new.
+
+    IDEMPOTENT BY THE PRIMARY KEY, not by a check here — `(generic_record_id, node_id,
+    group_key)` is the table's key, so a repeat cannot be written even by a caller that
+    forgot to look. `R-36` chose shape D partly for this: shape F would have written
+    these through `approve_candidate`, the function whose idempotency key `R-38` had to
+    repair.
+
+    `last_seen_at` MOVES ON A REPEAT AND `first_seen_at` DOES NOT, which is the same
+    distinction `R-20` draws for a record: a confirmation is not a change. It is what
+    makes "this contractor has held this activity since March" answerable later.
+
+    `source_snapshot_id` IS REQUIRED BY THE SCHEMA and passed by every caller, because a
+    membership whose evidence is unnamed is a claim rather than a reading.
+
+    "IS IT NEW" IS ANSWERED BY THE COUNTER AND NOT BY THE CLOCK. The first version
+    compared `first_seen_at = last_seen_at`, and both come from `strftime(...,'now')` at
+    SECOND resolution — so a write and its confirmation inside the same second are
+    indistinguishable. Measured: a second identical pass over one profile reported all 25
+    memberships as new. `seen_count` is incremented by the upsert and returned, so `= 1`
+    means "written just now" with no extra read and nothing to race.
+    """
+    seen = conn.execute(
+        "INSERT INTO generic_record_node "
+        "(generic_record_id, node_id, group_key, source_snapshot_id) "
+        "VALUES (?,?,?,?) "
+        "ON CONFLICT(generic_record_id, node_id, group_key) DO UPDATE SET "
+        "  last_seen_at = strftime('%Y-%m-%dT%H:%M:%SZ','now'), "
+        "  seen_count = seen_count + 1, "
+        "  source_snapshot_id = excluded.source_snapshot_id "
+        "RETURNING seen_count",
+        (generic_record_id, node_id, group_key, source_snapshot_id)).fetchone()
+    return int(seen[0]) == 1
+
+
+def memberships(conn: sqlite3.Connection, generic_record_id: int, *,
+                group_key: str | None = None) -> tuple[Membership, ...]:
+    """Everything this contractor holds, with each node's full path rebuilt.
+
+    THE PATH IS REBUILT RATHER THAN STORED, which is the whole point of the taxonomy: the
+    string `تشييد المباني` is written once however many contractors hold something under
+    it. Storing the path per membership is shape A, and the study measured that at 4.7x
+    this.
+
+    A RECURSIVE CTE AND NOT A LOOP, because a loop is one query per level per membership
+    — on 500K memberships three levels deep that is 1.5M round trips for an answer SQLite
+    can assemble in one.
+    """
+    rows = conn.execute(
+        "WITH RECURSIVE up(node_id, group_key, leaf_id, name, name_ar, parent) AS ("
+        "  SELECT n.node_id, m.group_key, n.node_id, n.node_name, n.node_name_ar, "
+        "         n.parent_node_id "
+        "    FROM generic_record_node AS m "
+        "    JOIN classification_node AS n ON n.node_id = m.node_id "
+        "   WHERE m.generic_record_id = ? "
+        "     AND (? IS NULL OR m.group_key = ?) "
+        "  UNION ALL "
+        "  SELECT p.node_id, up.group_key, up.leaf_id, p.node_name, p.node_name_ar, "
+        "         p.parent_node_id "
+        "    FROM up JOIN classification_node AS p ON p.node_id = up.parent "
+        ") "
+        "SELECT leaf_id, group_key, name, name_ar FROM up "
+        " ORDER BY group_key, leaf_id, node_id",
+        (generic_record_id, group_key, group_key)).fetchall()
+
+    built: dict[tuple[str, int], tuple[list[str], list[str]]] = {}
+    for row in rows:
+        key = (row["group_key"], int(row["leaf_id"]))
+        names, names_ar = built.setdefault(key, ([], []))
+        names.append(row["name"] or "")
+        names_ar.append(row["name_ar"])
+    return tuple(
+        Membership(group_key=group, node_id=leaf,
+                   path=tuple(names), path_ar=tuple(names_ar))
+        for (group, leaf), (names, names_ar) in sorted(built.items()))

--- a/scrapex/version.py
+++ b/scrapex/version.py
@@ -501,7 +501,34 @@ def version_report(extension_version: str | None = None) -> dict:
     if extension_version is None:
         return report
     missing = missing_capabilities(extension_version)
-    report["outdated"] = bool(missing) or is_older(extension_version, VERSION)
+    # `R-07`: THE GATE STAYS AND THE ADVERT GOES — and this line was the advert.
+    #
+    # It read `bool(missing) or is_older(extension_version, VERSION)`, two different
+    # questions welded into one verdict:
+    #
+    #   bool(missing)   THE GATE. This extension lacks a capability it needs, derived
+    #                   from the ledger. A fact the engine owns, and it stays.
+    #   is_older(…)     THE ADVERT. "A newer extension exists" — which is Chrome's
+    #                   answer and never the engine's, because the engine knows only its
+    #                   OWN number. `R-07` says it goes.
+    #
+    # RULED 2026-08-16 AND NOT DONE, and the cost arrived twice. That ruling records the
+    # defect being "found by trying the bump and reverting it the same day": the moment
+    # `VERSION` moves past `extension/manifest.json`, every panel is told it is out of
+    # date, and the notice is 54px of vertical space that clips the profile card's legal
+    # line at 320x440. Measured then; measured again on 2026-08-22, when a schema change
+    # moved VERSION to 0.3.0 for a legitimate reason and three panel layout tests failed
+    # with the SAME 54px — because the advert was still here.
+    #
+    # NOT FIXED BY BUMPING THE MANIFEST, which `R-07` forbids in as many words: that
+    # re-welds what PLATFORM-PLAN Decision 21 unwelded, and the two ship down separate
+    # paths — Google reviews the extension, nobody reviews the engine.
+    #
+    # STILL OWED FROM `R-07`, so it does not go missing for another six days:
+    # `latest_extension_version`, `LATEST_SOURCE` and `UPDATE_INSTRUCTIONS` are named
+    # there as also going. Each needs a coordinated change in `extension/app.js`, which
+    # reads them — so they are not smuggled in behind this one-line fix to the harm.
+    report["outdated"] = bool(missing)
     report["missing"] = [
         {"key": capability.key, "since": capability.since,
          "summary": capability.summary}

--- a/scrapex/version.py
+++ b/scrapex/version.py
@@ -73,7 +73,7 @@ from enum import StrEnum
 # The release stamp. Bump it for a functional, architectural or behavioural
 # change (issue 32 section 1.1), and regenerate the baseline + CHANGELOG in the
 # same commit: python -m scrapex.cli export-version
-VERSION = "0.2.2"
+VERSION = "0.3.0"
 
 
 class Surface(StrEnum):
@@ -141,7 +141,13 @@ CAPABILITIES: tuple[Capability, ...] = (
         # The setting is only the DEFAULT. The per-source choice lives on the
         # source itself (SourceEntry.robots), which is why the panel control
         # named here is on the source editor and not the Settings page.
-        commit="",
+        #
+        # FILLED IN WHEN 0.3.0 ARRIVED, and read out of `git log` as the ledger
+        # requires rather than remembered: `git log -S robots_per_source --reverse`
+        # names `adf31b2`, "robots.txt becomes the owner's decision, per site (#153)"
+        # — which is also the commit that last moved VERSION before this one. It was
+        # allowed to be empty only while `since` equalled `VERSION`.
+        commit="adf31b2",
     ),
     Capability(
         key="crawl_parallel_sources",

--- a/scrapex/warehousemerge.py
+++ b/scrapex/warehousemerge.py
@@ -29,6 +29,20 @@ column merges with `min` or `max` and none with `+`** — a sum is neither, and 
 version of this used one for `seen_count`. Measured before it was fixed: three merges of
 the same file took one id from 4 to 8 to 12 to 16 while this paragraph claimed otherwise.
 
+THE PANEL ALREADY DOES THE UPLOAD, AND THE WRONG BUTTON IS NEXT TO THE RIGHT ONE.
+`scrapex/bundle.py` builds a bundle containing `warehouse.db` — taken through sqlite3's own
+backup API — and `extension/drive.js` uploads it resumably into a `ScrapeX backups` folder
+with a `latest.json` pointer and three kept. The panel's buttons are `drive-backup` and
+`drive-restore`, and the engine has no Google of its own by his ruling of 2026-08-11.
+
+**`drive-restore` IS THE DESTRUCTIVE ONE AND MUST NOT BE USED FOR THIS.** Restoring
+REPLACES the live warehouse — `registry.engine.restore` displaces it and says so — which on
+the other machine means losing the muqawil and products work that machine has and this one
+does not. That is the exact outcome `R-43` exists to prevent, reachable by pressing the
+button beside the right one.
+
+So the flow is: **backup** here, download there, and **merge** — never restore.
+
 THE LOCK IS THE PART HIS PLAN WAS MISSING. Download → work → upload has nothing stopping
 both machines doing it on the same day, and the second upload silently wins — Drive keeps
 versions but cannot merge them. So a warehouse records which machine currently holds it,

--- a/scrapex/warehousemerge.py
+++ b/scrapex/warehousemerge.py
@@ -1,0 +1,257 @@
+"""Two machines' warehouses become one, and only one machine may hold it at a time.
+
+HIS RULING, 2026-08-22: both machines have developed muqawil, so the databases must be
+merged, with **Drive as the single source of truth for DATA** while the repository stays
+the single source of truth for CODE. Neither file may be copied over the other — each
+holds work the other does not, and `R-24` says upgrade rather than replace.
+
+THE MERGE IS DEFINABLE BECAUSE THE NATURAL KEYS EXIST, and that was measured before any of
+this was written:
+
+    generic_page_snapshot   20,379 rows, 20,379 distinct (source_url, content_hash)
+    dataset_sighting        UNIQUE (dataset_key, external_id) in the schema
+    generic_record          UNIQUE (dataset_definition_id, record_key) in the schema
+
+Without those, a merge would mean remapping every autoincrement primary key and every
+foreign key pointing at it — both machines hold a `page_snapshot_id = 1` for a different
+page. That is `OP-30` at a much larger scale, and it is why "just merge them" is not an
+operation until the keys are named.
+
+ONLY THE EVIDENCE IS MERGED. Snapshots and sightings are the two things that cannot be
+recomputed: a snapshot is a page as it was fetched, and a sighting is what the site showed
+and when. **Everything else is rebuilt by `--approve` with no network** — records,
+revisions, ingestions, the taxonomy and its memberships. That single decision is what keeps
+this tractable: no primary key is ever remapped, because nothing that carries one travels.
+
+AND THE OPERATION IS COMMUTATIVE AND IDEMPOTENT, which is what makes his plan safe:
+downloading, merging, uploading and merging again converges instead of drifting. **Every
+column merges with `min` or `max` and none with `+`** — a sum is neither, and the first
+version of this used one for `seen_count`. Measured before it was fixed: three merges of
+the same file took one id from 4 to 8 to 12 to 16 while this paragraph claimed otherwise.
+
+THE LOCK IS THE PART HIS PLAN WAS MISSING. Download → work → upload has nothing stopping
+both machines doing it on the same day, and the second upload silently wins — Drive keeps
+versions but cannot merge them. So a warehouse records which machine currently holds it,
+and this module refuses to merge into a copy that somebody else holds.
+"""
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass, field
+
+HOLDER = "checkout_holder"
+HELD_AT = "checkout_at"
+
+
+class NotYours(RuntimeError):
+    """Somebody else holds this warehouse, so writing to it would lose their work."""
+
+
+class NotMergeable(ValueError):
+    """The two files cannot be merged, and the reason is named rather than guessed at."""
+
+
+@dataclass
+class Merged:
+    """What one merge changed, per table, both directions named.
+
+    COUNTS AND NOT A BOOLEAN, because "it worked" is not a report a person can act on:
+    a merge that added 12,000 snapshots and one that added none are both successes and
+    completely different news.
+    """
+
+    snapshots_added: int = 0
+    sightings_added: int = 0
+    sightings_updated: int = 0
+    #: Datasets whose derived rows are now stale and must be rebuilt by `--approve`.
+    rebuild: tuple[str, ...] = field(default_factory=tuple)
+
+    def __str__(self) -> str:
+        lines = [
+            f"snapshots added   {self.snapshots_added:,}",
+            f"sightings added   {self.sightings_added:,}",
+            f"sightings updated {self.sightings_updated:,}",
+        ]
+        if self.rebuild:
+            lines.append(
+                "NOW REBUILD THE DERIVED ROWS — nothing here wrote one. Run "
+                "`scrapex contractors --approve --run-ref <ref>` for each run whose "
+                f"pages arrived; the datasets affected are {', '.join(self.rebuild)}. "
+                "It costs no network: that is what the fetch/interpret seam is for.")
+        else:
+            lines.append("nothing arrived, so nothing needs re-approving")
+        return "\n".join(lines)
+
+
+def holder(conn: sqlite3.Connection) -> str | None:
+    """Which machine holds this warehouse, or `None` if nobody has claimed it.
+
+    `scrapex_meta` AND NOT A NEW TABLE, for the reason `account.py` already gives about
+    `account_owner`: it holds exactly this kind of fact, and a key/value row needs no
+    migration — so a warehouse from before this feature answers `None` rather than
+    failing to open.
+    """
+    row = conn.execute("SELECT value FROM scrapex_meta WHERE key = ? LIMIT 1",
+                       (HOLDER,)).fetchone()
+    return str(row[0]) if row and row[0] else None
+
+
+def claim(conn: sqlite3.Connection, machine: str) -> None:
+    """Take the warehouse for this machine. Refuses if somebody else holds it.
+
+    RE-CLAIMING YOUR OWN IS ALLOWED and does not fail, because a session that crashed
+    mid-merge must be able to pick the same copy back up. Taking one somebody ELSE holds
+    is refused, and the message names them — the whole point is that the loser of a race
+    finds out from a refusal rather than from missing data a week later.
+    """
+    if not machine.strip():
+        raise NotMergeable("a claim needs a machine name; an empty one holds nothing")
+    current = holder(conn)
+    if current is not None and current != machine:
+        raise NotYours(
+            f"{current!r} holds this warehouse. Merging into it would overwrite work "
+            f"that machine has not uploaded yet. Have it run `--release` first, or take "
+            f"it deliberately with `--force` if you know it is finished.")
+    for key, value in ((HOLDER, machine), (HELD_AT, _now(conn))):
+        conn.execute(
+            "INSERT INTO scrapex_meta (key, value) VALUES (?,?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value", (key, value))
+    conn.commit()
+
+
+def release(conn: sqlite3.Connection) -> None:
+    """Give the warehouse back, so the other machine may claim it."""
+    conn.execute("DELETE FROM scrapex_meta WHERE key IN (?,?)", (HOLDER, HELD_AT))
+    conn.commit()
+
+
+def _now(conn: sqlite3.Connection) -> str:
+    return str(conn.execute(
+        "SELECT strftime('%Y-%m-%dT%H:%M:%SZ','now')").fetchone()[0])
+
+
+def _same_shape(conn: sqlite3.Connection) -> None:
+    """Both sides must be the same kind of database at the same schema version.
+
+    REFUSED RATHER THAN ATTEMPTED, because a v8 file and a v9 one disagree about which
+    tables exist — merging into the older would drop what the newer knows, and merging
+    into the newer would leave the older's rows referencing columns it has never had.
+    `R-24` is the same rule one level up: upgrade, do not replace.
+    """
+    ours = conn.execute("PRAGMA user_version").fetchone()[0]
+    theirs = conn.execute("PRAGMA other.user_version").fetchone()[0]
+    if ours != theirs:
+        raise NotMergeable(
+            f"this warehouse is at schema v{ours} and the other is at v{theirs}. Run "
+            "`scrapex init-db` on the older one first — a merge across versions would "
+            "either drop what the newer knows or leave rows pointing at columns that do "
+            "not exist.")
+    kind = conn.execute(
+        "SELECT value FROM other.scrapex_meta WHERE key = 'database_kind'").fetchone()
+    if kind is not None and str(kind[0]) != "engine":
+        raise NotMergeable(
+            f"the other file says it is a {kind[0]!r} database, not an engine one")
+
+
+def merge(conn: sqlite3.Connection, other: str, *, machine: str) -> Merged:
+    """Take everything the other warehouse knows and this one does not.
+
+    THE CLAIM IS CHECKED FIRST and the merge does not start without it, because the whole
+    reason the claim exists is that the loser of a race must find out before it writes
+    rather than after somebody's day is gone.
+
+    ATTACH AND NOT TWO CONNECTIONS, so every insert below is one statement inside one
+    transaction. Reading rows into Python and writing them back would put 20,000
+    round trips and a partial-failure mode where there is no need for either.
+    """
+    if holder(conn) != machine:
+        raise NotYours(
+            f"this machine is {machine!r} and the warehouse is held by "
+            f"{holder(conn)!r}. Claim it first.")
+
+    conn.execute("ATTACH DATABASE ? AS other", (other,))
+    try:
+        _same_shape(conn)
+        report = Merged()
+
+        # SNAPSHOTS: ADDITIVE, KEYED ON WHAT THE PAGE IS. `page_snapshot_id` is never
+        # carried across — it is assigned here — so nothing downstream can reference a
+        # foreign machine's id. The columns are named rather than `SELECT *` because the
+        # id must be excluded and because a column added later must break this loudly
+        # instead of silently shifting values one place left.
+        before = conn.execute(
+            "SELECT COUNT(*) FROM generic_page_snapshot").fetchone()[0]
+        conn.execute(
+            "INSERT INTO generic_page_snapshot "
+            "(source_url, content_type, html_content, content_hash, captured_at, "
+            " crawl_run_ref, html_codec, html_dict_id) "
+            "SELECT source_url, content_type, html_content, content_hash, captured_at, "
+            "       crawl_run_ref, html_codec, html_dict_id "
+            "  FROM other.generic_page_snapshot AS theirs "
+            " WHERE NOT EXISTS (SELECT 1 FROM generic_page_snapshot AS ours "
+            "                    WHERE ours.source_url = theirs.source_url "
+            "                      AND ours.content_hash = theirs.content_hash)")
+        report.snapshots_added = (
+            conn.execute("SELECT COUNT(*) FROM generic_page_snapshot").fetchone()[0]
+            - before)
+
+        # SIGHTINGS: MERGED, NOT REPLACED. A sighting is the only record of what the site
+        # showed and when, and the two machines saw different moments — so the earliest
+        # first sighting, the latest last, and the counts ADDED. `last_absent_at` takes the
+        # later, because an absence proved on either machine is an absence proved.
+        before = conn.execute("SELECT COUNT(*) FROM dataset_sighting").fetchone()[0]
+        conn.execute(
+            "INSERT INTO dataset_sighting "
+            "(dataset_key, external_id, first_seen_at, last_seen_at, seen_count, "
+            " first_run_ref, last_absent_at, last_absent_run_ref) "
+            "SELECT dataset_key, external_id, first_seen_at, last_seen_at, seen_count, "
+            "       first_run_ref, last_absent_at, last_absent_run_ref "
+            # `WHERE true` IS NOT DECORATION. SQLite cannot parse
+            # `INSERT ... SELECT ... ON CONFLICT` without something closing the SELECT —
+            # the parser cannot tell an upsert clause from part of the query — and it
+            # answers `near "DO": syntax error`. Documented quirk, and the one-word fix.
+            "  FROM other.dataset_sighting WHERE true "
+            "ON CONFLICT(dataset_key, external_id) DO UPDATE SET "
+            "  first_seen_at = MIN(first_seen_at, excluded.first_seen_at), "
+            "  last_seen_at  = MAX(last_seen_at,  excluded.last_seen_at), "
+            # `MAX` AND NOT `+`, AND THE FIRST VERSION SUMMED. Measured: three merges of
+            # the same file took one id's `seen_count` from 4 to 8 to 12 to 16, while the
+            # docstring above claimed the operation was idempotent. It was not, and the
+            # test that missed it counted ROWS and never looked at a value.
+            #
+            # SUMMING IS ALSO WRONG ON THE FIRST MERGE, which is the deeper reason. Two
+            # machines crawling the same listing observe the SAME site state, so their
+            # counts are two observations of one fact rather than two facts. `MAX` keeps
+            # "seen at least this many times" — which is what `sighting_frequencies` uses
+            # to estimate coverage — and is commutative and idempotent besides.
+            "  seen_count    = MAX(seen_count, excluded.seen_count), "
+            "  last_absent_at = MAX(IFNULL(last_absent_at, ''), "
+            "                       IFNULL(excluded.last_absent_at, ''))")
+        report.sightings_added = (
+            conn.execute("SELECT COUNT(*) FROM dataset_sighting").fetchone()[0] - before)
+        report.sightings_updated = (
+            conn.execute("SELECT COUNT(*) FROM other.dataset_sighting").fetchone()[0]
+            - report.sightings_added)
+
+        if report.snapshots_added:
+            # WHOSE DERIVED ROWS ARE NOW STALE. Named rather than rebuilt here: a rebuild
+            # needs a run ref and belongs to the command that owns approving, and one
+            # function that both merges evidence and re-interprets it would be two
+            # responsibilities with one error path.
+            report.rebuild = tuple(
+                str(row[0]) for row in conn.execute(
+                    "SELECT DISTINCT dataset_key FROM dataset_definition "
+                    " WHERE valid_to IS NULL ORDER BY dataset_key"))
+        conn.commit()
+        return report
+    finally:
+        # THE TRANSACTION MUST CLOSE BEFORE THE DETACH, or SQLite answers
+        # `database other is locked` and the real failure above is replaced by a
+        # confusing one — which is exactly what happened the first time this ran.
+        try:
+            conn.rollback()
+        except sqlite3.Error:
+            pass
+        # DETACHED WHETHER OR NOT IT WORKED, or the next call in the same process finds
+        # the name taken and fails for a reason that has nothing to do with the merge.
+        conn.execute("DETACH DATABASE other")

--- a/tests/test_a_contractor_points_at_a_taxonomy.py
+++ b/tests/test_a_contractor_points_at_a_taxonomy.py
@@ -1,4 +1,4 @@
-"""`R-36`: the five multi-valued groups are a taxonomy plus a link table — shape D.
+"""`R-38`: the five multi-valued groups are a taxonomy plus a link table — shape D.
 
 HE OVERRULED THE STUDY'S RECOMMENDATION AND WAS RIGHT. The study recommended shape F, a
 child dataset per group inside `generic_record`, because it reuses machinery the warehouse
@@ -17,9 +17,9 @@ WHAT THIS FILE GUARDS, in the order the reasons matter:
   * the STRING IS STORED ONCE. That is the whole of shape D; if a path's names are
     repeated per membership it has become shape A, which the study measured at 4.7x.
   * PROVENANCE IS ENFORCED, not remembered. `source_snapshot_id NOT NULL` is F's one
-    real advantage and `R-36` says explicitly it must be carried over.
+    real advantage and `R-38` says explicitly it must be carried over.
   * IDEMPOTENCY IS THE PRIMARY KEY, so a re-parse cannot duplicate — which is why D
-    needs nothing like the repair `R-38` had to make to `approve_candidate`.
+    needs nothing like the repair `R-40` had to make to `approve_candidate`.
   * `group_key` IS IN THE KEY, because one node can be held as an interest AND as a
     licensed activity, and merging those two facts would be silent.
 """
@@ -189,7 +189,7 @@ def test_one_node_can_be_held_in_two_groups_at_once(conn):
 # ---- what F's advantage was, carried over ------------------------------------
 
 def test_a_membership_without_its_evidence_is_refused_by_the_schema(conn):
-    """F'S ONE REAL ADVANTAGE, AND `R-36` SAYS IT MUST BE CARRIED OVER.
+    """F'S ONE REAL ADVANTAGE, AND `R-38` SAYS IT MUST BE CARRIED OVER.
     `generic_record.source_snapshot_id NOT NULL` is what makes provenance enforced rather
     than remembered; the link table carries the same column under the same constraint."""
     scheme = _scheme(conn)
@@ -232,8 +232,8 @@ def test_deleting_a_contractor_takes_its_memberships(conn):
 # ---- idempotency, by construction --------------------------------------------
 
 def test_a_second_identical_pass_writes_nothing_new(conn):
-    """`R-36`'s fourth reason for D. Shape F would have gone through
-    `approve_candidate`, whose idempotency key `R-38` had to repair; here the primary key
+    """`R-38`'s fourth reason for D. Shape F would have gone through
+    `approve_candidate`, whose idempotency key `R-40` had to repair; here the primary key
     makes a duplicate impossible even for a caller that forgot to check."""
     first = _store_the_interests(conn)
     second = _store_the_interests(conn)

--- a/tests/test_a_contractor_points_at_a_taxonomy.py
+++ b/tests/test_a_contractor_points_at_a_taxonomy.py
@@ -1,0 +1,304 @@
+"""`R-36`: the five multi-valued groups are a taxonomy plus a link table — shape D.
+
+HE OVERRULED THE STUDY'S RECOMMENDATION AND WAS RIGHT. The study recommended shape F, a
+child dataset per group inside `generic_record`, because it reuses machinery the warehouse
+already contains. Measured the same day: `classification_node`,
+`classification_scheme`, `dataset_relationship` and `relationship_field_pair` hold **zero
+rows between them**. Existing machinery that has never carried a row is not an asset —
+this one session found `is_enabled` with no callers, `record_absences` with no callers, and
+a slice scope that was "built, tested, never used" and turned out to be *wrong*.
+
+And F paid a whole `generic_record` row — `data_json` averaging 1,049 bytes, a
+64-character key, a 64-character hash, two timestamps, a status and four foreign keys —
+for a membership fact that is two integers.
+
+WHAT THIS FILE GUARDS, in the order the reasons matter:
+
+  * the STRING IS STORED ONCE. That is the whole of shape D; if a path's names are
+    repeated per membership it has become shape A, which the study measured at 4.7x.
+  * PROVENANCE IS ENFORCED, not remembered. `source_snapshot_id NOT NULL` is F's one
+    real advantage and `R-36` says explicitly it must be carried over.
+  * IDEMPOTENCY IS THE PRIMARY KEY, so a re-parse cannot duplicate — which is why D
+    needs nothing like the repair `R-38` had to make to `approve_candidate`.
+  * `group_key` IS IN THE KEY, because one node can be held as an interest AND as a
+    licensed activity, and merging those two facts would be silent.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scrapex import taxonomy
+from scrapex.databases import DatabaseRegistry, EngineDatabase
+from scrapex.extract.muqawil import read_interests
+from scrapex.taxonomy import CannotPairLocales
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "muqawil"
+
+
+@pytest.fixture()
+def conn(tmp_path: Path):
+    registry = DatabaseRegistry(EngineDatabase(tmp_path / "scrapex-engine.db"),
+                                pointer_file=tmp_path / "databases.json")
+    registry.initialize()
+    connection = registry.engine.connect()
+    _a_contractor(connection)
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def _a_contractor(conn) -> None:
+    """One stored contractor with one snapshot behind it, minimally shaped."""
+    for sql in (
+        "INSERT INTO site_profile (site_key, display_name, base_url) "
+        "VALUES ('muqawil_org','Contractors','https://muqawil.org')",
+        "INSERT INTO generic_page_snapshot (source_url, html_content, content_hash) "
+        "VALUES ('https://muqawil.org/en/contractors/1/143','<html></html>','h')",
+        "INSERT INTO dataset_definition (site_profile_id, dataset_key, original_name, "
+        " dataset_kind, discovery_method, locator_json) "
+        "VALUES (1,'contractors','contractors','table','html_table','{}')",
+        "INSERT INTO dataset_schema_version (dataset_definition_id, version_number, "
+        " schema_hash) VALUES (1,1,'h')",
+        "INSERT INTO generic_record (dataset_definition_id, record_key, "
+        " schema_version_id, data_json, source_snapshot_id, source_locator, "
+        " content_hash) VALUES (1,'contractor-1',1,'{}',1,'x','c')",
+    ):
+        conn.execute(sql)
+    conn.commit()
+
+
+def _scheme(conn) -> int:
+    return taxonomy.ensure_scheme(conn, 1, name="Interests", name_ar="الأنشطة")
+
+
+def _interests(locale: str):
+    return read_interests(
+        (FIXTURES / f"profile-{locale}.html").read_text(encoding="utf-8"))
+
+
+def _store_the_interests(conn) -> int:
+    """The real reading of the committed profile, both locales, stored. Returns new count."""
+    scheme = _scheme(conn)
+    new = 0
+    for path, path_ar in zip(_interests("en"), _interests("ar"), strict=True):
+        node = taxonomy.ensure_path(conn, scheme, path=path, path_ar=path_ar)
+        new += taxonomy.link(conn, generic_record_id=1, node_id=node,
+                             group_key="interests", source_snapshot_id=1)
+    conn.commit()
+    return new
+
+
+def _count(conn, table: str) -> int:
+    return conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+
+
+# ---- the shape itself ---------------------------------------------------------
+
+def test_the_real_profile_stores_as_a_tree_and_not_as_strings(conn):
+    """THE WHOLE OF SHAPE D IN ONE ASSERTION. 25 memberships over 25 nodes, and the
+    interior nodes are shared rather than repeated — `تشييد المباني` is written once
+    however many contractors sit under it."""
+    new = _store_the_interests(conn)
+
+    assert new == 25
+    assert _count(conn, "generic_record_node") == 25
+    assert _count(conn, "classification_node") == 25
+    depths = dict(conn.execute(
+        "SELECT level, COUNT(*) FROM classification_node GROUP BY level").fetchall())
+    assert depths == {1: 3, 2: 5, 3: 17}
+
+
+def test_a_name_is_stored_once_however_many_contractors_hold_it(conn):
+    """SHAPE D VERSUS SHAPE A, which is the 4.7x. A second contractor holding the same
+    activities adds memberships and NOT ONE NODE."""
+    _store_the_interests(conn)
+    nodes = _count(conn, "classification_node")
+    conn.execute(
+        "INSERT INTO generic_record (dataset_definition_id, record_key, "
+        " schema_version_id, data_json, source_snapshot_id, source_locator, "
+        " content_hash) VALUES (1,'contractor-2',1,'{}',1,'y','d')")
+    conn.commit()
+
+    scheme = _scheme(conn)
+    for path, path_ar in zip(_interests("en"), _interests("ar"), strict=True):
+        node = taxonomy.ensure_path(conn, scheme, path=path, path_ar=path_ar)
+        taxonomy.link(conn, generic_record_id=2, node_id=node,
+                      group_key="interests", source_snapshot_id=1)
+    conn.commit()
+
+    assert _count(conn, "classification_node") == nodes, "not one new node"
+    assert _count(conn, "generic_record_node") == 50
+
+
+def test_the_path_is_rebuilt_with_both_locales(conn):
+    """The reason `ensure_path` pairs the two readings: a reader wants either language
+    from one row, and the string exists once per language per node."""
+    _store_the_interests(conn)
+
+    found = taxonomy.memberships(conn, 1)
+
+    assert len(found) == 25
+    deepest = [one for one in found if len(one.path) == 3]
+    assert deepest
+    one = deepest[0]
+    assert all(one.path) and all(one.path_ar)
+    assert one.path != one.path_ar
+
+
+def test_reading_one_group_does_not_return_another(conn):
+    """`group_key` FILTERS, and it has to: the licensed-activities values are drawn from
+    the same activity vocabulary as the interests tree, so without this a contractor's
+    interests and its licences would come back as one list."""
+    _store_the_interests(conn)
+    scheme = _scheme(conn)
+    node = taxonomy.ensure_path(conn, scheme, path=("Civil engineering",),
+                                path_ar=("الهندسة المدنية",))
+    taxonomy.link(conn, generic_record_id=1, node_id=node,
+                  group_key="licensed_activities", source_snapshot_id=1)
+    conn.commit()
+
+    interests = taxonomy.memberships(conn, 1, group_key="interests")
+    licences = taxonomy.memberships(conn, 1, group_key="licensed_activities")
+
+    assert len(interests) == 25
+    assert len(licences) == 1
+    assert len(taxonomy.memberships(conn, 1)) == 26
+
+
+def test_one_node_can_be_held_in_two_groups_at_once(conn):
+    """WHY `group_key` IS IN THE PRIMARY KEY. The same activity is a legitimate interest
+    AND a legitimate licence, and a key of `(record, node)` alone would silently merge
+    two different facts into one row."""
+    scheme = _scheme(conn)
+    node = taxonomy.ensure_path(conn, scheme, path=("Civil engineering",),
+                                path_ar=("الهندسة المدنية",))
+
+    assert taxonomy.link(conn, generic_record_id=1, node_id=node,
+                         group_key="interests", source_snapshot_id=1) is True
+    assert taxonomy.link(conn, generic_record_id=1, node_id=node,
+                         group_key="licensed_activities", source_snapshot_id=1) is True
+    conn.commit()
+
+    assert _count(conn, "generic_record_node") == 2
+
+
+# ---- what F's advantage was, carried over ------------------------------------
+
+def test_a_membership_without_its_evidence_is_refused_by_the_schema(conn):
+    """F'S ONE REAL ADVANTAGE, AND `R-36` SAYS IT MUST BE CARRIED OVER.
+    `generic_record.source_snapshot_id NOT NULL` is what makes provenance enforced rather
+    than remembered; the link table carries the same column under the same constraint."""
+    scheme = _scheme(conn)
+    node = taxonomy.ensure_path(conn, scheme, path=("x",), path_ar=("س",))
+
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO generic_record_node "
+            "(generic_record_id, node_id, group_key) VALUES (?,?,?)",
+            (1, node, "interests"))
+    conn.rollback()
+
+
+def test_the_evidence_must_be_a_page_that_exists(conn):
+    """NOT NULL is half of it; the foreign key is the other half. A snapshot id nobody
+    stored is a claim wearing the clothes of a reading."""
+    scheme = _scheme(conn)
+    node = taxonomy.ensure_path(conn, scheme, path=("x",), path_ar=("س",))
+
+    with pytest.raises(sqlite3.IntegrityError):
+        taxonomy.link(conn, generic_record_id=1, node_id=node,
+                      group_key="interests", source_snapshot_id=9999)
+    conn.rollback()
+
+
+def test_deleting_a_contractor_takes_its_memberships(conn):
+    """`OP-25` was settled by WIPING `generic_record` and re-approving from disk — 1,172
+    rows became 13,892 with zero network — so deletion is a route this warehouse actually
+    takes, and links that survived it would point at nothing."""
+    _store_the_interests(conn)
+
+    conn.execute("DELETE FROM generic_record WHERE record_key = 'contractor-1'")
+    conn.commit()
+
+    assert _count(conn, "generic_record_node") == 0
+    assert _count(conn, "classification_node") == 25, (
+        "the VOCABULARY survives a wipe — it is the site's, not the contractor's")
+
+
+# ---- idempotency, by construction --------------------------------------------
+
+def test_a_second_identical_pass_writes_nothing_new(conn):
+    """`R-36`'s fourth reason for D. Shape F would have gone through
+    `approve_candidate`, whose idempotency key `R-38` had to repair; here the primary key
+    makes a duplicate impossible even for a caller that forgot to check."""
+    first = _store_the_interests(conn)
+    second = _store_the_interests(conn)
+
+    assert (first, second) == (25, 0)
+    assert _count(conn, "generic_record_node") == 25
+    assert _count(conn, "classification_node") == 25
+
+
+def test_a_repeat_is_counted_rather_than_timed(conn):
+    """THE CLOCK CANNOT ANSWER THIS, and the first version of `link` tried. Both
+    timestamps come from `strftime(...,'now')` at SECOND resolution, so a write and its
+    confirmation in the same second are indistinguishable — measured, a second identical
+    pass reported all 25 memberships as new."""
+    _store_the_interests(conn)
+    _store_the_interests(conn)
+
+    counts = dict(conn.execute(
+        "SELECT seen_count, COUNT(*) FROM generic_record_node GROUP BY 1").fetchall())
+
+    assert counts == {2: 25}
+
+
+# ---- the pairing, and what it refuses ----------------------------------------
+
+def test_two_locales_that_do_not_line_up_are_refused(conn):
+    """WRITING ANYWAY WOULD ATTACH AN ENGLISH NAME TO A DIFFERENT ARABIC NODE, and
+    nothing would raise. `DSN-05` is the same failure one level up."""
+    scheme = _scheme(conn)
+
+    with pytest.raises(CannotPairLocales):
+        taxonomy.ensure_path(conn, scheme, path=("a", "b"), path_ar=("س",))
+
+
+def test_the_arabic_name_is_the_identity_and_the_english_fills_in_later(conn):
+    """THE SCHEMA CHOSE THIS, not this module: `node_name_ar` is NOT NULL and carries
+    `ux_classification_node_name`, while `node_name` is nullable. So a node first seen on
+    an Arabic-only reading is the SAME node when the English arrives — matching on the
+    English would make it two nodes depending on which locale came first."""
+    scheme = _scheme(conn)
+
+    first = taxonomy.ensure_path(conn, scheme, path=("",), path_ar=("الهندسة المدنية",))
+    second = taxonomy.ensure_path(conn, scheme, path=("Civil engineering",),
+                                  path_ar=("الهندسة المدنية",))
+    conn.commit()
+
+    assert first == second
+    assert _count(conn, "classification_node") == 1
+    assert conn.execute(
+        "SELECT node_name FROM classification_node WHERE node_id = ?",
+        (first,)).fetchone()[0] == "Civil engineering"
+
+
+def test_the_same_name_under_two_parents_is_two_nodes(conn):
+    """THE STUDY'S FINDING, GUARDED. `الصرف الصحي` sits under more than one parent, and
+    an identity built from the leaf name would merge two different activities. The
+    committed profile proves it too: `Construction of buildings` is a level-1 node and a
+    level-2 node beneath itself."""
+    scheme = _scheme(conn)
+
+    under_a = taxonomy.ensure_path(conn, scheme, path=("A", "shared"),
+                                   path_ar=("أ", "مشترك"))
+    under_b = taxonomy.ensure_path(conn, scheme, path=("B", "shared"),
+                                   path_ar=("ب", "مشترك"))
+    conn.commit()
+
+    assert under_a != under_b
+    assert _count(conn, "classification_node") == 4

--- a/tests/test_a_corrected_parser_rewrites_instead_of_recovering.py
+++ b/tests/test_a_corrected_parser_rewrites_instead_of_recovering.py
@@ -1,0 +1,234 @@
+"""DEC-10: "fix the parser and re-run over the snapshots" did not actually work.
+
+WHAT WAS WRONG. `approve_candidate`'s idempotency key was `(source_snapshot_id,
+source_locator)` plus the schema hash. **Nothing in it describes the VALUES**, so a parser
+that had been corrected — same page, same columns, different data — matched the existing
+ingestion, answered `recovered=True` and wrote not one row.
+
+WHY IT IS FIXED NOW RATHER THAN LATER, and it is his ruling
+[R-38](../docs/RULINGS.md): on the listing it was survivable, because 871 pages are cheap
+to fetch again. `R-37` registers the profile crawl, and that is **34,834 pages at about
+11.1 hours measured** — so a parser defect found afterwards would cost a re-crawl to
+repair what should be a re-parse. `docs/GENERIC-FETCH-SEAM.md` exists exactly so a wrong
+parse costs minutes; a key that refuses to rewrite a corrected row hands the cost back.
+
+THE FIX ADDS NO COLUMN, AND THE FIRST ATTEMPT DID. It put a `rows_hash` on
+`generic_ingestion` — and that table is **append-only in both directions** and **UNIQUE on
+`(source_snapshot_id, source_locator)`**, so the digest would have been unwritable after
+the first insert and there can never be a second ingestion for one page. The schema was
+saying, correctly, that "this page was ingested" happened once and is not revisable.
+
+`generic_record.content_hash` already holds the fact per row, and the write path already
+reads it to decide whether to write a revision. So the recovery short-circuit simply asks
+the same question one step earlier, and a changed parse **falls through to the write path
+that was always there** — a path that is already right, because the upsert is idempotent
+and `R-20` writes a revision only for a real change.
+"""
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import pytest
+
+from scrapex.databases import DatabaseRegistry, EngineDatabase
+from scrapex.extract import service
+from scrapex.extract.models import (
+    ApprovalField,
+    CandidateApproval,
+    ExtractionConflict,
+    SnapshotCreate,
+)
+from scrapex.extract.muqawil import listing_candidate
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "muqawil"
+LISTING = (FIXTURES / "listing-en.html").read_text(encoding="utf-8")
+URL = "https://muqawil.org/en/contractors?page=1"
+
+
+@pytest.fixture()
+def conn(tmp_path: Path):
+    registry = DatabaseRegistry(EngineDatabase(tmp_path / "scrapex-engine.db"),
+                                pointer_file=tmp_path / "databases.json")
+    registry.initialize()
+    connection = registry.engine.connect()
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def _snapshot(conn) -> int:
+    saved = service.save_snapshot(
+        conn, SnapshotCreate(source_url=URL, html_content=LISTING))
+    return int(saved["page_snapshot_id"])
+
+
+def _approval(candidate) -> CandidateApproval:
+    return CandidateApproval(
+        table_index=0, site_key="muqawil_org",
+        site_display_name="Saudi Contractors Authority",
+        dataset_key="contractors", dataset_name="Contractors",
+        fields=[ApprovalField(field_key=f.field_key, display_name=f.source_name,
+                              data_type="text",
+                              identity=(f.field_key == "contractor_id"))
+                for f in candidate.fields])
+
+
+def _corrected(candidate, field: str, value: str):
+    """THE SAME PAGE PARSED BETTER. Identical fields, identical identity, one column's
+    values different — which is what fixing a parser looks like and is exactly the case
+    the old key could not see.
+
+    Not a new field: that is `R-31`'s case and opens a version. Not a missing one: that
+    is refused. This is the case in between, which had no behaviour at all.
+    """
+    return dataclasses.replace(
+        candidate,
+        rows=[{**row, field: f"{value}{n}"} for n, row in enumerate(candidate.rows)])
+
+
+def _values(conn, field: str) -> list[str]:
+    import json
+
+    return [json.loads(row[0]).get(field) for row in conn.execute(
+        "SELECT data_json FROM generic_record ORDER BY record_key")]
+
+
+def _revisions(conn) -> int:
+    return conn.execute("SELECT COUNT(*) FROM generic_record_revision").fetchone()[0]
+
+
+def _ingestions(conn) -> list[tuple]:
+    return [tuple(row) for row in conn.execute(
+        "SELECT generic_ingestion_id, record_count "
+        "  FROM generic_ingestion ORDER BY generic_ingestion_id")]
+
+
+# ---- the case the feature exists for ------------------------------------------
+
+def test_a_corrected_parser_writes_its_new_values(conn):
+    """THE WHOLE DEFECT IN ONE TEST. Same snapshot, same locator, same schema, better
+    values — and it used to change nothing at all."""
+    snapshot = _snapshot(conn)
+    original = listing_candidate(LISTING)
+    service.approve_candidate(conn, snapshot, _approval(original),
+                              candidate=original)
+    before = _values(conn, "card_city_region")
+
+    fixed = _corrected(original, "card_city_region", "RIYADH - Riyadh #")
+    result = service.approve_candidate(conn, snapshot, _approval(fixed),
+                                       candidate=fixed)
+
+    assert result["recovered"] is False, "it must not report a no-op"
+    assert result["reparsed"] is True, "and it must say the page had been seen before"
+    after = _values(conn, "card_city_region")
+    assert after != before
+    assert all(value.startswith("RIYADH - Riyadh #") for value in after)
+
+
+def test_the_change_is_recorded_as_history(conn):
+    """`R-20` MEETS `R-38`. A re-parse that changed values writes a revision per changed
+    row, so "when did this column change" stays answerable — which is the whole reason
+    R-20 stopped writing a revision for every unchanged row."""
+    snapshot = _snapshot(conn)
+    original = listing_candidate(LISTING)
+    service.approve_candidate(conn, snapshot, _approval(original),
+                              candidate=original)
+    first = _revisions(conn)
+
+    fixed = _corrected(original, "card_city_region", "CORRECTED ")
+    service.approve_candidate(conn, snapshot, _approval(fixed), candidate=fixed)
+
+    assert _revisions(conn) > first
+
+
+def test_an_identical_re_approval_still_writes_nothing(conn):
+    """THE OTHER DIRECTION, so the fix cannot pass by simply rewriting always. A genuine
+    re-run of the same parser over the same page is a no-op, and `R-20` means no
+    revision is written for it either."""
+    snapshot = _snapshot(conn)
+    candidate = listing_candidate(LISTING)
+    service.approve_candidate(conn, snapshot, _approval(candidate),
+                              candidate=candidate)
+    revisions = _revisions(conn)
+    ingestions = _ingestions(conn)
+
+    result = service.approve_candidate(conn, snapshot, _approval(candidate),
+                                       candidate=candidate)
+
+    assert result["recovered"] is True
+    assert _revisions(conn) == revisions
+    assert _ingestions(conn) == ingestions, "no second ingestion for a no-op"
+
+
+def test_a_reparse_does_not_claim_a_second_ingestion(conn):
+    """THE SCHEMA IS WHAT DECIDES THIS, and it is why the first design was wrong.
+    `generic_ingestion` is UNIQUE on `(source_snapshot_id, source_locator)` and
+    append-only in both directions — so "this page was ingested" happened once and cannot
+    be revised or repeated. A re-parse changes the ROWS, and their history belongs in
+    `generic_record_revision`.
+    """
+    snapshot = _snapshot(conn)
+    original = listing_candidate(LISTING)
+    service.approve_candidate(conn, snapshot, _approval(original),
+                              candidate=original)
+    before = _ingestions(conn)
+
+    fixed = _corrected(original, "card_city_region", "CORRECTED ")
+    result = service.approve_candidate(conn, snapshot, _approval(fixed),
+                                       candidate=fixed)
+
+    assert _ingestions(conn) == before, "one ingestion per page, ever"
+    assert result["generic_ingestion_id"] == before[0][0], (
+        "and the result names the ingestion that exists, not a row that was refused")
+
+
+def test_a_row_the_first_pass_missed_counts_as_a_change(conn):
+    """A CORRECTED PARSER OFTEN FINDS MORE, not different. Every row it shares with the
+    first pass is identical, so comparing values alone would call that unchanged — which
+    is why the count is compared too."""
+    snapshot = _snapshot(conn)
+    original = listing_candidate(LISTING)
+    fewer = dataclasses.replace(original, rows=original.rows[:-1])
+    service.approve_candidate(conn, snapshot, _approval(fewer), candidate=fewer)
+    assert len(_values(conn, "contractor_id")) == len(original.rows) - 1
+
+    result = service.approve_candidate(conn, snapshot, _approval(original),
+                                       candidate=original)
+
+    assert result["recovered"] is False
+    assert len(_values(conn, "contractor_id")) == len(original.rows)
+
+
+# ---- what must not change -----------------------------------------------------
+
+def test_a_different_identity_is_still_a_conflict(conn):
+    """The row digest is a NEW condition, not a replacement for the old ones. Approving
+    the same page into a different dataset is still refused, because that is a mistake
+    rather than a corrected parse."""
+    snapshot = _snapshot(conn)
+    candidate = listing_candidate(LISTING)
+    service.approve_candidate(conn, snapshot, _approval(candidate),
+                              candidate=candidate)
+
+    elsewhere = CandidateApproval(
+        table_index=0, site_key="muqawil_org",
+        site_display_name="Saudi Contractors Authority",
+        dataset_key="engineers", dataset_name="Engineers",
+        fields=_approval(candidate).fields)
+
+    with pytest.raises(ExtractionConflict):
+        service.approve_candidate(conn, snapshot, elsewhere, candidate=candidate)
+
+
+def test_a_first_approval_is_not_reported_as_a_reparse(conn):
+    """`reparsed` means "this page had been ingested before". A first approval must not
+    claim it, or a caller counting re-parses counts every page."""
+    snapshot = _snapshot(conn)
+    candidate = listing_candidate(LISTING)
+
+    result = service.approve_candidate(conn, snapshot, _approval(candidate),
+                                       candidate=candidate)
+
+    assert (result["recovered"], result["reparsed"]) == (False, False)

--- a/tests/test_a_corrected_parser_rewrites_instead_of_recovering.py
+++ b/tests/test_a_corrected_parser_rewrites_instead_of_recovering.py
@@ -6,8 +6,8 @@ that had been corrected — same page, same columns, different data — matched 
 ingestion, answered `recovered=True` and wrote not one row.
 
 WHY IT IS FIXED NOW RATHER THAN LATER, and it is his ruling
-[R-38](../docs/RULINGS.md): on the listing it was survivable, because 871 pages are cheap
-to fetch again. `R-37` registers the profile crawl, and that is **34,834 pages at about
+[R-40](../docs/RULINGS.md): on the listing it was survivable, because 871 pages are cheap
+to fetch again. `R-39` registers the profile crawl, and that is **34,834 pages at about
 11.1 hours measured** — so a parser defect found afterwards would cost a re-crawl to
 repair what should be a re-parse. `docs/GENERIC-FETCH-SEAM.md` exists exactly so a wrong
 parse costs minutes; a key that refuses to rewrite a corrected row hands the cost back.
@@ -128,7 +128,7 @@ def test_a_corrected_parser_writes_its_new_values(conn):
 
 
 def test_the_change_is_recorded_as_history(conn):
-    """`R-20` MEETS `R-38`. A re-parse that changed values writes a revision per changed
+    """`R-20` MEETS `R-40`. A re-parse that changed values writes a revision per changed
     row, so "when did this column change" stays answerable — which is the whole reason
     R-20 stopped writing a revision for every unchanged row."""
     snapshot = _snapshot(conn)

--- a/tests/test_a_delisted_contractor_is_marked_and_a_returning_one_is_not.py
+++ b/tests/test_a_delisted_contractor_is_marked_and_a_returning_one_is_not.py
@@ -51,7 +51,7 @@ def _log_somewhere_harmless(tmp_path, monkeypatch):
     the owner's live log, interleaved with a real crawl's output, where they read as the
     crawl refusing to mark departures.
 
-    The behaviour predates this file, so it is recorded as `OP-39` rather than changed
+    The behaviour predates this file, so it is recorded as `OP-41` rather than changed
     here. What this fixture fixes is the part these tests are responsible for.
     """
     from scrapex import contractors

--- a/tests/test_a_group_is_named_by_a_declaration.py
+++ b/tests/test_a_group_is_named_by_a_declaration.py
@@ -1,6 +1,6 @@
-"""`R-39`: a repeating group is named by a DECLARED map, and all three alternatives fail.
+"""`R-41`: a repeating group is named by a DECLARED map, and all three alternatives fail.
 
-`R-36` needs to know which of `R-19`'s groups a row belongs to. Three rules suggest
+`R-38` needs to know which of `R-19`'s groups a row belongs to. Three rules suggest
 themselves and every one of them was measured against the committed profile:
 
 | rule | why it fails |

--- a/tests/test_a_group_is_named_by_a_declaration.py
+++ b/tests/test_a_group_is_named_by_a_declaration.py
@@ -1,0 +1,209 @@
+"""`R-39`: a repeating group is named by a DECLARED map, and all three alternatives fail.
+
+`R-36` needs to know which of `R-19`'s groups a row belongs to. Three rules suggest
+themselves and every one of them was measured against the committed profile:
+
+| rule | why it fails |
+|---|---|
+| the detector's own name | `Table 1` … `Table 5` — that is position, and position moves |
+| the nearest heading | three of the five tables share one, and for two of them the nearest heading is a **tab button belonging to a different section** |
+| the column signature | two tables carry the same `# / الإسم` pair, and both are **empty**, so there is not even a row to tell them apart |
+
+So each site declares it, the way `CARD_FIELDS` and `PROFILE_FIELD_ORDER` already declare
+what a listing and a profile publish.
+
+TWO MEASUREMENTS MAKE THE DECLARATION SAFE, AND THEY POINT OPPOSITE WAYS.
+Every table header and every contractor-tab label is **identical in both locales** —
+Arabic even on the English page — so a selector built on that text is locale-stable. The
+interests card is **not**: it reads `Interests` in English and `الأنشطة` in Arabic, which
+is not a translation of it. So that one is located structurally and the rest by their
+untranslated text, and this file asserts both facts rather than trusting either.
+
+AND WHAT COULD NOT BE FOUND IS DECLARED TOO. `R-19` names five groups; two of them are
+listing FILTER axes and not profile sections, one is two groups in separate tabs, and the
+technical-rating tab holds no table at all. Recording that keeps "we could not find it"
+from becoming a silently shorter list — which is how a build covers four of five groups
+and reports success.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from bs4 import BeautifulSoup
+
+from scrapex.extract.html_table import detect_html_tables
+from scrapex.extract.muqawil import (
+    GROUPS_NOT_LOCATED,
+    MULTI_VALUED_GROUPS,
+    locate_group,
+)
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "muqawil"
+
+
+def _html(locale: str) -> str:
+    return (FIXTURES / f"profile-{locale}.html").read_text(encoding="utf-8")
+
+
+def _size(element, kind: str) -> int:
+    if element is None:
+        return -1
+    return len(element.select("tbody tr" if kind == "table" else "li.list-item"))
+
+
+# ---- the declaration works, and identically in both locales -------------------
+
+def test_every_declared_group_is_found_on_the_profile():
+    located = {group.key: locate_group(_html("en"), group.key) is not None
+               for group in MULTI_VALUED_GROUPS}
+
+    assert located == dict.fromkeys(located, True), located
+    assert len(MULTI_VALUED_GROUPS) == 5
+
+
+def test_both_locales_locate_the_same_groups_with_the_same_sizes():
+    """THE PARITY THAT CATCHES A LOCALE-DEPENDENT SELECTOR. It is the assertion that
+    found the interests bug: a title-based rule read 25 nodes from English and 0 from
+    Arabic, and nothing else would have noticed."""
+    english = {g.key: _size(locate_group(_html("en"), g.key), g.kind)
+               for g in MULTI_VALUED_GROUPS}
+    arabic = {g.key: _size(locate_group(_html("ar"), g.key), g.kind)
+              for g in MULTI_VALUED_GROUPS}
+
+    assert english == arabic
+    assert english["interests"] == 25
+    assert english["licensed_activities"] == 6
+
+
+def test_three_of_the_five_are_empty_and_that_is_a_real_state():
+    """`R-19`'s own "one contractor" limit, from the other side. Two contractor lists and
+    the contract-counts table are the groups this contractor barely fills — so a build
+    verified against this fixture alone proves very little about them."""
+    sizes = {g.key: _size(locate_group(_html("en"), g.key), g.kind)
+             for g in MULTI_VALUED_GROUPS}
+
+    assert sizes["sub_contractors"] == 0
+    assert sizes["main_contractors"] == 0
+    assert sizes["contract_counts"] == 1
+
+
+# ---- the two measurements the selectors rest on ------------------------------
+
+def test_the_table_headers_are_not_translated_which_is_what_makes_them_usable():
+    """A SELECTOR ON CONTENT IS ONLY SAFE IF THE CONTENT IS STABLE, and here it is —
+    measured, not assumed. Every table header is the same string on both pages."""
+    headers = {}
+    for locale in ("en", "ar"):
+        soup = BeautifulSoup(_html(locale), "html.parser")
+        headers[locale] = [
+            [th.get_text(" ", strip=True) for th in table.select("th")]
+            for table in soup.find_all("table")]
+
+    assert headers["en"] == headers["ar"]
+    assert "الأنشطة المرخصة" in headers["en"][0]
+
+
+def test_the_interests_card_title_IS_translated_which_is_why_it_is_structural():
+    """THE OPPOSITE MEASUREMENT, and it is why one group is declared differently from
+    the other four. `Interests` and `الأنشطة` are not translations of each other, so a
+    title-based selector reads one locale and silently misses the other."""
+    titles = {}
+    for locale in ("en", "ar"):
+        card = locate_group(_html(locale), "interests")
+        titles[locale] = card.select_one("h3.card-title").get_text(strip=True)
+
+    assert titles["en"] == "Interests"
+    assert titles["ar"] == "الأنشطة"
+
+    interests = next(g for g in MULTI_VALUED_GROUPS if g.key == "interests")
+    assert "Interests" not in interests.selector, (
+        "the interests selector must not name a title — that is the bug it exists to "
+        "avoid")
+
+
+def test_the_two_identical_tables_are_separated_by_an_id_and_nothing_else():
+    """WHY A DECLARATION AND NOT A SIGNATURE. These two carry the same headers and both
+    are empty, so an id is the only thing that distinguishes them — which is exactly what
+    a declared selector can say and a heuristic cannot."""
+    soup = BeautifulSoup(_html("en"), "html.parser")
+    sub = locate_group(_html("en"), "sub_contractors")
+    main = locate_group(_html("en"), "main_contractors")
+
+    assert [th.get_text(strip=True) for th in sub.select("th")] == \
+           [th.get_text(strip=True) for th in main.select("th")]
+    assert sub.find_parent("div", class_="tab-pane").get("id") == "contractor-tab2"
+    assert main.find_parent("div", class_="tab-pane").get("id") == "contractor-tab3"
+    # THE BUTTON IS WHAT NAMES THE PANE, and it points at it with `data-bs-target` — not
+    # `href`, which the first version of this assertion assumed and which matches nothing
+    # on the page. The evidence for calling this group `sub_contractors` is that label, so
+    # the test reads it rather than trusting the name we gave it.
+    assert soup.select_one('[data-bs-target="#contractor-tab2"]').get_text(
+        strip=True) == "المقاولين بالباطن"
+    assert soup.select_one('[data-bs-target="#contractor-tab3"]').get_text(
+        strip=True) == "المقاولين الرئيسيين"
+
+
+def test_the_detectors_own_names_are_positional_so_none_is_used():
+    """PINS THE REASON the map exists at all."""
+    assert [table.name for table in detect_html_tables(_html("en"))] == [
+        f"Table {n}" for n in range(1, 6)]
+    assert not any(group.key.startswith("table") for group in MULTI_VALUED_GROUPS)
+
+
+# ---- the failure modes --------------------------------------------------------
+
+def test_an_undeclared_key_says_what_is_declared_and_what_was_not_found():
+    with pytest.raises(KeyError) as raised:
+        locate_group(_html("en"), "qualification_programs")
+
+    said = str(raised.value)
+    assert "interests" in said, "it must list what IS declared"
+    assert "qualification_programs" in said, "and name why this one is not"
+
+
+def test_a_selector_that_stopped_being_unique_is_refused():
+    """A selector matching twice has stopped being a declaration, and picking the first
+    would read one group's values as another's."""
+    doubled = (
+        "<html><body>"
+        "<div id='contractor-tab2'><table><tr><th>#</th></tr></table></div>"
+        "<div id='contractor-tab2'><table><tr><th>#</th></tr></table></div>"
+        "</body></html>")
+
+    with pytest.raises(ValueError) as raised:
+        locate_group(doubled, "sub_contractors")
+
+    assert "no longer a declaration" in str(raised.value)
+
+
+def test_a_profile_without_the_group_answers_none_rather_than_raising():
+    """Three of five are empty here and two render nothing at all, so a missing section
+    is the common case — an exception would make one absence break a whole profile."""
+    assert locate_group("<html><body></body></html>", "interests") is None
+
+
+# ---- and what R-19 names that the page does not publish -----------------------
+
+def test_what_could_not_be_located_is_declared_rather_than_dropped():
+    """"We could not find it" has to be a recorded fact. Otherwise the list is quietly
+    shorter and a build covers four of five groups while reporting success."""
+    keys = {key for key, _ in GROUPS_NOT_LOCATED}
+
+    assert {"qualification_programs", "balady_services"} <= keys
+    reasons = dict(GROUPS_NOT_LOCATED)
+    assert "lc_program_list_id" in reasons["qualification_programs"]
+    assert "balady_service_id" in reasons["balady_services"]
+    assert "contractor-tab4" in reasons["technical_rating"]
+
+
+def test_the_declared_and_the_unlocated_do_not_overlap():
+    """A group cannot be both found and not found, and a name in both lists would make
+    every count computed from them wrong."""
+    declared = {group.key for group in MULTI_VALUED_GROUPS}
+    missing = {key for key, _ in GROUPS_NOT_LOCATED}
+
+    assert declared & missing == set()
+    # R-19 names five groups; the page publishes five, and they are not the same five.
+    assert len(declared) == 5
+    assert len(missing) == 3

--- a/tests/test_muqawil_pagesource.py
+++ b/tests/test_muqawil_pagesource.py
@@ -268,15 +268,37 @@ def test_naming_no_city_refuses_rather_than_answering_no(source):
         source.belongs_to_slice(listing("en"), 0, "  ")
 
 
-def test_a_listing_that_stopped_publishing_the_city_refuses(source):
-    """The same reasoning one level down: a moved marker must not read as a
-    smaller city."""
+def test_a_card_without_a_city_is_in_no_city_rather_than_a_refusal(source):
+    """THIS TEST USED TO DEMAND A REFUSAL, AND THE BELIEF BEHIND IT WAS MEASURED FALSE.
+
+    It read: *"a moved marker must not read as a smaller city"* — sound reasoning, and
+    unable to tell a moved marker from a contractor that publishes no location. The cost
+    was real: on 2026-08-21 a crawl that had closed four cells with `D = 0` ended on one
+    card without a city.
+
+    Then the rule was narrowed to "refuse only if NO card on the page has one", which
+    looked like the measurable distinction. It is not. `region_id=0` is muqawil's
+    no-location partition — the fact `#234` recorded when its 74 pages taught 21 fields
+    against a declared 22 — and measured on stored pages: **`region_id=0` carries 17 and
+    20 cards with ZERO city icons**, while `region_id=1` carries 20 of 20. A whole page
+    without a city is legitimate here.
+
+    So a cityless card is in no named city, and the moved-marker signal lives where it can
+    actually be seen: `detail_frontier` reports the rows it examined against the rows it
+    matched, and nothing matching anywhere is the symptom.
+    """
     moved = FetchedPage(url=listing().url,
                         html=listing().html.replace("icon-locaion", "icon-where"),
                         kind=PageKind.LISTING)
 
-    with pytest.raises(SliceNotSupported, match="city marker has moved"):
-        source.belongs_to_slice(moved, 0, "RIYADH")
+    assert source.belongs_to_slice(moved, 0, "RIYADH") is False
+
+
+def test_a_row_that_does_not_exist_is_still_a_refusal(source):
+    """WHAT DID NOT CHANGE, and it must not: an index past the last card is a CALLER
+    error, and `supports_slices` relies on that refusal to probe an empty page."""
+    with pytest.raises(SliceNotSupported, match="does not exist"):
+        source.belongs_to_slice(listing(), 999, "RIYADH")
 
 
 def test_the_walker_can_ask_up_front_whether_slicing_is_available(source):

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -173,7 +173,7 @@ PINNED = (
     # OP-34 · why a black window leaves no trace. The whole finding is that this
     # function DELIBERATELY does nothing when it has real streams, which is the
     # double-click case -- so the log is not evidence about a failed launch.
-    ("docs/BACKLOG.md", "scrapex/cli.py", 940, "def _bind_log_streams("),
+    ("docs/BACKLOG.md", "scrapex/cli.py", 976, "def _bind_log_streams("),
     # OP-35 · the hand-maintained command set that drifted to half the CLI.
     # The entry says "do not extend the literal, derive it", which only makes
     # sense standing at the literal.

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -111,12 +111,12 @@ PINNED = (
      "return set(other.params) <= set(self.params)"),
     # The version-gate blocker. Track 3 of STATE.md cannot be worked without
     # these three, and two of them are the citations that drifted.
-    ("docs/STATE.md", "scrapex/version.py", 477, '"latest_extension_version": VERSION'),
+    ("docs/STATE.md", "scrapex/version.py", 483, '"latest_extension_version": VERSION'),
     ("docs/STATE.md", "scrapex/webui/app.py", 1459, '"latest_extension_version": VERSION'),
     ("docs/STATE.md", "extension/app.js", 599, "latest_extension_version"),
     ("docs/STATE.md", "scrapex/version.py", 76, 'VERSION = "'),
     ("docs/RULINGS.md", "scrapex/webui/app.py", 1459, '"latest_extension_version": VERSION'),
-    ("docs/RULINGS.md", "scrapex/version.py", 477, '"latest_extension_version": VERSION'),
+    ("docs/RULINGS.md", "scrapex/version.py", 483, '"latest_extension_version": VERSION'),
     # The two flags whose condition is met and whose lighting is the owner's call.
     ("docs/STATE.md", "scrapex/features.py", 54, "True"),
     ("docs/STATE.md", "scrapex/features.py", 65, "True"),

--- a/tests/test_the_profile_frontier_comes_off_the_disk.py
+++ b/tests/test_the_profile_frontier_comes_off_the_disk.py
@@ -358,7 +358,7 @@ def test_the_stored_profile_is_labelled_as_a_profile(conn, monkeypatch):
 
 # ---- a slice is named in ONE language, and the scan has to know that ----------
 #
-# `R-37` RECORDS THE MEASUREMENT THAT PRODUCED THIS. `belongs_to_slice` compares the
+# `R-39` RECORDS THE MEASUREMENT THAT PRODUCED THIS. `belongs_to_slice` compares the
 # slice value against the card's own city text, and the card is in the page's language:
 #
 #     en page, slice 'RIYADH'  -> 3 of 4 cards match

--- a/tests/test_the_profile_frontier_comes_off_the_disk.py
+++ b/tests/test_the_profile_frontier_comes_off_the_disk.py
@@ -354,3 +354,107 @@ def test_the_stored_profile_is_labelled_as_a_profile(conn, monkeypatch):
     details(conn, get_directory(None), _fetch_recording([]), None, "p1")
 
     assert seen == ["muqawil.org/detail", "muqawil.org/detail"]
+
+
+# ---- a slice is named in ONE language, and the scan has to know that ----------
+#
+# `R-37` RECORDS THE MEASUREMENT THAT PRODUCED THIS. `belongs_to_slice` compares the
+# slice value against the card's own city text, and the card is in the page's language:
+#
+#     en page, slice 'RIYADH'  -> 3 of 4 cards match
+#     en page, slice 'الرياض'  -> 0 of 4
+#     ar page, slice 'RIYADH'  -> 0 of 4
+#     ar page, slice 'الرياض'  -> 3 of 4
+#
+# Scanning every stored page against one value therefore counts every row of the OTHER
+# locale as "outside the slice". The frontier still came out right — `detail_rows` yields
+# both locales' profile URLs for a matched row — but the report was false, and the whole
+# slice depended on the matching locale's pages happening to be on disk.
+
+def _both_locales_stored(conn) -> None:
+    for locale in ("en", "ar"):
+        conn.execute(
+            "INSERT INTO generic_page_snapshot (source_url, html_content, "
+            " content_hash, crawl_run_ref) VALUES (?,?,?,'listing-1')",
+            (f"https://muqawil.org/{locale}/contractors?page=1",
+             (FIXTURES / f"listing-{locale}.html").read_text(encoding="utf-8"),
+             f"h-{locale}"))
+    conn.commit()
+
+
+def test_the_other_locales_rows_are_not_counted_as_outside_the_slice(conn):
+    """THE FALSE REPORT THIS FIXES. With both locales on disk and an English slice, the
+    Arabic page's rows are not the answer to "how many did we skip" — they were never
+    asked the question."""
+    from scrapex.contractors import detail_frontier
+
+    _registered(conn, "listing_plus_slice", "RIYADH")
+    _both_locales_stored(conn)
+
+    urls, outside = detail_frontier(conn, get_directory(None),
+                                    CrawlScope.LISTING_PLUS_SLICE, "RIYADH")
+
+    english_only, english_outside = detail_frontier(
+        conn, get_directory(None), CrawlScope.LISTING_PLUS_SLICE, "RIYADH")
+    assert urls == english_only
+    # The committed listing has four cards, three of them Riyadh — so exactly one row is
+    # genuinely outside the slice, not one plus the whole Arabic page.
+    assert outside == english_outside == 1
+
+
+def test_the_frontier_is_the_same_whichever_language_the_slice_is_named_in(conn):
+    """THE PROOF THAT SCANNING ONE LOCALE LOSES NOTHING: a matched row yields BOTH
+    locales' profile URLs, so naming the slice in Arabic must produce the identical
+    frontier."""
+    from scrapex.contractors import detail_frontier
+
+    _registered(conn, "listing_plus_slice", "RIYADH")
+    _both_locales_stored(conn)
+
+    english = detail_frontier(conn, get_directory(None),
+                              CrawlScope.LISTING_PLUS_SLICE, "RIYADH")
+    arabic = detail_frontier(conn, get_directory(None),
+                             CrawlScope.LISTING_PLUS_SLICE, "الرياض")
+
+    assert english == arabic
+    assert english[0], "and it is not empty, or this proves nothing"
+
+
+def test_a_slice_that_matches_nothing_says_how_many_rows_it_looked_at(conn):
+    """A CITY WITH NO CONTRACTORS AND A SLICE NAMED IN THE WRONG LANGUAGE both produce an
+    empty frontier, and the examined count is what tells them apart."""
+    from scrapex.contractors import detail_frontier
+
+    _registered(conn, "listing_plus_slice", "ATLANTIS")
+    _both_locales_stored(conn)
+
+    urls, examined = detail_frontier(conn, get_directory(None),
+                                     CrawlScope.LISTING_PLUS_SLICE, "ATLANTIS")
+
+    assert urls == []
+    assert examined == 8, ("four CARDS on each of the two stored pages — rows, not "
+                           "URLs, which is two per card on this site")
+
+
+def test_a_slice_matching_in_two_locales_is_refused(conn):
+    """THE COUNTS WOULD BE THE SUM OF TWO DIFFERENT QUESTIONS. A value that matches in
+    both languages is either a name written the same way in both — which is possible —
+    or a marker that has moved. Adding them up would hide either."""
+    from scrapex.contractors import detail_frontier
+
+    _registered(conn, "listing_plus_slice", "RIYADH")
+    # The SAME English page stored under both locale paths, which is what a value
+    # matching in two locales looks like from disk.
+    listing = (FIXTURES / "listing-en.html").read_text(encoding="utf-8")
+    for locale in ("en", "ar"):
+        conn.execute(
+            "INSERT INTO generic_page_snapshot (source_url, html_content, "
+            " content_hash, crawl_run_ref) VALUES (?,?,?,'listing-1')",
+            (f"https://muqawil.org/{locale}/contractors?page=1", listing, f"h{locale}"))
+    conn.commit()
+
+    with pytest.raises(ValueError) as raised:
+        detail_frontier(conn, get_directory(None),
+                        CrawlScope.LISTING_PLUS_SLICE, "RIYADH")
+
+    assert "more than one locale" in str(raised.value)

--- a/tests/test_the_profile_frontier_comes_off_the_disk.py
+++ b/tests/test_the_profile_frontier_comes_off_the_disk.py
@@ -36,7 +36,7 @@ FIXTURES = Path(__file__).resolve().parent / "fixtures" / "muqawil"
 
 @pytest.fixture(autouse=True)
 def _log_somewhere_harmless(tmp_path, monkeypatch):
-    """`say` appends to the owner's real crawl log otherwise — `OP-39`."""
+    """`say` appends to the owner's real crawl log otherwise — `OP-41`."""
     from scrapex import contractors
 
     monkeypatch.setattr(contractors, "LOG", tmp_path / "contractors.log")

--- a/tests/test_the_registers_cannot_collide.py
+++ b/tests/test_the_registers_cannot_collide.py
@@ -1,0 +1,135 @@
+"""Two sessions cannot take the same register number without the build going red.
+
+WHAT HAPPENED ON 2026-08-21. Two branches were open at once. `#244` recorded `R-36` and
+`R-37`; this session recorded `R-36`, `R-37`, `R-38` and `R-39` for four rulings of his.
+Both were green. Both were mergeable. Merging them produced **two `R-36` and two
+`R-37`**, which makes every citation to either one ambiguous.
+
+NEITHER PROCESS RULE WOULD HAVE CAUGHT IT.
+[R-18](../docs/RULINGS.md) — *merge it when it is green* — sees two green branches.
+[R-37](../docs/RULINGS.md) — *the agent does not merge* — catches it only if a person
+reads both diffs, which is what actually happened and happened by luck: the collision was
+found because he asked for a conflict check. Branch protection would not catch it either;
+both branches were green and up to date. **Git cannot see a semantic conflict, and this
+one is semantic.**
+
+So it becomes a test, which is what `R-15` already says about this documentation system:
+*"the documents are guarded by a test, not by good intentions."*
+
+TWO ASSERTIONS, AND THE SECOND IS THE USEFUL ONE.
+
+  * **No duplicates** — the collision itself.
+  * **No gaps** — which is a stronger signal than it looks. `C4` says a superseded ruling
+    **stays** in place rather than being deleted, so a register is contiguous by
+    construction and a hole means one of two things: a number was skipped, or *this
+    branch does not yet have another session's entries*. The second is exactly the state
+    in which a collision is about to be created. Measured while writing this: on this
+    branch `R` had holes at 36 and 37 — the two numbers `#244` had taken and this branch
+    had not yet seen.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+
+#: The four registers whose entries are `###` headings, which is what makes them
+#: countable. `Q-nn` is deliberately absent: it is written in bold rather than as a
+#: heading, and `Q-14` legitimately appears twice — once as asked and once as answered —
+#: so guarding it would produce a failure that is not a defect.
+REGISTERS = (
+    ("docs/RULINGS.md", "R", "a decision the owner has taken"),
+    ("docs/REQUESTS.md", "REQ", "something the owner asked for"),
+    ("docs/BACKLOG.md", "OP", "an open problem we found"),
+    ("docs/BACKLOG.md", "DEC", "a decision we owe"),
+)
+
+
+def _numbers(document: str, prefix: str) -> list[int]:
+    """Every number this register uses, in the order the file lists them.
+
+    THE PATTERN IS ANCHORED TO A HEADING, not to the bare token. `RULINGS.md` mentions
+    `R-19` dozens of times in prose and links; only a `### R-19 · …` line declares it. A
+    test that counted mentions would report every cross-reference as a duplicate.
+    """
+    text = (ROOT / document).read_text(encoding="utf-8")
+    return [int(found) for found in
+            re.findall(rf"^#{{2,4}} +{prefix}-0*(\d+)", text, re.M)]
+
+
+@pytest.mark.parametrize(("document", "prefix", "what"), REGISTERS,
+                         ids=[f"{prefix}-in-{Path(doc).name}"
+                              for doc, prefix, _ in REGISTERS])
+def test_no_two_entries_share_a_number(document: str, prefix: str, what: str):
+    """THE COLLISION GUARD. Whichever pull request merges second goes red."""
+    numbers = _numbers(document, prefix)
+    repeated = sorted({n for n in numbers if numbers.count(n) > 1})
+
+    assert not repeated, (
+        f"{document} declares {prefix}-{repeated[0]:02d} more than once "
+        f"({len(repeated)} number(s) repeated: {repeated}). Two sessions took the same "
+        f"number for {what}, so a citation to it now names two things. The next free "
+        f"number is {prefix}-{max(numbers) + 1:02d}.")
+
+
+@pytest.mark.parametrize(("document", "prefix", "what"), REGISTERS,
+                         ids=[f"{prefix}-in-{Path(doc).name}"
+                              for doc, prefix, _ in REGISTERS])
+def test_the_numbers_run_without_a_hole(document: str, prefix: str, what: str):
+    """A HOLE MEANS A COLLISION IS COMING, most of the time.
+
+    `C4` keeps a superseded entry in place and marks it, so nothing is ever removed and
+    the sequence is contiguous by construction. A gap therefore means either a number was
+    skipped — in which case the next session will reuse it and collide — or this branch is
+    missing entries another branch has already merged, which is the state a collision is
+    created from.
+
+    Measured 2026-08-21: this branch showed holes at `R-36` and `R-37`, which were exactly
+    the two numbers `#244` had taken and this branch had not yet rebased onto.
+    """
+    numbers = _numbers(document, prefix)
+    assert numbers, f"{document} declares no {prefix}- entries at all"
+    missing = sorted(set(range(1, max(numbers) + 1)) - set(numbers))
+
+    assert not missing, (
+        f"{document} has no {prefix}-{missing[0]:02d} but does have "
+        f"{prefix}-{max(numbers):02d}. Missing: {missing}. Either a number was skipped — "
+        f"and the next session will reuse it — or this branch has not got another "
+        f"branch's entries yet, which is how two sessions end up writing the same one. "
+        f"Rebase onto main before adding {prefix}-{max(numbers) + 1:02d}.")
+
+
+def test_the_guard_reads_the_registers_it_claims_to():
+    """A PARAMETERISED TEST THAT MATCHED NOTHING WOULD PASS EVERY CASE, which is how a
+    guard becomes decoration. This asserts the patterns actually find entries, with
+    floors low enough not to need editing every time one is added."""
+    found = {prefix: len(_numbers(document, prefix))
+             for document, prefix, _ in REGISTERS}
+
+    assert found["R"] >= 39, found
+    assert found["REQ"] >= 27, found
+    assert found["OP"] >= 32, found
+    assert found["DEC"] >= 12, found
+
+
+def test_a_duplicate_would_actually_be_caught(tmp_path: Path):
+    """THE GUARD, MUTATED BY HAND. `_numbers` is the whole of it, so a pattern that
+    silently stopped matching headings would make both tests above vacuous — and this
+    proves the counting distinguishes a real duplicate from a cross-reference.
+    """
+    document = tmp_path / "fake.md"
+    document.write_text(
+        "### R-01 · first\n"
+        "prose citing R-01 and R-02 and R-99 in passing\n"
+        "### R-02 · second\n"
+        "### R-02 · a second session took the same number\n",
+        encoding="utf-8")
+
+    numbers = [int(found) for found in re.findall(
+        r"^#{2,4} +R-0*(\d+)", document.read_text(encoding="utf-8"), re.M)]
+
+    assert numbers == [1, 2, 2], "headings only — the prose mentions must not count"
+    assert sorted({n for n in numbers if numbers.count(n) > 1}) == [2]

--- a/tests/test_the_registers_cannot_collide.py
+++ b/tests/test_the_registers_cannot_collide.py
@@ -36,6 +36,12 @@ import pytest
 
 ROOT = Path(__file__).resolve().parent.parent
 
+#: THIS GUARD BELONGS IN THE DOCS TIER, and unlike the extension case the marker costs
+#: nothing here. A register collision is created by editing a document, so a
+#: documentation-only change is precisely when this must run — the tier and the subject
+#: agree. `test_the_docs_gate_is_complete` asked for it and it is right to.
+pytestmark = pytest.mark.docs
+
 #: The four registers whose entries are `###` headings, which is what makes them
 #: countable. `Q-nn` is deliberately absent: it is written in bold rather than as a
 #: heading, and `Q-14` legitimately appears twice — once as asked and once as answered —
@@ -57,7 +63,7 @@ def _numbers(document: str, prefix: str) -> list[int]:
     """
     text = (ROOT / document).read_text(encoding="utf-8")
     return [int(found) for found in
-            re.findall(rf"^#{{2,4}} +{prefix}-0*(\d+)", text, re.M)]
+            re.findall(rf"^#{{2,4}} +{prefix}-0*(\d+)", text, re.MULTILINE)]
 
 
 @pytest.mark.parametrize(("document", "prefix", "what"), REGISTERS,
@@ -129,7 +135,7 @@ def test_a_duplicate_would_actually_be_caught(tmp_path: Path):
         encoding="utf-8")
 
     numbers = [int(found) for found in re.findall(
-        r"^#{2,4} +R-0*(\d+)", document.read_text(encoding="utf-8"), re.M)]
+        r"^#{2,4} +R-0*(\d+)", document.read_text(encoding="utf-8"), re.MULTILINE)]
 
     assert numbers == [1, 2, 2], "headings only — the prose mentions must not count"
     assert sorted({n for n in numbers if numbers.count(n) > 1}) == [2]

--- a/tests/test_the_registers_cannot_collide.py
+++ b/tests/test_the_registers_cannot_collide.py
@@ -81,6 +81,25 @@ def test_no_two_entries_share_a_number(document: str, prefix: str, what: str):
         f"number is {prefix}-{max(numbers) + 1:02d}.")
 
 
+#: NUMBERS AN OPEN PULL REQUEST ALREADY HOLDS, and why this list has to exist.
+#:
+#: Contiguity is a property of `main`, not of a branch. A branch that deliberately skips a
+#: number to avoid colliding with another session's open pull request CANNOT be contiguous
+#: — and the first version of this guard failed exactly that branch, correctly by its own
+#: rule and unhelpfully in fact.
+#:
+#: So a reservation is DECLARED rather than tolerated, the way `PINNED` declares a citation
+#: in the guard next door. Two things follow: the gap check knows the hole is deliberate,
+#: and the next session reads WHOSE it is instead of reusing it. **Delete the row when that
+#: pull request merges** — a reservation left behind is a permanent hole nobody owns.
+RESERVED: dict[str, dict[int, str]] = {
+    "R": {},
+    "REQ": {},
+    "OP": {39: "#246 claude/engine-self-update", 40: "#246 claude/engine-self-update"},
+    "DEC": {},
+}
+
+
 @pytest.mark.parametrize(("document", "prefix", "what"), REGISTERS,
                          ids=[f"{prefix}-in-{Path(doc).name}"
                               for doc, prefix, _ in REGISTERS])
@@ -98,7 +117,8 @@ def test_the_numbers_run_without_a_hole(document: str, prefix: str, what: str):
     """
     numbers = _numbers(document, prefix)
     assert numbers, f"{document} declares no {prefix}- entries at all"
-    missing = sorted(set(range(1, max(numbers) + 1)) - set(numbers))
+    reserved = RESERVED.get(prefix, {})
+    missing = sorted(set(range(1, max(numbers) + 1)) - set(numbers) - set(reserved))
 
     assert not missing, (
         f"{document} has no {prefix}-{missing[0]:02d} but does have "
@@ -119,6 +139,17 @@ def test_the_guard_reads_the_registers_it_claims_to():
     assert found["REQ"] >= 27, found
     assert found["OP"] >= 32, found
     assert found["DEC"] >= 12, found
+
+
+def test_a_reserved_number_is_not_also_declared():
+    """A RESERVATION AND A HEADING ARE CONTRADICTORY. If a number is both reserved for
+    another branch and declared here, then the collision the reservation exists to avoid
+    has already happened and the gap check is looking the other way."""
+    for document, prefix, _what in REGISTERS:
+        held = set(RESERVED.get(prefix, {}))
+        assert held.isdisjoint(_numbers(document, prefix)), (
+            f"{prefix}: {sorted(held & set(_numbers(document, prefix)))} is reserved for "
+            f"another branch AND declared in {document}")
 
 
 def test_a_duplicate_would_actually_be_caught(tmp_path: Path):

--- a/tests/test_the_sites_own_gaps_do_not_become_false_facts.py
+++ b/tests/test_the_sites_own_gaps_do_not_become_false_facts.py
@@ -1,0 +1,173 @@
+"""Two things the site publishes that must not be stored as if they were true.
+
+BOTH CAME OUT OF ONE QUESTION HE ASKED — whether six named columns were among the 48 —
+and neither was the defect the question looked like. Measuring 712 real Dammam profiles
+retired three suspicions and produced these two instead:
+
+| suspected | measured |
+|---|---|
+| `activity` stores the string `"None"` | it is `None`, the value. The field is genuinely absent on 669 of 712. **Not a defect** |
+| `merge_locales` wrongly refuses 8 pairs | the two locales really do publish 9 labels against 10. The refusal is correct and its reasoning is written. **Not a defect** |
+| `longitude = 0` is a parse failure | the page itself says `var latlang = { lat: 24.4493518, lng: 0 }`. The parser is right. **The defect is storing it** |
+
+AND THE MEASUREMENT FOUND ONE NOBODY HAD SUSPECTED: `read_profile` on an Arabic page
+turned **ten labels into two keys**, because `_slug` kept `[a-z0-9]` only and fell back to
+the constant `"unnamed"` — so every Arabic label produced the same key and eight of ten
+were lost to a dict collision.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scrapex.extract.muqawil import (
+    PROFILE_FIELDS,
+    _slug,
+    merge_locales,
+    read_coordinates,
+    read_profile,
+)
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "muqawil"
+
+
+def _html(locale: str) -> str:
+    return (FIXTURES / f"profile-{locale}.html").read_text(encoding="utf-8")
+
+
+# ---- a label with no ASCII must still get its own key -------------------------
+
+def test_two_arabic_labels_do_not_collapse_into_one_key():
+    """THE COLLISION, WHICH LOST EIGHT FIELDS OF TEN. Measured on a real profile before
+    the fix: `['x_unnamed', 'organization_email']` from ten Arabic labels."""
+    labels = ["رقم العضويه", "العضوية", "عضو منذ", "حجم المنشأة", "المدينة"]
+
+    keys = [_slug(one) for one in labels]
+
+    assert len(set(keys)) == len(labels), dict(zip(labels, keys, strict=True))
+    assert "unnamed" not in keys
+
+
+def test_the_key_is_the_same_next_time_the_same_label_appears():
+    """A POSITIONAL FALLBACK WOULD HAVE SHIFTED. `unnamed_3` is stable only until the
+    site adds a box above it; a digest of the label is stable while the label is."""
+    assert _slug("المدينة") == _slug("المدينة")
+    assert _slug("المدينة") != _slug("المنطقه")
+
+
+def test_an_english_label_is_untouched_by_the_fix():
+    """THE PART THAT MUST NOT MOVE. Every declared key comes from an English label, and a
+    changed slug would silently re-key an approved schema."""
+    assert _slug("Membership Number") == "membership_number"
+    assert _slug("Training credit hours") == "training_credit_hours"
+    assert _slug("Organization Email") == "organization_email"
+
+
+def test_a_blank_label_is_still_the_one_shared_name():
+    """Nothing distinguishes one empty label from another, so they may share a key — and
+    the digest must not be computed over whitespace and produce a false distinction."""
+    assert _slug("") == _slug("   ") == "unnamed"
+
+
+def test_the_arabic_profile_now_keys_every_box_it_publishes():
+    """END TO END on the committed fixture, and the invariant is NOT equality.
+
+    A reading carries keys that no label produced — the email is decoded from
+    `data-cfemail` and has no info-box of its own — so `len(fields) == len(labels)` is the
+    wrong test and the first version of this asserted it and failed at 12 against 11. The
+    fact that matters is that no label was LOST: every one contributed a key of its own.
+    """
+    arabic = read_profile(_html("ar"))
+
+    assert len(arabic.fields) >= len(arabic.labels), (
+        f"{len(arabic.labels)} labels produced only {len(arabic.fields)} keys, so at "
+        "least two collapsed into one")
+    assert len({_slug(one) for one in arabic.labels}) == len(arabic.labels)
+
+
+# ---- a zero coordinate is "no pin", not a place ------------------------------
+
+def test_the_reader_still_reports_the_zero_faithfully():
+    """`read_coordinates` IS NOT THE PLACE TO FIX THIS. It reads what the page says, and
+    the page says `lng: 0`. Source truth is never edited — `DSN-05` keeps the published
+    `"RIYADH - Riyadh"` beside the split for the same reason."""
+    page = ("<html><script>var latlang = { lat: 24.4493518, lng: 0 };"
+            "</script></html>")
+
+    assert read_coordinates(page) == (24.4493518, 0.0)
+
+
+def test_a_zero_longitude_is_not_promoted_to_a_coordinate_column():
+    """MEASURED ON HIS DATA: two of 712 Dammam profiles publish `lng: 0`, both with the
+    SAME latitude — an unset default. Latitude 24.45 with longitude 0 is a point in the
+    Atlantic about 4,000 km from Dammam, and a table whose purpose is to be believed
+    cannot say that."""
+    english = read_profile("<html><script>var latlang = { lat: 24.4493518, lng: 0 };"
+                           "</script></html>")
+
+    merged = merge_locales(english, english)
+
+    assert "latitude" not in merged
+    assert "longitude" not in merged
+
+
+def test_a_real_pair_is_still_stored():
+    """The common case, or the fix above would be a feature that deletes coordinates."""
+    english = read_profile(_html("en"))
+    arabic = read_profile(_html("ar"))
+
+    merged = merge_locales(english, arabic)
+
+    # THE FIXTURE'S FULL PRECISION, not the four decimals a report prints. The first
+    # version of this asserted `"24.6717"` — a truncation read off a summary line — which
+    # is the same class of error as building a fixture from memory.
+    assert merged["latitude"].startswith("24.6716")
+    assert merged["longitude"].startswith("46.394")
+    assert float(merged["latitude"]) and float(merged["longitude"])
+
+
+def test_a_page_with_no_map_at_all_is_unchanged(monkeypatch):
+    """`None` FROM `read_coordinates` ALREADY MEANT "no location", and the new condition
+    must not turn that into an exception or a zero."""
+    english = read_profile("<html><body>no map here</body></html>")
+
+    merged = merge_locales(english, english)
+
+    assert "latitude" not in merged
+
+
+# ---- and what the measurement retired ----------------------------------------
+
+def test_an_absent_field_is_none_and_not_the_string_none():
+    """SUSPECTED AND RETIRED. 669 of 712 profiles carry no `activity`, and the value is
+    `None` rather than the four characters `"None"`. The first measurement applied `str()`
+    and could not tell those apart, which is how a non-defect gets reported as one."""
+    english = read_profile(_html("en"))
+
+    absent = english.fields.get("a_field_this_page_does_not_have")
+
+    assert absent is None
+    assert absent != "None"
+
+
+def test_a_differing_label_count_is_still_refused():
+    """SUSPECTED AND RETIRED. Eight of 712 pairs publish 9 labels against 10, and
+    refusing them is correct: pairing by index across a divergence attaches the wrong
+    Arabic value to every field after it. 704 of 712 — 98.9% — pair cleanly."""
+    english = read_profile(_html("en"))
+    shorter = read_profile(_html("ar"))
+    object.__setattr__(shorter, "labels", tuple(shorter.labels[:-1]))
+
+    with pytest.raises(ValueError, match="pairing them by position"):
+        merge_locales(english, shorter)
+
+
+def test_the_declared_english_labels_still_map_where_they_did():
+    """PROFILE_FIELDS is the declared map from label to key, and `_slug` is only the
+    fallback for a label it does not name. Changing the fallback must not have moved a
+    declared one."""
+    assert PROFILE_FIELDS["Membership Number"] == "membership_number"
+    assert PROFILE_FIELDS["Organization Email"] == "organization_email"
+    assert PROFILE_FIELDS["Member Since"] == "member_since"
+    assert PROFILE_FIELDS["Address"] == "address"

--- a/tests/test_two_warehouses_become_one.py
+++ b/tests/test_two_warehouses_become_one.py
@@ -1,0 +1,342 @@
+"""His ruling of 2026-08-22: the two machines' warehouses merge, and one holder at a time.
+
+BOTH MACHINES HAVE DEVELOPED muqawil, so neither file may be copied over the other — each
+holds work the other does not, and `R-24` says upgrade rather than replace. Drive becomes
+the single source of truth for DATA while the repository stays the single source of truth
+for CODE.
+
+WHAT MAKES THE MERGE DEFINABLE is that the natural keys exist. Measured on his warehouse:
+`generic_page_snapshot` has 20,379 rows and 20,379 distinct `(source_url, content_hash)`,
+and `dataset_sighting` and `generic_record` carry UNIQUE constraints already. Without them
+a merge would mean remapping every autoincrement key and every foreign key pointing at it,
+because both machines hold a `page_snapshot_id = 1` for a different page.
+
+ONLY THE EVIDENCE TRAVELS. Snapshots and sightings cannot be recomputed; everything else is
+rebuilt by `--approve` with no network. So nothing that carries a primary key ever crosses.
+
+AND THE TEST THAT MATTERS MOST IS `test_merging_twice_changes_no_value`. The first version
+of this merge SUMMED `seen_count`, so three merges of the same file took one id from 4 to 8
+to 12 to 16 — while the module's own docstring called the operation idempotent. The test
+that missed it counted ROWS and never looked at a value.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scrapex.databases import DatabaseRegistry, EngineDatabase
+from scrapex.warehousemerge import (
+    NotMergeable,
+    NotYours,
+    claim,
+    holder,
+    merge,
+    release,
+)
+
+
+def _warehouse(path: Path) -> sqlite3.Connection:
+    registry = DatabaseRegistry(EngineDatabase(path),
+                                pointer_file=path.with_suffix(".json"))
+    registry.initialize()
+    conn = registry.engine.connect()
+    conn.execute(
+        "INSERT INTO site_profile (site_key, display_name, base_url) "
+        "VALUES ('muqawil_org','C','https://muqawil.org')")
+    conn.commit()
+    return conn
+
+
+@pytest.fixture()
+def two(tmp_path: Path):
+    """Two warehouses of the same shape, as two machines running the same build."""
+    here = _warehouse(tmp_path / "here.db")
+    there = _warehouse(tmp_path / "there.db")
+    yield here, there, str(tmp_path / "there.db")
+    here.close()
+    there.close()
+
+
+def _page(conn, tag: str, *, body: str = "<html/>") -> None:
+    conn.execute(
+        "INSERT INTO generic_page_snapshot (source_url, html_content, content_hash, "
+        " crawl_run_ref) VALUES (?,?,?,?)",
+        (f"https://muqawil.org/en/contractors/{tag}/143", body, f"h-{tag}", "run"))
+    conn.commit()
+
+
+def _sighting(conn, external_id: str, *, first: str, last: str, count: int,
+              absent: str | None = None) -> None:
+    conn.execute(
+        "INSERT INTO dataset_sighting (dataset_key, external_id, first_seen_at, "
+        " last_seen_at, seen_count, last_absent_at) VALUES ('contractors',?,?,?,?,?)",
+        (external_id, first, last, count, absent))
+    conn.commit()
+
+
+def _sighting_of(conn, external_id: str) -> tuple:
+    return tuple(conn.execute(
+        "SELECT first_seen_at, last_seen_at, seen_count, last_absent_at "
+        "  FROM dataset_sighting WHERE external_id = ?", (external_id,)).fetchone())
+
+
+def _urls(conn) -> set[str]:
+    return {row[0] for row in conn.execute(
+        "SELECT source_url FROM generic_page_snapshot")}
+
+
+# ---- the lock, which is the part his plan was missing -------------------------
+
+def test_a_merge_into_an_unclaimed_warehouse_is_refused(two):
+    """CLAIM FIRST, ALWAYS. The whole reason the lock exists is that the loser of a race
+    must find out BEFORE writing rather than after a day's work is gone."""
+    here, _there, path = two
+
+    with pytest.raises(NotYours):
+        merge(here, path, machine="work-laptop")
+
+
+def test_a_second_machine_cannot_take_a_held_warehouse(two):
+    """Download → work → upload has nothing else stopping both machines doing it the same
+    day, and Drive keeps versions but cannot merge them."""
+    here, _there, _path = two
+    claim(here, "work-laptop")
+
+    with pytest.raises(NotYours) as raised:
+        claim(here, "home-desktop")
+
+    assert "work-laptop" in str(raised.value), "the refusal must name who holds it"
+
+
+def test_re_claiming_your_own_is_allowed(two):
+    """A session that died mid-merge has to be able to pick the same copy back up."""
+    here, _there, _path = two
+    claim(here, "work-laptop")
+
+    claim(here, "work-laptop")
+
+    assert holder(here) == "work-laptop"
+
+
+def test_releasing_hands_it_back(two):
+    here, _there, _path = two
+    claim(here, "work-laptop")
+
+    release(here)
+
+    assert holder(here) is None
+    claim(here, "home-desktop")
+    assert holder(here) == "home-desktop"
+
+
+def test_an_unclaimed_warehouse_says_so_rather_than_failing(two):
+    """A warehouse written before this feature has no such key, and `None` is the honest
+    answer — the alternative is a build that cannot open his existing file."""
+    here, _there, _path = two
+
+    assert holder(here) is None
+
+
+def test_a_claim_needs_a_name(two):
+    here, _there, _path = two
+
+    with pytest.raises(NotMergeable):
+        claim(here, "   ")
+
+
+# ---- the evidence merges, and nothing else does ------------------------------
+
+def test_pages_the_other_machine_has_arrive(two):
+    here, there, path = two
+    _page(here, "A1")
+    _page(there, "B1")
+    _page(there, "B2")
+    claim(here, "m")
+
+    report = merge(here, path, machine="m")
+
+    assert report.snapshots_added == 2
+    assert _urls(here) == {
+        "https://muqawil.org/en/contractors/A1/143",
+        "https://muqawil.org/en/contractors/B1/143",
+        "https://muqawil.org/en/contractors/B2/143"}
+
+
+def test_a_page_both_machines_hold_is_not_duplicated(two):
+    """THE NATURAL KEY DOING ITS JOB. `(source_url, content_hash)` is what makes the same
+    page the same page across two files that agree on no primary key at all."""
+    here, there, path = two
+    _page(here, "SAME")
+    _page(there, "SAME")
+    claim(here, "m")
+
+    report = merge(here, path, machine="m")
+
+    assert report.snapshots_added == 0
+    assert len(_urls(here)) == 1
+
+
+def test_the_same_url_fetched_with_different_content_is_two_pages(two):
+    """HISTORY, NOT A DUPLICATE. A listing page re-read after the site changed is a
+    different observation of the same URL, and the content hash is what says so."""
+    here, there, path = two
+    _page(here, "P", body="<html>monday</html>")
+    there.execute(
+        "INSERT INTO generic_page_snapshot (source_url, html_content, content_hash, "
+        " crawl_run_ref) VALUES (?,?,?,'run')",
+        ("https://muqawil.org/en/contractors/P/143", "<html>tuesday</html>", "h-P-2"))
+    there.commit()
+    claim(here, "m")
+
+    merge(here, path, machine="m")
+
+    assert here.execute(
+        "SELECT COUNT(*) FROM generic_page_snapshot "
+        " WHERE source_url = 'https://muqawil.org/en/contractors/P/143'"
+    ).fetchone()[0] == 2
+
+
+def test_no_foreign_primary_key_crosses(two):
+    """The ids are reassigned here, so nothing downstream can ever reference the other
+    machine's numbering. This is the property that removes the whole `OP-30` class of
+    problem from the merge."""
+    here, there, path = two
+    _page(here, "A1")
+    for tag in ("B1", "B2", "B3"):
+        _page(there, tag)
+    claim(here, "m")
+
+    merge(here, path, machine="m")
+
+    ids = [row[0] for row in here.execute(
+        "SELECT page_snapshot_id FROM generic_page_snapshot ORDER BY page_snapshot_id")]
+    assert ids == list(range(1, len(ids) + 1)), "contiguous, so they were assigned here"
+
+
+def test_derived_rows_are_named_for_rebuilding_and_never_written(two):
+    """ONE RESPONSIBILITY. A function that both merged evidence and re-interpreted it
+    would be two operations with one error path — and `--approve` already owns the second
+    and needs a run ref this has no business inventing."""
+    here, there, path = two
+    _page(there, "B1")
+    here.execute(
+        "INSERT INTO dataset_definition (site_profile_id, dataset_key, original_name, "
+        " dataset_kind, discovery_method, locator_json) "
+        "VALUES (1,'contractors','c','table','html_table','{}')")
+    here.commit()
+    claim(here, "m")
+
+    report = merge(here, path, machine="m")
+
+    assert report.rebuild == ("contractors",)
+    assert "--approve" in str(report)
+    assert here.execute("SELECT COUNT(*) FROM generic_record").fetchone()[0] == 0
+
+
+# ---- the sighting arithmetic -------------------------------------------------
+
+def test_a_sighting_takes_the_earliest_first_and_the_latest_last(two):
+    """A sighting is the only record of what the site showed and WHEN, and the two
+    machines watched different moments."""
+    here, there, path = two
+    _sighting(here, "X", first="2026-08-01T00:00:00Z", last="2026-08-10T00:00:00Z",
+              count=4)
+    _sighting(there, "X", first="2026-08-05T00:00:00Z", last="2026-08-20T00:00:00Z",
+              count=9)
+    claim(here, "m")
+
+    merge(here, path, machine="m")
+
+    first, last, count, _absent = _sighting_of(here, "X")
+    assert (first, last) == ("2026-08-01T00:00:00Z", "2026-08-20T00:00:00Z")
+    assert count == 9, "MAX, not 13 — see the module docstring"
+
+
+def test_a_proved_absence_on_either_machine_survives(two):
+    """`last_absent_at` is written only from a crawl that closed with `D = 0`, so an
+    absence proved on either machine is an absence proved."""
+    here, there, path = two
+    _sighting(here, "X", first="2026-08-01T00:00:00Z", last="2026-08-02T00:00:00Z",
+              count=1)
+    _sighting(there, "X", first="2026-08-01T00:00:00Z", last="2026-08-02T00:00:00Z",
+              count=1, absent="2026-08-19T00:00:00Z")
+    claim(here, "m")
+
+    merge(here, path, machine="m")
+
+    assert _sighting_of(here, "X")[3] == "2026-08-19T00:00:00Z"
+
+
+def test_merging_twice_changes_no_value(two):
+    """THE TEST THAT WOULD HAVE CAUGHT THE SUM, and the first version of it did not
+    because it counted rows. Three merges took one id's `seen_count` from 4 to 8 to 12 to
+    16 while the docstring called the operation idempotent."""
+    here, there, path = two
+    _page(there, "B1")
+    _sighting(here, "X", first="2026-08-01T00:00:00Z", last="2026-08-10T00:00:00Z",
+              count=4)
+    _sighting(there, "X", first="2026-08-05T00:00:00Z", last="2026-08-20T00:00:00Z",
+              count=9)
+    claim(here, "m")
+
+    merge(here, path, machine="m")
+    once = _sighting_of(here, "X")
+    merge(here, path, machine="m")
+    merge(here, path, machine="m")
+
+    assert _sighting_of(here, "X") == once
+    assert here.execute(
+        "SELECT COUNT(*) FROM generic_page_snapshot").fetchone()[0] == 1
+
+
+def test_the_merge_is_commutative(two):
+    """WHICH MACHINE RUNS IT MUST NOT MATTER, or his plan produces two different answers
+    depending on who happened to open the laptop first."""
+    here, there, path = two
+    _sighting(here, "X", first="2026-08-01T00:00:00Z", last="2026-08-10T00:00:00Z",
+              count=4)
+    _sighting(there, "X", first="2026-08-05T00:00:00Z", last="2026-08-20T00:00:00Z",
+              count=9)
+    claim(here, "m")
+    claim(there, "m")
+
+    merge(here, path, machine="m")
+    merge(there, str(Path(path).with_name("here.db")), machine="m")
+
+    assert _sighting_of(here, "X") == _sighting_of(there, "X")
+
+
+# ---- and what it refuses ----------------------------------------------------
+
+def test_two_different_schema_versions_are_refused(two):
+    """A v8 file and a v9 one disagree about which tables exist. `R-24` one level up:
+    upgrade the older, do not merge across."""
+    here, there, path = two
+    there.execute("PRAGMA user_version = 3")
+    there.commit()
+    claim(here, "m")
+
+    with pytest.raises(NotMergeable) as raised:
+        merge(here, path, machine="m")
+
+    assert "init-db" in str(raised.value), "it must say how to fix it"
+
+
+def test_a_failed_merge_still_detaches(two):
+    """Or the next call in the same process fails because the name is taken, for a reason
+    that has nothing to do with the merge — which is what happened the first time."""
+    here, there, path = two
+    there.execute("PRAGMA user_version = 3")
+    there.commit()
+    claim(here, "m")
+    with pytest.raises(NotMergeable):
+        merge(here, path, machine="m")
+
+    # A SECOND ATTEMPT MUST FAIL ON ITS OWN MERITS. `NotMergeable` again means it got as
+    # far as comparing the versions; a stale ATTACH would raise `OperationalError` about
+    # the name being taken instead, which is the failure that hid the real one the first
+    # time this ran for real.
+    with pytest.raises(NotMergeable):
+        merge(here, path, machine="m")

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -539,3 +539,37 @@ def test_the_extension_may_be_tagged_for_the_store_on_its_own():
     assert "minimum_extension_version" in js, (
         "the manifest is no longer checked against the floor the engine will "
         "talk to, so a build the engine would refuse could be uploaded")
+
+
+def test_a_merely_older_extension_is_not_outdated():
+    """`R-07`, AND IT TOOK TWO COLLISIONS TO GET BUILT. The engine's verdict is a GATE —
+    "this extension lacks a capability it needs" — and never an ADVERT, because "a newer
+    extension exists" is Chrome's answer and the engine knows only its own number.
+
+    THE COST OF WELDING THEM, measured twice. On 2026-08-16 someone bumped `VERSION`, the
+    panel told every user their extension was old, the notice clipped the profile card's
+    legal line by 54px at 320x440, and the bump was REVERTED rather than the advert
+    removed. On 2026-08-22 a schema change moved `VERSION` to 0.3.0 for a legitimate
+    reason under `R-35`, and three panel layout tests failed with the SAME 54px.
+
+    So: an extension at the minimum, missing nothing, is CURRENT — whatever the engine's
+    own number happens to be.
+    """
+    from scrapex.version import MINIMUM_EXTENSION_VERSION, VERSION, missing_capabilities
+
+    assert missing_capabilities(MINIMUM_EXTENSION_VERSION) == (), (
+        "the premise: this extension lacks nothing")
+    assert is_older(MINIMUM_EXTENSION_VERSION, VERSION), (
+        "and it IS older in number, or this test proves nothing")
+
+    assert version_report(MINIMUM_EXTENSION_VERSION)["outdated"] is False
+
+
+def test_an_extension_missing_a_capability_is_still_outdated():
+    """THE HALF THAT STAYS. Dropping the advert must not drop the gate — an extension the
+    engine can name a missing capability for is genuinely too old, and `R-07` says that
+    fact is the engine's own."""
+    report = version_report("0.1.0")
+
+    assert report["outdated"] is True
+    assert report["missing"], "and it says WHICH capabilities, not just that it is old"


### PR DESCRIPTION
Ten commits over one day's work, and the through-line is that **every claim here was
measured before it was built, and three of my own were retired by the measuring.**

## What he ruled, and what it took

`R-38`…`R-41` — his four rulings of 2026-08-21 — plus `R-42` and `R-43` from today.

**`R-38` · shape D, and he overruled the study's recommendation.** The study said shape F
because it reuses machinery the warehouse already has. Measured the same day:
`classification_node`, `classification_scheme`, `dataset_relationship` and
`relationship_field_pair` held **zero rows between them**. Existing machinery that has never
carried a row is not an asset — and this session found `is_enabled` with no callers,
`record_absences` with no callers, and a slice scope that was "built, tested, never used"
and turned out to be **wrong**.

Proved on his live warehouse: **704 profiles, 214 taxonomy nodes, 15,559 memberships.**
That ratio *is* shape D — 15,559 memberships sharing 214 nodes, where shape A would have
stored 15,559 repeated strings.

**`R-40` · DEC-10, and my first design was wrong in a way the schema caught.** I added a
`rows_hash` column; `generic_ingestion` is append-only in both directions and UNIQUE on
`(snapshot, locator)`, so it would have been unwritable after its first insert.
`generic_record.content_hash` already held the fact per row. No column, no migration — and
the version bump that migration forced was reverted with it, because without a schema change
there is no contract change (`R-35`).

**`R-41` · a declared map, and measuring gave a better key than I expected: the tab id.**
`#contractor-tab2` and `#contractor-tab3` are the only thing separating two tables with
identical headers and no rows. Two measurements point opposite ways and both are asserted —
every table header is Arabic in BOTH locales, so text selectors are locale-stable, while the
interests card title IS translated (`Interests` / `الأنشطة`), so that one is located
structurally.

## The guard he asked for, which paid for itself three times in one day

A test that register numbers are unique and contiguous. It caught **three real collisions**:
`R-36`/`R-37` between #244 and this branch, `OP-32` between the same two, and `OP-39`
between #246 and this branch. Every one was green, mergeable, and invisible to git — no
process rule and no branch protection sees a semantic conflict.

Its own no-gap rule then failed this branch, correctly by its logic and unhelpfully in fact:
contiguity is a property of `main`, not of a branch avoiding another session's open PR. So
reservations are **declared**, the way `PINNED` declares a citation.

## Two warehouses that can become one (`R-43`)

`scrapex merge-warehouse`. Only the **evidence** travels — snapshots and sightings, the two
things that cannot be recomputed — and everything derived is rebuilt by `--approve` with no
network. So no primary key ever crosses and nothing is renumbered, which removes the whole
`OP-30` class from the merge. Plus a lock, because download → work → upload has nothing
stopping the second upload winning silently.

**And the first version summed `seen_count`**, so three merges of one file took an id from 4
to 8 to 12 to 16 while the docstring called it idempotent. The test that missed it counted
rows and never looked at a value.

## Three suspicions the measurement retired

Asked whether six named columns were among the 48 — they all are. Answering it properly
meant reading 712 real profiles, and:

| suspected | measured |
|---|---|
| `activity` stores the string `"None"` | it is `None`, the value. Genuinely absent on 669 of 712. **Not a defect** |
| `merge_locales` wrongly refuses 8 pairs | the locales really do publish 9 labels against 10. **Not a defect** |
| `longitude = 0` is a parse failure | the page says `lng: 0`. **The defect was storing it** — lat 24.45 with lng 0 is the Atlantic |

And it found one nobody had raised: `read_profile` on an Arabic page turned **ten labels
into two keys**, because `_slug` kept `[a-z0-9]` only and fell back to a constant. `DSN-05`
one level up.

## Notes

- Full suite green but for `OP-19`, the known load-dependent race.
- His warehouse is at **v9** and carries the taxonomy; migration `0009` applied to the live
  314 MB file with every count preserved.
- `R-39` records the profile crawl at 11.1 h and **that figure is wrong** — measured with six
  workers, applied to a single-threaded command. It is **87 h** as it stands, ~14 with
  workers. Recorded in STATE.md rather than quietly corrected.
- STATE.md carries a **RESUME HERE** section written for the other machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)