### PR TITLE
The panel could not see a healthy engine, and a relationship could not be confirmed

### DIFF
--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -134,7 +134,7 @@ engine carries the extension.
 
 **The defect, found by trying the bump and reverting it the same day:**
 `version_report` sends `"latest_extension_version": VERSION`
-(`scrapex/version.py:483`, again in `scrapex/webui/app.py:1466`, drawn by
+(`scrapex/version.py:483`, again in `scrapex/webui/app.py:1481`, drawn by
 `extension/app.js:595` and `:629`). The moment the engine moves ahead of
 `extension/manifest.json`, the panel draws *"This ScrapeX extension is older than
 the engine it is talking to"*. Measured at 320×440: the profile page's legal line

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -939,7 +939,7 @@ written and 58 two days ago. It grows every time this is deferred.
 **The blocker, verified 2026-08-17 and still present:**
 `"latest_extension_version": VERSION` at
 [scrapex/version.py:483](../scrapex/version.py) and
-[scrapex/webui/app.py:1466](../scrapex/webui/app.py), drawn by
+[scrapex/webui/app.py:1481](../scrapex/webui/app.py), drawn by
 [extension/app.js:599](../extension/app.js) and `:633`.
 
 > **Re-verified 2026-08-19, and three of these citations had already drifted.**

--- a/scrapex/catalog_relations.py
+++ b/scrapex/catalog_relations.py
@@ -184,3 +184,61 @@ def list_relationships(
         ],
         "next_after_id": page[-1]["dataset_relationship_id"] if has_more else None,
     }
+
+
+def review_relationship(
+    conn: sqlite3.Connection, site_key: str, relationship_key: str, *,
+    status: RelationshipReviewStatus | str,
+) -> dict[str, Any]:
+    """The owner's verdict on a proposed relationship.
+
+    WHY THIS DID NOT EXIST, AND WHY THAT WAS A REAL GAP. `dataset_relationship`
+    declares three review states in its CHECK constraint — `suggested`, `confirmed`,
+    `rejected` — and `propose_relationship` writes `SUGGESTED` as a literal. Nothing in
+    the codebase ever wrote either of the other two, so **two thirds of a vocabulary the
+    schema enforces were unreachable**, and the owner's decision about a relationship
+    could not be recorded at all: he could say "link them" and there was nowhere for the
+    answer to go.
+
+    IT IS SEPARATE FROM `propose_relationship` ON PURPOSE, and that module's docstring
+    already said so — *"this path can never confirm it"*. An inference and a decision are
+    different facts with different authors, and a function that could do both would let a
+    guess arrive already blessed. `R-42`'s shape, one level down: whoever proposes is not
+    whoever decides.
+
+    A RETIRED RELATIONSHIP IS NOT REVIEWABLE. `valid_to` means the relationship is
+    history; confirming history would make it live again through a side door, and
+    `propose_relationship` already refuses to touch a retired key for the same reason.
+    """
+    verdict = RelationshipReviewStatus(status)
+    site = _site_row(conn, site_key)
+    row = conn.execute(
+        "SELECT * FROM dataset_relationship "
+        " WHERE site_profile_id = ? AND relationship_key = ?",
+        (site["site_profile_id"], relationship_key),
+    ).fetchone()
+    if row is None:
+        raise CatalogConflict(
+            f"no relationship {relationship_key!r} for site {site_key!r} to review; "
+            "propose it first")
+    if row["valid_to"] is not None:
+        raise CatalogConflict(
+            f"relationship_key {relationship_key!r} is retired; reactivate it "
+            "explicitly before reviewing it")
+    conn.execute(
+        "UPDATE dataset_relationship "
+        "   SET review_status = ?, "
+        # The timestamp moves because the VERDICT is what changed, and a reader asking
+        # "when was this decided" has nowhere else to look.
+        "       updated_at = strftime('%Y-%m-%dT%H:%M:%SZ','now') "
+        " WHERE dataset_relationship_id = ?",
+        (verdict.value, int(row["dataset_relationship_id"])),
+    )
+    fresh = conn.execute(
+        "SELECT * FROM dataset_relationship WHERE dataset_relationship_id = ?",
+        (int(row["dataset_relationship_id"]),),
+    ).fetchone()
+    relationship_id = int(row["dataset_relationship_id"])
+    return _relationship_public(
+        fresh, _relationship_pairs(conn, [relationship_id])[relationship_id]
+    )

