### PR TITLE
The engine carries the files it opens, and the gate stops one line later

### DIFF
--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -293,6 +293,25 @@ jobs:
         # first run can prepare a warehouse — the step that has the most ways to
         # fail on somebody else's machine.
         #
+        # AND THEN `ScrapeX UI`, WHICH IS THE ONE THAT MATTERS, because the three
+        # above were not enough and 0.3.0 proved it. Every one of them is printed
+        # BEFORE the server is built (`packaging/engine_entry.py`
+        # `_set_up_then_serve` announces the three steps, then hands over to
+        # `scrapex ui`), so a published engine printed all three and then said:
+        #
+        #     error: Directory '...\_MEI000036d42\scrapex\webui\static' does not exist
+        #
+        # The recipe bundled `db` and `sources.yaml`; the runtime opens five
+        # things. This gate had again stopped one line short of the failure —
+        # exactly what it was built to stop doing after 0.2.1.
+        #
+        # `scrapex/cli.py:_cmd_ui` prints `ScrapeX UI → <url>` only once `create_app`
+        # HAS RETURNED: the static mount, every template environment and the job
+        # worker are all behind it. So that line is the difference between "the
+        # engine spoke" and "the engine can serve a page", and it is the last
+        # thing printed before uvicorn takes the process — which is why a
+        # timeout, not an exit code, is how this step passes.
+        #
         # ITS OWN DATA ROOT, because this genuinely creates a database. A release
         # check must not find, open or migrate anything but what it made itself.
         shell: bash
@@ -311,6 +330,14 @@ jobs:
           echo "$spoke" | grep -q "ScrapeX-Engine"
           echo "$spoke" | grep -q "Preparing your database"
           echo "$spoke" | grep -q "Starting the engine"
+          if ! echo "$spoke" | grep -q "ScrapeX UI"; then
+            echo "REFUSED: the engine announced all three steps and never got a" >&2
+            echo "server up. That is 0.3.0: every line above is printed BEFORE" >&2
+            echo "create_app, so the .exe was missing a file the runtime opens" >&2
+            echo "and the owner met 'error: Directory ... does not exist'." >&2
+            echo "packaging/build_engine.py RUNTIME_DATA is the list to check." >&2
+            exit 1
+          fi
 
       - name: Checksum, so a download can be proved whole
         shell: bash

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -623,7 +623,7 @@ this was found in one command rather than by counting rows afterwards.
 
 **The mechanism exists and the product does not reach it.** `carry_over` has exactly
 **one** production caller — the manual subcommand `scrapex carry-over`
-(`scrapex/cli.py:993`). Nothing automatic calls it: not `ui`, not autostart, not the
+(`scrapex/cli.py:1009`). Nothing automatic calls it: not `ui`, not autostart, not the
 native host, not the panel.
 
 **What a split-era user actually gets**, simulated end to end against a fake split
@@ -631,7 +631,7 @@ installation:
 
 | path | result |
 |---|---|
-| any CLI command | clean message naming `scrapex carry-over` — `main()` catches everything (`scrapex/cli.py:1127`) |
+| any CLI command | clean message naming `scrapex carry-over` — `main()` catches everything (`scrapex/cli.py:1143`) |
 | `native.startup_check()` — how the PANEL starts the engine | `ok: false`, `action: "check_storage"`, detail = *"Run 'scrapex carry-over'"* |
 | `native.upgrade_database()` — **the panel's own repair action** | `ok: false`. **It cannot fix this**: `DatabaseRegistry.defaults()` refuses before `initialize()` is ever reached |
 
@@ -1282,7 +1282,7 @@ confirmation that the published build installs on his machine; that stays on
 > written about it.** `extension/releases.js:32` reads
 > `ScrapeX/json/version.json` from the hub, `extension/app.js:3514` prints the
 > `version` it finds, the workflow writes that same field
-> (`.github/workflows/release-engine.yml:352`), and
+> (`.github/workflows/release-engine.yml:379`), and
 > `tests/test_the_two_release_paths.py:276` already pins the writer's output to the
 > reader's input. The manifest says 0.2.1 because 0.2.1 is the only engine tag that
 > exists.
@@ -1362,7 +1362,7 @@ then the only engine that runs on this machine is that worktree's.
 **Status: OPEN, filed not fixed, per `R-01`.** Found while looking for the black
 window's trace and finding none.
 
-`_bind_log_streams` (`scrapex/cli.py:976`) says it plainly: *"run it from a terminal
+`_bind_log_streams` (`scrapex/cli.py:992`) says it plainly: *"run it from a terminal
 and this does nothing at all."* It exists for the `pythonw` autostart path, which
 has no streams. A double-click **does** get a console, so the redirect no-ops and
 the failure goes to a window that is closing. `~/.scrapex/engine.log` is dated
