### PR TITLE
The dictionary travels with the pages, or the pages arrive unreadable

### DIFF
--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -1226,3 +1226,56 @@ Both of these are the same mistake with two faces: **an absence found by one ins
 was reported as an absence in the world.** Before recording that something cannot be
 done, name the instrument that failed to find it.
 
+---
+
+## 10 · Two features written two days apart, neither knowing the other exists
+
+### The merge moved the pages and left the key to reading them behind
+
+`snapshotbody.py` landed on 2026-08-20 and stores a page as a zstd frame compressed
+against a **dictionary row**, without which the body cannot be decoded and the plaintext
+exists nowhere else. `warehousemerge.py` landed on 2026-08-22 and moves "only the
+evidence" between two machines. Both are correct on their own. Together they were not:
+
+- `snapshot_dictionary` was **not merged at all**, and
+- `html_dict_id` was **copied verbatim** — a foreign machine's primary key, which the
+  merge's own docstring says never crosses.
+
+His real transfer hit it: 20,379 pages, every one `zstd-raw-dict`, arriving into a
+warehouse holding zero dictionaries → `FOREIGN KEY constraint failed`.
+
+**AND THE LOUD FAILURE WAS THE LUCKY ONE.** The foreign key only fired because the
+receiving side had *no* dictionaries, so the arriving ids pointed at nothing. Had the
+receiver held two dictionaries of its own — which it will, the moment it crawls anything —
+ids `1` and `2` would have been perfectly legal numbers naming **the wrong bodies**. No
+constraint fires on that. 20,379 pages would have been "merged" successfully and decoded
+to garbage, discovered whenever somebody next opened one.
+
+### What the seventeen passing tests could not see
+
+`test_two_warehouses_become_one.py` had seventeen tests, including a sharp one about
+`seen_count` being summed instead of maxed. **All seventeen passed before the fix and
+after it**, because not one of them stored a *compressed* page — every fixture wrote
+`html_content` as plain text through raw SQL.
+
+> **A test suite for feature B, written while feature A already existed, tests the
+> author's mental model of A rather than A.** The fixtures here were written by hand
+> against the columns the author was thinking about. The new tests go through
+> `save_snapshot` — the production writer — so the row is shaped by the code that really
+> writes it, and a future column arrives in the fixture without anyone remembering to add
+> it.
+
+### The generalisable rule
+
+**When a feature moves, copies, backs up or exports rows, list the table's foreign keys
+and ask what happens to each one.** Not "does it round-trip" — that passes — but *does
+the destination hold the thing this column points at, and is the value still true there?*
+An id is only meaningful inside the database that issued it, and the merge already knew
+that; it just did not notice that a column added two days earlier had made a second id
+travel.
+
+The matching key is worth stating too, because the obvious one was wrong: dictionaries
+match on **body**, never on `label`. Each machine seeds a dictionary from the first page
+of that kind *it* fetched, so `muqawil.org/listing` is a 298,954-byte page here and a
+different page there. Matching on the label would have merged two unrelated dictionaries
+into one and broken both sides' pages.

