### PR TITLE
A membership carries what the site said about it, and the contractor does not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ work predates this file, the commit that built it — evidence read out of
 record of what was done; this file answers a narrower question: which version
 has it.
 
-## 0.3.0
+## 0.3.1
 
 Minimum supported extension: `0.2.2`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,16 @@ the thing came from: **he asked** → `REQUESTS.md`; **we found it** →
 `BACKLOG.md`; **a decision was taken** → `RULINGS.md`. The boundary table is in
 [docs/REQUESTS.md](docs/REQUESTS.md#the-boundary--which-file-does-a-thing-belong-in).
 
+**And several sessions run at once, which is its own discipline.** `R-42` says exactly
+one primary session merges — ask, never infer, and default to secondary. What that
+costs in practice is written in
+[docs/ORCHESTRATION.md](docs/ORCHESTRATION.md): on 2026-08-22 five sessions produced
+seven pull requests in an afternoon and also produced a red `main`, four register
+collisions, and 2,159 insertions of one session's work living only in a git index when
+the API limit hit. **Not one of those was a coding mistake** — they all failed at the
+seams between sessions. He gave the primary session the standing right to evolve that
+file: «ولها الحق انها تطور workflow لتجنب المشاكل التى تقابلها».
+
 ---
 
 ## The map
@@ -109,6 +119,7 @@ the thing came from: **he asked** → `REQUESTS.md`; **we found it** →
 | [docs/BACKLOG.md](docs/BACKLOG.md) | what *we* found — open problems, declared debt, decided-not-built, questions for him | when hunting for what needs doing |
 | [docs/LESSONS.md](docs/LESSONS.md) | hard-won engineering knowledge — the traps that cost real time, the failures that are silent | before touching ingest, the warehouse, the design system, or the version ledger |
 | [docs/APPROACHES.md](docs/APPROACHES.md) | **the methods available** for writing code and solving problems, and which wins where two disagree | when choosing how to attack a task |
+| [docs/ORCHESTRATION.md](docs/ORCHESTRATION.md) | **how the primary session runs several sessions and agents at once** — the merge sequence, register numbers, rescuing unsaved work, and what a green is allowed to mean | before spawning a session, claiming a register number, or merging anything |
 | [ENGINEERING.md](ENGINEERING.md) | the code rules — architecture, quality, testing, performance | before writing code |
 | [docs/plans/](docs/plans/README.md) | the plans, current and historical | when picking up a track |
 

--- a/contracts/capability-baseline.json
+++ b/contracts/capability-baseline.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "0.3.1",
   "minimum_extension_version": "0.2.2",
   "capabilities": {
     "crawl_pace": "0.2.0",

--- a/contracts/contract-baseline.json
+++ b/contracts/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "0.3.1",
   "schema": [
     "0002_the_price_source_key_is_named_for_what_it_is.sql",
     "0003_a_source_says_how_deep_its_crawl_goes.sql",
@@ -8,7 +8,8 @@
     "0006_a_row_says_when_it_was_last_proved_absent.sql",
     "0007_a_taxonomy_says_which_site_it_belongs_to.sql",
     "0008_a_page_remembers_how_to_ask_whether_it_changed.sql",
-    "0009_a_contractor_points_at_a_taxonomy_instead_of_repeating_it.sql"
+    "0009_a_contractor_points_at_a_taxonomy_instead_of_repeating_it.sql",
+    "0010_a_membership_carries_what_the_site_said_about_it.sql"
   ],
   "protocol": "1",
   "endpoints": [

--- a/contracts/version-vectors.json
+++ b/contracts/version-vectors.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "0.3.1",
   "minimum_extension_version": "0.2.2",
   "capability_reporting_since": "0.2.0",
   "note": "Both copies of capabilityProblem must reproduce every `problem` string exactly. Python: scrapex/version.py. JavaScript: extension/version.js.",
@@ -7,8 +7,8 @@
     {
       "name": "in step — the engine deploys it and the extension is new enough",
       "key": "crawl_parallel_sources",
-      "extension_version": "0.3.0",
-      "engine_version": "0.3.0",
+      "extension_version": "0.3.1",
+      "engine_version": "0.3.1",
       "deployed": {
         "crawl_pace": {
           "since": "0.2.0",
@@ -50,7 +50,7 @@
       "name": "the extension is behind the engine",
       "key": "crawl_parallel_sources",
       "extension_version": "0.1.0",
-      "engine_version": "0.3.0",
+      "engine_version": "0.3.1",
       "deployed": {
         "crawl_pace": {
           "since": "0.2.0",
@@ -86,12 +86,12 @@
         }
       },
       "update_instructions": "Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards.",
-      "problem": "«Crawl several different sites at the same time. Two sources on the SAME site still take turns, so no site is asked for more than before.» needs ScrapeX extension 0.2.0; this extension is 0.1.0 and the engine is 0.3.0. Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards."
+      "problem": "«Crawl several different sites at the same time. Two sources on the SAME site still take turns, so no site is asked for more than before.» needs ScrapeX extension 0.2.0; this extension is 0.1.0 and the engine is 0.3.1. Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards."
     },
     {
       "name": "the engine is behind and says so",
       "key": "crawl_parallel_sources",
-      "extension_version": "0.3.0",
+      "extension_version": "0.3.1",
       "engine_version": "0.1.0",
       "deployed": {
         "crawl_pace": {
@@ -124,22 +124,22 @@
         }
       },
       "update_instructions": "Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards.",
-      "problem": "«crawl_parallel_sources» is not deployed by this ScrapeX engine (0.1.0); this extension is 0.3.0. Update the engine to 0.3.0 or newer."
+      "problem": "«crawl_parallel_sources» is not deployed by this ScrapeX engine (0.1.0); this extension is 0.3.1. Update the engine to 0.3.1 or newer."
     },
     {
       "name": "the engine is too old to say anything",
       "key": "crawl_parallel_sources",
-      "extension_version": "0.3.0",
+      "extension_version": "0.3.1",
       "engine_version": "0.1.0",
       "deployed": null,
       "update_instructions": "Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards.",
-      "problem": "«crawl_parallel_sources» cannot be confirmed: the ScrapeX engine reports version 0.1.0 and is too old to say which features it deploys. This extension is 0.3.0. Update the engine to 0.3.0."
+      "problem": "«crawl_parallel_sources» cannot be confirmed: the ScrapeX engine reports version 0.1.0 and is too old to say which features it deploys. This extension is 0.3.1. Update the engine to 0.3.1."
     },
     {
       "name": "an extension newer than the requirement is not refused for being newer",
       "key": "crawl_parallel_sources",
       "extension_version": "9.9.9",
-      "engine_version": "0.3.0",
+      "engine_version": "0.3.1",
       "deployed": {
         "crawl_pace": {
           "since": "0.2.0",

--- a/db/engine/migrations/0010_a_membership_carries_what_the_site_said_about_it.sql
+++ b/db/engine/migrations/0010_a_membership_carries_what_the_site_said_about_it.sql
@@ -1,0 +1,84 @@
+-- =====================================================================
+-- 0010 — A MEMBERSHIP CARRIES WHAT THE SITE SAID ABOUT IT
+--
+-- `R-45`, his ruling of 2026-08-22, and it arrived as a refusal of the
+-- question I asked him. `Q-17` offered two options for the licences' readiness
+-- level — a column on the contractors table, or read it and do not store it —
+-- and he took neither:
+--
+--     «لا داعى لوضعها فى عمود خاص فى الجدول ولكن عند الضغط على صف معين وهو
+--      يحملها تظهر فى الكارد الخاص بالمقاول · لان المقاولون سيكون هناك عدة
+--      مصادر له فى المستقبل»
+--
+-- A field is not a column. The readiness level is a real fact the site
+-- publishes and it is stored; it is simply not a column on the contractors
+-- table, because a column is a promise every source in the category must keep
+-- and `المقاولون` will have Balady, the UAE registries and the Gulf sources.
+--
+-- SO IT BELONGS TO THE MEMBERSHIP, NOT TO THE CONTRACTOR, and that is a fact
+-- about the data rather than a convenience. `مستوى الجاهزية` is published in
+-- the licences table BESIDE each activity — one readiness per activity, not one
+-- per company. A contractor with six licences can hold `أساسي | Basic` on one
+-- and nothing on the other five, which is exactly what the committed fixture
+-- does. On the contractors table that fact has nowhere to live that is not a
+-- lie about which activity it describes.
+--
+-- WHY THREE GENERIC COLUMNS AND NOT ONE CALLED `readiness`. `generic_record_node`
+-- is the link table for EVERY site's groups, and a column named for muqawil's
+-- vocabulary on a generic table repeats the mistake his ruling was about, one
+-- level down: Balady's per-membership attribute would want a fourth column and
+-- the UAE's a fifth. So the SITE names the attribute — `attribute_label` holds
+-- `مستوى الجاهزية` as published — and `R-45`'s other half is why that is the
+-- honest shape: «ما يقوله الموقع هو مصدر الحقيقة الوحيد لا نعدل عليه».
+--
+-- AND WHY COLUMNS RATHER THAN A CHILD TABLE, which `R-19` would otherwise
+-- suggest. `R-19` rules that MULTI-VALUED groups go in child tables; a
+-- membership attribute measured over 1,685 real licence rows is
+-- SINGLE-valued — one label, one value, on 10 of 1,500 rows, five distinct
+-- values (`ذهبي | Gold`, `فضي | Silver`, `ماسي | Dimond` as the site spells
+-- it, `أساسي | Basic`). A child table for one nullable value would be the
+-- machinery `0009`'s own header warns about: *"Existing machinery that has
+-- never carried a row is not an asset."* If a second attribute ever appears,
+-- the child table is that migration — and the snapshots make it a re-parse
+-- with no network, not a re-crawl.
+--
+-- NO CHECK CONSTRAINT ON THE VALUE, deliberately. The five levels are a closed
+-- set today and a `CHECK` would turn the site adding a sixth into an error we
+-- invented. `R-45` again: the site is the record, and this schema does not get
+-- a vote on its vocabulary.
+--
+-- NULLABLE, AND THAT IS THE COMMON CASE. 1,490 of 1,500 measured licence rows
+-- publish no readiness at all, and interests publish none by construction —
+-- there is no column beside them. An empty attribute is a contractor whose
+-- activity the site has not graded, which is a real state and not a gap.
+--
+-- ADDITIVE ONLY. Three nullable columns on a `WITHOUT ROWID` table: every one
+-- of the 15,559 memberships already stored keeps its row untouched and reads
+-- NULL, and the next `--approve` over the snapshots on disk fills in the ten
+-- per fifteen hundred that have something to say.
+-- =====================================================================
+
+-- What the SITE calls this attribute, in the site's own words. `مستوى الجاهزية`
+-- for muqawil's licences. NULL where the group publishes no attribute column at
+-- all, which is every interest.
+ALTER TABLE generic_record_node ADD COLUMN attribute_label TEXT;
+
+-- The value as published, Latin half. `Basic` out of `أساسي | Basic`.
+--
+-- SPLIT ON THE SITE'S OWN PIPE AND NEVER TRANSLATED. Measured over 1,500 rows,
+-- the readiness cell is `<arabic> | <latin>` and nothing else; where the site
+-- publishes no Latin half this stays NULL rather than borrowing the Arabic,
+-- for the same reason `classification_node.node_name` does — an empty English
+-- name is repairable by a later page and a wrong one is not.
+ALTER TABLE generic_record_node ADD COLUMN attribute_value TEXT;
+
+-- The value as published, Arabic half. `أساسي`.
+ALTER TABLE generic_record_node ADD COLUMN attribute_value_ar TEXT;
+
+-- "Which contractors hold a GRADED licence, and at what level" is the read this
+-- exists for — the question the card asks per row and an export asks per table.
+-- Partial, because 99.3% of the rows measured have nothing here and an index
+-- over 15,559 NULLs would be paid for on every write to buy nothing.
+CREATE INDEX IF NOT EXISTS ix_record_node_by_attribute
+    ON generic_record_node(group_key, attribute_value_ar)
+    WHERE attribute_value_ar IS NOT NULL;

--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -1,0 +1,329 @@
+# Many sessions, one `main` — how the primary session runs the queue
+
+**Read this before spawning a session, before claiming a register number, and before
+merging anything.**
+
+He works with several Claude sessions and several agents at once, and on 2026-08-22 he
+asked for this document by name:
+
+> «دائما طور workflow الخاص بالتعامل مع الجلسات الاخرى و agents حتى لا نفقد شى ونكون
+> اسرع فى التنفيذ · يمكنك اضافة ملف يوضح كيف يتعامل الsesion الرئيسية المسشؤولة عن الدمج
+> ولها الحق انها تطور workflow لتجنب المشاكل التى تقابلها وتسرع وتيرة التنفيذ والدمج»
+
+So: **the primary session owns this file and is expected to change it.** A rule here that
+cost an afternoon and did not prevent the next afternoon's version of the same thing is a
+bug in this document, and fixing it is part of the work — the same standing that **C2**
+gives the rest of the system.
+
+**Every rule below was paid for.** The date beside each one is the day it cost something,
+and the count is what it cost. Nothing here is a preference.
+
+---
+
+## 0 · Why this file exists at all
+
+On **2026-08-22** five sessions worked one repository for one afternoon. The output was
+good — seven pull requests, a published release, a 1,685-row measurement that overturned
+four written premises. The *coordination* produced, in the same afternoon:
+
+| what happened | cost |
+|---|---|
+| `main` went **red** from two pull requests that were each green on their own base | one broken `main`, repaired in a third PR |
+| **four** register-number collisions between sessions | four renumbers, one of them twice |
+| 2,159 insertions of another session's work living **only in a git index** when the API limit hit | nearly lost; recovered by snapshot |
+| a 34,834-page crawl killed by the same limit and not noticed for hours | ~3 h of machine time |
+| a reservation row that **passed its own guard the whole time it was wrong** | a permanent hole nobody owned |
+| one session read a suite as green off a compound command's exit code | two real failures nearly merged |
+
+**Not one of those was a coding mistake.** Every session was careful, every claim was
+measured, and every measurement was true when it was made. They failed at the *seams*,
+and the seams are what this file is about.
+
+---
+
+## 1 · There is exactly one primary session, and it is the only one that merges
+
+`R-42`. The primary session merges; every other session and agent pushes a branch,
+opens a pull request if it is green, and **stops there**.
+
+**Ask, never infer.** A session that assumes it is primary because nobody said otherwise
+is the one that merges over somebody. The default is secondary.
+
+**What the primary owes in return**, and this is the half that is usually skipped:
+
+- **The base SHA at the moment of the merge, not before it.** Never hand a session
+  `main`'s SHA and let it plan around that; tell it when its turn arrives.
+- **The merge order, and a warning when the order changes.**
+- **A register number when asked**, from the ends that are actually free — see §3.
+- **A correction when the primary is wrong.** On 2026-08-22 the primary was corrected by
+  peers **five** times: a false z-index claim, a `source_product` index it had measured
+  with a blind query, a `RESERVED` row it had orphaned by describing only one side of a
+  renumber, `Q`'s exclusion being declared rather than silent, and `REQ-30` already being
+  taken. A primary that is not being corrected is not being read.
+
+---
+
+## 2 · The merge, step by step
+
+The order matters and it is decided **at merge time**, never in advance.
+
+1. **`git fetch`. Read `main`'s SHA now.** Any SHA you were told earlier is a guess.
+2. **Check the PR is `MERGEABLE` *and* `CLEAN`.** `UNSTABLE` means a check is still
+   running. `DIRTY` means it conflicts. Read both fields separately — and read them with
+   two commands, because `jq`-style string joins get mangled by MSYS path translation on
+   this machine and a guard that reads `MERGEABLEC:/Program Files/Git/CLEAN` refuses for
+   the wrong reason. *(2026-08-22: this actually happened and the refusal was correct by
+   accident.)*
+3. **Merge one. Verify it landed** — `state == MERGED` and a `mergedAt` — rather than
+   trusting the command's output. A merge that reported success and did not happen has
+   occurred here before.
+4. **`main` has now moved. Every remaining PR is stale.** Tell each one, by name, with
+   the new SHA. Do not let one of them discover it from a red CI run.
+5. **Squash-merge.** This repository's history is one commit per PR with `(#nnn)`.
+
+### The failure this sequence exists to prevent
+
+> **#252 and #251 changed no file in common and broke each other anyway.**
+
+`#251` added fifteen lines to `scrapex/webui/app.py`, moving a symbol from line 2710 to
+2725. `#252` had pinned that symbol at **2710** — correct against the base it was tested
+on — and never touched `app.py`. Git found nothing to conflict on. GitHub did not
+recompute `#252`'s merge check after `#251` landed. **Both PRs were green, truthfully,
+about a base that had stopped existing**, and `main` was red the moment the second one
+merged.
+
+**"Do the files overlap?" is the reflex that fails here.** They were *disjoint in files
+and coupled in content*.
+
+**The only mechanical fix is a repository setting, not a workflow file:** `require
+branches up to date` on `main`, which forces the rebase that makes CI recompute. Nothing
+in `.github/workflows/` can catch it, because the checks were not wrong — they were
+answers to a question nobody asked again. That setting is `REQ-11` and it is **his**.
+
+Until it is on, the primary carries the rule by hand: **after every merge, every
+remaining PR must rebase and re-run before it is eligible.**
+
+---
+
+## 3 · Register numbers: the rules that stopped four collisions
+
+`REQUESTS.md`, `RULINGS.md` and `BACKLOG.md` hand out sequential numbers, and several
+sessions take "the next free one" simultaneously.
+
+**An open pull request outranks a branch without one.** When two sessions hold the same
+number, the one with the open PR keeps it and the other moves. Otherwise two sessions
+renumber past each other indefinitely — which is exactly what began to happen on
+2026-08-22 before this rule was stated.
+
+**An unpushed claim is invisible and still real.** Three sessions concluded this
+independently in one afternoon. `OP-47` and `OP-48` were free in **all 164 refs** and
+still taken; a session stepped over them rather than trust the repository, and it was
+right. So:
+
+- When you assign numbers, name **every** holder you know of, including the ones with
+  nothing pushed.
+- When you receive numbers, **step over anything you were told is claimed**, even if you
+  cannot see it. Two skipped numbers cost nothing; a collision costs a merge.
+
+**A declared hole must name a holder a reader can verify** — a branch ref or a PR number,
+**never a description of a session**. `RESERVED` in
+`tests/test_the_registers_cannot_collide.py` is the mechanism, and it is not optional:
+the guard fails on a *hole* as well as on a duplicate, so a skipped number without a
+`RESERVED` row is a red build.
+
+Two reasons the holder must be a ref, both met the same day: **sessions do not outlive
+their branches**, and **the claim may be unverifiable from the repository at the moment
+it is written**.
+
+**The branch that creates a reservation deletes it** — unless the branch that fills the
+number has already merged, in which case the reservation is not merely stale but *fails*
+`test_a_reserved_number_is_not_also_declared`. Delete it on the rebase. Never delete
+another branch's row.
+
+### And the failure mode of the mechanism itself
+
+> **A `RESERVED` row passed the gap check the entire time it was wrong.**
+
+A row naming a holder that had moved off the number satisfied every guard while the
+register carried a permanent wart. Nothing caught it; a session *asking who holds 44*
+caught it. **A row is a claim about the world and it rots exactly like a line citation
+does** — so re-check the rows you inherit rather than inheriting them.
+
+**One register is deliberately unguarded and says so:** `Q-nn` is written in bold rather
+than as a heading, and `Q-11`, `Q-14` and `Q-17` each legitimately appear twice — once as
+asked and once as answered. Guarding it would produce a failure that is not a defect.
+That exclusion is declared at the point of definition, which is what makes it debt rather
+than a blind spot. Do not "fix" it without a ruling: under a heading-based register a
+`C4` struck-and-kept question reads as a duplicate, so **the register guard and `C4` are
+in direct conflict** and that is his decision.
+
+---
+
+## 4 · Citations: re-derive, never carry
+
+`tests/test_the_documents_cite_what_they_claim.py` tests every `file:line` a document
+writes, and `PINNED` pins the ones that matter to a symbol.
+
+**Re-derive every cited line from the file, at the base you are about to push onto.**
+Computed, never typed. On 2026-08-22 this bit five times: `app.py:2710 → 2725 → 2787` in
+one day, `domain.py:201/:297 → :206/:329`, `webui/app.py:2589 → :2604`, `cli.py:164 →
+:185`, and one session's *own* edit moving its *own* pinned line inside the very PR that
+added the lesson about it.
+
+**Do not pin a line in a file another session is editing.** Cite the symbol in prose and
+say why it is unpinned, with the commit the measurement was taken at. A session that
+pinned seven citations into `extension/app.js` while another session was rewriting it
+would be knowingly shipping the failure above.
+
+**Write measurements as measurements.** *"Measured at `451468d`"* — a commit, not a
+standing claim. Four of the six things that went wrong that afternoon were **true
+measurements that outlived their base**.
+
+**Better still, make the citation carry its own correction:** *"cite `REQ-36` once it is
+on `main`; `REQ-30` is its root and is truthful until then."* A note that fixes itself is
+one nobody has to remember.
+
+---
+
+## 5 · Never lose work: commit before you verify
+
+The repository's own discipline is *do not touch the tree while the suite runs*, so the
+green describes the tree that gets committed. **That discipline has a cost nobody had
+priced: the work sits uncommitted for exactly as long as the suite takes** — and a full
+run here is twenty minutes or more.
+
+> **A practice adopted to prevent one failure can create a second one, and only stating
+> both makes the practice safe.**
+
+So: **commit first, run the suite against the commit, amend if it fails.** A commit is
+recoverable; an index is not. On 2026-08-22 an API limit hit a session holding **2,159
+insertions across 16 files in its index alone**, with the pushed branch pointing at a
+pre-rebase commit. It survived by luck and a snapshot.
+
+### How the primary rescues another session's work without disturbing it
+
+`git stash create` writes a commit object and **does not** stash, reset or clean anything:
+
+```bash
+sha=$(git -C <worktree> stash create "safety: <whose> work, <date>")
+git -C <worktree> update-ref refs/safety/<name>-<date> "$sha"
+git -C <worktree> push origin refs/safety/<name>-<date>:refs/heads/safety/<name>-<date>
+```
+
+Then tell that session exactly what you did and that its index is untouched. Also push
+any **unpushed commit** on a branch nobody has pushed — a whole commit living in one
+worktree is as fragile as an index.
+
+**Audit for this rather than waiting for it.** One command over every worktree:
+
+```bash
+for w in .claude/worktrees/*/; do
+  b=$(git -C "$w" branch --show-current)
+  echo "$w  $b  dirty=$(git -C "$w" status --porcelain | wc -l)" \
+       " local=$(git -C "$w" rev-parse --short HEAD)" \
+       " remote=$(git -C "$w" rev-parse --short "origin/$b" 2>/dev/null || echo none)"
+done
+```
+
+Three states are dangerous and all three occurred that day: **dirty**, **local ahead of
+remote**, and **branch not on the remote at all**.
+
+---
+
+## 6 · Long-running work dies with the session that started it
+
+A crawl, a suite or a build launched from a session's shell is killed when that session
+is cut off. On 2026-08-22 a 34,834-page crawl died at **38.6%** with an API limit and was
+not noticed for hours, because nothing was watching it and its absence looked exactly
+like its silence.
+
+- **Launch long work detached** (`nohup … &`) so a session ending does not end it.
+- **Prefer resumable commands.** `--details --run-ref <ref>` re-reads what it stored and
+  continues; the frontier comes off the disk with no network.
+- **When a session is restored, check the machine before checking the code.** Is the
+  crawl alive? Is a suite still running? Compare *last written row* against *now*, not
+  against your memory of it.
+
+---
+
+## 7 · Verification, and the two ways a green lies
+
+**Non-vacuous or it does not count.** Every one of these has produced a false green here:
+
+| check | why |
+|---|---|
+| output is **non-empty** | `grep -c FAILED` on an empty file is `0`, and five tests were failing |
+| it reached **`100%`** | a suite killed at 40% prints no failures either |
+| `grep -c '^FAILED'` is **0** | `addopts` already carries `-q`, so `-q` makes it `-qq` and pytest prints **no** summary line at all |
+| `grep -c '^ERROR'` is **0** | collection errors are not failures |
+| the exit code is **pytest's** | `cmd; echo "exit=$?"` in a compound reports the **echo**'s status. This read as green with two real failures |
+| the run started **after** the last edit | compare mtimes; a green about an older tree is not a green |
+
+**A guard is untrusted until the defect it names makes it red.** Restore the defect, watch
+it fail, restore the fix, re-run the control. Mutation caught, that afternoon: three
+guards that passed under their own defect, a `.pyc` that kept a mutation alive after a
+byte-identical restore (purge `__pycache__` between runs), and a guard whose *non-vacuity
+assertion* broke when the repository became correct.
+
+**Simulate the red build on the tree instead of finding out from CI.** Two sessions
+predicted a failing check by running the guard's own logic against the post-merge state,
+before pushing. That is minutes against a round trip, and it is the single biggest
+throughput win available.
+
+---
+
+## 8 · Delegating: a brief is not a record
+
+**Anything he asks for goes on the board in the session he asked it** — `C7` — **and
+briefing an agent does not count.** On 2026-08-22 two requests of his were briefed to a
+session within a minute, acted on correctly, and never reached `REQUESTS.md`. Nothing but
+one agent's context knew they had been asked for. It surfaced only because a *different*
+session quoted him in a `BACKLOG` entry and
+`test_every_finding_that_quotes_him_is_reachable_from_the_request_board` refused it.
+
+**That guard reports a pair, not two faults:** a finding that quotes him with no request
+of his to answer. The temptation when it fires is to delete the quote and move on — which
+leaves his request off the board with the test green. **Capture the request instead.**
+
+`REQ-04` is why: ruled, unbuilt, and out of sight for sixteen days.
+
+### What a brief must carry
+
+An agent starts with nothing. Every brief needs: the **base ref**, the **register numbers
+it may take**, the files another session is editing, the non-vacuity rules from §7, *do
+not merge* (`R-42`), *never `git add -A`* (`SR-19`), *never write to the live warehouse*,
+and **what to report** — including *what it found that contradicts the brief*, which is
+consistently the most valuable thing that comes back.
+
+---
+
+## 9 · Speed: what actually made it faster
+
+Measured across that afternoon, not guessed:
+
+- **Parallel read-only lenses over one question.** Four agents reading four aspects of
+  the same subsystem, then one synthesis, then adversarial refutation. It found a **price
+  column no document in the repository had ever named**, and it found it because one lens
+  was told to census what the page *has* rather than check what we expected.
+- **Adversarial verification before building.** Three refuters told to *refute*, not
+  review. A design that survives a real attempt is worth more than one nobody attacked.
+- **Snapshot, then continue.** Rescuing work with `git stash create` cost seconds and did
+  not interrupt the session holding it.
+- **Answer a peer's question with a measurement, not an opinion.** Every cross-session
+  disagreement that afternoon was settled by one query against the live warehouse or one
+  `git show`. None was settled by argument.
+- **Say the number.** «١٧٢٦٩ من ١٧٤١٧ مخزَّن» ends a conversation that "coverage looks
+  good" would have extended by three rounds.
+
+And what made it **slower**, so it is not repeated: renumbering four times; three sessions
+independently re-deriving the same citations; and one full suite discarded because the
+tree was edited mid-run.
+
+---
+
+## 10 · The standing invitation
+
+He gave the primary session the right to change this document, and that right comes with
+an obligation: **when the seams cost something, the rule that failed is written here
+before the session ends.** Add the date and the count. A rule without its price is a
+preference, and preferences do not survive the next afternoon.

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -93,6 +93,7 @@ IDs are stable and never reused, matching the convention BACKLOG.md already uses
 | [REQ-36](#req-36--the-three-dots-are-missing-on-a-contractor-card-and-unprofessional-on-the-others) | The three dots are missing on a contractor card, and unprofessional on the others | **In flight** — a session is measuring which treatment he means before restyling | 2026-08-22 |
 | [REQ-37](#req-37--one-card-per-site-and-its-crawls-are-options-under-it--the-way-gpp-does-it) | One card per site, and its crawls are options under it — the way GPP does it | **Ruled** ([R-47](RULINGS.md#r-47--muqawil-is-one-card-with-two-crawls-and-the-two-stored-datasets-stay-two)) — two crawls of one dataset; the storage stays two | 2026-08-22 |
 | [REQ-38](#req-38--the-backup-must-check-its-own-digest-and-the-panel-must-be-able-to-finish-the-build) | The backup must check its own digest, and the panel must be able to finish the build | **Captured** — measured: the digest is written and never read; the button aborts at 10 s on a 5-minute build | 2026-08-22 |
+| [REQ-39](#req-39--the-extension-must-report-what-drive-holds-because-nothing-else-can-ask) | The extension must report what Drive holds, because nothing else can ask | **Captured** — the panel is the only holder of the token and it stores no answer | 2026-08-22 |
 
 ---
 
@@ -1808,3 +1809,89 @@ the deadline** — `git show` on that commit touches none of `extension/startup.
 **Filed while the workaround is still fresh**, which is the point: the manual procedure
 that produced tonight's backup is written down in the same session, so this request can be
 measured against something that actually ran rather than against a description of it.
+
+---
+
+## REQ-39 · The extension must report what Drive holds, because nothing else can ask
+**Captured 2026-08-22 · Not built**
+
+> «اذن يجب ان نجعل الاضافة تخبرنا بحالة الرفع · امال هنتاكد ونتابع ازاى»
+
+He said it after being told that the session could verify the local bundle completely —
+73 files CRC-checked, both digests matched — and could **not** confirm the upload, because
+Drive authentication lives in the extension (`chrome.identity`) and no session is going
+into his account.
+
+**He is right, and the gap is larger than tonight's verification.**
+
+### The measurement
+
+`extension/drive.js` is the only holder of a Drive token in the product. Measured on
+`main`: the panel's Drive surface calls `renderDriveFacts` with `state: "error"` and a
+failure detail — and there is **no success state carrying what Drive actually contains.**
+No file listing, no size, no digest, no time of the last upload that worked.
+
+**And the knowledge does not leave the panel.** Nothing writes it anywhere. So closing the
+side panel closes the only window onto Drive, and nothing in the repository, the
+warehouse, or the CLI can answer *"is the backup there?"*
+
+### Why that contradicts a ruling of his own
+
+`R-43` makes **Drive the source of truth for DATA** and the repository the source of truth
+for CODE. A source of truth nobody can query is not a source of truth. Today the honest
+description is: the backup exists in a place only one browser tab can see, and only while
+it is open.
+
+It also makes `REQ-38` unobservable. That request asks for the digest to be verified
+automatically — but **a verification whose result is not recorded cannot be trusted or
+audited**, only re-run. The two requests are halves of one thing: *check it by machine*,
+and *say what the machine found, durably.*
+
+### The channel already exists and has never been used this way
+
+The panel already talks to the engine over `127.0.0.1:8000` on every poll. So:
+
+1. **The panel asks Drive**, which only it can do: the backup folder's listing with
+   `id, name, size, createdTime, sha256Checksum` — the same `files.get` fields the
+   unmerged branch `claude/drive-without-a-server` already added for its own check.
+2. **It compares** each file against the local manifest the engine produced, and forms a
+   verdict per file: verified by digest, verified by size only, mismatched, or absent.
+3. **It reports the verdict to the engine**, which stores it — so the state is durable and
+   readable with the panel closed.
+4. **`scrapex drive-status` prints it**, the way `database-status` prints the warehouse's.
+
+**The evidence, not the conclusion.** The stored record must say *which* evidence it had —
+Drive's own `sha256Checksum`, a size match, or nothing — because on `main` today the
+download path compares a byte count and an absent digest is treated as a pass. A status
+line reading *"verified by size only"* is useful; one reading *"verified"* when nothing was
+compared is worse than silence.
+
+**And it must be honest about staleness.** What the panel last saw is not what Drive holds
+now — another machine may have uploaded since. So the record carries the time it was taken
+and the CLI says so, rather than presenting a remembered answer as a current one. That is
+the same rule this repository learned four times today about measurements and their bases.
+
+### What it buys, concretely
+
+- **Tonight's question answered by a command** instead of by reading a size in a browser.
+- **Multi-device tracking at all**, which is what he asked for originally: «حتى استطيع
+  الوصول اليها من عدة اجهزة». Two machines can only coordinate through a state both can
+  read, and right now neither can read anything.
+- **A pruning decision that can be reviewed.** `extension/drive.js` keeps three files and
+  deletes the rest with `files.delete`, which **bypasses the trash** — and it chooses by
+  Drive's own `createdTime`, not by anything it verified. A recorded listing makes that
+  reviewable before it is destructive rather than after.
+
+### The workaround, until it is built
+
+The two numbers to compare by hand in Drive's file details, for the backup of
+2026-08-22 — recorded here because a workaround that is not written down is a workaround
+that gets misremembered:
+
+| file | bytes | sha256 |
+|---|---|---|
+| `scrapex-bundle-20260822-153242.zip` | **309,589,440** | `aabf5c2678218cf82d60d6e42b86e8f7c9e46305d8c8ee045466e8e844c555e7` |
+| `scrapex-bundle-20260822-153242-panel.jsonl.gz` | **4,386,341** | `fa58ea4bf5022a19bcb86df6ac35f429bbea0c37c3e3279c7ead123e4db28ff6` |
+
+A browser upload does not leave a truncated file — it either completes at full size or
+fails and leaves nothing — so a size match is sufficient evidence that it finished.

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -89,6 +89,8 @@ IDs are stable and never reused, matching the convention BACKLOG.md already uses
 | [REQ-31](#req-31--start-the-profile-parser--and-the-pages-are-not-consistent) | Start the profile parser — and the pages are not consistent | **In flight** — the cards are built, guarded and mutation-tested; `Q-17` and `Q-18` are his | 2026-08-22 |
 | [REQ-32](#req-32--fixed-columns-and-everything-else-in-the-rows-own-card) | Fixed columns, and everything else in the row's own card | **Ruled** ([R-45](RULINGS.md#r-45--the-site-is-the-only-source-of-truth-and-a-field-the-table-does-not-need-goes-in-the-rows-card)) — not built; the card does not exist on either surface | 2026-08-22 |
 | [REQ-33](#req-33--the-dataset-cards-said-no-successful-crawl-over-crawled-rows) | The dataset cards said "no successful crawl yet" over 17,304 crawled rows | **Done** — the date is derived from the evidence; the two registries stay his | 2026-08-22 |
+| [REQ-35](#req-35--the-card-must-say-the-engine-is-running-from-source-not-that-it-is-missing) | The card must say the engine is running from source, not that it is missing | **Captured** — the engine knows how it was started and never reports it | 2026-08-22 |
+| [REQ-36](#req-36--the-three-dots-are-missing-on-a-contractor-card-and-unprofessional-on-the-others) | The three dots are missing on a contractor card, and unprofessional on the others | **In flight** — a session is measuring which treatment he means before restyling | 2026-08-22 |
 
 ---
 
@@ -1562,3 +1564,87 @@ has no run ledger of its own, and whether a generic crawl belongs in the price j
 queue is still the open question at the foot of that document. The measurement, the
 four findings it produced and the mutation results are in
 [BACKLOG.md](BACKLOG.md) as `OP-44`.
+## REQ-35 · The card must say the engine is running from source, not that it is missing
+**Captured 2026-08-22 · Not built**
+
+> «المحرك يعمل الان عن طريقك ويتجدد باستمرار لاننا نطوره · انا عاوز طريقة توضح فى الكارد
+> ان المحرك غير مثبت على الجهاز ولكنه يعمل فى نظام developer · ويظهر المحرك يعمل»
+
+The engine on his machine is not an installed build. It is started from this
+checkout and it changes several times a day because that is what we are doing to
+it. The panel has no word for that state, so it uses the word for the other one:
+
+    Installed version   Not detected
+    Protocol            Not available
+
+Both are literally true — nothing is installed — and both read as **broken**, which
+is the second time this month the panel has told him the engine was absent while it
+was serving. The first was `/api/health` taking 3.8 s against a 2,500 ms deadline
+(`R-45`'s sibling, fixed in #251); this one is not a bug at all. It is a state the
+product has no vocabulary for.
+
+**THE ENGINE ALREADY KNOWS AND HAS NEVER BEEN ASKED.** The frozen build enters
+through `packaging/engine_entry.py`, which `cli.py`'s own `--version` comment says
+*"cannot reach this parser at all"* — so the two ways of starting it are already
+distinct in the code. What is missing is that neither says so on the wire: nothing
+in `/api/health` reports **how** this engine is running.
+
+**So the shape is: the engine reports its own run mode, and the panel has a third
+word.** Not the panel guessing from an empty version string, which is what it does
+now (`extension/app.js:3484` on empty `state.engineVersion`) — a guess is how
+"running from source" became "not detected" in the first place.
+
+**And it is not cosmetic.** He works from two machines and the update path is real:
+`REQ-28`/`OP-32` exist because the engine he *downloaded* was behind the source, and
+a panel that cannot tell "installed 0.2.1" from "source 0.3.0" cannot help him see
+which one he is looking at. A developer-mode engine must also never be offered an
+update that would overwrite his checkout.
+
+**Blocked on nothing.** It is one field on an endpoint the panel already polls, plus
+the words on the card.
+
+---
+
+## REQ-36 · The three dots are missing on a contractor card, and unprofessional on the others
+**Captured 2026-08-22 · In flight**
+
+> «ال 3 نقاط لا تظهر فى كارد مقاول»
+>
+> «توجد ال3 نقاط بشكل غير احترافى فوق الكارت وداخل مربع اعتقد ان ال3 نقاط معمولة فى صفحة
+> profile بشكل احترافى عن هذا الشكل»
+
+Sent with a screenshot of the Data screen after he reloaded the extension and confirmed
+#252's fix had worked — the duplicated `⋮` is gone. These are what remained.
+
+**FILED LATE, AND THAT IS THE POINT OF `C7`.** He said both of these hours before this
+entry existed. They were briefed to a session and acted on immediately, and **a
+delegation is not a record**: nothing on the board carried them, so nothing but one
+agent's context knew they had been asked for. `test_every_finding_that_quotes_him_is_reachable_from_the_request_board`
+is what caught it — a *different* session quoted him in a `BACKLOG` entry and the guard
+refused it, because a finding may quote him only where a request of his exists to
+answer. The guard found my omission, not that session's.
+
+`REQ-04` is why this rule exists: ruled, unbuilt, and out of sight for sixteen days.
+
+**One · no menu at all on a dataset card.** `sourceMenu` returns `""` for
+`kind === "dataset"` (`extension/app.js`), and its comment justifies it — every action
+posts to a manifest-backed route and a dataset is not in the manifest, so *"a button that
+cannot work is worse than no button."* Right for five of six. **Wrong for the sixth:**
+`/api/table/{key}` resolves the dataset catalogue first, so *Open the data table* works
+today. Measured: `contractors` and `contractor_profiles` render **0** triggers,
+`LONG_AR`/`SHORT` render 1 each. Already recorded as `OP-42`, which is now his ask.
+
+**Two · the trigger's treatment.** `.dataset-card > .split-button` is absolutely
+positioned in the card's corner (`extension/app.css`), and he reads the result as a
+filled box crowding the card's edge. He is comparing it against something he calls the
+profile page, and **which** control that is has to be measured rather than guessed —
+the panel and the engine UI ship several overflow triggers (the shared split button,
+`.account-menu`, `.sx-select-list`, `.source-filter-menu`), each with its own size,
+padding and open state. The session on it is enumerating them, naming the one he means,
+and bringing the card's trigger to that treatment in **card-local rules only**:
+`design/components.css` generates the shared copy that five surfaces consume, and
+`OP-47` already records that fixing consumers instead of the component is how this class
+of defect spreads.
+
+**Verified visually, not by reading CSS back**, in both themes — the panel renders light
+and dark, and a trigger that reads well on one ground often does not on the other.

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -1530,6 +1530,34 @@ has neither half and its data is already on disk.
 **Not started.** `REQ-31` (the profile parser) is what is in flight, and this is the
 surface it feeds.
 
+**CORRECTED 2026-08-22, same day — and the correction is that HE WAS RIGHT.** Kept per
+**C4**, because what was wrong here is more useful than what is right.
+
+The table above says a per-row card exists on **neither** surface. **It has shipped on
+the engine since 2026-07-22** — 967 lines, opened by row **selection** rather than by
+`rowFormatter`, with an image gallery, AR/EN pairing, a price timeline and a *"Moved out
+of the table"* card that `scrapex/reports.py` builds under a comment reading *"the
+owner's ask, using the mechanism that already exists."*
+
+So the line *"he remembers this as built. It is half built, and not the half he needs"*
+is wrong twice. It is **fully built for products**, and he was not half-remembering
+anything — he said «نفس الشى اريده فى كاتوجرى المقاولون» and meant exactly that: the
+contractors category does not have it. **Step 3 below was already done before this entry
+was written.**
+
+**The measurement failed by searching for one symbol** — `rowFormatter`, `row-detail`,
+`expandRow`, `detailsDrawer` — and finding none. See
+[R-45](RULINGS.md#r-45--the-site-is-the-only-source-of-truth-and-a-field-the-table-does-not-need-goes-in-the-rows-card)
+for the full correction and for the two things it turned out to be worse than assumed:
+the chooser has registered **11 price-path keys** against the `contractors` dataset, and
+`dataset_table_payload` never reads `dataset_field` at all, so every hide and rename on a
+dataset is a silent no-op.
+
+**And this entry is now the same work as [REQ-07](#req-07--the-data-page-must-carry-everything-the-engines-page-carries)'s
+"details drawer"** — asked for independently, in his own words, two weeks apart. The
+session on `REQ-07` is writing one plan covering both, on his instruction: «ضع خطة
+لتنفيذها كلها وتتبع التنفيذ حتى لا نفقده».
+
 ---
 
 ## REQ-33 · The dataset cards said no successful crawl over crawled rows

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -91,6 +91,7 @@ IDs are stable and never reused, matching the convention BACKLOG.md already uses
 | [REQ-33](#req-33--the-dataset-cards-said-no-successful-crawl-over-crawled-rows) | The dataset cards said "no successful crawl yet" over 17,304 crawled rows | **Done** — the date is derived from the evidence; the two registries stay his | 2026-08-22 |
 | [REQ-35](#req-35--the-card-must-say-the-engine-is-running-from-source-not-that-it-is-missing) | The card must say the engine is running from source, not that it is missing | **Captured** — the engine knows how it was started and never reports it | 2026-08-22 |
 | [REQ-36](#req-36--the-three-dots-are-missing-on-a-contractor-card-and-unprofessional-on-the-others) | The three dots are missing on a contractor card, and unprofessional on the others | **In flight** — a session is measuring which treatment he means before restyling | 2026-08-22 |
+| [REQ-37](#req-37--one-card-per-site-and-its-crawls-are-options-under-it--the-way-gpp-does-it) | One card per site, and its crawls are options under it — the way GPP does it | **Captured** — cause found: the listing groups by DATASET, not by site | 2026-08-22 |
 
 ---
 
@@ -1648,3 +1649,64 @@ of defect spreads.
 
 **Verified visually, not by reading CSS back**, in both themes — the panel renders light
 and dark, and a trigger that reads well on one ground often does not on the other.
+
+---
+
+## REQ-37 · One card per site, and its crawls are options under it — the way GPP does it
+**Captured 2026-08-22 · Not built**
+
+> «المفروض مصدر مقاول يظهر مرة واحدة فقط واختيارات الزحف الخاصة به تكون متعغددة · انظر
+> الى gpp لتفهم كيف تم عمل هذا»
+
+Sent with a screenshot of two cards that are both `muqawil.org`:
+
+```
+muqawil.org   Saudi Contractors Authority   contractors          [Row 17,304]
+muqawil.org   Contractor profiles           contractor_profiles  [Row 704]
+```
+
+**THE CAUSE IS ONE CLAUSE, and it is not a display bug.** `_dataset_rows` in
+`scrapex/webui/app.py` ends its query with `GROUP BY d.dataset_definition_id` — **one row
+per dataset**, keyed on `dataset_key` as its `source_key`. The panel draws a card per row,
+so two datasets under one site are two cards, and neither knows the other exists.
+
+**AND HIS COMPARISON IS EXACT, which is why he made it.** `GPP_ENERGY` is **one**
+`source_key` in `sources.yaml`, and everything that varies underneath it — four energy
+types across 169 countries — lives *inside the connector*, never as a second source. So
+the panel has always drawn GPP as one card. muqawil's multiplicity was modelled one level
+higher, as two `dataset_definition` rows, and the listing has no notion of a site above
+them.
+
+**The shapes differ in a way that matters, and the fix is not "copy GPP".** GPP's axes
+are one crawl producing many rows; muqawil's are **two different crawls** — the listing
+sweep (`--crawl`, a 56-cell partition) and the profile sweep (`--details`, 34,834 pages) —
+which run separately, resume separately, and are approved separately. So the card must
+carry *two crawls*, not two column-sets. That is what he means by «اختيارات الزحف الخاصة
+به تكون متعددة».
+
+### What this needs, and the coupling that decides its order
+
+1. **`_dataset_rows` groups by `site_profile_id`**, emitting one row carrying its datasets
+   rather than one row per dataset. The `site_profile` row already holds the display
+   identity — which is why the first card reads `Saudi Contractors Authority` (the site's
+   name) and the second reads `Contractor profiles` (the dataset's).
+2. **A card-level identity that is a SITE.** Today `source_key` on a dataset row *is* the
+   `dataset_key`, and `/api/table/{key}` and `/source/{key}` resolve on it. A site-level
+   card needs its actions to say **which dataset**, or those routes break.
+3. **So this is the same surface as `REQ-36`.** That request gives a dataset card the
+   `⋮` menu it can use; this one asks the menu to offer *per-dataset* actions under one
+   card. Building them apart would mean writing the menu twice.
+
+**Therefore it lands after `REQ-36`**, and this is a sequencing decision rather than a
+priority one: the branch `fix/a-dataset-card-gets-the-menu-it-can-use` is editing
+`extension/app.js`'s `sourceMenu` right now, and two sessions in that function is the
+collision `docs/ORCHESTRATION.md` §3 exists to prevent.
+
+**One question is his, and it should be asked before the grouping is written:** the two
+muqawil datasets are a **listing** and its **detail pages** — the same contractors seen
+twice, 17,304 rows and 704 rows over one population. Should the card show them as *two
+crawls of one dataset*, or *two datasets of one site*? `dataset_relationship` already
+records them as `one_to_one`, `confirmed` (his own instruction, «اربطهم فى
+dataset_relationship»), so the warehouse already believes the first. The panel would then
+show one row count, not two — and 704 against 17,304 is a coverage number, not a second
+dataset.

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -91,7 +91,7 @@ IDs are stable and never reused, matching the convention BACKLOG.md already uses
 | [REQ-33](#req-33--the-dataset-cards-said-no-successful-crawl-over-crawled-rows) | The dataset cards said "no successful crawl yet" over 17,304 crawled rows | **Done** — the date is derived from the evidence; the two registries stay his | 2026-08-22 |
 | [REQ-35](#req-35--the-card-must-say-the-engine-is-running-from-source-not-that-it-is-missing) | The card must say the engine is running from source, not that it is missing | **Captured** — the engine knows how it was started and never reports it | 2026-08-22 |
 | [REQ-36](#req-36--the-three-dots-are-missing-on-a-contractor-card-and-unprofessional-on-the-others) | The three dots are missing on a contractor card, and unprofessional on the others | **In flight** — a session is measuring which treatment he means before restyling | 2026-08-22 |
-| [REQ-37](#req-37--one-card-per-site-and-its-crawls-are-options-under-it--the-way-gpp-does-it) | One card per site, and its crawls are options under it — the way GPP does it | **Captured** — cause found: the listing groups by DATASET, not by site | 2026-08-22 |
+| [REQ-37](#req-37--one-card-per-site-and-its-crawls-are-options-under-it--the-way-gpp-does-it) | One card per site, and its crawls are options under it — the way GPP does it | **Ruled** ([R-47](RULINGS.md#r-47--muqawil-is-one-card-with-two-crawls-and-the-two-stored-datasets-stay-two)) — two crawls of one dataset; the storage stays two | 2026-08-22 |
 
 ---
 
@@ -1653,7 +1653,7 @@ and dark, and a trigger that reads well on one ground often does not on the othe
 ---
 
 ## REQ-37 · One card per site, and its crawls are options under it — the way GPP does it
-**Captured 2026-08-22 · Not built**
+**Captured 2026-08-22 · Ruled ([R-47](RULINGS.md#r-47--muqawil-is-one-card-with-two-crawls-and-the-two-stored-datasets-stay-two)) · Not built**
 
 > «المفروض مصدر مقاول يظهر مرة واحدة فقط واختيارات الزحف الخاصة به تكون متعغددة · انظر
 > الى gpp لتفهم كيف تم عمل هذا»
@@ -1702,11 +1702,11 @@ priority one: the branch `fix/a-dataset-card-gets-the-menu-it-can-use` is editin
 `extension/app.js`'s `sourceMenu` right now, and two sessions in that function is the
 collision `docs/ORCHESTRATION.md` §3 exists to prevent.
 
-**One question is his, and it should be asked before the grouping is written:** the two
-muqawil datasets are a **listing** and its **detail pages** — the same contractors seen
-twice, 17,304 rows and 704 rows over one population. Should the card show them as *two
-crawls of one dataset*, or *two datasets of one site*? `dataset_relationship` already
-records them as `one_to_one`, `confirmed` (his own instruction, «اربطهم فى
-dataset_relationship»), so the warehouse already believes the first. The panel would then
-show one row count, not two — and 704 against 17,304 is a coverage number, not a second
-dataset.
+**ANSWERED THE SAME DAY — «زحفين لمجموعة واحدة».** Two crawls of one dataset. Recorded
+as [R-47](RULINGS.md#r-47--muqawil-is-one-card-with-two-crawls-and-the-two-stored-datasets-stay-two),
+which also records the half he did not have to decide because the code already had:
+**the two `dataset_definition` rows stay two.** `contractors._approval` refuses to put a
+27-field profile and a 28-field listing under one approved schema, because a subset is
+what a broken parser looks like (`R-31`) — so it is one CARD over two datasets, joined by
+the relationship he already had confirmed. And the second number stops being a population:
+704 of 17,304 is **coverage**, which is what `--coverage` already computes.

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -92,6 +92,7 @@ IDs are stable and never reused, matching the convention BACKLOG.md already uses
 | [REQ-35](#req-35--the-card-must-say-the-engine-is-running-from-source-not-that-it-is-missing) | The card must say the engine is running from source, not that it is missing | **Captured** — the engine knows how it was started and never reports it | 2026-08-22 |
 | [REQ-36](#req-36--the-three-dots-are-missing-on-a-contractor-card-and-unprofessional-on-the-others) | The three dots are missing on a contractor card, and unprofessional on the others | **In flight** — a session is measuring which treatment he means before restyling | 2026-08-22 |
 | [REQ-37](#req-37--one-card-per-site-and-its-crawls-are-options-under-it--the-way-gpp-does-it) | One card per site, and its crawls are options under it — the way GPP does it | **Ruled** ([R-47](RULINGS.md#r-47--muqawil-is-one-card-with-two-crawls-and-the-two-stored-datasets-stay-two)) — two crawls of one dataset; the storage stays two | 2026-08-22 |
+| [REQ-38](#req-38--the-backup-must-check-its-own-digest-and-the-panel-must-be-able-to-finish-the-build) | The backup must check its own digest, and the panel must be able to finish the build | **Captured** — measured: the digest is written and never read; the button aborts at 10 s on a 5-minute build | 2026-08-22 |
 
 ---
 
@@ -1738,3 +1739,72 @@ which also records the half he did not have to decide because the code already h
 what a broken parser looks like (`R-31`) — so it is one CARD over two datasets, joined by
 the relationship he already had confirmed. And the second number stops being a population:
 704 of 17,304 is **coverage**, which is what `--coverage` already computes.
+
+---
+
+## REQ-38 · The backup must check its own digest, and the panel must be able to finish the build
+**Captured 2026-08-22 · Not built**
+
+> «ضع طلب بتصليح هذا العيب … اتوماتكيا فى المستقبل»
+
+He said it after being shown that the first real backup of his warehouse had to be built
+with `curl --max-time 3600` and its digest compared **by hand**. He is right that a
+safeguard a person has to remember is not a safeguard.
+
+### The three defects, measured 2026-08-22 on a 1.18 GB warehouse
+
+**1 · THE DIGEST IS WRITTEN AND NEVER READ.** `extension/drive.js` puts `sha256` into
+`latest.json` on upload and nothing on `main` ever compares it again — the download path
+checks a **byte count** and nothing else. A file that arrived complete and corrupt passes.
+Two bytes swapped inside a 309 MB zip is exactly the failure the digest is for, and it is
+the one case the byte count cannot see.
+
+**2 · THE PANEL'S BUTTON CANNOT FINISH, AND FAILS DESTRUCTIVELY.**
+`extension/app.js` sends `POST /api/bundle` with **no `deadlineMs`**, so it matches no
+policy in `extension/startup.js` and takes the `localMutation` default of **10,000 ms**.
+The build measured **73 seconds** on this machine and would be minutes on a slower disk —
+so the client aborts, always.
+
+**And the abort does not stop the engine**: `/api/bundle`'s handler is a synchronous `def`
+running in a threadpool, so it keeps going and writes the whole archive. Measured today:
+a **309,589,440-byte** zip plus a **4,386,341-byte** panel pack that **nothing ever
+deletes** — `scrapex/storage.py` prunes `scrapex-engine.*backup*` and these are named
+`scrapex-bundle-*`. So every press of a button that cannot succeed leaves 314 MB behind on
+a disk that is 95% full, and reports failure.
+
+**3 · THE SIZE FIGURES IN THE CODE ARE STALE BY TEN TIMES.** `scrapex/bundle.py`,
+`scrapex/webui/app.py`, `extension/drive.js` and `scrapex/backupschedule.py` all describe
+this archive as **33–40 MB**. It is **309 MB**. Every one of those numbers was written
+when the warehouse was 112 MB, and one of them is inside the very docstring that explains
+why the upload had to become resumable.
+
+### What "automatically" has to mean here
+
+- **The engine hashes the archive it just wrote and the reply carries it** — it already
+  does this correctly, which is why the hand-check succeeded: `aabf5c26…` matched, first
+  time, on both files. The gap is entirely on the *reading* side.
+- **The download verifies the digest before anything is allowed to use the file**, and
+  says which evidence it had — Drive's own `sha256Checksum`, a local re-hash, or none.
+  Reporting *"verified by size only"* is honest; treating an absent digest as a pass is
+  not.
+- **The button gets a deadline that fits the work**, or the route stops being
+  synchronous. A 10-second clock on a job that measured 73 seconds is not a timeout, it
+  is a guarantee of failure.
+- **A build that is abandoned cleans up after itself**, or the pruner learns the name it
+  actually writes. Two hundred failed presses is 63 GB of orphans on a full disk.
+- **The stale numbers get a guard**, not a correction: a comment saying 40 MB will be
+  wrong again the next time the warehouse doubles, and this class has already cost a red
+  `main` today through a different register.
+
+### What exists to build on, so this is not a rewrite
+
+`claude/drive-without-a-server` (`e00711d`, pushed, no PR) already adds `PRAGMA
+quick_check` before a bundle is written and a `files.get` that compares Drive's own
+`sha256Checksum` against the manifest, reporting which evidence it had. **It does not fix
+the deadline** — `git show` on that commit touches none of `extension/startup.js`,
+`extension/backend.js`, or the call site. So the branch closes defect 1 and leaves defects
+2 and 3 open, and merging it does not make the button work.
+
+**Filed while the workaround is still fresh**, which is the point: the manual procedure
+that produced tonight's backup is written down in the same session, so this request can be
+measured against something that actually ran rather than against a description of it.

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -1251,6 +1251,55 @@ question at all. It is one more value in a card that has to be built anyway.
 **Recorded as its own track**, because it is a surface feature with a data-model half
 and it is larger than the field that raised it: `REQ-32`.
 
+> **CORRECTED 2026-08-22, SAME DAY, AND THE TABLE ABOVE IS WRONG IN ITS FIRST ROW.**
+> Kept in place per **C4** because the error is more instructive than the fix.
+>
+> That row says a per-row card *"does not exist, on either surface — no `rowFormatter`,
+> no expansion handler, nothing."* **A record card has shipped on the engine since
+> 2026-07-22** (`6f99a93`, redesigned `bac9c94` on 07-26) — a month before this ruling
+> was written. It is 967 lines, about 30% of `grid.js`, and it carries an image gallery,
+> spec lists, AR/EN pairing, a price timeline, a changes feed, and a **"Moved out of the
+> table"** card fed by `payload.moved_to_details`. `scrapex/reports.py` builds that list
+> and its own comment reads *"the owner's ask, using the mechanism that already
+> exists."*
+>
+> **It is opened by row SELECTION, not by `rowFormatter`** — `grid.js` binds
+> `table.on("rowSelectionChanged")` → `openOfferPanel` → `GET /api/offer/{key}/{id}` →
+> `renderOfferPanel` into `#offer-panel`, and the container's own comment in
+> `scrapex/webui/templates/source.html` says *"ONE container under the table, opened by
+> SELECTING a row (the owner's ruling)"*.
+>
+> **WHY THE MEASUREMENT FAILED, because that is the transferable part.** It searched for
+> `rowFormatter`, `row-detail`, `expandRow` and `detailsDrawer`, found none, and
+> concluded the feature was absent. **A false negative from searching for one symbol** —
+> the third instance in a single day of the instrument deciding the answer:
+> `sqlite_master` asked for `UNIQUE` cannot see an auto-index from a table constraint,
+> and a card census asking for `h3.card-title` cannot see a card titled with an `h4`.
+> The lesson is `LESSONS.md` §9's, arriving through a third door: **a search for one
+> spelling of a feature is not a measurement of the feature.**
+>
+> **AND IT CHANGES WHAT HE ASKED FOR. He was not misremembering.** This ruling and
+> `REQ-32` both read as though he half-recalled something that was never built. The
+> truth is that it is **fully built for products, on the engine**, and his complaint was
+> precisely that the contractors category lacks it — which is what he said: «نفس الشى
+> اريده فى كاتوجرى المقاولون». `REQ-32`'s step 3, *"the same card for the products
+> category"*, was already done before it was written.
+>
+> **The ruling itself stands unchanged**, and this correction strengthens rather than
+> weakens it: a field is not a column, and the row's card is where the extras go. What
+> changes is the cost and the shape of the work — the shell exists and is a **port**,
+> while the contractors body is **new engine work**, because four of the five endpoints
+> the engine's data page consumes run against the price warehouse and there is no
+> dataset equivalent of `/api/offer`.
+>
+> Two further measurements from the same session, both worse than this ruling assumed:
+> `dataset_field` holds **11 rows for `source_key='contractors'` and every one is a
+> price-path key** (`price`, `tax`, `stock_quantity`, `curation`) — opening the chooser
+> on the contractors table registered the *price* header against the dataset — and
+> `dataset_table_payload` **never reads `dataset_field` at all**, so hiding, renaming
+> and reordering a dataset's columns are silent no-ops. The chooser does not merely
+> lack a dataset branch; it lies in both directions.
+
 ---
 
 ### R-47 · muqawil is ONE card with TWO crawls, and the two stored datasets stay two

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -1251,6 +1251,64 @@ question at all. It is one more value in a card that has to be built anyway.
 **Recorded as its own track**, because it is a surface feature with a data-model half
 and it is larger than the field that raised it: `REQ-32`.
 
+---
+
+### R-47 · muqawil is ONE card with TWO crawls, and the two stored datasets stay two
+
+**2026-08-22 · surface + data model · answers the question `REQ-37` put to him**
+
+> «زحفين لمجموعة واحدة»
+
+`REQ-37` asked whether the panel should show the two muqawil datasets as *two crawls of
+one dataset* or *two datasets of one site*. He chose the first, and the warehouse already
+agreed with him: `dataset_relationship` records `contractor_profiles` against
+`contractors` as `one_to_one`, **confirmed** — on his own earlier instruction, «اربطهم فى
+dataset_relationship». The panel was the only place still saying otherwise.
+
+**WHAT THIS CHANGES, AND IT IS THE LISTING RATHER THAN THE SCHEMA.** Three things:
+
+1. **One card per site.** `_dataset_rows` in `scrapex/webui/app.py` ends
+   `GROUP BY d.dataset_definition_id` — one row per dataset, with `dataset_key` standing
+   in as `source_key`. It groups by the site instead.
+2. **One row count, and the second number becomes COVERAGE.** Today the cards read
+   `17,304` and `704` as if they were two populations. They are one: 17,304 contractors,
+   of whom 704 have an approved profile. So the card says the population once and reports
+   the profile crawl as *how much of it has been fetched* — which is the number he
+   actually wants, and the one `--coverage` already computes.
+3. **Two crawl options on the card**, because they really are two: the listing sweep is a
+   56-cell partition and the profile sweep is 34,834 pages, and they run, resume and
+   approve separately. That is what «اختيارات الزحف» means here, and it is the one place
+   the GPP comparison he made does *not* transfer — GPP's four energy types across 169
+   countries are **one** crawl producing many rows.
+
+**AND WHAT IT MUST NOT CHANGE: the two `dataset_definition` rows stay two.** This is not
+a hedge, it is a constraint already recorded in the code. `contractors._approval` says it
+in its own words:
+
+> *"A PROFILE IS ITS OWN DATASET… Two documents with two declared field sets — 21 against
+> 28 — cannot share one approved schema: every profile would read as a subset of the
+> listing's and `R-31` refuses a subset, on purpose, because that is what a broken parser
+> looks like."*
+
+Since #254 the profile declares **27** fields against the listing's 28, which makes the
+subset closer and the refusal no less correct. Merging the two datasets would either be
+refused at approval or — worse — retire the listing's live schema version and drop columns
+the site still publishes. **So one card over two datasets, joined by a relationship that
+is already confirmed.** The join is the thing that makes the single card honest rather
+than a label over two unrelated tables.
+
+**The precedent this sets, and it is why the ruling is worth recording rather than just
+building:** a *site* is now a first-class thing in the listing, above the dataset. Track 5
+queues Balady, the UAE registries and the Gulf and Egypt sources, and several of those
+will publish a directory and its detail pages exactly as muqawil does. Deciding it once,
+here, is cheaper than deciding it per source — and it is the same argument he made for
+`R-45`: a column is a promise every source in the category must keep.
+
+**Sequenced behind [REQ-36](REQUESTS.md#req-36--the-three-dots-are-missing-on-a-contractor-card-and-unprofessional-on-the-others)**,
+which gives a dataset card the `⋮` menu it can use. This ruling asks that menu for
+per-dataset actions under one card, so building them apart would mean writing the menu
+twice — and a branch is inside `sourceMenu` as this is written.
+
 ### R-43 · Drive is the single source of truth for DATA; the repository stays it for CODE
 
 **2026-08-22 · two machines · extends `CLAUDE.md`'s founding rule to the warehouse**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "scrapex"
 # A MIRROR of scrapex/version.py:VERSION — setuptools cannot import the package
 # to ask. tests/test_version.py reads this line back and fails when they drift.
-version = "0.3.0"
+version = "0.3.1"
 description = "ScrapeX ecosystem: contract-driven web data collection into a SQLite warehouse. Categories: products, contractors"
 requires-python = ">=3.12"
 dependencies = [

--- a/scrapex/contractors.py
+++ b/scrapex/contractors.py
@@ -743,8 +743,14 @@ def _contractor_of(key: str) -> str | None:
 _WIRED_GROUPS = ("interests", "licensed_activities")
 
 
-def _interest_paths(english: str, arabic: str) -> list[tuple[tuple[str, ...],
-                                                             tuple[str, ...]]]:
+#: One membership to write: the path in each language, and what the site said about
+#: it -- `(label, value, value_ar)` or `None`. The third element is `0010`'s columns
+#: and `R-45`'s reason for them: an attribute describes ONE membership, so it travels
+#: with the pair rather than beside it.
+Membership = tuple[tuple[str, ...], tuple[str, ...], tuple[str, str, str] | None]
+
+
+def _interest_paths(english: str, arabic: str) -> list[Membership]:
     """`interests`, paired across the two pages. Raises when the counts differ.
 
     PAIRED BY POSITION, LIKE `merge_locales`, AND REFUSED THE SAME WAY. Both locales
@@ -765,11 +771,14 @@ def _interest_paths(english: str, arabic: str) -> list[tuple[tuple[str, ...],
         raise taxonomy.CannotPairLocales(
             f"published {len(paths_en)} interests in English and "
             f"{len(paths_ar)} in Arabic")
-    return list(zip(paths_en, paths_ar, strict=True))
+    # NO ATTRIBUTE, AND THE PAGE IS WHY RATHER THAN A DEFAULT: the interests card is
+    # a nested list with no column beside it, so there is nothing the site says about
+    # an interest. `None` here is a reading, not an omission.
+    return [(path, path_ar, None)
+            for path, path_ar in zip(paths_en, paths_ar, strict=True)]
 
 
-def _licence_paths(english: str, arabic: str) -> list[tuple[tuple[str, ...],
-                                                           tuple[str, ...]]]:
+def _licence_paths(english: str, arabic: str) -> list[Membership]:
     """`licensed_activities`, which needs ONE page rather than two.
 
     THE CELL IS ALREADY BILINGUAL, and that is the whole difference from interests:
@@ -798,7 +807,13 @@ def _licence_paths(english: str, arabic: str) -> list[tuple[tuple[str, ...],
     # which is the same property `MultiValuedGroup.published_as` records for the
     # table headers, one level down.
     activities = read_licensed_activities(english or arabic)
-    return [(one.english or ("",) * len(one.arabic), one.arabic)
+    return [(one.english or ("",) * len(one.arabic), one.arabic,
+             # THE READINESS, WHICH IS PER LICENCE AND NOT PER CONTRACTOR -- `0010`
+             # and `R-45`. The label comes off the table's own header rather than a
+             # constant of ours, so a renamed column arrives as its new name. `None`
+             # where the site graded nothing, which is 1,490 of 1,500 rows measured.
+             (one.readiness_label, one.readiness_en, one.readiness_ar)
+             if one.readiness_ar or one.readiness_en else None)
             for one in activities if one.arabic]
 
 
@@ -885,11 +900,11 @@ def write_groups(conn, directory: Directory, snapshot_id: int, *,
         except taxonomy.CannotPairLocales as exc:
             raise taxonomy.CannotPairLocales(
                 f"contractor {contractor_id}, group {group_key}: {exc}") from exc
-        for path, path_ar in pairs:
+        for path, path_ar, attribute in pairs:
             node = taxonomy.ensure_path(conn, scheme, path=path, path_ar=path_ar)
             if taxonomy.link(conn, generic_record_id=int(record["generic_record_id"]),
                              node_id=node, group_key=group_key,
-                             source_snapshot_id=snapshot_id):
+                             source_snapshot_id=snapshot_id, attribute=attribute):
                 written += 1
             else:
                 repeated += 1

--- a/scrapex/extract/muqawil.py
+++ b/scrapex/extract/muqawil.py
@@ -967,6 +967,12 @@ class LicensedActivity:
     english: tuple[str, ...]
     readiness_ar: str = ""
     readiness_en: str = ""
+    #: WHAT THE SITE CALLS THE READINESS COLUMN, read off the table's own header
+    #: rather than declared as a constant. `R-45`: «ما يقوله الموقع هو مصدر الحقيقة
+    #: الوحيد لا نعدل عليه» -- so if muqawil renames that column, the warehouse
+    #: carries the new name instead of asserting the old one. Measured today:
+    #: `مستوى الجاهزية`, identical on both locales.
+    readiness_label: str = ""
     #: The cell exactly as published, kept so a disagreement can be looked at.
     published_as: str = ""
 
@@ -1011,6 +1017,12 @@ def read_licensed_activities(html: str) -> tuple[LicensedActivity, ...]:
     card = _card(html, "licensed_activities")
     if card is None:
         return ()
+    # THE LAST HEADER IS THE READINESS COLUMN'S NAME, taken from the page. Two
+    # headers are measured on every page -- `الأنشطة المرخصة` and `مستوى الجاهزية`
+    # -- and the readiness is the second, which is why the value cells are read
+    # from the END of the row too. A table that grows a column keeps both aligned.
+    headers = [_text(cell) for cell in card.select("th")]
+    label = headers[-1] if len(headers) >= 2 else ""
     found: list[LicensedActivity] = []
     for row in card.select("tr"):
         cells = row.select("td")
@@ -1033,6 +1045,7 @@ def read_licensed_activities(html: str) -> tuple[LicensedActivity, ...]:
             arabic=arabic_path,
             english=english_path if len(english_path) == len(arabic_path) else (),
             readiness_ar=ready_ar.strip(), readiness_en=ready_en.strip(),
+            readiness_label=label if readiness else "",
             published_as=published))
     return tuple(found)
 

--- a/scrapex/taxonomy.py
+++ b/scrapex/taxonomy.py
@@ -49,6 +49,17 @@ class Membership:
     node_id: int
     path: tuple[str, ...]
     path_ar: tuple[str, ...]
+    #: WHAT THE SITE SAID ABOUT THIS MEMBERSHIP, from `0010`: the site's own name
+    #: for the attribute and its two published halves. Empty strings where the
+    #: group publishes no attribute column, which is every interest and 1,490 of
+    #: 1,500 measured licences.
+    #:
+    #: THIS IS WHAT THE ROW'S CARD SHOWS AND THE TABLE CANNOT. `R-45`: a field is
+    #: not a column, and `مستوى الجاهزية` describes one activity rather than the
+    #: contractor -- so it has no honest home on the contractors table at all.
+    attribute_label: str = ""
+    attribute_value: str = ""
+    attribute_value_ar: str = ""
 
 
 def ensure_scheme(conn: sqlite3.Connection, site_profile_id: int, *,
@@ -124,7 +135,8 @@ def ensure_path(conn: sqlite3.Connection, scheme_id: int, *,
 
 
 def link(conn: sqlite3.Connection, *, generic_record_id: int, node_id: int,
-         group_key: str, source_snapshot_id: int) -> bool:
+         group_key: str, source_snapshot_id: int,
+         attribute: tuple[str, str, str] | None = None) -> bool:
     """This contractor holds this node, in this group. `True` if it is new.
 
     IDEMPOTENT BY THE PRIMARY KEY, not by a check here — `(generic_record_id, node_id,
@@ -146,17 +158,40 @@ def link(conn: sqlite3.Connection, *, generic_record_id: int, node_id: int,
     indistinguishable. Measured: a second identical pass over one profile reported all 25
     memberships as new. `seen_count` is incremented by the upsert and returned, so `= 1`
     means "written just now" with no extra read and nothing to race.
+
+    `attribute` IS `(label, value, value_ar)` AND IT BELONGS TO THE MEMBERSHIP, which is
+    `0010` and `R-45`. What the site says about one activity — muqawil publishes
+    `مستوى الجاهزية` beside each licence, `أساسي | Basic` — describes THAT membership and
+    not the contractor, so a contractor with six licences can be graded on one and
+    ungraded on five. `None` is the common case: measured, 1,490 of 1,500 licence rows
+    publish nothing here and interests publish nothing by construction.
+
+    THE LABEL IS THE SITE'S, NEVER OURS, which is why it is a value rather than a column
+    name. A column called `readiness` on a table that serves every site would need a
+    fourth for Balady's attribute and a fifth for the UAE's — the shape his ruling was
+    about, one level down.
+
+    A REPEAT OVERWRITES IT RATHER THAN KEEPING THE OLD ONE, on the same reasoning as
+    `source_snapshot_id` on the line below it: the newest reading of a page is the one
+    whose evidence we still hold. A contractor upgraded from `أساسي` to `ذهبي` must not
+    keep the old grade because the membership itself is unchanged.
     """
+    label, value, value_ar = attribute or ("", "", "")
     seen = conn.execute(
         "INSERT INTO generic_record_node "
-        "(generic_record_id, node_id, group_key, source_snapshot_id) "
-        "VALUES (?,?,?,?) "
+        "(generic_record_id, node_id, group_key, source_snapshot_id, "
+        " attribute_label, attribute_value, attribute_value_ar) "
+        "VALUES (?,?,?,?,?,?,?) "
         "ON CONFLICT(generic_record_id, node_id, group_key) DO UPDATE SET "
         "  last_seen_at = strftime('%Y-%m-%dT%H:%M:%SZ','now'), "
         "  seen_count = seen_count + 1, "
-        "  source_snapshot_id = excluded.source_snapshot_id "
+        "  source_snapshot_id = excluded.source_snapshot_id, "
+        "  attribute_label = excluded.attribute_label, "
+        "  attribute_value = excluded.attribute_value, "
+        "  attribute_value_ar = excluded.attribute_value_ar "
         "RETURNING seen_count",
-        (generic_record_id, node_id, group_key, source_snapshot_id)).fetchone()
+        (generic_record_id, node_id, group_key, source_snapshot_id,
+         label or None, value or None, value_ar or None)).fetchone()
     return int(seen[0]) == 1
 
 
@@ -173,30 +208,43 @@ def memberships(conn: sqlite3.Connection, generic_record_id: int, *,
     — on 500K memberships three levels deep that is 1.5M round trips for an answer SQLite
     can assemble in one.
     """
+    # THE ATTRIBUTE IS CARRIED THROUGH THE RECURSION RATHER THAN JOINED AGAIN.
+    # It lives on the membership row, which only the ANCHOR of this CTE touches --
+    # every later step walks `classification_node` upward and has no membership to
+    # read. Selecting it once in the anchor and passing it along costs three
+    # columns; a second join would cost a query per membership, which is the round
+    # trip this CTE exists to avoid.
     rows = conn.execute(
-        "WITH RECURSIVE up(node_id, group_key, leaf_id, name, name_ar, parent) AS ("
+        "WITH RECURSIVE up(node_id, group_key, leaf_id, name, name_ar, parent, "
+        "                  label, value, value_ar) AS ("
         "  SELECT n.node_id, m.group_key, n.node_id, n.node_name, n.node_name_ar, "
-        "         n.parent_node_id "
+        "         n.parent_node_id, m.attribute_label, m.attribute_value, "
+        "         m.attribute_value_ar "
         "    FROM generic_record_node AS m "
         "    JOIN classification_node AS n ON n.node_id = m.node_id "
         "   WHERE m.generic_record_id = ? "
         "     AND (? IS NULL OR m.group_key = ?) "
         "  UNION ALL "
         "  SELECT p.node_id, up.group_key, up.leaf_id, p.node_name, p.node_name_ar, "
-        "         p.parent_node_id "
+        "         p.parent_node_id, up.label, up.value, up.value_ar "
         "    FROM up JOIN classification_node AS p ON p.node_id = up.parent "
         ") "
-        "SELECT leaf_id, group_key, name, name_ar FROM up "
+        "SELECT leaf_id, group_key, name, name_ar, label, value, value_ar FROM up "
         " ORDER BY group_key, leaf_id, node_id",
         (generic_record_id, group_key, group_key)).fetchall()
 
     built: dict[tuple[str, int], tuple[list[str], list[str]]] = {}
+    said: dict[tuple[str, int], tuple[str, str, str]] = {}
     for row in rows:
         key = (row["group_key"], int(row["leaf_id"]))
         names, names_ar = built.setdefault(key, ([], []))
         names.append(row["name"] or "")
         names_ar.append(row["name_ar"])
+        said[key] = (row["label"] or "", row["value"] or "", row["value_ar"] or "")
     return tuple(
         Membership(group_key=group, node_id=leaf,
-                   path=tuple(names), path_ar=tuple(names_ar))
+                   path=tuple(names), path_ar=tuple(names_ar),
+                   attribute_label=said[(group, leaf)][0],
+                   attribute_value=said[(group, leaf)][1],
+                   attribute_value_ar=said[(group, leaf)][2])
         for (group, leaf), (names, names_ar) in sorted(built.items()))

--- a/scrapex/version.py
+++ b/scrapex/version.py
@@ -73,7 +73,7 @@ from enum import StrEnum
 # The release stamp. Bump it for a functional, architectural or behavioural
 # change (issue 32 section 1.1), and regenerate the baseline + CHANGELOG in the
 # same commit: python -m scrapex.cli export-version
-VERSION = "0.3.0"
+VERSION = "0.3.1"
 
 
 class Surface(StrEnum):

--- a/tests/test_a_membership_carries_what_the_site_said.py
+++ b/tests/test_a_membership_carries_what_the_site_said.py
@@ -1,0 +1,309 @@
+"""A membership carries what the site said about it, and the contractor does not.
+
+WHY THIS TABLE AND NOT THE CONTRACTORS TABLE. `Q-17` asked him whether the licences'
+readiness level should be a column or should go unstored. He refused the question:
+
+    «لا داعى لوضعها فى عمود خاص فى الجدول ولكن عند الضغط على صف معين وهو يحملها تظهر
+     فى الكارد الخاص بالمقاول · لان المقاولون سيكون هناك عدة مصادر له فى المستقبل»
+
+A field is not a column — `R-45`. And the shape follows from the page rather than from
+the ruling alone: `مستوى الجاهزية` is published in the licences table BESIDE each
+activity, one grade per activity. A contractor with six licences can be graded on one
+and ungraded on five, which is exactly what the committed fixture does. On the
+contractors table that fact has no home that is not a lie about which activity it
+describes.
+
+THE MEASUREMENTS THIS FILE IS WRITTEN AGAINST, over 1,685 real licence rows on 2,419
+profile pairs:
+
+    rows publishing a readiness      10 of 1,500      so NULL is the common case
+    distinct values                  5                ذهبي|Gold, فضي|Silver,
+                                                      ماسي|Dimond (the site's
+                                                      spelling), أساسي|Basic
+    the separator                     " | "           arabic, pipe, latin
+    interests publishing one          0                there is no column beside them
+
+AND NO CHECK CONSTRAINT ON THE VALUE, which one of these tests pins. Five levels are a
+closed set today, and a CHECK would turn the site adding a sixth into an error we
+invented — `R-45`'s other half: «ما يقوله الموقع هو مصدر الحقيقة الوحيد لا نعدل عليه».
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scrapex import taxonomy
+from scrapex.contractors import write_groups
+from scrapex.databases import DatabaseRegistry, EngineDatabase
+from scrapex.directories import get
+from scrapex.extract.muqawil import read_licensed_activities
+from scrapex.extract.service import _canonical, _digest
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "muqawil"
+
+#: The fixture's own numbers, read off the pages rather than assumed.
+FIXTURE_LICENCE_ROWS = 6
+FIXTURE_GRADED_ROWS = 1
+FIXTURE_INTEREST_NODES = 25
+READINESS_LABEL = "مستوى الجاهزية"
+
+
+def _page(locale: str) -> str:
+    return (FIXTURES / f"profile-{locale}.html").read_text(encoding="utf-8")
+
+
+@pytest.fixture()
+def pages() -> tuple[str, str]:
+    return _page("en"), _page("ar")
+
+
+@pytest.fixture()
+def conn(tmp_path: Path):
+    registry = DatabaseRegistry(EngineDatabase(tmp_path / "scrapex-engine.db"),
+                               pointer_file=tmp_path / "databases.json")
+    registry.initialize()
+    connection = registry.engine.connect()
+    _a_profile_row(connection, "775")
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def _a_profile_row(conn, contractor_id: str) -> None:
+    conn.execute("INSERT OR IGNORE INTO site_profile (site_key, display_name, base_url) "
+                 "VALUES ('muqawil_org','Contractors','https://muqawil.org')")
+    conn.execute(
+        "INSERT OR IGNORE INTO generic_page_snapshot "
+        "(page_snapshot_id, source_url, html_content, content_hash) "
+        "VALUES (1,'https://muqawil.org/en/contractors/775/143','<html></html>','h')")
+    conn.execute(
+        "INSERT OR IGNORE INTO dataset_definition (dataset_definition_id, "
+        " site_profile_id, dataset_key, original_name, dataset_kind, "
+        " discovery_method, locator_json) "
+        "VALUES (1,1,'contractor_profiles','contractor_profiles','table',"
+        " 'html_table','{}')")
+    conn.execute("INSERT OR IGNORE INTO dataset_schema_version "
+                 "(schema_version_id, dataset_definition_id, version_number, "
+                 " schema_hash) VALUES (1,1,1,'h')")
+    conn.execute(
+        "INSERT INTO generic_record (dataset_definition_id, record_key, "
+        " schema_version_id, data_json, source_snapshot_id, source_locator, "
+        " content_hash) VALUES (1,?,1,'{}',1,'div.info-box',?)",
+        (_digest(_canonical([contractor_id])), f"c{contractor_id}"))
+    conn.commit()
+
+
+def _record_id(conn, contractor_id: str) -> int:
+    return int(conn.execute(
+        "SELECT generic_record_id FROM generic_record WHERE record_key = ?",
+        (_digest(_canonical([contractor_id])),)).fetchone()[0])
+
+
+# ---- the schema ---------------------------------------------------------------
+
+def test_the_three_columns_exist_and_are_nullable(conn):
+    """ADDITIVE, which is what lets 15,559 stored memberships keep their rows. Every
+    one of them reads NULL and the next `--approve` fills in the ten per fifteen
+    hundred that have something to say."""
+    columns = {row[1]: row for row in
+               conn.execute("PRAGMA table_info(generic_record_node)")}
+
+    for name in ("attribute_label", "attribute_value", "attribute_value_ar"):
+        assert name in columns, f"{name} is missing; migration 0010 did not apply"
+        assert columns[name][3] == 0, (
+            f"{name} is NOT NULL, but 1,490 of 1,500 measured licence rows publish "
+            "nothing here and every interest publishes nothing by construction")
+
+
+def test_the_value_has_no_check_constraint(conn):
+    """`R-45` PINNED IN THE SCHEMA. Five readiness levels are a closed set today; a
+    CHECK would make the site adding a sixth an error we invented, and the site is the
+    record."""
+    sql = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE name = 'generic_record_node'"
+    ).fetchone()[0]
+    tail = sql[sql.index("attribute_label"):] if "attribute_label" in sql else ""
+
+    assert "CHECK" not in tail.upper(), (
+        "a CHECK now constrains the attribute columns, so a readiness level the site "
+        f"invents becomes our error rather than its news: {tail!r}")
+
+
+# ---- the write ---------------------------------------------------------------
+
+def test_the_attribute_is_stored_and_read_back(conn):
+    node = taxonomy.ensure_path(
+        conn, taxonomy.ensure_scheme(conn, 1, name="Licensed Activities",
+                                     name_ar="الأنشطة المرخصة"),
+        path=("Construction of Buildings",), path_ar=("تشييد المباني",))
+
+    taxonomy.link(conn, generic_record_id=_record_id(conn, "775"), node_id=node,
+                  group_key="licensed_activities", source_snapshot_id=1,
+                  attribute=(READINESS_LABEL, "Basic", "أساسي"))
+
+    held = taxonomy.memberships(conn, _record_id(conn, "775"))
+    assert len(held) == 1
+    assert held[0].attribute_label == READINESS_LABEL
+    assert held[0].attribute_value == "Basic"
+    assert held[0].attribute_value_ar == "أساسي"
+
+
+def test_a_membership_with_nothing_said_about_it_reads_empty_not_none(conn):
+    """The card renders these, and `None` in a template prints "None". Empty is the
+    only honest rendering of "the site graded nothing"."""
+    node = taxonomy.ensure_path(
+        conn, taxonomy.ensure_scheme(conn, 1, name="Interests", name_ar="الأنشطة"),
+        path=("Civil engineering",), path_ar=("الهندسة المدنية",))
+    taxonomy.link(conn, generic_record_id=_record_id(conn, "775"), node_id=node,
+                  group_key="interests", source_snapshot_id=1)
+
+    held = taxonomy.memberships(conn, _record_id(conn, "775"))
+
+    assert (held[0].attribute_label, held[0].attribute_value,
+            held[0].attribute_value_ar) == ("", "", "")
+
+
+def test_a_regrade_overwrites_rather_than_keeping_the_old_grade(conn):
+    """A contractor promoted from `أساسي` to `ذهبي` must not keep both. The membership
+    is unchanged — same contractor, same activity — so the upsert has to move the
+    attribute the way it already moves `source_snapshot_id`."""
+    scheme = taxonomy.ensure_scheme(conn, 1, name="Licensed Activities",
+                                    name_ar="الأنشطة المرخصة")
+    node = taxonomy.ensure_path(conn, scheme, path=("Demolition",),
+                                path_ar=("الهدم",))
+    record = _record_id(conn, "775")
+    taxonomy.link(conn, generic_record_id=record, node_id=node,
+                  group_key="licensed_activities", source_snapshot_id=1,
+                  attribute=(READINESS_LABEL, "Basic", "أساسي"))
+
+    fresh = taxonomy.link(conn, generic_record_id=record, node_id=node,
+                          group_key="licensed_activities", source_snapshot_id=1,
+                          attribute=(READINESS_LABEL, "Gold", "ذهبي"))
+
+    assert fresh is False, "a regrade is a confirmation of the membership, not a new one"
+    held = taxonomy.memberships(conn, record)
+    assert held[0].attribute_value == "Gold"
+    assert held[0].attribute_value_ar == "ذهبي"
+
+
+def test_the_attribute_belongs_to_the_membership_and_not_to_the_node(conn):
+    """THE PROPERTY THE WHOLE MIGRATION IS FOR. Two contractors licensed for the same
+    activity at different grades must each keep their own — which is impossible if the
+    grade hangs off `classification_node`, the shape a reader might reach for because
+    the vocabulary is shared."""
+    _a_profile_row(conn, "776")
+    scheme = taxonomy.ensure_scheme(conn, 1, name="Licensed Activities",
+                                    name_ar="الأنشطة المرخصة")
+    node = taxonomy.ensure_path(conn, scheme, path=("Site Preparation",),
+                                path_ar=("تحضير الموقع",))
+    for contractor, grade, grade_ar in (("775", "Basic", "أساسي"),
+                                        ("776", "Gold", "ذهبي")):
+        taxonomy.link(conn, generic_record_id=_record_id(conn, contractor),
+                      node_id=node, group_key="licensed_activities",
+                      source_snapshot_id=1,
+                      attribute=(READINESS_LABEL, grade, grade_ar))
+
+    first = taxonomy.memberships(conn, _record_id(conn, "775"))[0]
+    second = taxonomy.memberships(conn, _record_id(conn, "776"))[0]
+
+    assert first.node_id == second.node_id, "the fixture no longer shares one node"
+    assert (first.attribute_value, second.attribute_value) == ("Basic", "Gold")
+
+
+# ---- the reader, and the label that is the site's ----------------------------
+
+def test_the_label_comes_off_the_page_and_not_off_a_constant(pages):
+    """`R-45`: the site's words are the record. A constant would keep asserting
+    `مستوى الجاهزية` after the site renamed that column, and the warehouse would
+    carry a name the site had stopped using."""
+    english, _ = pages
+    graded = [one for one in read_licensed_activities(english) if one.readiness_ar]
+
+    assert len(graded) == FIXTURE_GRADED_ROWS
+    assert graded[0].readiness_label == READINESS_LABEL
+
+    # THE HEADER CELL ONLY, and the first attempt at this test taught why. The card's
+    # own TITLE is `التراخيص ومستوى الجاهزية` -- it CONTAINS the column's name as a
+    # substring -- so a whole-page replace renamed the title too, `_card` stopped
+    # finding the card by title, and the reader returned nothing at all. The test
+    # failed for the right reason and told the wrong story.
+    renamed = english.replace(f">{READINESS_LABEL}<", ">درجة التأهيل<")
+    assert READINESS_LABEL in renamed, (
+        "the card title lost its own name, so this rename hit more than the header")
+    graded_again = [one for one in read_licensed_activities(renamed)
+                    if one.readiness_ar]
+    assert graded_again, "the rename made the card unreadable instead of renaming it"
+    assert graded_again[0].readiness_label == "درجة التأهيل", (
+        "the label is hardcoded, so a renamed column would be recorded under its old "
+        "name for as long as nobody noticed")
+
+
+def test_an_ungraded_licence_carries_no_label_either(pages):
+    """A label with no value is a column heading, not a fact about this activity."""
+    english, _ = pages
+    ungraded = [one for one in read_licensed_activities(english)
+                if not one.readiness_ar and not one.readiness_en]
+
+    assert len(ungraded) == FIXTURE_LICENCE_ROWS - FIXTURE_GRADED_ROWS
+    assert all(one.readiness_label == "" for one in ungraded)
+
+
+# ---- and end to end, on the committed pages ---------------------------------
+
+def test_the_fixture_grades_exactly_one_of_its_six_licences(conn, pages):
+    """THE SHAPE THAT MAKES THIS A MEMBERSHIP ATTRIBUTE, on real published data: one
+    contractor, six licences, one grade. A column on the contractors table would have
+    to choose which of the six it described."""
+    english, arabic = pages
+
+    write_groups(conn, get("muqawil_org"), 1, english=english, arabic=arabic,
+                 contractor_id="775")
+
+    held = taxonomy.memberships(conn, _record_id(conn, "775"))
+    licences = [one for one in held if one.group_key == "licensed_activities"]
+    interests = [one for one in held if one.group_key == "interests"]
+
+    assert len(licences) == FIXTURE_LICENCE_ROWS
+    assert len(interests) == FIXTURE_INTEREST_NODES
+
+    graded = [one for one in licences if one.attribute_value_ar]
+    assert len(graded) == FIXTURE_GRADED_ROWS, (
+        f"{len(graded)} of {len(licences)} licences carry a grade; the committed "
+        "contractor publishes exactly one")
+    assert graded[0].attribute_value_ar == "أساسي"
+    assert graded[0].attribute_value == "Basic"
+    assert graded[0].attribute_label == READINESS_LABEL
+
+
+def test_no_interest_carries_an_attribute(conn, pages):
+    """There is no column beside the interests list, so `None` there is a READING and
+    not a default that happened to be right."""
+    english, arabic = pages
+    write_groups(conn, get("muqawil_org"), 1, english=english, arabic=arabic,
+                 contractor_id="775")
+
+    interests = [one for one in taxonomy.memberships(conn, _record_id(conn, "775"))
+                 if one.group_key == "interests"]
+
+    assert interests, "the fixture stored no interests at all"
+    assert all(not one.attribute_label and not one.attribute_value
+               and not one.attribute_value_ar for one in interests)
+
+
+def test_the_stored_attribute_survives_a_second_approval(conn, pages):
+    """A re-parse over the snapshots on disk is the recovery path `R-40` repaired, and
+    it must not blank an attribute it re-reads identically."""
+    english, arabic = pages
+    directory = get("muqawil_org")
+    write_groups(conn, directory, 1, english=english, arabic=arabic,
+                 contractor_id="775")
+    write_groups(conn, directory, 1, english=english, arabic=arabic,
+                 contractor_id="775")
+
+    graded = [one for one in taxonomy.memberships(conn, _record_id(conn, "775"))
+              if one.attribute_value_ar]
+
+    assert len(graded) == FIXTURE_GRADED_ROWS
+    assert graded[0].attribute_value_ar == "أساسي"

--- a/tests/test_the_registers_cannot_collide.py
+++ b/tests/test_the_registers_cannot_collide.py
@@ -109,7 +109,10 @@ def test_no_two_entries_share_a_number(document: str, prefix: str, what: str):
 #: description cannot be checked at all. **The row is only as fresh as the last person who
 #: checked it, so re-check before trusting it.**
 RESERVED: dict[str, dict[int, str]] = {
-    "R": {},
+    # R-46 belongs to `claude/drive-without-a-server` (pushed at e00711d, no PR
+    # yet), and this branch declares R-47 -- so 46 is a hole here that exists
+    # elsewhere. Delete this row the day that branch merges.
+    "R": {46: "branch claude/drive-without-a-server"},
     # DECLARED HOLES, not tolerated ones. Both numbers exist on other branches and
     # not on this one, which is the state this table is for -- and being handed a
     # number by another session is not enough on its own: the assignment that named

--- a/tests/test_the_registers_cannot_collide.py
+++ b/tests/test_the_registers_cannot_collide.py
@@ -110,7 +110,16 @@ def test_no_two_entries_share_a_number(document: str, prefix: str, what: str):
 #: checked it, so re-check before trusting it.**
 RESERVED: dict[str, dict[int, str]] = {
     "R": {},
-    "REQ": {},
+    # DECLARED HOLES, not tolerated ones. Both numbers exist on other branches and
+    # not on this one, which is the state this table is for -- and being handed a
+    # number by another session is not enough on its own: the assignment that named
+    # this guard without naming this mechanism nearly turned a sibling branch red.
+    #
+    # DELETE A ROW THE MOMENT ITS PR LANDS. A reservation left behind is a permanent
+    # hole nobody owns, which is the rule the comment above already states.
+    "REQ": {
+        34: "branch claude/drive-without-a-server",
+    },
     # #246 merged on 2026-08-22 and brought its own 39 and 40, so the reservation is
     # gone with it — which is the rule the comment above states: a row left behind is a
     # permanent hole nobody owns.


### PR DESCRIPTION
## He refused the question, and the answer is a better shape than either option

`Q-17` asked him whether the licences' readiness level should be a column on the
contractors table, or should be read and not stored. He took neither — **`R-45`**:

> «ما يقوله الموقع هو مصدر الحقيقة الوحيد لا نعدل عليه»
>
> «لا داعى لوضعها فى عمود خاص فى الجدول ولكن عند الضغط على صف معين وهو يحملها تظهر فى
> الكارد الخاص بالمقاول · لان المقاولون سيكون هناك عدة مصادر له فى المستقبل»

A field is not a column. The readiness level is stored — it is a real fact the site
publishes — and it is simply **not a column**, because *contractors will have several
sources in the future*. A column is a promise every source in the category must keep,
and `المقاولون` has Balady, the UAE registries and the Gulf sources queued in Track 5.
Measured on the products side, that shape is madar at **59 variation axes, 33 non-empty
on under 1% of rows** — which he asked three times to have moved.

## And the shape follows from the page, not from the ruling alone

`مستوى الجاهزية` is published **beside each activity**, one grade per activity. The
committed fixture is the proof: **six licences, one graded.** On the contractors table
that fact has no home that is not a lie about *which* activity it describes.

So it belongs to the membership. `generic_record_node` had nowhere to put it:

```
generic_record_id · node_id · group_key · source_snapshot_id
first_seen_at · last_seen_at · seen_count
```

## Three generic columns, not one called `readiness`

Migration `0010` adds `attribute_label`, `attribute_value`, `attribute_value_ar`.

**Generic, because the table is generic.** A column named for muqawil's vocabulary on
the link table that serves *every* site repeats the mistake his ruling was about, one
level down: Balady's per-membership attribute would want a fourth column and the UAE's a
fifth. So **the site names the attribute** — `attribute_label` holds `مستوى الجاهزية` as
published, read off the table's own `<th>` rather than a constant of ours. Rename that
column on the site and the warehouse carries the new name. That is `R-45`'s other half.

**Columns and not a child table**, which `R-19` would otherwise suggest — and the
distinction is measured, not asserted. `R-19` rules on **multi-valued** groups; a
membership attribute over 1,685 real licence rows is **single-valued**: one label, one
value, on **10 of 1,500 rows**, five distinct values (`ذهبي | Gold`, `فضي | Silver`,
`ماسي | Dimond` — the site's spelling — `أساسي | Basic`). A child table for one nullable
value is the machinery `0009`'s own header warns about: *"existing machinery that has
never carried a row is not an asset."* If a second attribute ever appears, the child
table is **that** migration, and the snapshots make it a re-parse with no network.

**No `CHECK` on the value, and a test pins it.** Five levels are a closed set today; a
`CHECK` would turn the site adding a sixth into an error *we* invented. The site is the
record and this schema does not get a vote on its vocabulary.

**Additive only.** Three nullable columns on a `WITHOUT ROWID` table: all 15,559
memberships already stored keep their rows and read NULL, and the next `--approve` over
the snapshots on disk fills in the ten per fifteen hundred that have something to say.

## Guards: 11, and 6 of 6 mutations killed

| mutation | result |
|---|---|
| the upsert keeps the old grade instead of moving it | KILLED |
| `memberships()` stops carrying the attribute out of the recursion | KILLED |
| the readiness label becomes a constant of ours | KILLED |
| an ungraded licence still carries the column heading | KILLED |
| the interests are given the licences' attribute | KILLED |
| `write_groups` drops the attribute on the way to `link()` | KILLED |

Control green before each, tree restored and **re-hashed** after each, `__pycache__`
purged between runs, post-control green.

**The sharpest guard is the one about ownership.** Two contractors licensed for the same
activity at different grades each keep their own — which is impossible if the grade hangs
off `classification_node`, and that is the shape a reader reaches for *because the
vocabulary is genuinely shared*. It is the property the whole migration exists for, and
it is asserted directly rather than inferred.

**And one guard's first draft was wrong in an instructive way.** The label test renames
the header in the page and asserts the stored label followed. Renaming it across the whole
page broke the *card locator* — because the card's title, `التراخيص ومستوى الجاهزية`,
**contains the column's name as a substring**. The test failed for the right reason and
told the wrong story; it now renames only the `<th>` and asserts the title survived.

## `VERSION` 0.3.0 → 0.3.1, and the gate is why

A migration is a contract change, so `R-35`'s guard refused to let `0010` land at
`0.3.0`: *"an older build can no longer talk to this one and nothing said so."*
`pyproject.toml` carries a second copy of the number and its own guard caught that
immediately after — *"bump both or neither"*.

**The ordering was lucky rather than planned.** `engine-v0.3.0` was cut and published
**before** this migration existed, so the published contract is coherent; ten minutes
later and the release would have carried a schema no number announced. The public
manifest now reads `"version": "0.3.0"`, `"published_at": "2026-08-22T13:17:13Z"`, after
sitting at `0.2.1` since 9 August — which makes source-ahead-of-published the *normal*
development state, and `REQ-35` the thing that lets the panel say which of the two he is
looking at.

## Two requests filed, and one of them is filed late on purpose

**`REQ-35`** — the engine must report how it was started. The panel shows *"Installed
version: Not detected"* for an engine running from source, which is literally true and
reads as broken. It guesses from an empty version string; the engine knows and is never
asked.

**`REQ-36`** — his two asks from the screenshot: no `⋮` on a contractor card, and the
trigger's treatment. **It says in its own text that it was filed hours late**, because a
**delegation is not a record**: it was briefed to a session immediately and never reached
the board, so nothing but one agent's context knew it had been asked for.
`test_every_finding_that_quotes_him_is_reachable_from_the_request_board` caught it — when
a *different* session quoted him in a `BACKLOG` entry and the guard refused it. The guard
found my omission, not that session's. `C7` exists because `REQ-04` sat ruled and unbuilt
for sixteen days after dropping out of view.

## Numbering, and why this branch moved

`REQ-33` → `REQ-35`: #255 claimed 33 while this branch was unpushed, and **an open PR
outranks a branch without one** — otherwise two sessions renumber past each other
forever. `RESERVED` declares both resulting holes **with the branch that owns each**,
because a hole whose owner is a description rather than a ref is a hole nobody can
resolve later.

Four sessions mis-numbered something today, every one of them reading a board that was
true when they read it. The rule that came out of it: **ask the base you are merging
onto, at the moment you merge, and never carry an answer forward.** It is the same rule
that would have prevented `main` going red from a pinned line citation — and it is the
argument for *require branches up to date* over *require the check suite*, since both of
those checks passed truthfully about a base that had stopped existing.

## Verification

`SCRAPEX_FULL_MIGRATIONS=1 python -m pytest -q` — **real exit 0**, 4,251 bytes of output,
reached `[100%]`, `grep -c '^FAILED'` = **0**, `^ERROR` = **0**, and the trailer confirms
non-vacuity: *"schema template: DISABLED (SCRAPEX_FULL_MIGRATIONS) — every migrate() ran
for real."*

That is the **second** run. The first reported three failures across two rounds — the
`R-35` contract gate, then `pyproject.toml` — and I read the first one as green off an
`exit=$?` that belonged to an `echo` in a compound command rather than to pytest. Worth
recording because it is the same class as reading "0 failures" off an empty output file,
which has also happened in this repository.

`pytest -m docs` green after the renumber. `ruff check scrapex/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
