### PR TITLE
The release the documents ask for is the release that would run

### DIFF
--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -2,7 +2,15 @@ name: Release the engine
 
 # PATH B of PLATFORM-PLAN §5c. A tag starts it; nothing else does.
 #
-#     git tag engine-v0.3.0 && git push origin engine-v0.3.0
+#     git tag engine-v<VERSION> && git push origin engine-v<VERSION>
+#
+# <VERSION> IS DELIBERATELY NOT SPELLED OUT HERE. It is `scrapex/version.py:VERSION`
+# and nothing else — the first step below refuses any other tag — and this line used
+# to carry the literal, which made it one more copy of a number that moves on every
+# contract change (R-35). It read `0.3.0` on the day 0.3.0 was released and would
+# have been wrong by the next migration. Read it instead of typing it:
+#
+#     python -c "from scrapex.version import VERSION; print(VERSION)"
 #
 # Decision 4: releasing is manual, updating is not. This is the manual half —
 # the owner decides when. The extension notices the result on its own.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1203,9 +1203,11 @@ many workers are asked for, and the cost is bounded by arithmetic rather than by
 hoping. (a) as an immediate mitigation.*
 **Not started.**
 
-### OP-32 · The fix for the black window has sat in the repository for twelve days, unreleased
+### OP-32 · ~~The fix for the black window has sat in the repository, unreleased~~ — RELEASED 2026-08-22 as `engine-v0.3.0`
 
