### PR TITLE
Three comments outlived the test they cite by two days, and nothing could tell

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2006,25 +2006,59 @@ supplies the second, because only one is *repeated*:
 |---|---|---|
 | dataset cards | `querySelectorAll(".dataset-card .split-button")` in `extension/app.js` | **yes — the broken one** |
 | Activity log | `$("activity").querySelector(".split-button")` in `extension/app.js` | no, singular |
-| grid toolbar | `toolbar.querySelector(".split-button")` ([scrapex/webui/static/grid.js:3118](../scrapex/webui/static/grid.js#L3118)) | no, singular |
-| source page export | one control in `#grid-toolbar` ([scrapex/webui/templates/source.html:291](../scrapex/webui/templates/source.html#L291)) | no, singular |
-| gallery example | one control ([design/gallery.html:379](../design/gallery.html#L379)) | no, singular |
+| Manage account danger menu | `$("drive-disconnect")`, markup at [extension/app.html:1347](../extension/app.html#L1347) | no, singular |
+| source page export | one control in `#grid-toolbar` ([scrapex/webui/templates/source.html:291](../scrapex/webui/templates/source.html#L291)), wired by [scrapex/webui/static/grid.js:3118](../scrapex/webui/static/grid.js#L3118) | no, singular |
+| gallery example | one control ([design/gallery.html:379](../design/gallery.html#L379)) | not a product surface |
+| grid harness fixture | [tools/grid_harness.py:68](../tools/grid_harness.py#L68) | not a product surface |
+
+**THE FIRST VERSION OF THAT TABLE WAS WRONG TWICE, corrected 2026-08-22 when the
+re-measurement below came due. Both errors were in the instrument, not the conclusion:**
+
+* **It missed the Manage account danger menu entirely.** The search was
+  `class="split-button"` — an exact match including the closing quote — and that markup
+  reads `class="split-button danger"`. A multi-class attribute is invisible to it. The
+  shared component's own comment *names* this consumer ("Manage account's danger menu")
+  and the omission still survived reading that comment.
+* **It listed the source page's Export control twice**, once as "grid toolbar" and once
+  as "source page export". `grid.js`'s `toolbar` is `document.getElementById("grid-toolbar")`,
+  which is the `<div id="grid-toolbar">` enclosing that very control. One control, two
+  rows — so the table claimed five consumers where there were four product surfaces.
+
+**Neither error changed the conclusion**, which is the only reason this is a correction
+and not a retraction: every consumer except the dataset card template is still
+singular, so only that one can lose a tie to a later sibling. **But a table that was
+wrong twice is exactly what "measured at a commit" is supposed to protect against, and
+it did not, because re-measuring was left to a person remembering.**
 
 Checked at the same commit: `.toolbar` carries no `z-index`, there is no rule for
 `#activity .split-button`, and neither `.dataset-card` nor `#datasets` carries a
 `transform`, `filter`, `opacity`, `contain`, `isolation` or `will-change` that would
 build a context another way. **This is future safety, not a live defect.**
 
-**RE-TAKE THIS COUNT AFTER `fix/a-dataset-card-gets-the-menu-it-can-use` LANDS. It is a
-measurement at `451468d`, not a standing claim.** That branch gives the `dataset`-kind
-cards the menu entries that work — `OP-42`'s tail — which moves the stub from 3 cards / 2
-triggers to 3 cards / 3 triggers. Reported as card-local only: `.dataset-card`'s block
-and `sourceMenu`, with the shared component and its generated copy untouched and no
-consumer added anywhere new. **So the conclusion holds and only the number changes** —
-the cards given triggers are still `.dataset-card`, matched by the same
-`querySelectorAll`, so the repeated-consumer fact gets stronger rather than weaker. Any
-future branch that adds a consumer or lifts a different wrapper invalidates the table,
-not just the count.
+**RE-TAKEN 2026-08-22 at `d10e974`, after `fix/a-dataset-card-gets-the-menu-it-can-use`
+landed as `#258` — this is the discharge of that instruction, not a fresh promise.**
+The instruction it replaces said the table was a measurement at `451468d` and had to be
+re-taken; it was, and the table above carries the result plus the two errors the
+re-measurement exposed.
+
+**The conclusion held and only the number moved, as predicted.** `#258` gave the
+`dataset`-kind cards the menu entries that work — `OP-42`'s tail — so the stub goes from
+3 cards / 2 triggers to 3 cards / 3 triggers. It was card-local: `.dataset-card`'s block
+and `sourceMenu`, with the shared component and its generated copies untouched and no
+consumer added anywhere new. The cards given triggers are still `.dataset-card`, matched
+by the same `querySelectorAll`, so the repeated-consumer fact is **stronger** than when
+it was written, not weaker.
+
+**Verified at the same commit** that all four of `OP-46`'s `extension/app.js` citations
+still name their symbols after `#258` moved that file, and that no open pull request
+touches `extension/app.js` — which is what let the two `PINNED` rows this entry's
+neighbour was waiting on finally be added.
+
+**Still true, and now the standing instruction:** any future branch that adds a consumer
+or lifts a different wrapper invalidates the table rather than just the count. The
+`querySelectorAll`-versus-`querySelector` distinction is the thing to re-derive, and it
+must be searched on the CLASS TOKEN rather than on `class="split-button"`, which is the
+mistake recorded above.
 
 **The risk is specific, and that session makes it likelier rather than moot.** The
 defect is *created* by fixing consumers instead of the component, and another consumer

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -1866,8 +1866,41 @@ rots like any other.**
   written at the top of the guard, where someone will try to "fix" it by adding the
   marker.
 
-**Apply:** when you delete or rename a test, grep `tests/` for its name before you
+**Apply, for this class:** when you delete or rename a test, grep `tests/` for its name before you
 commit — `test_the_tests_name_tests_that_exist.py` now does it for you and fails
 with the file and line. When you cite a test as your reason, prefer citing the
 live rule or file it rests on: `design/components.css:369-371` outlives any test
 that measured it.
+
+### The general form: a claim survives being wrong wherever nothing checks it
+
+This is not really about test files. **Three instances turned up on one day, in three
+different shapes, and the only thing they share is that no check covered the place
+the claim was written:**
+
+| the claim | where | why nothing caught it |
+|---|---|---|
+| three docstrings naming a deleted test | `tests/` | the citation guard reads documents, not tests |
+| three citations resolving to a **blank line** | `docs/BACKLOG.md` | tier 1 asks only that the line exists |
+| the design system's copies are guarded by `tests/test_vendor.py` | `tests/test_ui_kit.py` | nothing checks a claim about where a guard lives |
+
+The third is the sharpest and the last to be fixed. That comment justified reading
+only `design/` — *"so reading the canon is reading both"* — and named the wrong file:
+`test_vendor.py`'s only byte-equality assertion compares the two vendored copies of
+Tabulator. The copies **are** guarded, by
+`test_generated_design_assets_are_current` in `tests/test_design_system.py`. So the
+conclusion was true, the evidence pointed at nothing, and a reader who checked would
+have found less assurance than actually exists. **A wrong pointer to a real guard is
+worse than no pointer: it spends the reader's trust and returns nothing.**
+
+Note also what the new guard in this section does **not** catch: that one is a
+reference to a test *file*, not a backticked test *name*, so it falls outside the
+pattern. Fixed by hand, recorded here, and left unguarded on purpose — the shape that
+would catch it is "resolve every claim about which guard covers what", which is the
+prose-inference design `tests/test_the_documents_cite_what_they_claim.py` measured and
+rejected in its own docstring.
+
+**Apply, generally:** when you write down why something is true, ask which check
+would fail if the reason stopped being true. If the answer is *none*, you have
+written a claim that will outlive its evidence, and the more carefully it is written
+the longer it will survive.

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -1771,3 +1771,103 @@ its own base, `#251` had already moved the symbol, and `main` went red between t
 merges with no conflict for git to find, because no file was changed by both. Re-read
 the number out of the file at the new base on every rebase. Never adjust it by
 arithmetic, and never carry it.
+
+---
+
+## 13 · A test named in a docstring is a citation, and nothing was checking it
+
+**The documents are guarded and the tests were not.** `R-15` put every `file:line`
+in `CLAUDE.md`, `ENGINEERING.md` and `docs/` behind
+`tests/test_the_documents_cite_what_they_claim.py`. A test docstring saying *"this
+is why, see `test_foo`"* is the same kind of claim and had nothing behind it at all.
+
+**THE DATES ARE THE ARGUMENT, and they kill the obvious excuse.**
+`test_the_engine_overflow_trigger_has_no_visible_resting_container` was added by
+`8796fb5` on **2026-08-10** and removed by `ce80886` on **2026-08-20**, when the
+Engine page's overflow menu became action rows and the trigger it measured stopped
+existing. **Three references outlived it.** A ten-day-old test accumulated three
+dangling citations within two days of dying. Nobody can call that neglect over a
+long period: they were wrong almost immediately, and nothing noticed.
+
+**And the number in the first draft of that sentence was "nine months", written
+from an assumption and corrected by running `git log` before it was pushed.** That
+is the fourth time in one afternoon a session caught its own claim by measuring it
+rather than by being contradicted. Measure the thing you are about to assert, even
+when — especially when — it is only the connective tissue of a sentence.
+
+### `settle_view` is the case that proves the class, not an example of it
+
+The worst of the three was in the docstring of `settle_view`
+([tests/test_panel_dom.py:147](../tests/test_panel_dom.py#L147)) — a helper used at
+four call sites, one of them the guard `#252` added. Its docstring **is** the entire
+evidentiary basis for the wait: 20/20 runs reading the box mid-animation, 7/20
+failing outright, height `47.99999237060547` = 48 − 2⁻¹⁷ at one float32 ulp. Every
+one of those numbers was measured against the deleted test, so a reader who doubted
+the wait had **nothing they could re-run**.
+
+Its own first line reads *"a wait with no visible cause is a wait the next reader
+deletes."*
+
+**A docstring that argues for its own necessity, on evidence nobody can check, is
+exactly what this class produces.** It reads as the most careful thing in the file
+and it is the least verifiable.
+
+### Facts kept, references repaired — not paragraphs deleted
+
+Neither comment was **wrong**. The clamp it named is real and still in the sheet —
+`button, .button { min-height: var(--control-height) }`
+([design/components.css:369-371](../design/components.css#L369)), applying to every
+bare `<button>`, which is why a rendered box alone cannot catch a height
+regression. The 47.5 incident happened. What had gone was the ability to **check**
+either.
+
+So the temptation on finding a dangling citation is the trap: **deleting the
+paragraph throws away a true fact in order to fix a broken pointer.** Repair the
+pointer. Name the commit that added the test and the one that removed it, say
+plainly that it is gone, and point at the `git show` that still produces it.
+
+### The guard reads the claim, not the prose around it
+
+The first version of the guard forgave any dead name sitting near the words
+*"renamed from"* or *"no longer exists"*. It was thrown away, and the reason is the
+sharpest form of a trap this repository keeps meeting: **it decides honesty by
+adjacency.** It would pass any dead name that happened to fall near the word
+"removed" and fail an honest one phrased differently.
+
+What replaced it is the shape already settled twice here — `PINNED` in the citation
+guard and `RESERVED` in `tests/test_the_registers_cannot_collide.py`: **a
+deliberate exception is DECLARED, not inferred.** A historical name goes in
+`HISTORICAL` ([tests/test_the_tests_name_tests_that_exist.py:86](../tests/test_the_tests_name_tests_that_exist.py#L86))
+with the ref to read it at, and every row is **verified** rather than trusted —
+`git show <ref>:<path>` must still produce the test
+([tests/test_the_tests_name_tests_that_exist.py:144](../tests/test_the_tests_name_tests_that_exist.py#L144)).
+
+That verification caught its own author on its first run: the row for the
+native-host test named `6ccdd3c`, which does not contain it. The commit that does
+is `ff21042`. **A row asserting where to find something is itself a claim, and it
+rots like any other.**
+
+### Two collection facts, learned from the gates rather than guessed
+
+* **`pytestmark = ()` is not how to say "no marks".** pytest unpacks it and
+  collection dies with `got () instead of Mark`. Say it in prose instead.
+* **The extension gate keys on the browser directory's name appearing anywhere in a
+  test file's text** — including in prose explaining that the file does *not* read
+  it. That is a guard reading text and concluding intent, which is the same shape
+  as the keyword version rejected above; the difference is that this one is
+  deliberately broad, and its own note says a false positive "costs one marker".
+
+  Here the marker would cost the guard: carrying it moves the file into the tier CI
+  runs **separately**, so a guard about test docstrings would stop running on
+  engine-only and docs-only changes — which is precisely when docstrings change.
+  So the prose avoids the name, the same trade already taken in
+  `tests/test_the_version_moves_when_the_contract_does.py`. **Two independent
+  tenants make that a practice rather than a preference**, and the reason is
+  written at the top of the guard, where someone will try to "fix" it by adding the
+  marker.
+
+**Apply:** when you delete or rename a test, grep `tests/` for its name before you
+commit — `test_the_tests_name_tests_that_exist.py` now does it for you and fails
+with the file and line. When you cite a test as your reason, prefer citing the
+live rule or file it rests on: `design/components.css:369-371` outlives any test
+that measured it.

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -1874,33 +1874,52 @@ that measured it.
 
 ### The general form: a claim survives being wrong wherever nothing checks it
 
-This is not really about test files. **Three instances turned up on one day, in three
-different shapes, and the only thing they share is that no check covered the place
-the claim was written:**
+This is not really about test files. **Four instances turned up on one day, in four
+shapes, and the only thing they share is that no check covered the place the claim
+was written** — ordered worst first, because the first one punishes the reader who
+does the right thing:
 
 | the claim | where | why nothing caught it |
 |---|---|---|
+| the design system's copies are guarded by `tests/test_vendor.py` | `tests/test_ui_kit.py` | nothing checks a claim about **where a guard lives** |
+| a document joins the map, so it joins the checked list | the citation guard's own `DOCUMENTS` | the sentence was a comment, enforced nowhere |
 | three docstrings naming a deleted test | `tests/` | the citation guard reads documents, not tests |
-| three citations resolving to a **blank line** | `docs/BACKLOG.md` | tier 1 asks only that the line exists |
-| the design system's copies are guarded by `tests/test_vendor.py` | `tests/test_ui_kit.py` | nothing checks a claim about where a guard lives |
+| three citations resolving to a **blank line** | `docs/BACKLOG.md` | tier 1 asks only that the line *exists* |
 
-The third is the sharpest and the last to be fixed. That comment justified reading
-only `design/` — *"so reading the canon is reading both"* — and named the wrong file:
-`test_vendor.py`'s only byte-equality assertion compares the two vendored copies of
-Tabulator. The copies **are** guarded, by
-`test_generated_design_assets_are_current` in `tests/test_design_system.py`. So the
-conclusion was true, the evidence pointed at nothing, and a reader who checked would
-have found less assurance than actually exists. **A wrong pointer to a real guard is
-worse than no pointer: it spends the reader's trust and returns nothing.**
+**The first is a different failure from a dangling reference: it is a MISDIRECTED
+one, and it punishes diligence.** That comment justified reading only `design/` —
+*"so reading the canon is reading both"* — and named the wrong file. `test_vendor.py`'s
+only byte-equality assertion compares the two vendored copies of Tabulator. The copies
+**are** guarded, by `test_generated_design_assets_are_current` in
+`tests/test_design_system.py`. So the conclusion was true, the evidence pointed at
+nothing, and **a reader who checked would have found less assurance than actually
+exists.** A dangling reference wastes a reader's time; this one spends their trust and
+returns nothing. The careless reader was unaffected.
 
-Note also what the new guard in this section does **not** catch: that one is a
-reference to a test *file*, not a backticked test *name*, so it falls outside the
-pattern. Fixed by hand, recorded here, and left unguarded on purpose — the shape that
-would catch it is "resolve every claim about which guard covers what", which is the
-prose-inference design `tests/test_the_documents_cite_what_they_claim.py` measured and
-rejected in its own docstring.
+**The second is the guard doing it to itself, which is why it is second.** The comment
+above `DOCUMENTS` reads *"if a document joins that map, it joins this list"* —
+and `docs/ORCHESTRATION.md` joined the map in `#257` without joining the list, so the
+one document that tells a session how to merge had its citations checked by nothing,
+while the comment promised otherwise. Found by reading the map against the list rather
+than trusting the sentence. **A rule written as a comment is a rule with nothing behind
+it, however well the comment is written.**
+
+**And what this section's own guard does NOT catch, said plainly.** The first instance
+is a reference to a test *file*, not a backticked test *name*, so it falls outside the
+pattern. It was fixed by hand and left unguarded on purpose: the shape that would catch
+it is *"resolve every claim about which guard covers what"*, which is prose inference —
+the design `tests/test_the_documents_cite_what_they_claim.py` measured and rejected in
+its own docstring, and the same design thrown away here for deciding honesty by
+adjacency. **A known gap named beats a guard that infers intent.**
+
+**Recording is not building, and this section has its own instance.** The misdirected
+pointer above was found in the morning, written down, and left for hours while three
+other things were fixed. It cost nothing this time. Two of his requests went the same
+way on the same day — briefed to a session, acted on correctly, and never reaching
+`REQUESTS.md`, which is exactly the failure `C7` exists to prevent and `REQ-04` is
+named after.
 
 **Apply, generally:** when you write down why something is true, ask which check
 would fail if the reason stopped being true. If the answer is *none*, you have
-written a claim that will outlive its evidence, and the more carefully it is written
-the longer it will survive.
+written a claim that will outlive its evidence — and the more carefully it is
+written, the longer it will survive.

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -1904,6 +1904,14 @@ while the comment promised otherwise. Found by reading the map against the list 
 than trusting the sentence. **A rule written as a comment is a rule with nothing behind
 it, however well the comment is written.**
 
+**And it is the first failure again, one level up: not a citation pointing at the wrong
+line but a GUARD pointing at the wrong scope.** The guard was not merely silent about
+that file — it was *affirmatively misleading*, because a reader who checked the comment
+would have concluded the file was covered. Misdirection is the worse half of this class
+wherever it appears, and it appears at every level: in a comment about where a test
+lives, in a comment about which guard covers what, and in a guard's own statement of
+what it reads.
+
 **And what this section's own guard does NOT catch, said plainly.** The first instance
 is a reference to a test *file*, not a backticked test *name*, so it falls outside the
 pattern. It was fixed by hand and left unguarded on purpose: the shape that would catch

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -1798,7 +1798,7 @@ when — especially when — it is only the connective tissue of a sentence.
 ### `settle_view` is the case that proves the class, not an example of it
 
 The worst of the three was in the docstring of `settle_view`
-([tests/test_panel_dom.py:147](../tests/test_panel_dom.py#L147)) — a helper used at
+([tests/test_panel_dom.py:160](../tests/test_panel_dom.py#L160)) — a helper used at
 four call sites, one of them the guard `#252` added. Its docstring **is** the entire
 evidentiary basis for the wait: 20/20 runs reading the box mid-animation, 7/20
 failing outright, height `47.99999237060547` = 48 − 2⁻¹⁷ at one float32 ulp. Every

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -162,11 +162,22 @@ def settle_view(page, name: str) -> None:
 
     THE NUMBERS BELOW ARE THE POINT OF THIS FUNCTION. A wait with no visible
     cause is a wait the next reader deletes — which is precisely how the guard
-    in `test_the_engine_overflow_trigger_has_no_visible_resting_container` came
-    to be broken: someone loosened it to 47.5 without writing down why, and the
-    next person along removed the 47.5 as unjustified slack. Both were right
-    about the other's evidence and wrong about the cause. Do not repeat that by
-    deleting this because it looks like a sleep.
+    that produced these numbers came to be broken: someone loosened it to 47.5
+    without writing down why, and the next person along removed the 47.5 as
+    unjustified slack. Both were right about the other's evidence and wrong about
+    the cause. Do not repeat that by deleting this because it looks like a sleep.
+
+    THAT GUARD NO LONGER EXISTS, AND THIS SAYS SO RATHER THAN NAMING IT AS IF IT
+    DID. It was `test_the_engine_overflow_trigger_has_no_visible_resting_container`
+    — added by `8796fb5` (#151), removed by `ce80886` (#217) when the Engine page's
+    overflow menu was replaced by action rows, so the trigger it measured stopped
+    existing. Read it with `git show 8796fb5:tests/test_panel_dom.py` if you want
+    the original; the measurements below were taken against it and are reproducible
+    against any test that measures a box in a view this settles, of which
+    `test_the_back_button_out_of_one_engine_is_a_borderless_pill` below is the
+    closest live equivalent — same screen, same borderless-control geometry.
+    Naming a deleted test as though a reader could open it is how evidence stops
+    being checkable, which is the one thing this docstring is for.
 
     `showView` animates a view in with `transform: translateY(8px) -> (0)` over
     180ms (extension/app.js). The animation is on the `#view-<name>` element
@@ -178,7 +189,7 @@ def settle_view(page, name: str) -> None:
 
     While the animation runs the view carries a live transform, so every box
     read through it comes back as a float32 compositor quad. Measured on
-    Windows, Chromium, devicePixelRatio 1, running the overflow-trigger test
+    Windows, Chromium, devicePixelRatio 1, running that overflow-trigger test
     ALONE — no suite around it:
 
       * 20/20 runs read the box MID-animation. The `wait_for_function` that
@@ -4729,11 +4740,17 @@ def test_the_back_button_out_of_one_engine_is_a_borderless_pill(open_panel):
     """The same control Manage account already ships, held to the same values:
     a 40px pill with no resting border or background, muted until hovered.
 
-    Read from the CSSOM as well as the box, for the reason
-    `test_the_engine_overflow_trigger_has_no_visible_resting_container` was
-    rewritten around: a global `button {min-height: var(--control-height)}`
-    clamps the rendered height back up, so a rendered box alone cannot catch a
+    Read from the CSSOM as well as the box, and the reason is a live rule rather
+    than a remembered one: `button, .button { min-height: var(--control-height) }`
+    in `design/components.css:369-371` applies to every bare `<button>`, so it
+    clamps the rendered height back up and a rendered box alone cannot catch a
     height regression at all.
+
+    The technique was established by
+    `test_the_engine_overflow_trigger_has_no_visible_resting_container`, which is
+    GONE — removed by `ce80886` (#217) with the overflow menu it measured. Cited
+    here as history, not as somewhere to look: the clamp above is the evidence,
+    and it is still in the sheet.
     """
     page = open_panel()
     page.click("#tab-engines")

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -286,7 +286,7 @@ PINNED = (
     # declared allowlist, and the check that a row is READABLE where it claims.
     ("docs/LESSONS.md", "design/components.css", 369,
      "min-height: var(--control-height)"),
-    ("docs/LESSONS.md", "tests/test_panel_dom.py", 147, "def settle_view("),
+    ("docs/LESSONS.md", "tests/test_panel_dom.py", 160, "def settle_view("),
     ("docs/LESSONS.md", "tests/test_the_tests_name_tests_that_exist.py", 86,
      "HISTORICAL = {"),
     ("docs/LESSONS.md", "tests/test_the_tests_name_tests_that_exist.py", 144,

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -77,6 +77,16 @@ ROOT = pathlib.Path(__file__).resolve().parents[1]
 
 # The map in CLAUDE.md -- the documents C1 sends every session to read before it
 # writes a line of code. If a document joins that map, it joins this list.
+#
+# AND THAT SENTENCE WENT UNENFORCED ON ITS FIRST TEST. `docs/ORCHESTRATION.md`
+# joined the map in `#257` and did not join this tuple, so the one document telling
+# a session how to merge had its citations checked by nothing -- while the comment
+# directly above said it would. A rule stated in a comment and enforced nowhere is
+# LESSONS §13's subject, and this is the guard's own instance of it. Found 2026-08-22
+# by reading the map against this list rather than trusting the sentence.
+#
+# Measured before adding it, so it goes green rather than arriving red: 4 citations,
+# all resolving, none on a blank line.
 DOCUMENTS = (
     "CLAUDE.md",
     "ENGINEERING.md",
@@ -86,6 +96,7 @@ DOCUMENTS = (
     "docs/BACKLOG.md",
     "docs/LESSONS.md",
     "docs/APPROACHES.md",
+    "docs/ORCHESTRATION.md",
 )
 
 # `sql` JOINED THIS LIST ON 2026-08-22, and the hole it closed was found by

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -266,6 +266,20 @@ PINNED = (
     # "bump both or neither" is a rule with a guard behind it rather than advice.
     ("docs/LESSONS.md", "tests/test_version.py", 73,
      "def test_the_installer_carries_the_same_number("),
+    # LESSONS §13 · a test named in a docstring is a citation. All four of these are
+    # the section's ARGUMENT rather than decoration, and each fails differently if a
+    # reader lands off it. The clamp is the section's whole point about citing a live
+    # rule instead of a test that measured it -- land off that and the advice reads as
+    # unsupported. `settle_view` is the case that proves the class, and the other two
+    # are the mechanism the section says replaced deciding honesty by adjacency: the
+    # declared allowlist, and the check that a row is READABLE where it claims.
+    ("docs/LESSONS.md", "design/components.css", 369,
+     "min-height: var(--control-height)"),
+    ("docs/LESSONS.md", "tests/test_panel_dom.py", 147, "def settle_view("),
+    ("docs/LESSONS.md", "tests/test_the_tests_name_tests_that_exist.py", 86,
+     "HISTORICAL = {"),
+    ("docs/LESSONS.md", "tests/test_the_tests_name_tests_that_exist.py", 144,
+     "def test_a_historical_test_is_still_readable_where_the_row_says("),
     # DELIBERATELY ABSENT, AND THE ABSENCE IS RECORDED HERE RATHER THAN ONLY IN THE
     # ENTRY THAT WANTS IT. `OP-46` cites seven lines in `extension/app.js` --
     # `setupFinanceConverterSelect` and `setupRunModeSelect` chief among them -- and

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -291,19 +291,29 @@ PINNED = (
      "HISTORICAL = {"),
     ("docs/LESSONS.md", "tests/test_the_tests_name_tests_that_exist.py", 144,
      "def test_a_historical_test_is_still_readable_where_the_row_says("),
-    # DELIBERATELY ABSENT, AND THE ABSENCE IS RECORDED HERE RATHER THAN ONLY IN THE
-    # ENTRY THAT WANTS IT. `OP-46` cites seven lines in `extension/app.js` --
-    # `setupFinanceConverterSelect` and `setupRunModeSelect` chief among them -- and
-    # pins none of them, because that file was under concurrent edit by another
-    # session when the entry was written. Pinning a line another branch is moving is
-    # how `scrapex/webui/app.py:2710` above became 2725 and then 2787.
+    # OP-46 · THE CONDITION BELOW FIRED, AND THESE TWO ROWS ARE ITS DISCHARGE.
     #
-    # A CONDITION, NOT A CHORE ASSIGNED TO NOBODY: pin those two symbols the next
-    # time you add a row here AND `extension/app.js` is quiet. It is written beside
-    # the mechanism instead of in `OP-46` because this table is re-read every time
-    # someone adds a row, whereas a BACKLOG entry is read when someone goes looking
-    # for work -- and this instruction has to fire while its reader is doing
-    # something else.
+    # The condition, written here on 2026-08-22 and kept for the record: `OP-46` cites
+    # seven lines in `extension/app.js` and pinned none of them, because that file was
+    # under concurrent edit when the entry was written -- pinning a line another branch
+    # is moving is how `scrapex/webui/app.py:2710` above became 2725 and then 2787. It
+    # said: pin those two symbols the next time you add a row here AND
+    # `extension/app.js` is quiet.
+    #
+    # It was written beside the mechanism rather than in `OP-46` because this table is
+    # re-read whenever someone adds a row, while a BACKLOG entry is read only when
+    # someone goes looking for work -- so the instruction had to fire while its reader
+    # was doing something else. IT DID, TWICE: once refusing to pin while #258 was open
+    # against that file, and once here, releasing.
+    #
+    # Discharged at `d10e974`, after #258 landed, having checked BOTH halves rather than
+    # assuming either: no open pull request's own diff touches `extension/app.js`, and
+    # all four of `OP-46`'s citations into it still name their symbols after #258 moved
+    # that file. The remaining five citations in that entry stay unpinned on purpose --
+    # they are the measured numbers, not the two symbols the argument rests on.
+    ("docs/BACKLOG.md", "extension/app.js", 956,
+     "function setupFinanceConverterSelect("),
+    ("docs/BACKLOG.md", "extension/app.js", 2008, "function setupRunModeSelect("),
 )
 
 # A guard that can be emptied without anyone noticing is the defect -- SR-23, and

--- a/tests/test_the_tests_name_tests_that_exist.py
+++ b/tests/test_the_tests_name_tests_that_exist.py
@@ -1,0 +1,190 @@
+"""A test named in a comment has to be a test somebody can open.
+
+WHY THIS EXISTS. The documents are guarded -- `R-15`, and
+`tests/test_the_documents_cite_what_they_claim.py` checks every `file:line` in
+`CLAUDE.md`, `ENGINEERING.md` and `docs/`. Test files are guarded by nothing, and
+they carry the same kind of claim: a docstring that says *"this is why, see
+`test_foo`"* is a citation, and it rots the same way.
+
+FOUND ON 2026-08-22, three references, all to one deleted test, and THE DATES ARE
+THE ARGUMENT. `test_the_engine_overflow_trigger_has_no_visible_resting_container`
+was added by `8796fb5` on 2026-08-10 and removed by `ce80886` on 2026-08-20, when
+the Engine page's overflow menu was replaced by action rows and the trigger it
+measured stopped existing. A ten-day-old test had accumulated three dangling
+citations within two days of dying. This is not slow rot that a careful reader
+would eventually notice -- it is the default outcome of deleting a test anything
+else explains itself by. Two comments in `tests/test_panel_dom.py` went on naming
+it as though a reader could open it:
+
+  * `settle_view`'s docstring -- the whole evidentiary basis for a helper still
+    used four times. Every number in it (20/20 reads mid-animation, 7/20 outright
+    failures, height 47.99999237060547 = 48 - 2**-17) was measured against that
+    test. A reader who doubted the wait had nothing to re-measure against, and
+    that docstring's own first line is *"a wait with no visible cause is a wait
+    the next reader deletes"*.
+  * `test_the_back_button_out_of_one_engine_is_a_borderless_pill` -- cited it for
+    the technique of reading the CSSOM as well as the box.
+
+Neither comment was WRONG about the facts. The `button, .button { min-height:
+var(--control-height) }` clamp is real and still in `design/components.css`, and
+the 47.5 incident happened. What had gone was the ability to CHECK either, which
+is the only thing a citation is for.
+
+WHY AN ALLOWLIST RATHER THAN A PATTERN. The obvious version greps the surrounding
+prose for "renamed from" or "no longer exists" and forgives those. That was
+written first and thrown away: it decides whether a reference is honest by
+keyword, so it passes any dead name that happens to sit near the word "removed"
+and fails an honest one phrased differently. This repository already settled this
+shape twice -- `PINNED` in the guard next door, and `RESERVED` in
+`test_the_registers_cannot_collide.py`. **A deliberate exception is DECLARED, not
+inferred.** So a historical name is written down here with where to read it, and
+anything else must be a test that exists.
+"""
+from __future__ import annotations
+
+import collections
+import pathlib
+import re
+
+import pytest
+
+# NO `pytestmark`, DELIBERATELY AND NOT BY OMISSION. This file reads `tests/` and
+# nothing else -- not the browser side's sources, not a document -- so it belongs
+# to neither tier and runs in the full suite, which is where it has to run: test
+# docstrings change on every kind of pull request, not on one tier's.
+#
+# AND THAT IS WHY THE PROSE HERE DOES NOT SPELL THE BROWSER DIRECTORY'S NAME.
+# `test_the_extension_gate_is_complete` matches that name in any file under
+# `tests/` and then demands the matching marker, which would move this file into
+# the tier CI runs SEPARATELY -- so it would stop running on an engine-only or
+# docs-only change. The gate's own note says a false positive "costs one marker";
+# here the marker would cost the guard. The same trade, for the same reason, is
+# already taken in `tests/test_the_version_moves_when_the_contract_does.py`, whose
+# prose avoids the name for exactly this. Caught by that gate on the first run of
+# this file, which is the gate working.
+#
+# (An empty `pytestmark = ()` is not the way to say "no marks": pytest unpacks it
+# and fails collection with `got () instead of Mark`. Say it in prose, as here.)
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+TESTS = ROOT / "tests"
+
+#: A backticked test name in prose. Six characters past the prefix keeps `test_x`
+#: placeholders in example snippets out of it, and the backticks keep ordinary
+#: prose about "the test_foo family" out too -- only a name someone deliberately
+#: marked up as code is treated as a reference.
+REFERENCE = re.compile(r"`(test_[A-Za-z0-9_]{6,})`")
+
+#: TESTS THAT NO LONGER EXIST AND ARE NAMED ON PURPOSE, with where to read them.
+#: A row here is a promise that `git show <ref>:<path>` still produces the test,
+#: which is what makes naming it useful rather than decorative -- and it is
+#: checked below rather than trusted.
+#:
+#: Delete a row when the last reference to it goes. Add one only when the history
+#: is the point; if a test was renamed and the new name says the same thing, cite
+#: the new name instead and add nothing here.
+HISTORICAL = {
+    "test_the_engine_overflow_trigger_has_no_visible_resting_container": (
+        "8796fb5", "tests/test_panel_dom.py",
+        "added by 8796fb5 (#151), removed by ce80886 (#217) with the Engine "
+        "page's overflow menu; settle_view's measurements were taken against it"),
+    "test_frozen_entry_defaults_to_the_native_host": (
+        "ff21042", "tests/test_native.py",
+        "renamed to test_an_unknown_argument_is_chrome_rather_than_cli_usage by "
+        "7a067c5 (#141), when no-arguments stopped meaning the native host and "
+        "started meaning first-run setup"),
+}
+
+#: A guard that can be emptied without anyone noticing is the defect -- SR-23 and
+#: OP-18, the same reason `PINNED_FLOOR` exists next door. This floor is below
+#: today's count on purpose.
+REFERENCE_FLOOR = 20
+
+
+def _test_files() -> list[pathlib.Path]:
+    return sorted(TESTS.glob("test_*.py"))
+
+
+def _defined() -> dict[str, set[str]]:
+    """Test function name -> the files defining it."""
+    found: dict[str, set[str]] = collections.defaultdict(set)
+    for path in _test_files():
+        for match in re.finditer(r"^def (test_[A-Za-z0-9_]+)",
+                                 path.read_text(encoding="utf-8"), re.M):
+            found[match.group(1)].add(path.name)
+    return found
+
+
+def _references():
+    for path in _test_files():
+        text = path.read_text(encoding="utf-8")
+        for match in re.finditer(REFERENCE, text):
+            line = text.count("\n", 0, match.start()) + 1
+            yield path.name, line, match.group(1)
+
+
+def test_every_test_named_in_a_comment_exists_or_is_declared_historical():
+    """THE GUARD. A name that is neither a live test, a gate module, nor a
+    declared historical row sends its reader looking for nothing."""
+    defined = _defined()
+    modules = {path.stem for path in _test_files()}
+    dangling = [
+        f"{where}:{line} names `{name}`"
+        for where, line, name in _references()
+        if name not in defined and name not in modules and name not in HISTORICAL
+    ]
+
+    assert not dangling, "\n  ".join([
+        "these comments name a test that does not exist. Either cite the test "
+        "that replaced it, or add a row to HISTORICAL saying where to read the "
+        "one that is gone:", *dangling])
+
+
+@pytest.mark.parametrize("name", sorted(HISTORICAL))
+def test_a_historical_test_is_still_readable_where_the_row_says(name):
+    """A row here promises a reader can recover the test. Unverified, that
+    promise is worth exactly as much as the dead name it replaced."""
+    import subprocess
+
+    ref, path, _why = HISTORICAL[name]
+    shown = subprocess.run(
+        ["git", "show", f"{ref}:{path}"],
+        cwd=ROOT, capture_output=True, text=True, encoding="utf-8", errors="replace")
+    assert shown.returncode == 0, (
+        f"HISTORICAL[{name!r}] points at `{ref}:{path}`, which git cannot read: "
+        f"{shown.stderr.strip()[:200]}")
+    assert f"def {name}(" in shown.stdout, (
+        f"HISTORICAL[{name!r}] says to read it at `{ref}:{path}`, and it is not "
+        f"defined there. Find the commit that still has it and correct the row.")
+
+
+def test_a_historical_row_is_not_also_a_live_test():
+    """The mirror of `RESERVED`'s disjointness check. A name that is both declared
+    dead and defined means the row outlived what it was for, and the guard above
+    is forgiving a reference it should be checking."""
+    defined = _defined()
+    both = sorted(set(HISTORICAL) & set(defined))
+    assert not both, (
+        f"declared historical AND defined: {both}. Delete the row -- the test is "
+        f"back, so references to it need no exception.")
+
+
+def test_a_historical_row_is_not_orphaned():
+    """A row nobody cites is a row that should go, by the same rule `RESERVED`
+    states: an exception left behind is a permanent one nobody owns."""
+    cited = {name for _where, _line, name in _references()}
+    orphaned = sorted(set(HISTORICAL) - cited)
+    assert not orphaned, (
+        f"HISTORICAL rows nothing references any more: {orphaned}. The last "
+        f"comment naming them went; the row should go with it.")
+
+
+def test_the_guard_reads_something():
+    """A parameterised sweep that matched nothing would pass every case, which is
+    how a guard becomes decoration -- the lesson `test_the_registers_cannot_collide`
+    records for the same shape."""
+    total = sum(1 for _ in _references())
+    assert total >= REFERENCE_FLOOR, (
+        f"only {total} backticked test references found across "
+        f"{len(_test_files())} files, against a floor of {REFERENCE_FLOOR}. The "
+        f"pattern has probably stopped matching.")

--- a/tests/test_ui_kit.py
+++ b/tests/test_ui_kit.py
@@ -48,8 +48,18 @@ ROOT = pathlib.Path(__file__).resolve().parents[1]
 #: Stylesheets whose rules are available to the markup checked below. The two
 #: canonical sheets in `design/` are the shared vocabulary; the rest are the
 #: per-surface sheets. Distributed copies under `extension/` and
-#: `scrapex/webui/static/` are byte-equal to the canon (tests/test_vendor.py),
-#: so reading the canon is reading both.
+#: `scrapex/webui/static/` are byte-equal to the canon, so reading the canon is
+#: reading both.
+#:
+#: THE GUARD FOR THAT IS `tests/test_design_system.py`, whose
+#: `test_generated_design_assets_are_current` asserts `sync(check=True) == []` over
+#: `tools/sync_design_assets.py`'s ASSETS map. This line named `tests/test_vendor.py`
+#: until 2026-08-22, which does not check it: the only byte-equality assertion in
+#: that file compares the two vendored copies of Tabulator. So the claim above was
+#: true and its stated evidence was the wrong file -- a reader checking it would have
+#: found nothing and could reasonably have concluded the copies were unguarded.
+#: LESSONS §13 is about this class; it is the instance that is a FILE reference
+#: rather than a test name, which is why the guard added there cannot catch it.
 CANONICAL = ("design/components.css", "design/tokens.css")
 #: DERIVED, not typed. This was a hand-written tuple until 2026-08-15, and the
 #: Data page's stylesheet was missing from it the moment the page was written —


### PR DESCRIPTION
**Tests only. No behaviour changed, no source touched.** Two files:
`tests/test_panel_dom.py` (three comment references repaired) and a new
`tests/test_the_tests_name_tests_that_exist.py` (the guard).

## What was wrong

The documents are guarded — `R-15`, `test_the_documents_cite_what_they_claim.py`
checks every `file:line` in `CLAUDE.md`, `ENGINEERING.md` and `docs/`. **Test files
are guarded by nothing**, and they carry the same kind of claim: a docstring saying
*"this is why, see `test_foo`"* is a citation, and it rots identically.

`test_the_engine_overflow_trigger_has_no_visible_resting_container` was added by
`8796fb5` on **2026-08-10** and removed by `ce80886` on **2026-08-20**, when the
Engine page's overflow menu became action rows and the trigger it measured stopped
existing. **Three references outlived it** — a ten-day-old test accumulated three
dangling citations within two days of dying. That is not slow rot a careful reader
would notice; it is the default outcome.

| where | what it claimed |
|---|---|
| `settle_view` docstring (×2) | the **entire evidentiary basis** for a helper used at four call sites — every number in it (20/20 reads mid-animation, 7/20 failures, `47.99999237060547` = 48 − 2⁻¹⁷) was measured against that test |
| `test_the_back_button_out_of_one_engine_is_a_borderless_pill` | the reason for reading the CSSOM as well as the box |

**Neither comment was wrong about the facts**, which is why this is a citation
defect and not a stale comment. The clamp is real — `button, .button { min-height:
var(--control-height) }` at `design/components.css:369-371`, verified, applying to
every bare `<button>` — and the 47.5 incident happened. What had gone was the
ability to **check** either. `settle_view`'s own first line is *"a wait with no
visible cause is a wait the next reader deletes."*

## The fix

Facts kept, references made recoverable. The docstring now says the test is gone,
names the commit that added it and the one that removed it, points at
`git show 8796fb5:tests/test_panel_dom.py`, and names the closest live equivalent
to re-measure against. The back-button test cites the **live rule** as its evidence
and the deleted test only as history.

## And the class is guarded, not just the instances

A backticked test name under `tests/` must be a live test, a gate module, or a
declared `HISTORICAL` row carrying the ref to read it at.

- **An allowlist, not a pattern.** The keyword version — forgive anything near
  "renamed from" — was written first and thrown away: it decides honesty by
  adjacency. Declared-not-inferred is the shape this repo already settled twice,
  in `PINNED` next door and `RESERVED` in the register guard.
- **Rows are verified, not trusted.** `git show <ref>:<path>` must still produce
  the test. **That check caught its own author immediately**: my first row named
  `6ccdd3c`, which does not contain the test; the real last commit is `ff21042`.
- Rows are also asserted not-also-live and not-orphaned, and a floor stops the
  sweep being emptied.
- **Proved non-vacuous by mutation**: an injected dangling reference fails with the
  file and line named. Restored after.

## Two things the gates taught me rather than me guessing

- `pytestmark = ()` is **not** how to say "no marks" — pytest unpacks it and fails
  collection with `got () instead of Mark`.
- The prose deliberately does not spell the browser directory's name. The extension
  gate matches it anywhere under `tests/` and would demand the marker that moves
  this file into a **separately-run tier** — so the guard would stop running on
  engine-only and docs-only changes, which is when test docstrings change too. The
  same trade is already taken in
  `tests/test_the_version_moves_when_the_contract_does.py`. Caught by that gate on
  this file's first run.

## Verification

```
gates + new guard   14 passed
docs tier           311 passed, 1 skipped
sweep               23 references across 190 test files, 0 dangling
base                a9e8103
```

---

**Secondary session: this does not merge itself** (`R-42`).

## Added since opening: `docs/LESSONS.md` §13

The primary session confirmed §13 was free and I verified it independently — `git show
a9e8103:docs/LESSONS.md` has exactly 12 sections, §1–§12 contiguous; #255 took §12,
#253 added *inside* §7 and §8, and neither open branch adds a LESSONS section.

§13 records the **kind** of thing this was, which is what someone needs while writing
a docstring that cites a test — not while reading the guard. It leads with the dates,
carries the three points that generalise past this guard (`settle_view` as the case
that proves the class; facts kept and references repaired, because deleting the
paragraph throws away a true fact to fix a broken pointer; and the guard reading the
claim rather than the prose around it), and records both collection facts.

It also records that the first draft of that sentence said "nine months", written from
an assumption and corrected by running `git log` before it was pushed.

**Four `PINNED` rows**, because §13's argument turns on them and each fails
differently if a reader lands off it. Three point into files this branch owns or
creates; the fourth is `design/components.css:369`, which no open branch touches.

**And `OP-46`'s `app.js` citations correctly stay unpinned.** The condition written
into `PINNED`'s comment last PR says pin them once `extension/app.js` is quiet — it is
not, `fix/a-dataset-card-gets-the-menu-it-can-use` is still open against it. The
condition worked as designed on its first test.

## Verification

```
CI              all checks pass on 86ef241
state           MERGEABLE / CLEAN
base            a9e8103   (merge-base == origin/main, re-checked after CI)
head            86ef241   (pushed == local)
docs tier       315 passed, 1 skipped
gates + guard   14 passed
sweep           23 references across 190 test files, 0 dangling
```

Merge order noted: #257, then #258, then this. If `main` moves first I will rebase,
re-derive, re-run and hand over that green rather than this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