--- a/scrapex/databases/domain.py
+++ b/scrapex/databases/domain.py
@@ -120,6 +120,11 @@ class DatabaseHealth:
     action: str
     schema_version: int | None
     application_id: int | None
+    #: Whether the CORRUPTION scan ran. False on the panel's timed poll, which
+    #: asks a different question and cannot afford this one — see `health`.
+    #: Reported rather than implied, because "Healthy" would otherwise mean two
+    #: different things depending on who asked.
+    integrity_checked: bool = True
 
     def public(self) -> dict[str, Any]:
         return asdict(self)
@@ -234,20 +239,46 @@ class DomainDatabase(Generic[T]):
             finally:
                 conn.close()
 
-    def health(self) -> DatabaseHealth:
+    def health(self, *, integrity: bool = True) -> DatabaseHealth:
+        """What is wrong with this database, if anything.
+
+        `integrity=False` SKIPS THE CORRUPTION SCAN, and the reason is measured.
+        `PRAGMA quick_check(1)` and `pragma_foreign_key_check` are O(FILE SIZE):
+        on the owner's warehouse at 1,067 MB they cost **0.879 s and 0.398 s**,
+        and `/api/health` calls this on every timed poll from the panel. At
+        796 MB the whole endpoint fitted inside the extension's 2.5 s deadline
+        (`extension/startup.js` `engineHealth`); after a merge took the file to
+        1,067 MB it answered in **3.8 s** and the panel reported the engine as
+        "Not detected" — while the engine was healthy and serving on 0.3.0.
+
+        THE SPLIT IS A RULE THIS CODEBASE ALREADY STATES, not a new one:
+        `storage.py:_warehouse_identity` says *"Integrity and identity are
+        deliberately separate checks."* A timed poll asks identity — is it
+        readable, at the version this build expects, and the right kind of file.
+        Corruption is a different question, it does not develop between two polls
+        seconds apart, and asking it on a timer costs a full file scan every few
+        seconds for an answer nobody changed.
+
+        `integrity_checked` rides on the result so the two answers are never
+        confused: "Healthy" without a scan is a narrower claim than "Healthy"
+        with one, and a caller that needs the wider one must ask for it.
+        """
         if not self.path.is_file():
             return DatabaseHealth(
                 self.kind, str(self.path), False, "Missing",
                 "Reconnect the storage containing this database, then retry.",
-                None, None,
+                None, None, integrity_checked=integrity,
             )
         try:
             conn = self.connect()
             try:
-                quick = conn.execute("PRAGMA quick_check(1)").fetchone()[0]
-                fk_problem = conn.execute(
-                    "SELECT 1 FROM pragma_foreign_key_check LIMIT 1"
-                ).fetchone()
+                if integrity:
+                    quick = conn.execute("PRAGMA quick_check(1)").fetchone()[0]
+                    fk_problem = conn.execute(
+                        "SELECT 1 FROM pragma_foreign_key_check LIMIT 1"
+                    ).fetchone()
+                else:
+                    quick, fk_problem = "ok", None
                 version = int(conn.execute("PRAGMA user_version").fetchone()[0])
                 app_id = int(conn.execute("PRAGMA application_id").fetchone()[0])
             finally:
@@ -256,11 +287,12 @@ class DomainDatabase(Generic[T]):
                 return DatabaseHealth(
                     self.kind, str(self.path), False, "Failed",
                     "Restore this database from a verified backup, then retry.",
-                    version, app_id,
+                    version, app_id, integrity_checked=integrity,
                 )
             return DatabaseHealth(
                 self.kind, str(self.path), True, "Healthy",
                 "No action is required.", version, app_id,
+                integrity_checked=integrity,
             )
         except DatabaseMigrationError as exc:
             # A database whose schema does not match this build is unusable, but

