### PR TITLE
The profile page has seven cards, and one of the three nobody read is a price

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -85,6 +85,43 @@ to `RULINGS.md`; a thing we discovered goes here.
 
 Ordered by consequence.
 
+### OP-43 · Four written premises about the muqawil profile page were wrong, and one of them hid a price
+**Found 2026-08-22** under `REQ-31`, measured over **2,419 real profile pairs** read
+read-only out of the running crawl, after he warned that the pages are not consistent —
+«المعلومات غير ثابته ولا متفقثة بين الصفح يعنى ممكن تلاقى معلومات تانية وطريقة عرض مختلفة».
+
+Everything this repository believed about that page came from two committed fixtures,
+which are **one contractor**. `R-19` labelled that limit honestly; the conclusions
+outlived the label.
+
+| premise, and where it was written | what 2,419 pages say |
+|---|---|
+| `extract/muqawil.py`'s module docstring: the fifth `<table>` is *the technical rating* | There is no technical-rating table. `contractor-tab4` holds **zero tables** in its DOM subtree on 2,360 of 2,360 pages. The fifth table is the **self-build price** schedule |
+| `GROUPS_NOT_LOCATED`: the technical rating *"carries no table for this contractor"* | Not this contractor — the site. It is a tab button over an empty pane |
+| the plan: `contract_request_url` *"has no known URL pattern and is not on the card"* | The card is on **100%** of pages. The URL is one site-wide constant, so it earns no column — and the form carries the **Commercial Registration number** |
+| `write_groups`: the licences cell carries both languages *"with no separator"* | There are two dashes in it. They are **hierarchy** separators inside each language, and splitting on them would have cut a path into pieces and called each piece a language |
+
+**All four are fixed and the fixes are in the same pull request**, per **C2**. What is
+left over is recorded rather than repaired:
+
+- **The site's own English is wrong on 100 of 1,685 licence rows** — 30 truncated to
+  `Civil Engineering -` (the same string for two different activities) and 70 naming a
+  *different activity*. Detected by level count, stored with the Arabic path alone.
+  Across the corpus that leaves **3 of 29** taxonomy nodes with no English name, which
+  are the three the site never publishes correctly. → `Q-17`.
+- **`sub_contractors` and `main_contractors` carry rows on 2 and 0 of 2,419 pages.**
+  Declared and unbuilt. → `Q-18`.
+- **The card census has one stated blind spot.** `undeclared_cards()` reports an
+  undeclared card only when it carries a table or a list, because the contractor's own
+  name is a text card whose title differs on every page. Measured: filtering by
+  position is wrong on 40 of 5,668 pages, by content on 0 — so a new **text** card
+  would not be reported. The narrower guard with no false positives was chosen
+  deliberately.
+
+**Next action:** none blocking. The 34,834-page crawl is storing evidence now and
+`R-40` made the re-parse path work, so every column above lands on a re-approval with
+no network.
+
 ### OP-1 · The engine on the owner's machine ran unmerged, half-written code
 **Status: CLOSED, re-measured 2026-08-09.** `_host_lanes` is on `origin/main` in
 `scrapex/jobs.py`; the PR was opened and merged. The account below is kept because
@@ -1554,7 +1591,7 @@ worse for a dataset"* ([scrapex/webui/app.py:639](../scrapex/webui/app.py#L639))
 It was the right call for five of the six entries and it is still right for them:
 `update`, `pause` and `settings` post to routes that read the manifest, and
 `/api/export/{key}` validates the key against `manifest.sources` and answers 404