--- a/scrapex/warehousemerge.py
+++ b/scrapex/warehousemerge.py
@@ -74,6 +74,7 @@ class Merged:
     completely different news.
     """
 
+    dictionaries_added: int = 0
     snapshots_added: int = 0
     sightings_added: int = 0
     sightings_updated: int = 0
@@ -82,6 +83,7 @@ class Merged:
 
     def __str__(self) -> str:
         lines = [
+            f"dictionaries      {self.dictionaries_added:,}",
             f"snapshots added   {self.snapshots_added:,}",
             f"sightings added   {self.sightings_added:,}",
             f"sightings updated {self.sightings_updated:,}",
@@ -144,6 +146,63 @@ def _now(conn: sqlite3.Connection) -> str:
         "SELECT strftime('%Y-%m-%dT%H:%M:%SZ','now')").fetchone()[0])
 
 
+def _carry_dictionaries(conn: sqlite3.Connection) -> int:
+    """The compression dictionaries travel too, and they are not derived data.
+
+    THE ONE APPARENT EXCEPTION TO "ONLY THE EVIDENCE TRAVELS", and it stops being an
+    exception once stated properly: a `zstd-raw-dict` body is UNREADABLE without the exact
+    page it was compressed against, and that page is stored nowhere else. So a dictionary
+    IS evidence — it is part of how the snapshot is written down. `scrapex/snapshotbody.py`
+    reaches the same conclusion from the other side, which is why `snapshot_dictionary`
+    forbids UPDATE and DELETE: losing one loses every page compressed against it, silently,
+    with no repair.
+
+    MATCHED ON THE BODY, NEVER ON THE LABEL. A dictionary is seeded from the first page of
+    its kind that a machine happens to fetch, so `muqawil.org/listing` names one
+    298,954-byte page here and a different one there. `label` is UNIQUE, so an arriving
+    dictionary whose label is taken but whose body is new gets a suffixed label rather than
+    being dropped — dropping it would leave its pages unreadable, and overwriting is
+    forbidden by the trigger anyway.
+    """
+    ours = {bytes(body) for (body,) in conn.execute(
+        "SELECT body FROM snapshot_dictionary")}
+    labels = {label for (label,) in conn.execute(
+        "SELECT label FROM snapshot_dictionary")}
+    added = 0
+    for label, body in conn.execute(
+            "SELECT label, body FROM other.snapshot_dictionary ORDER BY dict_id"):
+        if bytes(body) in ours:
+            continue
+        wanted, n = label, 2
+        while wanted in labels:
+            wanted, n = f"{label}#{n}", n + 1
+        conn.execute("INSERT INTO snapshot_dictionary (label, body) VALUES (?,?)",
+                     (wanted, body))
+        labels.add(wanted)
+        ours.add(bytes(body))
+        added += 1
+    return added
+
+
+def _no_page_lost_its_dictionary(conn: sqlite3.Connection) -> None:
+    """A compressed page that names no dictionary is a page that no longer exists.
+
+    CHECKED INSIDE THE TRANSACTION, so a failure rolls the merge back instead of reporting
+    a success for somebody to discover later. The remap above is a lookup that may yield
+    NULL, and SQLite accepts NULL there because the column is nullable for the sake of
+    'plain' rows. That is the one way this can lose data quietly, so it is the one thing
+    asserted afterwards.
+    """
+    orphans = conn.execute(
+        "SELECT COUNT(*) FROM generic_page_snapshot "
+        " WHERE html_codec <> 'plain' AND html_dict_id IS NULL").fetchone()[0]
+    if orphans:
+        raise NotMergeable(
+            f"{orphans:,} merged pages are compressed but name no dictionary, so their "
+            "bodies could never be decoded again. The merge was rolled back. The other "
+            "warehouse is missing rows from snapshot_dictionary that its own pages need.")
+
+
 def _same_shape(conn: sqlite3.Connection) -> None:
     """Both sides must be the same kind of database at the same schema version.
 
@@ -188,11 +247,22 @@ def merge(conn: sqlite3.Connection, other: str, *, machine: str) -> Merged:
         _same_shape(conn)
         report = Merged()
 
+        report.dictionaries_added = _carry_dictionaries(conn)
+
         # SNAPSHOTS: ADDITIVE, KEYED ON WHAT THE PAGE IS. `page_snapshot_id` is never
         # carried across — it is assigned here — so nothing downstream can reference a
         # foreign machine's id. The columns are named rather than `SELECT *` because the
         # id must be excluded and because a column added later must break this loudly
         # instead of silently shifting values one place left.
