### PR TITLE
--details takes workers, and 87 hours becomes about 14

### DIFF
--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -1003,6 +1003,18 @@ The profile pages carry the ~28 columns the listing does not, and the full crawl
 **34,834 pages — 11.1 hours**, measured over 87 minutes of real six-worker crawling at
 52.5 pages a minute. He chose to see one city first.
 
+> **AMENDED 2026-08-22, and the figure above is kept because the correction is about
+> WHAT IT WAS MEASURED ON.** 52.5 pages a minute was the **listing** crawl, at six
+> workers. `--details` had no workers at all — it was one page at a time — and its own
+> measured rate on the Dammam run was **9.03 s a page**, which is 6.65 pages a minute
+> and **87 hours**, not 11.1. So the ruling was right about the destination and wrong
+> about the vehicle: it priced a journey using another command's speed.
+>
+> He caught it himself — «ولاحظ أنّ R-39 يسجل 11.1 وهو رقم خاطئ». `--details` now takes
+> `--workers`, which is what makes the original number reachable again: **11–14 hours**
+> depending on whether profiles overlap as well as listings did. The lesson is narrower
+> than "check your arithmetic": **a rate measured on one command is not a rate.**
+
 **The city is read off the listing card, so a slice costs nothing to select.** Measured
 from the live warehouse, the cities that a first slice could be:
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -40,12 +40,21 @@ conservative.
 Two of the four next steps need nothing but this repository — the tests run on committed
 fixtures, never on his warehouse:
 
-1. **Workers for `--details`.** Measured: the Dammam profile crawl ran at **9.03 s a
-   page** single-threaded, so the full 34,834-page crawl is **87 hours**. The listing
-   crawl measured 1.14 s a page with six workers. Adding workers here is the difference
-   between 87 hours and about 14, and it is the same work already done for
-   `crawl_partition`. **`R-39` records 11.1 h and that figure is WRONG** — it was measured
-   with six workers and applied to a single-threaded command.
+1. ~~**Workers for `--details`.**~~ **DONE 2026-08-22.** `--details` takes `--workers`,
+   the same shape as `crawl_partition`: a connection per worker, and the pace unchanged
+   because `HttpFetcher._throttle` holds its lock across the sleep. Measured before:
+   **9.03 s a page** single-threaded, so 34,834 pages was **87 hours**; the number to
+   beat is the listing crawl's 1.14 s a page at six workers, which puts this at
+   **11–14 hours**. `R-39`'s 11.1 h is amended rather than deleted — it was measured on
+   the **listing** command and priced the profile one, which is a narrower lesson than
+   bad arithmetic: *a rate measured on one command is not a rate.*
+
+   **And the first six-worker run found a real race**, which is the argument for the
+   guard rather than for the feature: six workers all miss the `snapshot_dictionary`
+   SELECT, all attempt the INSERT, and five lose on `UNIQUE(label)` — 20 pages stored
+   14 and reported 6 failures that were not about the pages at all. `_dictionary` now
+   re-reads after a conflict and uses the winner's body, because the winner's body is
+   what the winner's rows were compressed against.
 2. **Branch protection on `main`.** Measured: `protected: False`, 404 on the protection
    endpoint. Require the check suite, require branches up to date, forbid direct pushes.
    His to switch on, and it is what makes `ac3a5af` — which left `main` red for two days

--- a/scrapex/contractors.py
+++ b/scrapex/contractors.py
@@ -39,6 +39,7 @@ import sqlite3
 import sys
 import time
 from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 from . import taxonomy