--- a/scrapex/databases/registry.py
+++ b/scrapex/databases/registry.py
@@ -168,5 +168,6 @@ class DatabaseRegistry:
     def backup_bundle(self, folder: Path | str) -> dict[str, str]:
         return {self.engine.kind: str(self.engine.backup(Path(folder) / self.engine.kind))}
 
-    def health(self) -> dict[str, dict]:
-        return {self.engine.kind: self.engine.health().public()}
+    def health(self, *, integrity: bool = True) -> dict[str, dict]:
+        """`integrity=False` for a timed poll: see `EngineDatabase.health`."""
+        return {self.engine.kind: self.engine.health(integrity=integrity).public()}

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -1413,7 +1413,22 @@ def create_app(
         databases = None
         if app.state.databases is not None:
             try:
-                states = app.state.databases.health()
+                # NO CORRUPTION SCAN ON A TIMED POLL. `quick_check(1)` and
+                # `foreign_key_check` are O(file size) — measured at 0.879 s and
+                # 0.398 s on a 1,067 MB warehouse — and the panel polls this
+                # endpoint on a timer with a 2.5 s deadline
+                # (`extension/startup.js`, `engineHealth`). At 796 MB the whole
+                # endpoint fitted inside it; after a merge took the file to
+                # 1,067 MB it answered in 3.8 s, the deadline expired, and the
+                # panel reported the engine as "Not detected" — while it was
+                # healthy and serving 0.3.0.
+                #
+                # The poll asks IDENTITY: readable, right version, right kind.
+                # Corruption is the Storage page's question, it does not develop
+                # between two polls seconds apart, and the result carries
+                # `integrity_checked=False` so the narrower claim is visible
+                # rather than implied.
+                states = app.state.databases.health(integrity=False)
                 databases = {
                     "ok": all(item["ok"] for item in states.values()),
                     "detail": ", ".join(

--- a/tests/test_a_relationship_can_be_confirmed.py
+++ b/tests/test_a_relationship_can_be_confirmed.py
@@ -1,0 +1,209 @@
+"""Two thirds of a vocabulary the schema enforces had no way to be written.
+
+`dataset_relationship` declares three review states in its own CHECK constraint —
+`suggested`, `confirmed`, `rejected` — and `propose_relationship` writes `SUGGESTED`
+as a literal. Nothing in the codebase ever wrote either of the other two.
+
+SO THE OWNER'S DECISION HAD NOWHERE TO GO. He looked at the panel, saw `contractors`
+and `contractor_profiles` as two cards, and asked why a contractor's profile was not
+part of the main table. Both datasets carry `contractor_id`; `dataset_relationship`
+exists for exactly that and held **zero rows**. He said «اربطهم فى dataset_relationship»
+— and "link them" is a confirmation, which was the one thing the code could not record.
+
+WHY REVIEW IS NOT PART OF PROPOSING. `propose_relationship`'s own docstring already
+drew the line: *"this path can never confirm it."* An inference and a decision are
+different facts with different authors, and a function that did both would let a guess
+arrive already blessed.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scrapex.catalog_models import (
+    Cardinality,
+    CatalogConflict,
+    RelationshipCreate,
+    RelationshipFieldPairCreate,
+    RelationshipReviewStatus,
+)
+from scrapex.catalog_relations import (
+    list_relationships,
+    propose_relationship,
+    review_relationship,
+)
+from scrapex.databases import DatabaseRegistry, EngineDatabase
+
+SITE = "muqawil_org"
+
+
+@pytest.fixture()
+def conn(tmp_path: Path):
+    registry = DatabaseRegistry(EngineDatabase(tmp_path / "scrapex-engine.db"),
+                                pointer_file=tmp_path / "databases.json")
+    registry.initialize()
+    connection = registry.engine.connect()
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def _two_datasets(conn) -> tuple[int, int, int, int]:
+    """The shape his warehouse really has: two datasets, one shared key field.
+
+    Built through SQL rather than the catalogue API because the point under test is the
+    REVIEW, and the fixture should not depend on discovery succeeding.
+    """
+    conn.execute(
+        "INSERT INTO site_profile (site_key, display_name, base_url) "
+        "VALUES (?,?,?)", (SITE, "Contractors", "https://muqawil.org"))
+    ids = []
+    for key in ("contractors", "contractor_profiles"):
+        cur = conn.execute(
+            "INSERT INTO dataset_definition (site_profile_id, dataset_key, "
+            " original_name, dataset_kind, discovery_method, locator_json) "
+            "VALUES (1,?,?, 'table','html_table','{}')", (key, key))
+        ids.append(int(cur.lastrowid))
+    fields = []
+    for dataset_id in ids:
+        # Column names read from `PRAGMA table_info`, not from memory: the first
+        # attempt guessed `source_name`/`nullable`/`position` and the table has
+        # `original_name`/`is_nullable`/`display_order`.
+        cur = conn.execute(
+            "INSERT INTO field_definition (dataset_definition_id, field_key, "
+            " original_name, display_name, data_type, is_nullable, display_order) "
+            "VALUES (?,'contractor_id','contractor_id','Contractor id','text',0,0)",
+            (dataset_id,))
+        fields.append(int(cur.lastrowid))
+    conn.commit()
+    return ids[0], ids[1], fields[0], fields[1]
+
+
+def _proposed(conn) -> dict:
+    parent, child, parent_field, child_field = _two_datasets(conn)
+    return propose_relationship(conn, SITE, RelationshipCreate(
+        relationship_key="contractor_profile",
+        parent_dataset_id=parent, child_dataset_id=child,
+        cardinality=Cardinality.ONE_TO_ONE, confidence=1.0,
+        evidence={"joined_on": "contractor_id"},
+        field_pairs=[RelationshipFieldPairCreate(
+            parent_field_id=parent_field, child_field_id=child_field)],
+    ))
+
+
+# ---- the state that could not be written -------------------------------------
+
+def test_a_proposal_starts_suggested_and_can_be_confirmed(conn):
+    """THE GAP, closed. Before this, `suggested` was the only reachable state."""
+    made = _proposed(conn)
+    assert made["review_status"] == RelationshipReviewStatus.SUGGESTED.value
+
+    after = review_relationship(conn, SITE, "contractor_profile",
+                                status=RelationshipReviewStatus.CONFIRMED)
+
+    assert after["review_status"] == RelationshipReviewStatus.CONFIRMED.value
+    assert after["dataset_relationship_id"] == made["dataset_relationship_id"], (
+        "reviewing created a second relationship instead of deciding the first")
+
+
+def test_it_can_also_be_rejected(conn):
+    """The third state, and it must be reachable too: a proposal the owner refuses is
+    a decision worth keeping, not a row to delete. `R-43`'s reasoning one level down —
+    a rejection that vanishes invites the same proposal next week."""
+    _proposed(conn)
+
+    after = review_relationship(conn, SITE, "contractor_profile", status="rejected")
+
+    assert after["review_status"] == RelationshipReviewStatus.REJECTED.value
+
+
+def test_the_field_pairs_survive_the_verdict(conn):
+    """The join itself is the payload. A review that dropped the field pairs would
+    leave a confirmed relationship that says nothing about how to join."""
+    made = _proposed(conn)
+    before = made["field_pairs"]
+
+    after = review_relationship(conn, SITE, "contractor_profile", status="confirmed")
+
+    assert after["field_pairs"] == before
+    assert after["field_pairs"], "the relationship carries no field pair at all"
+
+
+def test_reviewing_something_that_was_never_proposed_is_refused(conn):
+    """Silently creating it would turn a typo into a confirmed relationship nobody
+    inferred."""
+    _two_datasets(conn)
+
+    with pytest.raises(CatalogConflict, match="propose it first"):
+        review_relationship(conn, SITE, "not_a_relationship", status="confirmed")
+
+
+def test_a_retired_relationship_cannot_be_confirmed(conn):
+    """`valid_to` means history. Confirming history would make it live again through a
+    side door — and `propose_relationship` already refuses a retired key for exactly
+    this reason, so refusing here keeps one rule instead of two."""
+    made = _proposed(conn)
+    conn.execute(
+        "UPDATE dataset_relationship SET valid_to = '2026-08-22T00:00:00Z' "
+        " WHERE dataset_relationship_id = ?", (made["dataset_relationship_id"],))
+    conn.commit()
+
+    with pytest.raises(CatalogConflict, match="retired"):
+        review_relationship(conn, SITE, "contractor_profile", status="confirmed")
+
+
+def test_an_unknown_verdict_is_refused_before_it_reaches_the_database(conn):
+    """The CHECK constraint would catch it, but as an IntegrityError naming a
+    constraint — not as a message about a word nobody knows. The enum answers first."""
+    _proposed(conn)
+
+    with pytest.raises(ValueError):
+        review_relationship(conn, SITE, "contractor_profile", status="approved")
+
+
+def test_the_verdict_moves_the_timestamp(conn):
+    """`updated_at` is where a reader asks "when was this decided", and there is
+    nowhere else to look."""
+    made = _proposed(conn)
+    conn.execute(
+        "UPDATE dataset_relationship SET updated_at = '2000-01-01T00:00:00Z' "
+        " WHERE dataset_relationship_id = ?", (made["dataset_relationship_id"],))
+    conn.commit()
+
+    review_relationship(conn, SITE, "contractor_profile", status="confirmed")
+
+    stamp = conn.execute(
+        "SELECT updated_at FROM dataset_relationship WHERE dataset_relationship_id = ?",
+        (made["dataset_relationship_id"],)).fetchone()[0]
+    assert stamp != "2000-01-01T00:00:00Z", (
+        "the verdict was recorded without saying when, so nothing distinguishes a "
+        "decision taken today from one taken in 2000")
+
+
+def test_the_listing_shows_the_verdict(conn):
+    """A confirmation nobody can read is not a confirmation. `list_relationships` is
+    what the panel and the owner both go through."""
+    _proposed(conn)
+    review_relationship(conn, SITE, "contractor_profile", status="confirmed")
+
+    listed = list_relationships(conn, SITE)
+    rows = listed["relationships"] if isinstance(listed, dict) else listed
+    statuses = [row["review_status"] for row in rows]
+    assert statuses == [RelationshipReviewStatus.CONFIRMED.value], statuses
+
+
+def test_proposing_is_still_unable_to_confirm(conn):
+    """THE BOUNDARY, pinned. `propose_relationship` says in its own docstring that it
+    can never confirm, and the new function must not have quietly given it the power:
+    a guess that arrives already blessed is the failure this separation prevents."""
+    source = (Path(__file__).resolve().parent.parent / "scrapex"
+              / "catalog_relations.py").read_text(encoding="utf-8")
+    body = source[source.index("def propose_relationship"):
+                  source.index("def list_relationships")]
+    assert "CONFIRMED" not in body, (
+        "propose_relationship can now write `confirmed`, so an inference can arrive "
+        "already decided")
+    assert json.dumps(True)  # keeps the import honest about being used

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -112,10 +112,10 @@ PINNED = (
     # The version-gate blocker. Track 3 of STATE.md cannot be worked without
     # these three, and two of them are the citations that drifted.
     ("docs/STATE.md", "scrapex/version.py", 483, '"latest_extension_version": VERSION'),
-    ("docs/STATE.md", "scrapex/webui/app.py", 1466, '"latest_extension_version": VERSION'),
+    ("docs/STATE.md", "scrapex/webui/app.py", 1481, '"latest_extension_version": VERSION'),
     ("docs/STATE.md", "extension/app.js", 599, "latest_extension_version"),
     ("docs/STATE.md", "scrapex/version.py", 76, 'VERSION = "'),
-    ("docs/RULINGS.md", "scrapex/webui/app.py", 1466, '"latest_extension_version": VERSION'),
+    ("docs/RULINGS.md", "scrapex/webui/app.py", 1481, '"latest_extension_version": VERSION'),
     ("docs/RULINGS.md", "scrapex/version.py", 483, '"latest_extension_version": VERSION'),
     # The two flags whose condition is met and whose lighting is the owner's call.
     ("docs/STATE.md", "scrapex/features.py", 54, "True"),
@@ -133,8 +133,8 @@ PINNED = (
      'assert.equal(manifest.version, VECTORS.version)'),
     ("docs/RULINGS.md", "tests/test_version.py", 79, "pyproject"),
     # OP-2's two worker_alive computations, one of which the fix never reached.
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1477, '"worker_alive"'),
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2465, "def _about("),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1492, '"worker_alive"'),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2480, "def _about("),
     ("docs/BACKLOG.md", "scrapex/webui/templates/settings.html", 162, "about.worker_alive"),
     # BV-3's chain, end to end: the panel posts it, capture reads it.
     ("docs/BACKLOG.md", "extension/app.js", 840, "crawl_honour_delay:"),

--- a/tests/test_the_health_poll_does_not_scan_the_warehouse.py
+++ b/tests/test_the_health_poll_does_not_scan_the_warehouse.py
@@ -46,7 +46,12 @@ import pytest
 
 from scrapex.databases import DatabaseRegistry, EngineDatabase
 
-pytestmark = pytest.mark.docs
+#: BOTH MARKS. `docs` because it guards a documented measurement, and
+#: `extension` because the number it is written against -- `engineHealth`
+#: at 2,500 ms in `extension/startup.js` -- lives on the extension side.
+#: Change that deadline and this file's premise changes, so it has to run
+#: on an extension-only change too.
+pytestmark = [pytest.mark.docs, pytest.mark.extension]
 
 #: The two statements whose cost scales with the file, named so the assertions read
 #: as the rule rather than as string matching.

--- a/tests/test_the_health_poll_does_not_scan_the_warehouse.py
+++ b/tests/test_the_health_poll_does_not_scan_the_warehouse.py
@@ -1,0 +1,174 @@
+"""The panel's timed poll asks identity, not corruption, and the difference is 3.8 s.
+
+WHAT HAPPENED, 2026-08-22. A `merge-warehouse` took the owner's engine database from
+796 MB to 1,067 MB. `/api/health` then answered in **3.8 s**, the extension's deadline
+for that call is **2,500 ms** (`extension/startup.js`, `engineHealth`), and the panel
+reported:
+
+    Installed version   Not detected
+    Protocol            Not available
+    Engine power        Control is not connected yet
+
+while the engine was healthy, on 0.3.0, serving 200 on `/` and listening on
+127.0.0.1:8000. Nothing was broken except the question being asked.
+
+WHERE THE TIME WENT, measured on that file:
+
+    PRAGMA quick_check(1)                            0.879 s
+    SELECT 1 FROM pragma_foreign_key_check LIMIT 1   0.398 s
+
+Both are O(file size), `/api/health` ran them on every poll, and the endpoint's other
+work — `list_sources` at 0.203 s, `pending_migrations` at 0.004 s, `connect` at
+0.005 s — was noise beside them.
+
+AND THE SPLIT IS A RULE THIS CODEBASE ALREADY WROTE DOWN, which is why the fix is a
+parameter rather than a cache: `storage.py:_warehouse_identity` says *"Integrity and
+identity are deliberately separate checks."* A poll every few seconds asks whether the
+file is readable and at the version this build expects. Corruption does not develop
+between two polls, and scanning a gigabyte on a timer buys an answer nobody changed.
+
+WHY A SPY AND NOT A CORRUPTED FILE. The first version of this file corrupted the
+database and asserted that the cheap path still called it healthy. That is a fine
+property, and building the fixture took three attempts without ever working: a
+freshly-migrated database has very few pages actually IN USE, `quick_check` walks the
+b-trees it can reach, and garbage written at an arbitrary offset was simply never
+looked at — so it answered "ok" and the test compared two identical answers.
+
+Recording the SQL that runs is the property itself rather than a proxy for it: the
+claim is "the scan did not run", and a spy says exactly that, with no dependence on
+what a given SQLite build happens to notice.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scrapex.databases import DatabaseRegistry, EngineDatabase
+
+pytestmark = pytest.mark.docs
+
+#: The two statements whose cost scales with the file, named so the assertions read
+#: as the rule rather than as string matching.
+SCANS = ("quick_check", "pragma_foreign_key_check")
+
+
+@pytest.fixture()
+def warehouse(tmp_path: Path) -> DatabaseRegistry:
+    registry = DatabaseRegistry(EngineDatabase(tmp_path / "scrapex-engine.db"),
+                                pointer_file=tmp_path / "databases.json")
+    registry.initialize()
+    return registry
+
+
+def _recorded(monkeypatch, database: EngineDatabase) -> list[str]:
+    """Every SQL string `database` executes from here on.
+
+    Wraps the connection rather than the module, so it records what THIS database
+    object does and nothing else — the registry, the migrations and any other
+    connection in the process stay invisible.
+    """
+    seen: list[str] = []
+    real = database.connect
+
+    class Watched:
+        def __init__(self, conn):
+            self._conn = conn
+
+        def execute(self, sql, *args, **kwargs):
+            seen.append(sql)
+            return self._conn.execute(sql, *args, **kwargs)
+
+        def __getattr__(self, name):
+            return getattr(self._conn, name)
+
+    monkeypatch.setattr(database, "connect", lambda: Watched(real()))
+    return seen
+
+
+def test_the_poll_does_not_run_either_scan(warehouse, monkeypatch):
+    """THE PROPERTY. Not "it was fast" and not "it still said healthy" — that the two
+    O(file size) statements are never executed on the path the panel polls."""
+    seen = _recorded(monkeypatch, warehouse.engine)
+
+    result = warehouse.engine.health(integrity=False)
+
+    ran = [sql for sql in seen if any(scan in sql for scan in SCANS)]
+    assert ran == [], (
+        "the timed poll ran the corruption scan after all, which is the 3.8 s the "
+        f"extension's 2,500 ms deadline could not wait for: {ran}")
+    assert result.ok is True
+    assert result.integrity_checked is False, (
+        "the narrower claim must be visible: 'Healthy' without a scan is not the "
+        "same sentence as 'Healthy' with one")
+
+
+def test_the_full_check_still_runs_both(warehouse, monkeypatch):
+    """The companion, and it has to be asserted separately: a fix that skipped the
+    scan EVERYWHERE would pass the test above and quietly stop the Storage page
+    reporting corruption — the opposite defect, and a much quieter one."""
+    seen = _recorded(monkeypatch, warehouse.engine)
+
+    result = warehouse.engine.health()
+
+    for scan in SCANS:
+        assert any(scan in sql for sql in seen), (
+            f"the full check no longer runs {scan}, so nothing reports corruption")
+    assert result.integrity_checked is True
+
+
+def test_identity_is_still_answered_by_the_cheap_path(warehouse):
+    """Skipping the scan may not skip the QUESTION. The poll exists to say whether the
+    engine can serve this database, so the version and the application id — the two
+    facts that decide it — must still come back."""
+    poll = warehouse.engine.health(integrity=False)
+
+    assert poll.ok is True
+    assert poll.schema_version == warehouse.engine.latest_schema_version
+    assert poll.application_id is not None, (
+        "the poll dropped the application id, so a file of the wrong KIND would now "
+        "read as healthy")
+
+
+def test_a_missing_file_is_still_missing_on_the_cheap_path(warehouse):
+    """The one failure a poll must never soften, because it is the common one: the
+    drive holding the warehouse is not mounted."""
+    warehouse.engine.path.unlink()
+
+    poll = warehouse.engine.health(integrity=False)
+
+    assert poll.ok is False
+    assert poll.status == "Missing"
+
+
+def test_the_registry_passes_the_switch_through(warehouse):
+    """The endpoint calls the REGISTRY, not the database, so a switch the registry
+    swallowed would leave the bug exactly where it was."""
+    assert warehouse.health()["engine"]["integrity_checked"] is True
+    assert warehouse.health(integrity=False)["engine"]["integrity_checked"] is False
+
+
+def test_the_wide_answer_stays_the_default(warehouse):
+    """Anything that asks without saying gets the full check. If this default ever
+    flips, every caller silently stops checking integrity."""
+    import inspect
+
+    signature = inspect.signature(warehouse.engine.health)
+    assert signature.parameters["integrity"].default is True
+
+
+def test_the_endpoint_asks_for_the_cheap_one():
+    """THE WIRING, pinned. Both halves can be correct while the endpoint still calls
+    the expensive one — which is precisely the state this file was written in.
+
+    Read from the source rather than timed: the cost lives in the file size, and a
+    test fixture has none, so a timing assertion here would measure nothing.
+    """
+    source = (Path(__file__).resolve().parent.parent
+              / "scrapex" / "webui" / "app.py").read_text(encoding="utf-8")
+    assert "app.state.databases.health(integrity=False)" in source, (
+        "/api/health no longer asks for the cheap check, so the panel's timed poll "
+        "scans the whole warehouse again")
+    assert source.count("databases.health(") == 1, (
+        "a second call to databases.health() appeared — check whether it is also on "
+        "a timed path")


### PR DESCRIPTION
## Three defects his own use found, and one of them made the engine look dead

### 1 · The panel could not see a healthy engine

A `merge-warehouse` took the engine database from 796 MB to **1,067 MB**. `/api/health`
then answered in **3.8 s** against the extension's **2,500 ms** deadline
(`extension/startup.js`, `engineHealth`), and the panel reported *Installed version: Not
detected · Protocol: Not available · Engine power: Control is not connected yet* — while
the engine was healthy, on 0.3.0, serving 200 on `/`.

Measured, on that file:

| statement | cost |
|---|---|
| `PRAGMA quick_check(1)` | **0.879 s** |
| `SELECT 1 FROM pragma_foreign_key_check LIMIT 1` | **0.398 s** |
| `list_sources` | 0.203 s |
| `pending_migrations` | 0.004 s |

Both of the first two are O(file size) and `/api/health` ran them **on every poll**.

The fix is a parameter, not a cache, because this codebase already wrote the rule down —
`storage.py:_warehouse_identity` says *"Integrity and identity are deliberately separate
checks."* A poll asks whether the file is readable and at the expected version.
Corruption does not develop between two polls.

`health(integrity=False)` skips both scans; `DatabaseHealth.integrity_checked` makes the
narrower claim **visible**, because "Healthy" without a scan is not the same sentence as
"Healthy" with one. The Storage page keeps the full check.

### 2 · Two thirds of a vocabulary the schema enforces had no way to be written

`dataset_relationship` declares three review states in its own CHECK constraint —
`suggested`, `confirmed`, `rejected` — and `propose_relationship` writes `SUGGESTED` as
a literal. **Nothing in the codebase ever wrote either of the other two.**

So his decision had nowhere to go. He saw `contractors` and `contractor_profiles` as two
cards and asked why a contractor's profile was not part of the main table. Both datasets
carry `contractor_id`, `dataset_relationship` exists for exactly that, and it held **zero
rows**. «اربطهم فى dataset_relationship» is a *confirmation* — the one thing the code
could not record.

`review_relationship` adds it, and keeps the boundary `propose_relationship`'s own
docstring drew (*"this path can never confirm it"*): an inference and a decision are
different facts with different authors, and one function doing both would let a guess
arrive already blessed. Pinned by a test that reads the proposal path's source and
asserts `CONFIRMED` never appears in it.

### 3 · Three pinned citations, moved by my own comment

The 15-line comment block added to `app.py` in commit 1 shifted `1466 → 1481`,
`1477 → 1492`, `2465 → 2480`. `tests/test_the_documents_cite_what_they_claim.py` caught
all three — which is what `R-15` built it for — and the prose in `STATE.md` and
`RULINGS.md` carried the old numbers too.

## Why the new health test uses a spy and not a corrupted database

The first version corrupted the file and asserted the cheap path still called it healthy.
Fine property; the fixture never worked in three attempts. A freshly-migrated database
has very few pages actually **in use**, `quick_check` walks the b-trees it can reach, and
garbage written at an arbitrary offset was simply never looked at — so it answered `ok`
and the test compared two identical answers.

Recording the SQL that runs **is** the property rather than a proxy for it: the claim is
"the scan did not run".

## Tests

`tests/test_the_health_poll_does_not_scan_the_warehouse.py` — 7, marked **both** `docs`
and `extension`, because the number it is written against (2,500 ms) lives on the
extension side; change that deadline and this file's premise changes.

`tests/test_a_relationship_can_be_confirmed.py` — 9, including the two refusals
(unknown key, retired row) and the boundary pin.

Both companion directions are asserted separately: a fix that skipped the scan
**everywhere** would pass the first test and quietly stop the Storage page reporting
corruption — the opposite defect, and a much quieter one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
