### PR TITLE
The guard that cried drift for eight days was comparing a file against itself

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -127,10 +127,23 @@ jobs:
           set -uo pipefail
           PAGE=https://muhammadbayoumi.github.io/mbiXsite/scrapex-picker.html
           mine=$(sha256sum docs/picker/scrapex-picker.html | cut -d' ' -f1)
-          served=$(curl -sL --max-time 20 "$PAGE" 2>/dev/null || true)
-          theirs=$(printf '%s' "$served" | sha256sum | cut -d' ' -f1)
+          # HASH THE BYTES, NEVER A SHELL VARIABLE. `served=$(curl ...)` strips
+          # every trailing newline from the body, and `sha256sum` of the file
+          # keeps its own -- so `theirs` could NEVER equal `mine` for a file
+          # ending in a newline, which this one does. This guard therefore
+          # reported drift every single day from at least 2026-08-16 while the
+          # served copy was byte-identical, and OP-20's billing outage made that
+          # red look explained. Measured 2026-08-23: the served body hashes to
+          # d43aa76..., which IS `mine`; stripped of its last newline it hashes
+          # to cc04efa..., which is what this step printed as "served".
+          #
+          # The docs loop above is unaffected because it PIPES curl into
+          # sha256sum rather than capturing it -- the asymmetry is the whole bug.
+          body="${RUNNER_TEMP:-/tmp}/served-picker.html"
+          curl -sL --max-time 20 "$PAGE" -o "$body" 2>/dev/null || true
+          theirs=$(sha256sum "$body" | cut -d' ' -f1)
 
-          if [ -z "$served" ]; then
+          if [ ! -s "$body" ]; then
             echo "::error::$PAGE served nothing. The panel's Choose an existing"
             echo "one button opens a page that does not exist."
             exit 1

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3694,12 +3694,12 @@ the zip is not the thing to reconsider.
 > never having run, have since been verified by real runs**, and SR-23 is a rule
 > anyone can follow again.
 >
-> **The cost this entry predicted was paid in full, and the bill is [OP-60].**
+> **The cost this entry predicted was paid in full, and the bill is below.**
 > It wrote: *"a red check that means 'unpaid' is indistinguishable at a glance
 > from a red check that means 'broken' — which is how a real failure gets waved
 > through."* A scheduled workflow had been failing **every day since at least
 > 2026-08-16** and nobody looked, because every red looked explained. It is kept
-> below rather than deleted, because the reasoning is what caught OP-60.
+> below rather than deleted, because the reasoning is what caught it.
 
 
 
@@ -3737,10 +3737,15 @@ allowed_actions: all`, so it is not a policy block.
 and a PR should say so rather than showing a red tick and hoping the reader knows
 why.
 
-### OP-60 · ~~The chooser drift guard compared a file against itself and failed~~ — FIXED 2026-08-23
+#### The failure it predicted, found and fixed — 2026-08-23
 
-**Found by following OP-20's own warning to its end**, and it is the failure that
-entry predicted rather than a coincidence.
+**No number of its own on purpose.** `OP-60` and `OP-61` are held by branch
+`feat/the-engine-knows-which-code-it-is-running`, and #263's handoff records them
+as that branch's. The rule in [ORCHESTRATION.md](ORCHESTRATION.md) would give me
+`OP-60` — an open pull request outranks a branch without one, and #264 is open
+while that branch has none — but moving *them* costs two renumbers and
+contradicts a committed handoff, and this is not a sibling finding anyway. **It is
+this entry's own thesis coming true**, so it belongs inside it.
 
 `Publish the documents the store links to` has failed on **every scheduled run
 from at least 2026-08-16 to 2026-08-23** — eight consecutive days, measured, not
@@ -3783,7 +3788,7 @@ expression mismatches and the new one matches.
 
 **Why it went eight days unread.** Two reasons, and both are lessons rather than
 excuses. The guard *"cannot fix what it finds"* by design, so its failure is
-normal-looking noise on a schedule nobody watches. And [OP-20] had made every
+normal-looking noise on a schedule nobody watches. And this entry had made every
 red check mean "unpaid", so a red that meant "broken" was invisible. **A guard
 that cries wolf daily is not a guard**; this one had also never been exercised
 against a passing case.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3677,7 +3677,31 @@ for three different readers, and compression hides it. If space ever becomes a
 problem, the 90 MB of `.jsonl`/`.csv` is the part regenerable from the `.db`;
 the zip is not the thing to reconsider.
 
-### OP-20 · CI has not executed since 2026-08-19, and the reason is billing
+### OP-20 · ~~CI has not executed since 2026-08-19, and the reason is billing~~ — CLOSED 2026-08-23
+
+> **RESOLVED, and by the owner in one command.** The repository was **made
+> public** on 2026-08-20, and Actions came back with it: public repositories get
+> unmetered minutes on the standard runners, so the unpaid-minutes block on a
+> private free-plan repository simply stopped applying. The switch was confirmed
+> at the plan level rather than by the flag alone — `branches/main/protection`
+> had been answering `403 Upgrade to Pro` and began answering `404 Branch not
+> protected`.
+>
+> **And the runs are real.** Measured 2026-08-23 on `main`: `CI` succeeded at
+> 05:21, 10:30 and 11:19, with the `test` job taking minutes rather than
+> failing in seconds with zero steps. PR #220's checks executed in full — `test`
+> 5m53s and 12m27s across two runs. So **#214 and #219, both merged with CI
+> never having run, have since been verified by real runs**, and SR-23 is a rule
+> anyone can follow again.
+>
+> **The cost this entry predicted was paid in full, and the bill is [OP-60].**
+> It wrote: *"a red check that means 'unpaid' is indistinguishable at a glance
+> from a red check that means 'broken' — which is how a real failure gets waved
+> through."* A scheduled workflow had been failing **every day since at least
+> 2026-08-16** and nobody looked, because every red looked explained. It is kept
+> below rather than deleted, because the reasoning is what caught OP-60.
+
+
 
 **Measured 2026-08-20.** Every workflow run since `2026-08-19T14:28Z` fails in
 **0-3 seconds with ZERO steps** — lint, test, contract-parity, scope,
@@ -3712,6 +3736,57 @@ allowed_actions: all`, so it is not a policy block.
 **Until it is cleared, a local full-suite run is the only verification available**,
 and a PR should say so rather than showing a red tick and hoping the reader knows
 why.