-for anything else ([scrapex/webui/app.py:2710](../scrapex/webui/app.py#L2710)).
+for anything else ([scrapex/webui/app.py:2725](../scrapex/webui/app.py#L2725)).
 
 **But `Open the data table` would work, and it was built after the blanket
 hide.** `data.html?source=KEY` fetches `/api/table/{key}`, and that route looks
@@ -2297,6 +2334,30 @@ with HTTP 429.
 ## 6. Open questions for the owner
 
 Each is phrased as a question with its options. Nothing below can be answered by code.
+
+**Q-17 · The licences: a readiness level almost nobody publishes, and three activities the site names wrongly in English.**
+Two decisions in one place because they are the same table.
+*(a)* `مستوى الجاهزية` is **empty on 1,490 of 1,500 rows** — five distinct values across
+the other ten (Gold, Silver, `Dimond` as the site spells it, Basic).
+`classification_membership` has no column for a per-membership attribute, so storing it
+is a **migration** for a fact 0.7% of rows carry. Options: migrate now; leave it read
+and unstored, which is what today does — `read_licensed_activities` returns it either
+way, so the day it earns a column it is a re-parse of stored snapshots and not a
+re-crawl; or drop it.
+*(b)* For the **3 activities of 22** whose English half the site publishes truncated or
+simply wrong, the node is stored under its Arabic identity with **no English name**.
+Options: leave it empty and let the site fix itself; write our own English, which is a
+mapping only you can authorise (**R-02**); or show the raw published string, `Civil
+Engineering -`, which is the same string for two different activities.
+
+**Q-18 · Do the two contractor-relation groups still get tables?**
+`R-19` ruled child tables for all five groups, on one profile. Measured over 2,419:
+`main_contractors` carries rows on **0** pages and `sub_contractors` on **2**. They are
+also the only two of the five that are **relations between contractors** rather than
+classifications, so `dataset_relationship` — which now has its first tenant — may be
+their home rather than the taxonomy. Options: build them now at 2 rows; wait until the
+34,834-page crawl finishes and re-measure, which costs nothing because the snapshots
+keep the evidence; or rule them out and record it.
 
 **Q-15 · May a session run an unmerged migration against his LIVE warehouse?**
 Three times on 2026-08-21 his engine database moved ahead of `main` — v8 against v6

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2335,6 +2335,14 @@ with HTTP 429.
 
 Each is phrased as a question with its options. Nothing below can be answered by code.
 
+**~~Q-17~~ · RULED 2026-08-22 — see [R-45](RULINGS.md#r-45--the-site-is-the-only-source-of-truth-and-a-field-the-table-does-not-need-goes-in-the-rows-card).**
+He refused both options this question offered. **We never translate** — where the site
+publishes no usable English, the node keeps its Arabic identity and no English name.
+And the readiness level is **neither a column nor discarded**: fixed columns in the
+table, everything else in the **row's own card**, because contractors will have several
+sources and a column is a promise every source must keep. The question is kept below,
+unedited, because the answer is only legible beside what was asked (**C4**).
+
 **Q-17 · The licences: a readiness level almost nobody publishes, and three activities the site names wrongly in English.**
 Two decisions in one place because they are the same table.
 *(a)* `مستوى الجاهزية` is **empty on 1,490 of 1,500 rows** — five distinct values across

--- a/docs/CONTRACTOR-SOURCE.md
+++ b/docs/CONTRACTOR-SOURCE.md
@@ -468,6 +468,27 @@ displayed anywhere.
 the three cards checked had no rating and no modal), so it cannot be a reliable source for
 the column even if the identification is right.
 
+**FOUND 2026-08-22 — and not there. The lead above was the wrong trail.** The Commercial
+Registration number is the pre-filled `cr` input of the **contract-request form**, which
+every profile publishes. Measured over 2,543 profile pairs:
+
+| | |
+|---|---|
+| pages carrying it | **2,542 of 2,543** |
+| shape | **ten digits**, every one |
+| distinct values | **2,542 over 2,542 contractors — no two share one** |
+
+So it is a second natural key for this directory, and the first that is a **national**
+identifier rather than muqawil's own numbering — which is what a row here can be joined
+to Balady, or to a commercial register, on. The rating-modal lead needed a contractor to
+have a rating; the form needs nothing. `read_commercial_registration` in
+`scrapex/extract/muqawil.py`.
+
+**The same form answers `Contract Request URL`, and the answer is that it is not a
+column.** Its action is `https://muqawil.org/init_econtract_draft` — one endpoint,
+identical on all 2,479 pages measured. A site-wide constant is not a per-contractor
+field.
+
 ## The design
 
 ### Where it lives: one `dataset_definition`, and the G1 path unchanged
@@ -566,8 +587,9 @@ from the id, not fetched. Types are `field_definition.data_type`.
 | `main_contractors` · `subcontractors` | **json** | pr | edges; see the deferred question |
 | `technical_rating_by_activity` | **json** | pr | |
 | `technical_rating_by_company_size` | **json** | pr | |
-| `self_build_price_per_sqm` | **json** | pr | the three bands as one object; **renders only under `/143`** |
-| `commercial_registration_number` | text | — | optional and unobserved |
+| `self_build_price_under_five_projects` · `_five_to_ten_projects` · `_over_ten_projects` | text | pr | **THREE COLUMNS, not one JSON object — corrected 2026-08-22.** This row used to read "the three bands as one object". Measured over 2,419 pairs: exactly three labels and no fourth, values numeric with no currency or separator, and the three arrive **in different orders on different pages**, so they are read by label. Three fixed scalars are not a multi-valued group — the same reasoning `write_groups` already applied to the contract counts. `R-19` overruled JSON for the five *hierarchical* groups, and this is not one of them |
+| `model_contract_count` · `registered_contract_count` | text | pr | **NEW 2026-08-22.** Two scalars from the card titled `Previous Projects` / `المشاريع السابقة`, whose table holds contract counts and not projects — so the reader keys on the table's headers and never on the card's title. 92 of 2,419 pages, always exactly one row |
+| `commercial_registration_number` | text | pr | **FOUND 2026-08-22 — 2,542 of 2,543 pages, ten digits, all distinct.** The old verdict here, "optional and unobserved", was true of four profiles and false of the site. See the section above |
 | `company_description` / `_ar` | text | — | unobserved on four profiles |
 
 **`licensed_activities` is NOT an `[ar]`/non-`[ar]` pair.** The site stacks both languages
@@ -581,6 +603,28 @@ Construction of Buildings - Construction of Buildings – All Types
 — with readiness written `أساسي | Basic`. So it is one JSON field carrying both, not two
 columns. The same holds for every section that stays Arabic on the `/en/` page.
 
+**CORRECTED 2026-08-22, and the correction is the interesting part.** The dashes in that
+cell are **NOT** language separators — they are **hierarchy** separators, inside each
+language. `تشييد المباني - تشييد المباني - جميع الأنواع` is a three-level path, and its
+English half is the same three levels. The language boundary is the **first Latin
+letter**, and that is provable rather than plausible: measured over 1,500 rows, the
+script-run signature of every activity cell is `AL` — Arabic then Latin, exactly one
+transition, 1,500 of 1,500.
+
+So it is neither one JSON field nor two columns. It is a **taxonomy** — 1,685 rows over
+228 pages, drawn from a closed vocabulary of **22 distinct activities** — which is what
+[R-19](RULINGS.md#r-19--the-five-multi-valued-contractor-groups-go-in-child-tables-not-json)
+ruled and `R-38` shaped. `contractors.write_groups` writes it as of 2026-08-22.
+
+**And the site's own English is wrong on 100 of those 1,685 rows** — 30 truncated to
+`Civil Engineering -`, which is the same string for two different activities, and 70
+naming a *different activity* entirely. All three cases change the number of levels, so
+comparing level counts catches every one. Where they disagree the Arabic path is stored
+alone and the English name is left **empty**, which is the state `taxonomy.ensure_path`
+already repairs the moment a page with a usable English half arrives. Measured across the
+corpus, that repair leaves exactly **3 of 29 nodes** without an English name — the three
+the site never publishes correctly.
+
 ### What CANNOT be filled from public pages — measured, not assumed
 
 | specified column | verdict |
@@ -588,7 +632,7 @@ columns. The same holds for every section that stays Arabic on the `/en/` page.
 | Quality / Schedule / Environment Health and Safety / Value / Communication Rating Score | **not published per contractor.** Absent from four profiles, including three that HAVE ratings. The five names appear only on `/contractors-rate/info`, which describes the criteria. Behind login, or not published at all |
 | `Customer Rating Grade` / `[ar]` | not found on any profile read |
 | `Company Description` / `[ar]` | not found on four profiles — already called optional by the owner |
-| `Commercial Registration Number` | not found; he had not seen it either |
+| ~~`Commercial Registration Number`~~ | **FOUND 2026-08-22 on 2,542 of 2,543 pages.** Struck rather than deleted, per **C4**: the verdict was reached honestly on four profiles, and the lesson is that four profiles is not the site. It is in the contract-request form, not on the card |
 
 **Nine specified columns therefore have no public source.** They stay in the field list as
 nullable and are simply never written — a column that exists and is empty is a fact; a

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -1309,3 +1309,125 @@ match on **body**, never on `label`. Each machine seeds a dictionary from the fi
 of that kind *it* fetched, so `muqawil.org/listing` is a 298,954-byte page here and a
 different page there. Matching on the label would have merged two unrelated dictionaries
 into one and broken both sides' pages.
+
+---
+
+## 11 · A page you measured once is a page you have not measured
+
+**2026-08-22.** He said it in the middle of the work, and it was the most useful
+sentence of the session:
+
+> «المعلومات غير ثابته ولا متفقثة بين الصفح يعنى ممكن تلاقى معلومات تانية وطريقة عرض
+> مختلفة»
+
+*The information is neither fixed nor consistent between pages — you may find other
+information and a different presentation.*
+
+Everything this repository believed about the muqawil profile page came from **two
+committed fixtures**, which are one contractor. That was honest and it was labelled:
+`R-19` says *"The limit of this evidence, stated plainly: one contractor."* The
+problem is not that the limit was unrecorded. **The problem is that the conclusions
+outlived it** — they were written into a module docstring, a declaration and a plan,
+where nothing carries the caveat.
+
+Measured over **2,419 real profile pairs** read out of the running crawl, four
+written statements were wrong. Not stale: wrong.
+
+### 1 · A regex that chunks "until the next id" is not a DOM subtree
+
+The premise: the self-build price table lives in `div#contractor-tab4`, the pane the
+tab button `التقييم الفني` points at.
+
+The measurement that produced it chunked the HTML with
+
+```python
+re.compile(r'<div[^>]*id="(contractor-tab\d+)"[^>]*>(.*?)'
+           r'(?=<div[^>]*id="contractor-tab\d+"|\Z)', re.DOTALL)
+```
+
+On a page whose tab4 is **empty**, that chunk does not stop at the pane — it runs on
+into everything after it. So the price table, which sits in a `section-card` of its
+own several elements later, read as "inside tab4". Asking the same question through
+`BeautifulSoup.select('div#contractor-tab4')` gives **zero tables on 2,360 of 2,360
+pages**.
+
+**The tell was there and it was ignored:** the same census reported *15 distinct
+shapes* for that one pane, and 12 of the 15 contained the string `Interests` — the
+name of a card that is not in the pane at all. A shape count that explodes is a
+selector that is wrong, not a site that is inconsistent.
+
+### 2 · Naming the heading level hides a card
+
+The first card census asked for `h3.card-title` and `h2.card-title`, and reported
+**two** section titles per page. The page has seven. The price card's title is an
+**`h4`**, so the card that no document in this repository had ever named was also the
+card the census could not see.
+
+`_CARD_TITLE_TAGS` now lists `h1`…`h6` and the level is never named.
+
+### 3 · The dash in a bilingual cell was a hierarchy separator
+
+`contractors.write_groups` recorded the licensed-activities cell as carrying *"BOTH
+languages in one string with no separator"* and concluded that splitting it *"needs a
+script-boundary rule"*. Half right, and the wrong half was load-bearing.
+
+There **are** separators in that cell. They are inside each language and they
+separate **levels**:
+
+```
+تشييد المباني - تشييد المباني - جميع الأنواع Construction of Buildings - Construction of Buildings – All Types
+└──────────── a three-level Arabic path ────────────┘└──────── the same path in English ────────┘
+```
+
+A parser that split on the dash would have cut a path into pieces and called each
+piece a language. The real boundary is the **first Latin letter**, and it is provable
+rather than plausible: the script-run signature of all 1,500 activity cells measured
+is `AL` — Arabic, then Latin, exactly one transition.
+
+**And the site's own English is wrong on 100 of 1,685 rows** — 30 truncated to
+`Civil Engineering -` (the same string for two different activities) and 70 naming a
+*different activity* altogether. The lucky property, which is why nothing has to
+recognise an activity to be safe: **all three defects change the number of levels**,
+so comparing level counts catches every one.
+
+### 4 · Two vocabularies that look like one, and fuse at the root
+
+Interests and licensed activities are both trees of construction activities and the
+obvious move is one `classification_scheme` for both. Measured:
+
+| | English paths | Arabic paths |
+|---|---|---|
+| Interests | **211** | 214 |
+| Licensed activities | **19** | 21 |
+| exact overlap | **0** | 2 |
+
+Zero English overlap, because the site writes `Civil engineering` in one and `Civil
+Engineering` in the other. But their **Arabic roots do overlap**, and
+`taxonomy.ensure_path` is idempotent on `(scheme, parent, node_name_ar)` — the Arabic
+name is the identity. One scheme would have matched the licence root to the interests
+root, let the licence leaves hang under a node whose English name came from the other
+vocabulary, and produced a tree that is neither. Nothing would have raised.
+
+### What to do instead, and it is cheap
+
+**Declare what the page publishes, and let the page contradict the declaration.**
+`PROFILE_CARDS` names all seven cards and `undeclared_cards()` reports any
+data-carrying card that is not among them. It costs one tuple. It turns "the site
+grew a section" from something nobody notices into something a test says out loud.
+
+Two details of that guard were themselves decided by measurement rather than taste:
+
+- **The contractor's own name is a card**, and its title differs on every page, so it
+  must be excluded or the guard reports thousands of unknowns on its first run.
+  Position said *"card 0"* and was wrong on **40 of 5,668** pages; content said
+  *"carries no table and no list"* and was wrong on **0**. Content won, and the cost
+  is stated in the docstring: a new **text** card would not be reported.
+- **`read_licensed_activities` needs one page, not two.** The cell is already
+  bilingual, so a profile whose Arabic half never arrived still yields its licences —
+  unlike interests, which pair across locales by position and can raise.
+
+**And measure the failure path before you trust the count.** Two things would have
+stopped a 34,834-page approval dead, and both were measured before the parser was
+wired rather than after: interests paired in **2,252 of 2,252** pairs, and the info
+box carried **11 distinct labels, all of them known** — no field was being silently
+dropped. Neither number was known when the profile parser was declared finished.

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -87,6 +87,7 @@ IDs are stable and never reused, matching the convention BACKLOG.md already uses
 | [REQ-29](#req-29--an-install-surface-that-looks-like-a-professional-program-and-an-update-anyone-can-apply) | An install surface that looks like a professional program, and an update anyone can apply | **In flight** — the engine reads, fetches and verifies; the panel downloads with progress. The swap awaits a real frozen build | 2026-08-21 |
 | [REQ-30](#req-30--the-three-dots-button-appears-twice-on-a-source-card) | The three-dots button appears twice on a source card | **In flight** — cause proven, fixed and guarded; merging is his | 2026-08-22 |
 | [REQ-31](#req-31--start-the-profile-parser--and-the-pages-are-not-consistent) | Start the profile parser — and the pages are not consistent | **In flight** — the cards are built, guarded and mutation-tested; `Q-17` and `Q-18` are his | 2026-08-22 |
+| [REQ-32](#req-32--fixed-columns-and-everything-else-in-the-rows-own-card) | Fixed columns, and everything else in the row's own card | **Ruled** ([R-45](RULINGS.md#r-45--the-site-is-the-only-source-of-truth-and-a-field-the-table-does-not-need-goes-in-the-rows-card)) — not built; the card does not exist on either surface | 2026-08-22 |
 
 ---
 
@@ -1451,3 +1452,54 @@ that reading the price rows by position instead of by label goes red.
 **What is left is his:** `Q-17` (the readiness level, empty on 1,490 of 1,500 rows, and
 the three activities whose English the site itself publishes wrongly) and `Q-18` (do the
 two contractor-relation groups still get tables at 2 rows in 2,419 pages).
+
+---
+
+## REQ-32 · Fixed columns, and everything else in the row's own card
+**Captured 2026-08-22 · Ruled ([R-45](RULINGS.md#r-45--the-site-is-the-only-source-of-truth-and-a-field-the-table-does-not-need-goes-in-the-rows-card)) · Not built**
+
+> «فى كاتوجرى المنتجات كنا مثبتين اعمدة محددة فى الجدول واى معلومة زيادة عند الضغط على
+> الصف يظهر كارد تحتها ونضع فيه المعلومة · نفس الشى اريده فى كاتوجرى المقاولون · لان
+> المقاولون سيكون هناك عدة مصادر له فى المستقبل · الفائدة اى ان معلومة مثل مستوى
+> الجاهزيّة لا داعى لوضعها فى عمود خاص فى الجدول ولكن عند الضغط على صف معين وهو يحملها
+> تظهر فى الكارد الخاص بالمقاول»
+
+He said this answering `Q-17`, which had offered him a migration or nothing. He refused
+both framings: the field is **stored** and it is simply not a **column**.
+
+**HIS REASON IS ABOUT THE FUTURE, NOT ABOUT THIS FIELD.** `المقاولون` is a category and
+it will have several sources — Balady, the UAE registries, the Gulf and Egypt sources
+queued in [STATE.md](STATE.md) Track 5. A column is a promise every source in the
+category must keep, so a table whose columns are the union of every source's extras
+grows a column per source and a NULL per row. That is measured, not hypothetical: on the
+products side madar reached **59 variation axes, 33 of them non-empty on under 1% of
+rows**, and he asked three times to have them moved.
+
+**AND HE REMEMBERS THIS AS BUILT. It is half built, and not the half he needs.** Measured
+2026-08-22 across `extension/` and `scrapex/webui/`:
+
+| piece | state |
+|---|---|
+| a per-row card under a clicked row | **does not exist on either surface** — no `rowFormatter`, no expansion handler |
+| which fields are columns, for PRODUCTS | **built** — `/api/promotable/{source_key}`, `fields.promotable_attributes` / `set_promotion`, over `source_product_attribute` |
+| which fields are columns, for DATASETS | **not built**; `field_definition` is where it belongs |
+| the grid both surfaces ship | **Tabulator** — row expansion is a native feature, so this is a feature to use rather than a library to add |
+| the contractors' extras themselves | **already stored** in `generic_record.data_json`; nothing needs re-crawling |
+
+So the products category has the fixed-columns half and no card; the contractors category
+has neither half and its data is already on disk.
+
+**What it will take, in the order the dependencies fall:**
+
+1. **A row card for a DATASET table** — Tabulator's row expansion, rendering every field
+   the row carries that is not a visible column. This is the piece he actually asked for
+   and it unblocks nothing else, so it can go first.
+2. **Column visibility for datasets** — the `field_definition` equivalent of
+   `set_promotion`, so *which* fields are columns becomes his choice rather than the
+   parser's declaration order.
+3. **The same card for the products category**, which already has step 2.
+4. **The readiness level** — one value in that card. It stops being a schema question the
+   moment the card exists, which is why `Q-17` is closed rather than deferred.
+
+**Not started.** `REQ-31` (the profile parser) is what is in flight, and this is the
+surface it feeds.

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -86,6 +86,7 @@ IDs are stable and never reused, matching the convention BACKLOG.md already uses
 | [REQ-28](#req-28--the-engine-would-not-install-and-showed-a-black-screen) | The Engine would not install — a black screen, and no way to install it | **In flight** — cause proven; the gate is fixed, cutting the release is his | 2026-08-21 |
 | [REQ-29](#req-29--an-install-surface-that-looks-like-a-professional-program-and-an-update-anyone-can-apply) | An install surface that looks like a professional program, and an update anyone can apply | **In flight** — the engine reads, fetches and verifies; the panel downloads with progress. The swap awaits a real frozen build | 2026-08-21 |
 | [REQ-30](#req-30--the-three-dots-button-appears-twice-on-a-source-card) | The three-dots button appears twice on a source card | **In flight** — cause proven, fixed and guarded; merging is his | 2026-08-22 |
+| [REQ-31](#req-31--start-the-profile-parser--and-the-pages-are-not-consistent) | Start the profile parser — and the pages are not consistent | **In flight** — the cards are built, guarded and mutation-tested; `Q-17` and `Q-18` are his | 2026-08-22 |
 
 ---
 
@@ -1405,3 +1406,48 @@ where it paints.
 
 When it advances, move the state, add the link the new state produces (a ruling,
 a plan, a PR), and say so in [STATE.md](STATE.md) if it is live work.
+
+---
+
+## REQ-31 · Start the profile parser — and the pages are not consistent
+**Captured 2026-08-22 · In flight — the cards are built, guarded and mutation-tested; two questions are his**
+
+> «ابدأ القارئ»
+
+and then, in the middle of the measurement, the sentence that changed the design:
+
+> «contractor-tabs — المعلومات غير ثابته ولا متفقثة بين الصفح يعنى ممكن تلاقى معلومات
+> تانية وطريقة عرض مختلفة»
+
+*The information is neither fixed nor consistent between pages — you may find other
+information and a different presentation.*
+
+**He was right, and four written premises in this repository were wrong.** Everything
+believed about the muqawil profile page came from **two committed fixtures**, which are
+one contractor. `R-19` had labelled that limit honestly; the conclusions outlived the
+label. Re-measured over **2,419 real profile pairs** read read-only out of the running
+crawl — the full account is in `OP-43` and [LESSONS.md](LESSONS.md) §11.
+
+**The page publishes seven cards. Three had no reader at all**, and one of the three is
+a **price**: the card titled `العقود سعر البناء (برنامج البناء الذاتي)` carries a
+self-build price per square metre in three award tiers, and no document here had named
+it. It was invisible because a regex that chunked "from `id=contractor-tab4` until the
+next tab id" ran past an empty pane and attributed the table to a tab that holds **zero
+tables on 2,360 of 2,360 pages**.
+
+**Built, in the same session he asked:** six new columns — `commercial_registration`
+(2,542 of 2,543 pages, ten digits, no two contractors sharing one), the three
+self-build price tiers, and the two contract counts — taking the profile row from 21
+fields to 27, which `R-31` makes an additive schema upgrade rather than a migration.
+And `licensed_activities` is wired as a **second taxonomy**, in its own scheme: 1,685
+rows over 228 pages from a closed vocabulary of 22 activities.
+
+**His warning is now mechanical rather than remembered.** `PROFILE_CARDS` declares all
+seven cards and `undeclared_cards()` reports any data-carrying card that is not among
+them, so the next section the site grows is something a test says out loud. Twenty-five
+guards, and **seven of seven mutations killed** — including the one that matters most,
+that reading the price rows by position instead of by label goes red.
+
+**What is left is his:** `Q-17` (the readiness level, empty on 1,490 of 1,500 rows, and
+the three activities whose English the site itself publishes wrongly) and `Q-18` (do the
+two contractor-relation groups still get tables at 2 rows in 2,419 pages).

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -575,6 +575,40 @@ unambiguous and nothing in it favours JSON.
 > `classification_node` rather than five bespoke tables — which is **his to rule on**,
 > recorded as `Q-13`. Nothing has been built.
 
+> **MEASURED AGAIN 2026-08-22, over 2,419 real profile pairs instead of one profile,
+> and this is the reading that lifts the evidence limit stated above.** He warned that
+> the pages differ — «المعلومات غير ثابته ولا متفقثة بين الصفح» — and he was right. The
+> original text and the 2026-08-21 correction both stay, per **C4**; what follows
+> replaces neither. It finally counts them.
+>
+> | group | pages | rows | verdict |
+> |---|---|---|---|
+> | Interests | 2,419 of 2,419 | 211 English paths, 214 Arabic | a taxonomy — **built** |
+> | Licensed activities | 2,419, rows on 228 | 1,685 rows, **22 distinct activities** | a taxonomy — **built 2026-08-22** |
+> | Main contractors | 2,419 carry the table | rows on **0** | declared, not built |
+> | Sub contractors | 2,419 carry the table | rows on **2** | declared, not built |
+> | Contract counts | 92 | one row of two numbers | **two columns**, not a group |
+>
+> **THREE THINGS THIS RULING NAMES ARE NOT ON THE PROFILE PAGE AT ALL,** and the
+> measurement is now large enough to say so rather than suspect it. `Balady Services`
+> appears on **0 of 2,419** pages. `Qualification Programs` appears on 2,419 of 2,419
+> — **in the site's navigation JSON-LD**, not as a section of any contractor, which is
+> exactly the false positive a marker test produces when the marker lives in the
+> 119 KB of page chrome. And the **technical rating** is not a table at all:
+> `contractor-tab4` holds zero tables in its DOM subtree on 2,360 of 2,360 pages. The
+> tab button is a label over an empty pane.
+>
+> **AND THE FIFTH TABLE IS A PRICE, which no document here had named.** The card titled
+> `العقود سعر البناء (برنامج البناء الذاتي)` publishes a **self-build price per square
+> metre** in three award tiers — 713 of 2,419 pages carry the card and 163 carry
+> values, all numeric. In a price-tracking warehouse that is the most valuable thing on
+> the page, and it was invisible because a regex had attributed it to the empty tab.
+> See [LESSONS.md](LESSONS.md) §11.
+>
+> **What is left for him** is narrower than five groups: `Q-17` — the readiness level,
+> and the three activities whose English the site publishes wrongly — and `Q-18`, do
+> the two relation groups still get tables at 2 rows in 2,419 pages.
+
 **What it costs.** Five tables and their migration; a read path per table; and the
 dataset payload has to carry them, which today it cannot. That last part is the real
 work and it is not yet designed — and it would have been needed for JSON too.
@@ -1303,6 +1337,26 @@ silently produces nothing for half the data.
 
 **The price, stated:** one declaration per group per site. That is the cost of a rule that
 cannot drift, and this file already records what the alternative costs.
+
+> **AMENDED 2026-08-22 — the rule holds and TWO OF ITS OWN OBSERVATIONS were wrong.
+> Both kept visible per C4.** Measured over 2,419 profile pairs rather than the one
+> committed fixture:
+>
+> - *"two tables carry the same `الإسم / القيمة` pair"* — only one does, and it now has
+>   a name: it is the **self-build price** table, in a `section-card` of its own. The
+>   second sighting came from a regex chunk that ran past an empty tab pane into the
+>   next card.
+> - *"three are empty for this contractor"* — for the two relation tables that is not
+>   this contractor, it is the site. `contractor-tab3` carries rows on **0** of 2,419
+>   pages and `contractor-tab2` on **2**.
+>
+> **The rule gains a companion in its own shape.** A declared map names the groups; a
+> declared map now also names the **cards** — `PROFILE_CARDS` in
+> `scrapex/extract/muqawil.py`, with `undeclared_cards()` reporting any data-carrying
+> card that is not in it. `R-41` argues that a name must be declared rather than
+> inferred; the card census is that argument applied one level up, to *which sections
+> exist at all* — the question two fixtures could not answer, and the one that hid a
+> price for months.
 
 ---
 

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -1189,6 +1189,68 @@ isolation for free.
 
 ---
 
+---
+
+### R-45 · The site is the only source of truth, and a field the table does not need goes in the ROW'S CARD
+
+**2026-08-22 · data model + surface · answers `Q-17`, and rejects both options it offered**
+
+> «ما يقوله الموقع هو مصدر الحقيقة الوحيد لا نعدل عليه»
+>
+> «فى كاتوجرى المنتجات كنا مثبتين اعمدة محددة فى الجدول واى معلومة زيادة عند الضغط على
+> الصف يظهر كارد تحتها ونضع فيه المعلومة · نفس الشى اريده فى كاتوجرى المقاولون · لان
+> المقاولون سيكون هناك عدة مصادر له فى المستقبل · الفائدة اى ان معلومة مثل مستوى
+> الجاهزيّة لا داعى لوضعها فى عمود خاص فى الجدول ولكن عند الضغط على صف معين وهو يحملها
+> تظهر فى الكارد الخاص بالمقاول»
+
+`Q-17` asked two questions and he answered both by refusing the way they were framed.
+
+**1 · WE NEVER TRANSLATE. The site's words are the record.** The question offered
+"write our own English" as an option for the three licensed activities whose English
+half muqawil publishes truncated or simply wrong. **Refused, and on the principle
+rather than on the case.** Where the site publishes no usable English name, the node
+keeps its Arabic identity and **no English name at all** — which is what
+`contractors._licence_paths` already does, and now it does it because it was ruled
+rather than because it was the cautious default.
+
+This is `SR-1` — *the source of truth is what the site publishes* — reaching the
+extraction layer, and it settles a class of question rather than one field. A mapping
+we invent is our claim dressed as the site's data, and no column here may carry one.
+
+**2 · A FIELD IS NOT A COLUMN. Fixed columns, and everything else in the row's own
+card.** The question offered "a migration for a column" or "read but do not store",
+and both were wrong. The readiness level is **stored** — it is a real fact the site
+publishes on 10 of 1,500 rows — and it is simply not a **column**.
+
+**His reason is the load-bearing part, and it is about the future rather than about
+this field:** *"because contractors will have several sources in the future."* A
+column is a promise every source must keep. `المقاولون` is a **category**, and Balady,
+the UAE registries and the Gulf sources queued in `docs/STATE.md` will each publish
+their own extras. A table whose columns are the union of every source's fields grows a
+column per source and a NULL per row — which is exactly the shape
+[`OP-43`](BACKLOG.md) found on the products side, where madar reached 59 variation
+axes and 33 of them were non-empty on under 1% of rows, and he asked three times to
+have them moved.
+
+**WHAT THIS MEANS IS WORK, NOT A NOTE, AND THE HONEST PART IS THAT THE CARD DOES NOT
+EXIST YET.** Measured 2026-08-22 across `extension/` and `scrapex/webui/`:
+
+| piece | state |
+|---|---|
+| a per-row card shown under a clicked row | **does not exist**, on either surface. No `rowFormatter`, no expansion handler, nothing |
+| "which fields are columns" for PRODUCTS | **built** — `/api/promotable/{source_key}`, `fields.promotable_attributes` / `set_promotion`, backed by `source_product_attribute` |
+| "which fields are columns" for DATASETS | **not built.** `field_definition` is where it would live |
+| the grid both surfaces already ship | **Tabulator**, which supports row expansion natively — so this is a feature to use, not a library to add |
+| the extras themselves, for contractors | **already stored.** The dataset path keeps the row in `generic_record.data_json`, so nothing has to be re-crawled to show them |
+
+So the products category has the *fixed columns* half and no card; the contractors
+category has neither, and its data is already on disk. **Nothing about this is
+blocked** — and note what it does to the readiness level: it stops being a schema
+question at all. It is one more value in a card that has to be built anyway.
+
+**Recorded as its own track**, because it is a surface feature with a data-model half
+and it is larger than the field that raised it: `REQ-32`.
+
 ### R-43 · Drive is the single source of truth for DATA; the repository stays it for CODE
 
 **2026-08-22 · two machines · extends `CLAUDE.md`'s founding rule to the warehouse**

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -65,14 +65,29 @@ fixtures, never on his warehouse:
 
 ### What needs the data, and his plan for moving it
 
-3. **The full profile crawl** — 34,834 pages. Belongs on whichever machine holds the
-   warehouse.
-4. **The remaining four groups of `R-19`.** Only `interests` is wired, and
-   `contractors.write_groups` records why for each of the others: licensed activities
-   carry both languages in one unseparated string and one of six rows is already truncated
-   on the site's side; the two contractor lists are relations rather than classifications
-   and are empty on every page measured; contract counts are two scalars that belong in
-   the flat row.
+3. **The full profile crawl** — 34,834 pages. **RUNNING on this machine since
+   2026-08-22**, `--run-ref profiles-2026-08-22 --workers 6`, measured at **1.01 s a
+   page**. Belongs on whichever machine holds the warehouse.
+4. ~~**The remaining four groups of `R-19`.**~~ **RE-MEASURED AND HALF BUILT
+   2026-08-22**, and the re-measurement is the point: every reason recorded here was
+   read off **two committed fixtures**, which are one contractor, and he warned that
+   the pages are not consistent — «المعلومات غير ثابته ولا متفقثة بين الصفح». Counted
+   over **2,419 real profile pairs** off the running crawl:
+
+   | group | what the corpus says | done |
+   |---|---|---|
+   | `licensed_activities` | 1,685 rows over 228 pages, a **closed vocabulary of 22**. The "unseparated string" was separated after all — the dashes are **hierarchy** separators inside each language, and the language boundary is the first Latin letter, `AL` on 1,500 of 1,500 cells | **built**, its own taxonomy scheme |
+   | `contract_counts` | 92 pages, one row of two numbers — the flat row was right | **built**, two columns |
+   | `sub_contractors` · `main_contractors` | rows on **2** and **0** pages of 2,419 | declared, not built — `Q-18` |
+   | ~~`technical_rating`~~ | **not a table at all.** `contractor-tab4` holds zero tables in its DOM subtree on 2,360 of 2,360 pages | nothing to build |
+
+   **And the page has SEVEN cards, not five, one of which is a PRICE.** The card titled
+   `العقود سعر البناء (برنامج البناء الذاتي)` publishes a self-build price per square
+   metre in three tiers — three new columns — and the contract-request form, believed
+   absent, carries the **Commercial Registration number** on 2,542 of 2,543 pages, ten
+   digits, all distinct. Six new columns in all, 21 → 27, safe because `R-31` upgrades
+   a schema additively. See `OP-43`, [LESSONS.md](LESSONS.md) §11, and `Q-17`/`Q-18`,
+   which are what is actually left for him.
 
 **HIS RULING ON THE TWO WAREHOUSES, 2026-08-22.** Both machines have developed muqawil, so
 the databases must be **merged**, with Drive as the single source of truth for DATA while

--- a/docs/plans/2026-08-22-finish-muqawil-workers-crawl-columns.md
+++ b/docs/plans/2026-08-22-finish-muqawil-workers-crawl-columns.md
@@ -14,7 +14,7 @@ rule again: it began on the machine that did **not** have the warehouse.
 |---|---|
 | 1 · workers for `--details` | **DONE** — #249. 87 h → 11–14 h, and it found a real dictionary race |
 | 2 · the profile crawl, 34,834 pages | **ready to run**, ~14 h of machine time, resumable |
-| 3 · the profile parser, 48 columns | not started — the largest piece |
+| 3 · the profile parser | **the cards are done 2026-08-22** — six new columns and a second taxonomy group, on a census of 2,419 real pairs rather than two fixtures. What is left is `Q-17` and `Q-18`, both his |
 | 4 · `R-19`'s remaining four groups | **his ruling**; three of four measure as "do not build" |
 
 ## Context
@@ -74,9 +74,22 @@ So the arithmetic is a floor set by the pace, not the latency: 34,834 × ~1.4 s
 - **The profile crawl itself** — 34,834 pages, both locales, `body_class` set so the
   bodies compress (`~87 MB` instead of 3.95 GB). Resumable already: `already_stored`
   + `--run-ref`.
-- **The profile parser** — 48 of ~70 of his columns have no extractor. One
-  correction to carry: `contract_request_url` is marked `u` in
-  `CONTRACTOR-SOURCE.md` but has **no known URL pattern** and is not on the card.
+- **The profile parser** — ~~48 of ~70 of his columns have no extractor~~ **DONE for
+  the cards, 2026-08-22.** The info-box half was already built and measured clean
+  (11 labels, all known, on 2,252 pairs); what had no reader was three of the page's
+  **seven** cards. Six columns added — `commercial_registration`, three self-build
+  price tiers, two contract counts — and `licensed_activities` wired as a second
+  taxonomy, in its own scheme.
+
+  **The correction this step was told to carry was itself wrong.**
+  `contract_request_url` is not absent from the card: the card is on **100%** of pages,
+  and its form action is one **site-wide constant**, so it earns no column — while the
+  form's pre-filled `cr` input is the **Commercial Registration number**, on 2,542 of
+  2,543 pages, ten digits, no two contractors sharing one. Kept visible per **C4**: the
+  premise was recorded honestly off two fixtures and 2,419 pages overturned it.
+
+  Three more premises fell with it — see `OP-43` and [LESSONS.md](../LESSONS.md) §11 —
+  including a **price** that no document in this repository had named.
 - **`R-19`'s remaining four groups** — only `interests` is wired;
   `contractors.write_groups` records why for each of the others.
 

--- a/scrapex/contractors.py
+++ b/scrapex/contractors.py
@@ -737,33 +737,116 @@ def _contractor_of(key: str) -> str | None:
     return found.group(1) if found else None
 
 
+#: THE GROUPS THAT REACH THE WAREHOUSE, in the order they are written. Everything
+#: else `MULTI_VALUED_GROUPS` declares was measured and is not a taxonomy or is not
+#: there -- see `GROUPS_MEASURED_EMPTY` and `read_contract_counts`.
+_WIRED_GROUPS = ("interests", "licensed_activities")
+
+
+def _interest_paths(english: str, arabic: str) -> list[tuple[tuple[str, ...],
+                                                             tuple[str, ...]]]:
+    """`interests`, paired across the two pages. Raises when the counts differ.
+
+    PAIRED BY POSITION, LIKE `merge_locales`, AND REFUSED THE SAME WAY. Both locales
+    publish the nodes in the same order, so position names the same node in each. A
+    count that differs means it no longer does, and writing anyway would attach an
+    English name to a different Arabic one.
+
+    MEASURED 2026-08-22 over 2,252 real profile pairs: **2,252 of 2,252 paired**, so
+    this refusal is a guard rather than a common path. That number is worth having
+    before a 34,834-page approval: at a 1% mismatch rate this raise would have
+    stopped 348 pages.
+    """
+    from .extract.muqawil import read_interests
+
+    paths_en = read_interests(english)
+    paths_ar = read_interests(arabic) if arabic else paths_en
+    if len(paths_en) != len(paths_ar):
+        raise taxonomy.CannotPairLocales(
+            f"published {len(paths_en)} interests in English and "
+            f"{len(paths_ar)} in Arabic")
+    return list(zip(paths_en, paths_ar, strict=True))
+
+
+def _licence_paths(english: str, arabic: str) -> list[tuple[tuple[str, ...],
+                                                           tuple[str, ...]]]:
+    """`licensed_activities`, which needs ONE page rather than two.
+
+    THE CELL IS ALREADY BILINGUAL, and that is the whole difference from interests:
+    the licences table publishes `تشييد المباني - جميع الأنواع Construction of
+    Buildings - All Types` in one cell, identically on both locales. So there is
+    nothing to pair across pages and no `CannotPairLocales` to raise -- a profile
+    whose Arabic half failed to arrive still yields its licences in full.
+
+    WHERE THE SITE'S OWN ENGLISH IS UNUSABLE, THE ENGLISH NAME IS LEFT EMPTY rather
+    than filled with the Arabic. Measured over 1,685 rows, 100 of them publish an
+    English half that is truncated (`Civil Engineering -`, 30 rows) or names a
+    DIFFERENT ACTIVITY (70 rows) -- `read_licensed_activities` detects both by level
+    count and reports `paired=False`.
+
+    An empty English name is a state `taxonomy.ensure_path` already handles and
+    already documents: *"A node first seen on an Arabic page has no English name
+    yet; the next English page supplies it."* So the node exists under its Arabic
+    identity now, and the first page that publishes a usable English half fills it
+    in by UPDATE. Putting the Arabic string in the English column would have made
+    that repair impossible, because the column would no longer look empty.
+    """
+    from .extract.muqawil import read_licensed_activities
+
+    # THE ENGLISH PAGE, and either would do. Measured on both committed fixtures and
+    # across the corpus, the two locales publish byte-identical licence cells --
+    # which is the same property `MultiValuedGroup.published_as` records for the
+    # table headers, one level down.
+    activities = read_licensed_activities(english or arabic)
+    return [(one.english or ("",) * len(one.arabic), one.arabic)
+            for one in activities if one.arabic]
+
+
+#: `group_key -> reader`. A group is wired by appearing here and nowhere else.
+_GROUP_READERS = {
+    "interests": _interest_paths,
+    "licensed_activities": _licence_paths,
+}
+
+
 def write_groups(conn, directory: Directory, snapshot_id: int, *,
                  english: str, arabic: str, contractor_id: str) -> tuple[int, int]:
     """`R-38`'s memberships for one contractor. Returns `(written, already there)`.
 
-    ONLY `interests` IS WIRED, AND THE MEASUREMENT IS WHY. Read off the committed
-    profile on 2026-08-21, the five declared groups are not five of the same thing:
+    TWO OF THE FIVE ARE WIRED NOW, AND THE MEASUREMENT IS WHY -- the same reason the
+    other three are not. This function used to write `interests` alone, and it said
+    so in its own words about the licences: *"Six samples, one malformed, is not
+    enough to declare that rule on."* Correct then. Measured 2026-08-22 over 2,419
+    real profile pairs off the running crawl:
 
-        interests            a nested list, 25 nodes per locale, cleanly localised
-                             -> a taxonomy membership, which is what this writes
-        licensed_activities  6 rows whose activity cell carries BOTH languages in one
-                             string with no separator — `تشييد المباني … Construction of
-                             Buildings – All Types` — and whose readiness cell is
-                             `أساسي | Basic`. Splitting the first needs a script-boundary
-                             rule, and one of the six already has a TRUNCATED English half
-                             on the site's side (`Civil Engineering -`). Six samples, one
-                             malformed, is not enough to declare that rule on.
-        main_contractors     `# / name`, and EMPTY on every page measured. These are
-        sub_contractors      contractor-to-contractor RELATIONS, not classifications, so
-                             they do not belong in a taxonomy at all.
-        contract_counts      one row of two numbers, `455 / 64`. Two scalars — they belong
-                             in the flat row, and putting them in a link table would make
-                             a membership out of a count.
+        interests            2,419 of 2,419 pages, 211 English paths and 214 Arabic
+                             -> a taxonomy, and it was already built
+        licensed_activities  1,685 rows over 228 pages, a CLOSED vocabulary of 22
+                             activities, and the split rule is now PROVABLE: the
+                             script-run signature of all 1,500 activity cells is
+                             `AL`, Arabic then Latin, one transition
+        main_contractors     rows on 0 of 2,419 pages
+        sub_contractors      rows on 2 of 2,419 pages -- contractor-to-contractor
+                             RELATIONS rather than classifications, and two rows is
+                             not a shape to design on
+        contract_counts      92 pages, one row of two numbers -> two COLUMNS, which
+                             is what the earlier reading of it already argued, and
+                             `read_contract_counts` now puts them on the flat row
 
-    `R-19`'s own limit is the reason this stops here rather than guessing: the study says
-    it measured ONE profile, and three of these five are empty on every profile we hold.
-    The snapshots keep the evidence, so each of the four can be derived later with no
-    network the moment its shape is decided.
+    TWO SCHEMES, NOT ONE, AND A MEASUREMENT PREVENTED THE MERGE. Interests and
+    licences look like one vocabulary and are two: 211 English interest paths against
+    19 English licence paths, with **zero exact overlap** -- the site writes `Civil
+    engineering` in one and `Civil Engineering` in the other. Their ARABIC ROOTS DO
+    overlap, and `taxonomy.ensure_path` is idempotent on the Arabic name, so a single
+    scheme would have fused the two trees at the roots and let them diverge below,
+    producing a tree that is neither. Each group names its own scheme.
+
+    THE READINESS LEVEL IS READ AND NOT STORED, and the count is the argument:
+    `مستوى الجاهزية` is EMPTY on 1,490 of 1,500 rows, with five distinct values
+    across the other ten. `classification_membership` has no column for a per-
+    membership attribute, so storing it means a migration -- for a fact 0.7% of rows
+    carry. `read_licensed_activities` returns it either way, so the day it is worth a
+    column it is a re-parse of stored snapshots and not a re-crawl.
     """
     reader = directory.profiles
     if reader is None:
@@ -784,31 +867,32 @@ def write_groups(conn, directory: Directory, snapshot_id: int, *,
         # prevent, arriving from the other direction.
         return 0, 0
 
-    scheme = taxonomy.ensure_scheme(conn, int(site["site_profile_id"]),
-                                    name=reader.scheme_name,
-                                    name_ar=reader.scheme_name_ar)
-    from .extract.muqawil import read_interests
-
-    paths_en = read_interests(english)
-    paths_ar = read_interests(arabic) if arabic else paths_en
-    if len(paths_en) != len(paths_ar):
-        # PAIRED BY POSITION, LIKE `merge_locales`, AND REFUSED THE SAME WAY. Measured:
-        # both locales publish 25 nodes in the same order. A count that differs means
-        # position no longer describes the same node, and writing anyway would attach an
-        # English name to a different Arabic one.
-        raise taxonomy.CannotPairLocales(
-            f"contractor {contractor_id} published {len(paths_en)} interests in English "
-            f"and {len(paths_ar)} in Arabic")
-
     written = repeated = 0
-    for path, path_ar in zip(paths_en, paths_ar, strict=True):
-        node = taxonomy.ensure_path(conn, scheme, path=path, path_ar=path_ar)
-        if taxonomy.link(conn, generic_record_id=int(record["generic_record_id"]),
-                         node_id=node, group_key="interests",
-                         source_snapshot_id=snapshot_id):
-            written += 1
-        else:
-            repeated += 1
+    for group_key in _WIRED_GROUPS:
+        group = next((one for one in reader.groups if one.key == group_key), None)
+        if group is None or not group.scheme_name_ar:
+            # DECLARED WITHOUT A VOCABULARY IS NOT WIRED. Reaching here means the
+            # group's declaration lost its scheme name, and writing into a scheme
+            # named "" would silently collect two taxonomies into one row.
+            raise KeyError(
+                f"{group_key!r} is wired but declares no scheme name; "
+                f"see MULTI_VALUED_GROUPS")
+        scheme = taxonomy.ensure_scheme(conn, int(site["site_profile_id"]),
+                                        name=group.scheme_name,
+                                        name_ar=group.scheme_name_ar)
+        try:
+            pairs = _GROUP_READERS[group_key](english, arabic)
+        except taxonomy.CannotPairLocales as exc:
+            raise taxonomy.CannotPairLocales(
+                f"contractor {contractor_id}, group {group_key}: {exc}") from exc
+        for path, path_ar in pairs:
+            node = taxonomy.ensure_path(conn, scheme, path=path, path_ar=path_ar)
+            if taxonomy.link(conn, generic_record_id=int(record["generic_record_id"]),
+                             node_id=node, group_key=group_key,
+                             source_snapshot_id=snapshot_id):
+                written += 1
+            else:
+                repeated += 1
     return written, repeated
 
 

--- a/scrapex/directories.py
+++ b/scrapex/directories.py
@@ -87,9 +87,13 @@ class ProfileReader:
     each group on the page. `R-41` put the declaration in the site's own module, so this
     carries references to it rather than copies of it.
 
-    THE SCHEME NAME IS HERE AND NOT IN `taxonomy.py` because it is the SITE's vocabulary
-    — `classification_scheme.scheme_type='source'` says so — and the module that stores
-    trees has no business naming one site's.
+    THE SCHEME NAME WAS HERE AND HAS MOVED ONE LEVEL DOWN, to the group declaration in
+    the site's own module. The original reasoning still holds — a vocabulary is the
+    SITE's, `classification_scheme.scheme_type='source'` says so, and `taxonomy.py` has
+    no business naming one site's — but ONE pair of names for the whole reader was only
+    correct while `interests` was the only wired group. Measured 2026-08-22: interests
+    publishes 211 English paths and the licences 19, with zero exact overlap, so they are
+    two vocabularies and each group names its own. See `MultiValuedGroup.scheme_name`.
     """
 
     #: `(english_html, arabic_html, *, contractor_id) -> TableCandidate`.
@@ -98,9 +102,6 @@ class ProfileReader:
     groups: tuple[Any, ...]
     #: `(html, group_key) -> element | None`.
     locate: Callable[..., Any]
-    #: What the site calls its own vocabulary, in both languages.
-    scheme_name: str
-    scheme_name_ar: str
     #: ITS OWN DATASET, AND THIS IS NOT A DETAIL. A profile publishes 21 declared fields
     #: and a listing card 28, so putting both under one `dataset_key` makes every profile
     #: look like a SUBSET of the approved listing schema — which `R-31` correctly refuses,
@@ -135,11 +136,11 @@ def _muqawil() -> Directory:
             candidate=bilingual_profile_candidate,
             groups=MULTI_VALUED_GROUPS,
             locate=locate_group,
-            # THE SITE'S OWN WORDS. `Interests` in English and `الأنشطة` in Arabic,
-            # which `R-41` measured are not translations of each other — so both are
-            # recorded rather than one being derived from the other.
-            scheme_name="Interests",
-            scheme_name_ar="الأنشطة",
+            # THE SITE'S OWN WORDS FOR EACH VOCABULARY are declared beside the group
+            # that populates it, in `MULTI_VALUED_GROUPS` — `Interests` / `الأنشطة`,
+            # which `R-41` measured are not translations of each other, and
+            # `Licensed Activities` / `الأنشطة المرخصة`, where the site publishes no
+            # English name at all and ours is marked as ours.
             dataset_key="contractor_profiles",
             dataset_name="Contractor profiles"),
     )

--- a/scrapex/extract/muqawil.py
+++ b/scrapex/extract/muqawil.py
@@ -2,9 +2,15 @@
 
 Step 2 of the contractor plan, and it sits BESIDE `html_table.py` rather than
 replacing it: a profile page carries five real `<table>` elements — the licences
-and their readiness, the two contractor lists, the technical rating and the
-contract counts — and those go through `detect_html_tables` exactly as any other
-site's would. What this file reads is everything that is NOT a table, which on a
+and their readiness, the two contractor lists, the SELF-BUILD PRICE SCHEDULE and
+the contract counts — and those go through `detect_html_tables` exactly as any
+other site's would.
+
+CORRECTED 2026-08-22, because that sentence named the technical rating as the
+fifth table for months and there is no such table. Measured over 2,419 real
+profile pairs: `div#contractor-tab4`, the pane the tab button `التقييم الفني`
+points at, holds ZERO tables on 2,360 of 2,360 pages. The fifth table is the
+self-build price schedule, in a `section-card` of its own — see `PROFILE_CARDS`. What this file reads is everything that is NOT a table, which on a
 listing page is all of it: **a listing page contains zero `<table>` elements.**
 
 TWO FAILURES HERE ARE SILENT, AND BOTH HAVE A GUARD OF THEIR OWN.
@@ -156,6 +162,24 @@ PROFILE_FIELD_ORDER = (
     "activity", "activity_ar",
     "organization_mobile_number", "organization_email",
     "latitude", "longitude",
+    # SIX MORE, MEASURED 2026-08-22 over 2,419 real profile pairs and NOT on the
+    # info box -- which is why a count of the info box's labels said the profile
+    # was fully read when three of its seven cards had no reader at all.
+    #
+    # `R-31` is what makes adding them safe rather than a migration: every field
+    # already approved is still here, so `_retire_or_refuse` opens schema version 2
+    # and the 704 rows approved under version 1 keep theirs. A field REMOVED would
+    # be refused, and that is the direction that matters.
+    #
+    # THE PRICES LEAD THE NEW ONES because they are a price, and this is a
+    # price-tracking warehouse: `self_build_price_*` is what a contractor charges
+    # per square metre under the self-build programme, and nothing in this
+    # repository had a column for it.
+    "commercial_registration",
+    "self_build_price_under_five_projects",
+    "self_build_price_five_to_ten_projects",
+    "self_build_price_over_ten_projects",
+    "model_contract_count", "registered_contract_count",
 )
 
 #: Fields whose Arabic value is a DIFFERENT value rather than the same one
@@ -339,6 +363,19 @@ class MultiValuedGroup:
     kind: str
     #: A CSS selector locating the container, resolved with soupsieve.
     selector: str
+    #: THE VOCABULARY THIS GROUP POPULATES, in both languages -- and it lives HERE,
+    #: beside the group, because a measurement of 2026-08-22 says a group and its
+    #: taxonomy are one fact. `ProfileReader` used to carry a single pair for the whole
+    #: reader, which was true while `interests` was the only wired group and became a
+    #: trap the moment a second arrived: interests publishes 211 English paths and
+    #: licences 19, with ZERO exact overlap (`Civil engineering` against `Civil
+    #: Engineering`), while their ARABIC ROOTS DO overlap -- and `taxonomy.ensure_path`
+    #: is idempotent on the Arabic name. One scheme would have fused the two trees at
+    #: the roots and let them diverge below.
+    #:
+    #: EMPTY MEANS NOT WIRED. A group with no scheme name is declared and unwritten,
+    #: which is the state three of the five are in; `contractors.write_groups` refuses
+    #: to write one rather than defaulting it.
     #: What the SITE calls it, kept for the record and for a reader comparing with the
     #: page. **Arabic even on the English profile** — measured: every table header and
     #: every contractor tab label is identical in both locales, so a selector built on
@@ -346,6 +383,21 @@ class MultiValuedGroup:
     #: interests card IS translated (`Interests` / `الأنشطة`), which is why that one is
     #: located structurally instead.
     published_as: str
+    #: THE VOCABULARY THIS GROUP POPULATES, in both languages -- and it lives HERE,
+    #: beside the group, because a measurement of 2026-08-22 says a group and its
+    #: taxonomy are one fact. `ProfileReader` used to carry a single pair for the whole
+    #: reader, which was true while `interests` was the only wired group and became a
+    #: trap the moment a second arrived: interests publishes 211 English paths and
+    #: licences 19, with ZERO exact overlap (`Civil engineering` against `Civil
+    #: Engineering`), while their ARABIC ROOTS DO overlap -- and `taxonomy.ensure_path`
+    #: is idempotent on the Arabic name. One scheme would have fused the two trees at
+    #: the roots and let them diverge below.
+    #:
+    #: EMPTY MEANS NOT WIRED. A group with no scheme name is declared and unwritten,
+    #: which is the state three of the five are in; `contractors.write_groups` refuses
+    #: to write one rather than defaulting it.
+    scheme_name: str = ""
+    scheme_name_ar: str = ""
 
 
 #: The groups `R-19` asks for, as they are actually published. Measured against
@@ -359,12 +411,18 @@ MULTI_VALUED_GROUPS: tuple[MultiValuedGroup, ...] = (
         # selector read 25 nodes from one locale and 0 from the other. The card is the
         # one holding the nested list, and `read_interests` refuses if two ever do.
         selector="div.section-card:has(ul.list-numerical li.list-item)",
-        published_as="Interests / الأنشطة"),
+        published_as="Interests / الأنشطة",
+        scheme_name="Interests", scheme_name_ar="الأنشطة"),
     MultiValuedGroup(
         key="licensed_activities",
         kind="table",
         selector='table:has(th:-soup-contains("الأنشطة المرخصة"))',
-        published_as="الأنشطة المرخصة"),
+        published_as="الأنشطة المرخصة",
+        # THE SITE PUBLISHES NO ENGLISH NAME FOR THIS VOCABULARY -- the card's title is
+        # `التراخيص ومستوى الجاهزية` in both locales -- so the English one is OURS, and
+        # the Arabic one is the site's own table header. `ensure_scheme` keys on the
+        # Arabic name, which is the half that is not invented.
+        scheme_name="Licensed Activities", scheme_name_ar="الأنشطة المرخصة"),
     MultiValuedGroup(
         key="sub_contractors",
         kind="table",
@@ -413,7 +471,33 @@ GROUPS_NOT_LOCATED: tuple[tuple[str, str], ...] = (
      "a listing filter axis (balady_service_id, 8 values), not a profile section on the "
      "committed contractor"),
     ("technical_rating",
-     "tab contractor-tab4 (التقييم الفني) carries no table for this contractor"),
+     "NOT A GROUP AT ALL, corrected 2026-08-22. The tab button التقييم الفني names "
+     "div#contractor-tab4, and that pane holds ZERO tables in its DOM subtree on "
+     "2,360 of 2,360 measured pages -- it is a label over an empty pane. The earlier "
+     "reading, 'carries no table for this contractor', was measured on one fixture "
+     "and read as a property of that contractor; it is a property of the site. The "
+     "fifth table on the page is the SELF-BUILD PRICE schedule, in its own "
+     "section-card -- see PROFILE_CARDS and read_self_build_prices"),
+)
+
+#: WHAT 2,419 PAGES SAID ABOUT THE FOUR GROUPS `write_groups` DEFERRED, and it is
+#: recorded here beside the declarations because `R-19` asked for measurement and one
+#: fixture was all there was to measure. Counts, not impressions:
+#:
+#:   licensed_activities  1,685 rows over 228 pages, a CLOSED vocabulary of 22
+#:                        distinct activities -> a taxonomy. Built.
+#:   contract_counts      92 pages, always exactly one row of two numbers -> two
+#:                        columns, which is what `write_groups` already argued.
+#:   sub_contractors      2,419 pages carry the table. Rows on TWO of them.
+#:   main_contractors     2,419 pages carry the table. Rows on ZERO of them.
+#:
+#: The last two are the ones a study cannot settle: they are contractor-to-contractor
+#: RELATIONS rather than classifications, and 2 rows in 2,419 pages is not enough to
+#: design a shape on. They stay declared and unbuilt, and the snapshots keep the
+#: evidence, so the day the site fills them in it is a re-parse and not a re-crawl.
+GROUPS_MEASURED_EMPTY: tuple[tuple[str, str], ...] = (
+    ("sub_contractors", "rows on 2 of 2,419 pages measured 2026-08-22"),
+    ("main_contractors", "rows on 0 of 2,419 pages measured 2026-08-22"),
 )
 
 
@@ -554,6 +638,405 @@ def _path_to(item: Tag, card: Tag) -> tuple[str, ...]:
 def _within(node: Tag, card: Tag) -> bool:
     return any(one is card for one in node.parents)
 
+# ---- the cards, which he warned are not the same on every page ---------------
+
+#: EVERY CARD A PROFILE PUBLISHES, and a DECLARATION rather than a comment
+#: because of what he said on 2026-08-22, in the middle of this measurement:
+#:
+#:     «المعلومات غير ثابته ولا متفقثة بين الصفح يعنى ممكن تلاقى معلومات تانية
+#:      وطريقة عرض مختلفة»
+#:
+#: The information is neither fixed nor consistent between pages; you may find
+#: other information and a different presentation. He was right, and this file was
+#: wrong in three places at once. What follows was MEASURED over 2,419 real profile
+#: pairs off the running crawl, not read off the two committed fixtures.
+#:
+#: THE THREE CORRECTIONS, each of which was a written premise somewhere:
+#:
+#:   1. This module's own docstring says the five tables are "the licences and
+#:      their readiness, the two contractor lists, THE TECHNICAL RATING and the
+#:      contract counts". There is no technical-rating table. The tab labelled
+#:      التقييم الفني -- div#contractor-tab4 -- holds ZERO tables in its DOM
+#:      subtree on 2,360 of 2,360 pages, and the fifth table is the SELF-BUILD
+#:      PRICE schedule, which no document in this repository named.
+#:   2. GROUPS_NOT_LOCATED records the technical rating as "carries no table for
+#:      this contractor" -- true of the fixture, and true of every page measured.
+#:      It is not a group at all: the button is a label over an empty pane.
+#:   3. The price table was mis-attributed to that pane by a REGEX that chunked
+#:      from id="contractor-tab4" until the next tab id. On a page whose pane is
+#:      empty, that chunk runs on into the next card -- so the price table read as
+#:      "inside tab4" while its real ancestry is
+#:      div.table-responsive < div.section-card < div.col-12. A PANE IS A DOM
+#:      SUBTREE AND NOTHING ELSE, which is the lesson _INTEREST_LIST learned about
+#:      headings, arriving from the other side.
+#:
+#: AND THE CARD TITLES ARE NOT ALL TRANSLATED, which is why `titles` is a tuple.
+#: Interests/الأنشطة and Map/الموقع are translated; التراخيص ومستوى الجاهزية and
+#: العقود سعر البناء (برنامج البناء الذاتي) print in ARABIC on the English page,
+#: which is exactly what makes a title-based selector locale-stable for those two
+#: -- the same property MultiValuedGroup.published_as already records.
+@dataclass(frozen=True)
+class ProfileCard:
+    """One card the profile publishes, by every title the site prints for it."""
+
+    #: Our stable name for it.
+    key: str
+    #: Every spelling seen, both locales. A title-based selector uses these.
+    titles: tuple[str, ...]
+    #: `table`, `list` or `text` -- what a reader has to go through to reach it.
+    carries: str
+    #: The measured share of pages that publish it, kept as evidence rather than
+    #: as a promise: these are counts off 2,419 pairs, not a guarantee.
+    on_pages: str
+
+
+PROFILE_CARDS: tuple[ProfileCard, ...] = (
+    ProfileCard(key="contractor_relations", titles=("(no card-title)",),
+                carries="table",
+                on_pages="2,419 of 2,419 -- the two tab tables, rows on 2"),
+    ProfileCard(key="contract_request", titles=("Contract Request", "طلب تعاقد"),
+                carries="text", on_pages="2,419 of 2,419"),
+    ProfileCard(key="licensed_activities", titles=("التراخيص ومستوى الجاهزية",),
+                carries="table", on_pages="2,419 of 2,419, rows on 228"),
+    ProfileCard(key="self_build_prices",
+                titles=("العقود سعر البناء (برنامج البناء الذاتي)",),
+                carries="table", on_pages="713 of 2,419, rows on 163"),
+    ProfileCard(key="contract_counts",
+                titles=("Previous Projects", "المشاريع السابقة"),
+                carries="table", on_pages="92 of 2,419, always exactly one row"),
+    ProfileCard(key="interests", titles=("Interests", "الأنشطة"),
+                carries="list", on_pages="2,419 of 2,419"),
+    ProfileCard(key="map", titles=("Map", "الموقع"),
+                carries="text", on_pages="2,419 of 2,419"),
+)
+
+#: THE HEADING LEVEL IS NOT FIXED, and asking for the wrong one hides a card. The
+#: first census of card titles asked for `h3.card-title` and `h2.card-title`,
+#: reported two titles per page and MISSED the price card entirely -- its heading
+#: is an `h4`. So every level is asked for, and the level is never named.
+_CARD_TITLE_TAGS = ("h1", "h2", "h3", "h4", "h5", "h6")
+
+
+def _card_title(card: Tag) -> str:
+    """What the page calls this card, or `(no card-title)` for the one with none."""
+    head = card.find(_CARD_TITLE_TAGS, class_="card-title")
+    return _text(head) if head is not None else "(no card-title)"
+
+
+def _carries_data(card: Tag) -> bool:
+    """Whether this card holds something a parser can read out of it."""
+    return (bool(card.select("table"))
+            or bool(card.select("ul.list-numerical li.list-item")))
+
+
+def read_cards(html: str) -> tuple[tuple[str, bool], ...]:
+    """Every card on the page as `(title, carries data)`, in document order."""
+    return tuple(
+        (_card_title(card), _carries_data(card))
+        for card in BeautifulSoup(html, "html.parser").select("div.section-card"))
+
+
+def undeclared_cards(html: str) -> tuple[str, ...]:
+    """Cards this page publishes, carrying data, that `PROFILE_CARDS` does not name.
+
+    HIS WARNING, MADE MECHANICAL. A parser reads the cards it knows and cannot tell
+    a card that is absent from a card nobody declared -- which is how a site grows a
+    section and it stays unnoticed for a year. This is the question two fixtures
+    could not answer and 2,419 pages can.
+
+    "CARRYING DATA" IS THE FILTER, AND IT BEAT THE OBVIOUS ONE ON MEASUREMENT. The
+    contractor's own name is a card too, and its title is different on every page,
+    so it must be excluded or the guard reports thousands of unknown cards on its
+    first run. Two rules were available:
+
+        by POSITION -- the name card is card 0        wrong on 40 of 5,668 pages
+        by CONTENT  -- the name card carries no table wrong on 0 of 5,668 pages
+
+    Measured across both locales: the name card is first on 5,666 of 5,668 pages,
+    and on 40 pages an undeclared text-only card appears after the first. Every one
+    of those 40 carried neither a table nor a list. So content wins, and position is
+    not used at all.
+
+    THE COST OF THAT CHOICE, stated rather than hidden: a NEW TEXT card would not be
+    reported, because nothing distinguishes it from the contractor's name. Map and
+    Contract Request are text cards, so that is a real blind spot -- it is the
+    narrower one, and it is the one with no false positives.
+
+    Not an exception: a new card is news for a person, and raising here would let
+    one page's novelty stop the approval of the other 34,833.
+    """
+    known = {title for card in PROFILE_CARDS for title in card.titles}
+    return tuple(title for title, carries in read_cards(html)
+                 if carries and title not in known)
+
+
+def _card(html: str, key: str) -> Tag | None:
+    """The card one declared key names, or `None` when this page has not got it.
+
+    MORE THAN ONE IS REFUSED, for the reason `locate_group` states: a title that has
+    stopped being unique has stopped being a declaration, and taking the first would
+    read one card's values as another's.
+    """
+    card = next((one for one in PROFILE_CARDS if one.key == key), None)
+    if card is None:
+        raise KeyError(f"{key!r} is not a declared card. Declared: "
+                       f"{[one.key for one in PROFILE_CARDS]}")
+    found = [node
+             for node in BeautifulSoup(html, "html.parser").select("div.section-card")
+             if _card_title(node) in card.titles]
+    if len(found) > 1:
+        raise ValueError(
+            f"{key!r} matched {len(found)} cards, so its title is no longer a "
+            f"declaration: {card.titles}. The layout has changed.")
+    return found[0] if found else None
+
+
+# ---- the commercial registration, which was believed to be unavailable -------
+
+#: WHERE THE CONTRACT-REQUEST FORM POSTS. One endpoint, site-wide, identical on all
+#: 2,479 pages measured -- and that is the honest answer to `contract_request_url`
+#: in CONTRACTOR-SOURCE.md. The plan for this step says that field "has no known URL
+#: pattern and is not on the card"; the truth is narrower and more useful. The card
+#: IS on every page, and the URL is a CONSTANT rather than a per-contractor value,
+#: so it earns no column. What earns a column is what the form carries.
+_CONTRACT_FORM = 'form[action*="init_econtract_draft"]'
+
+
+def read_commercial_registration(html: str) -> str:
+    """The contractor's Commercial Registration number, or `""`.
+
+    FOUND IN A PLACE NOBODY LOOKED. `Commercial Registration` appears four times in
+    his column study and no extractor had it, because it is not in the info box and
+    not on the listing card -- it is the pre-filled `cr` input of the contract
+    request form, which every profile publishes.
+
+    MEASURED over 2,543 profile pairs: present on 2,542, always TEN DIGITS, and
+    2,542 DISTINCT VALUES OVER 2,542 CONTRACTORS -- no two share one. So it is a
+    second natural key for this directory, and the first that is a national
+    identifier rather than muqawil's own numbering: it is what a row here could be
+    joined to Balady, or to a commercial register, on.
+
+    THE SAME FORM'S `second_party_phone` IS NOT A SECOND PHONE, and it was worth
+    measuring rather than assuming. Over 900 pages it is filled on 434, and on every
+    one of those it equals `organization_mobile_number` exactly -- 0 differ, 0 carry
+    a number the info box lacks. A column for it would hold no new fact.
+    """
+    form = BeautifulSoup(html, "html.parser").select_one(_CONTRACT_FORM)
+    if form is None:
+        return ""
+    node = form.select_one('input[name="cr"]')
+    return (node.get("value") or "").strip() if node is not None else ""
+
+
+# ---- the self-build prices, which are a PRICE in a price warehouse -----------
+
+#: `label -> field_key` for the three tiers the self-build price card publishes.
+#: ARABIC LABELS ON THE ENGLISH PAGE, like every other table header here, so one map
+#: serves both locales.
+#:
+#: MEASURED over 2,419 pairs: exactly these three labels and no fourth, on
+#: 161/160/160 pages. The values are numerals with no currency, no thousands
+#: separator and no unit -- 466 of 466 parsed as numbers -- and the schedule is NOT
+#: always non-increasing across the tiers: 122 contractors quote a non-increasing
+#: one and 33 do not. Nothing here may assume a bigger award is cheaper.
+SELF_BUILD_PRICE_TIERS: dict[str, str] = {
+    "سعر المتر المربع في حال الحصول على أقل من خمسة مشاريع":
+        "self_build_price_under_five_projects",
+    "سعر المتر المربع في حال الحصول على خمسة حتى عشرة مشاريع":
+        "self_build_price_five_to_ten_projects",
+    "سعر المتر المربع في حال الحصول على أكثر من عشرة مشاريع":
+        "self_build_price_over_ten_projects",
+}
+
+
+class UnknownPriceTier(LookupError):
+    """The price card published a row this map does not know.
+
+    RAISED, AND DELIBERATELY, for the reason `CoordinatesMoved` is raised: the
+    alternative is a price the site publishes and this warehouse silently does not
+    store. A fourth tier is exactly the kind of change worth stopping for, and a
+    price-tracking warehouse that drops a price without a word has the one failure
+    mode it cannot afford.
+    """
+
+
+def read_self_build_prices(html: str) -> dict[str, str]:
+    """The self-build price schedule, `field_key -> value`. `{}` when absent.
+
+    THE ROWS ARE NOT IN A STABLE ORDER -- measured, the same three labels arrive in
+    different sequences on different pages -- so this reads them BY LABEL. Position
+    would have put the over-ten price in the under-five column on some pages and not
+    others, which is the class of defect that never looks wrong in a column count.
+
+    EMPTY IS NOT ABSENT. The card is published on 713 of 2,419 pages and carries
+    rows on 163, so a contractor in the self-build programme who has not priced it
+    has the card and no rows. Both are real states and neither is an error.
+    """
+    card = _card(html, "self_build_prices")
+    if card is None:
+        return {}
+    found: dict[str, str] = {}
+    for row in card.select("tr"):
+        cells = row.select("td")
+        if len(cells) < 2:
+            continue
+        label, value = _text(cells[0]), _text(cells[1])
+        key = SELF_BUILD_PRICE_TIERS.get(label)
+        if key is None:
+            raise UnknownPriceTier(
+                f"the self-build price card published {label!r}, which is not one of "
+                f"the three declared tiers. A price this warehouse cannot store is "
+                f"worth stopping for: {sorted(SELF_BUILD_PRICE_TIERS)}")
+        found[key] = value
+    return found
+
+
+# ---- the contract counts, under a card named for something else --------------
+
+#: `header -> field_key`. THE CARD IS NAMED FOR SOMETHING ELSE, which is why this is
+#: keyed on the table's headers and not on the card's title: the card prints
+#: `Previous Projects` / `المشاريع السابقة` and its table holds two contract counts.
+#: Measured on 92 of 2,419 pages, always exactly one row.
+CONTRACT_COUNT_COLUMNS: dict[str, str] = {
+    "عدد العقود النموذجية": "model_contract_count",
+    "عدد العقود المسجلة": "registered_contract_count",
+}
+
+
+def read_contract_counts(html: str) -> dict[str, str]:
+    """The two contract counts, `field_key -> value`. `{}` when the card is absent.
+
+    TWO SCALARS, WHICH IS WHY THEY ARE COLUMNS AND NOT A GROUP. `write_groups`
+    already recorded that reasoning -- "putting them in a link table would make a
+    membership out of a count" -- and the corpus agrees: one row, two numbers, on
+    every page that publishes the card at all.
+    """
+    card = _card(html, "contract_counts")
+    if card is None:
+        return {}
+    table = card.select_one("table")
+    if table is None:
+        return {}
+    keys = [CONTRACT_COUNT_COLUMNS.get(_text(cell)) for cell in table.select("th")]
+    found: dict[str, str] = {}
+    for row in table.select("tr"):
+        cells = row.select("td")
+        if len(cells) != len(keys):
+            continue
+        for key, cell in zip(keys, cells, strict=True):
+            if key is not None:
+                found[key] = _text(cell)
+    return found
+
+
+# ---- the licences, and the split rule that was never provable before ---------
+
+#: THE LANGUAGE BOUNDARY IS THE FIRST LATIN LETTER, not a separator. Measured over
+#: 1,500 rows: the script-run signature of every activity cell is `AL` and nothing
+#: else -- 1,500 of 1,500, one transition, Arabic then Latin.
+_FIRST_LATIN = re.compile(r"[A-Za-z]")
+
+#: THE DASH IS THE HIERARCHY SEPARATOR, which is what makes it dangerous.
+#: `write_groups` records the activity cell as carrying "BOTH languages in one
+#: string with no separator" and concludes that splitting "needs a script-boundary
+#: rule". The script-boundary half is right; the "no separator" half hid the real
+#: trap. There ARE dashes in the cell, they sit INSIDE each language, and they
+#: separate LEVELS: تشييد المباني - تشييد المباني - جميع الأنواع is a three-level
+#: path. A parser that split the cell on the dash would have cut a path into pieces
+#: and called each piece a language.
+#:
+#: BOTH DASHES, because the site mixes them inside one cell:
+#: `Construction of Buildings - Construction of Buildings – All Types` uses a
+#: hyphen and then an en dash.
+_PATH_SEPARATOR = re.compile(r"\s+[-–—]\s+")
+
+#: The readiness cell, when there is one: `أساسي | Basic` -- both languages, one
+#: pipe. Measured EMPTY on 1,490 of 1,500 rows, with five distinct values across the
+#: other ten: Gold, Silver, Dimond (the site's spelling) and Basic.
+_READINESS_SEPARATOR = " | "
+
+
+@dataclass(frozen=True)
+class LicensedActivity:
+    """One licensed activity, as a path in each language, plus its readiness."""
+
+    #: The path, root first, off the Arabic half. THE IDENTITY, always present.
+    arabic: tuple[str, ...]
+    #: The same path off the English half -- or `()` when the site's own two halves
+    #: disagree about how many levels there are. See `read_licensed_activities`.
+    english: tuple[str, ...]
+    readiness_ar: str = ""
+    readiness_en: str = ""
+    #: The cell exactly as published, kept so a disagreement can be looked at.
+    published_as: str = ""
+
+    @property
+    def paired(self) -> bool:
+        """Whether the two halves agreed. `False` is the SITE's defect, not ours."""
+        return bool(self.english)
+
+
+def read_licensed_activities(html: str) -> tuple[LicensedActivity, ...]:
+    """Every licensed activity on the page, in document order.
+
+    THIS IS THE GROUP `write_groups` DEFERRED, and its stated reason has expired:
+    "Six samples, one malformed, is not enough to declare that rule on." Correct at
+    the time. Measured now over 1,685 rows on 2,419 real pages, and the vocabulary
+    is CLOSED AT 22 DISTINCT ACTIVITIES -- a taxonomy, which is what `R-38` is for.
+
+    THE SITE'S ENGLISH IS WRONG ON 100 ROWS, AND A COUNT CATCHES ALL THREE CASES.
+    Splitting each half on the path separator and comparing the number of levels:
+
+        1,585 of 1,685 rows  the two halves agree, level for level
+           70 rows           Arabic says أعمال تركيبات السباكة والحرارة والتكييف
+                             and English says "Construction of Buildings - Medium &
+                             Low Rise". A DIFFERENT ACTIVITY, not a translation.
+           30 rows           English truncated by the site to "Civil Engineering -",
+                             and TWO different Arabic activities truncate to that
+                             same string, so it does not even distinguish them.
+
+    So the English half is not trustworthy and the Arabic half is. The load-bearing
+    property is luck worth writing down: EVERY ONE OF THE THREE DEFECTS CHANGES THE
+    LEVEL COUNT, so nothing has to recognise an activity to detect them, and no row
+    can be stored carrying an English name that belongs to a different activity.
+
+    THE ARABIC PATH STANDS ALONE WHERE THEY DISAGREE, rather than the row being
+    dropped or the halves zipped to the shorter. Both alternatives were available
+    and both are worse: zipping is what `merge_locales` refuses in its own words --
+    "a wrong value is worse than a missing one in a table whose whole purpose is to
+    be believed" -- and dropping would discard 100 rows of intact Arabic because the
+    site cannot spell its own English. `paired` says which happened, so the 100 are
+    countable rather than invisible.
+    """
+    card = _card(html, "licensed_activities")
+    if card is None:
+        return ()
+    found: list[LicensedActivity] = []
+    for row in card.select("tr"):
+        cells = row.select("td")
+        if len(cells) < 2:
+            continue
+        published, readiness = _text(cells[-2]), _text(cells[-1])
+        boundary = _FIRST_LATIN.search(published)
+        if boundary is None:
+            # NO LATIN HALF AT ALL. Measured zero times in 1,500 rows, so this is
+            # the shape changing rather than one contractor's data -- and the Arabic
+            # path is still the identity, so the row is kept rather than refused.
+            arabic, english = published.strip(), ""
+        else:
+            arabic = published[:boundary.start()].strip()
+            english = published[boundary.start():].strip()
+        arabic_path = tuple(part for part in _PATH_SEPARATOR.split(arabic) if part)
+        english_path = tuple(part for part in _PATH_SEPARATOR.split(english) if part)
+        ready_ar, _, ready_en = readiness.partition(_READINESS_SEPARATOR)
+        found.append(LicensedActivity(
+            arabic=arabic_path,
+            english=english_path if len(english_path) == len(arabic_path) else (),
+            readiness_ar=ready_ar.strip(), readiness_en=ready_en.strip(),
+            published_as=published))
+    return tuple(found)
+
+
 def read_profile(html: str) -> Reading:
     """One profile page, in whichever language it was fetched.
 
@@ -577,6 +1060,18 @@ def read_profile(html: str) -> Reading:
     coordinates = read_coordinates(html)
     if coordinates is not None:
         latitude, longitude = coordinates
+
+    # THE INFO BOX IS ONE CARD OF SEVEN. Everything above reads `div.info-box` and
+    # the inline map script; these three read the cards beside them. They are here
+    # rather than in `merge_locales` because none of them is bilingual -- the site
+    # prints these labels in Arabic on the English page, so there is no second value
+    # to attach, and `merge_locales` pairs by INDEX over `labels`, which these never
+    # enter.
+    registration = read_commercial_registration(html)
+    if registration:
+        fields["commercial_registration"] = registration
+    fields.update(read_self_build_prices(html))
+    fields.update(read_contract_counts(html))
 
     return Reading(fields=fields,
                    labels=tuple(label for label, _ in pairs),

--- a/tests/test_muqawil_parser.py
+++ b/tests/test_muqawil_parser.py
@@ -273,8 +273,16 @@ def test_a_profile_row_does_not_carry_the_listings_columns():
     """THE DEFECT THAT BLOCKED THIS. `_candidate_from` hardcoded `CARD_FIELDS` as the
     declared lead, so a profile row came out with **17 empty listing columns** —
     measured, 39 fields where the profile has 21. Every page kind has its own declared
-    list, and it is now a parameter rather than a constant."""
-    from scrapex.extract.muqawil import bilingual_profile_candidate
+    list, and it is now a parameter rather than a constant.
+
+    THE COUNT WENT 21 -> 27 ON 2026-08-22 and the assertion changed shape with it. A
+    bare `== 21` said only that nobody had touched the number; comparing against
+    `PROFILE_FIELD_ORDER` itself says the two things that matter — the candidate carries
+    exactly the declared fields, and **in the declared order**, which is load-bearing
+    because `_schema_payload` puts `position` in the hash. An order that drifts is a
+    different schema with identical fields, and that refused 105 pages of 120 once.
+    """
+    from scrapex.extract.muqawil import PROFILE_FIELD_ORDER, bilingual_profile_candidate
 
     english, arabic = _profile_pair()
     keys = [f.field_key
@@ -283,7 +291,9 @@ def test_a_profile_row_does_not_carry_the_listings_columns():
 
     leaked = [key for key in keys if key.startswith("card_")]
     assert not leaked, f"listing columns leaked into a profile row: {leaked}"
-    assert len(keys) == 21, f"21 declared fields, got {len(keys)}: {keys}"
+    assert keys == list(PROFILE_FIELD_ORDER), (
+        "the candidate's fields are not the declared list in the declared order; "
+        f"declared {len(PROFILE_FIELD_ORDER)}, got {len(keys)}: {keys}")
 
 
 def test_the_identity_is_passed_in_and_not_parsed_out():

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -199,7 +199,10 @@ PINNED = (
     ("docs/BACKLOG.md", "extension/app.js", 4549,
      'if (source.kind === "dataset") return "";'),
     ("docs/BACKLOG.md", "scrapex/webui/app.py", 639, '"kind": "dataset",'),
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2710, "if source_key not in known:"),
+    # 2710 -> 2725 on 2026-08-22: #252 measured this line on `main` at 4615a14 and
+    # #251 landed first, adding 15 lines to `app.py` above it. Two PRs, neither
+    # wrong on its own base, and `main` red between the second merge and this fix.
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2725, "if source_key not in known:"),
     ("docs/BACKLOG.md", "scrapex/webui/app.py", 986,
      "A GENERIC DATASET IS A TABLE LIKE ANY OTHER TABLE"),
 )

--- a/tests/test_the_profile_publishes_seven_cards_not_one.py
+++ b/tests/test_the_profile_publishes_seven_cards_not_one.py
@@ -1,0 +1,566 @@
+"""The profile page has seven cards and three of them had no reader.
+
+WHAT HE SAID, mid-measurement on 2026-08-22, and it changed the design:
+
+    «المعلومات غير ثابته ولا متفقثة بين الصفح يعنى ممكن تلاقى معلومات تانية وطريقة
+     عرض مختلفة»
+
+The information is neither fixed nor consistent between pages; you may find other
+information and a different presentation. He was right, and the parser was reading
+one card of seven while three written premises in this repository said otherwise.
+
+WHAT 2,419 REAL PROFILE PAIRS SAID, pulled read-only off the running crawl rather
+than off the two committed fixtures:
+
+    card                                        pages          what was wrong
+    ------------------------------------------  -------------  -----------------------
+    Contractor Detail (div.info-box)            2,419 / 2,419  nothing -- 11 labels,
+                                                               all known, no drops
+    التراخيص ومستوى الجاهزية                     2,419, rows on 228   deferred: "six
+                                                               samples is not enough"
+    العقود سعر البناء (برنامج البناء الذاتي)      713, rows on 163   NAMED BY NOBODY
+    Previous Projects / المشاريع السابقة          92             filed under the wrong
+                                                               card in the record
+    Contract Request / طلب تعاقد                 2,419 / 2,419  believed absent
+    Interests / الأنشطة                          2,419 / 2,419  nothing
+    Map / الموقع                                 2,419 / 2,419  nothing
+
+THE THREE CORRECTIONS, each of which was written down somewhere as fact:
+
+  1. `extract/muqawil.py`'s module docstring named **the technical rating** as the
+     fifth `<table>` on the page. There is no such table. `div#contractor-tab4`, the
+     pane the tab button `التقييم الفني` points at, holds ZERO tables in its DOM
+     subtree on 2,360 of 2,360 pages. The fifth table is the SELF-BUILD PRICE
+     schedule, which is a **price**, in a price-tracking warehouse.
+  2. The plan for this step says `contract_request_url` *"has no known URL pattern
+     and is not on the card"*. The card is on 100% of pages; the URL is a site-wide
+     constant, so it earns no column -- and the form it belongs to carries the
+     **Commercial Registration number**, one of his own requested columns, on 2,542
+     of 2,543 pages, ten digits, no two contractors sharing one.
+  3. `write_groups` deferred the licences because *"six samples, one malformed, is
+     not enough to declare that rule on"*. 1,685 rows say the split rule is
+     provable, and say something the six could not: the dash in that cell is a
+     HIERARCHY separator, not a language separator.
+
+AND ONE MEASUREMENT THAT PREVENTED A BAD MERGE. Interests and licensed activities
+look like one vocabulary and are two -- 211 English paths against 19, with **zero**
+exact overlap -- while their Arabic ROOTS do overlap, and `ensure_path` is
+idempotent on the Arabic name. One scheme would have fused the trees at the roots.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scrapex import taxonomy
+from scrapex.contractors import write_groups
+from scrapex.databases import DatabaseRegistry, EngineDatabase
+from scrapex.directories import get
+from scrapex.extract.muqawil import (
+    CONTRACT_COUNT_COLUMNS,
+    GROUPS_MEASURED_EMPTY,
+    MULTI_VALUED_GROUPS,
+    PROFILE_CARDS,
+    PROFILE_FIELD_ORDER,
+    SELF_BUILD_PRICE_TIERS,
+    UnknownPriceTier,
+    bilingual_profile_candidate,
+    read_cards,
+    read_commercial_registration,
+    read_contract_counts,
+    read_licensed_activities,
+    read_self_build_prices,
+    undeclared_cards,
+)
+from scrapex.extract.service import _canonical, _digest
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "muqawil"
+
+#: The contractor the committed fixtures are. Its own numbers, read off the pages.
+FIXTURE_CR = "7007506731"
+FIXTURE_LICENCE_ROWS = 6
+FIXTURE_INTEREST_NODES = 25
+
+
+def _page(locale: str) -> str:
+    return (FIXTURES / f"profile-{locale}.html").read_text(encoding="utf-8")
+
+
+@pytest.fixture()
+def pages() -> tuple[str, str]:
+    return _page("en"), _page("ar")
+
+
+# ---- the census, which is his warning made mechanical ------------------------
+
+def test_the_declaration_covers_every_card_the_page_publishes(pages):
+    """THE GUARD HE ASKED FOR WITHOUT ASKING FOR IT. A parser reads the cards it knows
+    and cannot tell a card that is absent from a card nobody declared."""
+    for html in pages:
+        assert undeclared_cards(html) == (), (
+            "this page publishes a data-carrying card PROFILE_CARDS does not name, "
+            "which is the state the price card sat in for months")
+
+
+def test_the_price_card_is_declared_and_it_was_the_one_nobody_named(pages):
+    """The specific hole. Had `PROFILE_CARDS` existed a day earlier, this card would
+    have been reported the first time a profile was read."""
+    declared = {card.key for card in PROFILE_CARDS}
+    assert "self_build_prices" in declared
+    assert "contract_counts" in declared
+    english, _ = pages
+    titles = [title for title, _ in read_cards(english)]
+    assert "العقود سعر البناء (برنامج البناء الذاتي)" in titles
+
+
+def test_a_new_card_with_a_table_is_reported(pages):
+    """THE PROPERTY, not the fixture's luck: an unknown card carrying data is news.
+
+    Injected rather than waited for, because the point is what happens the day the
+    site adds a section — and this repository has a documented case of exactly that
+    going unnoticed.
+    """
+    english, _ = pages
+    grown = english.replace(
+        '<div class="section-card">',
+        '<div class="section-card"><h4 class="card-title">Bank Guarantees</h4>'
+        "<table><thead><tr><th>Bank</th></tr></thead>"
+        "<tbody><tr><td>Al Rajhi</td></tr></tbody></table></div>"
+        '<div class="section-card">', 1)
+
+    assert "Bank Guarantees" in undeclared_cards(grown)
+
+
+def test_the_contractors_own_name_is_not_reported_as_a_new_card(pages):
+    """THE FALSE POSITIVE THAT WOULD MAKE THE GUARD USELESS, and the reason the filter
+    is content and not position.
+
+    The company name is a card too and its title differs on every page. Measured
+    across both locales: by POSITION the name card is first on 5,666 of 5,668 pages —
+    wrong on 40 — and by CONTENT it carries neither table nor list on 5,668 of 5,668.
+    """
+    english, arabic = pages
+    titles = {title for title, _ in read_cards(english)}
+    assert "sca" in titles, "the fixture's own company-name card moved"
+    assert "sca" not in undeclared_cards(english)
+    assert "شركة البناء التجريبية" not in undeclared_cards(arabic)
+
+
+# ---- the commercial registration, found in the form nobody opened ------------
+
+def test_the_commercial_registration_comes_off_the_contract_form(pages):
+    """One of HIS columns, believed unavailable. `Commercial Registration` appears four
+    times in his study and no extractor had it."""
+    for html in pages:
+        assert read_commercial_registration(html) == FIXTURE_CR
+
+
+def test_it_is_a_column_on_the_row(pages):
+    """READ IS NOT STORED. A reader nobody wired produces nothing, which is the state
+    `read_profile` left the profile's other cards in."""
+    english, arabic = pages
+    candidate = bilingual_profile_candidate(english, arabic, contractor_id="775")
+    row = candidate.rows[0]
+
+    assert row["commercial_registration"] == FIXTURE_CR
+    assert "commercial_registration" in PROFILE_FIELD_ORDER
+
+
+def test_a_page_with_no_contract_form_answers_empty_and_does_not_raise(pages):
+    """ABSENT IS A STATE. 1 of 2,543 pages measured carries no form, and one page
+    without one must not stop the approval of the others."""
+    english, _ = pages
+    without = english.replace("init_econtract_draft", "somewhere-else")
+
+    assert read_commercial_registration(without) == ""
+
+
+# ---- the prices, which are a price -------------------------------------------
+
+def test_the_three_tiers_are_read_by_label_and_not_by_position():
+    """MEASURED: the same three labels arrive in different orders on different pages.
+    Position would have put the over-ten price in the under-five column on some pages
+    and not others — a defect invisible in any column count.
+
+    Built by shuffling the fixture's own card, because the fixture contractor
+    publishes the card with no rows: 713 of 2,419 pages have the card and 163 have
+    rows, so an empty one is the common case and cannot demonstrate the ordering.
+    """
+    labels = list(SELF_BUILD_PRICE_TIERS)
+    rows = "".join(f"<tr><td>{label}</td><td>{value}</td></tr>"
+                   for label, value in zip(reversed(labels), ("1000", "2000", "3000"),
+                                           strict=True))
+    html = ('<div class="section-card">'
+            '<h4 class="card-title">العقود سعر البناء (برنامج البناء الذاتي)</h4>'
+            f"<table><tbody>{rows}</tbody></table></div>")
+
+    prices = read_self_build_prices(html)
+
+    # The LAST label in the declaration was published FIRST, so a positional reader
+    # would have given `under_five` the over-ten row's value.
+    assert prices[SELF_BUILD_PRICE_TIERS[labels[-1]]] == "1000"
+    assert prices[SELF_BUILD_PRICE_TIERS[labels[0]]] == "3000"
+
+
+def test_an_empty_price_card_is_not_an_absent_one(pages):
+    """Both are real states and neither is an error: the fixture contractor is in the
+    self-build programme and has not priced it."""
+    english, _ = pages
+
+    assert read_self_build_prices(english) == {}
+    assert any(card.key == "self_build_prices" for card in PROFILE_CARDS)
+
+
+def test_a_fourth_tier_stops_rather_than_being_dropped():
+    """THE ONE FAILURE A PRICE WAREHOUSE CANNOT HAVE. A price the site publishes and
+    this warehouse silently does not store looks exactly like success.
+
+    The same choice `CoordinatesMoved` already makes, applied to a number that is
+    worth more than a coordinate.
+    """
+    html = ('<div class="section-card">'
+            '<h4 class="card-title">العقود سعر البناء (برنامج البناء الذاتي)</h4>'
+            "<table><tbody><tr>"
+            "<td>سعر المتر المربع في حال الحصول على أكثر من عشرين مشروعا</td>"
+            "<td>900</td></tr></tbody></table></div>")
+
+    with pytest.raises(UnknownPriceTier, match="not one of the three declared tiers"):
+        read_self_build_prices(html)
+
+
+def test_two_price_cards_are_refused_rather_than_one_being_picked():
+    """A title that has stopped being unique has stopped being a declaration —
+    `locate_group`'s rule, and this reader obeys the same one."""
+    card = ('<div class="section-card">'
+            '<h4 class="card-title">العقود سعر البناء (برنامج البناء الذاتي)</h4>'
+            "<table></table></div>")
+
+    with pytest.raises(ValueError, match="no longer a declaration"):
+        read_self_build_prices(card + card)
+
+
+# ---- the contract counts, under a card named for something else --------------
+
+def test_the_counts_are_keyed_on_the_headers_and_not_on_the_card_title(pages):
+    """THE CARD IS NAMED FOR SOMETHING ELSE. It prints `Previous Projects` /
+    `المشاريع السابقة` and its table holds two contract counts."""
+    for html in pages:
+        counts = read_contract_counts(html)
+        assert counts == {"model_contract_count": "455",
+                          "registered_contract_count": "64"}, counts
+    assert set(CONTRACT_COUNT_COLUMNS.values()) == {"model_contract_count",
+                                                   "registered_contract_count"}
+
+
+def test_the_counts_reach_the_row(pages):
+    english, arabic = pages
+    row = bilingual_profile_candidate(english, arabic, contractor_id="775").rows[0]
+
+    assert row["model_contract_count"] == "455"
+    assert row["registered_contract_count"] == "64"
+
+
+# ---- the licences, and the split rule --------------------------------------
+
+def test_the_dash_is_a_hierarchy_separator_and_not_a_language_one(pages):
+    """THE TRAP THE SIX SAMPLES HID. `write_groups` recorded the activity cell as
+    carrying both languages *"in one string with no separator"*. There ARE dashes in
+    it — they sit inside each language and they separate LEVELS.
+
+    A parser that split on the dash would have cut a three-level path into pieces and
+    called each piece a language.
+    """
+    english, _ = pages
+    first = read_licensed_activities(english)[0]
+
+    assert first.arabic == ("تشييد المباني", "تشييد المباني", "جميع الأنواع")
+    assert first.english == ("Construction of Buildings",
+                            "Construction of Buildings", "All Types")
+    assert first.published_as.count(" - ") >= 2, (
+        "the fixture's own cell no longer carries the dashes this rule is about")
+
+
+def test_the_language_boundary_is_the_first_latin_letter(pages):
+    """MEASURED over 1,500 rows: the script-run signature of every activity cell is
+    `AL` — Arabic then Latin, exactly one transition, 1,500 of 1,500."""
+    english, _ = pages
+
+    for activity in read_licensed_activities(english):
+        assert not any("؀" <= ch <= "ۿ" for part in activity.english
+                       for ch in part), (
+            f"Arabic leaked into the English half: {activity.english}")
+        assert activity.arabic, "the Arabic half is the identity and cannot be empty"
+
+
+def test_the_sites_own_broken_english_is_detected_by_a_level_count(pages):
+    """THE LOAD-BEARING LUCK, and it is why nothing has to recognise an activity.
+
+    Measured over 1,685 rows, the site publishes 100 with an English half that is
+    truncated (`Civil Engineering -`, 30 rows) or names a DIFFERENT ACTIVITY (70
+    rows). Every one of the three cases changes the number of levels, so comparing
+    counts catches all of them — and the committed fixture happens to carry one.
+    """
+    english, _ = pages
+    activities = read_licensed_activities(english)
+
+    assert len(activities) == FIXTURE_LICENCE_ROWS
+    unpaired = [one for one in activities if not one.paired]
+    assert len(unpaired) == 1, (
+        "the fixture's truncated row is what this asserts on; if the site fixed it, "
+        "re-point this at another")
+    assert unpaired[0].arabic == ("الهندسة المدنية", "الصرف الصحي")
+    assert unpaired[0].english == (), (
+        "a truncated English half must be EMPTY, not stored as a name: "
+        "`Civil Engineering -` is the same string for two different activities, so "
+        "storing it would merge them")
+    assert "Civil Engineering -" in unpaired[0].published_as, (
+        "the raw cell is kept as evidence so the disagreement can be looked at")
+
+
+def test_the_readiness_level_is_read_even_though_it_is_not_stored(pages):
+    """READ AND NOT STORED, on a count: empty on 1,490 of 1,500 rows. Reading it now
+    means the day it earns a column it is a re-parse and not a re-crawl."""
+    english, _ = pages
+    first = read_licensed_activities(english)[0]
+
+    assert (first.readiness_ar, first.readiness_en) == ("أساسي", "Basic")
+    assert all(not one.readiness_ar for one in read_licensed_activities(english)[1:])
+
+
+def test_one_page_is_enough_for_the_licences(pages):
+    """THE DIFFERENCE FROM INTERESTS, and it is a property worth having: the cell is
+    already bilingual, so a profile whose Arabic half never arrived still yields its
+    licences in full. Nothing here can raise `CannotPairLocales`."""
+    english, arabic = pages
+
+    assert read_licensed_activities(english) == read_licensed_activities(arabic)
+
+
+# ---- and the two of them reaching the warehouse ------------------------------
+
+def _warehouse(tmp_path: Path):
+    registry = DatabaseRegistry(EngineDatabase(tmp_path / "scrapex-engine.db"),
+                                pointer_file=tmp_path / "databases.json")
+    registry.initialize()
+    return registry.engine.connect()
+
+
+def _a_profile_row(conn, contractor_id: str = "775") -> None:
+    """The one row `write_groups` requires, in the PROFILE dataset it looks in."""
+    conn.execute("INSERT INTO site_profile (site_key, display_name, base_url) "
+                 "VALUES ('muqawil_org','Contractors','https://muqawil.org')")
+    conn.execute(
+        "INSERT INTO generic_page_snapshot (source_url, html_content, content_hash) "
+        "VALUES ('https://muqawil.org/en/contractors/775/143','<html></html>','h')")
+    conn.execute(
+        "INSERT INTO dataset_definition (site_profile_id, dataset_key, original_name, "
+        " dataset_kind, discovery_method, locator_json) "
+        "VALUES (1,'contractor_profiles','contractor_profiles','table','html_table','{}')")
+    conn.execute("INSERT INTO dataset_schema_version (dataset_definition_id, "
+                 " version_number, schema_hash) VALUES (1,1,'h')")
+    conn.execute(
+        "INSERT INTO generic_record (dataset_definition_id, record_key, "
+        " schema_version_id, data_json, source_snapshot_id, source_locator, "
+        " content_hash) VALUES (1,?,1,'{}',1,'div.info-box','c')",
+        (_digest(_canonical([contractor_id])),))
+    conn.commit()
+
+
+def _a_second_contractor(conn, contractor_id: str) -> None:
+    """Another row in the same profile dataset, so a second page can be written."""
+    conn.execute(
+        "INSERT INTO generic_record (dataset_definition_id, record_key, "
+        " schema_version_id, data_json, source_snapshot_id, source_locator, "
+        " content_hash) VALUES (1,?,1,'{}',1,'div.info-box',?)",
+        (_digest(_canonical([contractor_id])), f"c{contractor_id}"))
+    conn.commit()
+
+
+def _a_licences_page(cell: str, readiness: str = "") -> str:
+    """A page carrying nothing but the licences card, with one row.
+
+    Built rather than fetched because the property under test is what happens when a
+    SECOND page arrives, and the committed fixtures are one contractor.
+    """
+    return ('<div class="section-card">'
+            '<h4 class="card-title">التراخيص ومستوى الجاهزية</h4>'
+            "<table><thead><tr><th>الأنشطة المرخصة</th>"
+            "<th>مستوى الجاهزية</th></tr></thead><tbody>"
+            f"<tr><td>{cell}</td><td>{readiness}</td></tr>"
+            "</tbody></table></div>")
+
+
+@pytest.fixture()
+def warehouse(tmp_path: Path):
+    conn = _warehouse(tmp_path)
+    _a_profile_row(conn)
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def test_both_groups_reach_the_warehouse_and_they_land_in_two_schemes(warehouse,
+                                                                     pages):
+    """THE MEASUREMENT THAT PREVENTED A MERGE, asserted. Interests publishes 211
+    English paths and the licences 19, with zero exact overlap, while their Arabic
+    ROOTS overlap and `ensure_path` is idempotent on the Arabic name.
+
+    One scheme would have fused the two trees at the roots and let them diverge below
+    — and the fixture is enough to show it, because `الهندسة المدنية` is a root in
+    both.
+    """
+    english, arabic = pages
+
+    written, repeated = write_groups(warehouse, get("muqawil_org"), 1,
+                                     english=english, arabic=arabic,
+                                     contractor_id="775")
+
+    assert repeated == 0
+    assert written == FIXTURE_INTEREST_NODES + FIXTURE_LICENCE_ROWS, (
+        f"{written} memberships written; expected the interests plus the licences")
+
+    schemes = dict(warehouse.execute(
+        "SELECT scheme_name_ar, scheme_id FROM classification_scheme").fetchall())
+    assert set(schemes) == {"الأنشطة", "الأنشطة المرخصة"}, (
+        f"the two vocabularies did not stay apart: {sorted(schemes)}")
+
+    by_group = dict(warehouse.execute(
+        "SELECT group_key, COUNT(*) FROM generic_record_node "
+        " GROUP BY group_key").fetchall())
+    assert by_group == {"interests": FIXTURE_INTEREST_NODES,
+                        "licensed_activities": FIXTURE_LICENCE_ROWS}, by_group
+
+
+def test_the_licence_root_is_a_different_node_from_the_interest_root(warehouse,
+                                                                    pages):
+    """THE FUSION, named. `الهندسة المدنية` is a root in both vocabularies and the
+    English names differ by case — `Civil engineering` against `Civil Engineering`.
+    In one scheme the second arrival would have matched the first by Arabic name and
+    inherited the other vocabulary's English."""
+    english, arabic = pages
+    write_groups(warehouse, get("muqawil_org"), 1, english=english, arabic=arabic,
+                 contractor_id="775")
+
+    rows = warehouse.execute(
+        "SELECT s.scheme_name_ar, n.node_name FROM classification_node AS n "
+        "  JOIN classification_scheme AS s ON s.scheme_id = n.scheme_id "
+        " WHERE n.node_name_ar = 'الهندسة المدنية' AND n.parent_node_id IS NULL "
+        " ORDER BY s.scheme_name_ar").fetchall()
+
+    assert len(rows) == 2, (
+        f"the shared Arabic root produced {len(rows)} node(s); two vocabularies must "
+        "keep two")
+    # ONE OF THE TWO IS EMPTY, and that is the fixture rather than a defect: the only
+    # `الهندسة المدنية` licence row this contractor holds is the TRUNCATED one, so its
+    # whole path is stored under its Arabic identity with no English name. The next
+    # test is the repair, and the corpus measurement behind it.
+    assert {row["node_name"] for row in rows} == {"Civil engineering", ""}, (
+        "the interests root lost its English name, or the licence root gained one it "
+        "was never published")
+
+
+def test_a_later_page_repairs_the_root_the_truncation_left_empty(warehouse, pages):
+    """WHAT THE TRUNCATION ACTUALLY COSTS, measured over the whole corpus rather than
+    argued: **3 leaf names out of 29 nodes**, and not one interior node.
+
+    Simulated `ensure_path`'s rule across all 22 distinct activity cells: every ROOT
+    gets its English name from some other contractor's cleanly-paired row —
+    `الهندسة المدنية` becomes `Civil Engineering` — and exactly three nodes are left
+    without one. They are the three the site itself publishes wrongly, and no correct
+    English name for them exists anywhere on the site to recover.
+
+    So the honest choice costs three leaf names, and it buys the repair below. Copying
+    the Arabic into the English column would have cost nothing today and made this
+    repair impossible forever, because `ensure_path` tests `if not node_name`.
+    """
+    english, arabic = pages
+    directory = get("muqawil_org")
+    write_groups(warehouse, directory, 1, english=english, arabic=arabic,
+                 contractor_id="775")
+    _a_second_contractor(warehouse, "776")
+
+    # A page whose two halves DO agree, for the same root and a different leaf --
+    # which is what 109 of the corpus's rows look like.
+    clean = _a_licences_page(
+        "الهندسة المدنية - تشييد الطرق والسكك الحديدية "
+        "Civil Engineering - Construction of Roads & Railways")
+    write_groups(warehouse, directory, 1, english=clean, arabic=clean,
+                 contractor_id="776")
+
+    named = dict(warehouse.execute(
+        "SELECT n.node_name_ar, n.node_name FROM classification_node AS n "
+        "  JOIN classification_scheme AS s ON s.scheme_id = n.scheme_id "
+        " WHERE s.scheme_name_ar = 'الأنشطة المرخصة'").fetchall())
+
+    assert named["الهندسة المدنية"] == "Civil Engineering", (
+        "the root the truncation left empty was not repaired by a later page, so "
+        "`ensure_path`'s fill-in branch is not being reached")
+    assert named["الصرف الصحي"] == "", (
+        "the truncated LEAF must stay empty -- the site publishes "
+        "'Civil Engineering -' for two different activities, so there is nothing "
+        "correct to fill it with")
+
+
+def test_the_unpaired_licence_stores_an_empty_english_name_for_later(warehouse,
+                                                                    pages):
+    """WHY THE ARABIC IS NOT COPIED INTO THE ENGLISH COLUMN. `ensure_path` repairs a
+    node whose English name is empty the first time a usable one arrives — and it
+    tests `if not found["node_name"]`, so a column holding Arabic would never look
+    empty again and the repair could never happen."""
+    english, arabic = pages
+    write_groups(warehouse, get("muqawil_org"), 1, english=english, arabic=arabic,
+                 contractor_id="775")
+
+    name = warehouse.execute(
+        "SELECT n.node_name FROM classification_node AS n "
+        "  JOIN classification_scheme AS s ON s.scheme_id = n.scheme_id "
+        " WHERE s.scheme_name_ar = 'الأنشطة المرخصة' "
+        "   AND n.node_name_ar = 'الصرف الصحي'").fetchone()
+
+    assert name is not None, "the truncated row did not store its Arabic identity"
+    assert not name["node_name"], (
+        f"the English column holds {name['node_name']!r}; the site published "
+        "'Civil Engineering -' for two different activities, so an empty column is "
+        "the honest state and the repairable one")
+
+
+def test_a_second_pass_writes_nothing_and_says_so(warehouse, pages):
+    """A re-parse over stored snapshots must be free. `R-40` repaired the idempotency
+    that makes this the recovery path instead of a re-crawl."""
+    english, arabic = pages
+    directory = get("muqawil_org")
+    write_groups(warehouse, directory, 1, english=english, arabic=arabic,
+                 contractor_id="775")
+
+    written, repeated = write_groups(warehouse, directory, 1, english=english,
+                                     arabic=arabic, contractor_id="775")
+
+    assert (written, repeated) == (0, FIXTURE_INTEREST_NODES
+                                   + FIXTURE_LICENCE_ROWS)
+
+
+# ---- the declarations that record what was NOT built -------------------------
+
+def test_the_two_empty_groups_are_declared_rather_than_forgotten():
+    """"WE MEASURED IT AND IT IS EMPTY" IS A DIFFERENT FACT FROM A SHORTER LIST, and
+    this is the shape that keeps them apart — the same argument
+    `GROUPS_NOT_LOCATED` already makes for the groups that are not on the page."""
+    measured = dict(GROUPS_MEASURED_EMPTY)
+
+    assert set(measured) == {"sub_contractors", "main_contractors"}
+    for key, why in measured.items():
+        assert "2,419" in why, f"{key} records no count: {why!r}"
+    declared = {group.key for group in MULTI_VALUED_GROUPS}
+    assert set(measured) <= declared, (
+        "a group measured empty must still be declared, or the day the site fills it "
+        "in nothing knows where to look")
+
+
+def test_only_the_groups_with_a_vocabulary_are_wired():
+    """A group is wired by naming its scheme. Three of the five name none, and that
+    is the record of a decision rather than an omission."""
+    wired = {group.key for group in MULTI_VALUED_GROUPS if group.scheme_name_ar}
+
+    assert wired == {"interests", "licensed_activities"}, wired


### PR DESCRIPTION
## He said the pages are not consistent, and four written premises fell

> «contractor-tabs — المعلومات غير ثابته ولا متفقثة بين الصفح يعنى ممكن تلاقى معلومات
> تانية وطريقة عرض مختلفة»

*The information is neither fixed nor consistent between pages — you may find other
information and a different presentation.*

Everything this repository believed about the muqawil profile page came from **two
committed fixtures**, which are one contractor. `R-19` labelled that limit honestly —
*"The limit of this evidence, stated plainly: one contractor."* The problem is not that
the limit went unrecorded. **The conclusions outlived it**, into a module docstring, a
declaration and a plan, where nothing carries the caveat.

Re-measured over **2,419 real profile pairs**, read read-only out of the running crawl.

| premise, and where it was written | what 2,419 pages say |
|---|---|
| `extract/muqawil.py` docstring: the fifth `<table>` is *the technical rating* | **There is no technical-rating table.** `contractor-tab4` holds **zero** tables in its DOM subtree on **2,360 of 2,360** pages. The fifth table is a **self-build price schedule** |
| `GROUPS_NOT_LOCATED`: it *"carries no table for this contractor"* | Not this contractor — the site. A tab button over an empty pane |
| the plan: `contract_request_url` *"has no known URL pattern and is not on the card"* | The card is on **100%** of pages. The URL is one site-wide constant, so it earns no column — and the form carries the **Commercial Registration number** |
| `write_groups`: the licences cell carries both languages *"with no separator"* | There are two dashes in it, and they are **hierarchy** separators **inside each language** |

### The fifth table is a price, and nothing here had named it

The card titled `العقود سعر البناء (برنامج البناء الذاتي)` publishes a **self-build price
per square metre** in three award tiers. 713 of 2,419 pages carry the card, 163 carry
values, **466 of 466 values parse as numbers** — no currency, no separator, no unit.

In a price-tracking warehouse that is the most valuable thing on the page. It was
invisible because a regex chunked *"from `id=contractor-tab4` until the next tab id"*,
and on a page whose pane is empty that chunk runs on into the following card. Asking the
same question through `select('div#contractor-tab4')` returns nothing, on every page.

**The tell was there and was ignored:** the same census reported *15 distinct shapes* for
one pane and 12 of the 15 contained the string `Interests` — a card that is not in the
pane at all. A shape count that explodes is a selector that is wrong.

And the schedule is **not** always non-increasing: 122 contractors quote a non-increasing
one and **33 do not**, so nothing may assume a bigger award is cheaper.

### The Commercial Registration number was in the form nobody opened

One of **his** requested columns, four times in his study, and the record said *"not
found; he had not seen it either"*. It is the pre-filled `cr` input of the
contract-request form.

| | |
|---|---|
| pages carrying it | **2,542 of 2,543** |
| shape | **ten digits**, every one |
| distinct values | **2,542 over 2,542 contractors — no two share one** |

So it is a second natural key, and the first that is a **national** identifier rather
than muqawil's own numbering — what a row here can be joined to Balady, or to a
commercial register, on. The old lead (a rating modal) needed a contractor to *have* a
rating; the form needs nothing.

**And the same form's `second_party_phone` is not a second phone** — measured rather than
assumed. Over 900 pages it is filled on 434 and equals `organization_mobile_number`
exactly on every one: **0 differ, 0 carry a number the info box lacks.** No column.

### The dash was a hierarchy separator

```
تشييد المباني - تشييد المباني - جميع الأنواع Construction of Buildings - Construction of Buildings – All Types
└─────────── a three-level Arabic path ───────────┘└──────── the same path in English ────────┘
```

A parser that split on the dash would have cut a path into pieces and called each piece a
language. The real boundary is the **first Latin letter**, and it is provable rather than
plausible: the script-run signature of all **1,500** activity cells is `AL` — Arabic then
Latin, exactly one transition.

**The site's own English is wrong on 100 of 1,685 rows:**

- **30** truncated to `Civil Engineering -` — and **two different Arabic activities**
  truncate to that same string, so it does not even distinguish them;
- **70** where Arabic says `أعمال تركيبات السباكة والحرارة والتكييف` and English says
  `Construction of Buildings – Medium & Low Rise`. **A different activity**, not a
  translation.

The load-bearing luck: **all three cases change the number of levels**, so nothing has to
recognise an activity to detect them. No row can be stored carrying an English name that
belongs to a different activity.

Where they disagree the **Arabic path stands alone** and the English name is left
**empty** — the state `taxonomy.ensure_path` already documents and already repairs
(*"A node first seen on an Arabic page has no English name yet; the next English page
supplies it"*). Putting the Arabic in the English column would have cost nothing today
and made that repair impossible forever, because the fill-in branch tests `if not
node_name`. Simulated across the corpus, the repair leaves **3 of 29 nodes** unnamed in
English — the three the site never publishes correctly.

### Two vocabularies that look like one, and fuse at the root

| | English paths | Arabic paths | exact overlap |
|---|---|---|---|
| Interests | **211** | 214 | — |
| Licensed activities | **19** | 21 | **0** English, 2 Arabic |

Zero English overlap, because the site writes `Civil engineering` in one and `Civil
Engineering` in the other. But their **Arabic roots do overlap**, and `ensure_path` is
idempotent on `(scheme, parent, node_name_ar)` — the Arabic name is the identity. **One
scheme would have matched the licence root to the interests root**, hung the licence
leaves under a node whose English name came from the other vocabulary, and produced a
tree that is neither. Nothing would have raised.

So the scheme names moved from `ProfileReader` — one pair for the whole reader, correct
only while `interests` was the only wired group — onto `MultiValuedGroup`, beside the
group that populates it. **A group with no scheme name is declared and unwritten**, which
is the state three of the five are in, and `write_groups` refuses to default it.

## What is built

**Six new columns, 21 → 27**, which `R-31` makes an additive schema upgrade rather than a
migration: the 704 rows approved under version 1 keep theirs, and a field *removed* would
still be refused.

- `commercial_registration`
- `self_build_price_under_five_projects` · `_five_to_ten_projects` · `_over_ten_projects`
  — read **by label**, because the same three labels arrive in different orders on
  different pages. Position would have put the over-ten price in the under-five column on
  some pages and not others, which is a defect invisible in any column count.
- `model_contract_count` · `registered_contract_count` — from the card titled *Previous
  Projects*, whose table is not projects, so the reader keys on the **headers** and never
  on the card's title.

**`licensed_activities` wired as a second taxonomy** — 1,685 rows over 228 pages from a
closed vocabulary of **22**. It needs **one page, not two**: the cell is already
bilingual, so a profile whose Arabic half never arrived still yields its licences, unlike
interests which pair across locales by position and can raise.

**`PROFILE_CARDS` declares all seven cards** and `undeclared_cards()` reports any
data-carrying card that is not among them. Its filter is **content** and not position
because the contractor's own name is a card too:

| rule | wrong on |
|---|---|
| by position — *the name card is card 0* | **40 of 5,668** pages |
| by content — *it carries no table and no list* | **0 of 5,668** |

The cost of that choice is stated in the docstring rather than hidden: **a new *text*
card would not be reported.**

### Raising on a fourth price tier does not risk the run

Worth stating because it looks like it should. `UnknownPriceTier` is raised rather than
answered — the same choice `CoordinatesMoved` already makes — and the reason is that a
price the site publishes and this warehouse silently drops is the one failure mode a
price-tracking warehouse cannot have.

`contractors.approve` wraps **each page** in `try/except Exception` and continues,
collecting refusals and printing the first twenty. So an unknown tier refuses **that
contractor** and names it; the other 34,833 approve. Loud per page, complete per run.

## Two failure paths measured before the parser was wired, not after

Both would have stopped a 34,834-page approval dead:

| | |
|---|---|
| interests pairing across locales | **2,252 of 2,252 paired** — `CannotPairLocales` will not fire |
| info-box labels | **11 distinct, every one known** — no field is being silently dropped |
| coordinates | **2,252 of 2,252** |

Neither number was known when the profile parser was last called finished.

## Tests

`tests/test_the_profile_publishes_seven_cards_not_one.py` — **25 guards**, and
**7 of 7 mutations killed**:

| mutation | result |
|---|---|
| `undeclared_cards` stops filtering on content | KILLED |
| the level count no longer gates the English half | KILLED |
| the price rows are read by position | KILLED |
| an unknown tier is dropped instead of raising | KILLED |
| the licences share the interests vocabulary | KILLED |
| the Arabic is copied into the English column | KILLED |
| the card title is looked for at `h3` only | KILLED |

Control green before each, tree restored and re-hashed after each, `__pycache__` purged
between runs, post-control green.

`tests/test_muqawil_parser.py` — the field-count assertion changed shape rather than its
number. `== 21` said only that nobody had touched it; `== list(PROFILE_FIELD_ORDER)` says
the candidate carries exactly the declared fields **in the declared order**, which is
load-bearing because `_schema_payload` puts `position` in the hash. An order that drifts
is a different schema with identical fields, and that refused 105 pages of 120 once.

## And a red `main` this repairs

`main` is red at `5f63bb0` on `test_a_pinned_citation_still_points_at_its_subject[BACKLOG.md-app.py-2710]`.
**Neither #251 nor #252 is wrong on its own base.** #252 measured `app.py:2710` against
`4615a14` and never touched `app.py`; #251 added fifteen lines above that symbol and
never touched the `PINNED` table. No file was changed by both, so there was no conflict
and no check could see it — #252's suite passed against a base that no longer existed by
the time it merged.

Repaired here, with the reason recorded on the row. The two PRs were **disjoint in files
and coupled in content**, which is why "do the files overlap?" is the reflex that fails,
and why *require branches up to date* is the branch-protection setting that catches it —
now `REQ-11`'s second reason after `ac3a5af`.

## He ruled on `Q-17` while this branch was open, so it closes here

> «ما يقوله الموقع هو مصدر الحقيقة الوحيد لا نعدل عليه»

**We never translate.** The question offered "write our own English" for the three
activities the site names wrongly. Refused on the principle rather than the case: the
node keeps its Arabic identity and no English name. `SR-1` reaching the extraction
layer — a mapping we invent is our claim dressed as the site's data. The code already
did this; now it does it because it was ruled.

> «لا داعى لوضعها فى عمود خاص فى الجدول ولكن عند الضغط على صف معين وهو يحملها تظهر فى
> الكارد الخاص بالمقاول · لان المقاولون سيكون هناك عدة مصادر له فى المستقبل»

**A field is not a column.** The readiness level is stored and is simply not a column,
and his reason is about the future rather than this field: a column is a promise every
source in the category must keep, and `المقاولون` will have Balady, the UAE registries
and the Gulf sources queued in Track 5. Measured on the products side, that shape is
madar at **59 variation axes, 33 non-empty on under 1% of rows**, which he asked three
times to have moved.

`R-45` records both. `Q-17` is closed rather than deferred — the readiness level stops
being a schema question the moment the card exists — and the question is kept below its
verdict unedited, per **C4**.

**And he remembers the card as built. It is half built, and not the half he needs** —
measured across `extension/` and `scrapex/webui/`: a per-row card exists on **neither**
surface, the fixed-columns half exists for **products only**
(`/api/promotable/{source_key}` over `source_product_attribute`), datasets have neither
half, their extras are already in `generic_record.data_json` so nothing needs
re-crawling, and both surfaces already ship Tabulator, whose row expansion is native.
`REQ-32`, four steps in dependency order.

## Left for him

- **`Q-18`** — `main_contractors` carries rows on **0** of 2,419 pages and
  `sub_contractors` on **2**. `R-19` ruled child tables for all five on one profile. They
  are also the only two that are **relations between contractors** rather than
  classifications, so `dataset_relationship` — which just gained its first tenant — may
  be their home instead.

Documents in the same pull request, per **C2**: `REQ-31`, `OP-43`, `Q-17`, `Q-18`,
`LESSONS.md` §11, `R-19` and `R-41` amended with the originals kept per **C4**,
`CONTRACTOR-SOURCE.md` corrected in four places, `STATE.md`, and the plan's step 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