+        #
+        # AND `html_dict_id` IS REMAPPED, NOT COPIED. It was copied, and that is the one
+        # place this module broke its own rule: a dictionary id is a foreign machine's
+        # PRIMARY KEY, so carrying it verbatim is exactly what the paragraph above says
+        # never happens. It failed loudly on his real transfer — FOREIGN KEY constraint
+        # failed, because `snapshot_dictionary` was not merged at all — and that was the
+        # LUCKY outcome. Had the ids happened to line up, 20,379 pages would have been
+        # inserted pointing at the WRONG dictionary and decoded to nothing, discovered
+        # whenever somebody next opened one.
         before = conn.execute(
             "SELECT COUNT(*) FROM generic_page_snapshot").fetchone()[0]
         conn.execute(
@@ -200,11 +270,19 @@ def merge(conn: sqlite3.Connection, other: str, *, machine: str) -> Merged:
             "(source_url, content_type, html_content, content_hash, captured_at, "
             " crawl_run_ref, html_codec, html_dict_id) "
             "SELECT source_url, content_type, html_content, content_hash, captured_at, "
-            "       crawl_run_ref, html_codec, html_dict_id "
+            "       crawl_run_ref, html_codec, "
+            # Matched on the BODY, which is the only honest key: each machine seeds a
+            # dictionary from its own first page of a kind, so the same `label` on two
+            # machines names two different bodies. A 'plain' row has no dict_id, and NULL
+            # stays NULL because a subquery over no rows IS NULL.
+            "       (SELECT ours.dict_id FROM snapshot_dictionary AS ours "
+            "          JOIN other.snapshot_dictionary AS od ON od.body = ours.body "
+            "         WHERE od.dict_id = theirs.html_dict_id) "
             "  FROM other.generic_page_snapshot AS theirs "
             " WHERE NOT EXISTS (SELECT 1 FROM generic_page_snapshot AS ours "
             "                    WHERE ours.source_url = theirs.source_url "
             "                      AND ours.content_hash = theirs.content_hash)")
+        _no_page_lost_its_dictionary(conn)
         report.snapshots_added = (
             conn.execute("SELECT COUNT(*) FROM generic_page_snapshot").fetchone()[0]
             - before)

--- a/tests/test_two_warehouses_become_one.py
+++ b/tests/test_two_warehouses_become_one.py
@@ -340,3 +340,155 @@ def test_a_failed_merge_still_detaches(two):
     # time this ran for real.
     with pytest.raises(NotMergeable):
         merge(here, path, machine="m")