@@ -2170,7 +2170,7 @@ fire after a regression has been written:
   `.workspace-menu-button` in `webui.css`, which is how the third row of the table above
   was found. That is exactly the rule `docs/LESSONS.md` now states in prose (*"The
   extension's layers are three tokens …; a fourth number invented at a call site is the
-  next instance of this bug"*, [docs/LESSONS.md:611](LESSONS.md#L611)) and nothing
+  next instance of this bug"*, [docs/LESSONS.md:755](LESSONS.md#L755)) and nothing
   enforces. It is also cheap: the three substitutions below are the whole of today's
   violation set, so the guard goes green the moment they land.
 * **Behavioural, for `.modal-veil`:** open the confirmation and hit-test a point over the
@@ -2428,6 +2428,150 @@ offers, on his direct request, and left every other screen's behaviour alone. Th
 two change what two more screens offer, and the `test_panel_dom.py` line that counts
 "4 of 4" carries a comment saying so, so that nobody closes this by shrinking the
 stub back.
+
+### OP-62 · The published engine could not serve one page, because PyInstaller was told to carry two files and the runtime opens five
+
+**Status: FIXED in this pull request. Reported by the owner 2026-08-23 against the
+published `engine-v0.3.0`, the newest thing the panel's Download button offers.**
+
+His console, in full — every step it announced succeeded:
+
+```
+  ScrapeX-Engine 0.3.0
+  [1/3] Unpacking...        done.
+  [2/3] Preparing your database...
+        already there: C:\Users\User01\.scrapex\engine\scrapex-engine.db
+  [3/3] Starting the engine...
+
+error: Directory 'C:\Users\User01\AppData\Local\Temp\_MEI000036d42\scrapex\webui\static' does not exist
+```
+
+**THE PATH IN THAT MESSAGE IS THE DIAGNOSIS.**
+[scrapex/webui/app.py:364](../scrapex/webui/app.py#L364) computes
+`Path(__file__).parent / "static"`, which in a one-file build is
+`_MEIPASS/scrapex/webui/static` — the string he was shown, `_MEI000036d42` and all.
+[scrapex/webui/app.py:539](../scrapex/webui/app.py#L539) hands it to `StaticFiles`,
+whose `check_dir=True` refuses a directory that is not there — the
+`RuntimeError` is Starlette's own, raised in its `StaticFiles.__init__` — and
+[scrapex/cli.py:1318](../scrapex/cli.py#L1318) prints the `RuntimeError` verbatim.
+
+**And the directory was never in the archive.** `packaging/build_engine.py` named two
+data entries; there is no `.spec` file and no PyInstaller hook in this repository, so
+that list was the whole of it:
+
+| the runtime opens | at | bundled before |
+|---|---|---|
+| `db/` | [scrapex/db.py:22](../scrapex/db.py#L22), [scrapex/databases/domain.py:20](../scrapex/databases/domain.py#L20) | **yes** |
+| `sources.yaml` | [scrapex/config.py:55](../scrapex/config.py#L55) | **yes** |
+| `scrapex/webui/templates` | [scrapex/webui/app.py:294](../scrapex/webui/app.py#L294), [scrapex/extract/api.py:33](../scrapex/extract/api.py#L33) | **no** |
+| `scrapex/webui/static` | [scrapex/webui/app.py:364](../scrapex/webui/app.py#L364) | **no** |
+| `apps_script/StagingAppScript.txt` | [scrapex/outputs.py:214](../scrapex/outputs.py#L214) | **no** |
+
+**Only one of the three crashes, and that is the luck in this.** `Jinja2Templates` does
+not check its directory when it is constructed, so a bundle with `static` and no
+`templates` starts, reports itself healthy, and answers every page with a
+`TemplateNotFound`. And `apps_script` has been missing from **every engine ever
+published**: [scrapex/outputs.py:215](../scrapex/outputs.py#L215) returns `""` and the
+route answers 404 saying the script *"is not bundled"* — a sentence that was true, that
+nobody had read, and that no log anywhere records.
+
+**WHY THE RELEASE GATE PASSED IT, which is worth more than the fix.** The double-click
+step demands three lines — `ScrapeX-Engine`, `Preparing your database`, `Starting the
+engine`. **All three are printed before `create_app` is called**, by
+`packaging/engine_entry.py:_set_up_then_serve`, which then hands over to `scrapex ui`.
+The gate had stopped one line short of the only call that can fail — the same shape of
+miss as `OP-32`, where it stopped at `--version`. Its own guard could not catch that,
+because `tests/test_the_release_proves_the_double_click.py` read `engine_entry.py`
+alone and so believed the double-click path ended three lines before the work did.
+
+**Fixed, and measured on a real artifact rather than argued.** `RUNTIME_DATA` in
+`packaging/build_engine.py` is now the one list, the build refuses to run when an entry
+is missing, and the rebuilt `dist/scrapex-engine.exe` — bare invocation, its own
+`SCRAPEX_DATA_ROOT` — printed the line no published engine has ever printed:
+
+```
+ScrapeX UI → http://127.0.0.1:8000   (Ctrl+C to stop)
+```
+
+Served from that same binary, sizes matching the repository byte for byte:
+
+| request | answer |
+|---|---|
+| `GET /` | **200**, 26,022 bytes — a rendered template |
+| `GET /static/webui.css` | **200**, 13,306 bytes = the repo file exactly |
+| `GET /static/grid.js` | **200**, 152,947 bytes = the repo file exactly |
+| `GET /static/vendor/tabulator.min.js` | **200**, 445,987 bytes |
+| `GET /api/outputs/apps-script/script` | **200**, 35,702 bytes — **this route has never worked in a shipped engine** |
+
+**What keeps it fixed.** `tests/test_the_frozen_engine_carries_its_own_files.py` stages
+a directory the way PyInstaller lays out `_MEIPASS` — modules from the package, then
+`RUNTIME_DATA`, and nothing else — and starts the engine inside it, so the path
+arithmetic under test is the real one and no binary has to be built. It carries its own
+mutation: drop the `static` entry and the probe must die with Starlette's own words.
+The release gate now also demands `ScrapeX UI`, and
+`test_it_proves_a_SERVER_came_up_and_not_only_that_three_lines_printed` locates
+`create_app(` by index in `_cmd_ui` and requires one demanded line to come from below
+it — the rule rather than the string, because this gate has now missed twice.
+
+**One fact, two hand-maintained lists, and the newer one was wrong.**
+`pyproject.toml` `[tool.setuptools.package-data]` already carried the same trees for
+wheels. Nothing compared them. It is also incomplete in its own right —
+`static/*.svg` is absent while `scrapex/webui/static/x-mark.svg` is tracked — so a
+`pip install` of this package drops that file today. Not fixed here: it is a wheel
+path nobody installs from, and it wants its own change.
+
+**It needs a tag to reach him.** The fix is in the source; nothing installable carries
+it. `scrapex/version.py` reads `0.3.1` against a published `0.3.0`, so `engine-v0.3.1`
+would ship it, and cutting it is his call (PLATFORM-PLAN Decision 4). **Until then the
+only installable engine cannot serve a page** — the same standing condition as
+`OP-32`, which lasted twelve days.
+
+**Not a contract change** ([R-35](RULINGS.md#r-35--the-engines-version-moves-on-a-contract-change-the-extensions-on-a-user-visible-one)):
+no migration, no route and no protocol move, so `VERSION` does not move for this.
+
+**The register number, and the two round trips it took.** `OP-60` was claimed before the
+primary session was asked, which is a breach of [R-42](RULINGS.md#r-42--one-primary-session-merges-every-other-session-is-secondary-and-asks)
+and was surfaced rather than left. It came back confirmed — and the *reservations*
+that came with it were wrong. Eleven `RESERVED` rows were written for 49–59, and by
+the time the rebase ran, `#258` had declared 51 and 52 and `#261` had declared 53–59,
+so nine of the eleven would have made `test_a_reserved_number_is_not_also_declared`
+red on the tree that merges. The reasoning was right and the base was two hours old,
+which is the same lesson the pointer at the top of [STATE.md](STATE.md) keeps teaching.
+
+**Then `OP-60` turned out to be taken too, and the number is `OP-62`.** It was handed
+over as free **twice**, by a session that had checked `main` — where the register does
+run unbroken to 59 — and not the branches in flight.
+`feat/the-engine-knows-which-code-it-is-running` had already pushed 60 **and** 61. That
+is §3 of [ORCHESTRATION.md](ORCHESTRATION.md)'s *"a claim can be real and invisible"*
+landing on the session that owns §3, and the method that caught it is the one worth
+keeping: **sweep the highest declared number on EVERY ref**, not on the branches you
+happen to know about —
+
+    for r in $(git for-each-ref --format='%(refname)' refs/heads refs/remotes); do
+      git grep -oh -E "^#{2,4} +OP-[0-9]+" "$r" -- docs/BACKLOG.md ...
+
+**That same sweep found a duplicate nobody was tracking:** two pushed branches both
+declared `OP-61`. It was ruled to
+`feat/the-engine-knows-which-code-it-is-running` and the card branch moved to 63 — on
+lower churn rather than on the open-PR rule, and the primary session said so rather
+than letting the rule appear to decide it. So the branch ends with **two** `RESERVED`
+rows, 60 and 61, both to that one branch, and the row for 61 records that the card
+branch's renumber had not yet been pushed when it was written. That last clause is
+deliberate: this file's own scar is a row that named a holder who had moved and passed
+every guard while doing it.
+
+**What an adversarial review of this fix found, because the fix's own comments were
+not exempt.** Sixteen findings raised, twelve refuted, and the survivor worth naming
+is a citation *inside this change*: `packaging/build_engine.py` cited
+`scrapex/cli.py:1301` for the line that prints the error, while the same change wrote
+the correct line in this file and in `LESSONS.md`. `R-15`'s guard scans eight
+markdown documents and cannot reach a build script, so it was green with the wrong
+number in the tree. Eleven citations in the three unguarded files this change touches
+now name **symbols** instead of lines. The refutations are worth as much: one reviewer
+checked `RUNTIME_DATA` against the real `.exe` table of contents and found no gap,
+and the worry that `contractstamp` reads a `.py` at runtime was refuted — it is a
+developer-only path.
+
 
 ## 3. Decided, not yet built
 

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -526,6 +526,123 @@ three read it as bookkeeping. The number was telling the truth: no release carry
 the fix had ever been cut, and the only thing installable was the broken one — for
 twelve days.
 
+### A gate stops one line short, and the second time it is a pattern
+
+**The same gate, the next release, the same shape of miss.** `engine-v0.3.0` was cut
+on 2026-08-22 with the lesson above already built into the workflow: it launches the
+binary with no arguments and requires three sentences of it. On 2026-08-23 the owner
+double-clicked that release and got all three, and then this:
+
+    [1/3] Unpacking...        done.
+    [2/3] Preparing your database...  already there: ...\scrapex-engine.db
+    [3/3] Starting the engine...
+    error: Directory '...\_MEI000036d42\scrapex\webui\static' does not exist
+
+**Every line the gate demanded is printed before the work begins.**
+`packaging/engine_entry.py:_set_up_then_serve` announces the three steps and *then*
+hands over to `scrapex ui`; `create_app` — the static mount, both Jinja environments,
+the job worker — is entirely behind the last of them. So a binary that could not build
+an app at all printed the gate's whole checklist and was published.
+
+The line that separates *"the engine spoke"* from *"the engine can serve a page"* is
+`scrapex/cli.py:906`, and it is one statement further on:
+
+    app = create_app(...)                             # everything that can fail
+    print(f"ScrapeX UI → {url}   (Ctrl+C to stop)")   # the first honest evidence
+
+**Apply:** a gate on a shipped artifact must demand a line printed **after** the last
+thing that can fail, and *after* is a property of the code, not a matter of taste —
+`test_it_proves_a_SERVER_came_up_and_not_only_that_three_lines_printed` locates
+`create_app(` by index in `_cmd_ui` and requires one demanded string to come from
+below it. The three step announcements are progress; only what prints past the last
+call is proof. And when a gate misses twice, widen the *rule*, not the string list.
+
+**The second half of the miss was the guard's model of the path.** The fixture named
+`double_click_path` read `packaging/engine_entry.py` alone, so the only sentences the
+gate could legally demand were ones printed before control left that file. The guard
+that was supposed to keep the gate honest had the same blind spot as the gate, for the
+same reason, and could not have caught it.
+
+### A killed process never flushes, so an unflushed line is not evidence of anything
+
+**This one was caught before it shipped, and only because the fix above was tested
+rather than reasoned about.** Having established that the release gate must demand a
+line printed after `create_app` returns, the obvious move is to demand
+`ScrapeX UI → …` from `scrapex/cli.py`. Measured against the source before changing
+anything:
+
+    timeout 20 python -m scrapex.cli ui --no-open --port 8131 2>&1
+    -> ZERO BYTES
+
+The server had started perfectly. **Three facts have to be true at once for that to
+happen, and they all are here:**
+
+1. `spoke=$(...)` makes stdout a **pipe**, and Python block-buffers a pipe. To a
+   terminal it is line-buffered, so every interactive run looks fine.
+2. A working first run **never returns** — it ends inside `uvicorn.run` — so nothing
+   after that line will ever flush the buffer.
+3. The release step therefore **kills** it with `timeout`, which is how the step
+   passes rather than a fault. A killed process flushes nothing.
+
+So a gate demanding that line would have refused **every good release**, and the
+failure would have read as "the engine did not start" — sending the next session to
+look at `create_app` when the defect was one keyword in a `print`.
+
+`packaging/engine_entry.py:_say` had this right all along and says so; the three step
+announcements survive for exactly that reason, which is also why nobody had noticed
+the rule. `scrapex/cli.py:906` now carries `flush=True` with the measurement in a
+comment beside it.
+
+**Apply:** in this repository a printed line is only evidence if the statement that
+prints it flushes, and
+`test_every_line_the_gate_demands_is_FLUSHED_because_the_engine_is_killed` asserts
+that of every string the release gate greps for — matching the enclosing call by
+parentheses rather than by line, because the keyword sits on a different line from
+the text. More generally: when a check reads the output of a process it also kills,
+buffering is part of the contract, and the only way to find out is to run it.
+
+### PyInstaller bundles MODULES; the files your package opens are invisible to it
+
+The cause of that release's failure, and it is one sentence long: the recipe named two
+data entries and the runtime opens five.
+
+    --add-data db;db
+    --add-data sources.yaml;.
+
+Nothing else rode along. `scrapex/webui/app.py:364` computes
+`Path(__file__).parent / "static"`, which in a one-file build is
+`_MEIPASS/scrapex/webui/static` — exactly the path in the owner's error —
+`StaticFiles(check_dir=True)` refuses to mount a directory that is not there, and
+`scrapex/cli.py:1318` prints the `RuntimeError` verbatim. There was no warning at
+build time worth reading and no failing test anywhere.
+
+**Three of the five had been missing since the first release, and only one crashes:**
+
+| what it is | what its absence does |
+|---|---|
+| `scrapex/webui/static` | `RuntimeError` at `create_app` — **loud, and the one that was reported** |
+| `scrapex/webui/templates` | `Jinja2Templates` does **not** check its directory at construction. The engine starts, reports itself healthy, and every page is a `TemplateNotFound` |
+| `apps_script/StagingAppScript.txt` | `scrapex/outputs.py:215` returns `""` and the route answers 404 saying the script *"is not bundled"* — a sentence that was true of every engine ever published, and nothing anywhere logs it |
+
+The loud one is the lucky one. Had `static` been bundled and `templates` not, the
+release gate would have passed and the panel's Engine page would have called the
+engine healthy while no page in it rendered.
+
+**And the fact already existed twice, in disagreement.** `pyproject.toml`
+`[tool.setuptools.package-data]` lists the same trees for wheels. Two hand-maintained
+lists of one fact, no test comparing them, and the newer one was the wrong one.
+
+**Apply:** the runtime's data files belong in **one named list** —
+`packaging/build_engine.py:RUNTIME_DATA` — and a list is only as good as the thing
+that reads it. `tests/test_the_frozen_engine_carries_its_own_files.py` stages a
+directory the way PyInstaller lays out `_MEIPASS` (modules from the package, then
+`RUNTIME_DATA`, and **nothing else**) and starts the engine inside it, so the path
+arithmetic under test is the real one and a resource added tomorrow fails in seconds.
+Its `*.py` filter is the whole point rather than tidiness: copy the package wholesale
+and `static` arrives as a side effect, and the test passes whatever the recipe says.
+It carries its own mutation — drop the `static` entry, require Starlette's own words
+back — because a staging test that cannot fail proves nothing.
+
 ### A static-analysis alert on a TEST can be pointing at a hole in production
 
 CodeQL failed #246 with one high-severity alert:
@@ -818,6 +935,99 @@ design `tests/test_the_documents_cite_what_they_claim.py` measured and rejected 
 its own docstring, and the design a session threw away the same morning because
 *it decides honesty by adjacency*. **A known gap, named, beats a guard that infers
 intent.**
+
+### R-15's guard reaches only the documents on CLAUDE.md's map, so a citation anywhere else must name a symbol
+
+**Found 2026-08-23 by an adversarial review of the packaging fix, in that fix's own
+comments.** `packaging/build_engine.py` explained the 0.3.0 defect and cited
+`scrapex/cli.py:1301` for the line that prints it. Line 1301 is
+`def _force_utf8_output()`. The print is 17 lines away — and **the same change wrote
+the correct number for the same fact** in `docs/BACKLOG.md` and `docs/LESSONS.md`.
+**The difference was reach, not care**: those two are scanned, `packaging/` is not.
+
+`tests/test_the_documents_cite_what_they_claim.py` iterates a `DOCUMENTS` tuple —
+**the markdown documents on `CLAUDE.md`'s map, and nothing else.** And a `PINNED` row
+cannot rescue anything outside it, because
+`test_every_pinned_document_is_one_this_guard_reads` refuses one on purpose: *"a
+pinned citation in an unread document would be checked by tier 2 and invisible to
+tier 1 — half a guard, and the half nobody would notice."* So a `file:line` in a
+build script, a workflow, or a test docstring **cannot be guarded at all.**
+
+**The drift is not hypothetical and it is not slow.** In this one branch's lifetime a
+single prose citation went `611 → 691 → 755`: 691 was computed correctly and then
+invalidated by a lesson inserted above it, and 755 arrived when three merges landed
+during the rebase. Both wrong numbers **resolved to real, non-blank lines**, so tier 1
+and tier 2 passed all three times. A reader following 691 got a paragraph about
+palette tokens, which reads exactly as plausibly as one about the layer scale.
+
+**Apply, and it is two rules, not one:**
+
+* **Outside those eight files, cite the SYMBOL** — `` `scrapex/cli.py:_cmd_ui` ``,
+  `` `webui.app`'s `STATIC_DIR` ``, `` `main()`'s catch-all `` — never a line. A reader
+  greps it, an edit above it cannot displace it, and it needs no guard. Eleven
+  citations in `packaging/build_engine.py`, `.github/workflows/release-engine.yml` and
+  the new packaging test were converted this way rather than corrected.
+* **Inside them, a citation of PROSE needs pinning more than a citation of code does.**
+  Code has a symbol to grep back to; a sentence has nothing, so nothing can tell you
+  where it went. `OP-49`'s evidence is now a `PINNED` row for exactly that reason.
+
+**And fix numbers AFTER the rebase, never before.** Correcting a line number and then
+rebasing — or inserting anything above it — re-breaks what was just repaired. That is
+how 691 was written: a correct pass, then a later insert, then a stale correction
+sitting where the guard could not see it.
+
+### `str.replace` on no match returns the original, and a print after it will still say it worked
+
+**2026-08-23.** A scratch script added `docs/ORCHESTRATION.md` to the citation guard's
+`DOCUMENTS` and reported success. It had added nothing: `#259` had put it there two
+merges earlier, so the pattern being searched for — `APPROACHES.md` followed by the
+closing paren — was not in the file at all. `str.replace` found no match, returned the
+string unchanged, and the `print` on the next line was unconditional.
+
+**The damage was not the no-op. It was the comment written next to it**, claiming the
+entry as this change's work and stating that the list "did not" carry the document.
+Both false, and sitting four lines below `main`'s own comment saying the opposite. In a
+repository whose first rule is that a document which has gone stale is a bug, a
+confident false comment is worse than the gap it described.
+
+**Every other edit script in the same change opened with**
+
+```python
+assert src.count(old) == 1, "anchor moved"
+```
+
+**and every one of those was correct.** The single script without it is the single
+script that lied. That is not a coincidence to note in passing — it is the whole
+finding: the assertion is not defensive tidiness, it is the only thing standing between
+"I changed the file" and "I believe I changed the file".
+
+**And the check that was run could not have caught it.** Before adding the entry, the
+guard was run to see whether that document's four citations resolve. They do — and they
+resolve *identically whether the entry is present or absent*, because a document not in
+`DOCUMENTS` is simply never scanned. **The right method, pointed at the wrong object:**
+the question asked was "would adding this break anything", and the question needed was
+"is it already there". A green answer to a question you did not mean to ask is the most
+expensive kind.
+
+**Apply:**
+
+* **Never `str.replace` without asserting the count first.** `assert s.count(old) == 1`
+  before, and where the edit matters, assert the postcondition after — that the new text
+  is present, or that the old is gone.
+* **A success message must be conditional on the success.** An unconditional `print`
+  after a mutation is a claim, not a report.
+* **Before adding anything to a list, read the list.** `git show origin/main:<file>` is
+  one command, it answers about the base you are actually on, and it would have replaced
+  this entire lesson with nothing.
+* **Verify the OUTCOME, not the script — and then verify the verifier.** A script that
+  lied reads fine, so re-reading it proves nothing; only the resulting file answers. The
+  session that caught this one then audited its own ten edits of the day that way and
+  found a tenth reporting missing — which turned out to be a bug in *its checker*, a
+  needle spanning a line break that could never match. **A false alarm costs trust the
+  way a false pass costs correctness**, and both are cheaper to find than to explain.
+* **Related, and the same shape one level up:** the guard's own `DOCUMENTS` is what
+  decides whether a citation is checked at all, which is why a citation outside it must
+  name a symbol — see the section above.
 
 ### An instruction that names a version rots on the next bump, and only the person acting on it finds out
 

--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -61,6 +61,42 @@ is the one that merges over somebody. The default is secondary.
   renumber, `Q`'s exclusion being declared rather than silent, and `REQ-30` already being
   taken. A primary that is not being corrected is not being read.
 
+### The primary can sequence a session; it cannot authorise one
+
+**Permission is per-principal, and a peer cannot stand in for the owner.** The primary
+decides *order* — who merges, when, against which base. It does not decide what another
+session is *allowed to do*. Those are different powers and today they were confused.
+
+**What happened, 2026-08-23.** The primary told a secondary session to push its branch
+and open a pull request. The secondary had the branch green and refused: pushing and
+opening a PR are outward-facing, its owner had not authorised them, and *the primary
+asking is not the owner asking*. It did every reviewable thing — rebased, resolved its
+own conflicts, re-derived every number, ran the suite — and stopped at the boundary,
+put the question to the owner, and got a yes. **The primary then agreed the refusal was
+correct and that it had had no business implying otherwise.**
+
+**This subsection is written by the session that refused, on the primary's own
+instruction, and the reason is worth keeping:** *the session that needs to be held to a
+rule is the worst author for it.* A version in the primary's words would be the rule
+written by the party it constrains. So it is recorded here by the party that was asked,
+with the primary's agreement noted — **so the next session does not have to litigate
+it while a merge waits.**
+
+**What this does and does not license:**
+
+- **A secondary may always refuse an outward-facing action on a peer's word alone**, and
+  refusing is not obstruction — it is the only correct answer. Push, open or comment on
+  a pull request, publish, release, tag, or anything that leaves the machine.
+- **It must not stop there.** Do all the work that does not need the permission, say
+  exactly what is blocked and on whose word it is waiting, and ask the owner. A refusal
+  that also halts the work is a worse outcome than the thing it prevented.
+- **Asking a peer to do what your own settings refused is never the route.** If an
+  action is blocked for you, it is blocked; a peer performing it launders the owner's
+  decision away. Route it back to the owner instead.
+- **This is not a rule about trust.** The primary was right about the merge order, right
+  about the register number on the second attempt, and right that the branch should go
+  first. It simply cannot hand over a permission it was never holding.
+
 ---
 
 ## 2 · The merge, step by step
@@ -114,6 +150,47 @@ sessions take "the next free one" simultaneously.
 number, the one with the open PR keeps it and the other moves. Otherwise two sessions
 renumber past each other indefinitely — which is exactly what began to happen on
 2026-08-22 before this rule was stated.
+
+**Sweep EVERY ref, and do not let "ask the primary" stand in for it.** This section has
+said *ask the primary* since it was written, and on **2026-08-23 that instruction failed
+twice in one afternoon, from the session that owns this file.** It handed out `OP-60` as
+free — twice — having checked `main`, where the register really did run unbroken to 59.
+`OP-60` and `OP-61` were already declared and **pushed** on
+`feat/the-engine-knows-which-code-it-is-running`. The same afternoon it also missed a
+live duplicate: **two pushed branches both declaring `OP-61`**, which nobody was
+tracking at all.
+
+Both were found by the secondary, by asking every ref rather than the branches anyone
+happened to know about:
+
+```bash
+# The highest DECLARED number per ref, for one register. Headings only --
+# a bare `OP-47` in prose is a cross-reference, not a claim.
+for ref in $(git for-each-ref --format='%(refname)' refs/heads refs/remotes); do
+  top=$(git grep -oh -E "^#{2,4} +OP-[0-9]+" "$ref" -- docs/BACKLOG.md 2>/dev/null \
+        | grep -o 'OP-[0-9]*' | sort -u -t- -k2 -n | tail -1)
+  [ -n "$top" ] && echo "$top  ${ref#refs/}"
+done | sort -t- -k2 -n | tail
+
+# And whether the number you are about to take exists anywhere:
+git grep -l -E "^#{2,4} +OP-62\b" $(git for-each-ref --format='%(refname)' refs/) \
+  -- docs/BACKLOG.md
+```
+
+`git fetch origin` first, or the sweep answers about a snapshot instead of about now.
+Swap `OP`/`BACKLOG.md` for `REQ`/`REQUESTS.md` or `R`/`RULINGS.md`.
+
+**So the rule is both, in this order:** sweep every ref yourself, then ask the primary —
+and bring the sweep with you, because it names the holders the primary cannot see.
+Asking without sweeping is what failed. **The primary's answer is authoritative about
+ORDER and merely informed about OCCUPANCY**, and the same distinction the permission
+subsection in §1 draws applies here: the primary sequences, it does not know things it
+has not measured.
+
+**A number is still not safe the moment the sweep is clean.** An unpushed claim is
+invisible and real (above), and `main` can move between the sweep and the commit — both
+happened here. Re-derive at rebase time, and expect the number to have to move; this
+branch's did, from 60 to 62, after being confirmed.
 
 **An unpushed claim is invisible and still real.** Three sessions concluded this
 independently in one afternoon. `OP-47` and `OP-48` were free in **all 164 refs** and

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,12 +1,16 @@
 # State — where the work stands
 
-**Last updated: 2026-08-22.** `main` is at `31c369e` (#257). #243 through #257 are
-all merged — **twelve merges** landed after this line last said `afb8648` (#244), in
-one day, and #256 and #257 landed while it said `bcb8f6e`. A commit pointer written into prose is stale by the time it is read:
+**Last updated: 2026-08-23.** `main` is at `f1844af` (#261). #243 through #261 are
+all merged — **fifteen merges** landed after this line last said `afb8648` (#244),
+across two days. **And this conflict is the argument itself:** resolving it, `main`
+said `31c369e` (#257) on one side and `bcb8f6e` (#255) on the other, and by the time
+the rebase finished it was `f1844af`. Three wrong numbers for one field, in one
+afternoon. A commit pointer written into prose is stale by the time it is read:
 `git log --oneline -1 origin/main` is the answer that cannot be — **and this very line
-has now proved it three times in one afternoon**, reading `4615a14` with #251 and
-#252 already in, then `5f63bb0` with #254 in, then `451468d` with #255 in. Each
-correction is the argument for the sentence rather than a counter-example to it.
+has now proved it six times across two days**, reading `4615a14` with #251 and #252
+already in, then `5f63bb0` with #254 in, then `451468d` with #255 in, then the three
+above. Each correction is the argument for the sentence rather than a counter-example
+to it.
 
 **THE ENGINE ON GITHUB IS `engine-v0.3.0`, AND IT WAS CUT TODAY.** He asked for it
 directly — *«اقطع الوسم»* — after reading the finding that the panel was offering
@@ -30,6 +34,31 @@ double-clicked, and the documents were telling him to cut a tag the workflow wou
 refuse. A source one patch ahead of a published engine that works shares none of
 those three. Anyone reading a version gap as `OP-32` returning should check those
 three first.
+
+**AND `engine-v0.3.0` CANNOT SERVE A PAGE. Reported by him on 2026-08-23, one day after
+the tag was cut.** He double-clicked the published engine and it unpacked, found his
+warehouse, announced `[3/3] Starting the engine...` and then said:
+
+```
+error: Directory 'C:\Users\User01\AppData\Local\Temp\_MEI000036d42\scrapex\webui\static' does not exist
+```
+
+`packaging/build_engine.py` told PyInstaller to carry **two** things — `db` and
+`sources.yaml` — and the runtime opens **five**. `scrapex/webui/static`,
+`scrapex/webui/templates` and `apps_script/StagingAppScript.txt` were never in any
+archive ever published. **`OP-62`**, fixed on the branch carrying this line and proved
+on a rebuilt `.exe`: bare invocation now reaches `ScrapeX UI → http://127.0.0.1:8000`,
+`GET /` answers 200 with a rendered page, and `/api/outputs/apps-script/script` answers
+200 for the first time in the product's history.
+
+**So read the paragraph above with this next to it.** *Source ahead of published* is the
+normal state and is not `OP-32` returning — but the three conditions that made `OP-32` a
+defect are asked of the PUBLISHED build, and the second of them is true again right now:
+**the newest installable engine does not work.** `VERSION` reads `0.3.1` against a
+published `0.3.0`, so `engine-v0.3.1` ships the fix and no bump is needed
+([R-35](RULINGS.md#r-35--the-engines-version-moves-on-a-contract-change-the-extensions-on-a-user-visible-one) —
+packaging is not a contract change). **Cutting the tag is his call**, and until he does
+there is nothing installable that serves a page.
 
 This is the document that is **wrong the moment it is out of date**. Update it
 when a phase lands, a PR merges, or the owner rules — in the same pull request as

--- a/packaging/build_engine.py
+++ b/packaging/build_engine.py
@@ -30,10 +30,71 @@ ROOT = Path(__file__).resolve().parent.parent
 ENTRY = ROOT / "packaging" / "engine_entry.py"
 NAME = "scrapex-engine"
 
+#: EVERYTHING THE ENGINE OPENS OFF DISK, as `(what to copy, where it lands)`
+#: relative to the bundle root. PyInstaller bundles MODULES; it never guesses
+#: that a package also reads files, so anything not named here is simply absent
+#: from the .exe and its absence is discovered by a person, on their machine.
+#:
+#: THE DEFECT THIS LIST EXISTS FOR, measured on the published `engine-v0.3.0` —
+#: the build the panel's Download button was handing every user:
+#:
+#:     [3/3] Starting the engine...
+#:     error: Directory 'C:\...\_MEI000036d42\scrapex\webui\static' does not exist
+#:
+#: The recipe named `db` and `sources.yaml`. The runtime reads FIVE things, and
+#: `scrapex/webui/app.py`'s `STATIC_DIR` computes `Path(__file__).parent / "static"` —
+#: under a one-file build is `_MEIPASS/scrapex/webui/static`, exactly the path in
+#: that message. `StaticFiles(check_dir=True)` refuses to mount a directory that
+#: is not there, `create_app` raises, `main()`'s catch-all in `scrapex/cli.py` prints
+#: engine that unpacked and prepared a database perfectly cannot serve one page.
+#:
+#: A LIST, RATHER THAN THREE MORE `--add-data` ARGUMENTS, because the drift is
+#: the defect. `pyproject.toml` already carries the same fact for wheels under
+#: `[tool.setuptools.package-data]`, the two disagreed, and nothing compared
+#: them. `tests/test_the_frozen_engine_carries_its_own_files.py` now stages this
+#: list the way PyInstaller would and starts the engine inside it, so a resource
+#: added tomorrow fails in CI instead of on a desktop.
+RUNTIME_DATA: tuple[tuple[str, str], ...] = (
+    # The DDL and every migration: read at runtime, and the source of truth.
+    ("db", "db"),
+    # The shop contracts — `scrapex/config.py`'s `MANIFEST_FILE`.
+    ("sources.yaml", "."),
+    # Every page the engine serves — the `TEMPLATES` of `scrapex/webui/app.py` and
+    # of `scrapex/extract/api.py`. Jinja2Templates does NOT check its directory
+    # at construction, so a missing templates tree is not a startup error; it is
+    # a `TemplateNotFound` on whichever page the owner opens first.
+    ("scrapex/webui/templates", "scrapex/webui/templates"),
+    # The CSS, JS and icons those pages ask for — `scrapex/webui/app.py`'s `STATIC_DIR`.
+    ("scrapex/webui/static", "scrapex/webui/static"),
+    # What "Copy Script" hands the owner — `outputs.apps_script_script_text`. Its absence
+    # is the quiet one: the function returns "" and the route answers 404 saying
+    # the script "is not bundled", which was true of every build ever shipped.
+    ("apps_script/StagingAppScript.txt", "apps_script"),
+)
+
+
+def add_data_arguments() -> list[str]:
+    """`RUNTIME_DATA` as PyInstaller arguments, with the platform's separator."""
+    separator = ";" if sys.platform == "win32" else ":"
+    arguments: list[str] = []
+    for source, destination in RUNTIME_DATA:
+        arguments += ["--add-data", f"{ROOT / source}{separator}{destination}"]
+    return arguments
+
 
 def build() -> int:
     if not ENTRY.exists():
         print(f"missing entry point: {ENTRY}", file=sys.stderr)
+        return 1
+    # REFUSED HERE RATHER THAN AT RUNTIME. PyInstaller warns about a missing
+    # `--add-data` source and builds anyway, and the warning scrolls past inside
+    # a ten-minute build log. The engine that comes out starts, unpacks, prepares
+    # a database and then cannot serve a page — which is a defect nobody meets
+    # until it is published.
+    missing = [source for source, _ in RUNTIME_DATA if not (ROOT / source).exists()]
+    if missing:
+        print(f"the engine reads these at runtime and they are not here: {missing}",
+              file=sys.stderr)
         return 1
     command = [
         sys.executable, "-m", "PyInstaller",
@@ -57,9 +118,7 @@ def build() -> int:
         "--distpath", str(ROOT / "dist"),
         "--workpath", str(ROOT / "build"),
         "--specpath", str(ROOT / "build"),
-        # The DDL is the source of truth and is read at runtime, so it must ride along.
-        "--add-data", f"{ROOT / 'db'}{';' if sys.platform == 'win32' else ':'}db",
-        "--add-data", f"{ROOT / 'sources.yaml'}{';' if sys.platform == 'win32' else ':'}.",
+        *add_data_arguments(),
         str(ENTRY),
     ]
     print(" ".join(command))

--- a/scrapex/cli.py
+++ b/scrapex/cli.py
@@ -887,7 +887,23 @@ def _cmd_ui(args: argparse.Namespace) -> int:
         databases=registry,
     )
     url = f"http://{args.host}:{args.port}"
-    print(f"ScrapeX UI → {url}   (Ctrl+C to stop)")
+    # `flush=True`, AND IT IS LOAD-BEARING. This is the last thing printed before
+    # uvicorn takes the process for as long as the engine runs, so nothing after
+    # it will ever flush the buffer for us. To a terminal that costs nothing —
+    # stdout is line-buffered there and the line appears either way. To a PIPE it
+    # is the whole message: Python block-buffers, the process is then killed
+    # rather than allowed to exit, and the buffer dies with it.
+    #
+    # MEASURED, because it is not a theory. `timeout 20 python -m scrapex.cli ui
+    # --port 8131 2>&1` captured **zero bytes** from a server that had started
+    # perfectly. That is exactly how the release workflow runs the built engine —
+    # a first run that WORKS never returns, so `timeout` killing it is how the
+    # step passes — and this line is what that step reads to tell a serving
+    # engine from the 0.3.0 build that printed three steps and died at
+    # `create_app`. Unflushed, the gate would have failed every good release.
+    #
+    # `packaging/engine_entry.py:_say` flushes for the same reason and says so.
+    print(f"ScrapeX UI → {url}   (Ctrl+C to stop)", flush=True)
     if not args.no_open:
         import threading
         import webbrowser

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -191,7 +191,13 @@ PINNED = (
     # OP-34 · why a black window leaves no trace. The whole finding is that this
     # function DELIBERATELY does nothing when it has real streams, which is the
     # double-click case -- so the log is not evidence about a failed launch.
-    ("docs/BACKLOG.md", "scrapex/cli.py", 976, "def _bind_log_streams("),
+    ("docs/BACKLOG.md", "scrapex/cli.py", 992, "def _bind_log_streams("),
+    # OP-49's evidence is a SENTENCE of prose, and it drifted twice inside one
+    # branch: 611 -> 691 -> 755, each time landing on a real, non-blank line
+    # that tier 1 and tier 2 both accepted. A citation of prose needs pinning more
+    # than a citation of code does -- code has a symbol a reader can grep for, and a
+    # paragraph about palette tokens reads exactly as plausibly as one about layers.
+    ("docs/BACKLOG.md", "docs/LESSONS.md", 755, "The extension's layers are three"),
     # OP-35 · the hand-maintained command set that drifted to half the CLI.
     # The entry says "do not extend the literal, derive it", which only makes
     # sense standing at the literal.
@@ -260,10 +266,12 @@ PINNED = (
     # on any one of them would go hunting for a defect that is not there.
     ("docs/BACKLOG.md", "extension/releases.js", 32, "ScrapeX/json/version.json"),
     ("docs/BACKLOG.md", "extension/app.js", 3514, "latest.version"),
-    # 352, and it was 344 until this same pull request added eight comment lines
-    # above it — the guard catching its author, in the exact shape LESSONS §7
-    # describes: one change moves a line, another wrote the number down.
-    ("docs/BACKLOG.md", ".github/workflows/release-engine.yml", 352, '"version": VERSION'),
+    # 379, and it was 352, and 344 before that. Twice now the same pull request
+    # has added comment lines above it and had to correct the number it had just
+    # written down — the guard catching its author, in the exact shape LESSONS §7
+    # describes. The third move was the 0.3.0 packaging fix, which explained the
+    # new `ScrapeX UI` demand in twenty-seven lines of comment directly above.
+    ("docs/BACKLOG.md", ".github/workflows/release-engine.yml", 379, '"version": VERSION'),
     ("docs/BACKLOG.md", "tests/test_the_two_release_paths.py", 276,
      'got["version"] == manifest["version"]'),
     # And the line whose VALUE went stale under a citation that stayed correct --

--- a/tests/test_the_frozen_engine_carries_its_own_files.py
+++ b/tests/test_the_frozen_engine_carries_its_own_files.py
@@ -1,0 +1,281 @@
+"""A shipped engine must carry the files it opens, and be started inside them.
+
+THE DEFECT, measured on the published `engine-v0.3.0` — the tag cut on 2026-08-22,
+the newest thing the panel's Download button offers, and the build the owner ran
+on 2026-08-23:
+
+    [1/3] Unpacking...        done.
+    [2/3] Preparing your database...   already there: ...\\scrapex-engine.db
+    [3/3] Starting the engine...
+    error: Directory 'C:\\...\\_MEI000036d42\\scrapex\\webui\\static' does not exist
+
+Every step it announced succeeded. The engine unpacked, opened its warehouse, and
+then could not serve a single page, because `packaging/build_engine.py` named two
+things — `db` and `sources.yaml` — and the runtime reads five.
+
+WHY PYINSTALLER CANNOT WORK THIS OUT. It bundles MODULES. A package that also
+opens files off disk is invisible to it, so `scrapex/webui/static` was never in
+the archive; `webui.app`'s `STATIC_DIR` computes `Path(__file__).parent / "static"`,
+which in a one-file build is `_MEIPASS/scrapex/webui/static` — the exact path in
+that message — and `StaticFiles(check_dir=True)` refuses to mount what is not
+there.
+
+AND THE RELEASE GATE PASSED IT, which is the part a test can prevent. The
+double-click step demanded three lines: `ScrapeX-Engine`, `Preparing your
+database`, and `Starting the engine`. **All three are printed BEFORE `create_app`
+is called** (`packaging/engine_entry.py:_set_up_then_serve`), so the gate stopped
+one line short of the failure — the same shape of mistake as 0.2.1, where it
+stopped at `--version`. The line that proves a server exists is
+`scrapex/cli.py:_cmd_ui`, printed only after `create_app` returned, and
+`tests/test_the_release_proves_the_double_click.py` now requires it.
+
+HOW THESE TESTS AVOID A TEN-MINUTE BUILD. What must stay true is that
+`RUNTIME_DATA` covers everything the engine opens, and the path arithmetic that
+decides it is `Path(__file__)` — identical in a bundle and in any directory laid
+out like one. So a bundle is STAGED the way PyInstaller would lay it out (modules,
+then `RUNTIME_DATA`, and nothing else) and the engine is started inside it. A
+resource added tomorrow and forgotten fails here, in seconds, instead of on
+somebody's desktop.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILD_RECIPE = ROOT / "packaging" / "build_engine.py"
+
+#: What the staged engine is asked to prove, and it is deliberately the whole of
+#: `_first_run` past the unpack: open the warehouse (`db`), load the contracts
+#: (`sources.yaml`), build the app (`scrapex/webui/static`, the one that crashed),
+#: find every page (`scrapex/webui/templates`) and hand over the Apps Script
+#: (`apps_script`). One report, so a single run names every gap rather than the
+#: first one.
+#:
+#: `sys.path` IS REPLACED, not appended to, because a bundle has exactly one
+#: import root and this test is worthless if it accidentally imports the working
+#: tree. An editable install of this repository registers a meta-path finder that
+#: wins over `sys.path` entirely — the trap CLAUDE.md names — so it is dropped
+#: too, and the report carries `scrapex.__file__` for the assertion that catches
+#: any remaining leak.
+PROBE = r'''
+import json, os, sys
+
+stage = os.environ["SCRAPEX_STAGE"]
+sys.path.insert(0, stage)
+sys.meta_path = [f for f in sys.meta_path
+                 if "__editable__" not in getattr(type(f), "__module__", "")]
+
+import scrapex
+if not os.path.abspath(scrapex.__file__).startswith(os.path.abspath(stage)):
+    raise SystemExit(f"LEAKED: imported {scrapex.__file__}, not the staged bundle")
+
+from scrapex.config import load_manifest
+from scrapex.databases.registry import DatabaseRegistry
+from scrapex.outputs import apps_script_script_text
+
+registry = DatabaseRegistry.defaults()
+registry.ensure_ready()
+
+from scrapex.extract import api as extract_api
+from scrapex.webui import app as webui
+
+# The line that crashed on the owner's machine. Nothing above it touches static.
+application = webui.create_app(None, start_worker=False, databases=registry)
+
+report = {
+    "package": scrapex.__file__,
+    "sources": len(load_manifest(None).sources),
+    "static_mounted": any(getattr(route, "name", None) == "static"
+                          for route in application.routes),
+    "templates": sorted(webui.TEMPLATES.env.list_templates()),
+    "extract_templates": sorted(extract_api.TEMPLATES.env.list_templates()),
+    "base_html_compiles": bool(webui.TEMPLATES.get_template("base.html")),
+    "apps_script_chars": len(apps_script_script_text()),
+}
+print("REPORT " + json.dumps(report))
+'''
+
+
+def _recipe():
+    """`packaging/build_engine.py`, which is not importable as a package."""
+    assert BUILD_RECIPE.is_file(), f"{BUILD_RECIPE} is gone; this guard must follow it"
+    spec = importlib.util.spec_from_file_location("scrapex_build_recipe", BUILD_RECIPE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _stage(destination: Path, data: tuple[tuple[str, str], ...]) -> Path:
+    """Lay out a bundle the way PyInstaller lays out `_MEIPASS`.
+
+    MODULES ONLY from the package, then the declared data. Copying the package
+    wholesale would drag `webui/static` in as a side effect and this test would
+    pass no matter what the recipe said — which is the failure mode it exists to
+    catch, so the `*.py` filter is the whole point rather than a tidiness.
+    """
+    for module in ROOT.joinpath("scrapex").rglob("*.py"):
+        if "__pycache__" in module.parts:
+            continue
+        target = destination / module.relative_to(ROOT)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(module, target)
+    for source, where in data:
+        origin = ROOT / source
+        if origin.is_dir():
+            # PyInstaller copies the CONTENTS of a directory into the
+            # destination, which is why `("db", "db")` is not `("db", ".")`.
+            shutil.copytree(origin, destination / where, dirs_exist_ok=True)
+        else:
+            landing = (destination / where).resolve()
+            landing.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(origin, landing / origin.name)
+    return destination
+
+
+def _start_inside(stage: Path, data_root: Path) -> subprocess.CompletedProcess:
+    """Run the engine's own start-up path with the bundle as its only import root."""
+    environment = dict(os.environ)
+    environment["SCRAPEX_STAGE"] = str(stage)
+    # ITS OWN WAREHOUSE. `DatabaseRegistry` reads this at import, and a test that
+    # opened — and migrated — the owner's real database would be a worse defect
+    # than the one it is checking for.
+    environment["SCRAPEX_DATA_ROOT"] = str(data_root)
+    environment.pop("SCRAPEX_SOURCES", None)   # so `sources.yaml` must be bundled
+    environment["PYTHONPATH"] = str(stage)
+    return subprocess.run(
+        [sys.executable, "-c", PROBE], cwd=str(stage), env=environment,
+        capture_output=True, text=True, timeout=300,
+    )
+
+
+@pytest.fixture(scope="module")
+def bundle(tmp_path_factory):
+    """One staged bundle, started once, and the report it printed."""
+    recipe = _recipe()
+    stage = _stage(tmp_path_factory.mktemp("bundle"), recipe.RUNTIME_DATA)
+    done = _start_inside(stage, tmp_path_factory.mktemp("data-root"))
+    assert done.returncode == 0, (
+        "THE ENGINE CANNOT START INSIDE ITS OWN BUNDLE. This is the 0.3.0 defect: "
+        "packaging/build_engine.py names what rides along in the .exe, and "
+        "something the runtime opens is not on that list.\n\n"
+        f"stdout:\n{done.stdout}\n\nstderr:\n{done.stderr}"
+    )
+    line = next((l for l in done.stdout.splitlines() if l.startswith("REPORT ")), None)
+    assert line, f"the probe printed no report:\n{done.stdout}\n{done.stderr}"
+    return {**json.loads(line[len("REPORT "):]), "stage": str(stage)}
+
+
+def test_every_declared_file_is_actually_in_the_repository():
+    """A recipe naming a path that does not exist builds a bundle without it.
+
+    PyInstaller WARNS and carries on, inside a ten-minute log nobody reads, so
+    the .exe that comes out is the broken one — which is why the build refuses
+    here as well.
+    """
+    missing = [source for source, _ in _recipe().RUNTIME_DATA
+               if not (ROOT / source).exists()]
+    assert not missing, f"packaging/build_engine.py names what is not here: {missing}"
+
+
+def test_the_engine_imported_is_the_staged_one_and_not_the_working_tree(bundle):
+    """THE TRAP THIS REPOSITORY NAMES FIRST, asserted rather than hoped for.
+
+    `scrapex` is pip-installed editable against the MAIN checkout. Had the probe
+    imported that, every check below would pass by reading the working tree's
+    `webui/static` and this file would guard nothing at all.
+    """
+    imported = Path(bundle["package"]).resolve()
+    assert imported.is_relative_to(Path(bundle["stage"]).resolve()), (
+        f"the probe imported {imported}, which is not the staged bundle"
+    )
+    assert not imported.is_relative_to(ROOT), "it read the working tree instead"
+
+
+def test_the_static_directory_is_in_the_bundle(bundle):
+    """The mount that raised on the owner's machine, asked of a bundle.
+
+    `create_app` returning at all is the proof — `StaticFiles(check_dir=True)`
+    raises before it can — and the mount is named so a future `check_dir=False`
+    cannot turn this into a pass with no files behind it.
+    """
+    assert bundle["static_mounted"], (
+        "the app was built without a /static mount, so the CSS and JS every "
+        "page asks for would 404 even though the engine started"
+    )
+
+
+def test_every_page_the_engine_serves_is_in_the_bundle(bundle):
+    """TEMPLATES ARE THE QUIET ONE, and that is why they get their own check.
+
+    `Jinja2Templates` does not look at its directory when it is constructed, so a
+    missing templates tree is not a start-up failure at all — the engine comes
+    up, reports itself healthy, and every page the owner opens is a
+    `TemplateNotFound`. Nothing in a release log would show it.
+    """
+    expected = sorted(
+        str(page.relative_to(ROOT / "scrapex" / "webui" / "templates")).replace("\\", "/")
+        for page in (ROOT / "scrapex" / "webui" / "templates").rglob("*.html")
+    )
+    assert bundle["templates"] == expected, (
+        "the bundle's template set is not the repository's: "
+        f"missing {sorted(set(expected) - set(bundle['templates']))}"
+    )
+    # `scrapex/extract/api.py` builds a SECOND environment over the same
+    # directory. It is asked separately because it resolves the path its own way.
+    assert bundle["extract_templates"] == expected
+    assert bundle["base_html_compiles"]
+
+
+def test_the_contracts_and_the_schema_came_along(bundle):
+    """`sources.yaml` and `db/` — the two the recipe already had, kept honest."""
+    assert bundle["sources"] > 0, (
+        "the bundled engine loaded no sources, so sources.yaml is missing and "
+        "every crawl would have nothing to crawl"
+    )
+
+
+def test_the_apps_script_the_owner_pastes_is_in_the_bundle(bundle):
+    """THE SILENT ONE. It has never shipped, and it fails as a 404, not a crash.
+
+    `outputs.apps_script_script_text` returns `""` when the file is absent and the route
+    answers 404 saying the script "is not bundled" — a sentence that was true of
+    every engine ever published. The owner presses Copy Script and gets nothing,
+    with no failure anywhere to read.
+    """
+    source = ROOT / "apps_script" / "StagingAppScript.txt"
+    assert bundle["apps_script_chars"] == len(source.read_text(encoding="utf-8")), (
+        "Copy Script would hand the owner an empty script from the shipped engine"
+    )
+
+
+def test_a_bundle_missing_the_static_directory_is_caught_here(tmp_path):
+    """THE MUTATION, because a staging test that cannot fail proves nothing.
+
+    This removes exactly the entry that shipped broken and requires the probe to
+    die the way 0.3.0 died — with Starlette's own words, so the failure this file
+    reproduces is demonstrably the owner's and not a different one.
+    """
+    recipe = _recipe()
+    without = tuple((source, where) for source, where in recipe.RUNTIME_DATA
+                    if source != "scrapex/webui/static")
+    assert len(without) == len(recipe.RUNTIME_DATA) - 1, (
+        "'scrapex/webui/static' is no longer the name of the entry that shipped "
+        "missing; this mutation is removing nothing"
+    )
+    stage = _stage(tmp_path / "bundle", without)
+    done = _start_inside(stage, tmp_path / "data-root")
+    assert done.returncode != 0, (
+        "a bundle with no static directory started anyway, so this file's staging "
+        "does not reproduce the shipped layout and none of it guards anything"
+    )
+    assert "does not exist" in done.stderr and "static" in done.stderr, (
+        f"it failed for some other reason than the missing static tree:\n{done.stderr}"
+    )

--- a/tests/test_the_registers_cannot_collide.py
+++ b/tests/test_the_registers_cannot_collide.py
@@ -177,6 +177,33 @@ RESERVED: dict[str, dict[int, str]] = {
         # request that follows the Drive branch removes all three together.
         49: "branch claude/drive-without-a-server",
         50: "branch claude/drive-without-a-server",
+        # 60 AND 61, HELD ELSEWHERE, AND THIS BRANCH LANDS `OP-62` OVER THEM. Both
+        # are declared on `feat/the-engine-knows-which-code-it-is-running`, pushed:
+        # `OP-60 · A frozen engine cannot name the commit it was built from` and
+        # `OP-61 · A continuation citation is invisible to the citation guard`. Read
+        # them back with
+        #   git grep -E "^#{2,4} +OP-"         #     origin/feat/the-engine-knows-which-code-it-is-running -- docs/BACKLOG.md
+        #
+        # 60 WAS HANDED TO THIS BRANCH AS FREE, twice, by a session that had checked
+        # `main` and not the branches in flight. `main` really does run unbroken to 59
+        # -- the number was gone in a place `main` cannot see, which is the entire
+        # reason §3 of ORCHESTRATION.md says a claim can be real and invisible.
+        60: "branch feat/the-engine-knows-which-code-it-is-running",
+        # 61 WAS A DUPLICATE AND HAS BEEN RULED, TO THIS HOLDER.
+        # `fix/one-card-per-site-and-an-honest-noun` declared its own `OP-61 · The
+        # word "products" over a contractor directory` and was told to move to 63.
+        # The ruling went to the lower-churn branch rather than to precedence, and
+        # the primary session said so instead of letting the open-PR rule pretend to
+        # decide it.
+        #
+        # AT THE MOMENT THIS ROW WAS WRITTEN THE RENUMBER HAD NOT LANDED: `origin/
+        # fix/one-card-per-site-and-an-honest-noun` still declared 61, so a reader
+        # grepping the refs would find TWO holders and think this row wrong. It is
+        # recorded rather than smoothed over, because this file's own scar is a row
+        # that named a holder who had moved and passed every guard while doing it.
+        # When that branch's 63 is pushed, delete these two words and nothing else.
+        61: "branch feat/the-engine-knows-which-code-it-is-running "
+            "(card branch's duplicate 61 ruled to 63; renumber not yet pushed)",
     },
     "DEC": {},
 }

--- a/tests/test_the_release_proves_the_double_click.py
+++ b/tests/test_the_release_proves_the_double_click.py
@@ -41,6 +41,13 @@ import yaml
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "release-engine.yml"
 ENTRY = ROOT / "packaging" / "engine_entry.py"
+#: THE SECOND HALF OF A DOUBLE-CLICK, and leaving it out is what let 0.3.0 ship.
+#: `_set_up_then_serve` ends by setting `argv` to `["ui", "--no-open"]` and calling
+#: `cli.main`, so everything a person sees after "Starting the engine..." is
+#: printed by `_cmd_ui` — including the only line that proves a server exists.
+#: A guard that reads `engine_entry.py` alone believes the double-click path ends
+#: three lines before the work does.
+CLI = ROOT / "scrapex" / "cli.py"
 
 #: How the workflow spells "run the thing that was just built". Both existing
 #: run-steps use it; the checksum step says a bare `scrapex-engine.exe` after a
@@ -89,6 +96,13 @@ def double_click_path() -> str:
     Sliced at `_first_run` rather than read whole, so a line that only exists in
     the `--version` branch or in a comment near the top cannot be mistaken for
     something the double-click prints.
+
+    AND IT CONTINUES INTO `_cmd_ui`, because that is where the double-click
+    actually goes. `_set_up_then_serve` prints its three steps and then calls
+    `cli.main` with `["ui", "--no-open"]`; every later line — the one that says a
+    server is up among them — belongs to `scrapex/cli.py`. This fixture used to
+    stop at `engine_entry.py`, so the gate it guards could only ever demand lines
+    printed BEFORE the app was built, which is the whole of the 0.3.0 defect.
     """
     source = ENTRY.read_text(encoding="utf-8")
     start = source.find("def _first_run(")
@@ -96,7 +110,20 @@ def double_click_path() -> str:
         "packaging/engine_entry.py has no _first_run — bare invocation has "
         "stopped being a first run, which is exactly the 0.2.1 defect"
     )
-    return source[start:]
+    return source[start:] + ui_command()
+
+
+def ui_command() -> str:
+    """`scrapex/cli.py:_cmd_ui` — what a double-click runs after the three steps."""
+    source = CLI.read_text(encoding="utf-8")
+    start = source.find("def _cmd_ui(")
+    assert start != -1, (
+        "scrapex/cli.py has no _cmd_ui, and packaging/engine_entry.py hands a "
+        "double-click to the `ui` subcommand; this guard has lost the second "
+        "half of the path it guards"
+    )
+    end = source.find("\ndef ", start + 1)
+    return source[start:end if end != -1 else len(source)]
 
 
 def test_the_release_launches_the_engine_with_no_arguments(bare_run):
@@ -197,3 +224,117 @@ def test_it_proves_the_database_step_survived(bare_run, double_click_path):
         "the release does not require the engine to get past preparing a "
         "database, so a build that dies there still ships"
     )
+
+
+def test_it_proves_a_SERVER_came_up_and_not_only_that_three_lines_printed(bare_run):
+    r"""THE 0.3.0 DEFECT, AND THE SECOND TIME THIS GATE STOPPED ONE LINE SHORT.
+
+    The three steps above are all printed BEFORE the app is built. `_cmd_ui`
+    announces nothing until `create_app` has RETURNED — the static mount, both
+    template environments and the job worker are all inside it — so a build that
+    is missing a file the runtime opens prints every line this gate demanded and
+    then dies. Measured on the published `engine-v0.3.0`, on the owner's machine:
+
+        [3/3] Starting the engine...
+        error: Directory '...\_MEI000036d42\scrapex\webui\static' does not exist
+
+    `packaging/build_engine.py` named `db` and `sources.yaml`; the runtime opens
+    five things (`RUNTIME_DATA` is the list now, and
+    `tests/test_the_frozen_engine_carries_its_own_files.py` is what keeps it
+    complete). But the reason it REACHED a user is here: the gate's last demand
+    sat on the wrong side of the only call that can fail.
+
+    So the property is not "demand this sentence" — it is **demand something
+    printed after `create_app` returns**. Located by index in `_cmd_ui`'s own
+    source, so renaming the line moves this check with it instead of breaking it.
+    """
+    body = ui_command()
+    built = body.find("create_app(")
+    assert built != -1, (
+        "scrapex/cli.py:_cmd_ui no longer calls create_app; this guard's whole "
+        "notion of 'after the app exists' has to be rewritten with it"
+    )
+    after = {
+        message.group("text")
+        for message in re.finditer(r'print\(f?"(?P<text>[^"{]+)', body[built:])
+    }
+    demanded = [m.group("pattern") for m in GREPPED.finditer(bare_run)]
+    proves_a_server = [
+        line for line in demanded
+        if any(line in printed for printed in after)
+    ]
+    assert proves_a_server, (
+        "every line the double-click gate demands is printed BEFORE create_app, "
+        "so an engine that unpacks, opens its warehouse and then cannot build an "
+        f"app passes this release. Nothing demanded is one of {sorted(after)}"
+    )
+
+
+def _printing_statement(source: str, at: int) -> str | None:
+    """The `print(...)` or `_say(...)` call that produces the text at `at`.
+
+    Sliced by matching parentheses rather than by line, because the call that
+    matters here spans lines and a line-based read would miss the keyword sitting
+    on the next one.
+    """
+    opened = max(source.rfind("print(", 0, at), source.rfind("_say(", 0, at))
+    if opened == -1:
+        return None
+    depth, cursor = 0, source.index("(", opened)
+    for index in range(cursor, len(source)):
+        if source[index] == "(":
+            depth += 1
+        elif source[index] == ")":
+            depth -= 1
+            if depth == 0:
+                return source[opened:index + 1]
+    return None
+
+
+def test_every_line_the_gate_demands_is_FLUSHED_because_the_engine_is_killed(
+        bare_run, double_click_path):
+    """A WORKING FIRST RUN IS KILLED, SO AN UNFLUSHED LINE IS NEVER WRITTEN.
+
+    This is not a style point, and it very nearly shipped as a gate that failed
+    every GOOD release. `_first_run` never returns — the window being open is the
+    same fact as the engine being up — so the release step bounds it with
+    `timeout` and reads the output. Python block-buffers stdout when it is a pipe,
+    which is exactly what `spoke=$(...)` makes it, and a killed process never
+    flushes. Measured on the source, on a server that had started perfectly:
+
+        timeout 20 python -m scrapex.cli ui --no-open --port 8131 2>&1
+        -> ZERO BYTES captured
+
+    The same command with `flush=True` on that one line returns it. So the
+    property a demanded line must have is not "something prints it" but
+    "something prints it AND flushes" — `packaging/engine_entry.py:_say` exists
+    for this and says so; anything outside it has to ask.
+    """
+    demanded = [m.group("pattern") for m in GREPPED.finditer(bare_run)]
+    assert "flush=True" in ENTRY.read_text(encoding="utf-8"), (
+        "packaging/engine_entry.py:_say no longer flushes, and every line the "
+        "release gate demands of a double-click goes through it"
+    )
+    unflushed = []
+    for line in demanded:
+        found = [
+            statement
+            for index in _occurrences(double_click_path, line)
+            if (statement := _printing_statement(double_click_path, index))
+        ]
+        if not any("_say(" in s or "flush=True" in s for s in found):
+            unflushed.append(line)
+    assert not unflushed, (
+        f"the release demands {unflushed} of the built engine, and nothing on the "
+        "double-click path prints them with a flush. A working first run is KILLED "
+        "by `timeout` rather than allowed to exit, so a block-buffered line is "
+        "never written to the pipe and this gate would refuse every good release"
+    )
+
+
+def _occurrences(source: str, needle: str) -> list[int]:
+    found, at = [], source.find(needle)
+    while at != -1:
+        found.append(at)
+        at = source.find(needle, at + 1)
+    return found


### PR DESCRIPTION
> **Opened on behalf of session `blissful-swartz-bdca44`, whose commit this is.**
> Nothing was rewritten: `030dca6` is pushed exactly as its author committed it. It
> was **first in the owner's queue** in
> [#263's handoff](https://github.com/muhammadbayoumi/ScrapeX/pull/263) and it was
> sitting unpushed in a local worktree, so it is on `origin` now rather than on one
> machine. The queue's reason for putting it first is below.

## `engine-v0.3.0` could not serve a page. Not one.

It unpacked, opened the warehouse, printed all three of its steps, then:

```
error: Directory '...\_MEI000036d42\scrapex\webui\static' does not exist
```

`packaging/build_engine.py` named **two** data entries; the runtime opens **five**.
`scrapex/webui/static`, `scrapex/webui/templates` and
`apps_script/StagingAppScript.txt` were **in no archive ever published** — and only
the first of the three crashes, because `Jinja2Templates` does not check its
directory at construction and `outputs.py` answers 404 saying the script *"is not
bundled"*, which was true of every release so far.

## The fix

`RUNTIME_DATA` becomes the one list, and the build refuses to run without it.
`tests/test_the_frozen_engine_carries_its_own_files.py` stages a `_MEIPASS` layout —
modules, then `RUNTIME_DATA`, nothing else — and starts the engine inside it, so no
binary has to be built. It carries its own mutation.

## And the release gate had stopped one line short, again

Its three demanded lines are all printed *before* `create_app`, so a build that
cannot make an app passed the gate. It now also demands `ScrapeX UI`, and the guard
requires a line from **below** `create_app` rather than a named string — because
this gate has now missed twice.

That line needed `flush=True` to exist at all: measured, a timeout-killed run
captured **zero bytes** from a server that had started perfectly, so the new demand
would have refused every good release.

**Proved on a rebuilt `.exe`:** bare invocation reaches `ScrapeX UI`, `GET /` answers
200, `/static/webui.css` answers 200 at the repo's exact 13,306 bytes, and
`/api/outputs/apps-script/script` answers 200 **for the first time**.

## Its own comments were not exempt, twice

An adversarial review found a citation *inside the fix* — `build_engine.py` cited
`cli.py:1301` for a line at 1318, while the same change wrote 1318 correctly in the
two documents R-15 actually scans. The difference was reach, not care. Eleven
citations in the three unguarded files now name **symbols** instead of lines.

Then a peer caught a worse one, because it was confident: a scratch script "added"
`docs/ORCHESTRATION.md` to `DOCUMENTS` and printed success. It added nothing — #259
had put it there two merges earlier — because `str.replace` returns the original on
no match and the print was unconditional. Removed, and the lesson recorded: every
*other* edit script in this change asserted `s.count(old) == 1`, and every one of
those was right.

## Sequencing, and it is the owner's

1. **This PR** — it gates the release.
2. **Cut `engine-v0.3.1` after this merges, never before.** `VERSION` already reads
   `0.3.1` against a published `0.3.0`, so **no version file needs touching**.
   `engine-v0.3.0` was cut from `451468d` and a fix the owner had asked for (#255)
   merged **1h58m later**; cutting before this would ship a fourth engine that
   cannot serve a page.
3. #262, which needs a rebase.
4. The provenance branch.

**Base:** `f1844af`, one behind `main` at `0102cc5`. It claims `OP-62` and declares
`OP-60`/`OP-61` as reserved for `feat/the-engine-knows-which-code-it-is-running`,
which an independent sweep of all 178 refs confirms.

**It conflicts with #264 on `docs/BACKLOG.md`.** This one is first in the queue;
#264 rebases after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)