### PR TITLE
The handoff that outlives the session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,10 @@ native command and CLI subcommand measured against the code, and the four-questi
 test. **It is a snapshot at `31c369e` and says so**, which is why its citations are checked
 against that commit and not against `HEAD`.
 
+**If a session ended abruptly, start at [docs/HANDOFF-2026-08-23.md](docs/HANDOFF-2026-08-23.md)** —
+the queue in the owner's order, the six things not to do with a measured incident behind each,
+and the crawl's resume command.
+
 Other long-standing documents — `docs/MIGRATION-PLAN.md`,
 `docs/COMPATIBILITY.md`, `docs/GENERIC-FETCH-SEAM.md`,
 `docs/CONTRACTOR-SOURCE.md`, `docs/STORAGE.md`, `docs/BALADY-ENG-OFFICES.md`,

--- a/docs/HANDOFF-2026-08-23.md
+++ b/docs/HANDOFF-2026-08-23.md
@@ -1,0 +1,190 @@
+# Handoff — 2026-08-23, written because a usage limit was about to end the session
+
+**Written by the primary session, at the owner's instruction, so that nothing depends on a
+prompt or on one machine's memory.** `CLAUDE.md`: *"the repository is the only memory. A
+note that is not committed did not happen."* Read this with
+[STATE.md](STATE.md), [RULINGS.md](RULINGS.md) and
+[ORCHESTRATION.md](ORCHESTRATION.md).
+
+**Re-derive every SHA before acting on it.** `git fetch origin && git rev-parse --short origin/main`.
+Every commit pointer written into prose on this page was accurate when written and is the
+one thing on it guaranteed to rot.
+
+---
+
+## 1 · Where `main` is, and what landed today
+
+`origin/main` was **`0102cc5`** when this was written. Four merges landed on 2026-08-23:
+
+| PR | what it did |
+|---|---|
+| **#258** `d10e974` | the dataset card gets its menu; the three dots stop wearing a box |
+| **#259** `4522158` | three comments outlived the test they cite; `ORCHESTRATION.md` joined the citation guard's `DOCUMENTS` |
+| **#261** `f1844af` | the source-page port **plan** (425 lines, in `docs/plans/`), and the chooser that lied on a dataset table |
+| **#260** `0102cc5` | `R-48`, `R-49`, `R-50`, `REQ-40`, `docs/ENGINE-ROLE-MEASURED.md`, and three `ORCHESTRATION.md` sections |
+
+---
+
+## 2 · THE QUEUE, in the owner's order. Do not reorder it.
+
+**1 · The packaging fix — FIRST, and it gates the release.** Session
+`blissful-swartz-bdca44-99`, branch `claude/scrapex-engine-webui-static-07a76e`, local
+`030dca6`, base `f1844af`. **NOT PUSHED as this was written** — the owner authorised the
+push and the PR directly, so it may be on `origin` by the time you read this. Check:
+`git rev-parse origin/claude/scrapex-engine-webui-static-07a76e`.
+
+> **Why it is first: `engine-v0.3.0` cannot serve a page at all.**
+> `packaging/build_engine.py:61-62` passes PyInstaller **two** `--add-data` entries (`db`,
+> `sources.yaml`) and the runtime opens **five** — `scrapex/webui/app.py:539` mounts
+> `StaticFiles(directory=STATIC_DIR)`, `:294` builds `Jinja2Templates`, and
+> `scrapex/outputs.py:214` reads `apps_script/StagingAppScript.txt`. **Three were in no
+> published archive, ever.** Only `static` crashes, because `Jinja2Templates` does not check
+> its directory at construction. Nothing installable serves a page right now.
+
+**2 · Cut `engine-v0.3.1` — AFTER that merges, never before.** The owner ruled the order
+twice, to this session and to that one. `VERSION` in the tree already reads **0.3.1**
+against a published **0.3.0**, so no version edit is needed — **do not touch a version
+file.** The reason for the order is `engine-v0.3.0`'s own history: it was cut from
+`451468d` at 15:45 on 2026-08-22 and a fix the owner had asked for (#255) merged at 17:44,
+**one hour 58 minutes later**. Cutting before the packaging fix would ship a fourth engine
+that cannot serve a page.
+
+**3 · `#262` — one card per muqawil, and the `products` noun.** Branch
+`fix/one-card-per-site-and-an-honest-noun`. **It went `DIRTY` the moment #260 merged** —
+both touch `docs/REQUESTS.md`. Its agent must rebase onto the new `main`. It was told to
+renumber its `OP-61` to **`OP-63`**; confirm it did.
+
+**4 · The provenance branch.** `feat/the-engine-knows-which-code-it-is-running`, pushed at
+`077f4bf`, holds `OP-60` and `OP-61`. Makes a stale engine visible: `scrapex/provenance.py`
+seals what the process imported and compares it against disk, reporting `stale` and
+`moved`. Mutation 24/24. **Its suite history is contaminated and it says so** — see §6.
+
+---
+
+## 3 · DO NOT DO THESE. Each one is a measured incident from today.
+
+- **Do not restart the engine on port 8000 while a crawl is running.** I did, told the
+  owner it was safe, and **a five-hour crawl died seven seconds later**. `relaunch.py` only
+  polls the port and does not kill siblings, so **the mechanism is still unproven** — but
+  the correlation is 7 seconds and the migration `0010` ran on that startup. Restarting is
+  not free. If you must, measure the crawl immediately afterwards.
+- **Never `git add .` or `git add -A`** (`SR-19`). Name every path. A blanket
+  find-and-replace across `docs/BACKLOG.md` corrupted three other sessions' entries today.
+- **Never write to the live warehouse.** Read-only, always:
+  `sqlite3.connect("file:<path>?mode=ro", uri=True)`. It is at
+  `~/.scrapex/engine/scrapex-engine.db`, 1.2 GB, and a crawl is writing to it.
+- **Do not hand out a register number from `main` alone.** I did it twice today and
+  collided twice. Sweep every ref:
+  ```bash
+  git fetch origin --quiet
+  for r in $(git for-each-ref --format='%(refname)' refs/remotes/origin); do
+    git show "$r:docs/BACKLOG.md" 2>/dev/null | grep -oE '^#{2,4} +OP-[0-9]+'
+  done | sort -u | tail
+  ```
+  **Your answer is authoritative about ORDER and merely informed about OCCUPANCY.**
+- **Do not ask a peer session to do something outward-facing on your word.** A secondary
+  refused to push on mine and was right: permission is per-principal and a peer cannot
+  stand in for the owner. See `ORCHESTRATION.md` §1.
+- **Do not use the Codex agent.** It returns HTTP 400 — *"the model is not supported when
+  using Codex with a ChatGPT account"* — on every invocation. `codex login status` says
+  logged in, so it is an **entitlement** limit on the owner's own account and only he can
+  clear it. It worked once early in the session, so the failure is intermittent or
+  something changed; that distinction is unresolved.
+
+---
+
+## 4 · The crawl
+
+```
+run-ref     profiles-2026-08-22
+command     python -m scrapex.cli contractors --details --run-ref profiles-2026-08-22 --workers 6
+frontier    34,834 profile pages
+progress    ~26,000 stored when this was written (~75%)
+```
+
+**It is resumable with zero re-fetch** — it prints `N already stored under
+profiles-2026-08-22 — resuming` and reads the frontier from disk with no network. If it
+has stopped, restart it detached with the same command from
+`C:\Users\User01\source\repos\ScrapeX`. Check liveness by the newest `captured_at`, not by
+the process list:
+
+```sql
+SELECT count(*), max(captured_at) FROM generic_page_snapshot
+WHERE crawl_run_ref = 'profiles-2026-08-22';
+```
+
+---
+
+## 5 · What the owner ruled today, and what he still owes an answer on
+
+**Ruled (all on `main` via #260):**
+
+- **`R-49`** — `docs/MIGRATION-PLAN.md` (**2026-08-12**) is the base plan. Anything
+  contradicting it dated **before** that is superseded per `C4`; anything **after** is his
+  to settle. Applied at line level, this closed **eight** of the day's twenty
+  contradictions and **closed `Q-6`** — his own Topology A decision of 2026-07-18 is
+  superseded.
+- **`R-50`** — *«المحرك اداة مساعدة للاداة وليس الشى الرئيسى · اذا اى مهمة تستطيع تنفيذها
+  الاداة تنقل لها»* — **the engine is a helper to the extension, and any task the extension
+  CAN perform moves to it. The test is capability, not category.** It supersedes
+  `MIGRATION-PLAN.md:60`'s *"Export stays in the engine"* as a statement of where the
+  capability lives. **It is NOT discharged by `engine-v0.3.1`** — that fixes why the engine
+  was broken, not the coupling that lets a broken engine take the export down with it.
+
+**Open, and his alone:**
+
+- **The eleven questions** in [ENGINE-ROLE-MEASURED.md](ENGINE-ROLE-MEASURED.md) §8. The
+  first governs the rest: *"only" in «المحرك له مهام محددة فقط» — on which axis?* The
+  interface axis (the engine keeps `extract`, `domain`, `store`; only display leaves) or the
+  pipeline axis (everything but the fetch leaves)?
+- **`Jobs stay in the engine`** (`MIGRATION-PLAN.md:61`) — the same shape as export, but he
+  deferred it personally, so `R-50` does not settle it.
+- **`REQ-11`** branch protection · **`Q-18`–`Q-23`** on the Drive branch · **`O-5`** saved
+  views · **`REQ-25`** which registry a generic crawl belongs in.
+- **Where `~/.claude/agents/codex.md` should live** — it is untracked, on one machine, and
+  that is the failure of 2026-08-17 repeating.
+
+---
+
+## 6 · Things that are true and easy to get wrong
+
+- **`docs/ENGINE-ROLE-MEASURED.md` is a snapshot at `31c369e` and is deliberately OUTSIDE
+  the citation guard.** Verify its citations with `git show 31c369e:<path>`, never against
+  `HEAD`. Its header says so. Do not "fix" its line numbers.
+- **Nine refutations were applied to that study before it was written down**, including its
+  own headline: the browsable rows are **16,151,610 gzipped bytes (1.34%, 74×)**, not the
+  9,511,282 / 0.79% / 126× a first pass reported and this session repeated to the owner
+  before it was checked.
+- **`R-45` and `REQ-32` are factually wrong about the row's record card.** #261 measured it:
+  the card has existed on the engine since **2026-07-22**, 967 lines, ~30% of `grid.js`,
+  opened by row **selection** and not `rowFormatter` — which is the symbol the original
+  measurement searched for and missed. **Products have it; contractors do not**, which is
+  exactly what the owner said. The `C4`/`C5` correction is still owed.
+- **The provenance branch's early suite reports are withdrawn by its own author.** A fixed
+  log path let two runs of two different commits interleave into one file with two
+  `PYTEST_EXIT` lines. Only its isolated re-run (1 failed / 20 passed) and its direct
+  `ruff check scrapex/` stand. `ORCHESTRATION.md` §5 was corrected because of it: the log
+  path now carries the head SHA, the header goes in the same file as the result, and an
+  atomic lock refuses a concurrent run.
+- **Safety refs on `origin`** — do not delete without checking: `safety/drive-stash-2026-08-22`
+  (`ae05256`, 113 lines that exist on no other branch), plus the `safety/*` and `pr253-*`
+  refs from 2026-08-22.
+- **A register collision is live:** the Drive branch's `REQ-32` is *"Open a session that
+  starts on the Drive plan"* while `main`'s `REQ-32` is *"Fixed columns, and everything else
+  in the row's own card"*. **Two requests, one number.** It will collide when
+  `claude/drive-without-a-server` (`e00711d`, no PR) merges.
+
+---
+
+## 7 · Peer sessions, and who owns what
+
+| session | what it is doing |
+|---|---|
+| `blissful-swartz-bdca44-99` | the packaging fix. **First in the queue.** `OP-62` |
+| `a2821275636abdd2c` (agent) | the provenance branch. `OP-60`, `OP-61`. Second |
+| `a494f80cf9093a6b3` (agent) | `#262`, needs a rebase and the `OP-63` renumber |
+| `engine-page-modifications-fc9442-91` | read-only review of #261's plan with the owner, in Arabic. Announces before any edit |
+| `bold-pare-769007-f7` | built the Codex agent. Outside the repo entirely |
+| `suspicious-chatelet-1ff60b-ea` | a `/code-review`; produces findings, not commits |
+
+**`R-42`: exactly one session merges. Ask, never infer, and default to secondary.**

--- a/docs/HANDOFF-2026-08-23.md
+++ b/docs/HANDOFF-2026-08-23.md
@@ -1,5 +1,7 @@
 # Handoff — 2026-08-23, written because a usage limit was about to end the session
 
+**Its queue completed on 2026-08-26. The outcome is the first section below.**
+
 **Written by the primary session, at the owner's instruction, so that nothing depends on a
 prompt or on one machine's memory.** `CLAUDE.md`: *"the repository is the only memory. A
 note that is not committed did not happen."* Read this with
@@ -9,6 +11,42 @@ note that is not committed did not happen."* Read this with
 **Re-derive every SHA before acting on it.** `git fetch origin && git rev-parse --short origin/main`.
 Every commit pointer written into prose on this page was accurate when written and is the
 one thing on it guaranteed to rot.
+
+---
+
+## OUTCOME, written 2026-08-26 — the queue below is DONE. Read this first.
+
+**Everything §2 asks for happened, and the crawl this page was worried about finished.**
+The page is kept rather than rewritten, because a handoff is evidence of what was true
+when it was written and a reader needs to be able to tell the two apart. What follows the
+banner is 2026-08-23; this banner is 2026-08-26.
+
+| the queue said | what happened |
+|---|---|
+| **1 · merge the packaging fix** | **[#265](https://github.com/muhammadbayoumi/ScrapeX/pull/265)** `467a3ac` — *"The engine carries the files it opens, and the gate stops one line later"* |
+| **2 · cut `engine-v0.3.1`** | **cut**, at `f76857d`. First engine release that can serve a page |
+| **3 · `#262`** | **merged** `1237f0e` — one card per muqawil, and the `products` noun |
+| **4 · the provenance branch** | **[#266](https://github.com/muhammadbayoumi/ScrapeX/pull/266)** `4868f91` — *"The engine says which code it is running, and 199 seconds stops being invisible"*. The 199 seconds is the incident in §3 |
+| **and one nobody queued** | **[#264](https://github.com/muhammadbayoumi/ScrapeX/pull/264)** `759a9df` — *"The guard that cried drift for eight days was comparing a file against itself"* |
+
+**THE PROFILE CRAWL IS COMPLETE.** `34,834 of 34,834`, last page `2026-08-23T13:43:52Z`.
+The number that matters is the one it produced: **`contractor_profiles` went from 704 to
+17,371 active records** on 18,089 ingestions. That is «كلّ ما ينشره الموقع» for the
+profile half of muqawil, and it is the data every open question about export and offline
+browsing is now about.
+
+**What §3's six prohibitions cost, settled.** The engine-restart incident that killed a
+five-hour crawl is now guarded rather than remembered: #266 makes a process older than its
+own source tree *visible*, which is what §3 could only ask a person to remember. **The
+mechanism of that specific kill is still unproven** and nothing since has explained it —
+it stays an open question, not a closed one.
+
+**Still open as of 2026-08-26:** the eleven questions in
+[ENGINE-ROLE-MEASURED.md](ENGINE-ROLE-MEASURED.md) §8, headed by *"only" on which axis*;
+`Jobs stay in the engine`, which he deferred personally so `R-50` does not reach it; and
+everything in §5's second list. **`R-50` is not discharged by `engine-v0.3.1`** — that
+release fixed why the engine was broken, not the coupling that let a broken engine take
+the export down with it.
 
 ---
 


### PR DESCRIPTION
The handoff that outlives the session

The owner expected a usage limit to end the session and asked for the work to
continue without losing anything or making mistakes. A prompt to an agent lives
in one session; this repository's first rule is that the repository is the only
memory. So the handoff is committed first, and the agent reads it from here.

docs/HANDOFF-2026-08-23.md carries:

- THE QUEUE IN HIS ORDER, with the reason the order is his: the packaging fix
  first, because engine-v0.3.0 cannot serve a page at all -- build_engine.py
  passes PyInstaller two --add-data entries and the runtime opens five, so
  static, templates and StagingAppScript.txt were in no published archive ever
  -- then engine-v0.3.1, then #262, then the provenance branch.
- SIX THINGS NOT TO DO, each with the measured incident behind it, headed by the
  one that cost most today: restarting the engine mid-crawl, which I did after
  telling him it was safe, and a five-hour crawl died seven seconds later. The
  mechanism is still unproven and the page says so rather than inventing one.
- THE CRAWL'S RESUME COMMAND and how to check it is alive -- by the newest
  captured_at, not by the process list.
- WHAT HE RULED TODAY (R-49, R-50) and WHAT HE STILL OWES AN ANSWER ON, headed
  by the eleven questions in ENGINE-ROLE-MEASURED section 8, whose first governs
  the rest.
- FIVE THINGS TRUE AND EASY TO GET WRONG: that ENGINE-ROLE-MEASURED.md is a
  snapshot at 31c369e whose citations must be checked against that commit and
  not against HEAD; that nine refutations were applied to it before it was
  written down, including its own headline number; that R-45 and REQ-32 are
  factually wrong about the row card in a way #261 measured; the safety refs not
  to delete; and the live REQ-32 collision waiting on the Drive branch.
- WHO OWNS WHICH BRANCH, so the next session does not collide the way I collided
  two register numbers today.

CLAUDE.md points at it from the map, because a handoff nobody is sent to is a
handoff nobody reads.

Every SHA on the page is labelled as needing re-derivation, which is the one
thing on it guaranteed to rot.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