+
+# ---- the compression dictionary, which the first version left behind ---------
+#
+# HIS REAL TRANSFER FAILED HERE, on 2026-08-22: 20,379 pages, every one
+# `zstd-raw-dict`, arriving into a warehouse with no dictionaries at all ->
+# "FOREIGN KEY constraint failed". The seventeen tests above all passed before the
+# fix AND after it, because not one of them stored a compressed page. The merge was
+# written on 2026-08-22 and the codec on 2026-08-20; neither knew about the other.
+
+
+def _compressed_page(conn, tag: str, label: str, *, filler: str = "x") -> str:
+    """One page stored the way `snapshotcrawl` stores them, and its plaintext back.
+
+    Goes through `save_snapshot`, not raw SQL, so the row is shaped by the production
+    writer rather than by this test's idea of it.
+    """
+    from scrapex.extract.models import SnapshotCreate
+    from scrapex.extract.service import save_snapshot
+
+    html = ("<html><body>" + f"{filler} shared skeleton " * 400
+            + f"<main>{tag}</main></body></html>")
+    save_snapshot(conn, SnapshotCreate(
+        source_url=f"https://muqawil.org/en/contractors?page={tag}",
+        html_content=html, body_class=label))
+    conn.commit()
+    return html
+
+
+def _decoded(conn, url: str) -> str:
+    from scrapex.snapshotbody import decode
+
+    row = conn.execute(
+        "SELECT page_snapshot_id, html_content, html_codec, html_dict_id "
+        "FROM generic_page_snapshot WHERE source_url = ?", (url,)).fetchone()
+    return decode(conn, row)
+
+
+def test_a_compressed_page_still_decodes_after_it_crosses(two):
+    """THE PROPERTY, and it is not "the row arrived".
+
+    A `zstd-raw-dict` body is unreadable without the exact page it was compressed
+    against, and that page is stored nowhere else. So a merge that moves the row and
+    not the dictionary has not moved the evidence — it has destroyed it and returned
+    success.
+    """
+    here, there, path = two
+    wanted = _compressed_page(there, "7", "muqawil.org/listing")
+
+    claim(here, "here")
+    merge(here, path, machine="here")
+
+    url = "https://muqawil.org/en/contractors?page=7"
+    assert _decoded(here, url) == wanted
+
+
+def test_the_dictionary_id_is_remapped_and_not_copied(two):
+    """THE FAILURE THAT WOULD HAVE BEEN SILENT, which is why it is asserted separately.
+
+    The old code copied `html_dict_id` verbatim — a foreign machine's PRIMARY KEY, the
+    one thing this module's docstring says never crosses. It happened to fail loudly on
+    his transfer only because the receiving warehouse had NO dictionaries, so the
+    foreign key had nothing to point at. Here the receiving side already holds two, so
+    the arriving ids 1 and 2 are legal numbers naming the WRONG bodies — no constraint
+    fires, and the pages decode to nothing.
+    """
+    here, there, path = two
+    _compressed_page(here, "1", "ours.example/listing", filler="local-a")
+    _compressed_page(here, "2", "ours.example/detail", filler="local-b")
+    wanted = _compressed_page(there, "9", "muqawil.org/listing", filler="theirs")
+
+    theirs_id = there.execute(
+        "SELECT html_dict_id FROM generic_page_snapshot "
+        "WHERE source_url LIKE '%page=9'").fetchone()[0]
+    assert theirs_id == 1, "the fixture must reproduce the id collision"
+
+    claim(here, "here")
+    merge(here, path, machine="here")
+
+    row = here.execute(
+        "SELECT html_dict_id FROM generic_page_snapshot "
+        "WHERE source_url LIKE '%page=9'").fetchone()
+    assert row[0] != theirs_id, (
+        "the arriving page kept the other machine's dict_id, which here names a "
+        "different body entirely")
+    assert _decoded(here, "https://muqawil.org/en/contractors?page=9") == wanted
+
+
+def test_one_label_two_bodies_keeps_both(two):
+    """Each machine seeds a dictionary from the first page of that kind IT fetched, so
+    `muqawil.org/listing` is a different 298,954-byte page on each. `label` is UNIQUE,
+    so the arriving one cannot take the name — and it must not be dropped either,
+    because its pages would become unreadable."""
+    here, there, path = two
+    mine = _compressed_page(here, "3", "muqawil.org/listing", filler="mine")
+    yours = _compressed_page(there, "4", "muqawil.org/listing", filler="yours")
+
+    claim(here, "here")
+    merge(here, path, machine="here")
+
+    labels = sorted(l for (l,) in here.execute("SELECT label FROM snapshot_dictionary"))
+    assert len(labels) == 2, f"one of the two dictionaries was lost: {labels}"
+    assert _decoded(here, "https://muqawil.org/en/contractors?page=3") == mine
+    assert _decoded(here, "https://muqawil.org/en/contractors?page=4") == yours
+
+
+def test_the_same_dictionary_is_not_stored_twice(two):
+    """Commutative and idempotent has to hold for the dictionaries too, or every
+    round trip through Drive grows the table by two rows."""
+    here, there, path = two
+    _compressed_page(there, "5", "muqawil.org/listing")
+
+    claim(here, "here")
+    first = merge(here, path, machine="here")
+    second = merge(here, path, machine="here")
+
+    assert first.dictionaries_added == 1
+    assert second.dictionaries_added == 0
+    assert here.execute("SELECT COUNT(*) FROM snapshot_dictionary").fetchone()[0] == 1
+
+
+def test_a_compressed_page_whose_dictionary_is_missing_rolls_the_merge_back(two):
+    """The one way the remap can lose data quietly: it is a lookup, so it yields NULL,
+    and the column is nullable for the sake of 'plain' rows. A page that says it is
+    compressed and names no dictionary can never be read again, so the merge refuses
+    instead of reporting how many rows it added.
+
+    WORTH SAYING WHAT THIS TOOK TO REACH: the donor's own foreign key forbids the row,
+    which is the schema doing its job. The state is only reachable through a file
+    written with foreign keys off -- which is SQLite's DEFAULT for any connection that
+    does not opt in, so it is a real possibility rather than a hypothetical, and it is
+    exactly how this fixture builds it.
+    """
+    here, there, path = two
+    _compressed_page(there, "6", "muqawil.org/listing")
+    there.commit()
+
+    raw = sqlite3.connect(path)              # foreign_keys defaults to OFF
+    raw.execute(
+        "INSERT INTO generic_page_snapshot (source_url, html_content, content_hash, "
+        " html_codec, html_dict_id) VALUES (?,?,?,?,?)",
+        ("https://muqawil.org/en/contractors?page=99", b"not-a-real-frame", "h-99",
+         "zstd-raw-dict", 4242))
+    raw.commit()
+    raw.close()
+
+    claim(here, "here")
+    with pytest.raises(NotMergeable, match="could never be decoded"):
+        merge(here, path, machine="here")
+
+    assert here.execute(
+        "SELECT COUNT(*) FROM generic_page_snapshot").fetchone()[0] == 0, (
+        "the merge did not roll back, so a partial transfer is now on disk")