-**Status: OPEN. The gate that let it happen is closed in this PR; publishing is his.**
+**Status: CLOSED 2026-08-22 — the gate that let it happen was closed first, then he
+published.** The entry is kept in full rather than trimmed: it is the only record of
+why an install path where every component worked still handed him a black window.
 Reported by the owner on 2026-08-21 as *"it did not install — black screen"*, and
 captured as [REQ-28](REQUESTS.md#req-28--the-engine-would-not-install-and-showed-a-black-screen).
 
@@ -1245,9 +1247,33 @@ this guard accepting a data root that was named but never assigned.
 0.2.1"* — and filed it as a **wording** defect about the two meanings of
 "installed". The numbers were the finding: the release had not happened.
 
-**Next action, and it is his:** `git tag engine-v0.3.0 && git push origin engine-v0.3.0`.
-Nothing needs bumping — `scrapex/version.py:76` already carries the number, and the
-tag is derived from it rather than chosen.
+~~**Next action, and it is his.**~~ **— HE TOOK IT. `engine-v0.3.0` IS PUBLISHED,
+2026-08-22.** *«اقطع الوسم»*, said after reading this entry, so the finding is what
+produced the release. Recorded as facts rather than as a green workflow run:
+
+| | |
+|---|---|
+| tag | `engine-v0.3.0` → `451468d`, which is `main` |
+| the version at that tag | `scrapex/version.py:76` **0.3.0**, `pyproject.toml` mirror **0.3.0** — so the workflow's `test "$tag" = "$version"` had two numbers that agreed |
+| workflow | completed, 28m36s |
+| the manifest the panel reads | `"version": "0.3.0"`, `"tag": "engine-v0.3.0"`, `"published_at": "2026-08-22T13:17:13Z"`, `"minimum_extension_version": "0.2.2"`, protocol 1 |
+| what it said before | `0.2.1`, unchanged since 9 August |
+
+**The floor it published is 0.2.2, and that is the number that matters most here:**
+`extension/manifest.json` is also 0.2.2, so this release demands nothing the
+installed extension cannot do — checked before the tag by
+`tests/test_version.py`'s floor guard, not after it.
+
+**This entry is CLOSED as the defect it described.** What is not closed is the
+confirmation that the published build installs on his machine; that stays on
+`REQ-28`.
+
+> **AND THE VERSION GAP THAT OPENS NEXT IS NOT THIS DEFECT RETURNING.** Migration
+> `0010` is a contract change, so `R-35` moved the source to **0.3.1** against a
+> published **0.3.0** — which is the ordinary state between two hand-cut releases,
+> not a fault. `OP-32` was three things at once: nothing released across two bumps,
+> the newest installable engine silent on a double-click, and the documents naming a
+> tag the workflow would refuse. A gap alone is none of them.
 
 > **STILL OPEN A DAY LATER, AND THE INSTRUCTION HAD GONE STALE WHILE IT WAITED.**
 > He reported it again on 2026-08-22 — *«المحرك الموجود على github 0.2.1»* — with the
@@ -1256,7 +1282,7 @@ tag is derived from it rather than chosen.
 > written about it.** `extension/releases.js:32` reads
 > `ScrapeX/json/version.json` from the hub, `extension/app.js:3514` prints the
 > `version` it finds, the workflow writes that same field
-> (`.github/workflows/release-engine.yml:344`), and
+> (`.github/workflows/release-engine.yml:352`), and
 > `tests/test_the_two_release_paths.py:276` already pins the writer's output to the
 > reader's input. The manifest says 0.2.1 because 0.2.1 is the only engine tag that
 > exists.
@@ -1655,10 +1681,11 @@ process that waits for a named pid to exit, for exactly this reason. **This is
 why `OP-36` had to be fixed first** — before that, the helper a frozen engine
 spawned was a silent native messaging host and would have waited for ever.
 
-**Next action, and it belongs after a release rather than before one:** cut
-`engine-v0.3.0` (`OP-32` — the number comes from `scrapex/version.py:76`, never from
-a document), then implement the swap against a binary that exists. The order is not
-a preference — the first artifact that can exercise any of this is the next release.
+**Next action, and its precondition is now met.** This belonged after a release
+rather than before one, and the release happened on 2026-08-22 (`OP-32`): a published
+`engine-v0.3.0` is the first frozen artifact that can exercise any of this. So the
+swap can now be implemented against a binary that exists rather than against
+`sys.frozen` set by a test.
 
 ### OP-40 · His warehouse has moved ahead of `main` again — v9 now, and this is the third time
 
@@ -2489,26 +2516,37 @@ their home rather than the taxonomy. Options: build them now at 2 rows; wait unt
 34,834-page crawl finishes and re-measure, which costs nothing because the snapshots
 keep the evidence; or rule them out and record it.
 
-**Q-16 · Should something in CI go red when the PUBLISHED engine falls behind the
-source?** Asked because `OP-32` has now been reported twice, thirteen days and two
-`VERSION` bumps after the only release that exists (`engine-v0.2.1`, commit
-`4386d25`, 2026-08-09). The repository can prove that the tag he is
-*told* to push is the tag the workflow accepts — that guard is built and named in
-`OP-32`. It cannot prove a release happened: the tag list is absent from a
-`fetch-depth: 1` checkout and the hub is a network fetch, so a test that looked would
-either skip silently or flake, and both are worse than not looking.
+**Q-16 · Should anything in CI go red when the published engine falls behind the
+source — and the answer got harder the day it was asked.** The repository can prove
+that the tag he is *told* to push is the tag the workflow accepts (`OP-32`). It
+cannot prove a release happened: the tag list is absent from a `fetch-depth: 1`
+checkout and the hub is a network fetch, so a test that looked would either skip
+silently or flake, and both are worse than not looking.
 
-**Three shapes.** (a) **Nothing** — releasing is manual by PLATFORM-PLAN Decision 4,
-and a red build over a decision he has not taken is a build that trains him to ignore
-red. (b) **A scheduled workflow** that fetches the hub manifest weekly and fails when
-it is behind `scrapex/version.py:VERSION`, naming the tag command. It cannot flake the
-suite because it is not in it — but it stays red every week until he tags, which is
-the crying-wolf failure `tests/test_the_published_documents_are_checked_not_announced.py`
-warns about in its own words. (c) **A step in the release path only**, which is where
-it already is: the dispatch run prints `published says 0.2.1 / this run says 0.3.0`.
+**WHAT CHANGED THE QUESTION.** When this was written the source was 0.3.0 and the
+published engine was 0.2.1 — two bumps behind, with the newest installable build
+silent on a double-click. Hours later he tagged `engine-v0.3.0`, and `R-35`
+immediately moved the source to **0.3.1** for migration `0010`. So the steady state
+of this
+project is **source ahead of published**, by design: `VERSION` moves on a contract
+change and releases are cut by hand (Decision 4).
 
-*No recommendation is offered, because the answer depends on how often he intends to
-release — and that is the thing only he knows.*
+**Which kills option (b) rather than merely weakening it.** A weekly job that fails
+whenever published < source would be red in the *normal* case and silent only in the
+minutes after a release — the crying-wolf failure
+`tests/test_the_published_documents_are_checked_not_announced.py` names in its own
+words, reached by arithmetic rather than by bad luck.
+
+**So the live options are:** (a) **nothing** — the gap is expected, and `OP-32`'s
+actual defect was three things at once (nothing released across two bumps, a silent
+binary, and documents naming a refused tag), none of which a gap alone implies; or
+(c) **a threshold rather than a comparison** — red only when the published engine is
+behind by more than one minor version, or older than some age, so it distinguishes
+*between releases* from *abandoned*. (c) needs a number from him, which is the whole
+reason this is a question and not a commit.
+
+*No recommendation on (a) versus (c), because it depends on how often he intends to
+release. But (b) is now argued against rather than merely listed.*
 
 **Q-15 · May a session run an unmerged migration against his LIVE warehouse?**
 Three times on 2026-08-21 his engine database moved ahead of `main` — v8 against v6

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1220,8 +1220,8 @@ What arrives is the build from **before** `_first_run` existed:
 | bare invocation there | `4386d25:packaging/engine_entry.py:62` → `return serve()` — the native host. **A citation of a past commit**: today's line 62 is a comment |
 | `_first_run` landed | `7a067c5`, 2026-08-09T19:09+03:00 — **six hours after the release** |
 | `--splash` landed | `756fa39`, 2026-08-10 |
-| `scrapex/version.py:76` | `VERSION = "0.2.2"` |
-| engine tags in the repo | `engine-v0.2.1`. That is the whole list. |
+| `scrapex/version.py:76` | `VERSION = "0.3.0"` — 0.2.2 when this was written, 0.3.0 since #247 |
+| engine tags in the repo | `engine-v0.2.1`. That is the whole list, re-checked 2026-08-22. |
 
 **Measured on the published artifact, twice, on 2026-08-21.** Stdin closed: zero
 bytes, exit 0 — the window opens and vanishes. Stdin held open, as a real console
@@ -1245,9 +1245,43 @@ this guard accepting a data root that was named but never assigned.
 0.2.1"* — and filed it as a **wording** defect about the two meanings of
 "installed". The numbers were the finding: the release had not happened.
 
-**Next action, and it is his:** `git tag engine-v0.2.2 && git push origin engine-v0.2.2`.
-Track 3 in [STATE.md](STATE.md) holds `VERSION` at 0.2.2 behind `R-07`, so the number
-is already right and nothing needs bumping to release it.
+**Next action, and it is his:** `git tag engine-v0.3.0 && git push origin engine-v0.3.0`.
+Nothing needs bumping — `scrapex/version.py:76` already carries the number, and the
+tag is derived from it rather than chosen.
+
+> **STILL OPEN A DAY LATER, AND THE INSTRUCTION HAD GONE STALE WHILE IT WAITED.**
+> He reported it again on 2026-08-22 — *«المحرك الموجود على github 0.2.1»* — with the
+> panel reading `Latest version 0.2.1 · Available to install`. **Nothing is broken
+> anywhere on that path, and this is the third time that sentence has had to be
+> written about it.** `extension/releases.js:32` reads
+> `ScrapeX/json/version.json` from the hub, `extension/app.js:3514` prints the
+> `version` it finds, the workflow writes that same field
+> (`.github/workflows/release-engine.yml:344`), and
+> `tests/test_the_two_release_paths.py:276` already pins the writer's output to the
+> reader's input. The manifest says 0.2.1 because 0.2.1 is the only engine tag that
+> exists.
+>
+> **What HAD broken is this entry's own next action.** It said `engine-v0.2.2` while
+> `VERSION` had moved to 0.2.2 at `adf31b2` and then to **0.3.0** at `e963269`
+> (2026-08-22, #247, a schema change under `R-35`). The release workflow's first
+> step is `test "$tag" = "$version"`, so the release the documents were telling him
+> to cut would have been **refused before anything was built**. Six copies of
+> `engine-v0.2.2` across `STATE.md`, `REQUESTS.md` and this file — two of them the
+> whole command to copy, three the sentence telling him to cut it, one a note about
+> a past failure — and nothing compared any of them with the source. Corrected here,
+> and guarded by
+> `tests/test_the_release_the_documents_ask_for_is_the_one_that_would_run.py`: an
+> engine tag named as an *instruction* must equal `VERSION`, while a tag named in
+> narrative prose is left alone so history is not rewritten to keep a test green.
+> **It found all six on the untouched documents before a single mutation was
+> tried.**
+>
+> **The limit of that guard, stated rather than discovered later:** it proves the
+> tag he is told to push is the tag the workflow accepts. It cannot prove a release
+> was cut, because nothing committed here knows what the hub holds — the tag list is
+> absent from a `fetch-depth: 1` checkout and the hub is a network fetch, and either
+> would turn this into a guard that skips or flakes. `Q-16` asks whether he wants a
+> scheduled workflow that does look.
 
 ### OP-33 · ~~The owner's own warehouse is ahead of `main`, so the engine refuses to start on his machine~~ — FIXED 2026-08-21 by #243
 
@@ -1548,9 +1582,10 @@ now on.** It passed every run before 12:00Z, which is why #235 merged green.
 
 **Why it blocks the release.** `.github/workflows/release-engine.yml` runs the whole
 suite in *"The engine must pass its own tests before it is shipped"* **before** it
-builds. So `git tag engine-v0.2.2` fails at that step, and `OP-32` — the thing the
-owner actually asked for — cannot ship until this is repaired. `R-18` (merge it when
-it is green) is also unsatisfiable for every open pull request while this stands.
+builds. So the release failed at that step whatever it was tagged, and `OP-32` — the
+thing the owner actually asked for — could not ship until this was repaired. `R-18`
+(merge it when it is green) was also unsatisfiable for every open pull request while
+it stood.
 
 **The repair, which preserves what the test means.** Its intent is *one* row first
 appeared in the newest crawl and the others predate it. The `last_seen_at` lines two
@@ -1621,9 +1656,9 @@ why `OP-36` had to be fixed first** — before that, the helper a frozen engine
 spawned was a silent native messaging host and would have waited for ever.
 
 **Next action, and it belongs after a release rather than before one:** cut
-`engine-v0.2.2`, then implement the swap against a binary that exists. The order
-is not a preference — the first artifact that can exercise any of this is the
-next release.
+`engine-v0.3.0` (`OP-32` — the number comes from `scrapex/version.py:76`, never from
+a document), then implement the swap against a binary that exists. The order is not
+a preference — the first artifact that can exercise any of this is the next release.
 
 ### OP-40 · His warehouse has moved ahead of `main` again — v9 now, and this is the third time
 
@@ -2453,6 +2488,27 @@ classifications, so `dataset_relationship` — which now has its first tenant �
 their home rather than the taxonomy. Options: build them now at 2 rows; wait until the
 34,834-page crawl finishes and re-measure, which costs nothing because the snapshots
 keep the evidence; or rule them out and record it.
+
+**Q-16 · Should something in CI go red when the PUBLISHED engine falls behind the
+source?** Asked because `OP-32` has now been reported twice, thirteen days and two
+`VERSION` bumps after the only release that exists (`engine-v0.2.1`, commit
+`4386d25`, 2026-08-09). The repository can prove that the tag he is
+*told* to push is the tag the workflow accepts — that guard is built and named in
+`OP-32`. It cannot prove a release happened: the tag list is absent from a
+`fetch-depth: 1` checkout and the hub is a network fetch, so a test that looked would
+either skip silently or flake, and both are worse than not looking.
+
+**Three shapes.** (a) **Nothing** — releasing is manual by PLATFORM-PLAN Decision 4,
+and a red build over a decision he has not taken is a build that trains him to ignore
+red. (b) **A scheduled workflow** that fetches the hub manifest weekly and fails when
+it is behind `scrapex/version.py:VERSION`, naming the tag command. It cannot flake the
+suite because it is not in it — but it stays red every week until he tags, which is
+the crying-wolf failure `tests/test_the_published_documents_are_checked_not_announced.py`
+warns about in its own words. (c) **A step in the release path only**, which is where
+it already is: the dispatch run prints `published says 0.2.1 / this run says 0.3.0`.
+
+*No recommendation is offered, because the answer depends on how often he intends to
+release — and that is the thing only he knows.*
 
 **Q-15 · May a session run an unmerged migration against his LIVE warehouse?**
 Three times on 2026-08-21 his engine database moved ahead of `main` — v8 against v6

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1268,8 +1268,8 @@ tag is derived from it rather than chosen.
 > to cut would have been **refused before anything was built**. Six copies of
 > `engine-v0.2.2` across `STATE.md`, `REQUESTS.md` and this file — two of them the
 > whole command to copy, three the sentence telling him to cut it, one a note about
-> a past failure — and nothing compared any of them with the source. Corrected here,
-> and guarded by
+> a past failure — and nothing compared any of them with the source. Corrected in
+> [#253](https://github.com/muhammadbayoumi/ScrapeX/pull/253), and guarded by
 > `tests/test_the_release_the_documents_ask_for_is_the_one_that_would_run.py`: an
 > engine tag named as an *instruction* must equal `VERSION`, while a tag named in
 > narrative prose is left alone so history is not rewritten to keep a test green.

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -746,6 +746,53 @@ and the lesson for anyone writing a citation: **paste the line you are citing,
 from the file, at the moment you cite it.** Every wrong number above came from
 remembering a number instead of reading one.
 
+### An instruction that names a version rots on the next bump, and only the person acting on it finds out
+
+Found 2026-08-22, when the owner asked why the panel offered `0.2.1` with the
+engine at `0.3.0`. The panel was right, the manifest was right, the workflow was
+right; the only engine tag in the repository was `engine-v0.2.1` and no release
+had been cut. **What was wrong was the way out.** Six places named the tag
+`engine-v0.2.2` — two of them the whole command to copy, three the sentence
+telling him to cut it, one a note about a past failure — while
+`.github/workflows/release-engine.yml` opens with `test "$tag" = "$version"` and
+`VERSION` had moved to 0.3.0. Everything but the last had been dead since #247. It
+would have failed at the release's first step, having built nothing, on the day he
+finally had time to ship.
+
+*(That paragraph is written as narrative on purpose. Naming the dead tag inside a
+copy-pasteable command would make this file a seventh place holding one — see
+shape 3 below, which is the guard refusing exactly that.)*
+
+**A citation guard cannot see this.** `docs/BACKLOG.md` cited
+`scrapex/version.py:76` — the right file, the right line, the right symbol — and
+the *value* on that line had changed under it. Tier 1 checks existence, tier 2
+pins the symbol, and neither reads what the symbol is worth today.
+
+**The class:** a document that repeats a number the code owns is a copy, and every
+copy is a thing that stops agreeing. Three shapes, in order of preference:
+
+1. **Derive it.** Say *"the tag is `engine-v$(VERSION)`"* and there is nothing to
+   rot. Not always possible — a copy-pasteable command needs the literal.
+2. **Guard it**, which is what was built here:
+   `tests/test_the_release_the_documents_ask_for_is_the_one_that_would_run.py`
+   compares every engine tag named **as an instruction** with `VERSION`. It found
+   all six copies on the untouched documents before a single mutation was tried,
+   which is the only kind of first run worth having.
+3. **Write it as history instead.** The guard deliberately matches only the two
+   shapes a person acts on — `git tag engine-v…` and `cut engine-v…` — because
+   `engine-v0.2.1` shipped the black window and every sentence saying so is true
+   for ever. A guard that demanded *every* tag name equal `VERSION` would force
+   history to be rewritten on each bump, which is how a test comes to be satisfied
+   by a lie.
+
+**And the reason it does not simply ask the hub**, which is where "published"
+actually lives: `actions/checkout@v4` fetches no tags, and a network fetch in the
+suite is red on a train and vacuously green wherever it is skipped. Both failures
+are already recorded in this file under *A skip is not a failure*. The guard
+proves the tag he is told to push is the tag the workflow accepts, and says in its
+own docstring that it cannot prove a release happened. `Q-16` asks him whether he
+wants something that does look.
+
 ### A guard that infers its subject from prose cannot be both sensitive and precise
 
 The natural design for the above is to read the symbol out of the sentence — take
@@ -1155,6 +1202,40 @@ is the same fact making *different* files look equal: **normalise when you are a
 "is the content the same", and compare bytes when you are asking "did I put the file
 back".** The two questions have different right answers, and one function cannot serve
 both.
+
+### A byte-perfect restore still leaves the mutation running, because `__pycache__` believes it
+
+Found 2026-08-22, mutating the release-instruction guard. The harness restored
+every file by writing the **original bytes** back and verified each restore by
+**re-hashing the file on disk** — the strongest form of the check the lesson above
+argues for. All eight mutations reported `restored=True`, `git status` showed
+`scrapex/version.py` unmodified, and the file said `VERSION = "0.3.0"`.
+
+**And `import scrapex.version` said `0.4.0`.**
+
+```
+grep '^VERSION = ' scrapex/version.py   ->  VERSION = "0.3.0"
+python -c "import scrapex.version as v; print(v.VERSION)"  ->  0.4.0
+```
+
+The `.pyc` written while the mutation was in place was still being trusted.
+CPython invalidates a cache entry on the source's **mtime and size**, and a
+mutation that swaps one version string for another of the same length, restored
+inside the same filesystem timestamp tick, changes neither. The cache was valid by
+its own rule and wrong by every other.
+
+**What it cost, and why the post-control run is not optional.** Every mutation
+after M2 ran with an extra test failing for a reason nobody had asked for, and the
+one whose kill criterion was that same test could have reported KILLED over a
+mutation that did nothing. The only thing that caught it was running the guard
+**again after the whole set finished** and finding it red on a clean tree — the
+check LESSONS §8 already insists on, catching a cause it had not met before. Both
+runs are recorded rather than only the good one: eight KILLED with a red
+post-control is a result to throw away, not to report.
+
+**The rule: purge `__pycache__` between runs, not just the source.** A restore is
+not complete until everything derived from the mutated file is gone too. With the
+purge in place: eight mutations, eight killed, post-control green.
 
 ---
 

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -793,6 +793,59 @@ proves the tag he is told to push is the tag the workflow accepts, and says in i
 own docstring that it cannot prove a release happened. `Q-16` asks him whether he
 wants something that does look.
 
+### Two pull requests, DISJOINT IN FILES and COUPLED IN CONTENT, merge into a red `main`
+
+Found 2026-08-22 by two sessions independently within minutes — one rebasing onto
+`main`, one on its own branch — which is the strongest thing that can be said for
+the guard that found it. `main` at `5f63bb0` was **red**:
+
+```
+FAILED tests/test_the_documents_cite_what_they_claim.py::
+  test_a_pinned_citation_still_points_at_its_subject[BACKLOG.md-app.py-2710]
+```
+
+| | |
+|---|---|
+| both written against | `4615a14` (#250) |
+| #252 added | `("docs/BACKLOG.md", "scrapex/webui/app.py", 2710, "if source_key not in known:")` |
+| that symbol at `4615a14` | **2710** — #252 was **correct** |
+| #251 added | fifteen lines to `scrapex/webui/app.py` |
+| that symbol at `5f63bb0` | **2725** |
+| did #251 touch the PINNED table? | **no** |
+| did #252 touch `app.py`? | **no** |
+
+**"CHECK WHETHER THE FILES OVERLAP" IS THE REFLEX THAT FAILS HERE, and that is the
+whole lesson.** Not one file is changed by both, so git finds nothing to conflict
+on and merges both cleanly. The coupling is in the *content*: one moved a line, the
+other wrote that line's number down. Disjoint in files, coupled in content — and
+only the second half decides whether the pair is safe.
+
+**AND #252 WAS NOT MERGED UNTESTED, which is the part worth getting right.** GitHub
+reported it MERGEABLE and CLEAN with every check passing. Those checks ran against
+#252's own merge commit **against `4615a14`** — a base that stopped existing the
+moment #251 landed. So the suite did not fail to run and did not fail to notice:
+**it passed, truthfully, about a `main` that no longer existed.** "Green" without a
+base is not a claim about anything.
+
+**Which is why the setting is `require branches up to date`, not `require the check
+suite`.** `docs/STATE.md` lists branch protection as his to switch on; *require the
+check suite* — the obvious half — would have passed this pair through, because both
+checks genuinely passed. Only re-testing against the `main` that will actually
+receive the merge catches it. This is the second reason for that setting after
+`ac3a5af`.
+
+**Why a citation guard is the detector.** A `file:line` citation is the rare
+assertion whose truth depends on a file the pull request does not touch, so it is
+the most sensitive instrument for this class in the repository. The class is
+general: any test pinning a **line, an offset, a byte count or a row count** is
+exposed the same way, and the remedy is never a wider window.
+
+*The repair itself — the PINNED row and `docs/BACKLOG.md`'s prose citation both
+moving `2710` → `2725` — landed in `feat/the-profile-page-becomes-columns`, not
+here. Two branches editing one table at one place is a guaranteed conflict for
+whichever merges second, and only one of them needed to carry it. This entry is the
+class; that branch is the fix.*
+
 ### A guard that infers its subject from prose cannot be both sensitive and precise
 
 The natural design for the above is to read the symbol out of the sentence — take

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -793,6 +793,60 @@ proves the tag he is told to push is the tag the workflow accepts, and says in i
 own docstring that it cannot prove a release happened. `Q-16` asks him whether he
 wants something that does look.
 
+**IT ENDED IN A RELEASE, WHICH IS THE ONLY OUTCOME THAT SETTLES ANYTHING.** He read
+the finding and said *«اقطع الوسم»*; `engine-v0.3.0` went out on 2026-08-22 and the
+manifest the panel reads moved from `0.2.1` — where it had sat since 9 August — to
+`0.3.0`. That is worth recording because the defect was never in the code: three
+sessions had verified the install path and found nothing wrong with it, and what was
+wrong was a number written down in six places.
+
+**THREE THINGS THE RELEASE THEN TAUGHT, all within the hour:**
+
+**1 · A completed instruction must be rewritten, not just satisfied.** Every one of
+those six places became history the moment the tag existed, and a guard that reads
+instructions cannot tell a finished one from a pending one. Left alone they would
+have failed at the very next bump — which arrived immediately (below). Shape 3 is not
+optional tidying; it is the step that ends the task.
+
+**2 · `cut` is its own past tense, and English will not help you.** `Q-16` was
+rewritten with that verb and the tag immediately after it — *"hours later he …
+`engine-v0.3.0`"* — which is finished history that the pattern reads as an
+instruction. It passed only because `0.3.0` was still `VERSION`, and would have gone
+red at the next bump. The discipline is to write a completed release with any verb
+but that one: **tagged, published, released, went out.** Pinned in
+`test_the_pattern_cannot_tell_the_tense_of_cut_apart`, because the next person will
+reach for the wrong one.
+
+> **AND THIS PARAGRAPH WALKED INTO IT WHILE EXPLAINING IT** — the first draft quoted
+> the bad sentence verbatim, verb and tag together, so the entry describing the trap
+> was itself matched. Found by mutation, not by reading. That is twice now that an
+> entry in this file has had to be written *around* the guard it documents, the other
+> being the `git tag …` command a few paragraphs up. **A document that quotes an
+> instruction is holding one**, and the elision above is the fix.
+
+**3 · "No release is owed" is a legitimate state, and a guard must permit it.** The
+guard originally asserted that at least one instruction existed, reasoning that a
+pattern matching nothing measures nothing. After the release the set went empty and
+the assertion failed **on the repository being correct**. Non-vacuity now comes from
+running the pattern against fixed strings instead — a guard whose only evidence of
+working is a live instruction stops being checkable the moment the work is done.
+
+**AND THE NUMBER HAS A SECOND HOME, which a release runbook must name.** `VERSION`
+lives in `scrapex/version.py` and is mirrored in `pyproject.toml` because the
+installer cannot import Python. Both moved to `0.3.1` for migration `0010` — a
+contract change under `R-35`, refused at `0.3.0` by the gate, which is that gate
+working — and the primary session reports the mirror's guard firing on it when only
+the first was bumped. That guard is `tests/test_version.py:73`, and the words below
+are its own: **bump both or neither.** Three copies of one number now exist only if a document adds a
+third, which is what this guard is for; the workflow's header comment gave up its
+literal for the same reason and now says `engine-v<VERSION>`.
+
+**One consequence to carry forward:** source ahead of published is the *ordinary*
+state here, not a repeat of this defect. `0.3.1` in the tree against `0.3.0` on the
+hub is development. `OP-32` was three faults at once — nothing released across two
+bumps, a published binary silent on a double-click, and documents naming a tag the
+workflow would refuse — and a version gap on its own is none of them.
+
 ### Two pull requests, DISJOINT IN FILES and COUPLED IN CONTENT, merge into a red `main`
 
 Found 2026-08-22 by two sessions independently within minutes — one rebasing onto

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -812,10 +812,22 @@ optional tidying; it is the step that ends the task.
 rewritten with that verb and the tag immediately after it — *"hours later he …
 `engine-v0.3.0`"* — which is finished history that the pattern reads as an
 instruction. It passed only because `0.3.0` was still `VERSION`, and would have gone
-red at the next bump. The discipline is to write a completed release with any verb
-but that one: **tagged, published, released, went out.** Pinned in
-`test_the_pattern_cannot_tell_the_tense_of_cut_apart`, because the next person will
-reach for the wrong one.
+red at the next bump — which was `0.3.1`, already written on another branch.
+
+> **THE RULE, FOR ANYONE WRITING RELEASE PROSE IN THIS REPOSITORY.** A release that
+> has happened is written **tagged**, **published**, **released** or **went out** —
+> **never `cut`**, and never with `git tag …` spelled out beside it. `cut` and
+> `git tag` are the two shapes
+> `tests/test_the_release_the_documents_ask_for_is_the_one_that_would_run.py` reads as
+> *"a release somebody still has to make"*, and it holds those to
+> `scrapex/version.py:VERSION`. Use them for work that is still owed and nothing else.
+>
+> It is a rule about four words because the alternative is a regex that guesses tense,
+> and the cost is asymmetric: the wrong word costs one rewording, while the wrong
+> silence costs a release instruction that the workflow refuses at its first step.
+
+Pinned in `test_the_pattern_cannot_tell_the_tense_of_cut_apart`, because a rule that
+lives only in a test message is a rule nobody writing prose will meet.
 
 > **AND THIS PARAGRAPH WALKED INTO IT WHILE EXPLAINING IT** — the first draft quoted
 > the bad sentence verbatim, verb and tag together, so the entry describing the trap

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -83,7 +83,7 @@ IDs are stable and never reused, matching the convention BACKLOG.md already uses
 | [REQ-25](#req-25--one-source-registry-with-a-category-visible-to-every-user) | One source registry, with a category, visible to every user | **Planned** — half exists (`active: false`, `TBD-probe`); the category and the single registry do not | 2026-08-21 |
 | [REQ-26](#req-26--a-database-per-account-not-per-machine) | A database per account, not per machine | **In flight** — `Q-14` answered (`R-34`): the account is the signed-in address, and his warehouse records it; the per-account layout remains | 2026-08-21 |
 | [REQ-27](#req-27--a-second-source-of-a-category-reuses-the-firsts-machinery) | A second source of a category reuses the first's machinery | **Done** — `scrapex/directories.py`; `--source`, and the crawl is inherited | 2026-08-21 |
-| [REQ-28](#req-28--the-engine-would-not-install-and-showed-a-black-screen) | The Engine would not install — a black screen, and no way to install it | **In flight** — cause proven; the gate is fixed, cutting `engine-v0.3.0` is his. Raised again 2026-08-22 | 2026-08-21 |
+| [REQ-28](#req-28--the-engine-would-not-install-and-showed-a-black-screen) | The Engine would not install — a black screen, and no way to install it | **In flight** — cause proven, gate closed, and `engine-v0.3.0` published 2026-08-22 after he raised it a second time; his confirmation that it installs is what remains | 2026-08-21 |
 | [REQ-29](#req-29--an-install-surface-that-looks-like-a-professional-program-and-an-update-anyone-can-apply) | An install surface that looks like a professional program, and an update anyone can apply | **In flight** — the engine reads, fetches and verifies; the panel downloads with progress. The swap awaits a real frozen build | 2026-08-21 |
 | [REQ-30](#req-30--the-three-dots-button-appears-twice-on-a-source-card) | The three-dots button appears twice on a source card | **In flight** — cause proven, fixed and guarded; merging is his | 2026-08-22 |
 | [REQ-31](#req-31--start-the-profile-parser--and-the-pages-are-not-consistent) | Start the profile parser — and the pages are not consistent | **In flight** — the cards are built, guarded and mutation-tested; `Q-17` and `Q-18` are his | 2026-08-22 |
@@ -1185,8 +1185,8 @@ gets its own enum. Planned in [the platform plan](plans/2026-08-21-the-platform-
 ---
 
 ## REQ-28 · The Engine would not install, and showed a black screen
-**Captured 2026-08-21 · Reported again 2026-08-22 · In flight — the release gate is
-fixed; cutting `engine-v0.3.0` is his**
+**Captured 2026-08-21 · Reported again 2026-08-22 · In flight — gate closed and
+`engine-v0.3.0` published that same day; his confirmation that it installs remains**
 
 > He downloaded the Engine, it did not install, he got a **BLACK SCREEN**, and he
 > does not know how to install it. The panel read: *"ScrapeX Engine — Not detected —
@@ -1219,9 +1219,20 @@ warehouse is at schema **v8**; `main` ships engine migrations to **0006** and re
 v6, so `scrapex ui` exits 1 before binding a port. Both are recorded as `OP-32` and
 `OP-33` in [BACKLOG.md](BACKLOG.md).
 
-**What is his to decide:** whether to cut `engine-v0.3.0` now. The gate that let
-0.2.1 through is closed in this PR — the release now runs the binary the way a
-person runs it and refuses a build that prints nothing.
+~~**What is his to decide:** whether to cut the release now.~~ **— HE DECIDED, AND
+IT IS OUT.** *«اقطع الوسم»*, 2026-08-22, after reading the finding below. The tag
+`engine-v0.3.0` sits on `451468d`, the release workflow completed in 28m36s, and the
+manifest the panel reads was verified on the wire rather than inferred from a green
+run:
+
+    "version": "0.3.0"   "tag": "engine-v0.3.0"
+    "published_at": "2026-08-22T13:17:13Z"
+    "minimum_extension_version": "0.2.2"   protocol 1
+
+It had said `0.2.1` since 9 August. **The gate that let `0.2.1` through is closed and
+this is the first release to pass it** — the binary is now launched the way a person
+launches it, with no arguments, and a build that prints nothing is refused. So the
+engine he can install is, for the first time, one that carries `_first_run`.
 
 **He reported it a second time on 2026-08-22** — *«المحرك الموجود على github 0.2.1»*,
 with the panel reading `Latest version 0.2.1 · Available to install`. The finding is

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -83,7 +83,7 @@ IDs are stable and never reused, matching the convention BACKLOG.md already uses
 | [REQ-25](#req-25--one-source-registry-with-a-category-visible-to-every-user) | One source registry, with a category, visible to every user | **Planned** — half exists (`active: false`, `TBD-probe`); the category and the single registry do not | 2026-08-21 |
 | [REQ-26](#req-26--a-database-per-account-not-per-machine) | A database per account, not per machine | **In flight** — `Q-14` answered (`R-34`): the account is the signed-in address, and his warehouse records it; the per-account layout remains | 2026-08-21 |
 | [REQ-27](#req-27--a-second-source-of-a-category-reuses-the-firsts-machinery) | A second source of a category reuses the first's machinery | **Done** — `scrapex/directories.py`; `--source`, and the crawl is inherited | 2026-08-21 |
-| [REQ-28](#req-28--the-engine-would-not-install-and-showed-a-black-screen) | The Engine would not install — a black screen, and no way to install it | **In flight** — cause proven; the gate is fixed, cutting the release is his | 2026-08-21 |
+| [REQ-28](#req-28--the-engine-would-not-install-and-showed-a-black-screen) | The Engine would not install — a black screen, and no way to install it | **In flight** — cause proven; the gate is fixed, cutting `engine-v0.3.0` is his. Raised again 2026-08-22 | 2026-08-21 |
 | [REQ-29](#req-29--an-install-surface-that-looks-like-a-professional-program-and-an-update-anyone-can-apply) | An install surface that looks like a professional program, and an update anyone can apply | **In flight** — the engine reads, fetches and verifies; the panel downloads with progress. The swap awaits a real frozen build | 2026-08-21 |
 | [REQ-30](#req-30--the-three-dots-button-appears-twice-on-a-source-card) | The three-dots button appears twice on a source card | **In flight** — cause proven, fixed and guarded; merging is his | 2026-08-22 |
 | [REQ-31](#req-31--start-the-profile-parser--and-the-pages-are-not-consistent) | Start the profile parser — and the pages are not consistent | **In flight** — the cards are built, guarded and mutation-tested; `Q-17` and `Q-18` are his | 2026-08-22 |
@@ -1185,7 +1185,8 @@ gets its own enum. Planned in [the platform plan](plans/2026-08-21-the-platform-
 ---
 
 ## REQ-28 · The Engine would not install, and showed a black screen
-**Captured 2026-08-21 · In flight — the release gate is fixed; cutting 0.2.2 is his**
+**Captured 2026-08-21 · Reported again 2026-08-22 · In flight — the release gate is
+fixed; cutting `engine-v0.3.0` is his**
 
 > He downloaded the Engine, it did not install, he got a **BLACK SCREEN**, and he
 > does not know how to install it. The panel read: *"ScrapeX Engine — Not detected —
@@ -1218,15 +1219,25 @@ warehouse is at schema **v8**; `main` ships engine migrations to **0006** and re
 v6, so `scrapex ui` exits 1 before binding a port. Both are recorded as `OP-32` and
 `OP-33` in [BACKLOG.md](BACKLOG.md).
 
-**What is his to decide:** whether to cut `engine-v0.2.2` now. The gate that let
+**What is his to decide:** whether to cut `engine-v0.3.0` now. The gate that let
 0.2.1 through is closed in this PR — the release now runs the binary the way a
 person runs it and refuses a build that prints nothing.
 
-**But `OP-37` has to go first.** `main` has been red since 12:00Z on 2026-08-21 for
-a reason unrelated to any of this, and the release workflow runs the whole suite
-before it builds — so the tag would fail before it reached the compiler. The repair
-is one line and is written out in that entry; it was not applied here because it
-changes what somebody else's merged test asserts.
+**He reported it a second time on 2026-08-22** — *«المحرك الموجود على github 0.2.1»*,
+with the panel reading `Latest version 0.2.1 · Available to install`. The finding is
+the same one and no new defect stands behind it: the only engine tag in the
+repository is still `engine-v0.2.1`. **What HAD gone stale is the number this entry
+and five other places named.** `VERSION` reached **0.3.0** at #247 (2026-08-22), so
+`engine-v0.2.2` would have been refused by the release workflow's first step —
+`test "$tag" = "$version"`, before anything is built. Corrected above and
+guarded by `tests/test_the_release_the_documents_ask_for_is_the_one_that_would_run.py`;
+the measurement is in `OP-32`.
+
+~~**But `OP-37` has to go first.**~~ **— closed by #243.** `main` was red from 12:00Z
+on 2026-08-21 for a reason unrelated to any of this, and the release workflow runs
+the whole suite before it builds, so the tag would have failed before it reached the
+compiler. That is no longer in the way: nothing now stands between the tag and the
+release except pushing it.
 
 ---
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -7,6 +7,12 @@ pointer written into prose is stale by the time it is read: `git log --oneline -
 origin/main` is the answer that cannot be — and this very line proves it twice, since
 #251 and #252 merged while it said `4615a14`.
 
+**THE ENGINE ON GITHUB IS STILL `engine-v0.2.1`, and he asked about it again today**
+— *«المحرك الموجود على github 0.2.1»*. Nothing on the install path is broken; no
+release has been cut since 2026-08-09 while `VERSION` has reached **0.3.0**. The one
+command that changes it is item 2 of *STILL HIS* below, and the number in it is now
+guarded rather than typed. `OP-32` · `REQ-28`.
+
 This is the document that is **wrong the moment it is out of date**. Update it
 when a phase lands, a PR merges, or the owner rules — in the same pull request as
 the work it describes (**C2**, [../CLAUDE.md](../CLAUDE.md)).
@@ -274,26 +280,37 @@ lie. It no longer would. **But it is not yet proved against a real frozen build*
 the guards set `sys.frozen` and `sys.executable`, which is what makes them possible
 at all, and the first artifact to exercise them for real is the next release.
 
-**STILL HIS, AND NOW ONLY TWO:**
+**STILL HIS, AND NOW ONLY ONE — item 2:**
 
 1. ~~`OP-37`~~ **— fixed, and by #243 in parallel rather than by this branch.** So
    the release is no longer blocked by a red suite. The pattern was not invented:
    `tests/test_a_crawl_says_what_it_saw.py:215` already pins every row and then
    overrides one, for the same column.
-2. **Cut `engine-v0.2.2`.** `VERSION` is already 0.2.2, so nothing needs bumping —
-   `git tag engine-v0.2.2 && git push origin engine-v0.2.2`. `OP-32`.
-3. **`claude/his-four-rulings` must merge, or the release will not help him.** His
-   warehouse is at schema **v8**; `main` reads **v6**, so `scrapex ui` exits 1 before
-   it binds a port. Migrations 0007/0008 exist only in that unmerged worktree, whose
-   code *did* run against his live database today. `OP-33`.
+2. **Cut `engine-v0.3.0`.** `git tag engine-v0.3.0 && git push origin engine-v0.3.0`.
+   `OP-32`. **The number is derived, not chosen:** `scrapex/version.py:76` is the
+   only thing that decides it, and `.github/workflows/release-engine.yml` refuses
+   any other tag at its first step. This line said `engine-v0.2.2`, which stopped
+   being cuttable the moment #247 moved `VERSION` to 0.3.0 — so the release the
+   repository was asking for would have been refused before anything was built.
+   `tests/test_the_release_the_documents_ask_for_is_the_one_that_would_run.py` is
+   what stops that recurring.
+3. ~~**`claude/his-four-rulings` must merge, or the release will not help him.**~~
+   **— merged as #243** (`eb691d9`), which brought engine migrations 0007 and 0008,
+   so `main` reads schema v8 and the v8-against-v6 gap this item named is closed.
+   `OP-33`. **A v9-against-v8 gap was found later the same day** and is a different
+   entry — `OP-40`, with `Q-15` for him.
 
-**Until then, the engine that runs on this machine is that worktree's**, verified —
-`/api/health` 200, `worker_alive: true`, in about 16 s:
+~~**Until then, the engine that runs on this machine is that worktree's**~~ — **the
+instruction is dead: `determined-liskov-0c89fe` is not among the worktrees any
+more** (checked 2026-08-22), and #243 merged what it was carrying. Run it from the
+checkout you are in:
 
 ```
-cd .claude/worktrees/determined-liskov-0c89fe
 python -m scrapex.cli ui --no-open
 ```
+
+Whether `main` can open **his** warehouse is a separate and still-open question —
+`OP-40` and `Q-15`, not this line.
 
 **AND HE ASKED FOR THE NEXT THING IN THE SAME BREATH — `REQ-29`:** an install
 surface *«تشبه اى برنامج محترف»* and an update anyone can apply. **Measured before

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,20 +1,35 @@
 # State — where the work stands
 
-**Last updated: 2026-08-22.** `main` is at `5f63bb0` (#252). #243 through #252 are
-all merged — #246 (the engine's own updater) and #247–#252 landed after this line
-last said `afb8648` (#244), which is **seven merges** of drift in one day. A commit
-pointer written into prose is stale by the time it is read: `git log --oneline -1
-origin/main` is the answer that cannot be — and this very line proves it twice, since
-#251 and #252 merged while it said `4615a14`.
+**Last updated: 2026-08-22.** `main` is at `bcb8f6e` (#255). #243 through #255 are
+all merged — **ten merges** landed after this line last said `afb8648` (#244), in one
+day. A commit pointer written into prose is stale by the time it is read:
+`git log --oneline -1 origin/main` is the answer that cannot be — **and this very line
+has now proved it three times in one afternoon**, reading `4615a14` with #251 and
+#252 already in, then `5f63bb0` with #254 in, then `451468d` with #255 in. Each
+correction is the argument for the sentence rather than a counter-example to it.
 
-**THE ENGINE ON GITHUB IS STILL `engine-v0.2.1`, and he asked about it again today**
-— *«المحرك الموجود على github 0.2.1»*. Nothing on the install path is broken; no
-release has been cut since 2026-08-09 while `VERSION` has reached **0.3.0**. The one
-command that changes it is item 2 of *STILL HIS* below, and the number in it is now
-guarded rather than typed by
+**THE ENGINE ON GITHUB IS `engine-v0.3.0`, AND IT WAS CUT TODAY.** He asked for it
+directly — *«اقطع الوسم»* — after reading the finding that the panel was offering
+`0.2.1`, the build whose bare invocation printed nothing. The tag sits on `451468d`,
+which is this `main`; `scrapex/version.py:76` and the `pyproject.toml` mirror both
+read `0.3.0` there. **Thirteen days and two `VERSION` bumps of unreleased engine,
+closed.** `OP-32` · `REQ-28` · guarded by
 [#253](https://github.com/muhammadbayoumi/ScrapeX/pull/253) — **open, not merged**
 ([R-42](RULINGS.md#r-42--one-primary-session-merges-every-other-session-is-secondary-and-asks)).
-`OP-32` · `REQ-28`.
+
+**AND THE NORMAL STATE FROM HERE IS SOURCE AHEAD OF PUBLISHED, WHICH IS NOT `OP-32`
+RETURNING.** `VERSION` moves on a contract change ([R-35](RULINGS.md#r-35--the-engines-version-moves-on-a-contract-change-the-extensions-on-a-user-visible-one))
+and releases are cut by hand (PLATFORM-PLAN Decision 4), so the two are *expected* to
+differ between releases. Migration `0010` has already taken the source to **0.3.1**
+on the branch that carries it, against a published **0.3.0** — that gap is
+development, not a defect.
+
+**What made `OP-32` a defect was never the gap itself.** It was that **nothing** had
+been released across two bumps, the newest installable engine printed nothing when
+double-clicked, and the documents were telling him to cut a tag the workflow would
+refuse. A source one patch ahead of a published engine that works shares none of
+those three. Anyone reading a version gap as `OP-32` returning should check those
+three first.
 
 This is the document that is **wrong the moment it is out of date**. Update it
 when a phase lands, a PR merges, or the owner rules — in the same pull request as
@@ -293,20 +308,30 @@ lie. It no longer would. **But it is not yet proved against a real frozen build*
 the guards set `sys.frozen` and `sys.executable`, which is what makes them possible
 at all, and the first artifact to exercise them for real is the next release.
 
-**STILL HIS, AND NOW ONLY ONE — item 2:**
+**STILL HIS — ~~and now only one~~ NONE. Item 2 is DONE:**
 
 1. ~~`OP-37`~~ **— fixed, and by #243 in parallel rather than by this branch.** So
    the release is no longer blocked by a red suite. The pattern was not invented:
    `tests/test_a_crawl_says_what_it_saw.py:215` already pins every row and then
    overrides one, for the same column.
-2. **Cut `engine-v0.3.0`.** `git tag engine-v0.3.0 && git push origin engine-v0.3.0`.
-   `OP-32`. **The number is derived, not chosen:** `scrapex/version.py:76` is the
-   only thing that decides it, and `.github/workflows/release-engine.yml` refuses
-   any other tag at its first step. This line said `engine-v0.2.2`, which stopped
-   being cuttable the moment #247 moved `VERSION` to 0.3.0 — so the release the
-   repository was asking for would have been refused before anything was built.
+2. ~~**Cut the release.**~~ **— DONE 2026-08-22. He asked for it directly**
+   (*«اقطع الوسم»*) after reading the finding, and the tag `engine-v0.3.0` is on
+   `451468d`, which is this `main`. Verified from the tag rather than reported:
+   `scrapex/version.py:76` and the `pyproject.toml` mirror both read `0.3.0` there,
+   so the workflow's first step had a tag and a version that agreed. **The first
+   engine release in thirteen days, and the first that carries `_first_run`** — the
+   black window of `engine-v0.2.1` is no longer the only thing installable.
+   `OP-32` · `REQ-28`.
+
+   **This line is now history and is written as history on purpose.** It said
+   `engine-v0.2.2`, which stopped being cuttable the moment #247 moved `VERSION` to
+   0.3.0, and the release the repository was asking for would have been refused
+   before anything was built.
    `tests/test_the_release_the_documents_ask_for_is_the_one_that_would_run.py` is
-   what stops that recurring.
+   what stops that recurring — and the reason the sentence above no longer spells
+   the tag inside a command is that guard's own third shape: **a completed release
+   must stop reading as an instruction, or it rots at the next bump.** It would have
+   rotted at the very next one, which is `0.3.1`.
 3. ~~**`claude/his-four-rulings` must merge, or the release will not help him.**~~
    **— merged as #243** (`eb691d9`), which brought engine migrations 0007 and 0008,
    so `main` reads schema v8 and the v8-against-v6 gap this item named is closed.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -11,7 +11,10 @@ origin/main` is the answer that cannot be — and this very line proves it twice
 — *«المحرك الموجود على github 0.2.1»*. Nothing on the install path is broken; no
 release has been cut since 2026-08-09 while `VERSION` has reached **0.3.0**. The one
 command that changes it is item 2 of *STILL HIS* below, and the number in it is now
-guarded rather than typed. `OP-32` · `REQ-28`.
+guarded rather than typed by
+[#253](https://github.com/muhammadbayoumi/ScrapeX/pull/253) — **open, not merged**
+([R-42](RULINGS.md#r-42--one-primary-session-merges-every-other-session-is-secondary-and-asks)).
+`OP-32` · `REQ-28`.
 
 This is the document that is **wrong the moment it is out of date**. Update it
 when a phase lands, a PR merges, or the owner rules — in the same pull request as

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -73,6 +73,16 @@ fixtures, never on his warehouse:
    His to switch on, and it is what makes `ac3a5af` — which left `main` red for two days
    with no pull request — impossible rather than merely regretted.
 
+   **AND IT HAS A SECOND REASON NOW, measured 2026-08-22.** *Require branches up to
+   date* is the clause that matters, and *require the check suite* on its own would
+   **not** have caught it: #251 and #252 both passed every check, shared no changed
+   file, and merged into a **red `main`** — #251 moved a line in
+   `scrapex/webui/app.py`, #252 wrote that line's old number into the PINNED citation
+   table, and #252's checks passed against a base that stopped existing when #251
+   landed. Repaired on `feat/the-profile-page-becomes-columns`; the mechanism is in
+   [LESSONS.md](LESSONS.md) under *Two pull requests, disjoint in files and coupled
+   in content*.
+
 ### What needs the data, and his plan for moving it
 
 3. **The full profile crawl** — 34,834 pages. **RUNNING on this machine since

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -245,7 +245,10 @@ PINNED = (
     # on any one of them would go hunting for a defect that is not there.
     ("docs/BACKLOG.md", "extension/releases.js", 32, "ScrapeX/json/version.json"),
     ("docs/BACKLOG.md", "extension/app.js", 3514, "latest.version"),
-    ("docs/BACKLOG.md", ".github/workflows/release-engine.yml", 344, '"version": VERSION'),
+    # 352, and it was 344 until this same pull request added eight comment lines
+    # above it — the guard catching its author, in the exact shape LESSONS §7
+    # describes: one change moves a line, another wrote the number down.
+    ("docs/BACKLOG.md", ".github/workflows/release-engine.yml", 352, '"version": VERSION'),
     ("docs/BACKLOG.md", "tests/test_the_two_release_paths.py", 276,
      'got["version"] == manifest["version"]'),
     # And the line whose VALUE went stale under a citation that stayed correct --
@@ -254,6 +257,11 @@ PINNED = (
     # is why tests/test_the_release_the_documents_ask_for_is_the_one_that_would_run.py
     # exists beside this file rather than as another row here.
     ("docs/BACKLOG.md", "scrapex/version.py", 76, 'VERSION = "'),
+    # The second home of the number, cited by LESSONS §7's release-runbook line.
+    # `pyproject.toml` is a mirror because setuptools cannot import the package, so
+    # "bump both or neither" is a rule with a guard behind it rather than advice.
+    ("docs/LESSONS.md", "tests/test_version.py", 73,
+     "def test_the_installer_carries_the_same_number("),
 )
 
 # A guard that can be emptied without anyone noticing is the defect -- SR-23, and

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -239,6 +239,21 @@ PINNED = (
      "INSERT INTO generic_page_snapshot "),
     ("docs/LESSONS.md", "scrapex/warehousemerge.py", 269,
      "INSERT INTO generic_page_snapshot "),
+    # OP-32, second report · THE FOUR LINKS OF THE CHAIN THAT IS NOT BROKEN. The
+    # entry's whole argument is that the panel, the manifest and the workflow all
+    # agree and the release simply was not cut, so a reader sent to the wrong line
+    # on any one of them would go hunting for a defect that is not there.
+    ("docs/BACKLOG.md", "extension/releases.js", 32, "ScrapeX/json/version.json"),
+    ("docs/BACKLOG.md", "extension/app.js", 3514, "latest.version"),
+    ("docs/BACKLOG.md", ".github/workflows/release-engine.yml", 344, '"version": VERSION'),
+    ("docs/BACKLOG.md", "tests/test_the_two_release_paths.py", 276,
+     'got["version"] == manifest["version"]'),
+    # And the line whose VALUE went stale under a citation that stayed correct --
+    # the defect this row exists to make visible next time. `VERSION = "` is what
+    # can be pinned; the number on it is what six places copied and lost. That gap
+    # is why tests/test_the_release_the_documents_ask_for_is_the_one_that_would_run.py
+    # exists beside this file rather than as another row here.
+    ("docs/BACKLOG.md", "scrapex/version.py", 76, 'VERSION = "'),
 )
 
 # A guard that can be emptied without anyone noticing is the defect -- SR-23, and

--- a/tests/test_the_release_the_documents_ask_for_is_the_one_that_would_run.py
+++ b/tests/test_the_release_the_documents_ask_for_is_the_one_that_would_run.py
@@ -144,12 +144,19 @@ def test_every_release_the_documents_ask_for_is_the_release_that_would_run():
     The failure is not subtle when it happens — the workflow stops at its first
     step — but it is completely invisible until somebody tries, and the person
     who tries is the owner, on the day he finally has time to ship.
+
+    FINDING NOTHING IS A PASS, AND THAT IS A CORRECTION MADE ON EVIDENCE. This
+    test used to `assert named` first, on the reasoning that a guard matching
+    nothing is measuring nothing. Then `engine-v0.3.0` was released on
+    2026-08-22, every documented instruction correctly became history, and the
+    set went empty — so the assertion failed on the repository being in exactly
+    the state it should be in. **No release is owed between a release and the next
+    contract change, and a guard that demands one forces a document to carry a
+    fake instruction to stay green.** Non-vacuity is proved instead by
+    `test_a_tag_named_in_narrative_prose_is_left_alone`, which runs the pattern
+    against known shapes and needs no live instruction to do it.
     """
     named = _named_releases()
-    assert named, (
-        "no release instruction was found in any document, so this guard is "
-        "measuring nothing. Either the pattern stopped matching or the way out "
-        "of an unreleased engine is no longer written down anywhere")
 
     wrong = [(name, line, version) for name, line, version in named
              if version != VERSION]
@@ -181,6 +188,12 @@ def test_a_tag_named_in_narrative_prose_is_left_alone():
     correct for ever. A guard that demanded every tag name equal VERSION would
     force those sentences to be rewritten on each bump, which is how a test comes
     to be satisfied by a lie.
+
+    AND THIS IS ALSO THE NON-VACUITY PROOF for the guard above, which is why it
+    asserts both directions on fixed strings: the pattern must still match the
+    shapes a person acts on even when no document currently holds one. A guard
+    whose only evidence of working is a live instruction stops being checkable at
+    the moment the work is done.
     """
     history = ("The black window shipped in engine-v0.2.1, and engine-v0.2.1 is "
                "commit 4386d25.")
@@ -191,3 +204,31 @@ def test_a_tag_named_in_narrative_prose_is_left_alone():
                         "**Next action:** cut\n`engine-v9.9.9`, then swap."):
         assert INSTRUCTION.findall(instruction) == ["9.9.9"], (
             f"an instruction this guard must read is not matched: {instruction!r}")
+
+
+def test_the_pattern_cannot_tell_the_tense_of_cut_apart():
+    """A KNOWN LIMIT, asserted so it is a documented constraint and not a surprise.
+
+    `cut engine-v0.3.0` is matched whether it means *"cut this"* or *"he cut
+    this"*. English puts the imperative and the past tense of `cut` in the same
+    letters, and no regex over prose recovers the difference.
+
+    THIS COST A REWORDING RATHER THAN A DEFECT, which is the direction to err in:
+    after the release, `Q-16` read *"Hours later he cut `engine-v0.3.0`"* — true,
+    finished, and matched as though it were an instruction. It passed only because
+    0.3.0 was still `VERSION`, and would have failed at the next contract change.
+    It now reads *"he tagged"*.
+
+    So the discipline, recorded here because the next person will hit it: **write a
+    completed release with any verb but `cut`** — tagged, published, released, went
+    out. A false positive costs one word; a false negative costs a stale
+    instruction the release workflow refuses.
+    """
+    assert INSTRUCTION.findall("Hours later he cut `engine-v0.3.0`.") == ["0.3.0"]
+
+    for finished in ("Hours later he tagged `engine-v0.3.0`.",
+                     "`engine-v0.3.0` was published on 2026-08-22.",
+                     "The release engine-v0.3.0 went out that afternoon."):
+        assert not INSTRUCTION.findall(finished), (
+            f"this is finished history and must not be read as an instruction: "
+            f"{finished!r}")

--- a/tests/test_the_release_the_documents_ask_for_is_the_one_that_would_run.py
+++ b/tests/test_the_release_the_documents_ask_for_is_the_one_that_would_run.py
@@ -1,0 +1,193 @@
+"""The release the documents tell him to cut must be the release that would run.
+
+WHAT HAPPENED, and it is the whole reason this file exists. On 2026-08-22 the
+Settings panel read *Latest version 0.2.1* while `scrapex/version.py:76` said
+`VERSION = "0.3.0"`. Nothing was broken: the panel reads the published manifest
+correctly, the manifest says 0.2.1 correctly, and `git tag` lists exactly one
+engine tag — `engine-v0.2.1`. The release simply was never cut. `OP-32` in
+`docs/BACKLOG.md` had recorded that on 2026-08-21 and named the way out:
+
+    git tag engine-v0.2.2 && git push origin engine-v0.2.2
+
+**And by then that command could not work.** `VERSION` moved to 0.2.2 at
+`adf31b2`, then to 0.3.0 at `e963269`, and the first step of
+`.github/workflows/release-engine.yml` is `test "$tag" = "$version"` — so the
+release the repository was telling him to cut would be REFUSED before anything
+was built. Six places said 0.2.2 — two the whole command to copy, three the
+sentence telling him to cut it, one a note about a past failure. Nothing compared
+any of them with the number in the source, so the instruction rotted the moment
+`VERSION` moved, in the registers a session reads before it decides what to do
+(**C1**).
+
+THE RULE, and it is the narrowest one that catches this: **an engine release
+NAMED AS AN INSTRUCTION must name `VERSION`.** Not every mention of a tag — a
+document may say `engine-v0.2.1` shipped a black window as often as it likes,
+because that is history and history does not move. What may not go stale is the
+sentence a person acts on.
+
+TWO SHAPES ARE ACTED ON, so both are matched: the command that gets copied
+(`git tag engine-v…`) and the sentence that says to cut one (`cut engine-v…`).
+A tag name in narrative prose is neither and is deliberately left alone.
+
+WHY NOT ASK THE HUB, which is where "published" actually lives. A test that
+fetched `ScrapeX/json/version.json` would be the most direct check imaginable and
+this suite would then depend on somebody else's CDN: red on a train, red behind a
+proxy, and — worse — GREEN AND VACUOUS wherever the fetch is skipped. This
+repository has already paid for exactly that twice, in workflows that checked out
+depth 1 and turned two date guards into permanent skips
+(`tests/test_the_workflows_check_out_enough_history.py`). `git tag -l` was
+rejected for the same reason: `actions/checkout@v4` fetches no tags by default,
+so the docs tier would compare against an empty set and pass over anything.
+
+So this reads two committed files and compares two strings. It cannot flake, and
+it cannot pass by accident.
+
+WHAT IT DOES NOT CLAIM. It cannot notice that no release has been cut — that is
+the owner's decision, recorded as `OP-32` and `REQ-28`, and a test cannot make it
+for him. What it guarantees is that when he acts on what the repository tells
+him, the tag he pushes is the tag the workflow accepts.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+from scrapex.version import VERSION
+
+# Reads the documents in CLAUDE.md's map, so it belongs to the docs tier — a
+# documentation-only change is exactly the change that rots an instruction.
+# See tests/test_the_docs_gate_is_complete.py.
+pytestmark = pytest.mark.docs
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+#: The documents C1 sends every session to read, plus the workflow whose own
+#: header carries the command. The workflow is in scope because its comment is
+#: copied by a person exactly like a document's is; being next to the check that
+#: would refuse it does not stop it being read first.
+#:
+#: `docs/plans/` is OUT of scope for the reason the citation guard gives for
+#: excluding it: those files are verbatim historical records, and a plan edited
+#: after the fact stops being evidence of what was decided when.
+INSTRUCTIONS_LIVE_IN = (
+    "CLAUDE.md",
+    "ENGINEERING.md",
+    "docs/STATE.md",
+    "docs/REQUESTS.md",
+    "docs/RULINGS.md",
+    "docs/BACKLOG.md",
+    "docs/LESSONS.md",
+    "docs/APPROACHES.md",
+    ".github/workflows/release-engine.yml",
+)
+
+#: An engine release named as something to DO. The backtick is optional because
+#: Markdown wraps the tag and the workflow's shell comment does not, and `\s+`
+#: rather than a space because "cut\n`engine-v0.2.2`" is one instruction wrapped
+#: across two lines — which is how one of the six copies was written, and a bare
+#: space would have missed it.
+INSTRUCTION = re.compile(
+    r"(?:git\s+tag\s+|\bcut\s+`?)engine-v(\d+\.\d+\.\d+)", re.IGNORECASE)
+
+#: The line in the release workflow that makes the rule above true rather than a
+#: preference. Asserted here as well as in tests/test_the_two_release_paths.py
+#: because this guard's entire justification is that a tag which disagrees with
+#: VERSION is refused: delete that check and this file is measuring nothing.
+TAG_MUST_EQUAL_VERSION = 'test "$tag" = "$version"'
+
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release-engine.yml"
+
+
+def _named_releases() -> list[tuple[str, int, str]]:
+    """Every instruction found, as (document, line, version)."""
+    found = []
+    for name in INSTRUCTIONS_LIVE_IN:
+        text = (ROOT / name).read_text(encoding="utf-8")
+        for match in INSTRUCTION.finditer(text):
+            line = text.count("\n", 0, match.start()) + 1
+            found.append((name, line, match.group(1)))
+    return found
+
+
+def test_the_documents_are_where_they_say_they_are():
+    """A path that stopped existing would empty the search and pass over
+    everything — the shape of vacuous green this whole file is arranged to
+    avoid."""
+    missing = [name for name in INSTRUCTIONS_LIVE_IN
+               if not (ROOT / name).is_file()]
+    assert not missing, f"these are named here and are not in the repository: {missing}"
+
+
+def test_the_places_a_release_instruction_actually_lives_cannot_leave_the_scope():
+    """The set can be shrunk one path at a time and every assertion above stays
+    green, because the remaining paths still hold an instruction.
+
+    Proved by mutation: dropping `docs/STATE.md` and `docs/BACKLOG.md` from the
+    tuple left the whole file passing, and those are the two documents that
+    carried four of the six stale copies. So the members that matter are named
+    rather than counted — a floor would have to be lowered every time an entry is
+    struck, and the number is not what makes this guard work.
+    """
+    for required in ("docs/STATE.md", "docs/BACKLOG.md", "docs/REQUESTS.md",
+                     ".github/workflows/release-engine.yml"):
+        assert required in INSTRUCTIONS_LIVE_IN, (
+            f"{required} is out of scope, and it is one of the places a release "
+            "instruction is actually written. Removing it does not fail anything "
+            "else here")
+
+
+def test_every_release_the_documents_ask_for_is_the_release_that_would_run():
+    """THE GUARD. A documented tag that is not `VERSION` is a failed release.
+
+    The failure is not subtle when it happens — the workflow stops at its first
+    step — but it is completely invisible until somebody tries, and the person
+    who tries is the owner, on the day he finally has time to ship.
+    """
+    named = _named_releases()
+    assert named, (
+        "no release instruction was found in any document, so this guard is "
+        "measuring nothing. Either the pattern stopped matching or the way out "
+        "of an unreleased engine is no longer written down anywhere")
+
+    wrong = [(name, line, version) for name, line, version in named
+             if version != VERSION]
+    assert not wrong, (
+        "these documents tell him to cut a release the workflow would refuse "
+        f"before it built anything — scrapex/version.py says VERSION = {VERSION!r} "
+        f"and {RELEASE_WORKFLOW.name} checks {TAG_MUST_EQUAL_VERSION}:\n  "
+        + "\n  ".join(f"{name}:{line} says engine-v{version}"
+                      for name, line, version in wrong)
+        + "\n\nA tag name in narrative prose is fine and is not matched. This is "
+          "an instruction: either update it to the version in the source, or "
+          "write it as history rather than as something to do.")
+
+
+def test_the_check_that_makes_this_rule_real_is_still_in_the_workflow():
+    """Without it a documented tag could be any number and nothing would care,
+    and this file would be enforcing a rule the release path no longer has."""
+    workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    assert TAG_MUST_EQUAL_VERSION in workflow, (
+        f"{RELEASE_WORKFLOW.name} no longer refuses a tag that disagrees with "
+        "scrapex/version.py:VERSION, so a release can be cut under any number "
+        "and the guard beside this one is enforcing nothing")
+
+
+def test_a_tag_named_in_narrative_prose_is_left_alone():
+    """The rule has to be narrow or it falsifies history to stay green.
+
+    `engine-v0.2.1` shipped the black window, and every document that says so is
+    correct for ever. A guard that demanded every tag name equal VERSION would
+    force those sentences to be rewritten on each bump, which is how a test comes
+    to be satisfied by a lie.
+    """
+    history = ("The black window shipped in engine-v0.2.1, and engine-v0.2.1 is "
+               "commit 4386d25.")
+    assert not INSTRUCTION.findall(history)
+
+    for instruction in ("git tag engine-v9.9.9 && git push origin engine-v9.9.9",
+                        "Cut `engine-v9.9.9`.",
+                        "**Next action:** cut\n`engine-v9.9.9`, then swap."):
+        assert INSTRUCTION.findall(instruction) == ["9.9.9"], (
+            f"an instruction this guard must read is not matched: {instruction!r}")


### PR DESCRIPTION
## What he saw

    Installed version   Not detected
    Latest version      0.2.1   [Available to install]
    Protocol            Not available

— with `scrapex/version.py:76` reading `VERSION = "0.3.0"`. *«المحرك الموجود على
github 0.2.1»*.

## The root cause: (a) a publish step that exists and was not run

**Nothing on the install path is broken, and every link is already pinned by a
test.** Traced end to end:

| link | where |
|---|---|
| the host is granted | `extension/manifest.json:39` — `https://raw.githubusercontent.com/muhammadbayoumi/mbiX-hub/*` |
| the panel fetches | `extension/app.js:14` imports `latestEngineRelease`; called at `:3755` and `:3777` |
| the URL | `extension/releases.js:32` — `.../mbiX-hub/main/ScrapeX/json/version.json` |
| the field read | `extension/releases.js:83` — `body.version` |
| what is printed | `extension/app.js:3514` — `latest.state === "ok" ? latest.version` |
| the field written | `.github/workflows/release-engine.yml:344` — `"version": VERSION` |
| writer and reader already pinned together | `tests/test_the_two_release_paths.py:276` |

So it is **not** (c) — the panel is not reading the wrong field. And it is not
(b) — the publish step exists: `release-engine.yml` builds, checks, publishes to
`mbiX-hub` and rewrites the manifest last (`:441`–`:462`).

**It is (a).** The workflow triggers on `engine-v*` tags and nothing else
(`release-engine.yml:39-42`), and:

```
$ git tag -l "engine-v*"
engine-v0.2.1
```

`VERSION` moved to 0.2.2 at `adf31b2` (2026-08-10) and to 0.3.0 at `e963269`
(#247, 2026-08-22). Neither was tagged. The manifest says 0.2.1 because 0.2.1 is
the only release that has ever existed. That is `OP-32`, open since 2026-08-21,
and **cutting the release is his** (PLATFORM-PLAN Decision 4, `R-37`/`R-42`).

*The other two rows are a different fact and not a version-publishing defect:
`extension/app.js:3484` prints "Not detected" when `state.engineVersion` is
empty, and `:3472` returns "Not available" for the protocol on the same
condition. The panel never reached a running engine.*

## What this PR fixes — the way out had gone stale

`.github/workflows/release-engine.yml` opens with `test "$tag" = "$version"`
(`:111`), so a tag that disagrees with `VERSION` is refused **before anything is
built**. Six places named `engine-v0.2.2` — line numbers as they were **before**
this PR:

| where | shape |
|---|---|
| `docs/STATE.md:248` | the sentence telling him to cut it |
| `docs/STATE.md:249` | the whole command to copy |
| `docs/REQUESTS.md:1217` | the sentence |
| `docs/BACKLOG.md:1124` | the whole command to copy |
| `docs/BACKLOG.md:1427` | a note about a past failure — history, reworded not renumbered |
| `docs/BACKLOG.md:1499` | the sentence |

Nothing compared any of them with the source, so the moment `VERSION` moved, the
repository was telling him to run a release that would fail at step one — in the
registers **C1** sends every session to read first.

## The guard

`tests/test_the_release_the_documents_ask_for_is_the_one_that_would_run.py`:
**an engine tag named as an INSTRUCTION must equal `VERSION`.** Two shapes are
matched, because they are the two a person acts on — `git tag engine-v…` and
`cut engine-v…`. A tag in narrative prose is deliberately left alone: `engine-v0.2.1`
shipped the black window and every sentence saying so is true for ever, so a guard
demanding *every* tag equal `VERSION` would force history to be rewritten to stay
green.

**It found all six on the untouched documents before a single mutation was tried.**

### Why it does not fetch the hub, and does not ask git for tags

The published version lives on the hub, and the released set lives in the tag
list. Both were rejected, for the reason this repository has already paid for
twice:

* `actions/checkout@v4` fetches **no tags**, so `git tag -l` in the docs tier
  would compare against an empty set and pass over anything.
* A network fetch is red on a train, red behind a proxy, and **vacuously green**
  wherever it is skipped — the failure recorded in `docs/LESSONS.md` under *A
  skip is not a failure* and in
  `tests/test_the_workflows_check_out_enough_history.py`.

So the guard reads two committed files and compares two strings. It **cannot**
prove a release was cut, and says so in its own docstring. `Q-16` in
`docs/BACKLOG.md` puts that question to the owner with three shapes and no
recommendation, because the answer depends on how often he intends to release.

### What has to change in `mbiX-hub`, and nothing here can do it

Nothing, by hand. `ScrapeX/json/version.json` there is **written by the release
workflow**, not maintained: pushing `engine-v0.3.0` publishes the release, sends
the two store documents, and rewrites the manifest last. One command:

```
git tag engine-v0.3.0 && git push origin engine-v0.3.0
```

The "must be newer than what is published" check passes — 0.3.0 > 0.2.1 — and the
publishing job needs `PUBLIC_SITE_TOKEN` as a repository secret. Whether it is set
is not visible from here; the workflow names its absence rather than crashing on it
(`release-engine.yml:394-401`), so a first attempt reports that in one sentence
rather than as a permissions error.

### `MINIMUM_EXTENSION_VERSION` — the constraint, checked

`R-07`: the floor is *"a fact the engine owns"* and it **stays**; the advert goes.
So the question is whether cutting 0.3.0 would advertise a floor above the
extension people actually have. Measured: `MINIMUM_EXTENSION_VERSION` derives to
**0.2.2** and `extension/manifest.json` reads **0.2.2** — equal, so the release
demands nothing new. That is already guarded by
`tests/test_version.py:474` (`test_an_engine_release_does_not_raise_the_floor_under_the_published_extension`),
which reads the shipped manifest rather than trusting the ledger. Nothing in this
PR touches either number, and `R-07`'s standing prohibition on re-pinning
`extension/manifest.json` to `VERSION` is untouched.

## Mutation — eight killed, and the first pass was thrown away

| | |
|---|---|
| M1 | the state document names the dead tag again → **KILLED** |
| M2 | `VERSION` moves and no document follows → **KILLED** |
| M3 | the workflow stops refusing a tag that disagrees with `VERSION` → **KILLED** |
| M4 | the pattern stops reading the sentence shape → **KILLED** |
| M5 | the pattern widens to every tag name, history included → **KILLED** |
| M6 | the two documents carrying four of the six copies leave the scope → **KILLED** |
| M7 | a newly pinned citation drifts off its subject → **KILLED** |
| M8 | the workflow's own header instruction goes stale → **KILLED** |

Control green before, **post-control green after** — and that last word is the
finding, because the first pass was not. Every restore wrote the original bytes
back and was verified by re-hashing the file on disk; all eight reported
`restored=True`; `git status` was clean. And the post-control run was **red**:

```
grep '^VERSION = ' scrapex/version.py                      ->  VERSION = "0.3.0"
python -c "import scrapex.version as v; print(v.VERSION)"  ->  0.4.0
```

The `.pyc` compiled while M2 was in place was still being trusted — CPython
invalidates on the source's mtime and size, and a same-length restore inside one
timestamp tick changes neither. Every run after M2 carried an extra failing test,
and M8's kill criterion was that same test, so it could have reported KILLED over
a mutation that did nothing. The harness now purges `__pycache__` between runs and
the table above is from the clean pass. Recorded in `docs/LESSONS.md` beside the
existing *`restored: True` can be true while the file on disk has changed*.

## Documents (C2)

* **`docs/STATE.md`** — the header names the real `main` (`4615a14`, #250) and the
  unreleased engine; *STILL HIS* item 2 now names `engine-v0.3.0` and says the
  number is derived; item 3 and the dead `cd .claude/worktrees/determined-liskov-0c89fe`
  instruction are struck (that worktree is gone — checked).
* **`docs/BACKLOG.md`** — `OP-32` carries the second report, the corrected next
  action, and the guard's stated limit; `OP-37`'s and `OP-39`'s stale tag
  references corrected; **`Q-16`** added.
* **`docs/REQUESTS.md`** — `REQ-28` records the second report and the corrected
  number; its board row follows; the closed `OP-37` blocker is struck.
* **`docs/LESSONS.md`** — two entries: the instruction that rots on the next bump
  (§7), and the `__pycache__` trap (§8).
* **`tests/test_the_documents_cite_what_they_claim.py`** — five `PINNED` rows for
  the citations added here, including `scrapex/version.py:76`, the citation that
  stayed correct while the value on the line changed under it.

**No register drift:** he asked → `REQUESTS.md` (`REQ-28`, second report); we
found it → `BACKLOG.md` (`OP-32`, `Q-16`); no decision was taken, so
`RULINGS.md` is untouched.

## Verification

* `SCRAPEX_FULL_MIGRATIONS=1 python -m pytest -q` — green (`R-22`).
* `ruff check scrapex/` — clean. No file under `scrapex/` is touched by this PR.
* `python -m pytest -m docs` — green.

## Not merged

`R-42`: this is a secondary session. Opened and reported; the merge and the tag
are his.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
