### PR TITLE
muqawil is one card, and 17,304 contractors stop being products

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -301,8 +301,8 @@ And only one of the **two** `worker_alive` computations was fixed:
 
 | where | what it calls | verdict |
 |---|---|---|
-| `scrapex/webui/app.py:1554` — `/api/health` | the new two-heartbeat `worker` verdict | correct; the panel reads this one (`extension/engine.js:38`) |
-| `scrapex/webui/app.py:2598` — `_about` | `worker_is_alive(conn)`, single heartbeat | **the function the fix superseded** |
+| `scrapex/webui/app.py:1673` — `/api/health` | the new two-heartbeat `worker` verdict | correct; the panel reads this one (`extension/engine.js:38`) |
+| `scrapex/webui/app.py:2666` — `_about` | `worker_is_alive(conn)`, single heartbeat | **the function the fix superseded** |
 
 `_about` renders the engine's own `/settings` page
 (`scrapex/webui/templates/settings.html:162-167`), so **the engine still shows
@@ -310,7 +310,7 @@ And only one of the **two** `worker_alive` computations was fixed:
 engine is started at all.
 
 **Next action:** three separate things — the second `worker_alive` at
-`app.py:2598`; the heartbeat's behaviour under a held write lock; and the 409 on
+`app.py:2666`; the heartbeat's behaviour under a held write lock; and the 409 on
 `/api/storage/restore` with a mirror of
 `test_start_fresh_is_refused_while_a_crawl_runs`.
 
@@ -1074,7 +1074,7 @@ profile crawl was running against it):
 
 **THE CAUSE WAS NOT THE MISSING `crawl_run` ROW.** `_dataset_rows` wrote
 `"last_success": None` as a **literal**, and `freshnessLine`
-(`extension/app.js:4489`) prints that sentence whenever the key is absent or
+(`extension/app.js:4549`) prints that sentence whenever the key is absent or
 carries no `started_at`. So a `crawl_run` row for muqawil would have changed
 nothing on the card — the fix had to arrive at that key.
 
@@ -1785,7 +1785,7 @@ the two `muqawil.org` cards carry none. So it belongs here and not in
 **That absence is deliberate, and it is written down in both halves.**
 `sourceMenu` returned an empty string for a dataset — the line is gone, and what
 stands where it stood is the filter that replaced it