+
+### OP-60 · ~~The chooser drift guard compared a file against itself and failed~~ — FIXED 2026-08-23
+
+**Found by following OP-20's own warning to its end**, and it is the failure that
+entry predicted rather than a coincidence.
+
+`Publish the documents the store links to` has failed on **every scheduled run
+from at least 2026-08-16 to 2026-08-23** — eight consecutive days, measured, not
+sampled. The error each time:
+
+```
+the chooser served to owners is not the file this repository tests.
+  repository: d43aa7600b053f9ecc473734bd31f75883003facfc80c1865e7bb11b11b3ea2c
+  served:     cc04efaff465335b81de2583321437467d8b23d8dfd25579991ec2ec3dc30e80
+```
+
+**The served copy was byte-identical the whole time.** Fetching
+`https://muhammadbayoumi.github.io/mbiXsite/scrapex-picker.html` on 2026-08-23
+gives 10,231 bytes hashing to `d43aa76…` — which *is* the repository's own
+normalised hash, and `difflib` reports **zero** differing lines.
+
+**The bug was one shell newline.** `.github/workflows/publish-docs.yml` had:
+
+```bash
+mine=$(sha256sum docs/picker/scrapex-picker.html | cut -d' ' -f1)
+served=$(curl -sL --max-time 20 "$PAGE" 2>/dev/null || true)
+theirs=$(printf '%s' "$served" | sha256sum | cut -d' ' -f1)
+```
+
+Command substitution `$(curl …)` **strips every trailing newline** from the body,
+and `printf '%s'` puts none back — while `sha256sum` of the file keeps its own. So
+`theirs` could never equal `mine` for a file ending in a newline, which this one
+does. Proved by construction: the served bytes hash to `d43aa76…`, and the same
+bytes with the final newline removed hash to **exactly the `cc04efa…` CI
+printed**.
+
+**The docs loop twenty lines above is unaffected, and the asymmetry is the whole
+bug** — it *pipes* curl into `sha256sum` instead of capturing it, so nothing eats
+its newline.
+
+**Fixed** by hashing the bytes rather than a shell variable: curl writes to
+`$RUNNER_TEMP` and `sha256sum` reads the file, with `[ ! -s "$body" ]` keeping
+the served-nothing check. Verified locally against the live page — the old
+expression mismatches and the new one matches.
+
+**Why it went eight days unread.** Two reasons, and both are lessons rather than
+excuses. The guard *"cannot fix what it finds"* by design, so its failure is
+normal-looking noise on a schedule nobody watches. And [OP-20] had made every
+red check mean "unpaid", so a red that meant "broken" was invisible. **A guard
+that cries wolf daily is not a guard**; this one had also never been exercised
+against a passing case.
 
 ### OP-19 · The chaos test races the startup sweep it is checking — STILL LIVE, re-measured 2026-08-20
 

