### PR TITLE
A dataset says when it was crawled, and 17,304 rows stop reading as none

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -301,8 +301,8 @@ And only one of the **two** `worker_alive` computations was fixed:
 
 | where | what it calls | verdict |
 |---|---|---|
-| `scrapex/webui/app.py:1470` — `/api/health` | the new two-heartbeat `worker` verdict | correct; the panel reads this one (`extension/engine.js:38`) |
-| `scrapex/webui/app.py:2458` — `_about` | `worker_is_alive(conn)`, single heartbeat | **the function the fix superseded** |
+| `scrapex/webui/app.py:1554` — `/api/health` | the new two-heartbeat `worker` verdict | correct; the panel reads this one (`extension/engine.js:38`) |
+| `scrapex/webui/app.py:2542` — `_about` | `worker_is_alive(conn)`, single heartbeat | **the function the fix superseded** |
 
 `_about` renders the engine's own `/settings` page
 (`scrapex/webui/templates/settings.html:162-167`), so **the engine still shows
@@ -310,7 +310,7 @@ And only one of the **two** `worker_alive` computations was fixed:
 engine is started at all.
 
 **Next action:** three separate things — the second `worker_alive` at
-`app.py:2458`; the heartbeat's behaviour under a held write lock; and the 409 on
+`app.py:2542`; the heartbeat's behaviour under a held write lock; and the 409 on
 `/api/storage/restore` with a mirror of
 `test_start_fresh_is_refused_while_a_crawl_runs`.
 
@@ -1046,6 +1046,93 @@ has data consequences:
 impossible rather than deferred; (b) or (c) as the real model, once he rules.*
 **Not started — his call, on live data.**
 