-([extension/app.js:4595](../extension/app.js#L4595)) — and the engine stamps the
+([extension/app.js:4655](../extension/app.js#L4655)) — and the engine stamps the
 marker it keys on precisely so the panel can do that — `"kind": "dataset"` in
 `_dataset_rows`, whose docstring says *"the row menu offers Update, Wipe and
 Rename, and every one of those is a price-path action that would answer 400 or
@@ -1793,12 +1793,12 @@ worse for a dataset"* ([scrapex/webui/app.py:697](../scrapex/webui/app.py#L697))
 It was the right call for five of the six entries and it is still right for them:
 `update`, `pause` and `settings` post to routes that read the manifest, and
 `/api/export/{key}` validates the key against `manifest.sources` and answers 404
-for anything else ([scrapex/webui/app.py:2843](../scrapex/webui/app.py#L2843)).
+for anything else ([scrapex/webui/app.py:2911](../scrapex/webui/app.py#L2911)).
 
 **But `Open the data table` would work, and it was built after the blanket
 hide.** `data.html?source=KEY` fetches `/api/table/{key}`, and that route looks
 the key up in the dataset catalogue FIRST — *"a generic dataset is a table like
-any other table"* ([scrapex/webui/app.py:1048](../scrapex/webui/app.py#L1048)) —
+any other table"* ([scrapex/webui/app.py:1167](../scrapex/webui/app.py#L1167)) —
 so `/api/table/contractors` serves the directory in full. The panel hides the one
 entry that works on the marker that was introduced for the five that do not.
 
@@ -4085,7 +4085,7 @@ date it was measured.
 1. **ALSWEED is being refused with HTTP 429**, five times on 2026-08-11, because
    `crawl_honour_delay` is `'0'`. **BV-3**.
 2. **The engine's own Settings page says "Not running" while it crawls** — a
-   second `worker_alive` computation at `app.py:2598` that the fix never reached
+   second `worker_alive` computation at `app.py:2666` that the fix never reached
    — and the runtime heartbeat freezes under `database is locked` when a job
    holds a write transaction. **OP-6 · ت2**.
 3. **The diagnostic-page guard is still blind**, and this file said it had been

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2412,9 +2412,20 @@ separately". So the Run screen offering a dataset a single checkbox is not merel
 broken, it is the wrong shape: there is no one crawl to tick. The fix is a card that
 offers the two, and it needs a panel path to a dataset crawl, which does not exist
 (`REQ-24` shipped `scrapex contractors` as a CLI command and says the panel path is
-still missing). `_dataset_rows` still ends `GROUP BY d.dataset_definition_id`
-(`scrapex/webui/app.py:694`, re-derived at `31c369e`), so the ruling is recorded and
-not yet built.
+still missing).
+
+**UPDATED 2026-08-23: HALF OF THAT IS NOW BUILT AND THIS ENTRY IS THE HALF THAT IS
+NOT.** `R-47`'s points 1 and 2 shipped — `_dataset_listing` folds the two muqawil
+datasets into one listing row and reports the profile crawl as coverage, so the Data
+screen draws one card. The sentence this paragraph used to end on — *"`_dataset_rows`
+still ends `GROUP BY d.dataset_definition_id`, so the ruling is recorded and not yet
+built"* — is **kept as history and no longer true of the listing**: that function still
+groups per dataset, deliberately, because `/source/{key}` resolves one dataset out of
+it by key and folding there would 404 the profile table. What remains open is exactly
+what this entry names: **the Run screen and the Source manager still draw a dataset from
+the same `/api/sources` answer and still offer it controls that cannot touch it.** The
+fold changed the number of cards on those two screens as well; it did not give either
+of them an action that works.
 
 **Note what the Run screen already knows how to do**: `NOT_READY` is rendered
 DISABLED with "Not supported yet" on it, because `implemented` is false. So the
@@ -2572,6 +2583,78 @@ checked `RUNTIME_DATA` against the real `.exe` table of contents and found no ga
 and the worry that `contractstamp` reads a `.py` at runtime was refuted — it is a
 developer-only path.
 
+
+### OP-53 · The word "products" over a contractor directory, on two surfaces
+
+**Status: the PANEL half is CLOSED by this branch. The ENGINE PAGE half is OPEN and
+is a design question, not a noun.** Found 2026-08-23 while diagnosing why his Data
+screen still showed two muqawil cards — he did not report this one, which is why it
+is here and not in `REQUESTS.md`.
+
+His screen read:
+
+```
+muqawil.org / Saudi Contractors Authority · contractors [Row 17,304]
+  17,304 products
+```
+
+**A contractor is not a product, and 17,304 contractors are not 17,304 products.**
+
+**THE PART THAT MAKES IT A REAL FINDING RATHER THAN A TYPO: the engine already knew
+the word was meaningless, in writing.** `_dataset_rows` (`scrapex/webui/app.py`)
+carries this comment over the line that fills the field:
+
+> *"`observations` is what the Data screen filters on, and for a directory the honest
+> number is its rows. `products` has no meaning for a company, so it carries the same
+> count rather than a zero that would read as an empty dataset."*
+
+So the engine deliberately passed a duplicate of the row count through a field it
+documents as meaningless for a company, and the panel printed the meaningless word
+underneath it. Neither side was unaware; the two notes never met.
+
+#### What was fixed, and why the noun is not a special case
+
+`extension/app.js` hardcoded `${fmtCount(s.products)} products` for every card. The
+replacement is `countLine`, three branches, each keyed on what the engine reports
+rather than on a key's spelling — because `jobs` and `tenders` are named in
+`CLAUDE.md` as coming and `if (contractors)` would be the third wrong noun the day
+`tenders` lands:
+
+| the card | the second line | why that |
+|---|---|---|
+| a price source | `1,812 products` — **unchanged** | there the word is TRUE and the number is a DIFFERENT one: spark-eshop reads `[Row 6,969]` above `1,812 products`. This is why the noun could not simply be replaced |
+| a dataset with a confirmed one-to-one detail crawl | `Contractor profiles: 704 of 17,304 (4.1%)` | `R-47`'s second point. For a dataset `observations` and `products` are the SAME number, so any noun would print the figure twice; coverage is the fact that slot was missing |
+| any other dataset | `8,412 rows` | the honest generic |
+
+**WHY `rows` AND NOT A BETTER WORD, since `R-45` governs it.** «ما يقوله الموقع هو
+مصدر الحقيقة الوحيد» forbids inventing a label the site never gave, and it rules out
+the two tempting alternatives: `dataset_definition.original_name` would print
+`17,304 contractors` for one dataset and `704 contractor_profiles` for the next, and a
+raw key dressed as an English noun is exactly the invented claim `R-45` refuses.
+`dataset_kind` was checked and is not the unit of a row — measured read-only on his
+warehouse 2026-08-23, it is `'table'` for both muqawil datasets, a structural kind.
+**Nothing in the warehouse names the unit of a row.** `rows` claims nothing about the
+site, and it is not a new vocabulary either: `sourceIdentity`'s default metric label
+is already `Row`, so the line above reads `[Row 17,304]`, and the Drive offline card
+in the same function already prints `<n> rows`. The COVERAGE label is the one word
+taken from the site, and it is the child dataset's stored `display_name` — what the
+approval recorded, never ours.
+
+#### The open half: the engine's own page says it too
+
+**`/source/contractors` prints a "Products" tile over the same 17,304 rows** — and
+that is the surface this branch did not touch. `_source_overview.html` renders four
+tiles from `SourceSummary`, and `/source/{key}` fills `products` for a dataset out of
+`_dataset_rows`, which is why the field is still sent rather than dropped:
+
+```
+Products 17,304 · Variants 0 · Data rows 17,304 · Matched 0
+```
+
+**Two of those four are meaningless for a directory and a third is a duplicate**, so
+this is not the panel's one-line fix wearing a different template — it is a question
+about what a dataset's overview should show at all, which is his call under `W3`. Left
+here with the measurement rather than guessed at.
 
 ## 3. Decided, not yet built
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2685,8 +2685,29 @@ GET /source/contractors -> 200, 42,058 bytes
 duplicates the first**: `Products` is the meaningless field, `Variants` and `Matched`
 are price-path concepts a company has none of, and `Data rows` is the honest number
 already. So this is not the panel's one-line fix wearing a different template — it is a
-question about what a dataset's overview should show at all, which is his call under
-`W3`. Left here with the measurement rather than guessed at.
+question about what a dataset's overview should show at all.
+
+#### The options, per `W3`, because this one is his
+
+| | what it does | effort | risk | what it costs later |
+|---|---|---|---|---|
+| **(a) do nothing** | the tile keeps reading `Products 17,304` over a directory | none | the engine page goes on saying what the panel stopped saying — **two surfaces disagreeing about the same rows**, which is the shape `#255` already had to fix once | the disagreement is the maintenance |
+| **(b) rename the one tile** | `Products` → `Rows` when `kind == dataset` | one line + a guard | **low, and it looks finished when it is not**: `Variants 0` and `Matched 0` still state price-path facts about a company | invites a third fix later for the same panel |
+| **(c) the tile SET follows the kind** | a dataset shows `Rows` and its coverage; a price source keeps all four | ~half a day, template + a shape the template can read | the tile list becomes data rather than a literal — the same move `countLine` just made on the panel | lowest: `jobs` and `tenders` need no new template work |
+
+**Recommendation: (c)**, mapped to **P1** (one source of truth for what a card shows —
+the panel now decides its noun from the engine's marker, and the page deciding its
+tiles from a hardcoded four is the same defect one surface over) and **P3** (not a
+premature abstraction: there are already two kinds and `CLAUDE.md` names two more
+coming). **(b) is the trap** — it is what "fix the noun" sounds like, and it would
+leave two of the three wrong tiles standing while reading as done.
+
+**The question for him:** *for a dataset like the contractor directory, should the
+overview show only the row count and how much of it has been fetched — or do you want
+the four tiles kept, with the ones that do not apply shown as blank rather than `0`?*
+`0` is the specific problem: it reads as a measured zero rather than as "not a thing
+this source has", which is the same distinction `last_successful_run` already documents
+for a crawl that never ran.
 
 ## 3. Decided, not yet built
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -302,7 +302,7 @@ And only one of the **two** `worker_alive` computations was fixed:
 | where | what it calls | verdict |
 |---|---|---|
 | `scrapex/webui/app.py:1673` — `/api/health` | the new two-heartbeat `worker` verdict | correct; the panel reads this one (`extension/engine.js:38`) |
-| `scrapex/webui/app.py:2666` — `_about` | `worker_is_alive(conn)`, single heartbeat | **the function the fix superseded** |
+| `scrapex/webui/app.py:2722` — `_about` | `worker_is_alive(conn)`, single heartbeat | **the function the fix superseded** |
 
 `_about` renders the engine's own `/settings` page
 (`scrapex/webui/templates/settings.html:162-167`), so **the engine still shows
@@ -310,7 +310,7 @@ And only one of the **two** `worker_alive` computations was fixed:
 engine is started at all.
 
 **Next action:** three separate things — the second `worker_alive` at
-`app.py:2666`; the heartbeat's behaviour under a held write lock; and the 409 on
+`app.py:2722`; the heartbeat's behaviour under a held write lock; and the 409 on
 `/api/storage/restore` with a mirror of
 `test_start_fresh_is_refused_while_a_crawl_runs`.
 
@@ -1793,7 +1793,7 @@ worse for a dataset"* ([scrapex/webui/app.py:697](../scrapex/webui/app.py#L697))
 It was the right call for five of the six entries and it is still right for them:
 `update`, `pause` and `settings` post to routes that read the manifest, and
 `/api/export/{key}` validates the key against `manifest.sources` and answers 404
-for anything else ([scrapex/webui/app.py:2911](../scrapex/webui/app.py#L2911)).
+for anything else ([scrapex/webui/app.py:2967](../scrapex/webui/app.py#L2967)).
 
 **But `Open the data table` would work, and it was built after the blanket
 hide.** `data.html?source=KEY` fetches `/api/table/{key}`, and that route looks
@@ -2584,7 +2584,7 @@ and the worry that `contractstamp` reads a `.py` at runtime was refuted — it i
 developer-only path.
 
 
-### OP-53 · The word "products" over a contractor directory, on two surfaces
+### OP-61 · The word "products" over a contractor directory, on two surfaces
 
 **Status: the PANEL half is CLOSED by this branch. The ENGINE PAGE half is OPEN and
 is a design question, not a noun.** Found 2026-08-23 while diagnosing why his Data
@@ -2639,6 +2639,27 @@ is already `Row`, so the line above reads `[Row 17,304]`, and the Drive offline 
 in the same function already prints `<n> rows`. The COVERAGE label is the one word
 taken from the site, and it is the child dataset's stored `display_name` — what the
 approval recorded, never ours.
+
+**`rows` IS THE ANSWER, NOT A FALLBACK, and the distinction matters because nothing
+has been ruled here.** No ruling covers the boundary between `products` and a
+directory, so this is a choice and it is recorded as one: a generic word that is true
+of every dataset beats a specific word that is true of one and invented for the rest.
+The moment the site itself gives us a word for what a row IS — not what the table is
+called, which `display_name` already holds — that word wins and this branch should be
+revisited. **His call if he wants a different word;** the reason for this one is above.
+
+> **CHECKED AGAINST `R-45`'s CORRECTION, 2026-08-23, because that correction landed
+> while this was open.** #261 measured that the per-row record card **has existed on
+> the engine since 2026-07-22** — 967 lines of `grid.js`, opened by row *selection*,
+> which is why a census searching for `rowFormatter` missed it — so `R-45`'s own table
+> was wrong about the card, and products have it while contractors do not.
+>
+> **None of that moves the noun.** This entry rests on `R-45` **part 1** — *"WE NEVER
+> TRANSLATE. The site's words are the record… A mapping we invent is our claim dressed
+> as the site's data"* — and the correction is about **part 2**, whether the row's card
+> exists and what it costs. The ruling's own words are that it *"stands unchanged"*.
+> Re-checked rather than assumed, since a reasoning chain resting on a ruling that has
+> just been corrected is exactly the thing worth re-reading.
 
 #### The open half: the engine's own page says it too
 
@@ -4096,7 +4117,7 @@ date it was measured.
 1. **ALSWEED is being refused with HTTP 429**, five times on 2026-08-11, because
    `crawl_honour_delay` is `'0'`. **BV-3**.
 2. **The engine's own Settings page says "Not running" while it crawls** — a
-   second `worker_alive` computation at `app.py:2666` that the fix never reached
+   second `worker_alive` computation at `app.py:2722` that the fix never reached
    — and the runtime heartbeat freezes under `database is locked` when a job
    holds a write transaction. **OP-6 · ت2**.
 3. **The diagnostic-page guard is still blind**, and this file said it had been

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2584,7 +2584,7 @@ and the worry that `contractstamp` reads a `.py` at runtime was refuted — it i
 developer-only path.
 
 
-### OP-61 · The word "products" over a contractor directory, on two surfaces
+### OP-63 · The word "products" over a contractor directory, on two surfaces
 
 **Status: the PANEL half is CLOSED by this branch. The ENGINE PAGE half is OPEN and
 is a design question, not a noun.** Found 2026-08-23 while diagnosing why his Data

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2642,19 +2642,30 @@ approval recorded, never ours.
 
 #### The open half: the engine's own page says it too
 
-**`/source/contractors` prints a "Products" tile over the same 17,304 rows** — and
-that is the surface this branch did not touch. `_source_overview.html` renders four
-tiles from `SourceSummary`, and `/source/{key}` fills `products` for a dataset out of
-`_dataset_rows`, which is why the field is still sent rather than dropped:
+**`/source/contractors` prints a "Products" tile over the very same rows** — and that
+is the surface this branch did not touch. `_source_overview.html` renders four tiles
+from `SourceSummary`, and `/source/{key}` fills `products` for a dataset out of
+`_dataset_rows`, which is why the field is still sent rather than dropped.
+
+**RENDERED, not read.** The page was fetched from a real engine holding one approved
+dataset of 4 rows and the four `<dd>` values read off the returned HTML — because a
+claim about what a template prints, reached by reading the template, is the shape this
+repository keeps catching:
 
 ```
-Products 17,304 · Variants 0 · Data rows 17,304 · Matched 0
+GET /source/contractors -> 200, 42,058 bytes
+  Products    4
+  Variants    0
+  Data rows   4
+  Matched     0
 ```
 
-**Two of those four are meaningless for a directory and a third is a duplicate**, so
-this is not the panel's one-line fix wearing a different template — it is a question
-about what a dataset's overview should show at all, which is his call under `W3`. Left
-here with the measurement rather than guessed at.
+**Three of those four say nothing about a contractor directory and the fourth
+duplicates the first**: `Products` is the meaningless field, `Variants` and `Matched`
+are price-path concepts a company has none of, and `Data rows` is the honest number
+already. So this is not the panel's one-line fix wearing a different template — it is a
+question about what a dataset's overview should show at all, which is his call under
+`W3`. Left here with the measurement rather than guessed at.
 
 ## 3. Decided, not yet built
 

--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -444,6 +444,77 @@ predicted a failing check by running the guard's own logic against the post-merg
 before pushing. That is minutes against a round trip, and it is the single biggest
 throughput win available.
 
+### And a RED lies too, which is the same problem pointing the other way — 2026-08-23
+
+A green that is not a green wastes a merge. **A red that is not a red wastes an
+afternoon hunting a defect that is not there**, and it is more expensive because it
+looks like diligence. One local run on this machine reported **22 failed and 259
+errors** against a branch whose only real defect was a single shouted word in a
+document. Three separate causes, none of them the branch:
+
+| what it looked like | what it was |
+|---|---|
+| the panel and grid suites collapsing, `AttributeError: 'PlaywrightContextManager' object has no attribute '_playwright'` on ~250 tests | **the Playwright driver could not spawn.** Not a test failing — the browser never started. Two full suites were running on the machine at once |
+| `test_the_engine_survives_being_killed`, the CLI chain, the lint gate, the panel-script parse all failing together | subprocess and port contention between the two runs, plus the owner's crawl. Anything that spawns a process or binds a port is the first thing to go |
+| a suite that had passed **in full** twenty minutes earlier | it had — alone. Nothing about the tree had changed |
+
+**Three rules come out of it, and the first one is the one I got wrong.**
+
+**1 · `TaskStop`, `Ctrl-C` and killing the wrapper do not kill `pytest`.** A suite
+stopped through its shell wrapper left the `python -m pytest` grandchild alive and
+competing for the next twenty minutes, which is what turned a peer's concurrent run
+from *slow* into *259 errors*. **Verify the process is gone, do not assume the stop
+reached it** — and identify it before killing it: the signature is the exact command
+line plus a creation time that matches your own recorded `started`, because a peer's
+run looks identical otherwise. On this machine the owner's crawl and the engine UI are
+also long-lived Python processes, and neither is ever yours to stop.
+
+**2 · One full suite at a time, per machine — not per worktree.** Worktrees isolate
+files; they share one Playwright install, one port space and one CPU. `Get-CimInstance
+Win32_Process` filtered on `pytest` is the check, and it costs a second. If a peer is
+running, **wait it out rather than kill it** (`R-42`), and say so in the report instead
+of reporting the contaminated numbers.
+
+**3 · A mass of errors in one family is an instrument failure until proven otherwise.**
+250 tests do not break at once from one branch's diff. `LESSONS.md` §9 says a
+measurement is only as good as its instrument; the corollary for a suite is that the
+shape of the failures tells you where to look — **all in one fixture, all in one
+family, all at one setup step** means the harness, not the code. Read the first error
+body before reading the count.
+
+### `gh pr checks` can show `test pass` while the code tier never ran
+
+Measured on this branch the same day, and it nearly closed the verification early.
+
+CI tiers the suite by what changed, and **the base it diffs against depends on the
+event.** A `push` compares against the branch's **previous tip**, so a push whose last
+commit touches only `docs/` classifies as `docs` and **skips the Python engine tier
+entirely** — correctly, for that push. A `pull_request` has no previous tip, so it
+falls back to the **merge base** and tiers on the whole PR diff.
+
+So after a docs-only follow-up commit, the `push` run reported `test pass` in 90
+seconds having run 317 document tests and skipped everything else, while the
+`pull_request` run on the same head was the one carrying the engine suite. **Reading
+`gh pr checks` alone cannot tell those apart** — both rows are called `test`.
+
+**The check:** confirm which STEP ran, not which job passed.
+
+```bash
+gh run view <run-id> --json jobs \
+  --jq '.jobs[] | select(.name=="test") | .steps[] | "\(.conclusion) \(.name)"'
+```
+
+A `skipped Tests (Python engine …)` line means that run verified nothing about the
+code. And prefer the `pull_request` run when you want the whole-PR answer:
+
+```bash
+gh run list --branch <branch> --json databaseId,event,headSha,status,conclusion
+```
+
+**None of this is a CI defect** — incremental tiering on a push is the point, and it is
+what makes a documentation change cost 90 seconds instead of eight minutes. The defect
+is a reader treating a per-push tier as a per-PR verdict.
+
 ---
 
 ### Escalate on suspicion, resolve on evidence

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -1780,8 +1780,8 @@ the relationship he already had confirmed. And the second number stops being a p
 
 ### BUILT 2026-08-23 — points 1 and 2 of three, and the third cannot ship yet
 
-**HE ASKED FOR THIS ON 2026-08-22 AND IT WAS RULED THE SAME DAY. It was still not
-built on 2026-08-23**, which is why he asked «حل المشكلة لم يصل لى ما السبب ؟» — the
+**HE ASKED FOR THIS ON 2026-08-22 AND HE GOT HIS ANSWER THE SAME DAY. It was still
+not built on 2026-08-23**, which is why he asked «حل المشكلة لم يصل لى ما السبب ؟» — the
 fix has not reached me, why? Measured before starting: **no file under `extension/`,
 `scrapex/` or `tests/` cited `R-47` or `REQ-37` at all.** Ruled, recorded, and never
 carried into code. That gap — a ruling with no line of code behind it — is the whole

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -91,7 +91,7 @@ IDs are stable and never reused, matching the convention BACKLOG.md already uses
 | [REQ-33](#req-33--the-dataset-cards-said-no-successful-crawl-over-crawled-rows) | The dataset cards said "no successful crawl yet" over 17,304 crawled rows | **Done** — the date is derived from the evidence; the two registries stay his | 2026-08-22 |
 | [REQ-35](#req-35--the-card-must-say-the-engine-is-running-from-source-not-that-it-is-missing) | The card must say the engine is running from source, not that it is missing | **Captured** — the engine knows how it was started and never reports it | 2026-08-22 |
 | [REQ-36](#req-36--the-three-dots-are-missing-on-a-contractor-card-and-unprofessional-on-the-others) | The three dots are missing on a contractor card, and unprofessional on the others | **In flight** — a session is measuring which treatment he means before restyling | 2026-08-22 |
-| [REQ-37](#req-37--one-card-per-site-and-its-crawls-are-options-under-it--the-way-gpp-does-it) | One card per site, and its crawls are options under it — the way GPP does it | **Ruled** ([R-47](RULINGS.md#r-47--muqawil-is-one-card-with-two-crawls-and-the-two-stored-datasets-stay-two)) — two crawls of one dataset; the storage stays two | 2026-08-22 |
+| [REQ-37](#req-37--one-card-per-site-and-its-crawls-are-options-under-it--the-way-gpp-does-it) | One card per site, and its crawls are options under it — the way GPP does it | **In flight** ([R-47](RULINGS.md#r-47--muqawil-is-one-card-with-two-crawls-and-the-two-stored-datasets-stay-two)) — muqawil is ONE card and the population is stated once; the two crawl OPTIONS are blocked on a panel path to a dataset crawl ([OP-52](BACKLOG.md)) | 2026-08-22 |
 | [REQ-38](#req-38--the-backup-must-check-its-own-digest-and-the-panel-must-be-able-to-finish-the-build) | The backup must check its own digest, and the panel must be able to finish the build | **Captured** — measured: the digest is written and never read; the button aborts at 10 s on a 5-minute build | 2026-08-22 |
 | [REQ-39](#req-39--the-extension-must-report-what-drive-holds-because-nothing-else-can-ask) | The extension must report what Drive holds, because nothing else can ask | **Captured** — the panel is the only holder of the token and it stores no answer | 2026-08-22 |
 | [REQ-40](#req-40--the-extension-is-the-phone-and-the-engines-are-apps-installed-on-it) | The extension is the phone and the engines are apps installed on it — study which of the engine's duties shrink into it | **Captured** — measured: the premise is HALF BUILT since 2026-08-12 and undocumented; three counted holes, chief of them 0 of 18,008 contractors in the offline pack | 2026-08-23 |
@@ -1720,7 +1720,7 @@ and dark, and a trigger that reads well on one ground often does not on the othe
 ---
 
 ## REQ-37 · One card per site, and its crawls are options under it — the way GPP does it
-**Captured 2026-08-22 · Ruled ([R-47](RULINGS.md#r-47--muqawil-is-one-card-with-two-crawls-and-the-two-stored-datasets-stay-two)) · Not built**
+**Captured 2026-08-22 · Ruled ([R-47](RULINGS.md#r-47--muqawil-is-one-card-with-two-crawls-and-the-two-stored-datasets-stay-two)) · In flight 2026-08-23 — the card is one, the crawl options are not**
 
 > «المفروض مصدر مقاول يظهر مرة واحدة فقط واختيارات الزحف الخاصة به تكون متعغددة · انظر
 > الى gpp لتفهم كيف تم عمل هذا»
@@ -1777,6 +1777,70 @@ which also records the half he did not have to decide because the code already h
 what a broken parser looks like (`R-31`) — so it is one CARD over two datasets, joined by
 the relationship he already had confirmed. And the second number stops being a population:
 704 of 17,304 is **coverage**, which is what `--coverage` already computes.
+
+### BUILT 2026-08-23 — points 1 and 2 of three, and the third cannot ship yet
+
+**HE ASKED FOR THIS ON 2026-08-22 AND IT WAS RULED THE SAME DAY. It was still not
+built on 2026-08-23**, which is why he asked «حل المشكلة لم يصل لى ما السبب ؟» — the
+fix has not reached me, why? Measured before starting: **no file under `extension/`,
+`scrapex/` or `tests/` cited `R-47` or `REQ-37` at all.** Ruled, recorded, and never
+carried into code. That gap — a ruling with no line of code behind it — is the whole
+answer to his question, and it is the failure `C7` and `REQ-04` exist to catch.
+
+**What landed**
+
+1. **One card per site.** `_dataset_listing` in `scrapex/webui/app.py` folds a
+   confirmed one-to-one child dataset into its parent for `/api/sources`. `muqawil.org`
+   is listed once. «المفروض مصدر مقاول يظهر مرة واحدة فقط» — done.
+2. **The population once, the second crawl as coverage.** The card reads
+   `Contractor profiles: 704 of 17,304 (4.1%)` where it used to read a second
+   population — and, on the way, stopped reading `17,304 products` over a directory
+   ([`OP-53`](BACKLOG.md)).
+
+**What did not, and it is blocked rather than skipped: «اختيارات الزحف».** `R-47`'s
+third point is two crawl OPTIONS on the card. **There is no panel path to a dataset
+crawl at all.** `POST /api/jobs` answers `404 unknown source_key 'contractors'` —
+measured, and already recorded as [`OP-52`](BACKLOG.md); `REQ-24` shipped
+`scrapex contractors` as a CLI command and says the panel path is still missing. Adding
+two menu entries now would put two buttons on his card that answer 404, which is the
+rule #258 built a guard for: *a button that cannot work is worse than no button.* So
+**this request stays In flight until a dataset crawl can be started from the panel**,
+and closing it before then would be the `REQ-04` failure wearing a green tick.
+
+### THE FOLD KEYS ON THE RELATIONSHIP, NOT ON THE SITE — and measuring said so
+
+Point 1 above names `site_profile_id`. Measured read-only on his warehouse 2026-08-23,
+that is true and **insufficient**, and `base_url` — the obvious shortcut — is wrong:
+
+| | |
+|---|---|
+| `dataset_definition` | `contractors` and `contractor_profiles`, **both `site_profile_id = 2`** |
+| `dataset_relationship` | parent `contractors`, child `contractor_profiles`, `one_to_one`, **`confirmed`** |
+| active rows | 17,304 and 704 |
+| `site_profile` | **TWO muqawil rows** — id 1 `https://muqawil.org/ar/contractors`, id 2 `https://muqawil.org/`. Same host, different `base_url`; grouping on the URL works today only because id 1 carries no datasets |
+
+So the key is the site **plus a confirmed one-to-one relationship**, which is `R-47`'s
+own justification — *"the join is the thing that makes the single card honest rather
+than a label over two unrelated tables"* — rather than a caution added on top of it.
+Two datasets that merely share a site are two populations, and one card over them
+would state a number nobody could act on.
+
+### AND HIS GPP COMPARISON HAS NO PRESENTATION TO COPY, which is worth stating plainly
+
+He said «انظر الى gpp لتفهم كيف تم عمل هذا». Measured: **`grep -rin gpp extension/`
+returns nothing.** There is no GPP branch, no GPP card, no split-button, no accordion
+and no picker anywhere in the panel. `GPP_ENERGY` is one `source_key` in `sources.yaml`
+and its five energy types live in a dict inside `scrapex/connectors/gpp.py`, so the
+panel has always drawn it as one card *without knowing it was one card*.
+
+**The GPP pattern is therefore "collapse below the surface", and it is the right
+lesson even though it does not transfer as a control**, which is what this request and
+`R-47` both already say: GPP's axes are one crawl producing many rows, muqawil's are
+two crawls. So the multiplicity that could be hidden was hidden — the listing is one
+row per site — and the multiplicity that cannot be (two separately-run, separately-
+resumed, separately-approved crawls) is left for the `⋮` menu `REQ-36` built, rather
+than given a second vocabulary of its own. That is Decision 26 of `PLATFORM-PLAN.md`
+applied: no second implementation of an existing one.
 
 ---
 

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -1795,7 +1795,7 @@ answer to his question, and it is the failure `C7` and `REQ-04` exist to catch.
 2. **The population once, the second crawl as coverage.** The card reads
    `Contractor profiles: 704 of 17,304 (4.1%)` where it used to read a second
    population — and, on the way, stopped reading `17,304 products` over a directory
-   ([`OP-53`](BACKLOG.md)).
+   ([`OP-61`](BACKLOG.md)).
 
 **What did not, and it is blocked rather than skipped: «اختيارات الزحف».** `R-47`'s
 third point is two crawl OPTIONS on the card. **There is no panel path to a dataset

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -1795,7 +1795,7 @@ answer to his question, and it is the failure `C7` and `REQ-04` exist to catch.
 2. **The population once, the second crawl as coverage.** The card reads
    `Contractor profiles: 704 of 17,304 (4.1%)` where it used to read a second
    population — and, on the way, stopped reading `17,304 products` over a directory
-   ([`OP-61`](BACKLOG.md)).
+   ([`OP-63`](BACKLOG.md)).
 
 **What did not, and it is blocked rather than skipped: «اختيارات الزحف».** `R-47`'s
 third point is two crawl OPTIONS on the card. **There is no panel path to a dataset

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -1358,6 +1358,39 @@ which gives a dataset card the `⋮` menu it can use. This ruling asks that menu
 per-dataset actions under one card, so building them apart would mean writing the menu
 twice — and a branch is inside `sourceMenu` as this is written.
 
+> **CORRECTED 2026-08-23, WHILE BUILDING IT. THE RULING STANDS; ONE SENTENCE IN IT IS
+> FALSE.** Kept in place per **C4**, and recorded per **C5** — an unwritten objection
+> helps no one on the other machine.
+>
+> Point 2 above ends: *"which is the number he actually wants, and the one `--coverage`
+> already computes."* **`--coverage` does not compute it.** Measured read-only on his
+> warehouse, 2026-08-23:
+>
+> | asked | answered |
+> |---|---|
+> | `coverage("contractor_profiles")` | *"nothing has been sighted, so coverage cannot be stated"* — `dataset_sighting` holds **zero** rows for that key |
+> | `coverage("contractors")` | *"17,269 stored of 17,417 sighted — 148 seen and never fetched (99.2%)"* |
+> | the card's figure | **704 of 17,304 (4.1%)** |
+>
+> Three different numbers, because `sightings.coverage` answers a different question:
+> **stored-of-sighted WITHIN ONE dataset**, from `dataset_sighting`. It has nothing to
+> say about how much of the listing the profile crawl has reached, and the profile
+> crawl never wrote a sighting at all. Its own docstring is the tell — *"SIGHTED **AND**
+> HELD, which is not the same as the number of rows"*.
+>
+> **THE SHAPE HE RULED IS UNAFFECTED, and the source of the number is the thing that
+> was wrong.** 704 of 17,304 comes from the `dataset_relationship` row he had already
+> asked for by name — «اربطهم فى dataset_relationship» — which is `confirmed`,
+> `one_to_one`, and is the same join this ruling calls *"the thing that makes the
+> single card honest"*. So the figure is computed from the relationship and the two
+> row counts, which the listing query already has, and no sighting is consulted.
+>
+> **WHY IT IS WORTH THE SPACE RATHER THAN A QUIET FIX.** "The mechanism already exists"
+> is the most expensive kind of wrong sentence in a ruling: it turns a design decision
+> into a wiring job and the next session sizes the work off it. This is the same family
+> as the correction under `R-45` — there a capability was said to be missing and had
+> shipped a month earlier; here one was said to exist and does not. Both were settled by
+> running the thing instead of reading about it.
 ---
 
 ### R-48 · The extension is the control room and the only interface; the engine executes and reports

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -134,7 +134,7 @@ engine carries the extension.
 
 **The defect, found by trying the bump and reverting it the same day:**
 `version_report` sends `"latest_extension_version": VERSION`
-(`scrapex/version.py:483`, again in `scrapex/webui/app.py:1543`, drawn by
+(`scrapex/version.py:483`, again in `scrapex/webui/app.py:1662`, drawn by
 `extension/app.js:595` and `:629`). The moment the engine moves ahead of
 `extension/manifest.json`, the panel draws *"This ScrapeX extension is older than
 the engine it is talking to"*. Measured at 320×440: the profile page's legal line

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,15 +1,17 @@
 # State — where the work stands
 
-**Last updated: 2026-08-23.** `main` is at `f1844af` (#261). #243 through #261 are
-all merged — **fifteen merges** landed after this line last said `afb8648` (#244),
-across two days. **And this conflict is the argument itself:** resolving it, `main`
-said `31c369e` (#257) on one side and `bcb8f6e` (#255) on the other, and by the time
-the rebase finished it was `f1844af`. Three wrong numbers for one field, in one
-afternoon. A commit pointer written into prose is stale by the time it is read:
-`git log --oneline -1 origin/main` is the answer that cannot be — **and this very line
-has now proved it six times across two days**, reading `4615a14` with #251 and #252
-already in, then `5f63bb0` with #254 in, then `451468d` with #255 in, then the three
-above. Each correction is the argument for the sentence rather than a counter-example
+**Last updated: 2026-08-23.** `main` is at `759a9df` (#264). #246 through #264 are
+all merged — **eighteen merges** landed after this line last said `afb8648` (#244),
+across two days, and the count here was measured with
+`git log --oneline afb8648..origin/main` rather than carried. **And this conflict is
+the argument itself:** resolving it, one side said `f1844af` (#261) with "fifteen"
+and the other `d10e974` (#258) with "thirteen", and both were already wrong before
+either could be read. A commit pointer written into prose is stale by the time it is
+read: `git log --oneline -1 origin/main` is the answer that cannot be — **and this
+very line has now proved it seven times across two days**, reading `4615a14` with
+#251 and #252 already in, then `5f63bb0` with #254 in, then `451468d` with #255 in,
+then `31c369e` with #258 in, then `f1844af`, then `467a3ac` with #265 in, and now
+this. Each correction is the argument for the sentence rather than a counter-example
 to it.
 
 **THE ENGINE ON GITHUB IS `engine-v0.3.0`, AND IT WAS CUT TODAY.** He asked for it
@@ -208,6 +210,66 @@ tracks *his requests* through Captured → Ruled → Planned → In flight → D
 ---
 
 ## Open pull requests
+
+### muqawil is ONE card, and 17,304 contractors stop being products — 2026-08-23
+
+**`REQ-37` was ruled on 2026-08-22 as `R-47` and was still not built on 2026-08-23**,
+which is why he asked «حل المشكلة لم يصل لى ما السبب ؟» — the fix has not reached me,
+why? Measured before starting: **no file under `extension/`, `scrapex/` or `tests/`
+cited `R-47` or `REQ-37`.** A ruling with no code behind it is the `REQ-04` failure, and
+that is the whole answer to his question.
+
+Two of the four defects on that screenshot are this branch's; the other two
+(`no successful crawl yet` on both muqawil cards) landed as #255.
+
+- **`REQ-37` / `R-47` points 1 and 2 — BUILT.** `_dataset_listing` folds a confirmed
+  one-to-one child dataset into its parent for `/api/sources`, so `muqawil.org` is
+  listed once, and the second number stops being a second population: the card reads
+  `Contractor profiles: 704 of 17,304 (4.1%)`. **`_dataset_rows` is deliberately
+  untouched** — `/source/{key}` resolves one dataset out of it by key, so folding
+  in place would have made `/source/contractor_profiles` answer 404 again, which is
+  the regression #212 closed. Only the presentation collapses, which is what `R-47`
+  ruled.
+- **`R-47` point 3 — BLOCKED, not skipped.** «اختيارات الزحف» needs two crawl options
+  on the card and there is **no panel path to a dataset crawl at all**: `POST /api/jobs`
+  answers `404 unknown source_key 'contractors'` (`OP-52`). `REQ-37` therefore stays
+  **In flight**.
+- **`OP-53` — the panel half CLOSED, the engine half OPEN.** `17,304 products` over a
+  contractor directory. `countLine` replaces the hardcoded noun with three branches
+  keyed on what the engine reports, so `jobs` and `tenders` need no new code. The
+  engine's own `/source/{key}` page still prints a "Products" tile over the same rows —
+  left filed with the measurement because that page shows four tiles and two are
+  meaningless for a directory, which is his call, not a noun.
+- **`R-47` CORRECTED, ruling intact (`C4`/`C5`).** Its point 2 says the coverage figure
+  is *"the one `--coverage` already computes"*. It is not: `coverage("contractor_profiles")`
+  answers *"nothing has been sighted"* — `dataset_sighting` holds zero rows for that
+  key — and `coverage("contractors")` answers 17,269 of 17,417 (99.2%), a different
+  question. The 704-of-17,304 figure comes from the `dataset_relationship` row he asked
+  for by name, not from a sighting.
+- **His GPP comparison has no presentation to copy.** `grep -rin gpp extension/` returns
+  **nothing** — no branch, no card, no picker. `GPP_ENERGY` is one `source_key` and its
+  five energy types live in a dict inside `scrapex/connectors/gpp.py`, so the panel has
+  always drawn it as one card without knowing it was one. The transferable lesson is
+  *collapse below the surface*, which is what the listing now does; the part that cannot
+  be hidden — two separately-run crawls — goes to the `⋮` menu `REQ-36` built rather
+  than to a second vocabulary (`PLATFORM-PLAN` Decision 26).
+
+**Twelve mutations, twelve caught.** Every guard on this branch had its defect restored
+and was proven RED, then GREEN on restore, with `__pycache__` purged between runs and
+the restore verified by `git status --porcelain` rather than a content hash. **One
+mutation was NOT caught on the first pass and the guard was replaced**: a seam test
+asserted the string `c.stored` appears in `app.js`, and `c.stored` appears **twice**
+there, so renaming the occurrence the card reads left the substring present and the
+test green. It now compares the harness stub's coverage keys to the engine's own —
+behaviour at the seam, which is where #255 failed. *A search for one spelling of a
+feature is not a measurement of the feature* (`LESSONS.md` §9), arriving through a
+fourth door: a test.
+
+**This branch is from a SECONDARY session and does not merge itself** (`R-42`).
+**`OP-53` was taken as the next free number off the end** — `main` tops out at `OP-52`
+and `45`/`49`/`50` are reserved for `claude/drive-without-a-server` — so it needs the
+primary's confirmation against any unpushed claim, per `ORCHESTRATION.md` §3. No
+`RESERVED` row was added and none was deleted: 53 creates no hole.
 
 **A DRY review of `#252` recorded `OP-46`, `OP-47` and `OP-48` — documentation only,
 no code touched.** The review followed that PR's own comment to the three popovers it

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1223,7 +1223,7 @@ written and 58 two days ago. It grows every time this is deferred.
 **The blocker, verified 2026-08-17 and still present:**
 `"latest_extension_version": VERSION` at
 [scrapex/version.py:483](../scrapex/version.py) and
-[scrapex/webui/app.py:1543](../scrapex/webui/app.py), drawn by
+[scrapex/webui/app.py:1662](../scrapex/webui/app.py), drawn by
 [extension/app.js:599](../extension/app.js) and `:633`.
 
 > **Re-verified 2026-08-19, and three of these citations had already drifted.**

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -234,7 +234,7 @@ Two of the four defects on that screenshot are this branch's; the other two
   on the card and there is **no panel path to a dataset crawl at all**: `POST /api/jobs`
   answers `404 unknown source_key 'contractors'` (`OP-52`). `REQ-37` therefore stays
   **In flight**.
-- **`OP-61` — the panel half CLOSED, the engine half OPEN.** `17,304 products` over a
+- **`OP-63` — the panel half CLOSED, the engine half OPEN.** `17,304 products` over a
   contractor directory. `countLine` replaces the hardcoded noun with three branches
   keyed on what the engine reports, so `jobs` and `tenders` need no new code. The
   engine's own `/source/{key}` page still prints a "Products" tile over the same rows —
@@ -267,24 +267,50 @@ fourth door: a test.
 
 **This branch is from a SECONDARY session and does not merge itself** (`R-42`).
 
-**The register moved twice under this branch, and the second time was a real
-collision.** It first took `OP-53` when `main` topped out at `OP-52`. Then #261 landed
-and declared **`OP-53` through `OP-59`** — so `OP-53` was a genuine duplicate, and
-`test_no_two_entries_share_a_number` would have caught it. Renumbered to **`OP-61`**,
-because `OP-60` is held by another session on the primary's word.
+**THE REGISTER MOVED THREE TIMES UNDER THIS ONE BRANCH, and the lesson is in the third
+move rather than the first two.**
 
-**Checked rather than assumed before renumbering:** none of `OP-53`…`OP-59` covers the
+| took | why it moved |
+|---|---|
+| `OP-53` | correct when written — `main` topped out at `OP-52` |
+| → `OP-61` | #261 landed and declared **53…59**. A genuine duplicate, and `test_no_two_entries_share_a_number` would have had it |
+| → **`OP-63`** | `OP-61` was **already declared on a pushed branch** — `feat/the-engine-knows-which-code-it-is-running` holds 60 **and** 61 as a cross-linked pair. `OP-62` is a third session's |
+
+**The primary handed out two colliding numbers in one day and said so** — from the
+session that owns `ORCHESTRATION.md` §3. Its tables covered the branches it knew about,
+and this branch was in neither. **What found the second collision was a sweep of EVERY
+ref**, not of a named list:
+
+```bash
+git for-each-ref --format='%(refname:short)' refs/remotes/origin | while read -r r; do
+  git show "$r:docs/BACKLOG.md" 2>/dev/null | grep -oE '^#{2,4} +OP-[0-9]+'; done | sort -u
+```
+
+**Run independently here before accepting 63** rather than resting on the handover: it
+confirmed 60 and 61 on that branch and found nothing anywhere above 61. So a number you
+are handed is **provisional until you have swept for it** — which is §3's *"an unpushed
+claim is invisible and still real"* arriving from the other side: **a pushed claim is
+visible and still missed, if you look at a list of branches instead of at all of them.**
+
+**Checked rather than assumed before each renumber:** none of `OP-53`…`OP-59` covers the
 noun (they are the price-path columns registered against the directory, Choose-Columns,
-the unreachable server capabilities, the truthy `{}`, the `offer_id` index, his
-deletion gate, and the `HANDOFF` citations), so this is a distinct finding and not a
-second entry for one thing.
+the unreachable server capabilities, the truthy `{}`, the `offer_id` index, his deletion
+gate, and the `HANDOFF` citations), so this is a distinct finding and not a second entry
+for one thing.
 
-**`RESERVED` now carries `60`, and it is the weakest row in that table.** Every remote
-branch was searched for `OP-60` in `docs/BACKLOG.md` and **none carries it**, so the
-row cannot name the branch that `ORCHESTRATION.md` §3 requires and says so instead of
-inventing one. It carries an action: replace it with the ref the moment that holder
-pushes, or delete it if 60 turns out free. **`OP-61` still needs the primary's
-confirmation.**
+**`RESERVED` carries `60`, `61` and `62`.** The first two name a verifiable branch ref
+because the sweep found them. **`62` is the weak row and says so** — no ref carries it,
+so it cannot name the branch §3 requires and admits that instead of inventing one,
+carrying an action: replace it with the ref when that holder pushes, or delete it if 62
+turns out free. **`OP-63` still needs the primary's confirmation.**
+
+**`R-49` was checked against this work and does not touch it.** The ruling makes
+`docs/MIGRATION-PLAN.md` the base plan for conflicts of *intent*. That document says
+nothing about `products`, a noun, or a dataset's row label — grepped — and the noun
+decision rests on **measurement** (`dataset_kind` is `'table'` for both muqawil
+datasets; nothing in the warehouse names the unit of a row) plus `R-45` part 1, which is
+a ruling rather than a plan. Where a measurement and a document disagree, the
+measurement wins regardless of dates.
 
 **A DRY review of `#252` recorded `OP-46`, `OP-47` and `OP-48` — documentation only,
 no code touched.** The review followed that PR's own comment to the three popovers it

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -234,7 +234,7 @@ Two of the four defects on that screenshot are this branch's; the other two
   on the card and there is **no panel path to a dataset crawl at all**: `POST /api/jobs`
   answers `404 unknown source_key 'contractors'` (`OP-52`). `REQ-37` therefore stays
   **In flight**.
-- **`OP-53` — the panel half CLOSED, the engine half OPEN.** `17,304 products` over a
+- **`OP-61` — the panel half CLOSED, the engine half OPEN.** `17,304 products` over a
   contractor directory. `countLine` replaces the hardcoded noun with three branches
   keyed on what the engine reports, so `jobs` and `tenders` need no new code. The
   engine's own `/source/{key}` page still prints a "Products" tile over the same rows —
@@ -266,10 +266,25 @@ feature is not a measurement of the feature* (`LESSONS.md` §9), arriving throug
 fourth door: a test.
 
 **This branch is from a SECONDARY session and does not merge itself** (`R-42`).
-**`OP-53` was taken as the next free number off the end** — `main` tops out at `OP-52`
-and `45`/`49`/`50` are reserved for `claude/drive-without-a-server` — so it needs the
-primary's confirmation against any unpushed claim, per `ORCHESTRATION.md` §3. No
-`RESERVED` row was added and none was deleted: 53 creates no hole.
+
+**The register moved twice under this branch, and the second time was a real
+collision.** It first took `OP-53` when `main` topped out at `OP-52`. Then #261 landed
+and declared **`OP-53` through `OP-59`** — so `OP-53` was a genuine duplicate, and
+`test_no_two_entries_share_a_number` would have caught it. Renumbered to **`OP-61`**,
+because `OP-60` is held by another session on the primary's word.
+
+**Checked rather than assumed before renumbering:** none of `OP-53`…`OP-59` covers the
+noun (they are the price-path columns registered against the directory, Choose-Columns,
+the unreachable server capabilities, the truthy `{}`, the `offer_id` index, his
+deletion gate, and the `HANDOFF` citations), so this is a distinct finding and not a
+second entry for one thing.
+
+**`RESERVED` now carries `60`, and it is the weakest row in that table.** Every remote
+branch was searched for `OP-60` in `docs/BACKLOG.md` and **none carries it**, so the
+row cannot name the branch that `ORCHESTRATION.md` §3 requires and says so instead of
+inventing one. It carries an action: replace it with the ref the moment that holder
+pushes, or delete it if 60 turns out free. **`OP-61` still needs the primary's
+confirmation.**
 
 **A DRY review of `#252` recorded `OP-46`, `OP-47` and `OP-48` — documentation only,
 no code touched.** The review followed that PR's own comment to the three popovers it

--- a/extension/app.js
+++ b/extension/app.js
@@ -4387,7 +4387,7 @@ async function loadDatasets() {
         ${sourceMenu(s)}
         <div><div class="dataset-identity-line">${sourceIdentity(
           s, false, fmtCount(s.observations))}</div>
-          <div class="n">${fmtCount(s.products)} products</div>
+          <div class="n">${countLine(s)}</div>
           <div class="n muted">${freshnessLine(s)}</div></div>
       </article>`).join("");
     box.querySelectorAll(".dataset-card .split-button").forEach((root) => {
@@ -4480,6 +4480,66 @@ async function browseFromDrive(box) {
   } finally {
     if ($("browse-offline")) $("browse-offline").disabled = false;
   }
+}
+
+/**
+ * The card's SECOND number, and the word that belongs over it.
+ *
+ * THIS LINE SAID "products" ABOUT 17,304 CONTRACTORS. A contractor is not a
+ * product, and the engine already knew the word was meaningless there — the
+ * comment beside `_dataset_rows` (scrapex/webui/app.py) says `products` "has no
+ * meaning for a company, so it carries the same count rather than a zero that
+ * would read as an empty dataset". So the engine passed a duplicate of the row
+ * count through a field it documents as meaningless, and the panel printed the
+ * meaningless word underneath it.
+ *
+ * NOT A SPECIAL CASE FOR CONTRACTORS, because `jobs` and `tenders` are named in
+ * CLAUDE.md as coming and `if (contractors)` would be the third wrong noun the
+ * day `tenders` lands. Three branches, each one keyed on what the engine reports
+ * rather than on a key's spelling:
+ *
+ *   COVERAGE   a site whose crawls include a confirmed one-to-one detail sweep.
+ *              "Contractor profiles: 704 of 17,304 (4.1%)" — `R-47`'s second
+ *              point: the population is stated ONCE, on the identity line above,
+ *              and the second crawl reports how much of it has been fetched. The
+ *              label is the child dataset's own stored `display_name`, which is
+ *              what the site called it (`R-45`), never a word of ours.
+ *   ROWS       any other dataset. `rows` is the honest generic, and it is not a
+ *              new vocabulary: `sourceIdentity`'s default metric label is already
+ *              "Row" (so the line above reads `[Row 17,304]`) and the Drive
+ *              offline card a few lines up already prints "<n> rows". It also
+ *              claims nothing about the site, which is what rules out the
+ *              alternatives — `original_name` would print "17,304 contractors"
+ *              for one dataset and "704 contractor_profiles" for the next, and a
+ *              raw key dressed as an English noun is exactly the invented label
+ *              `R-45` refuses.
+ *   PRODUCTS   a price source, unchanged, because there the word is TRUE and the
+ *              number is a different one: spark-eshop reads `[Row 6,969]` above
+ *              `1,812 products`, and flattening that to "rows" would lose a real
+ *              fact. This is why the noun could not simply be replaced.
+ *
+ * WHY THE FIRST BRANCH IS NOT A THIRD COPY OF THE COUNT: for a dataset
+ * `observations` and `products` are the SAME number, so "17,304 rows" under
+ * `[Row 17,304]` is the same figure twice. Coverage is the fact that slot was
+ * missing, which is what `R-47` ruled it should carry.
+ */
+function countLine(s) {
+  const covered = (s.coverage || []).map((c) =>
+    `${esc(c.label)}: ${fmtCount(c.stored)} of ${fmtCount(c.population)}` +
+    `${coverageShare(c)}`).join(" · ");
+  if (covered) return covered;
+  if (s.kind === "dataset") return `${fmtCount(s.observations)} rows`;
+  return `${fmtCount(s.products)} products`;
+}
+
+// The share, in the words `sightings.Coverage.__str__` already uses on the CLI —
+// one decimal, in brackets after the pair. Omitted rather than shown as "0.0%"
+// when there is no population to be a fraction of: a percentage of nothing is
+// not a small number, it is not a number.
+function coverageShare(c) {
+  const population = Number(c.population || 0);
+  if (!population) return "";
+  return ` (${(100 * Number(c.stored || 0) / population).toFixed(1)}%)`;
 }
 
 // The freshness of a dataset — the first thing anyone asks, and the fact the

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -712,7 +712,7 @@ def create_app(
                 # (`templates/_source_overview.html`). So a contractor directory
                 # still reads "Products 17,304" THERE — the same defect this
                 # branch fixed on the panel, on the surface this branch did not
-                # touch. Recorded as `OP-53` rather than fixed here, because
+                # touch. Recorded as `OP-61` rather than fixed here, because
                 # that page shows four tiles and two of them are meaningless for
                 # a directory, which is a design question and not a noun.
                 "observations": row["rows"], "products": row["rows"],

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -704,6 +704,17 @@ def create_app(
                 # directory the honest number is its rows. `products` has no
                 # meaning for a company, so it carries the same count rather
                 # than a zero that would read as an empty dataset.
+                #
+                # THE PANEL NO LONGER READS THIS KEY FOR A DATASET, and the note
+                # above now describes exactly one surviving reader: the engine's
+                # own `/source/{key}` page, which fills `SourceSummary.products`
+                # from it at line ~960 and prints it as a "Products" tile
+                # (`templates/_source_overview.html`). So a contractor directory
+                # still reads "Products 17,304" THERE — the same defect this
+                # branch fixed on the panel, on the surface this branch did not
+                # touch. Recorded as `OP-53` rather than fixed here, because
+                # that page shows four tiles and two of them are meaningless for
+                # a directory, which is a design question and not a noun.
                 "observations": row["rows"], "products": row["rows"],
                 # WHEN THE DATA ON SCREEN WAS GATHERED, and it is DERIVED rather
                 # than recorded. The card printed "no successful crawl yet"
@@ -722,6 +733,114 @@ def create_app(
             } for row in catalogue]
         finally:
             general.close()
+
+    def _dataset_listing():
+        """The same datasets, as ONE CARD PER SITE. `R-47`, and `REQ-37` before it.
+
+        HIS COMPLAINT, twice, with a screenshot each time: «المفروض مصدر مقاول يظهر
+        مرة واحدة فقط واختيارات الزحف الخاصة به تكون متعغددة». The Data screen drew
+        `muqawil.org` twice, once per `dataset_definition` row, and neither card knew
+        the other existed.
+
+        **ONLY THE PRESENTATION COLLAPSES, and that is the whole of `R-47`.** The two
+        `dataset_definition` rows stay two — `contractors._approval` refuses to put a
+        27-field profile and a 28-field listing under one approved schema, because a
+        subset is what a broken parser looks like (`R-31`). So this folds the LISTING
+        and `_dataset_rows` is left alone, which is not a stylistic split: it has a
+        second caller. `/source/{key}` resolves ONE dataset out of it by key, so
+        folding in place would have made `/source/contractor_profiles` answer 404
+        again — the exact regression #212 was built to close.
+
+        THE GROUPING KEY IS NOT THE SITE ALONE, and measuring it is what settled
+        that. `REQ-37` names `site_profile_id`, and both muqawil datasets do share
+        one (id 2, `muqawil_org`) — but `R-47`'s own justification is narrower than
+        the site: *"the join is the thing that makes the single card honest rather
+        than a label over two unrelated tables."* Two datasets that happen to sit on
+        one site and are NOT related are two populations, and one card over them
+        would state a number nobody could act on. So the key is the site **plus a
+        confirmed one-to-one relationship**, which is the thing he had already asked
+        for by name — «اربطهم فى dataset_relationship» — and which is `confirmed` in
+        his warehouse today.
+
+        MEASURED READ-ONLY ON HIS WAREHOUSE, 2026-08-23:
+
+            dataset_definition   1 contractors         site_profile_id 2
+                                 2 contractor_profiles site_profile_id 2
+            dataset_relationship parent 1, child 2, one_to_one, confirmed
+            active rows          17,304 and 704
+
+        AND `base_url` WOULD HAVE BEEN THE WRONG KEY, which only the measurement
+        shows: `site_profile` holds TWO muqawil rows — id 1 `https://muqawil.org/ar/
+        contractors` and id 2 `https://muqawil.org/` — so the host is shared and the
+        base URL is not. Grouping on the URL works today only because id 1 carries no
+        datasets.
+
+        WHAT IS NOT BUILT HERE, deliberately: the two crawl OPTIONS on the card,
+        which is `R-47`'s third point. `POST /api/jobs` answers 404
+        `unknown source_key 'contractors'` — measured, `OP-52` — so there is no panel
+        path to a dataset crawl, and offering two menu entries that cannot run is the
+        "button that cannot work is worse than no button" rule #258 built a guard
+        for. The profile crawl reaches the card as COVERAGE instead, which is
+        `R-47`'s second point and the number he actually wants.
+        """
+        rows = _dataset_rows()
+        if len(rows) < 2:
+            return rows
+        general = general_read_conn()
+        try:
+            # CONFIRMED AND ONE-TO-ONE, both load-bearing. `review_status` is the
+            # human gate — a proposed relationship is a guess, and collapsing two
+            # cards on a guess would hide a population behind a percentage. And
+            # `one_to_one` is what makes "704 of 17,304" a sentence: under
+            # `one_to_many` a parent row can carry several children, so the child
+            # count is not a fraction of the parent count at all.
+            links = general.execute(
+                "SELECT p.dataset_key AS parent, c.dataset_key AS child "
+                "FROM dataset_relationship AS r "
+                "JOIN dataset_definition AS p "
+                "ON p.dataset_definition_id = r.parent_dataset_id "
+                "JOIN dataset_definition AS c "
+                "ON c.dataset_definition_id = r.child_dataset_id "
+                "WHERE r.valid_to IS NULL AND r.review_status = 'confirmed' "
+                "AND r.cardinality = 'one_to_one'"
+            ).fetchall()
+        finally:
+            general.close()
+        entries = {row["source_key"]: row for row in rows}
+        parents = {link["parent"] for link in links}
+        # A CHILD THAT IS ITSELF A PARENT KEEPS ITS OWN CARD. Folding it away would
+        # take its own children off the listing with it, and a dataset that reaches
+        # no card is worse than one that reaches a redundant card. One level, and the
+        # limit is stated rather than discovered: nothing in the warehouse is two
+        # deep today, and the day something is, its middle row stays visible.
+        folded_into = {link["child"]: link["parent"] for link in links
+                       if link["parent"] in entries and link["child"] in entries
+                       and link["child"] not in parents}
+        listing = []
+        for row in rows:
+            key = row["source_key"]
+            if key in folded_into:
+                continue
+            children = [entries[child] for child, parent in folded_into.items()
+                        if parent == key]
+            if not children:
+                listing.append(row)
+                continue
+            # THE SECOND NUMBER STOPS BEING A POPULATION. Today the cards read
+            # 17,304 and 704 as if they were two populations; they are one —
+            # 17,304 contractors, of whom 704 have an approved profile. A LIST
+            # because a site may grow a second detail crawl, and one line each is
+            # the shape that does not have to be rewritten when it does.
+            listing.append(dict(row, coverage=[{
+                "dataset_key": child["source_key"],
+                # The child's own stored `display_name`, never a word of ours:
+                # `R-45` — «ما يقوله الموقع هو مصدر الحقيقة الوحيد» — and this is
+                # the label the approval recorded from the site.
+                "label": child["source_name"],
+                "stored": child["observations"],
+                "population": row["observations"],
+            } for child in children]))
+        return listing
 
     def _source_catalog(conn):
         """Every configured source, split by whether it has warehouse data."""
@@ -1646,7 +1765,12 @@ def create_app(
         # Wipe and Rename, and every one of those is a price-path action that
         # would answer 400 or worse for a dataset. A button that cannot work is
         # worse than no button, so the panel hides them on this marker.
-        out.extend(_dataset_rows())
+        #
+        # `_dataset_listing` AND NOT `_dataset_rows`, which is `R-47`: this is the
+        # LISTING, where one site is one card, and `/source/{key}` is the resolver,
+        # where the two stored datasets stay two. The same function serving both is
+        # what drew `muqawil.org` twice on his Data screen (`REQ-37`).
+        out.extend(_dataset_listing())
         return {"sources": out}
 
     @app.get("/api/resolve")

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -712,7 +712,7 @@ def create_app(
                 # (`templates/_source_overview.html`). So a contractor directory
                 # still reads "Products 17,304" THERE — the same defect this
                 # branch fixed on the panel, on the surface this branch did not
-                # touch. Recorded as `OP-61` rather than fixed here, because
+                # touch. Recorded as `OP-63` rather than fixed here, because
                 # that page shows four tiles and two of them are meaningless for
                 # a directory, which is a design question and not a noun.
                 "observations": row["rows"], "products": row["rows"],

--- a/tests/test_one_card_per_site_not_one_per_dataset.py
+++ b/tests/test_one_card_per_site_not_one_per_dataset.py
@@ -1,0 +1,373 @@
+"""muqawil appears ONCE in the listing, and its two datasets are still two.
+
+HIS COMPLAINT, twice, with a screenshot each time. `REQ-37`:
+
+    «المفروض مصدر مقاول يظهر مرة واحدة فقط واختيارات الزحف الخاصة به تكون متعغددة»
+
+The Data screen drew two `muqawil.org` cards — `contractors [Row 17,304]` and
+`contractor_profiles [Row 704]` — because `_dataset_rows` ends
+`GROUP BY d.dataset_definition_id` and the panel draws a card per row. `R-47`
+answered it: «زحفين لمجموعة واحدة» — two crawls of one dataset — **and ruled that the
+two stored `dataset_definition` rows stay two.** Only the listing collapses.
+
+SO THIS FILE ASSERTS BOTH HALVES, and the second half is the one that would rot
+quietly. It is easy to collapse the listing by folding inside `_dataset_rows`, and
+that function has a SECOND caller: `/source/{key}` resolves one dataset out of it by
+key, so folding in place makes `/source/contractor_profiles` answer 404 again — the
+exact regression #212 was built to close, arriving through a change that looks like a
+display fix. `test_the_profile_table_still_opens_on_its_own` is that guard.
+
+AND THE COLLAPSE IS CONDITIONAL, which is `R-47`'s own justification rather than a
+caution of ours: *"the join is the thing that makes the single card honest rather than
+a label over two unrelated tables."* Two datasets that merely share a site are two
+populations. So a relationship that is `suggested` and not `confirmed`, or that is
+`one_to_many` rather than `one_to_one`, leaves two cards standing — each of those is a
+test here, because each is a way for one card to state a number nobody could act on.
+"""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from scrapex.catalog_models import (
+    Cardinality,
+    RelationshipCreate,
+    RelationshipFieldPairCreate,
+    RelationshipReviewStatus,
+)
+from scrapex.catalog_relations import propose_relationship, review_relationship
+from scrapex.config import MANIFEST_FILE
+from scrapex.databases import DatabaseRegistry, EngineDatabase
+from scrapex.extract import service
+from scrapex.extract.models import ApprovalField, CandidateApproval, SnapshotCreate
+from scrapex.extract.muqawil import bilingual_profile_candidate, listing_candidate
+from scrapex.webui.app import create_app
+
+ROOT = Path(__file__).resolve().parent.parent
+FIXTURES = ROOT / "tests" / "fixtures" / "muqawil"
+LISTING = (FIXTURES / "listing-en.html").read_text(encoding="utf-8")
+PROFILE_EN = (FIXTURES / "profile-en.html").read_text(encoding="utf-8")
+PROFILE_AR = (FIXTURES / "profile-ar.html").read_text(encoding="utf-8")
+
+#: The site both datasets hang off. Measured read-only on his warehouse
+#: 2026-08-23: `site_profile_id = 2`, `site_key = 'muqawil_org'`, carrying
+#: `contractors` (17,304 active rows) and `contractor_profiles` (704).
+SITE = "muqawil_org"
+PARENT = "contractors"
+CHILD = "contractor_profiles"
+
+
+def _approve(conn, url: str, candidate, dataset_key: str, dataset_name: str) -> int:
+    """One dataset on the muqawil site, approved the way the crawl approves one."""
+    snapshot = service.save_snapshot(conn, SnapshotCreate(
+        source_url=url, html_content=LISTING))
+    approved = service.approve_candidate(
+        conn, int(snapshot["page_snapshot_id"]),
+        CandidateApproval(
+            table_index=0, site_key=SITE, site_display_name="SCA",
+            dataset_key=dataset_key, dataset_name=dataset_name,
+            fields=[ApprovalField(field_key=f.field_key,
+                                  display_name=f.source_name,
+                                  data_type="text",
+                                  identity=(f.field_key == "contractor_id"))
+                    for f in candidate.fields]),
+        candidate=candidate)
+    return int(approved["dataset_definition_id"])
+
+
+def _field_id(conn, dataset_definition_id: int, field_key: str) -> int:
+    row = conn.execute(
+        "SELECT field_definition_id FROM field_definition "
+        " WHERE dataset_definition_id = ? AND field_key = ? AND valid_to IS NULL",
+        (dataset_definition_id, field_key)).fetchone()
+    assert row is not None, f"no {field_key!r} on dataset {dataset_definition_id}"
+    return int(row["field_definition_id"])
+
+
+GRANDCHILD = "contractor_projects"
+
+
+def _relate(conn, key: str, parent_id: int, child_id: int, cardinality, status):
+    """One relationship, proposed and then decided — the two-step path, kept whole."""
+    propose_relationship(conn, SITE, RelationshipCreate(
+        relationship_key=key,
+        parent_dataset_id=parent_id, child_dataset_id=child_id,
+        cardinality=cardinality, confidence=1.0,
+        evidence={"joined_on": "contractor_id"},
+        field_pairs=[RelationshipFieldPairCreate(
+            parent_field_id=_field_id(conn, parent_id, "contractor_id"),
+            child_field_id=_field_id(conn, child_id, "contractor_id"))]))
+    if status is not RelationshipReviewStatus.SUGGESTED:
+        review_relationship(conn, SITE, key, status=status)
+
+
+def _warehouse(tmp_path, *, cardinality=Cardinality.ONE_TO_ONE,
+               status=RelationshipReviewStatus.CONFIRMED, relate=True,
+               chain=False):
+    """Two datasets on one site, joined the way HIS warehouse joins them.
+
+    THROUGH `propose_relationship` AND `review_relationship`, not through an INSERT.
+    He asked for the join by name — «اربطهم فى dataset_relationship» — and those two
+    functions are the path his warehouse's row was written by, one proposing and one
+    deciding. A hand-built INSERT here would let this file pass over a shape the real
+    path cannot produce.
+
+    `chain` ADDS A THIRD DATASET UNDER THE SECOND, which nothing in his warehouse has
+    yet. It is here because the fold has to decide what to do about depth, and a
+    decision no test exercises is a coin toss waiting to land.
+    """
+    registry = DatabaseRegistry(EngineDatabase(tmp_path / "scrapex-engine.db"),
+                               pointer_file=tmp_path / "databases.json")
+    registry.initialize()
+    conn = registry.engine.connect()
+    try:
+        parent_id = _approve(
+            conn, "https://muqawil.org/en/contractors?page=1",
+            listing_candidate(LISTING), PARENT, "Saudi Contractors Authority")
+        # ONE ROW AGAINST FOUR, deliberately: a profile page holds one contractor
+        # and a listing page holds several, so the child count is genuinely a
+        # fraction of the parent's. Both at four would let the coverage arithmetic
+        # read 100% whatever it computed.
+        child_id = _approve(
+            conn, "https://muqawil.org/en/contractors/881/143",
+            bilingual_profile_candidate(PROFILE_EN, PROFILE_AR,
+                                        contractor_id="881"),
+            CHILD, "Contractor profiles")
+        if relate:
+            _relate(conn, "contractor_profile", parent_id, child_id,
+                    cardinality, status)
+        if chain:
+            grandchild_id = _approve(
+                conn, "https://muqawil.org/en/contractors/881/projects",
+                listing_candidate(LISTING), GRANDCHILD, "Contractor projects")
+            _relate(conn, "profile_projects", child_id, grandchild_id,
+                    Cardinality.ONE_TO_ONE, RelationshipReviewStatus.CONFIRMED)
+        conn.commit()
+    finally:
+        conn.close()
+    manifest = tmp_path / "sources.yaml"
+    shutil.copy(MANIFEST_FILE, manifest)
+    return TestClient(create_app(databases=registry, manifest_path=manifest))
+
+
+def _datasets(client: TestClient) -> list[dict]:
+    return [row for row in client.get("/api/sources").json()["sources"]
+            if row.get("kind") == "dataset"]
+
+
+# ---- the premise ------------------------------------------------------------
+
+def test_the_warehouse_really_holds_two_related_datasets(tmp_path):
+    """WITHOUT THIS EVERY ASSERTION BELOW IS VACUOUS. A warehouse that failed to
+    approve the second dataset shows one card for the right reason and one card for
+    the wrong reason, and nothing here could tell the two apart."""
+    client = _warehouse(tmp_path)
+    conn = client.app.state.general_database.connect()
+    try:
+        rows = conn.execute(
+            "SELECT d.dataset_key, d.site_profile_id FROM dataset_definition AS d "
+            " WHERE d.valid_to IS NULL ORDER BY d.dataset_key").fetchall()
+        keys = [row["dataset_key"] for row in rows]
+        sites = {row["site_profile_id"] for row in rows}
+        link = conn.execute(
+            "SELECT cardinality, review_status FROM dataset_relationship "
+            " WHERE valid_to IS NULL").fetchone()
+    finally:
+        conn.close()
+
+    assert keys == [CHILD, PARENT], keys
+    assert len(sites) == 1, (
+        "the two datasets are on two sites, so nothing here tests a collapse")
+    assert link["cardinality"] == "one_to_one"
+    assert link["review_status"] == "confirmed"
+
+
+# ---- the listing collapses --------------------------------------------------
+
+def test_the_two_muqawil_datasets_are_one_card(tmp_path):
+    """His screenshot showed two. `R-47` says one."""
+    datasets = _datasets(_warehouse(tmp_path))
+
+    assert [row["source_key"] for row in datasets] == [PARENT], (
+        "muqawil is listed once — «المفروض مصدر مقاول يظهر مرة واحدة فقط»")
+
+
+def test_the_card_states_the_population_once_and_the_second_crawl_as_coverage(tmp_path):
+    """`R-47`'s second point, and it is the number he actually wants.
+
+    The two cards read 17,304 and 704 as if they were two populations. They are one:
+    17,304 contractors, of whom 704 have an approved profile. So the population is
+    stated once and the profile crawl reports how much of it has been fetched.
+    """
+    card = _datasets(_warehouse(tmp_path))[0]
+
+    assert card["observations"] == 4, "the listing's own row count, unchanged"
+    assert card["coverage"] == [{
+        "dataset_key": CHILD,
+        # THE SITE'S OWN WORD FOR IT (`R-45`): the label is the child dataset's
+        # stored `display_name`, which the approval recorded, never a noun of ours.
+        "label": "Contractor profiles",
+        "stored": 1,
+        "population": 4,
+    }], card["coverage"]
+
+
+def test_a_lone_dataset_is_left_exactly_as_it_was(tmp_path):
+    """THE `jobs` AND `tenders` CASE, which CLAUDE.md names as coming.
+
+    A site with one dataset must be untouched by the fold, and it must carry NO
+    `coverage` key — the panel's noun branches on its absence, so a `coverage: []`
+    here would print an empty second line on every future dataset card.
+    """
+    datasets = _datasets(_warehouse(tmp_path, relate=False))
+
+    assert sorted(row["source_key"] for row in datasets) == [CHILD, PARENT], (
+        "with no relationship these are two populations and stay two cards")
+    for row in datasets:
+        assert "coverage" not in row, row
+
+
+# ---- and it collapses only on a join a person confirmed ---------------------
+
+def test_a_merely_suggested_relationship_does_not_collapse_anything(tmp_path):
+    """`review_status` IS THE HUMAN GATE. `propose_relationship`'s own docstring says
+    *"this path can never confirm it"*, and collapsing on a guess would hide a
+    population behind a percentage nobody had agreed was a percentage."""
+    datasets = _datasets(_warehouse(
+        tmp_path, status=RelationshipReviewStatus.SUGGESTED))
+
+    assert sorted(row["source_key"] for row in datasets) == [CHILD, PARENT]
+
+
+def test_a_rejected_relationship_does_not_collapse_anything(tmp_path):
+    """The third value of the vocabulary, and the one that means "no"."""
+    datasets = _datasets(_warehouse(
+        tmp_path, status=RelationshipReviewStatus.REJECTED))
+
+    assert sorted(row["source_key"] for row in datasets) == [CHILD, PARENT]
+
+
+def test_no_dataset_falls_off_the_listing_when_relationships_are_two_deep(tmp_path):
+    """EVERY DATASET REACHES A CARD, and a naive fold loses the deepest one.
+
+    Fold every child into its parent and a middle dataset disappears — it is somebody
+    else's child, so it is skipped — and its OWN child disappears with it, because the
+    card that would have carried its coverage was never emitted. Three datasets,
+    two reachable, and no error anywhere.
+
+    So a child that is itself a parent keeps its own card. Nothing in his warehouse is
+    two deep today; the point is that the day something is, the answer is already
+    decided and asserted rather than discovered from a screen with a table missing.
+    """
+    datasets = _datasets(_warehouse(tmp_path, chain=True))
+    keys = sorted(row["source_key"] for row in datasets)
+    covered = sorted(entry["dataset_key"]
+                     for row in datasets for entry in row.get("coverage", []))
+
+    assert keys == [CHILD, PARENT], keys
+    assert covered == [GRANDCHILD], covered
+    assert sorted(keys + covered) == sorted([PARENT, CHILD, GRANDCHILD]), (
+        "a dataset is reachable from no card at all")
+
+
+def test_one_to_many_does_not_become_a_fraction(tmp_path):
+    """CARDINALITY IS WHAT MAKES "704 of 17,304" A SENTENCE.
+
+    Under `one_to_many` a parent row can carry several children, so the child count
+    is not a fraction of the parent count at all — 9 rows against 4 parents would
+    print "9 of 4 (225.0%)". Confirmed is not sufficient on its own.
+    """
+    datasets = _datasets(_warehouse(tmp_path, cardinality=Cardinality.ONE_TO_MANY))
+
+    assert sorted(row["source_key"] for row in datasets) == [CHILD, PARENT]
+
+
+# ---- and the two stored datasets are still two ------------------------------
+
+def test_the_profile_table_still_opens_on_its_own(tmp_path):
+    """THE REGRESSION THIS CHANGE COULD EASILY HAVE SHIPPED.
+
+    `/source/{key}` resolves one dataset out of `_dataset_rows` by key
+    (`scrapex/webui/app.py`, `dataset = next((row for row in _dataset_rows() if
+    row["source_key"] == source_key), None)`). Folding the two datasets THERE rather
+    than in the listing would take `contractor_profiles` out of that lookup and the
+    page would answer 404 — which is precisely the defect #212 closed for
+    `contractors`, returning through a change that looks like a display fix.
+
+    `R-47` is explicit that this must not happen: *"the two `dataset_definition` rows
+    stay two."*
+    """
+    client = _warehouse(tmp_path)
+
+    for key in (PARENT, CHILD):
+        assert client.get(f"/source/{key}").status_code == 200, (
+            f"/source/{key} stopped resolving; the collapse reached the resolver")
+        assert client.get(f"/api/table/{key}").status_code == 200, (
+            f"/api/table/{key} stopped resolving")
+
+
+def test_the_folded_dataset_is_still_its_own_row_in_the_warehouse(tmp_path):
+    """The schema half of `R-47`, asserted on the schema rather than inferred.
+
+    `contractors._approval` refuses to put a 27-field profile and a 28-field listing
+    under one approved schema, because a subset is what a broken parser looks like
+    (`R-31`). A change that "simplified" the listing by merging the datasets would
+    either be refused there or retire the listing's live schema version.
+    """
+    client = _warehouse(tmp_path)
+    conn = client.app.state.general_database.connect()
+    try:
+        live = [row["dataset_key"] for row in conn.execute(
+            "SELECT dataset_key FROM dataset_definition WHERE valid_to IS NULL "
+            "ORDER BY dataset_key")]
+    finally:
+        conn.close()
+
+    assert live == [CHILD, PARENT], (
+        "the listing collapsed and took a stored dataset with it")
+
+
+# ---- the panel prints it, and does not print "products" over a directory ----
+#
+# The DOM half is `tests/test_panel_dom.py`
+# (`test_a_dataset_card_says_rows_and_coverage_never_products`), driven in a real
+# browser. This one asserts the SHAPE the panel reads, because the two failed apart
+# once already: #255 fixed `last_success` on the engine while the harness stub still
+# carried the `None` the engine had stopped sending.
+
+@pytest.mark.extension
+def test_the_harness_stub_carries_the_SHAPE_the_engine_really_sends(tmp_path):
+    """THE SEAM THAT FAILED ONCE ALREADY, and it failed exactly this way.
+
+    #255 taught the engine to report a real `last_success` for a dataset while the
+    panel harness stub still carried the literal `None` the engine had stopped
+    sending. Every DOM assertion stayed green about a state the product no longer
+    produced. The coverage entry is a new key with the same exposure, so the stub's
+    keys are compared to the ENGINE'S keys here rather than trusted.
+
+    A NOTE ON WHAT THIS REPLACED, because the first attempt was worse than nothing.
+    It asserted that the string `c.stored` appears in `app.js` — and `c.stored`
+    appears TWICE there, in `countLine` and in `coverageShare`, so renaming the one
+    the card reads left the substring present and the guard green. Mutation caught
+    it: M11 of this branch's table was the only mutation not caught, which is the
+    "search for one spelling is not a measurement" lesson (`LESSONS.md` §9) arriving
+    at a test instead of at a census. The property is behavioural, so the assertion
+    has to be.
+    """
+    import sys
+    sys.path.insert(0, str(ROOT / "tools"))
+    import panel_harness as harness
+
+    card = _datasets(_warehouse(tmp_path))[0]
+    stub = next(row for row in harness.STRESS_SOURCES
+                if row.get("kind") == "dataset")
+
+    assert "coverage" in stub, (
+        "the stub carries no coverage entry, so tests/test_panel_dom.py's "
+        "assertions about the card's second line are about nothing")
+    assert set(stub["coverage"][0]) == set(card["coverage"][0]), (
+        f"the stub and the engine disagree about a dataset card's coverage keys: "
+        f"stub {sorted(stub['coverage'][0])} vs engine {sorted(card['coverage'][0])}")

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -1040,6 +1040,87 @@ def test_a_dataset_card_offers_only_the_actions_that_work(open_panel):
             f"dataset key")
 
 
+def test_a_dataset_card_says_rows_and_coverage_never_products(open_panel):
+    """A CONTRACTOR IS NOT A PRODUCT, and the card said 17,304 of them were.
+
+    `<div class="n">${fmtCount(s.products)} products</div>` hardcoded the noun for
+    every card, and the ENGINE ALREADY KNEW the word was meaningless there: the
+    comment beside `_dataset_rows` (scrapex/webui/app.py) says `products` "has no
+    meaning for a company, so it carries the same count rather than a zero that
+    would read as an empty dataset". So the engine passed a duplicate of the row
+    count through a field it documents as meaningless and the panel printed the
+    meaningless word under it.
+
+    WHAT THE LINE CARRIES NOW is `R-47`'s second point: the population is stated
+    ONCE, on the identity line, and the second crawl reports how much of it has been
+    fetched. The three branches are asserted separately below, in the page, because
+    the DOM can only ever show the stub's one shape.
+    """
+    page = open_panel(view="data")
+    settle_view(page, "data")
+
+    card = page.locator('[data-open="contractors"]')
+    assert card.count() == 1, (
+        "the harness stub no longer carries a dataset-kind source; put it back "
+        "rather than deleting this — that hole let a false rule pass for ten days")
+    text = card.text_content() or ""
+
+    assert "products" not in text.lower(), (
+        f"the word 'products' is still over a contractor directory: {text!r}")
+    # `R-45` — the label is the CHILD DATASET'S own stored `display_name`, which the
+    # approval recorded from the site, and never a noun of ours.
+    assert "Contractor profiles: 704 of 17,304 (4.1%)" in " ".join(text.split()), (
+        f"the profile crawl is not reported as coverage of the listing: {text!r}")
+
+    # AND A PRICE CARD IS UNTOUCHED, because there the word is TRUE and the number
+    # is a different one — flattening it to "rows" would lose a real fact.
+    price = page.locator('[data-open="LONG_AR"]')
+    assert "9,321 products" in " ".join((price.text_content() or "").split())
+
+
+def test_the_noun_over_a_count_is_decided_by_what_the_engine_reports(open_panel):
+    """THE THREE BRANCHES, in the shipped function, in the real browser.
+
+    The stub can only put ONE dataset shape on screen, and the branch that matters
+    most for the future is the one it cannot show: `jobs` and `tenders` are named in
+    CLAUDE.md as coming, they will arrive as datasets with no detail crawl, and
+    nothing else here would notice if their card started printing "0 products".
+
+    `countLine` is a top-level function in a classic script, so it is reachable from
+    the page's own global scope — this calls the code that ships rather than a copy
+    of its rules, which is what `tests/test_a_dataset_card_offers_what_works.py`
+    learned the hard way about restating somebody else's behaviour.
+    """
+    page = open_panel(view="data")
+    settle_view(page, "data")
+
+    assert page.evaluate("() => typeof countLine") == "function", (
+        "countLine was renamed or scoped; this guard reads it off the global")
+
+    # A DATASET WITH NO DETAIL CRAWL — the `jobs`/`tenders` shape. `rows` is the
+    # honest generic and it is not a new vocabulary: the identity line above
+    # already reads `[Row 17,304]` and the Drive offline card already says "rows".
+    assert page.evaluate(
+        "() => countLine({kind: 'dataset', observations: 8412, products: 8412})"
+    ) == "8,412 rows"
+
+    # A PRICE SOURCE. Unchanged, and it must stay unchanged.
+    assert page.evaluate(
+        "() => countLine({observations: 6969, products: 1812})"
+    ) == "1,812 products"
+
+    # COVERAGE WINS OVER BOTH, and the label is escaped — it comes out of the
+    # warehouse, which `esc()` is the panel's whole XSS boundary for.
+    assert page.evaluate("""() => countLine({kind: 'dataset', observations: 4,
+        coverage: [{label: '<b>x</b>', stored: 1, population: 4}]})""") \
+        == "&lt;b&gt;x&lt;/b&gt;: 1 of 4 (25.0%)"
+
+    # A POPULATION OF NOTHING IS NOT A PERCENTAGE OF ANYTHING. "0.0%" would read as
+    # a measured floor; the share is omitted and the pair still shown.
+    assert page.evaluate("""() => countLine({kind: 'dataset', observations: 0,
+        coverage: [{label: 'P', stored: 0, population: 0}]})""") == "P: 0 of 0"
+
+
 #: Everything about a trigger that a person can SEE. Read off both screens and
 #: compared, because "unprofessional" is not a property a stylesheet can be
 #: grepped for — the two controls either look like one system or they do not.

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -130,10 +130,10 @@ PINNED = (
     # The version-gate blocker. Track 3 of STATE.md cannot be worked without
     # these three, and two of them are the citations that drifted.
     ("docs/STATE.md", "scrapex/version.py", 483, '"latest_extension_version": VERSION'),
-    ("docs/STATE.md", "scrapex/webui/app.py", 1543, '"latest_extension_version": VERSION'),
+    ("docs/STATE.md", "scrapex/webui/app.py", 1662, '"latest_extension_version": VERSION'),
     ("docs/STATE.md", "extension/app.js", 599, "latest_extension_version"),
     ("docs/STATE.md", "scrapex/version.py", 76, 'VERSION = "'),
-    ("docs/RULINGS.md", "scrapex/webui/app.py", 1543, '"latest_extension_version": VERSION'),
+    ("docs/RULINGS.md", "scrapex/webui/app.py", 1662, '"latest_extension_version": VERSION'),
     ("docs/RULINGS.md", "scrapex/version.py", 483, '"latest_extension_version": VERSION'),
     # The two flags whose condition is met and whose lighting is the owner's call.
     ("docs/STATE.md", "scrapex/features.py", 54, "True"),
@@ -151,8 +151,22 @@ PINNED = (
      'assert.equal(manifest.version, VECTORS.version)'),
     ("docs/RULINGS.md", "tests/test_version.py", 79, "pyproject"),
     # OP-2's two worker_alive computations, one of which the fix never reached.
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1554, '"worker_alive"'),
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2598, "def _about("),
+    #
+    # BOTH RE-READ 2026-08-23, and this pair is the one where reading matters most:
+    # `"worker_alive"` appears TWICE in `app.py` and the two rows below are exactly
+    # those two occurrences, so arithmetic on a diff cannot tell them apart. The
+    # first is in `/api/health`, three lines under `latest_extension_version`; the
+    # second is inside `_about`. Identified by reading the enclosing function, not
+    # by adding a delta -- and the two deltas differed anyway, because the branch
+    # that moved them edited `app.py` in two separate places.
+    #
+    # RE-READ AGAIN after rebasing onto #261, which also inserted into `app.py`.
+    # Both sides of the rebase had CHANGED these two numbers -- main said 1554/2598,
+    # this branch said 1673/2666, and the answer after both diffs is neither. That is
+    # the case for reading over resolving: taking either side of the conflict would
+    # have produced a confidently wrong pin.
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1729, '"worker_alive"'),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2722, "def _about("),
     ("docs/BACKLOG.md", "scrapex/webui/templates/settings.html", 162, "about.worker_alive"),
     # BV-3's chain, end to end: the panel posts it, capture reads it.
     ("docs/BACKLOG.md", "extension/app.js", 840, "crawl_honour_delay:"),
@@ -224,17 +238,27 @@ PINNED = (
     # than being loosened to keep passing — the same call `OP-36` records above.
     # `return ""` for a dataset is what OP-42 was about; the pin follows the
     # argument to the filter that replaced it.
-    ("docs/BACKLOG.md", "extension/app.js", 4595,
+    ("docs/BACKLOG.md", "extension/app.js", 4655,
      "SOURCE_ACTIONS.filter((item) => item.proof === RESOLVES_A_DATASET)"),
     ("docs/BACKLOG.md", "scrapex/webui/app.py", 697, '"kind": "dataset",'),
-    # 2710 -> 2725 -> 2787, and the third move is the same story as the first two.
+    # 2710 -> 2725 -> 2787 -> 2911, and the fourth move is the same story as the
+    # first three.
     # #252 measured this line on `main` at 4615a14, #251 landed first and added 15
     # lines to `app.py` above it, and `main` was red between the second merge and
-    # the fix. #255 then inserted above it again. Four pull requests, none wrong on
+    # the fix. #255 then inserted above it again, and the REQ-37 branch inserted
+    # `_dataset_listing` above it after that. Five pull requests, none wrong on
     # its own base -- which is why the number is re-read out of the file on every
     # rebase and never adjusted by arithmetic. This rebase re-read all four.
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2843, "if source_key not in known:"),
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1048,
+    #
+    # AND THIS ONE ALSO HAS TWO OCCURRENCES, which is why "re-read" is not a slogan.
+    # `if source_key not in known:` sits in `api_rename_source` as well. The one
+    # this row means is the export route -- the document's claim beside it is that
+    # `/api/export/{key}` "validates the key against `manifest.sources` and answers
+    # 404 for anything else" -- and only reading the enclosing function separates
+    # them. A delta applied to the old number would have picked the right line here
+    # by luck and the wrong one the first time the two moved apart.
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2967, "if source_key not in known:"),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1223,
      "A GENERIC DATASET IS A TABLE LIKE ANY OTHER TABLE"),
     # OP-44 · the dataset card that said "no successful crawl yet" over 17,304
     # crawled rows. Four citations carry the whole argument, and a reader sent one
@@ -243,7 +267,7 @@ PINNED = (
     # The sentence itself, so it is clear the card reads a MISSING key and not a
     # missing crawl -- which is why writing a `crawl_run` row would not have moved
     # this line at all.
-    ("docs/BACKLOG.md", "extension/app.js", 4489, "const last = s.last_success;"),
+    ("docs/BACKLOG.md", "extension/app.js", 4549, "const last = s.last_success;"),
     # Why the row could not honestly be written: the column is NOT NULL into
     # source_site, and muqawil is in site_profile.
     ("docs/BACKLOG.md", "db/engine/schema.sql", 122,

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -165,7 +165,7 @@ PINNED = (
     # this branch said 1673/2666, and the answer after both diffs is neither. That is
     # the case for reading over resolving: taking either side of the conflict would
     # have produced a confidently wrong pin.
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1729, '"worker_alive"'),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1673, '"worker_alive"'),
     ("docs/BACKLOG.md", "scrapex/webui/app.py", 2722, "def _about("),
     ("docs/BACKLOG.md", "scrapex/webui/templates/settings.html", 162, "about.worker_alive"),
     # BV-3's chain, end to end: the panel posts it, capture reads it.
@@ -258,7 +258,7 @@ PINNED = (
     # them. A delta applied to the old number would have picked the right line here
     # by luck and the wrong one the first time the two moved apart.
     ("docs/BACKLOG.md", "scrapex/webui/app.py", 2967, "if source_key not in known:"),
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1223,
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1167,
      "A GENERIC DATASET IS A TABLE LIKE ANY OTHER TABLE"),
     # OP-44 · the dataset card that said "no successful crawl yet" over 17,304
     # crawled rows. Four citations carry the whole argument, and a reader sent one

--- a/tests/test_the_registers_cannot_collide.py
+++ b/tests/test_the_registers_cannot_collide.py
@@ -177,6 +177,41 @@ RESERVED: dict[str, dict[int, str]] = {
         # request that follows the Drive branch removes all three together.
         49: "branch claude/drive-without-a-server",
         50: "branch claude/drive-without-a-server",
+        # 60, 61 AND 62 ARE THIS BRANCH'S HOLES, created when it took `OP-63` after
+        # #261 declared 53..59. Two of the three name a ref because a SWEEP found
+        # them, and that sweep is the point of this comment.
+        #
+        # THE PRIMARY HANDED OUT TWO COLLIDING NUMBERS IN ONE DAY — 60, then 61 —
+        # and said so, from the session that owns `ORCHESTRATION.md` §3. Its tables
+        # covered the branches it knew about; this branch was in neither. What found
+        # the second collision was a third session sweeping the highest declared
+        # `OP` across EVERY ref instead of across a named list:
+        #
+        #   git for-each-ref --format='%(refname:short)' refs/remotes/origin \
+        #     | while read -r r; do git show "$r:docs/BACKLOG.md" 2>/dev/null \
+        #       | grep -oE '^#{2,4} +OP-[0-9]+'; done | sort -u
+        #
+        # RUN INDEPENDENTLY HERE BEFORE ACCEPTING 63, and it confirmed the handover
+        # rather than resting on it: `feat/the-engine-knows-which-code-it-is-running`
+        # declares BOTH 60 and 61 on `origin`, and no ref anywhere declares 62 or 63.
+        # **A number you were handed is provisional until you have swept for it** —
+        # which is §3's "an unpushed claim is invisible and still real" arriving from
+        # the other direction: a PUSHED claim is visible and still missed, if you look
+        # at a list of branches instead of at all of them.
+        # 62 IS THE WEAK ROW AND SAYS SO. A third session holds it on the primary's
+        # word and **no ref carries it** — the sweep above found nothing above 61
+        # anywhere. So this row cannot name the branch §3 requires, and inventing one
+        # would be worse than admitting the gap. It carries an action rather than a
+        # claim: replace it with the ref the moment that holder pushes, or delete it
+        # if 62 turns out free. Do not leave it standing on a session that has ended
+        # — that is the wart the paragraph above this dict was written about, and it
+        # passed every guard the whole time it was wrong.
+        #
+        # AND 62 IS NOT RESERVED HERE. It was this branch's third hole, and
+        # #265 has since MERGED it — `OP-62 · The published engine could not
+        # serve one page` is declared on `main`. A row for a declared number
+        # fails `test_a_reserved_number_is_not_also_declared`, and this file's
+        # own rule says delete a row the moment its pull request lands.
         # 60 AND 61, HELD ELSEWHERE, AND THIS BRANCH LANDS `OP-62` OVER THEM. Both
         # are declared on `feat/the-engine-knows-which-code-it-is-running`, pushed:
         # `OP-60 · A frozen engine cannot name the commit it was built from` and

--- a/tests/test_the_registers_cannot_collide.py
+++ b/tests/test_the_registers_cannot_collide.py
@@ -201,9 +201,11 @@ RESERVED: dict[str, dict[int, str]] = {
         # grepping the refs would find TWO holders and think this row wrong. It is
         # recorded rather than smoothed over, because this file's own scar is a row
         # that named a holder who had moved and passed every guard while doing it.
-        # When that branch's 63 is pushed, delete these two words and nothing else.
-        61: "branch feat/the-engine-knows-which-code-it-is-running "
-            "(card branch's duplicate 61 ruled to 63; renumber not yet pushed)",
+        # THE 63 IS NOW PUSHED — `origin/fix/one-card-per-site-and-an-honest-noun`
+        # declares `OP-63` and no ref declares its old 61 — so the parenthetical this
+        # row carried has been deleted exactly as the line above instructed, and
+        # nothing else with it. The row now names one holder a reader can check.
+        61: "branch feat/the-engine-knows-which-code-it-is-running",
     },
     "DEC": {},
 }

--- a/tools/panel_harness.py
+++ b/tools/panel_harness.py
@@ -48,11 +48,20 @@ STRESS_SOURCES = [
     # crawled …" instead of "no successful crawl yet" over 17,304 rows. A literal
     # `None` here was true of the engine for about ten minutes and would now be the
     # stub disagreeing with the shipped product.
+    #
+    # `coverage` CARRIES THE SECOND CRAWL, and this row is now ONE card where the
+    # engine used to send two (`R-47`, `REQ-37`): `_dataset_listing` folds
+    # `contractor_profiles` into `contractors` on their confirmed one-to-one
+    # relationship and reports the child as coverage instead of as a second
+    # population. The numbers are his warehouse's, measured read-only 2026-08-23.
     {"kind": "dataset", "source_key": "contractors",
      "source_name": "muqawil.org contractors", "source_name_ar": "",
      "base_url": "https://muqawil.org", "family": "generic",
      "active": True, "implemented": True, "supports_history": False,
      "observations": 17304, "products": 17304,
+     "coverage": [{"dataset_key": "contractor_profiles",
+                   "label": "Contractor profiles",
+                   "stored": 704, "population": 17304}],
      "last_success": {"started_at": "2026-08-21T18:40:11Z",
                       "finished_at": "2026-08-21T18:40:11Z",
                       "rows_seen": 0, "requests_count": 0},


### PR DESCRIPTION
`REQ-37` was ruled on 2026-08-22 as `R-47` and was still not built on 2026-08-23. He
asked why: «حل المشكلة لم يصل لى ما السبب ؟».

**Measured before starting: no file under `extension/`, `scrapex/` or `tests/` cited
`R-47` or `REQ-37`.** Ruled, recorded, and never carried into code. That is the whole
answer to his question, and it is the `REQ-04` failure `C7` exists to catch.

Two of the four defects on his screenshot are here; the other two (`no successful
crawl yet` on both muqawil cards) landed as #255.

## 1 · muqawil appeared twice and must appear once

«المفروض مصدر مقاول يظهر مرة واحدة فقط واختيارات الزحف الخاصة به تكون متعغددة»

`_dataset_listing` folds a confirmed one-to-one child dataset into its parent for
`/api/sources`, so the Data screen draws one muqawil card, and the second number stops
being a second population — the card reads `Contractor profiles: 704 of 17,304 (4.1%)`,
which is `R-47`'s second point.

**Only the presentation collapses, and `_dataset_rows` is deliberately untouched.** It
has a second caller: `/source/{key}` resolves ONE dataset out of it by key, so folding
in place would have made `/source/contractor_profiles` answer 404 again — the exact
regression #212 closed, arriving through a change that looks like a display fix.
`test_the_profile_table_still_opens_on_its_own` is that guard.

**The grouping key is not the site alone.** Measured read-only on his warehouse:

| | |
|---|---|
| `dataset_definition` | `contractors` and `contractor_profiles`, **both `site_profile_id = 2`** |
| `dataset_relationship` | parent `contractors`, child `contractor_profiles`, `one_to_one`, **`confirmed`** |
| active rows | 17,304 and 704 |
| `site_profile` | **TWO muqawil rows** — id 1 `.../ar/contractors`, id 2 `.../`. Same host, different `base_url`, so the URL would have been the wrong key and works today only because id 1 carries no datasets |

`R-47`'s own justification is narrower than the site — *"the join is the thing that
makes the single card honest rather than a label over two unrelated tables"* — so the
fold requires a **confirmed, one-to-one** relationship. Suggested, rejected and
`one_to_many` each leave two cards standing, and each is a test.

## 2 · The word "products" over a contractor directory — `OP-63`

Not filed anywhere; found while diagnosing, so it is in `BACKLOG.md` and not
`REQUESTS.md`. **The engine already knew the word was meaningless, in writing** — its
own comment says `products` *"has no meaning for a company, so it carries the same
count rather than a zero that would read as an empty dataset"* — and the panel printed
the meaningless word underneath it. Neither side was unaware; the two notes never met.

`countLine` replaces the hardcoded noun with three branches keyed on what the engine
reports, never on a key's spelling, so `jobs` and `tenders` need no new code:

| the card | the second line |
|---|---|
| a price source | `1,812 products` — **unchanged**, because there the word is true and the number is a different one (`[Row 6,969]` over `1,812 products`) |
| a dataset with a confirmed detail crawl | `Contractor profiles: 704 of 17,304 (4.1%)` |
| any other dataset | `8,412 rows` |

**Why `rows`:** `R-45` forbids inventing a label the site never gave, which rules out
the alternatives — `original_name` would print `704 contractor_profiles` for the next
dataset, and `dataset_kind` is `'table'` for both (measured), so **nothing in the
warehouse names the unit of a row**. `rows` claims nothing about the site and is not
new vocabulary: the identity line already reads `[Row 17,304]` and the Drive offline
card already prints `<n> rows`. The one word taken from the site is the coverage
label — the child dataset's own stored `display_name`.

## What is NOT built, and it is blocked rather than skipped

`R-47`'s third point is two crawl **options** on the card. `POST /api/jobs` answers
`404 unknown source_key 'contractors'` (`OP-52`), so there is no panel path to a
dataset crawl at all, and two menu entries would be two buttons that 404 — the rule
#258 built a guard for. **`REQ-37` therefore stays `In flight`, not `Done`.**

## `R-47` is corrected and stands (`C4`/`C5`)

Its point 2 calls the coverage figure *"the one `--coverage` already computes"*. It is
not:

| asked | answered |
|---|---|
| `coverage("contractor_profiles")` | *"nothing has been sighted"* — `dataset_sighting` holds **zero** rows for that key |
| `coverage("contractors")` | 17,269 stored of 17,417 sighted (99.2%) |
| the card's figure | **704 of 17,304 (4.1%)** |

`sightings.coverage` answers stored-of-sighted *within one dataset*. The 704-of-17,304
figure comes from the `dataset_relationship` row he asked for by name — «اربطهم فى
dataset_relationship» — not from a sighting. *"The mechanism already exists"* is the
most expensive kind of wrong sentence in a ruling, because the next session sizes the
work off it.

## His GPP comparison has no presentation to copy

«انظر الى gpp لتفهم كيف تم عمل هذا» — measured: **`grep -rin gpp extension/` returns
nothing.** No branch, no card, no split-button, no picker. `GPP_ENERGY` is one
`source_key` in `sources.yaml` and its five energy types live in a dict inside
`scrapex/connectors/gpp.py`, so the panel has always drawn it as one card *without
knowing it was one*.

The transferable lesson is **collapse below the surface**, which is what the listing
now does. The multiplicity that cannot be hidden — two separately-run, separately-
resumed, separately-approved crawls — goes to the `⋮` menu `REQ-36` built, rather than
to a second vocabulary of its own (`PLATFORM-PLAN` Decision 26).

## Twelve mutations, twelve caught — and one guard was replaced because it was not

Every guard had its defect restored and was proven RED, then GREEN on restore, with
`__pycache__` purged between runs and the restore verified by `git status --porcelain`
rather than a content hash.

**M11 was not caught on the first pass.** A seam test asserted the string `c.stored`
appears in `app.js` — and `c.stored` appears **twice** there, in `countLine` and in
`coverageShare`, so renaming the occurrence the card reads left the substring present
and the test green. It now compares the harness stub's coverage keys to the engine's
own, which is behaviour at the seam where #255 failed. *A search for one spelling of a
feature is not a measurement of the feature* (`LESSONS.md` §9), reaching a test.

## Eight citations re-derived by reading, not by arithmetic

Adding `_dataset_listing` moved eight `file:line` citations across three documents.
Arithmetic would have been wrong twice: **the delta is not one number** (two edits to
`app.py`, so 119 lines above the second and 124 below), and **two subjects have two
occurrences each** — `"worker_alive"` in `/api/health` vs `_about`, and
`if source_key not in known:` in `api_rename_source` vs the export route. Both
identified by reading the enclosing function.

**This branch's own document edits deliberately cite no line numbers**, naming
`_dataset_listing`, `countLine`, `_source_overview.html` and `connectors/gpp.py` by
symbol instead — `LESSONS.md` §13's closing advice.

---

## Rebased onto #261 (`f1844af`), and it found a real collision

- **The number moved three times: `OP-53` → `OP-61` → `OP-63`.** #261 declared
  OP-53…OP-59, and then `OP-61` turned out to be declared on a **pushed** branch —
  `feat/the-engine-knows-which-code-it-is-running` holds 60 and 61 as a cross-linked
  pair. Checked first that none of OP-53…OP-59 covers the noun, so this is a distinct
  finding rather than a second entry for one thing.
- **A handed-out number is provisional until you sweep for it.** The collision was
  missed because the tables consulted listed *some* branches. Re-run here before
  accepting 63: `git for-each-ref … | git show "$r:docs/BACKLOG.md" | grep -oE
  '^#{2,4} +OP-[0-9]+'` over **every** ref — confirming 60/61 on that branch and nothing
  above 61 anywhere. That is §3's *"an unpushed claim is invisible and still real"* from
  the other side: a **pushed** claim is visible and still missed if you read a list of
  branches instead of all of them.
- **`RESERVED` carries 60, 61 and 62.** The first two name the branch ref the sweep
  found. **62 is the weak row and says so** — no ref carries it, so it admits it cannot
  name the branch §3 requires rather than inventing one, and carries the action to
  replace or delete it.
- **`R-49` checked and does not touch this.** It makes `MIGRATION-PLAN.md` the base plan
  for conflicts of *intent*; that document says nothing about `products`, a noun, or a
  row label (grepped), and the noun rests on **measurement** plus `R-45` part 1. Where a
  measurement and a document disagree, the measurement wins regardless of dates.
- **Four citations moved again, and both sides of the conflict were wrong.** `main` said
  `app.py:1554/2598/2843`, this branch said `1673/2666/2911`, and after both diffs the
  answers are `1673/2722/2967`. Two of my own four post-rebase guesses were also wrong
  (1729→1673, 1223→1167). Every one re-read out of the file. #261 also added a **second**
  occurrence of `A GENERIC DATASET IS A TABLE LIKE ANY OTHER TABLE` — `/api/table` at
  1167, `/api/fields` at 2226 — and a subject with two occurrences cannot be resolved by
  arithmetic at all.
- **`R-45`'s correction re-checked.** #261 measured that the per-row record card has
  existed on the engine since 2026-07-22, so `R-45`'s table was wrong about the card.
  It does not move the noun: this rests on `R-45` **part 1** (*"WE NEVER TRANSLATE"*),
  and the correction is about part 2 and says the ruling *"stands unchanged"*.
- **The noun is stated as an answer, not a fallback.** Nothing has been ruled on the
  boundary between `products` and a directory, so `OP-63` says plainly that this is a
  choice, why a generic word true of every dataset beats a specific word invented for
  most of them, and that the day the site gives us a word for what a row *is*, that word
  wins. **His call if he wants a different one.**

---

**SECONDARY session — this does not merge itself (`R-42`). `OP-63` still needs the
primary's confirmation.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
