### PR TITLE
The three dots appear once, because a z-index cannot leave its own stacking context

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1532,6 +1532,62 @@ already makes a private one free, and `R-24`'s repair path (`carry_over`) exists
 Recorded as `Q-15`.
 
 
+### OP-42 · A generic dataset card offers no actions at all, and one of the six would work
+
+**Status: OPEN. Found 2026-08-22, in the same screenshots as the double-⋮ defect,
+and it is a SEPARATE cause from it.**
+
+**He asked about one thing in that screenshot; this is the other thing in it.** His
+question was «لماذا تظهر مرتين» — a `⋮` appearing twice, a stacking-context bug,
+fixed and recorded as `REQ-30`. Reading the same picture to reproduce it turned up
+a second fact he did not raise: `aramco.com` and `spark-eshop.com` carry a `⋮` and
+the two `muqawil.org` cards carry none. So it belongs here and not in
+[REQUESTS.md](REQUESTS.md) — we found it.
+
+**That absence is deliberate, and it is written down in both halves.**
+`sourceMenu` returns an empty string for a dataset
+([extension/app.js:4549](../extension/app.js#L4549)), and the engine stamps the
+marker it keys on precisely so the panel can do that — `"kind": "dataset"` in
+`_dataset_rows`, whose docstring says *"the row menu offers Update, Wipe and
+Rename, and every one of those is a price-path action that would answer 400 or
+worse for a dataset"* ([scrapex/webui/app.py:639](../scrapex/webui/app.py#L639)).
+It was the right call for five of the six entries and it is still right for them:
+`update`, `pause` and `settings` post to routes that read the manifest, and
+`/api/export/{key}` validates the key against `manifest.sources` and answers 404
+for anything else ([scrapex/webui/app.py:2710](../scrapex/webui/app.py#L2710)).
+
+**But `Open the data table` would work, and it was built after the blanket
+hide.** `data.html?source=KEY` fetches `/api/table/{key}`, and that route looks
+the key up in the dataset catalogue FIRST — *"a generic dataset is a table like
+any other table"* ([scrapex/webui/app.py:986](../scrapex/webui/app.py#L986)) —
+so `/api/table/contractors` serves the directory in full. The panel hides the one
+entry that works on the marker that was introduced for the five that do not.
+
+**Measured, not assumed** — the panel driven with two `kind: "dataset"` rows
+shaped exactly as `_dataset_rows` builds them:
+
+| card | `.split-button-trigger` |
+|---|---|
+| `LONG_AR` | 1 |
+| `SHORT` | 1 |
+| `contractors` | 0 |
+| `contractor_profiles` | 0 |
+
+**And the guard for this is not just missing, it currently points the other
+way.** `tests/test_panel_dom.py::test_dataset_action_opens_the_workspace_directly`
+asserts *"every dataset card must carry exactly one actions menu"*, which holds
+only because `tools/panel_harness.py`'s stub contains no dataset-kind source at
+all. Add one honestly and that assertion fails — so the rule `sourceMenu`
+implements has never been executed by any test. Whichever way this is decided,
+the stub needs a dataset row and that assertion needs to be per-kind.
+
+**The narrow fix** is to give `SOURCE_ACTIONS` a per-entry predicate rather than
+gating the whole menu on `kind`, and to show a dataset the entries that work.
+Deliberately not done inside the double-⋮ fix: that one is a CSS stacking bug
+with a hit test to prove it, and this one changes what the panel offers, which is
+the owner's call under `R-32`'s reading of what a dataset is.
+
+
 ## 3. Decided, not yet built
 
 ### DEC-1 · Topology A — the TypeScript extension as the public product

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -552,6 +552,36 @@ fixed. **`--accent` is not a safe state colour**: device mode resolves it to the
 OS `AccentColor`, so it can collide with the fixed `--amber`. Guarded by
 `test_every_custom_property_a_stylesheet_reads_is_one_something_defines`.
 
+### A z-index cannot escape its own stacking context, so raising the number is not a fix
+
+A popover inside a repeated card was painted over by the NEXT card's button, and
+what the owner saw was the same button **twice** — once on its card and once
+floating over the open menu (`REQ-30`, 2026-08-22). The menu already carried
+`z-index: 120`; the card's wrapper carried `z-index: 1`.
+
+**Why:** any numeric z-index on a positioned element makes it a **stacking
+context**, and a descendant's z-index is then only ever compared with its
+siblings *inside* that context. The wrapper's `1` is what the outside world sees.
+Every card's wrapper tied at 1, ties break by document order, and the later card
+won. **Measured: the defect survives the menu going to 120, 1200 and
+2147483647** — the number was never the variable.
+
+**Apply:** when a popover is clipped or overpainted, look for a numeric z-index on
+an ANCESTOR before touching the popover's own, and lift **that** element — only
+while it is open, to `var(--z-overlay)`, which is what `.sx-select-list`,
+`.account-menu`, `.finance-converter-options` and `webui.css`'s
+`.source-filter-menu[open]` all already do. The extension's layers are three
+tokens (`--z-sticky: 10`, `--z-overlay: 20`, `--z-modal: 30`); a fourth number
+invented at a call site is the next instance of this bug.
+
+**And test it by hit-testing, not by reading the style back.** `elementFromPoint`
+at each row of the open menu answers the question a person asks — *what is in
+front?* — and an assertion on the computed z-index would have passed on the broken
+build, because the broken build's number was already large. Guarded by
+`tests/test_panel_dom.py::test_an_open_source_menu_is_not_overpainted_by_the_next_cards_button`,
+which also refuses to pass if no button lies under the menu at all: a guard whose
+overlap has drifted away proves nothing and must say so rather than go green.
+
 ---
 
 ## 6 · Two OAuth clients, therefore two grants

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -85,6 +85,7 @@ IDs are stable and never reused, matching the convention BACKLOG.md already uses
 | [REQ-27](#req-27--a-second-source-of-a-category-reuses-the-firsts-machinery) | A second source of a category reuses the first's machinery | **Done** — `scrapex/directories.py`; `--source`, and the crawl is inherited | 2026-08-21 |
 | [REQ-28](#req-28--the-engine-would-not-install-and-showed-a-black-screen) | The Engine would not install — a black screen, and no way to install it | **In flight** — cause proven; the gate is fixed, cutting the release is his | 2026-08-21 |
 | [REQ-29](#req-29--an-install-surface-that-looks-like-a-professional-program-and-an-update-anyone-can-apply) | An install surface that looks like a professional program, and an update anyone can apply | **In flight** — the engine reads, fetches and verifies; the panel downloads with progress. The swap awaits a real frozen build | 2026-08-21 |
+| [REQ-30](#req-30--the-three-dots-button-appears-twice-on-a-source-card) | The three-dots button appears twice on a source card | **In flight** — cause proven, fixed and guarded; merging is his | 2026-08-22 |
 
 ---
 
@@ -1357,6 +1358,41 @@ professional surface than no switch.
 - **Code signing.** `packaging/build_engine.py` states plainly that it is not
   implemented and needs a certificate only he can hold. Every install will show
   SmartScreen's blue warning until it exists, and no UI can hide that.
+
+---
+
+## REQ-30 · The three-dots button appears twice on a source card
+**Captured 2026-08-22 · In flight — cause proven, fixed and guarded; the PR is his to merge**
+
+> «لماذا تظهر مرتين»
+
+Sent with screenshots of the Data screen. He opened the `⋮` menu on the
+`aramco.com` card and a **second `⋮` sat inside the open dropdown**, over the
+*Recent changes* row.
+
+**Nothing renders it twice.** It is the NEXT card's button painting through the
+menu, and the cause is a stacking context rather than a z-index that is too small:
+`.dataset-card > .split-button` carries `z-index: 1`, which makes each card's
+wrapper a stacking context and spends the open menu's own `z-index: 120` inside
+it. Every wrapper then ties at level 1 and document order hands the win to the
+card below. Reproduced in the panel harness and measured — with the wrapper at 1
+the following card's trigger is the topmost element at the centre of that row with
+the menu at 120, at 1200 and at 2147483647.
+
+**Fixed** by lifting the wrapper to `var(--z-overlay)` while its menu is open —
+the layer `.sx-select-list`, `.account-menu` and `.finance-converter-options`
+already use on this screen. Guarded by
+`test_panel_dom.py::test_an_open_source_menu_is_not_overpainted_by_the_next_cards_button`,
+which hit-tests what is in front rather than reading a number back, and refuses to
+pass if no button lies under the menu at all.
+
+**The same screenshots showed a second thing he did not ask about:** the two
+`muqawil.org` cards carry no `⋮` at all. That is a different cause and a
+deliberate one — `sourceMenu` hides the whole menu for a generic dataset — but it
+is now over-broad by one entry. Recorded as `OP-42` in
+[BACKLOG.md](BACKLOG.md#op-42--a-generic-dataset-card-offers-no-actions-at-all-and-one-of-the-six-would-work),
+not folded into this fix, because it changes what the panel offers rather than
+where it paints.
 
 ---
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,7 +1,10 @@
 # State — where the work stands
 
-**Last updated: 2026-08-22.** `main` is at `afb8648` (#244). #243, #245 and #244 are
-merged.
+**Last updated: 2026-08-22.** `main` is at `4615a14` (#250). #243 through #250 are
+all merged — #246 (the engine's own updater) and #247–#250 landed after this line
+last said `afb8648` (#244), which is **five merges** of drift in one day. A commit
+pointer written into prose is stale by the time it is read: `git log --oneline -1
+origin/main` is the answer that cannot be.
 
 This is the document that is **wrong the moment it is out of date**. Update it
 when a phase lands, a PR merges, or the owner rules — in the same pull request as
@@ -127,10 +130,26 @@ tracks *his requests* through Captured → Ruled → Planned → In flight → D
 
 ## Open pull requests
 
-**[#244](https://github.com/muhammadbayoumi/ScrapeX/pull/244) — the engine he
-downloaded was built before its own fix.** `REQ-28`. The release gate now runs the
-binary the way a person runs it; the three things that actually unblock him are
-`OP-37`, `OP-32` and `OP-33`, and **all three are his**. See the section below.
+**The three-dots button appeared twice on a source card.** `REQ-30`, «لماذا تظهر
+مرتين», reported with screenshots on 2026-08-22 and fixed the same day. One CSS
+rule: `.dataset-card > .split-button` carried `z-index: 1`, which made every card's
+menu wrapper a **stacking context** and spent the open menu's own `z-index: 120`
+inside it — so all the wrappers tied at level 1 and the card BELOW painted its
+button through the menu hanging over it. The wrapper is now lifted to
+`var(--z-overlay)` while its menu is open, the layer three other popovers on that
+screen already use. Guarded by
+`test_panel_dom.py::test_an_open_source_menu_is_not_overpainted_by_the_next_cards_button`,
+which **hit-tests what is in front** rather than reading a z-index back: measured,
+the defect survives the menu's own z-index going to 2147483647, so any assertion
+about that number would have passed on the broken build. The same screenshots
+produced `OP-42` — the muqawil cards carry no `⋮` at all, a different and
+deliberate cause, over-broad by exactly one entry.
+
+**[#244](https://github.com/muhammadbayoumi/ScrapeX/pull/244) — MERGED (`afb8648`);
+kept here because the three blockers it named are still his.** `REQ-28`. The release
+gate now runs the binary the way a person runs it; the three things that actually
+unblock him are `OP-37`, `OP-32` and `OP-33`, and **all three are his**. See the
+section below.
 
 **THE NEXT MOVE IS HIS, NOT THE CODE'S.** `Q-13` in [BACKLOG.md](BACKLOG.md) asks how
 `R-19` should be implemented, and `R-19` is the largest thing he has ruled on that is

--- a/docs/UI-KIT.md
+++ b/docs/UI-KIT.md
@@ -197,6 +197,19 @@ flagged a sprite reference. Every other page reaches the sprite through a path,
 which is why it had never been seen. The guard now ignores fragment references
 and still bites on a real literal.
 
+**And a sixth came from a defect the owner photographed** (`REQ-30`, 2026-08-22),
+which is the one that concerns anyone PLACING this component: `.split-button-options`
+carries `z-index: 120`, and **a consumer that gives the `.split-button` wrapper a
+z-index of its own throws that away.** Any numeric z-index on a positioned element
+makes it a stacking context, so the menu's 120 is then only compared with its
+siblings inside the wrapper. On a list of cards every wrapper tied at `1`, and each
+card's button painted through the menu of the card above — the same `⋮` twice on
+one screen. Place the wrapper with `position` and offsets alone where you can; where
+a layer really is needed, raise it to `var(--z-overlay)` **only while the menu is
+open** (`:has(.split-button-menu[open])`), the way `.source-filter-menu[open]` does
+in `webui.css`. Raising the 120 does not help and cannot: measured at 1200 and at
+2147483647, the card below still won.
+
 ### UI-2 · Promote what repeats, delete the copies — *first slice done*
 
 **Measured**: 67 declaration blocks are written identically in more than one

--- a/extension/app.css
+++ b/extension/app.css
@@ -381,9 +381,10 @@
   .dataset-card:hover .dataset-card-open { color: var(--accent-ink); }
   .dataset-card-open svg { width: 1rem; height: 1rem; fill: currentColor; }
 
-  /* THE ACTIONS MENU ON A DATASET CARD, and the two things it inherited that
-     were wrong for this place. Both were mine, from the menu that replaced the
-     chevron, and both were visible in one screenshot.
+  /* THE ACTIONS MENU ON A DATASET CARD, and the three things that were wrong
+     for this place — two it inherited, and a third that the fix for the first one
+     caused. All three were mine, from the menu that replaced the chevron, and
+     each was visible in one screenshot the owner sent.
 
      ONE: the chevron was `position: absolute` in the corner. Its replacement is
      a real element, so it took the FIRST CELL of the card and pushed the whole
@@ -404,6 +405,29 @@
     inset-block-start: var(--sp-2);
     inset-inline-end: var(--sp-2);
     z-index: 1;
+  }
+  /* THREE: THE OPEN MENU WAS PAINTED OVER BY THE NEXT CARD'S BUTTON, so a ⋮
+     appeared TWICE — once on the card and once floating over the menu's third
+     row. The owner photographed it and asked «لماذا تظهر مرتين».
+
+     The cause is the `z-index: 1` immediately above, and it is a stacking-context
+     trap rather than a number that is too small. A positioned element with any
+     numeric z-index becomes a STACKING CONTEXT, so the open menu's own
+     `z-index: 120` (components.css, `.split-button-options`) is spent INSIDE this
+     wrapper and buys nothing outside it. Every card's wrapper then sits at level
+     1, ties are broken by document order, and the card BELOW paints on top of the
+     menu hanging over it. Raising 120 would have changed nothing, which is the
+     part worth writing down — measured with the wrapper left at 1: the following
+     card's trigger is still the topmost element at the centre of the "Recent
+     changes" row at 120, at 1200 and at 2147483647.
+
+     So the wrapper itself is lifted, and only while it is open: an open popover
+     belongs on the overlay layer, which is exactly what `.sx-select-list`,
+     `.account-menu` and `.finance-converter-options` on this screen already do,
+     and what webui.css does for `.source-filter-menu[open]`. A closed menu stays
+     at 1 so the cards keep the order they had. */
+  .dataset-card > .split-button:has(.split-button-menu[open]) {
+    z-index: var(--z-overlay);
   }
   /* Only the FLOOR is local now: the trigger is a 32px icon, so `min-width:
      100%` from the shared rule would let a one-word label make a menu narrower

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -865,6 +865,98 @@ def test_dataset_action_opens_the_workspace_directly(open_panel):
         "the menu did not open")
 
 
+# Reads the topmost element at a point, and reports enough to diagnose a failure
+# without re-running the browser by hand. `closest(...) === menu` rather than a
+# truthiness check: an option of the NEXT card's menu would satisfy the loose
+# version while being exactly the thing under test.
+_TOPMOST = """(key) => {
+  const card = document.querySelector(`[data-open="${key}"]`);
+  const menu = card.querySelector(".split-button-menu[open] .split-button-options");
+  const box = menu.getBoundingClientRect();
+  const hit = (x, y) => {
+    const element = document.elementFromPoint(x, y);
+    // getAttribute, not .className: on an SVG element that property is an
+    // SVGAnimatedString, and the icon inside the trigger IS an <svg>, so the
+    // diagnostic would read "[object SVGAnimatedString]" in the one message a
+    // failing run shows.
+    return {
+      in_menu: !!(element && element.closest(".split-button-options") === menu),
+      what: element
+        ? element.tagName.toLowerCase() + "." + (element.getAttribute("class") || "")
+        : "nothing",
+    };
+  };
+  return {
+    // Every trigger whose box the open menu covers. Empty means this guard has
+    // nothing to prove, so the assertions below say so instead of passing.
+    covered: [...document.querySelectorAll("#datasets .dataset-card .split-button-trigger")]
+      .map((trigger) => [trigger, trigger.getBoundingClientRect()])
+      .filter(([, r]) => r.top < box.bottom && r.bottom > box.top
+                      && r.left < box.right && r.right > box.left)
+      .map(([trigger, r]) => Object.assign(
+        {card: trigger.closest("[data-open]").dataset.open},
+        hit(r.left + r.width / 2, r.top + r.height / 2))),
+    // The END of each row, because that is the edge the corner buttons sit on
+    // and the middle of a row can be clear while its right-hand side is not.
+    rows: [...menu.querySelectorAll(".split-button-option")].map((option) => {
+      const r = option.getBoundingClientRect();
+      return Object.assign({label: option.textContent.trim().replace(/\\s+/g, " ")},
+                           hit(r.right - 12, r.top + r.height / 2));
+    }),
+  };
+}"""
+
+
+def test_an_open_source_menu_is_not_overpainted_by_the_next_cards_button(open_panel):
+    """A second ⋮ appeared over the open menu, and the owner asked why twice.
+
+    «لماذا تظهر مرتين» — the screenshot showed the three-dots button once on the
+    aramco.com card and once floating over the "Recent changes" row of that
+    card's own open menu. Nothing rendered it twice: the NEXT card's button was
+    painting through the menu.
+
+    THE ASSERTION IS A HIT TEST, NOT A Z-INDEX. `.dataset-card > .split-button`
+    carries `z-index: 1`, which makes it a stacking context and spends the open
+    menu's `z-index: 120` inside it, so every card's wrapper ties at level 1 and
+    document order hands the win to the card below. Reading a z-index back would
+    therefore have asserted the exact number that was already wrong — measured
+    with the wrapper left at 1, the following card's trigger is still topmost at
+    that row with the menu at 120, at 1200 and at 2147483647. What a person sees
+    is which element is in front, so that is what this reads.
+
+    IT REFUSES TO PASS VACUOUSLY. If no trigger's box is under the open menu
+    there is nothing to overpaint, and a green run would mean only that the
+    cards had drifted apart — so the overlap is asserted first.
+    """
+    page = open_panel(view="data")
+    settle_view(page, "data")
+
+    cards = page.locator("#datasets .dataset-card")
+    assert cards.count() >= 2, (
+        "this guard needs a second card below the open menu; the stub's sources "
+        "with observations changed")
+
+    page.click('[data-open="LONG_AR"] .split-button-trigger')
+    page.wait_for_timeout(300)   # the options carry a 120ms entry animation
+    report = page.evaluate(_TOPMOST, "LONG_AR")
+
+    assert report["covered"], (
+        "no card's actions button lies under the open menu, so this proves "
+        "nothing: the cards or the menu changed size and the guard needs "
+        "re-aiming, not deleting")
+    for trigger in report["covered"]:
+        # ASCII in the message on purpose: a console that cannot print an em
+        # dash turns the one line a failing run shows into mojibake.
+        assert trigger["in_menu"], (
+            f"the actions button of card {trigger['card']} paints through the "
+            f"open menu, so the three-dots button appears twice - the defect "
+            f"the owner photographed. Topmost there: {trigger['what']}")
+    for row in report["rows"]:
+        assert row["in_menu"], (
+            f'"{row["label"]}" is covered by {row["what"]}, so clicking the '
+            f"row does something else or nothing")
+
+
 def test_data_rows_scroll_inside_the_browse_card_not_the_page(open_panel):
     page = open_panel()
     page.click(DATA_TAB)

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -189,6 +189,19 @@ PINNED = (
     ("docs/BACKLOG.md", "scrapex/nativehost.py", 57, 'getattr(sys, "frozen", False)'),
     # And the module that generalised it, cited by OP-36's closing note.
     ("docs/BACKLOG.md", "scrapex/enginelaunch.py", 74, "def engine_argv("),
+    # OP-42 · the muqawil cards carry no actions button. All four of these are the
+    # entry's argument rather than colour, and the entry turns on the DIFFERENCE
+    # between them: the first two are the deliberate hide and the marker it keys
+    # on, the third is why five of the six entries must stay hidden, and the
+    # fourth is why the sixth should not be. A reader landing one line off any of
+    # them reads the entry as either a bug report about correct code or a licence
+    # to unhide the five that answer 400.
+    ("docs/BACKLOG.md", "extension/app.js", 4549,
+     'if (source.kind === "dataset") return "";'),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 639, '"kind": "dataset",'),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2710, "if source_key not in known:"),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 986,
+     "A GENERIC DATASET IS A TABLE LIKE ANY OTHER TABLE"),
 )
 
 # A guard that can be emptied without anyone noticing is the defect -- SR-23, and


### PR DESCRIPTION
`REQ-30`. He opened the `⋮` menu on the `aramco.com` card and photographed a
**second `⋮` sitting inside the open dropdown**, over the *Recent changes* row:
«لماذا تظهر مرتين».

## The cause, and it is not the number

Nothing renders the button twice. **The next card's button paints through the open
menu**, and the cause is a stacking context rather than a z-index that is too
small.

- `extension/app.css:403-408` — `.dataset-card > .split-button` is placed in the
  card's corner with `z-index: 1`.
- `extension/components.css:1427-1429` — `.split-button-options`, the dropdown
  itself, carries `z-index: 120`.

Any numeric z-index on a positioned element makes it a **stacking context**, so the
dropdown's 120 is only ever compared with its siblings *inside* that wrapper. What
the outside world sees is the wrapper's `1`. Every card's wrapper ties at 1, ties
break by document order, and the card **below** wins — so its button paints on top
of the menu hanging over it.

Reproduced in `tools/panel_harness.py` at `origin/main` (`4615a14`), 360x800, two
cards. `document.elementFromPoint` at the end of each row of the open menu:

    Update now              -> button.split-button-option    (in the menu)
    Open the data table     -> button.split-button-option    (in the menu)
    Recent changes          -> summary.split-button-trigger  <-- the second dots
    Source settings         -> button.split-button-option    (in the menu)
    Pause collecting        -> button.split-button-option    (in the menu)
    Export to Google Sheets -> button.split-button-option    (in the menu)

The third row, which is the row in his screenshot.

**Raising the 120 cannot fix it, and that is the part worth writing down.** Measured
with the wrapper left at 1: the following card's trigger is still the topmost element
at that row with the dropdown at **120**, at **1200** and at **2147483647**.

## The fix — one rule, one existing token

```css
.dataset-card > .split-button:has(.split-button-menu[open]) {
  z-index: var(--z-overlay);
}
```

The wrapper is lifted, and only while its menu is open. `--z-overlay` (20) is the
layer this screen already uses for open popovers — `.sx-select-list`,
`.account-menu`, `.finance-converter-options` — and it is the same shape
`webui.css` uses for `.source-filter-menu[open]`. A closed menu stays at 1, so the
cards keep the order they had. No new number, and the shared component is untouched:
`extension/components.css` is a generated copy of `design/components.css`, and the
Activity log's split button is not broken.

## The guard, and it hit-tests rather than reading a style back

`tests/test_panel_dom.py::test_an_open_source_menu_is_not_overpainted_by_the_next_cards_button`

An assertion on the computed z-index would have **passed on the broken build** — the
broken build's number was already 120. So the test asks the question a person asks:
*what is in front?* `elementFromPoint` at every row of the open menu, and at the
centre of every trigger whose box the menu covers.

It also refuses to pass vacuously: if no trigger's box lies under the open menu
there is nothing to overpaint, so the overlap is asserted **first**, and the message
says the guard needs re-aiming rather than deleting.

## MUTATION — the guard was not trusted until it failed

| mutation | result |
|---|---|
| the new rule deleted (the tree as it shipped) | **FAILED** — `the actions button of card SHORT paints through the open menu … Topmost there: summary.split-button-trigger` |
| the rule kept, `var(--z-overlay)` put back to `1` | **FAILED** — same message, so the guard watches the LAYER and not the presence of a rule |
| restored | passes |

## The muqawil cards have no `⋮` at all — different cause, deliberate, now over-broad

The same screenshots show `aramco.com` and `spark-eshop.com` with a `⋮` and the two
`muqawil.org` cards with none. **That is not this bug.** `sourceMenu` returns an
empty string for a generic dataset (`extension/app.js:4549`), keyed on the marker
the engine stamps for exactly that purpose (`scrapex/webui/app.py:639`), and it was
the right call for five of the six entries: `update`, `pause` and `settings` post to
manifest-backed routes, and `/api/export/{key}` 404s on any key not in
`manifest.sources` (`scrapex/webui/app.py:2710`).

But **`Open the data table` would work** — `/api/table/{key}` looks the key up in
the dataset catalogue first (*"a generic dataset is a table like any other table"*,
`scrapex/webui/app.py:986`), so `/api/table/contractors` serves the directory in
full. The panel hides the one entry that works, on a marker introduced for the five
that do not.

Measured — the panel driven with two `kind: "dataset"` rows shaped as `_dataset_rows`
builds them: `LONG_AR` 1 trigger, `SHORT` 1, `contractors` **0**,
`contractor_profiles` **0**.

Recorded as **`OP-42`**, not folded in here: it changes what the panel *offers*,
which is his call, while this PR changes only where the panel *paints*. The entry
also records that `test_dataset_action_opens_the_workspace_directly` currently
asserts *"every dataset card must carry exactly one actions menu"* and holds only
because the harness stub contains no dataset-kind source — so the rule `sourceMenu`
implements has never been executed by any test.

## Documents, in the same PR (C2)

- `docs/REQUESTS.md` — **`REQ-30`**, quoted in his words, plus the board row.
- `docs/BACKLOG.md` — **`OP-42`**, with four pinned citations.
- `docs/LESSONS.md` §5 — a z-index cannot escape its own stacking context, and the
  corollary that it must be tested by hit-testing.
- `docs/UI-KIT.md` §UI-1 — a sixth thing about the shared split button, for anyone
  placing it in a list of cards.
- `docs/STATE.md` — the open-PR section, and the `main` pointer, which still read
  `afb8648` (#244) while `main` was five merges further on at `4615a14` (#250).
- `tests/test_the_documents_cite_what_they_claim.py` — four `PINNED` rows for
  `OP-42`'s citations, per `R-15`.

`RULINGS.md` is untouched: nothing here is a decision of his.

## Verification

- `SCRAPEX_FULL_MIGRATIONS=1 python -m pytest -q` on the committed tree
  (`a88dc67`) — **green**, `R-22`. 3,139 tests: 3,128 passed, 10 skipped,
  1 xfailed, **0** lines matching `^FAILED`, **0** matching `^ERROR`, exit 0, and
  the run reached `[100%]`. (`addopts` already carries `-q`, so a second `-q`
  makes it `-qq` and pytest prints no summary line at all — the same trap
  `.github/workflows/ci.yml` documents for its collection counts. Green is
  established by the progress line reaching 100% with no `FAILED`, not by
  grepping for the word *passed*, which appears nowhere in a fully green run.)
- `ruff check scrapex/` — clean. No file under `scrapex/` is touched by this PR.
- No JS changed, so the JS lint has nothing to say; `eslint` has no install on
  this machine in any case.
- `SR-19`: named paths only, and the whole cached diff was read before committing.

## Not merged

`R-42`: this is a secondary session. Opened and reported — the merge is his.

**One coordination note.** Another session was writing to the shared scratchpad
while this ran, so `REQ-30` and `OP-42` were claimed without sight of what that
branch may have claimed. `tests/test_the_registers_cannot_collide.py` is the guard
for exactly that and passes here; if it fails on merge, the collision is between
two branches rather than inside this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