+### OP-44 · ~~A dataset card said "no successful crawl yet" over 17,304 crawled rows~~ — FIXED 2026-08-22
+
+**He reported it from his own panel** — on the board as
+[REQ-33](REQUESTS.md#req-33--the-dataset-cards-said-no-successful-crawl-over-crawled-rows).
+The two muqawil datasets read
+
+    muqawil.org · Saudi Contractors Authority · contractors [Row 17,304]
+    17,304 products
+    no successful crawl yet
+
+while `aramco.com` and `spark-eshop.com` beside them read *"Last crawled 16 August
+2026, 8:00 AM"*. 17,304 rows plainly came from a crawl, so the display was wrong
+about something it had the evidence to answer.
+
+**Measured on his live warehouse, read-only, 2026-08-22** (schema v9, while the
+profile crawl was running against it):
+
+| | |
+|---|---|
+| `crawl_run` | **155 rows over twelve source keys** — `ADVANCEDCASTLE` … `SPARK_ESHOP`, and **not one for muqawil** |
+| `source_site` | the same twelve keys. **muqawil is not among them** |
+| `site_profile` | `muqawil` and `muqawil_org` — the other registry |
+| `generic_record` | `contractors` **17,304**, `contractor_profiles` **704** |
+| `generic_page_snapshot` | **24,480** pages, 1,728 with no `crawl_run_ref`, **139** distinct refs |
+| the evidence behind the rows | `contractors` last captured **2026-08-21T17:56:31Z**, `contractor_profiles` **2026-08-21T21:44:48Z** |
+
+**THE CAUSE WAS NOT THE MISSING `crawl_run` ROW.** `_dataset_rows` wrote
+`"last_success": None` as a **literal**, and `freshnessLine`
+(`extension/app.js:4489`) prints that sentence whenever the key is absent or
+carries no `started_at`. So a `crawl_run` row for muqawil would have changed
+nothing on the card — the fix had to arrive at that key.
+
+**And the row could not honestly be written anyway.** `crawl_run.source_id` is
+`NOT NULL REFERENCES source_site(source_id)` (`db/engine/schema.sql:122`), and
+muqawil has no `source_site` row: which registry a source lands in is exactly the
+split [REQ-25](REQUESTS.md#req-25--one-source-registry-with-a-category-visible-to-every-user)
+holds and it is his decision, not a side effect of fixing a caption.
+`crawl_run.job_id` points into `crawl_job`, and *"does a generic crawl belong in
+the same job queue as a price crawl?"* is an open question for him at the foot of
+[GENERIC-FETCH-SEAM.md](GENERIC-FETCH-SEAM.md) — writing the row from a CLI that
+the scheduler does not drive would answer it by default. The same document says
+of the second-run question: *"It may be enough to ask `generic_ingestion`; check
+before adding a column."*
+
+**So the freshness is DERIVED, and nothing new is stored.**
+`extract/service.last_evidence_captured_at` reads
+`max(generic_page_snapshot.captured_at)` over the pages `generic_ingestion` says
+this dataset was built from, and `_dataset_freshness` puts it in
+`ingest.last_successful_run`'s shape so the panel keeps one code path.
+
+Four findings the measurement produced that the fix turns on:
+
+* **`generic_ingestion`, not `generic_record.source_snapshot_id`.** A record keeps
+  pointing at the snapshot that last **changed** it (`R-20`), so a confirming
+  re-crawl would leave the date stale — the very complaint. On his warehouse:
+  3,883 ingestions against 2,139 distinct record snapshots for `contractors`, and
+  the two answers differ (`17:56:31Z` against `17:54:31Z`).
+* **`ix_generic_page_snapshot_page` is worth 390x and had never been read.**
+  It is `(page_snapshot_id, captured_at)` (`db/engine/schema.sql:843`); SQLite
+  prefers the rowid because the planner cannot see that the row carries a
+  compressed ~100 KB body. Measured over 24,480 pages: **353–373 ms** by rowid,
+  **0.9 ms** through `INDEXED BY`, identical answer.
+* **`max(page_snapshot_id)` is NOT a cheaper spelling of the same thing.** It
+  agrees on this machine (0.2 ms) because `save_snapshot` never supplies
+  `captured_at` — but `warehousemerge.py:269` INSERTs the other machine's
+  `captured_at` verbatim under fresh local ids, so after the merge `R-43` makes
+  routine the highest id can be the oldest page.
+* **No measure goes beside the date, because *seen* is already taken.** Both
+  surfaces print `rows_seen` after the instant and fall back to
+  `requests_count`. The obvious candidate was the row count — and
+  `dataset_sighting` already means *what the site showed us*: on `contractors`,
+  **17,417 sighted against 17,304 stored**. Putting the stored count under the
+  word `seen` would be a wrong answer to a question this schema answers exactly.
+  `requests_count` is no better, because retries, 304s and the Arabic half of
+  every page leave no second row. Both stay 0, the line reads *"Last crawled …"*
+  and stops, and the count keeps its own line on the card.
+
+Six mutations, six killed. The one that mattered is M5 — swapping
+`generic_ingestion` for `generic_record` — which the newest-page test caught for
+exactly the reason above.
+
+**Still open, and it is his:** the two registries. This closes the display; it
+does not merge `site_profile` into `source_site`, and a dataset still has no run
+ledger of its own. If he wants one, that is `REQ-25`'s shape to decide.
+
+---
+
 ### OP-41 · The test suite writes into the owner's live crawl log
 
 **Found 2026-08-21, by reading the log to check on a crawl.**
@@ -1587,16 +1674,16 @@ the two `muqawil.org` cards carry none. So it belongs here and not in
 marker it keys on precisely so the panel can do that — `"kind": "dataset"` in
 `_dataset_rows`, whose docstring says *"the row menu offers Update, Wipe and
 Rename, and every one of those is a price-path action that would answer 400 or
-worse for a dataset"* ([scrapex/webui/app.py:639](../scrapex/webui/app.py#L639)).
+worse for a dataset"* ([scrapex/webui/app.py:697](../scrapex/webui/app.py#L697)).
 It was the right call for five of the six entries and it is still right for them:
 `update`, `pause` and `settings` post to routes that read the manifest, and
 `/api/export/{key}` validates the key against `manifest.sources` and answers 404
-for anything else ([scrapex/webui/app.py:2725](../scrapex/webui/app.py#L2725)).
+for anything else ([scrapex/webui/app.py:2787](../scrapex/webui/app.py#L2787)).
 
 **But `Open the data table` would work, and it was built after the blanket
 hide.** `data.html?source=KEY` fetches `/api/table/{key}`, and that route looks
 the key up in the dataset catalogue FIRST — *"a generic dataset is a table like
-any other table"* ([scrapex/webui/app.py:986](../scrapex/webui/app.py#L986)) —
+any other table"* ([scrapex/webui/app.py:1048](../scrapex/webui/app.py#L1048)) —
 so `/api/table/contractors` serves the directory in full. The panel hides the one
 entry that works on the marker that was introduced for the five that do not.
 
@@ -2942,7 +3029,7 @@ date it was measured.
 1. **ALSWEED is being refused with HTTP 429**, five times on 2026-08-11, because
    `crawl_honour_delay` is `'0'`. **BV-3**.
 2. **The engine's own Settings page says "Not running" while it crawls** — a
-   second `worker_alive` computation at `app.py:2458` that the fix never reached
+   second `worker_alive` computation at `app.py:2542` that the fix never reached
    — and the runtime heartbeat freezes under `database is locked` when a job
    holds a write transaction. **OP-6 · ت2**.
 3. **The diagnostic-page guard is still blind**, and this file said it had been

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -209,6 +209,44 @@ tolerance must be **generation-aware**.
 The 871 v5 pages were dropped on the owner's instruction and preserved at
 `~/.scrapex/journal-dropped-v5-ELBUROJ/`.
 
+### A rowid lookup is not free on a table of page bodies, and the planner cannot tell
+
+`generic_page_snapshot` stores compressed HTML — 24,480 rows over roughly 200 MB on
+his warehouse. `page_snapshot_id` IS the rowid, so SQLite reads `captured_at` by
+seeking the row, which drags in the page the body starts on. Measured 2026-08-22,
+same query, same answer:
+
+```
+max(captured_at) over one dataset's ingested pages     353-373 ms   by rowid
+                                              same       0.9 ms   INDEXED BY ix_generic_page_snapshot_page
+```
+
+`ix_generic_page_snapshot_page` is `(page_snapshot_id, captured_at)` and had existed,
+unread, since migration 0014. The planner will not choose it: a rowid seek looks
+cheaper than an index seek and nothing in the statistics says how wide the row is.
+**On a table whose rows are documents, name the covering index.** And if it is ever
+dropped, `INDEXED BY` makes SQLite raise instead of quietly paying the 373 ms — the
+failure you would rather have.
+
+### `max(id)` stops meaning `latest` the moment two warehouses are merged
+
+The cheap version of that same read was `max(page_snapshot_id)`, then one lookup —
+0.2 ms, and identical on this machine, because `save_snapshot` never supplies
+`captured_at` and lets the column default fire, so ids and timestamps rise together.
+
+`scrapex/warehousemerge.py:269` breaks it on purpose: the merge INSERTs the other
+machine's `captured_at` **verbatim** under freshly assigned local ids, because the
+row is evidence of when that machine fetched a page and rewriting it would be a
+forgery. So after a merge — which
+[R-43](RULINGS.md#r-43--drive-is-the-single-source-of-truth-for-data-the-repository-stays-it-for-code)
+makes the routine operation between his two machines — the highest id can be the
+oldest page.
+
+The lesson is not about snapshots. **Any "newest row" shortcut that reads a
+monotonic key instead of the timestamp is an assumption about who did the
+INSERT**, and this repository has a supported operation that does it differently.
+Order by the fact you mean.
+
 ---
 
 ## 3 · Silent failures on the ingest path
@@ -1431,3 +1469,49 @@ stopped a 34,834-page approval dead, and both were measured before the parser wa
 wired rather than after: interests paired in **2,252 of 2,252** pairs, and the info
 box carried **11 distinct labels, all of them known** — no field was being silently
 dropped. Neither number was known when the profile parser was declared finished.
+
+---
+
+## 12 · A register id is renamed by a sweep, never by an edit
+
+**Measured on this branch on 2026-08-22, twice in one afternoon.** Two pull requests
+merged while it was open and took every id it had reserved: `#252` took `REQ-30` and
+`OP-42`, then `#254` took `REQ-31`, `REQ-32` and `OP-43`. So one entry was renumbered
+twice — `OP-42` → `OP-43` → `OP-44`, and `REQ-30` → `REQ-31` → `REQ-33`.
+
+**Both times the heading moved and a reference did not.** The survivor was a link
+inside the `OP` entry's own body pointing at its `REQ` twin:
+
+    [REQ-30](REQUESTS.md#req-30--the-dataset-cards-said-no-successful-crawl-over-crawled-rows)
+
+Every part of that line is wrong in a way nothing catches. The **text** names a
+different request — `REQ-30` is the duplicated `⋮` button — and the **anchor**
+resolves to nothing, because no heading slugs to it any more. The citation guard does
+not see it: `tests/test_the_documents_cite_what_they_claim.py` checks `file:line`
+citations, and this is a markdown anchor. The board guard does not see it either:
+`test_the_request_board_matches_its_entries.py` compares the board against the
+entries, and this link is in neither.
+
+**Why a targeted fix is not enough, and this is the part worth keeping.** A sweep by
+SUBJECT — every line mentioning the work, checked for the right id — found the one
+above and **missed a second**, because the surviving reference was a comment about
+`SUFFIXES` that never names the subject at all. What found it was the opposite
+question: take every id the diff introduces and print the heading that number
+actually names today. A number that names something else is the defect, whatever the
+prose around it says.
+
+So, when a register id changes:
+
+1. `grep` the id, not the subject. The subject is what a rename does not mention.
+2. Check the **anchor** as well as the text — `#req-nn--slug` is a second copy of the
+   number and it rots silently, because a dead markdown anchor is not an error.
+3. Resolve every id against the register's headings afterwards, and read what each
+   number names. That is a two-line script and it is the only check that cannot be
+   fooled by wording.
+
+**And the same shape applies to line numbers, which this branch also carried three
+times.** `app.py:2710` → `2725` → `2787` in one day: `#252` measured it correctly on
+its own base, `#251` had already moved the symbol, and `main` went red between the two
+merges with no conflict for git to find, because no file was changed by both. Re-read
+the number out of the file at the new base on every rebase. Never adjust it by
+arithmetic, and never carry it.

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -88,6 +88,7 @@ IDs are stable and never reused, matching the convention BACKLOG.md already uses
 | [REQ-30](#req-30--the-three-dots-button-appears-twice-on-a-source-card) | The three-dots button appears twice on a source card | **In flight** — cause proven, fixed and guarded; merging is his | 2026-08-22 |
 | [REQ-31](#req-31--start-the-profile-parser--and-the-pages-are-not-consistent) | Start the profile parser — and the pages are not consistent | **In flight** — the cards are built, guarded and mutation-tested; `Q-17` and `Q-18` are his | 2026-08-22 |
 | [REQ-32](#req-32--fixed-columns-and-everything-else-in-the-rows-own-card) | Fixed columns, and everything else in the row's own card | **Ruled** ([R-45](RULINGS.md#r-45--the-site-is-the-only-source-of-truth-and-a-field-the-table-does-not-need-goes-in-the-rows-card)) — not built; the card does not exist on either surface | 2026-08-22 |
+| [REQ-33](#req-33--the-dataset-cards-said-no-successful-crawl-over-crawled-rows) | The dataset cards said "no successful crawl yet" over 17,304 crawled rows | **Done** — the date is derived from the evidence; the two registries stay his | 2026-08-22 |
 
 ---
 
@@ -1503,3 +1504,39 @@ has neither half and its data is already on disk.
 
 **Not started.** `REQ-31` (the profile parser) is what is in flight, and this is the
 surface it feeds.
+
+---
+
+## REQ-33 · The dataset cards said no successful crawl over crawled rows
+**Captured 2026-08-22 · Done — the date is derived from the evidence; the two registries stay his**
+
+> He reported it from the extension's source list. The two muqawil datasets read
+> `17,304 products` / *"no successful crawl yet"* and `704 products` / *"no
+> successful crawl yet"*, while `aramco.com` and `spark-eshop.com` beside them read
+> *"Last crawled 16 August 2026, 8:00 AM — Africa/Cairo · N rows seen"*.
+> **17,304 rows plainly did come from a crawl.**
+
+**Recorded in English, the same departure `REQ-28` documents.** His own words did not
+reach this session, and writing an Arabic quote to satisfy rule 2 below would put
+words in his mouth — the one thing this file exists to prevent. If he said it in
+Arabic, that quote replaces the paragraph above.
+
+**The cause was not the missing `crawl_run` row**, which is the finding that decided
+the fix. `_dataset_rows` handed the panel `"last_success": None` as a literal, and
+`freshnessLine` prints that sentence for a missing key — so giving muqawil a
+`crawl_run` row would have changed nothing on his screen. It could not honestly be
+written either: `crawl_run.source_id` is NOT NULL into `source_site`, muqawil is in
+`site_profile`, and that split is [REQ-25](#req-25--one-source-registry-with-a-category-visible-to-every-user)'s
+to settle.
+
+**So the date is read off the evidence the crawl already stored** —
+`max(generic_page_snapshot.captured_at)` over the pages `generic_ingestion` says the
+dataset was built from. Nothing new is recorded, and
+[`GENERIC-FETCH-SEAM.md`](GENERIC-FETCH-SEAM.md) had already asked for exactly that:
+*"It may be enough to ask `generic_ingestion`; check before adding a column."*
+
+**What this did NOT do, and it is his:** merge the two registries. A dataset still
+has no run ledger of its own, and whether a generic crawl belongs in the price job
+queue is still the open question at the foot of that document. The measurement, the
+four findings it produced and the mutation results are in
+[BACKLOG.md](BACKLOG.md) as `OP-44`.

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -134,7 +134,7 @@ engine carries the extension.
 
 **The defect, found by trying the bump and reverting it the same day:**
 `version_report` sends `"latest_extension_version": VERSION`
-(`scrapex/version.py:483`, again in `scrapex/webui/app.py:1481`, drawn by
+(`scrapex/version.py:483`, again in `scrapex/webui/app.py:1543`, drawn by
 `extension/app.js:595` and `:629`). The moment the engine moves ahead of
 `extension/manifest.json`, the panel draws *"This ScrapeX extension is older than
 the engine it is talking to"*. Measured at 320×440: the profile page's legal line

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,10 +1,11 @@
 # State — where the work stands
 
-**Last updated: 2026-08-22.** `main` is at `4615a14` (#250). #243 through #250 are
-all merged — #246 (the engine's own updater) and #247–#250 landed after this line
-last said `afb8648` (#244), which is **five merges** of drift in one day. A commit
+**Last updated: 2026-08-22.** `main` is at `5f63bb0` (#252). #243 through #252 are
+all merged — #246 (the engine's own updater) and #247–#252 landed after this line
+last said `afb8648` (#244), which is **seven merges** of drift in one day. A commit
 pointer written into prose is stale by the time it is read: `git log --oneline -1
-origin/main` is the answer that cannot be.
+origin/main` is the answer that cannot be — and this very line proves it twice, since
+#251 and #252 merged while it said `4615a14`.
 
 This is the document that is **wrong the moment it is out of date**. Update it
 when a phase lands, a PR merges, or the owner rules — in the same pull request as
@@ -797,6 +798,27 @@ that rule, and it does not exist.
 **Four questions are open and are his** — O-1 to O-4 in
 [RULINGS.md](RULINGS.md#open--awaiting-the-owners-ruling).
 
+### The dataset cards said "no successful crawl yet" — FIXED 2026-08-22
+
+He reported it from the panel: `17,304 products` and, under it, *"no successful crawl
+yet"*, while the price sources beside them read *"Last crawled 16 August 2026"*.
+[OP-44](BACKLOG.md) carries the whole measurement; the two facts worth having here:
+
+**The missing `crawl_run` row was not the cause.** `_dataset_rows` handed the panel
+`"last_success": None` as a literal, and `freshnessLine` prints that sentence for a
+missing key — so writing muqawil a `crawl_run` row would have changed nothing on
+screen. It could not honestly be written either: `crawl_run.source_id` is NOT NULL
+into `source_site` and muqawil is in `site_profile`, which is the split `REQ-25`
+holds and his to decide.
+
+**So the date is derived from evidence already stored** —
+`max(generic_page_snapshot.captured_at)` over the pages `generic_ingestion` says the
+dataset was built from. Measured read-only on his live warehouse while the profile
+crawl ran: `contractors` **2026-08-21T17:56:31Z**, `contractor_profiles`
+**2026-08-21T21:44:48Z**, against 155 `crawl_run` rows none of which is muqawil's.
+Six mutations, six killed. **The two registries are untouched** — this closes a
+display, not `REQ-25`.
+
 ---
 
 ## Track 5 · The source queue — eight countries and three product classes, none started
@@ -973,7 +995,7 @@ written and 58 two days ago. It grows every time this is deferred.
 **The blocker, verified 2026-08-17 and still present:**
 `"latest_extension_version": VERSION` at
 [scrapex/version.py:483](../scrapex/version.py) and
-[scrapex/webui/app.py:1481](../scrapex/webui/app.py), drawn by
+[scrapex/webui/app.py:1543](../scrapex/webui/app.py), drawn by
 [extension/app.js:599](../extension/app.js) and `:633`.
 
 > **Re-verified 2026-08-19, and three of these citations had already drifted.**

--- a/scrapex/extract/service.py
+++ b/scrapex/extract/service.py
@@ -636,6 +636,70 @@ def approve_candidate(
     return result
 
 
+#: The freshness read, as a constant so a test can put it through
+#: `EXPLAIN QUERY PLAN` and pin the index. `INDEXED BY` is the whole of the 390x
+#: below and nothing about the ANSWER changes when it is removed, so no
+#: assertion about a returned value can defend it.
+LAST_EVIDENCE_SQL = (
+    "SELECT max(p.captured_at) FROM generic_ingestion AS g "
+    "JOIN generic_page_snapshot AS p INDEXED BY ix_generic_page_snapshot_page "
+    "ON p.page_snapshot_id = g.source_snapshot_id "
+    "WHERE g.dataset_definition_id = ?"
+)
+
+
+def last_evidence_captured_at(conn: sqlite3.Connection,
+                              dataset_id: int) -> str | None:
+    """When this dataset was last FED A PAGE, read off the evidence itself.
+
+    THE DEFECT THIS ANSWERS. The panel's source card said *"no successful crawl
+    yet"* under `17,304 products` — and 17,304 rows plainly came from a crawl.
+    The price pipeline records one `crawl_run` row per ingest and the card reads
+    it; the generic pipeline records none, because `crawl_run.source_id` is
+    `NOT NULL REFERENCES source_site(source_id)` (db/engine/schema.sql:122) and
+    muqawil has no `source_site` row at all — it lives in `site_profile`, and
+    which registry a source lands in is the open question `REQ-25` holds. So the
+    card was reading a table that cannot describe a dataset, and answering
+    honestly about the wrong thing.
+
+    Nothing new is recorded to fix it. `generic_page_snapshot.captured_at` is
+    when a page was fetched and `generic_ingestion` is which pages this dataset
+    was built from — both already written on every crawl — so the freshness is
+    a read, not a column.
+
+    `generic_ingestion` AND NOT `generic_record.source_snapshot_id`, and the
+    difference is a re-crawl that changes nothing. A record keeps pointing at
+    the snapshot that last CHANGED it (`R-20`: unchanged means no revision), so
+    a confirming pass would leave the date stale — exactly the complaint. On his
+    warehouse, measured 2026-08-22: 3,883 ingestions against 2,139 distinct
+    record snapshots for `contractors`, and the two answers differ —
+    `17:56:31Z` from the ingestions, `17:54:31Z` from the records.
+
+    `INDEXED BY`, AND IT IS 390x. `ix_generic_page_snapshot_page` is
+    `(page_snapshot_id, captured_at)` (db/engine/schema.sql:843) and had no
+    reader; SQLite prefers the rowid because the planner cannot see that the row
+    it lands on carries a compressed 100 KB body. Measured on his 24,480-page
+    warehouse: **353-373 ms** on the rowid against **0.9 ms** on the covering
+    index, for the identical answer. A8 asks for the covering index to be noted;
+    this is the query that needed it. If the index is ever dropped, SQLite
+    raises rather than quietly paying the 373 ms — which is the failure anyone
+    would rather have.
+
+    AND NOT `max(page_snapshot_id)`, WHICH LOOKS EQUIVALENT AND IS NOT.
+    `save_snapshot` never supplies `captured_at`, so within one machine the ids
+    and the timestamps rise together and the newest id is the newest page — 0.2
+    ms instead of 0.9. `warehousemerge.py:269` breaks it: a merge INSERTs the
+    other machine's `captured_at` verbatim under freshly assigned local ids, so
+    after the merge `R-43` makes routine, the highest id can be the oldest page.
+    The 0.7 ms is not worth a claim that his own workflow falsifies.
+
+    None means no page has ever been ingested into this dataset. That is a real
+    answer and the card must say so in words.
+    """
+    row = conn.execute(LAST_EVIDENCE_SQL, (dataset_id,)).fetchone()
+    return row[0] if row is not None else None
+
+
 def list_datasets(
     conn: sqlite3.Connection,
     *,

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -305,6 +305,48 @@ def _source_domain(value: str | None) -> str:
     return host[4:] if host.lower().startswith("www.") else host
 
 
+def _dataset_freshness(conn, dataset_id: int) -> dict | None:
+    """A dataset's freshness in the shape both source surfaces already read.
+
+    THE FIELD NAMES ARE `ingest.last_successful_run`'s, ON PURPOSE, and one of
+    them earns a word. `started_at` is what `freshnessLine` (extension/app.js)
+    and `_source_list.html` print after *"Last crawled"*, so it holds the NEWEST
+    capture. For a price run that instant is when the run began, because the run
+    and its ingest are one transaction; the generic pipeline separates fetching
+    from interpreting by design (docs/GENERIC-FETCH-SEAM.md), so there is no run
+    interval to report and the honest instant is the last moment a page arrived.
+    Its oldest page would understate the freshness by the length of the crawl —
+    on his `contractors` dataset, by a day and twelve hours.
+
+    AND IT CARRIES NO MEASURE BESIDE THE DATE, WHICH IS A DECISION. Both
+    surfaces print `rows_seen` after the date, then fall back to
+    `requests_count`; a dataset has an honest number for neither.
+
+    * **Not `rows_seen`.** The obvious candidate is the dataset's own row count —
+      and *seen* already means something else in this warehouse. `dataset_sighting`
+      is *what the site showed us*, and on his `contractors` the two differ:
+      **17,417 sighted against 17,304 stored**. Printing the stored count under
+      the word `seen` would put a wrong answer to a question this schema can
+      answer exactly. The card states the count on its own line anyway.
+    * **Not `requests_count`.** The stored pages behind a dataset are not the
+      requests its crawl spent: retries, 304s and the Arabic half of every
+      muqawil page are all requests that leave no second row.
+
+    So both stay 0, which `last_successful_run` already documents as an absence
+    rather than a measurement of zero, and the line reads *"Last crawled …"* and
+    stops.
+
+    None when nothing has ever been ingested. The card then says "no successful
+    crawl yet", which at that point is true.
+    """
+    captured_at = extract_service.last_evidence_captured_at(conn, dataset_id)
+    if not captured_at:
+        return None
+    return {"started_at": captured_at, "finished_at": captured_at,
+            "rows_seen": 0, "requests_count": 0,
+            "products_discovered": 0, "errors_count": 0}
+
+
 TEMPLATES.env.filters["source_domain"] = _source_domain
 # The sidebar renders from the shared UI contract (scrapex/ui_manifest.py) —
 # the same module /api/ui serves to the panel, so the surfaces cannot drift.
@@ -635,6 +677,22 @@ def create_app(
             return []
         general = general_read_conn()
         try:
+            # READ WHOLE, THEN SHAPED. The freshness is a second query per
+            # dataset, and running it inside the walk of this one would nest a
+            # read in the middle of a GROUP BY scan for no gain — there are as
+            # many datasets as a site has tables, and the aggregate above is
+            # already the expensive half.
+            catalogue = general.execute(
+                "SELECT d.dataset_definition_id, d.dataset_key, d.display_name, "
+                "d.original_name, s.base_url, count(r.generic_record_id) AS rows "
+                "FROM dataset_definition AS d "
+                "JOIN site_profile AS s "
+                "ON s.site_profile_id = d.site_profile_id "
+                "LEFT JOIN generic_record AS r "
+                "ON r.dataset_definition_id = d.dataset_definition_id "
+                "AND r.status = 'active' "
+                "WHERE d.valid_to IS NULL GROUP BY d.dataset_definition_id"
+            ).fetchall()
             return [{
                 "kind": "dataset",
                 "source_key": row["dataset_key"],
@@ -647,17 +705,21 @@ def create_app(
                 # meaning for a company, so it carries the same count rather
                 # than a zero that would read as an empty dataset.
                 "observations": row["rows"], "products": row["rows"],
-                "last_success": None, "kept_pages": 0, "kept_at": None,
-            } for row in general.execute(
-                "SELECT d.dataset_key, d.display_name, d.original_name, "
-                "s.base_url, count(r.generic_record_id) AS rows "
-                "FROM dataset_definition AS d "
-                "JOIN site_profile AS s "
-                "ON s.site_profile_id = d.site_profile_id "
-                "LEFT JOIN generic_record AS r "
-                "ON r.dataset_definition_id = d.dataset_definition_id "
-                "AND r.status = 'active' "
-                "WHERE d.valid_to IS NULL GROUP BY d.dataset_definition_id")]
+                # WHEN THE DATA ON SCREEN WAS GATHERED, and it is DERIVED rather
+                # than recorded. The card printed "no successful crawl yet"
+                # under 17,304 rows, because this key was the literal `None` and
+                # `freshnessLine` says so in words when it is. A price source
+                # gets it from `crawl_run`; a dataset can have no row there at
+                # all — `crawl_run.source_id` is NOT NULL into `source_site` and
+                # muqawil is in `site_profile`, which is the split `REQ-25`
+                # holds — so this reads the evidence the crawl already stored.
+                # Same SHAPE as `ingest.last_successful_run`, deliberately: the
+                # panel and `_source_list.html` both draw `last_success`, and a
+                # second shape would be a second code path in each of them.
+                "last_success": _dataset_freshness(
+                    general, int(row["dataset_definition_id"])),
+                "kept_pages": 0, "kept_at": None,
+            } for row in catalogue]
         finally:
             general.close()
 

--- a/tests/test_a_dataset_is_a_table_like_any_other.py
+++ b/tests/test_a_dataset_is_a_table_like_any_other.py
@@ -966,3 +966,180 @@ def test_a_site_label_cannot_collide_with_an_observed_key():
         # A card label of ANY wording lands under `card_`, so it cannot reach here.
         assert f"card_{_slug('Observed Last Seen')}" != key
         assert f"x_{_slug('Observed Last Seen')}" != key
+
+
+# ---- and it has to say WHEN it was crawled, because 17,304 rows came from one ----
+#
+# THE DEFECT, in his own screen. `muqawil.org · contractors [Row 17,304]` sat above
+# `17,304 products` and then `no successful crawl yet`, while `aramco.com` beside it
+# read `Last crawled 16 August 2026, 8:00 AM`. Measured on his warehouse the same
+# day: `crawl_run` holds 155 rows across twelve source keys and NOT ONE of them is
+# muqawil, `generic_page_snapshot` holds 24,480 pages, and `generic_record` holds
+# 17,304 + 704 rows for the two datasets. The card was reading the price pipeline's
+# ledger about a dataset that can never appear in it — `crawl_run.source_id` is NOT
+# NULL into `source_site`, and muqawil lives in `site_profile`.
+
+
+def _dataset_id(conn, dataset_key: str = "contractors") -> int:
+    row = conn.execute(
+        "SELECT dataset_definition_id FROM dataset_definition WHERE dataset_key = ?",
+        (dataset_key,)).fetchone()
+    assert row is not None, f"no dataset called {dataset_key!r}"
+    return int(row["dataset_definition_id"])
+
+
+def _fed(conn, captured_at: str, url: str, dataset_key: str = "contractors") -> int:
+    """One more page into a dataset, captured at a STATED moment.
+
+    `captured_at` is a column DEFAULT and `generic_page_snapshot` is immutable by
+    trigger — `trg_generic_page_snapshot_immutable_update` aborts any UPDATE — so
+    stating it in the INSERT is the only way to place evidence in time. It is not a
+    test-only trick either: `warehousemerge.py:269` carries the other machine's
+    `captured_at` verbatim for exactly the same reason.
+    """
+    cursor = conn.execute(
+        "INSERT INTO generic_page_snapshot "
+        "(source_url, html_content, content_hash, captured_at) VALUES (?,?,?,?)",
+        (url, LISTING, f"hash-{url}", captured_at))
+    snapshot_id = int(cursor.lastrowid)
+    candidate = listing_candidate(LISTING)
+    service.approve_candidate(conn, snapshot_id, CandidateApproval(
+        table_index=0, site_key="muqawil_org", site_display_name="SCA",
+        dataset_key=dataset_key, dataset_name="Contractors",
+        fields=[ApprovalField(field_key=f.field_key, display_name=f.source_name,
+                              data_type="text",
+                              identity=(f.field_key == "contractor_id"))
+                for f in candidate.fields]), candidate=candidate)
+    return snapshot_id
+
+
+def test_the_freshness_is_the_newest_page_the_dataset_was_fed(conn):
+    """Not the oldest, and not whichever page happens to be approved last.
+
+    A crawl of muqawil's listing runs for hours — his `contractors` evidence spans
+    2026-08-20T05:52:28Z to 2026-08-21T17:56:31Z — so the two ends of it are a day
+    and a half apart. The line says *"Last crawled"*, and only one end of that span
+    answers it.
+    """
+    stored(conn)
+    dataset_id = _dataset_id(conn)
+    _fed(conn, "2019-03-04T05:06:07Z", "https://muqawil.org/en/contractors?page=2")
+    _fed(conn, "2031-03-04T05:06:07Z", "https://muqawil.org/en/contractors?page=3")
+    _fed(conn, "2024-03-04T05:06:07Z", "https://muqawil.org/en/contractors?page=4")
+
+    assert service.last_evidence_captured_at(conn, dataset_id) == "2031-03-04T05:06:07Z"
+
+
+def test_freshness_belongs_to_its_own_dataset_and_not_to_the_warehouse(conn):
+    """A page fed to the profiles dataset must not date the listing one.
+
+    Both muqawil datasets are crawled from the same site by the same command, and
+    on his warehouse they answer two different instants — 2026-08-21T17:56:31Z for
+    `contractors` and 2026-08-21T21:44:48Z for `contractor_profiles`. A read that
+    lost the dataset from its WHERE clause would give both the later one and nothing
+    on either card would look wrong.
+    """
+    stored(conn)
+    listing = _dataset_id(conn)
+    _fed(conn, "2027-01-01T00:00:00Z", "https://muqawil.org/en/contractors?page=9")
+    _fed(conn, "2033-12-31T23:59:59Z", "https://muqawil.org/en/contractors/1/2",
+         dataset_key="contractor_profiles")
+    profiles = _dataset_id(conn, "contractor_profiles")
+
+    assert service.last_evidence_captured_at(conn, listing) == "2027-01-01T00:00:00Z"
+    assert service.last_evidence_captured_at(conn, profiles) == "2033-12-31T23:59:59Z"
+
+
+def test_a_dataset_nothing_has_fed_reports_no_crawl_rather_than_inventing_one(conn):
+    """"Never" is a real answer. The whole complaint is a card that stated one thing
+    while the warehouse held another, so a freshness with no evidence behind it must
+    be absent and not `now`."""
+    from scrapex.webui.app import _dataset_freshness
+
+    stored(conn)
+    unfed = conn.execute(
+        "INSERT INTO dataset_definition "
+        "(site_profile_id, dataset_key, original_name, discovery_method) "
+        "SELECT site_profile_id, 'nothing_yet', 'nothing_yet', 'manual' "
+        "FROM site_profile LIMIT 1")
+
+    assert service.last_evidence_captured_at(conn, int(unfed.lastrowid)) is None
+    assert _dataset_freshness(conn, int(unfed.lastrowid)) is None
+
+
+def test_the_freshness_read_goes_through_the_covering_index(conn):
+    """The 390x, pinned — because no assertion about the ANSWER can defend it.
+
+    `ix_generic_page_snapshot_page` is `(page_snapshot_id, captured_at)` and had no
+    reader before this one. SQLite prefers the rowid, since the planner cannot see
+    that the row it lands on carries a compressed body of ~100 KB: measured on his
+    24,480-page warehouse, **353-373 ms** by rowid against **0.9 ms** by the
+    covering index, for the identical string. `INDEXED BY` is what chooses, and
+    removing it is invisible to every other test in this file.
+    """
+    stored(conn)
+    plan = " ".join(
+        str(row[3]) for row in
+        conn.execute("EXPLAIN QUERY PLAN " + service.LAST_EVIDENCE_SQL, (1,)))
+
+    assert "ix_generic_page_snapshot_page" in plan, (
+        f"the freshness read fell back to the rowid, which cost 373 ms: {plan}")
+
+
+# MARKED, AND ONLY THIS ONE. `tests/test_the_extension_gate_is_complete.py` scans
+# for the panel's directory in any test file's source and requires the mark, because
+# a file that guards the panel and lacks it silently stops running on exactly the
+# pull requests it was written for. This file names `app.js` twice in prose and reads
+# nothing under that tree — but THIS test is the one that has to run when the panel
+# changes: it pins the shape `freshnessLine` reads, and the defect it covers was the
+# server and the panel disagreeing about that shape. Per-test rather than
+# module-level, the way `test_the_lint_gate_cannot_be_quietly_widened.py` does it,
+# and for the reason that file states: only the test that guards the panel needs to
+# run on a panel-only change.
+@pytest.mark.extension
+def test_the_card_reports_the_crawl_that_produced_its_rows(tmp_path):
+    """END TO END, through the route the panel actually calls.
+
+    `freshnessLine` (extension/app.js) prints "no successful crawl yet" whenever
+    `last_success` is missing or carries no `started_at` — and `_dataset_rows` used
+    to hand it the literal `None`. So the honest fix has to arrive at THIS key in
+    THIS shape, or the card goes on saying it whatever the warehouse holds.
+    """
+    from fastapi.testclient import TestClient
+
+    from scrapex.databases import DatabaseRegistry, EngineDatabase
+    from scrapex.webui.app import create_app
+
+    registry = DatabaseRegistry(EngineDatabase(tmp_path / "scrapex-engine.db"),
+                               pointer_file=tmp_path / "databases.json")
+    registry.initialize()
+    conn = registry.engine.connect()
+    try:
+        stored(conn)
+        # DATED AHEAD OF `stored`'s page, which carries `now` because `captured_at`
+        # is a column default. A fixed past instant would lose to it and the
+        # assertion would be about the clock instead of about the newest page.
+        _fed(conn, "2031-08-21T17:56:31Z", "https://muqawil.org/en/contractors?page=2")
+        conn.commit()
+    finally:
+        conn.close()
+
+    client = TestClient(create_app(databases=registry))
+    row = next(r for r in client.get("/api/sources").json()["sources"]
+               if r["source_key"] == "contractors")
+
+    assert row["last_success"], (
+        "the card says 'no successful crawl yet' over rows a crawl produced")
+    assert row["last_success"]["started_at"] == "2031-08-21T17:56:31Z", (
+        "the line reads 'Last crawled <started_at>', so it holds the newest capture")
+    # AND NO MEASURE BESIDE THE DATE. Both surfaces print `rows_seen` after it
+    # and fall back to `requests_count`, and a dataset has an honest number for
+    # neither: *seen* is `dataset_sighting`'s word — 17,417 sighted against
+    # 17,304 stored on his warehouse — and the stored pages are not the requests
+    # the crawl spent. Absent, which `last_successful_run` documents 0 as.
+    assert row["last_success"]["rows_seen"] == 0, (
+        "the stored row count is not what the site SHOWED us; "
+        "dataset_sighting answers that and answers it differently")
+    assert row["last_success"]["requests_count"] == 0
+    # The row count still reaches the card — on its own line, where it is right.
+    assert row["products"] == 4

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -88,7 +88,14 @@ DOCUMENTS = (
     "docs/APPROACHES.md",
 )
 
-SUFFIXES = "py|js|css|html|json|yml|yaml|sh|md|toml"
+# `sql` JOINED THIS LIST ON 2026-08-22, and the hole it closed was found by
+# writing into it. OP-44's argument rests on two lines of `db/engine/schema.sql`
+# -- a NOT NULL foreign key and an index's column order -- and neither of them
+# was a citation as far as this regex was concerned, in a repository whose DDL is
+# 1,153 lines and 61 migrations. Measured before the change: four `.sql`
+# citations across the documents, all four still true, so nothing was being
+# forgiven; they were simply never asked.
+SUFFIXES = "py|js|css|html|json|yml|yaml|sh|md|toml|sql"
 # `path:line` or `path:start-end`. The lookbehind keeps the match from starting
 # inside a longer path, so `scrapex/webui/app.py:1375` is one citation and not two.
 CITATION = re.compile(
@@ -112,10 +119,10 @@ PINNED = (
     # The version-gate blocker. Track 3 of STATE.md cannot be worked without
     # these three, and two of them are the citations that drifted.
     ("docs/STATE.md", "scrapex/version.py", 483, '"latest_extension_version": VERSION'),
-    ("docs/STATE.md", "scrapex/webui/app.py", 1481, '"latest_extension_version": VERSION'),
+    ("docs/STATE.md", "scrapex/webui/app.py", 1543, '"latest_extension_version": VERSION'),
     ("docs/STATE.md", "extension/app.js", 599, "latest_extension_version"),
     ("docs/STATE.md", "scrapex/version.py", 76, 'VERSION = "'),
-    ("docs/RULINGS.md", "scrapex/webui/app.py", 1481, '"latest_extension_version": VERSION'),
+    ("docs/RULINGS.md", "scrapex/webui/app.py", 1543, '"latest_extension_version": VERSION'),
     ("docs/RULINGS.md", "scrapex/version.py", 483, '"latest_extension_version": VERSION'),
     # The two flags whose condition is met and whose lighting is the owner's call.
     ("docs/STATE.md", "scrapex/features.py", 54, "True"),
@@ -133,8 +140,8 @@ PINNED = (
      'assert.equal(manifest.version, VECTORS.version)'),
     ("docs/RULINGS.md", "tests/test_version.py", 79, "pyproject"),
     # OP-2's two worker_alive computations, one of which the fix never reached.
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1492, '"worker_alive"'),
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2480, "def _about("),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1554, '"worker_alive"'),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2542, "def _about("),
     ("docs/BACKLOG.md", "scrapex/webui/templates/settings.html", 162, "about.worker_alive"),
     # BV-3's chain, end to end: the panel posts it, capture reads it.
     ("docs/BACKLOG.md", "extension/app.js", 840, "crawl_honour_delay:"),
@@ -198,13 +205,40 @@ PINNED = (
     # to unhide the five that answer 400.
     ("docs/BACKLOG.md", "extension/app.js", 4549,
      'if (source.kind === "dataset") return "";'),
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 639, '"kind": "dataset",'),
-    # 2710 -> 2725 on 2026-08-22: #252 measured this line on `main` at 4615a14 and
-    # #251 landed first, adding 15 lines to `app.py` above it. Two PRs, neither
-    # wrong on its own base, and `main` red between the second merge and this fix.
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2725, "if source_key not in known:"),
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 986,
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 697, '"kind": "dataset",'),
+    # 2710 -> 2725 -> 2787, and the third move is the same story as the first two.
+    # #252 measured this line on `main` at 4615a14, #251 landed first and added 15
+    # lines to `app.py` above it, and `main` was red between the second merge and
+    # the fix. This branch then inserted above it again. Three pull requests, none
+    # wrong on its own base -- which is why the number is re-read out of the file
+    # on every rebase and never adjusted by arithmetic.
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2787, "if source_key not in known:"),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1048,
      "A GENERIC DATASET IS A TABLE LIKE ANY OTHER TABLE"),
+    # OP-44 · the dataset card that said "no successful crawl yet" over 17,304
+    # crawled rows. Four citations carry the whole argument, and a reader sent one
+    # line off would conclude the entry is wrong about each of them in turn.
+    #
+    # The sentence itself, so it is clear the card reads a MISSING key and not a
+    # missing crawl -- which is why writing a `crawl_run` row would not have moved
+    # this line at all.
+    ("docs/BACKLOG.md", "extension/app.js", 4489, "const last = s.last_success;"),
+    # Why the row could not honestly be written: the column is NOT NULL into
+    # source_site, and muqawil is in site_profile.
+    ("docs/BACKLOG.md", "db/engine/schema.sql", 122,
+     "REFERENCES source_site(source_id)"),
+    # The index that is worth 390x and had no reader. The entry's claim is about
+    # its COLUMN ORDER, so it has to be read where the order is written.
+    ("docs/BACKLOG.md", "db/engine/schema.sql", 843,
+     "CREATE INDEX ix_generic_page_snapshot_page"),
+    # And the reason `max(page_snapshot_id)` is not a cheaper spelling: the merge
+    # carries the other machine's captured_at under fresh local ids. LESSONS §2
+    # generalises it past snapshots, so it is pinned in both documents -- the
+    # generalisation is worth nothing if the one INSERT it rests on has moved.
+    ("docs/BACKLOG.md", "scrapex/warehousemerge.py", 269,
+     "INSERT INTO generic_page_snapshot "),
+    ("docs/LESSONS.md", "scrapex/warehousemerge.py", 269,
+     "INSERT INTO generic_page_snapshot "),
 )
 
 # A guard that can be emptied without anyone noticing is the defect -- SR-23, and


### PR DESCRIPTION
He reported it from his own panel: the two muqawil datasets read `17,304 products`
and, under that, **"no successful crawl yet"**, while `aramco.com` and
`spark-eshop.com` beside them read *"Last crawled 16 August 2026, 8:00 AM — Africa/Cairo
· N rows seen"*. 17,304 rows plainly came from a crawl, so the card was wrong about
something it had the evidence to answer.

## The root cause, and it is not the missing `crawl_run` row

**`scrapex/webui/app.py:650` (before this change) wrote `"last_success": None` as a
literal**, and `freshnessLine` at `extension/app.js:4489-4490` prints that exact
sentence whenever the key is absent or carries no `started_at`:

```js
const last = s.last_success;
if (!last || !last.started_at) return "no successful crawl yet";
```

So the first thing the diagnosis had to settle is that **writing muqawil a `crawl_run`
row would not have moved this line at all.** The card was never reading `crawl_run` for
a dataset. It was reading a hard-coded `None`.

The suspicion in the brief — that the contractors pipeline never records a `crawl_run`
row — is **confirmed**: `_insert(conn, "crawl_run", …)` exists once in the codebase, at
`scrapex/ingest.py:958`, on the price path only. `contractors.py`, `snapshotcrawl.py`
and `partitioncrawl.py` write snapshots and records and never touch it.

## Measured on his live warehouse, READ-ONLY, while the profile crawl was running

`~/.scrapex/engine/scrapex-engine.db` opened `file:…?mode=ro`; nothing was written.

| | |
|---|---|
| `crawl_run` | **155 rows over twelve source keys** — `ADVANCEDCASTLE` … `SPARK_ESHOP`, **none for muqawil** |
| `source_site` | the same twelve keys; **muqawil is not among them** |
| `site_profile` | `muqawil` and `muqawil_org` — the other registry |
| `generic_record` | `contractors` **17,304**, `contractor_profiles` **704** |
| `generic_page_snapshot` | **24,480** pages, 1,728 with no `crawl_run_ref`, **139** distinct refs |
| schema | **v9** |
| evidence behind the rows | `contractors` **2026-08-21T17:56:31Z**, `contractor_profiles` **2026-08-21T21:44:48Z** |

## Which option, and why (b)

**Option (b): derive "last crawled" from the evidence already stored.** Three
independent reasons, each of them a measurement or a written decision rather than a
preference:

1. **(a) is neither necessary nor sufficient.** The card reads `last_success`, not
   `crawl_run`. A `crawl_run` row without this change leaves the sentence on screen;
   this change without a `crawl_run` row removes it.
2. **The row cannot be written honestly.** `crawl_run.source_id` is
   `NOT NULL REFERENCES source_site(source_id)` (`db/engine/schema.sql:122`) and
   muqawil has no `source_site` row. Option (a) therefore needs either a fabricated
   `source_site` row for muqawil or a migration relaxing a NOT NULL foreign key — and
   which registry a source lives in is exactly the open decision
   [`REQ-25`](docs/REQUESTS.md) holds, his to make. `sourceboard.py`'s own header
   already says so: *"Merging `site_profile` into `source_site` is a migration over
   live rows and the owner's decision."*
3. **`docs/GENERIC-FETCH-SEAM.md` asks both questions and answers neither.** Its
   closing section lists *"Does a generic crawl belong in the same job queue as a price
   crawl?"* as an open question for the owner — and `crawl_run.job_id` points into
   `crawl_job`, so writing the row from a CLI the scheduler does not drive would answer
   it by default. The same section says of the second-run question: *"It may be enough
   to ask `generic_ingestion`; **check before adding a column.**"* That is what this
   does.

Nothing new is stored. The display stops lying and the pipeline gains no state it did
not have.

## Four findings the measurement produced

**1. `generic_ingestion`, not `generic_record.source_snapshot_id`.** A record keeps
pointing at the snapshot that last **changed** it (`R-20`: unchanged means no
revision), so a confirming re-crawl would leave the date stale — the very complaint.
On his warehouse: 3,883 ingestions against 2,139 distinct record snapshots for
`contractors`, and the two answers differ (`17:56:31Z` against `17:54:31Z`).

**2. `ix_generic_page_snapshot_page` is worth 390x and had never been read.** It is
`(page_snapshot_id, captured_at)` (`db/engine/schema.sql:843`), created by migration
0014 and unused since. SQLite prefers the rowid, because `page_snapshot_id` IS the
rowid and the planner cannot see that the row it lands on carries a compressed ~100 KB
body. Measured over 24,480 pages, identical answer:

```
max(captured_at) over one dataset's ingested pages   353-373 ms  by rowid
                                            same       0.9 ms  INDEXED BY ix_generic_page_snapshot_page
```

For comparison, the shape that reads the records instead costs 27 ms with the same
hint and 145 ms without it — the join count is the difference, and both are the wrong
link (finding 1).

**3. `max(page_snapshot_id)` is not a cheaper spelling of the same thing.** It agrees
on this machine (0.2 ms) because `save_snapshot` never supplies `captured_at` and lets
the column default fire, so ids and timestamps rise together. **`warehousemerge.py:269`
breaks it on purpose:** the merge INSERTs the other machine's `captured_at` verbatim
under freshly assigned local ids, because rewriting it would forge the other machine's
evidence. So after the merge [`R-43`](docs/RULINGS.md) makes routine between his two
machines, the highest id can be the oldest page. 0.7 ms is not worth a claim his own
workflow falsifies.

**4. And the card carries NO measure beside the date, which is the fourth finding.**
Both surfaces print `rows_seen` after the instant and fall back to `requests_count`. The
obvious candidate was the dataset's row count — and ***seen* already means something
else in this warehouse.** `dataset_sighting` is *what the site showed us*, and on his
`contractors` the two numbers differ: **17,417 sighted against 17,304 stored.** Printing
the stored count under the word `seen` would put a wrong answer to a question this
schema can answer exactly. `requests_count` is no better: the stored pages are not the
requests the crawl spent, because retries, 304s and the Arabic half of every muqawil
page leave no second row. So both stay 0 — which `last_successful_run` already documents
as an absence rather than a measurement — the line reads *"Last crawled …"* and stops,
and the row count keeps its own line on the card, where it is right.

## And the shipped function was run against his warehouse, read-only

Not the query — the function this PR adds, imported from this worktree (asserted on
the symbol added here, not on `__file__`, because `__file__` catches a misdirected
import and never a misdirected edit):

```
contractors            Last crawled 2026-08-21T17:56:31Z   (1.66 ms)
contractor_profiles    Last crawled 2026-08-21T21:44:48Z   (0.31 ms)
```

Those are the two lines that used to read *"no successful crawl yet"*.

## `main` moved THREE times while this was open, and collided every time

Rebased twice, now onto `451468d` (#254). This is not cosmetic — #251 and #252 both
touched `scrapex/webui/app.py` and #252 and #254 both touched the citation guard:

- **Every id I reserved was taken from under me.** #252 claimed `REQ-30` and `OP-42`;
  #254 then claimed `REQ-31`, `REQ-32` and `OP-43`. Mine are now **`REQ-33`** and
  **`OP-44`**. Ids are never reused, so the numbers moved and the entries stayed where
  they were written — beside #252's and #254's, none overwritten, board order matching
  entry order.
- **Six pinned `app.py` citations moved**, four of them mine and **two of them
  #252's** — its `OP-42` cites `_dataset_rows`, the export route and the
  generic-table branch, and this change shifts all three. Every one re-read out of the
  rebased file rather than adjusted by arithmetic: `1543`, `1554`, `2542`, `697`,
  `2787`, `1048`.

**The export-route citation has now moved three times in one day** — `2710` → `2725`
→ `2787` — and #252's own note in `PINNED` records why the second move happened:
it measured the line on `main` at `4615a14`, #251 landed first and added fifteen lines
above it, and `main` was red between the two merges. Three pull requests, none wrong
on its own base. That comment is extended here rather than replaced, because the
pattern is the finding: **re-read the number, never adjust it.**

## The renumber left two references behind, and the second one is the finding

Caught in review, not by me. `OP-44`'s own body still linked to its `REQ` twin by the
number that request had two renumbers ago — link text `REQ-30`, anchor `#req-30--`
plus my entry's slug — and every part of that is wrong in a way nothing catches.
(Written out here without reproducing the anchor, because a dead anchor quoted as an
example is still a dead anchor to the next grep — which is the second half of this
finding.) The **text** names a different request (`REQ-30` is
#252's duplicated `⋮`), the **anchor** resolves to nothing, the citation guard only
checks `file:line` and not markdown anchors, and the board guard compares the board
against the entries, where this link is in neither.

**Then a sweep by SUBJECT found that one and missed a second.** Every line mentioning
the work, checked for the right id — which cannot find a reference that never names
the subject, and the survivor was exactly that: the `SUFFIXES` comment in the citation
guard, which said "OP-42's argument rests on two lines of schema.sql".

What found it was the opposite question, and it is two lines of script: **take every
id the diff introduces and print the heading that number actually names today.**

| id in the diff | what it names now | uses |
|---|---|---|
| `OP-42` | A generic dataset card offers no actions at all (#252) | 1 |
| `OP-44` | this entry | 4 |
| `REQ-25` | One source registry, with a category | 7 |
| `REQ-28` | The Engine would not install (the missing-quote precedent) | 1 |
| `REQ-30` | The three-dots button appears twice (#252) | 1 |
| `REQ-33` | this request | 2 |

Every anchor the diff introduces was then resolved against the live headings; all
five do. `OP` runs 1–44 and `REQ` runs 1–33 with **no hole**, so
`test_the_registers_cannot_collide.py`'s `RESERVED` needs no row from this branch —
`OP-45` and `OP-46` sit above the maximum, which that guard does not examine, and a
reservation for a number this branch does not own is the permanent hole its own
comment warns about.

Written up as **LESSONS §12** — *a register id is renamed by a sweep, never by an
edit* — with the line-number half of the same lesson beside it.

## What changed

| file | what |
|---|---|
| `scrapex/extract/service.py` | `LAST_EVIDENCE_SQL` + `last_evidence_captured_at()` — the one read, with the reasoning above in its docstring |
| `scrapex/webui/app.py` | `_dataset_freshness()` at module level; `_dataset_rows` calls it instead of writing `None`, and its query now selects `dataset_definition_id` |
| `tests/test_a_dataset_is_a_table_like_any_other.py` | five tests — newest-not-oldest, per-dataset scoping, never-crawled stays `None`, the query plan, and the card end-to-end through `/api/sources` (which also pins `rows_seen == 0`, with the `dataset_sighting` reason in the assertion) |
| `tests/test_the_documents_cite_what_they_claim.py` | `sql` added to `SUFFIXES`; six PINNED rows for OP-44's citations; four pinned `app.py` lines re-read after this diff moved them |
| `docs/BACKLOG.md` | **OP-44**, with the measurement and what stays open |
| `docs/REQUESTS.md` | **REQ-33** — he reported it, so it goes on the board, in English under the departure `REQ-28` already documents: his own words did not reach this session and an invented Arabic quote is the one thing that file exists to prevent |
| `docs/STATE.md` | the head it names was six PRs stale; plus the fix under Track 2 |
| `docs/LESSONS.md` | §2 — a rowid lookup is not free on a table of page bodies, and `max(id)` stops meaning latest once two warehouses are merged; **§12** — a register id is renamed by a sweep, never by an edit |

**No engine migration.** No schema change. The extension is untouched — `freshnessLine`
already renders this shape for price sources, which is why the fix arrives in it.

### A guard the documents did not have

`.sql` was **not** in the citation guard's `SUFFIXES`, so `db/engine/schema.sql:122`
and `:843` — the two lines OP-44's argument rests on — were not citations as far as
`tests/test_the_documents_cite_what_they_claim.py` was concerned, in a repository whose
DDL is 1,153 lines and 61 migrations. Added. Measured first: four `.sql` citations exist
across the eight documents and all four were already true, so nothing was being
forgiven — they were simply never asked.

## Mutations: six applied, six killed

Each one applied to the worktree file, the suite run, the file restored. The harness
refuses to start unless the symbol added in this session is present in the file it is
about to patch — `__file__` catches a misdirected import and never a misdirected edit.

| | mutation | killed by |
|---|---|---|
| M1 | the card is handed `None` again | `test_the_card_reports_the_crawl_that_produced_its_rows` |
| M2 | `max(captured_at)` → `min` | the newest-page test, the scoping test **and** the end-to-end test |
| M3 | the dataset drops out of the `WHERE` | the scoping test and the never-crawled test |
| M4 | no evidence invents a date | the never-crawled test |
| M5 | `generic_ingestion` → `generic_record` | the newest-page test |
| M6 | the `INDEXED BY` hint is removed | the query-plan test |

**M5 and M6 are the two that matter.** M5 is finding 1 turned into a guard: the
newest-page test feeds the same rows three times under different URLs, so the records
never move off the first snapshot and a record-based read returns the wrong date — the
stale-after-a-confirming-crawl failure, caught. M6 is the reason the plan test exists at
all: removing the hint changes **no answer**, so nothing that asserts on a returned
value can defend 390x, and it was written specifically to be killable.

## Two of this repository's own guards caught this change, and both were right

Worth recording, because both are the documentation system doing exactly what it was
built for rather than incidental friction:

1. **The citation pins.** Inserting into `scrapex/webui/app.py` moved six pinned
   citations, listed in the rebase section above. Every one re-read out of the target
   file rather than arithmetic'd, in `PINNED` and in the documents both. Two of the
   document numbers (`app.py:1470` / `:2458`) were **already** seven lines stale before
   this change and are corrected here too — which is the drift the guard exists for,
   caught in passing.
2. **The extension gate.** `tests/test_the_extension_gate_is_complete.py` scans every
   test file's source for the panel's directory and demands the mark, because a file
   that guards the panel and lacks it silently stops running on panel-only pull
   requests. Naming `app.js` in a docstring is enough to trip it — its own comment
   says the broad match is deliberate, *"a false positive costs one marker, a false
   negative costs a guard nobody notices is gone."* Resolved with
   `@pytest.mark.extension` on the **one** test that must run on a panel change,
   following `test_the_lint_gate_cannot_be_quietly_widened.py`'s precedent rather than
   marking all fifty. `pytest -m extension` is green: 738 tests.

## Verification

```
SCRAPEX_FULL_MIGRATIONS=1 python -m pytest -q
  3,190 tests: 3,179 passed, 10 skipped, 1 xfailed, 0 FAILED, 0 ERROR, exit 0
  reached [100%], and the run reported
  "schema template: DISABLED (SCRAPEX_FULL_MIGRATIONS) - every migrate() ran for real"

ruff check scrapex/     All checks passed!
pytest -m extension     green
pytest -m docs          green
```

Non-vacuous by the three checks R-22 asks for: the output is not empty (51 lines),
it reached 100%, and `grep -c ^FAILED` is 0 **on a file that has content**. The
count is read off the progress marks, since `-q` plus this repository's conftest
prints no summary line.

## What is NOT fixed, and it is his

The two registries. `crawl_run` still cannot describe a dataset, `site_profile` and
`source_site` are still two lists, and a generic crawl still has no run ledger of its
own. This closes a display. Whether a dataset should get a real run ledger — and
whether a generic crawl belongs in the price queue — are `REQ-25`'s and
`GENERIC-FETCH-SEAM.md`'s open questions, and both are his to rule on.

Per [R-37](docs/RULINGS.md) this PR is **not merged** — the merge is the main
programmer's.