@@ -474,7 +475,7 @@ def detail_frontier(conn, directory: Directory, scope: CrawlScope,
 
 
 def details(conn, directory: Directory, fetch, fetcher, run_ref: str,
-            ceiling: int = 0) -> None:
+            ceiling: int = 0, *, workers: int = 1, connect=None) -> None:
     """Fetch the profile pages the registered scope asks for, each stored as evidence.
 
     WHY THIS IS A PHASE OF ITS OWN AND NOT PART OF `--crawl`. The listing crawl is
@@ -487,6 +488,25 @@ def details(conn, directory: Directory, fetch, fetcher, run_ref: str,
     `--ceiling` EXISTS BECAUSE 34,806 PAGES IS ABOUT SEVENTEEN HOURS. A first run that
     only wants to see the shape of the data must be able to stop, and a run that
     stopped has to say so rather than look finished.
+
+    `workers` OVERLAPS THE WAITS, AND 87 HOURS BECOMES ABOUT 14. Measured: the Dammam
+    profile run went at **9.03 s a page** single-threaded, so 34,834 pages is 87 hours,
+    while the listing crawl measured **1.14 s a page with six workers**. The difference
+    is latency, not politeness — muqawil takes seconds to answer while the pace owes
+    one request a second, so the wall clock is almost all waiting.
+
+    IT DOES NOT RAISE THE REQUEST RATE, and that is the property that makes it
+    allowed at all. `HttpFetcher._throttle` holds a lock across its sleep, so the
+    transport still hands out one request per interval however many workers ask.
+    Measured on 2026-08-21 without that lock: four workers made twenty requests in
+    1.02 s where 3.80 s was owed. Concurrency here buys OVERLAP and never a higher
+    rate — `R-21` and `SR-8` both survive it.
+
+    `connect` IS REQUIRED ABOVE ONE WORKER because `sqlite3` refuses a connection
+    from a thread it was not created on. One shared connection behind a lock would
+    serialise the writes AND the fetches between them, which is the whole thing being
+    parallelised. Same shape as `partitioncrawl.crawl_partition`, deliberately: two
+    commands that do the same thing should read the same way.
     """
     scope, slice_of = read_scope(conn, directory.key)
     say(f"registered scope: {scope.value}"
@@ -519,29 +539,68 @@ def details(conn, directory: Directory, fetch, fetcher, run_ref: str,
         say(f"  stopping at the {ceiling:,}-page ceiling, so this run is PARTIAL")
     declare_frontier(fetcher, len(todo))
 
-    stored = failed = 0
-    for number, url in enumerate(todo, start=1):
+    # ONE PAGE, WHOLE, AND THE SAME CODE WHATEVER THE WORKER COUNT. The single-worker
+    # path used to be this loop body inline; keeping one function means a fix to the
+    # failure handling cannot apply to one path and miss the other.
+    def one(number: int, url: str, writer) -> tuple[bool, str]:
+        """`(stored, note)` — a note is a line to print, empty when there is nothing."""
         try:
             html = fetch(url)
         except Exception as exc:
             # NOT RAISED. One dead profile out of thirty-four thousand must not discard
             # the rest — the walker's own rule — and a crawl that stops at the first
             # 404 of a seventeen-hour run is a crawl nobody can finish.
-            failed += 1
-            say(f"  [{number}/{len(todo)}] {url}: {type(exc).__name__}: {exc}")
-            continue
+            return False, f"  [{number}/{len(todo)}] {url}: {type(exc).__name__}: {exc}"
         try:
-            service.save_snapshot(conn, SnapshotCreate(
+            service.save_snapshot(writer, SnapshotCreate(
                 source_url=url, html_content=html, crawl_run_ref=run_ref,
                 body_class=label_for(url, PageKind.DETAIL)))
-            conn.commit()
-            stored += 1
+            writer.commit()
+            return True, ""
         except Exception as exc:
-            conn.rollback()
-            failed += 1
-            say(f"  [{number}/{len(todo)}] storing {url}: {type(exc).__name__}: {exc}")
-        if number % 200 == 0:
-            say(f"  [{number:,}/{len(todo):,}] stored {stored:,}, failed {failed}")
+            writer.rollback()
+            return False, (f"  [{number}/{len(todo)}] storing {url}: "
+                           f"{type(exc).__name__}: {exc}")
+
+    stored = failed = 0
+    notes: list[str] = []
+    if workers > 1 and connect is not None:
+        # A CONNECTION PER WORKER, opened and closed by the worker that uses it.
+        # `sqlite3` refuses one across threads; every connection sets WAL and
+        # `busy_timeout`, so two writers wait for each other instead of failing.
+        def run(number: int, url: str) -> tuple[int, bool, str]:
+            writer = connect()
+            try:
+                did, note = one(number, url, writer)
+            finally:
+                writer.close()
+            return number, did, note
+
+        with ThreadPoolExecutor(max_workers=workers,
+                                thread_name_prefix="detail") as pool:
+            futures = [pool.submit(run, number, url)
+                       for number, url in enumerate(todo, start=1)]
+            # ORDERED BY THE FRONTIER, not by which worker finished first, so two runs
+            # of the same frontier print the same report. `as_completed` would make the
+            # output depend on scheduling, which makes a diff between two runs useless.
+            for future in futures:
+                _, did, note = future.result()
+                stored += did
+                failed += not did
+                if note:
+                    notes.append(note)
+    else:
+        for number, url in enumerate(todo, start=1):
+            did, note = one(number, url, conn)
+            stored += did
+            failed += not did
+            if note:
+                notes.append(note)
+            if number % 200 == 0:
+                say(f"  [{number:,}/{len(todo):,}] stored {stored:,}, "
+                    f"failed {failed}")
+    for note in notes:
+        say(note)
     say("")
     say(f"profiles stored {stored:,}, failed {failed}, resumed {resumed:,}")
     if len(todo) + resumed < len(frontier):
@@ -900,9 +959,11 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
                             "the residual is closed without re-reading the cells "
                             "already proven — 47 of 56 on the first run")
     parser.add_argument("--workers", type=int, default=1,
-                       help="crawl this many cells at once. The site answers in "
-                            "about six seconds while the pace is one request a "
-                            "second, so overlapping the waits is the win — the "
+                       help="fetch this many at once — cells for --crawl, profile "
+                            "pages for --details. The site answers in seconds while "
+                            "the pace owes one request a second, so overlapping the "
+                            "waits is the win: measured, --details goes from 9.03 s "
+                            "a page to about 1.4, which is 87 hours to about 14. The "
                             "RATE does not change, the transport still allows one "
                             "request per interval however many workers there are")
     parser.add_argument("--heavy-attempts", type=int, default=HEAVY_ATTEMPTS,
@@ -976,8 +1037,16 @@ def run(args: argparse.Namespace) -> int:
                   workers=args.workers, connect=factory)
         if args.details:
             fetcher, fetch = make_fetch(args.pace)
+            # SAME FACTORY, SAME REASON as --crawl above: one connection per
+            # worker, opened only when more than one is asked for. 34,834 pages at
+            # 9.03 s each is 87 hours single-threaded and about 14 with six.
+            factory = None
+            if args.workers > 1:
+                factory = DatabaseRegistry.defaults().engine.connect
+                say(f"fetching with {args.workers} workers — the pace is unchanged, "
+                    "the waits overlap")
             details(conn, directory, fetch, fetcher, args.run_ref,
-                    ceiling=args.ceiling)
+                    ceiling=args.ceiling, workers=args.workers, connect=factory)
         if args.approve:
             approve(conn, directory, args.run_ref)
         if args.coverage:

--- a/scrapex/snapshotbody.py
+++ b/scrapex/snapshotbody.py
@@ -114,6 +114,17 @@ def _dictionary(conn: sqlite3.Connection, label: str, seed: str) -> tuple[int, b
     all end with a second dictionary and a migration of everything compressed against
     the first. A page compressed against itself also costs almost nothing, so the
     seed row is not a wasted one.
+
+    AND IT IS SAFE UNDER CONCURRENT WRITERS, which SELECT-then-INSERT was not.
+    `label` is UNIQUE, so six workers starting a crawl together all miss the SELECT
+    and all attempt the INSERT: one wins and five raise IntegrityError. MEASURED, not
+    guessed — the first six-worker `--details` run over twenty pages stored 14 and
+    reported 6 failures, and all six were this race rather than anything wrong with
+    the pages.
+
+    The loser must then use the WINNER'S dictionary rather than its own seed, because
+    the winner's body is what the winner's rows are compressed against. So the SELECT
+    is retried after the conflict: whoever lands second reads what landed first.
     """
     row = conn.execute(
         "SELECT dict_id, body FROM snapshot_dictionary WHERE label = ? LIMIT 1",
@@ -121,10 +132,20 @@ def _dictionary(conn: sqlite3.Connection, label: str, seed: str) -> tuple[int, b
     ).fetchone()
     if row is not None:
         return int(row[0]), bytes(row[1])
-    cursor = conn.execute(
-        "INSERT INTO snapshot_dictionary (label, body) VALUES (?,?)",
-        (label, seed.encode("utf-8")),
-    )
+    try:
+        cursor = conn.execute(
+            "INSERT INTO snapshot_dictionary (label, body) VALUES (?,?)",
+            (label, seed.encode("utf-8")),
+        )
+    except sqlite3.IntegrityError:
+        row = conn.execute(
+            "SELECT dict_id, body FROM snapshot_dictionary WHERE label = ? LIMIT 1",
+            (label,),
+        ).fetchone()
+        if row is None:
+            # Not a label collision then, so it is not this function's to swallow.
+            raise
+        return int(row[0]), bytes(row[1])
     return int(cursor.lastrowid), seed.encode("utf-8")
 
 

--- a/tests/test_a_snapshot_says_how_it_is_encoded.py
+++ b/tests/test_a_snapshot_says_how_it_is_encoded.py
@@ -296,3 +296,73 @@ def test_the_corpus_costs_far_less_than_the_sum_of_its_pages(conn):
         f"the shared dictionary bought only {ratio:.1f}x on a corpus of "
         "near-duplicates; per-page compression alone reaches about 15x here, so "
         "this says the dictionary is not being shared")
+
+def test_six_writers_racing_for_one_dictionary_all_get_the_winners(tmp_path):
+    """THE RACE A SIX-WORKER CRAWL HITS, forced with a barrier rather than hoped for.
+
+    `label` is UNIQUE, so writers that all miss the SELECT all attempt the INSERT and
+    all but one raise IntegrityError. Not hypothetical: the first six-worker
+    `--details` run over twenty pages stored 14 and reported 6 failures, and all six
+    were this.
+
+    TWO WEAKER VERSIONS OF THIS TEST WERE WRITTEN AND BOTH PASSED WITH THE FIX
+    REMOVED, which is the only reason it looks like this:
+
+      * six threads with no barrier -- twenty pages is not enough to force the
+        interleaving, so they mostly did not collide;
+      * a hand-ordered two-connection version -- B committed BEFORE A's SELECT, so A
+        found the row and returned early, never reaching the INSERT the fix is about.
+
+    A `threading.Barrier` fixes both: every thread is released only once all six have
+    arrived, and the SELECT is the first thing `_dictionary` does, so all six miss it.
+
+    The losers must end up with the WINNER'S body, never their own seed, because the
+    winner's body is what the winner's rows are compressed against.
+    """
+    import threading
+
+    from scrapex.snapshotbody import _dictionary
+
+    registry = DatabaseRegistry(EngineDatabase(tmp_path / "scrapex-engine.db"),
+                               pointer_file=tmp_path / "databases.json")
+    registry.initialize()
+
+    gate = threading.Barrier(6)
+    got: list[tuple[int, bytes]] = []
+    blew_up: list[Exception] = []
+    lock = threading.Lock()
+
+    def racer(n: int) -> None:
+        conn = registry.engine.connect()
+        try:
+            gate.wait()
+            found = _dictionary(conn, "muqawil.org/listing", f"page from {n}")
+            conn.commit()
+            with lock:
+                got.append(found)
+        except Exception as exc:
+            with lock:
+                blew_up.append(exc)
+        finally:
+            conn.close()
+
+    threads = [threading.Thread(target=racer, args=(n,)) for n in range(6)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not blew_up, (
+        f"{len(blew_up)} of six writers raised instead of reading the winner's "
+        f"dictionary: {blew_up[0]!r}")
+    assert len({dict_id for dict_id, _ in got} ) == 1, (
+        f"six writers produced {len({d for d, _ in got})} dictionaries for one label")
+    assert len({body for _, body in got}) == 1, (
+        "two writers disagree about the body behind one dict_id, so one of them "
+        "compressed its pages against a dictionary the row does not name")
+    reader = registry.engine.connect()
+    try:
+        assert reader.execute(
+            "SELECT COUNT(*) FROM snapshot_dictionary").fetchone()[0] == 1
+    finally:
+        reader.close()

--- a/tests/test_the_profile_frontier_comes_off_the_disk.py
+++ b/tests/test_the_profile_frontier_comes_off_the_disk.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -458,3 +459,168 @@ def test_a_slice_matching_in_two_locales_is_refused(conn):
                         CrawlScope.LISTING_PLUS_SLICE, "RIYADH")
 
     assert "more than one locale" in str(raised.value)
+
+# ---- workers: 87 hours becomes about 14, and the RATE must not move ----------
+#
+# MEASURED, which is why this section exists at all: the Dammam profile run went at
+# 9.03 s a page single-threaded, so 34,834 pages is 87 HOURS. The listing crawl
+# measured 1.14 s a page with six workers. The difference is latency, not politeness.
+#
+# `R-39` records 11.1 h for this and that figure is WRONG -- it was measured with six
+# workers and applied to a single-threaded command.
+
+
+def _threaded_conn(tmp_path: Path):
+    """A connection factory, as the CLI passes one: a NEW connection per worker.
+
+    `sqlite3` refuses a connection from a thread it was not created on, so a factory
+    is not a convenience here -- it is the only thing that works above one worker.
+    """
+    registry = DatabaseRegistry(EngineDatabase(tmp_path / "scrapex-engine.db"),
+                                pointer_file=tmp_path / "databases.json")
+    return registry.engine.connect
+
+
+def test_six_workers_store_every_page_exactly_once(conn, tmp_path):
+    """THE THING THAT MUST NOT BREAK. Overlapping the waits may not lose a page and
+    may not store one twice: a profile fetched twice is a wasted request and a second
+    snapshot of a page that has not changed."""
+    from scrapex.contractors import details
+
+    _registered(conn, CrawlScope.FULL_THEN_LISTING.value)
+    record_sightings(conn, "contractors", [str(n) for n in range(1, 41)])
+    conn.commit()
+    asked: list[str] = []
+
+    details(conn, get_directory(None), _fetch_recording(asked), None, "w6",
+            workers=6, connect=_threaded_conn(tmp_path))
+
+    stored = [r[0] for r in conn.execute(
+        "SELECT source_url FROM generic_page_snapshot "
+        " WHERE crawl_run_ref = 'w6'")]
+    assert len(asked) == len(set(asked)), "a page was fetched more than once"
+    assert sorted(stored) == sorted(set(asked)), (
+        "the set of stored pages is not the set of fetched pages")
+    assert len(stored) == 80, f"40 contractors x 2 locales, got {len(stored)}"
+
+
+def test_the_report_is_the_same_at_one_worker_and_at_six(conn, tmp_path, capsys):
+    """ORDERED BY THE FRONTIER, never by which worker finished.
+
+    THREE WEAKER VERSIONS WERE WRITTEN BEFORE THIS ONE, and each passed with the
+    ordered loop swapped for `as_completed` — which is the whole defect it exists to
+    catch. Recorded because the reasons are not obvious:
+
+      1. It compared only the SUMMARY lines. "profiles stored 20, failed 0" is the
+         same sentence in any order.
+      2. It added per-page failures but left 24 URLs against 6 workers. A pool that
+         size runs in BATCHES, the dead URLs landed one per batch, and batches
+         complete in order — so completion order equalled submission order anyway.
+      3. Its sleep used `url.rstrip("/143")`, a character strip, so `/11/143` lost
+         its 1s and `int` raised instead of sleeping.
+
+    What works: EVERY future in flight at once (8 URLs, 8 workers) with the sleep
+    DESCENDING, so completion order is provably the reverse of submission order. Then
+    an unordered report cannot accidentally look ordered.
+    """
+    from scrapex.contractors import details
+
+    _registered(conn, CrawlScope.FULL_THEN_LISTING.value)
+    record_sightings(conn, "contractors", ["1", "2", "3", "4"])
+    conn.commit()
+    dead = {f"https://muqawil.org/en/contractors/{n}/143" for n in (1, 2, 3, 4)}
+
+    def _reversed_fetch(url: str) -> str:
+        import time
+
+        # The id is the second-to-last path segment: /en/contractors/<id>/143.
+        number = int(url.split("/")[-2])
+        time.sleep((5 - number) * 0.05)          # id 1 sleeps longest, finishes last
+        if url in dead:
+            raise TimeoutError("the site did not answer")
+        return f"<html>{url}</html>"
+
+    details(conn, get_directory(None), _reversed_fetch, None, "serial")
+    serial = [line for line in capsys.readouterr().out.splitlines()
+              if "TimeoutError" in line]
+
+    details(conn, get_directory(None), _reversed_fetch, None, "parallel",
+            workers=8, connect=_threaded_conn(tmp_path))
+    parallel = [line for line in capsys.readouterr().out.splitlines()
+                if "TimeoutError" in line]
+
+    assert len(serial) == 4, f"the fixture did not produce four failures: {serial}"
+    assert serial == parallel, (
+        "the report order changed with the worker count, so two runs of the same "
+        f"frontier cannot be diffed: 1 worker {serial} vs 8 workers {parallel}")
+
+
+def test_a_dead_profile_still_does_not_end_a_parallel_run(conn, tmp_path, capsys):
+    """The failure isolation is in ONE function now, shared by both paths, so this
+    asserts the parallel path really uses it. One dead profile out of thirty-four
+    thousand must not discard the rest."""
+    from scrapex.contractors import details
+
+    _registered(conn, CrawlScope.FULL_THEN_LISTING.value)
+    record_sightings(conn, "contractors", [str(n) for n in range(1, 11)])
+    conn.commit()
+    dead = "https://muqawil.org/en/contractors/5/143"
+
+    details(conn, get_directory(None), _fetch_recording([], fails={dead}), None,
+            "w-dead", workers=6, connect=_threaded_conn(tmp_path))
+
+    out = capsys.readouterr().out
+    assert "stored 19, failed 1" in out, out.splitlines()[-1]
+    assert "TimeoutError" in out, "the dead page was not reported"
+
+
+def test_workers_do_not_raise_the_request_rate(conn, tmp_path):
+    """THE GUARD THAT KEEPS THIS ALLOWED AT ALL, and it is not theoretical.
+
+    Measured on 2026-08-21 in `partitioncrawl`: without the lock `HttpFetcher._throttle`
+    holds across its sleep, four workers made twenty requests in 1.02 s where 3.80 s was
+    owed. Concurrency that quadruples the real request rate against a live site and
+    calls itself a speedup is the thing `R-21` and `SR-8` forbid.
+
+    So this drives the REAL transport -- not the fake fetcher the tests above use --
+    against a local server, and asserts the floor. It is the only test here that cares
+    how long something took, deliberately: the property is a duration.
+    """
+    import http.server
+    import threading
+    import time
+
+    class Quiet(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):                     # stdlib's own spelling
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            self.wfile.write(b"<html>ok</html>")
+
+        def log_message(self, *_):            # keep the test output clean
+            return
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Quiet)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    port = server.server_address[1]
+    try:
+        from scrapex.connectors.base import HttpFetcher
+
+        pace = 0.2
+        fetcher = HttpFetcher(min_interval_s=pace)
+        urls = [f"http://127.0.0.1:{port}/{n}" for n in range(12)]
+
+        started = time.monotonic()
+        with ThreadPoolExecutor(max_workers=6) as pool:
+            list(pool.map(lambda u: fetcher.get(u).text, urls))
+        took = time.monotonic() - started
+    finally:
+        server.shutdown()
+
+    # The jitter is +/-30% around the interval, so the floor is the pessimistic end
+    # of it. Twelve requests owe eleven waits.
+    owed = 11 * pace * 0.7
+    assert took >= owed, (
+        f"six workers made {len(urls)} requests in {took:.2f}s where at least "
+        f"{owed:.2f}s was owed -- the concurrency raised the RATE instead of "
+        "overlapping the waits, which is what R-21 and SR-8 forbid")


### PR DESCRIPTION
`--details` was the last single-threaded crawl, and it was the longest one.

| | measured |
|---|---|
| Dammam profile run, single-threaded | **9.03 s a page** → 34,834 pages is **87 hours** |
| listing crawl, six workers | **1.14 s a page** |
| `--details` now | **11–14 hours** |

The difference is **latency, not politeness**: muqawil answers in seconds while the pace owes one request a second, so the wall clock is almost all waiting.

## A port, not a design

`partitioncrawl.py` had already solved every hard part, with measured reasoning, so `--details` takes the same shape: `workers` plus a `connect` factory, one `sqlite3` connection per worker because one is refused across threads.

**And it does not raise the request rate** — the property that makes it allowed at all. `HttpFetcher._throttle` holds a lock across its sleep, so the transport hands out one request per interval however many workers ask. Measured on 2026-08-21 *without* that lock: four workers made twenty requests in 1.02 s where 3.80 s was owed. `R-21` and `SR-8` both survive because the concurrency buys **overlap**, never a higher rate — and there is now a guard that drives the **real** transport against a local HTTP server and asserts the floor.

## The first six-worker run found a real race, and it was not in the new code

Twenty pages stored **14** and reported **6 failures**. None were about the pages: six workers all miss the `snapshot_dictionary` SELECT, all attempt the INSERT, and five lose on `UNIQUE(label)`.

`_dictionary` now re-reads after a conflict and returns **the winner's body** — the loser must not use its own seed, because the winner's body is what the winner's rows are compressed against.

## Four guards, and three took more than one attempt to earn

Mutation testing is the only reason this is trustworthy. The failed attempts are recorded *in the tests*, because the reasons are not obvious:

**The ordering guard passed with `as_completed` substituted three times.**
1. It compared only the summary lines — *"stored 20, failed 0"* is the same sentence in any order.
2. It added per-page failures but left 24 URLs against 6 workers. A pool that size runs in **batches**, the dead URLs landed one per batch, and batches complete in order — so completion order equalled submission order anyway.
3. Its sleep used `url.rstrip("/143")`, a **character** strip, so `/11/143` lost its `1`s and `int()` raised instead of sleeping.

What works: every future in flight at once, sleeps descending, so completion order is provably the reverse of submission order.

**The race guard passed with the fix removed twice.** Six threads with no barrier did not reliably collide; a hand-ordered two-connection version had B commit *before* A's SELECT, so A found the row and returned early without ever reaching the INSERT the fix is about. A `threading.Barrier` forces all six past the SELECT before any INSERT lands.

**Removing the per-worker connection** kills three tests, as it should.

| mutation | kills |
|---|---|
| share one connection | 3 |
| revert the dictionary race fix | 1 |
| `as_completed` instead of frontier order | 1 |

## `R-39` is amended, not corrected

He caught it: «ولاحظ أنّ R-39 يسجل 11.1 وهو رقم خاطئ». The figure came from *52.5 pages a minute over 87 minutes of real crawling* — of the **listing**, at six workers. Applied to a single-threaded `--details` it was 87 hours, not 11.1.

So the ruling was right about the destination and wrong about the vehicle. The original text stays with the amendment beside it, per **C4**. The lesson is narrower than bad arithmetic: **a rate measured on one command is not a rate.**

## Verification

- Full suite under `SCRAPEX_FULL_MIGRATIONS=1`: **zero failures**, before this PR opened — `R-22`.
- `ruff check scrapex/` clean; the two touched test files clean too.
- `--workers` defaults to **1**, so nothing changes for a caller that does not ask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