### PR DESCRIPTION
**His real transfer failed on this, 2026-08-22.** 20,379 pages, every one `zstd-raw-dict`, arriving into a warehouse holding zero dictionaries:

```
error: FOREIGN KEY constraint failed
```

## Two defects in one line, and the second is the dangerous one

- **`snapshot_dictionary` was not merged at all**, so nothing the arriving pages pointed at existed.
- **`html_dict_id` was copied verbatim** — a foreign machine's *primary key*. That is precisely what this module's own docstring says never happens: *"no primary key is ever remapped, because nothing that carries one travels."* A column added on 2026-08-20 had quietly made a second id travel, and the merge written on 2026-08-22 did not know it existed.

> **The loud failure was the lucky one.** The foreign key fired only because the receiver had *no* dictionaries, so the ids pointed at nothing. Had it held two of its own — which it will the moment it crawls anything — ids `1` and `2` would have been perfectly legal numbers naming **the wrong bodies**. No constraint fires on that. 20,379 pages would have merged successfully and decoded to garbage, discovered whenever somebody next opened one.

## The fix

**Dictionaries travel too, because they are evidence rather than derived data.** A `zstd-raw-dict` body is unreadable without the exact page it was compressed against, and that page is stored nowhere else — which is why `snapshot_dictionary` forbids UPDATE and DELETE.

**Matched on the BODY, never on the label.** Each machine seeds a dictionary from the first page of that kind *it* fetched, so `muqawil.org/listing` is a 298,954-byte page here and a different page there. Matching on the label would have merged two unrelated dictionaries into one and broken both sides' pages. A label collision carrying a new body gets a suffix instead.

`html_dict_id` is then **remapped** through a body join, and a guard inside the transaction refuses the merge if any compressed page ends up naming no dictionary — the one way the remap can lose data quietly, since the column is nullable for the sake of `plain` rows.

## Why seventeen passing tests did not catch it

They passed **before the fix and after it**, because not one of them stored a *compressed* page — every fixture wrote `html_content` as plain text through raw SQL.

> A suite for feature B, written while feature A already existed, tests the author's mental model of A rather than A.

The five new tests go through `save_snapshot`, the production writer, so the row is shaped by the code that really writes it and a future column arrives in the fixture without anyone remembering to add it.

**Mutation-proven three ways**, each killing only its own guard:

| mutation | tests it fails |
|---|---|
| restore the verbatim `html_dict_id` copy | 3 |
| stop carrying dictionaries | 4 |
| drop the rollback guard | 1 |

And the state that guard defends against turned out to be **unreachable through a normal write** — the donor's own foreign key forbids it — so the test builds it the only way reality could: through a connection with foreign keys off, which is SQLite's default for anything that does not opt in.

## Verified on his actual data, not only on fixtures

The merge then ran for real on this machine:

| | |
|---|---|
| dictionaries carried | **2** (`muqawil.org/listing` 298,954 B, `muqawil.org/detail` 120,470 B) |
| snapshots added | **20,379** — nothing overlapped, because a reshuffling listing gives the same URL a different `content_hash` on each machine |
| sightings added | **17,417** |
| orphaned compressed pages | **0** |
| sampled decodes | listing pages via dict 1 and a Dammam profile via dict 2, all returning real HTML |

Then `--approve` rebuilt the derived rows with **no network**, across all four run-ref families — the README named two, and the warehouse held four:

| | |
|---|---|
| `generic_record` | **18,008** (17,304 contractors + 704 profiles) — above either machine alone |
| coverage | **17,269 of 17,417 sighted — 99.2%** |
| taxonomy | 214 nodes, **15,559 memberships** — `R-38` reproduced to the row |

`LESSONS.md §10` records the generalisable rule: when a feature moves, copies, backs up or exports rows, list the table's foreign keys and ask of each one whether the destination holds what it points at, and whether the value is still true there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