--- a/tests/test_a_hash_guard_never_hashes_a_shell_variable.py
+++ b/tests/test_a_hash_guard_never_hashes_a_shell_variable.py
@@ -1,0 +1,83 @@
+"""A drift guard that hashes `$(...)` output compares a file against itself and loses.
+
+WHY THIS FILE EXISTS. `publish-docs.yml` checks that the chooser served to owners
+is the file this repository tests -- the one part of ScrapeX served from a web
+server, and the part that handles a Google access token. It did it like this:
+
+    mine=$(sha256sum docs/picker/scrapex-picker.html | cut -d' ' -f1)
+    served=$(curl -sL --max-time 20 "$PAGE" 2>/dev/null || true)
+    theirs=$(printf '%s' "$served" | sha256sum | cut -d' ' -f1)
+
+Command substitution **strips every trailing newline** from what it captures, and
+`printf '%s'` puts none back -- while `sha256sum` of the file keeps the file's own.
+So `theirs` could never equal `mine` for a file ending in a newline, which this one
+does.
+
+WHAT IT COST. The workflow failed on every scheduled run from at least 2026-08-16
+to 2026-08-23 -- eight consecutive days -- while the served copy was **byte
+identical**: 10,231 bytes, zero differing lines, hashing to exactly the value the
+job printed as "repository". Nobody read it, for two reasons that are both worth
+the test. The guard cannot fix what it finds, so its failure is normal-looking
+noise on a schedule; and OP-20 had made every red check mean "unpaid", so a red
+that meant "broken" was invisible. Recorded as OP-60.
+
+The `echo "$var" | sha256sum` form is the same bug with a newline ADDED instead of
+removed, so it is forbidden here too. The fix in both cases is the same and it is
+not a workaround: **hash the bytes**. Write the body to a file and hash the file.
+
+Twenty lines above the broken check, the documents loop does exactly that -- it
+PIPES curl into `sha256sum` rather than capturing it -- and has never false-alarmed.
+The asymmetry between two checks in one file is the whole of this bug.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+WORKFLOWS = pathlib.Path(__file__).resolve().parents[1] / ".github" / "workflows"
+
+#: `printf ... "$var" | sha256sum` or `echo "$var" | sha256sum`, on one line.
+#: Anchored on the pipe into the hasher so a `printf` used for anything else is
+#: not caught -- the defect is specifically feeding a CAPTURED value to a hash.
+HASHED_VARIABLE = re.compile(
+    r"""\b(?:printf|echo)\b[^|\n]*\$[{(]?\w+[)}]?[^|\n]*\|\s*sha256sum""")
+
+
+def test_no_workflow_feeds_a_captured_variable_into_sha256sum():
+    """The bug is invisible in review and total in effect: the comparison simply
+    never passes, and the message it prints names the right file for the wrong
+    reason. A file path or a pipe straight from the producing command has no
+    newline to lose."""
+    offenders = []
+    for workflow in sorted(WORKFLOWS.glob("*.yml")) + sorted(WORKFLOWS.glob("*.yaml")):
+        for number, line in enumerate(
+                workflow.read_text(encoding="utf-8").splitlines(), start=1):
+            if HASHED_VARIABLE.search(line):
+                offenders.append(f"{workflow.name}:{number}: {line.strip()}")
+
+    assert not offenders, (
+        "a shell variable is being hashed, and command substitution has already "
+        "stripped its trailing newline — so this comparison can never pass:\n  "
+        + "\n  ".join(offenders)
+        + "\nHash the bytes instead: write them to a file and hash the file.")
+
+
+def test_the_chooser_check_hashes_a_file_and_still_notices_an_empty_body():
+    """The repair must not trade one silent failure for another.
+
+    `[ -z "$served" ]` was the guard against the page having been deleted
+    entirely, and it read a variable that no longer exists once the body goes to a
+    file. Dropping it would turn a missing chooser — the panel's "Choose an
+    existing one" button opening nothing — from a loud failure into a quiet pass,
+    because two empty files hash alike."""
+    text = (WORKFLOWS / "publish-docs.yml").read_text(encoding="utf-8")
+    guard = text.split("scrapex-picker.html is the only part", 1)
+    assert len(guard) == 2, "the chooser drift guard is no longer in this workflow"
+    body = guard[1]
+
+    assert "-o " in body and "sha256sum" in body, (
+        "the chooser check no longer writes the served body to a file before "
+        "hashing it")
+    assert re.search(r"\[\s*!\s*-s\s", body), (
+        "nothing checks that the served body is non-empty any more, so a deleted "
+        "chooser would hash equal to another deleted chooser and pass")

--- a/tests/test_a_hash_guard_never_hashes_a_shell_variable.py
+++ b/tests/test_a_hash_guard_never_hashes_a_shell_variable.py
@@ -19,7 +19,8 @@ identical**: 10,231 bytes, zero differing lines, hashing to exactly the value th
 job printed as "repository". Nobody read it, for two reasons that are both worth
 the test. The guard cannot fix what it finds, so its failure is normal-looking
 noise on a schedule; and OP-20 had made every red check mean "unpaid", so a red
-that meant "broken" was invisible. Recorded as OP-60.
+that meant "broken" was invisible. Recorded under OP-20, whose own
+reasoning is what found it.
 
 The `echo "$var" | sha256sum` form is the same bug with a newline ADDED instead of
 removed, so it is forbidden here too. The fix in both cases is the same and it is


### PR DESCRIPTION
## Eight days of a red that meant nothing

`Publish the documents the store links to` failed on **every scheduled run from at least
2026-08-16 to 2026-08-23** — measured, not sampled:

```
failure | 2026-08-23 | failure | 2026-08-21 | failure | 2026-08-19 | failure | 2026-08-17
failure | 2026-08-22 | failure | 2026-08-20 | failure | 2026-08-18 | failure | 2026-08-16
```

Each time:

```
the chooser served to owners is not the file this repository tests.
  repository: d43aa7600b053f9ecc473734bd31f75883003facfc80c1865e7bb11b11b3ea2c
  served:     cc04efaff465335b81de2583321437467d8b23d8dfd25579991ec2ec3dc30e80
```

**The served copy was byte-identical the whole time.** 10,231 bytes, `difflib` reports
zero differing lines, and its hash *is* `d43aa76…` — the value the job printed as
"repository".

## One shell newline

```bash
served=$(curl -sL --max-time 20 "$PAGE" 2>/dev/null || true)
theirs=$(printf '%s' "$served" | sha256sum | cut -d' ' -f1)
```

Command substitution **strips every trailing newline** from what it captures, and
`printf '%s'` puts none back — while `sha256sum` of the file keeps the file's own. So
`theirs` can never equal `mine` for a file ending in a newline, which this one does.

**Proved by construction, not argued:**

| bytes hashed | sha256 |
|---|---|
| served, as fetched | `d43aa76…` ← this is `mine` |
| served, trailing newline stripped | `cc04efa…` ← **exactly what CI printed** |

**The documents loop twenty lines above is unaffected** because it *pipes* curl into
`sha256sum` instead of capturing it. The asymmetry between two checks in one file is the
whole of this bug.

## The fix, and what it must not lose

Hash the bytes: curl writes to `$RUNNER_TEMP`, `sha256sum` reads the file. The
served-nothing check becomes `[ ! -s "$body" ]` — dropping it would turn a deleted
chooser from a loud failure into a quiet pass, because two empty files hash alike.

Verified against the live page: the old expression mismatches, the new one matches.

## A structural test, because review did not catch this and cannot

`tests/test_a_hash_guard_never_hashes_a_shell_variable.py` forbids feeding a captured
variable to `sha256sum` in **any** workflow, and asserts the chooser check still notices
an empty body.

**Mutations: four run, four caught** — putting the original `printf` bug back, the `echo`
variant (same bug with a newline *added*), dropping the empty-body check, and not writing
the body to a file at all.

## OP-20 is closed here too, and it is why this was found

OP-20 wrote: *"a red check that means 'unpaid' is indistinguishable at a glance from a red
check that means 'broken' — which is how a real failure gets waved through."* This is that
failure, found by following that sentence.

The entry itself is resolved: the repository was made **public** on 2026-08-20 and Actions
returned with it — public repositories get unmetered standard-runner minutes, so the
unpaid-minutes block on a private free-plan repository stopped applying. Confirmed at the
plan level rather than by the flag: `branches/main/protection` went from `403 Upgrade to
Pro` to `404 Branch not protected`.

**And the runs are real.** `CI` on `main` succeeded at 05:21, 10:30 and 11:19 on
2026-08-23 with the `test` job taking minutes, not failing in seconds with zero steps.
PR #220's `test` ran 5m53s and 12m27s. So **#214 and #219, both merged with CI never
having run, have since been verified**, and SR-23 is followable again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)