### PR TITLE
The engine says which code it is running, and 199 seconds stops being invisible

### DIFF
--- a/docs/APPROACHES.md
+++ b/docs/APPROACHES.md
@@ -162,7 +162,7 @@ standing next to — do not tidy it, do not restyle it, mention dead code rather
 than deleting it. P1 governs *the thing you are building*.
 
 The live example is B2 step 2: the panel already has Choose-Columns
-(`extension/app.js:1594`, `:1633`), and the instruction is to **extract it into a
+(`extension/app.js:1602`, `:1641`), and the instruction is to **extract it into a
 shared module**, not to write a second one. Writing a duplicate in the name of
 staying surgical is precisely the failure the migration plan warns about — "or
 the two surfaces will disagree about how a column is saved."

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -301,8 +301,8 @@ And only one of the **two** `worker_alive` computations was fixed:
 
 | where | what it calls | verdict |
 |---|---|---|
-| `scrapex/webui/app.py:1673` — `/api/health` | the new two-heartbeat `worker` verdict | correct; the panel reads this one (`extension/engine.js:38`) |
-| `scrapex/webui/app.py:2722` — `_about` | `worker_is_alive(conn)`, single heartbeat | **the function the fix superseded** |
+| `scrapex/webui/app.py:1682` — `/api/health` | the new two-heartbeat `worker` verdict | correct; the panel reads this one (`extension/engine.js:38`) |
+| `scrapex/webui/app.py:2749` — `_about` | `worker_is_alive(conn)`, single heartbeat | **the function the fix superseded** |
 
 `_about` renders the engine's own `/settings` page
 (`scrapex/webui/templates/settings.html:162-167`), so **the engine still shows
@@ -310,7 +310,7 @@ And only one of the **two** `worker_alive` computations was fixed:
 engine is started at all.
 
 **Next action:** three separate things — the second `worker_alive` at
-`app.py:2722`; the heartbeat's behaviour under a held write lock; and the 409 on
+`app.py:2749`; the heartbeat's behaviour under a held write lock; and the 409 on
 `/api/storage/restore` with a mirror of
 `test_start_fresh_is_refused_while_a_crawl_runs`.
 
@@ -1074,7 +1074,7 @@ profile crawl was running against it):
 
 **THE CAUSE WAS NOT THE MISSING `crawl_run` ROW.** `_dataset_rows` wrote
 `"last_success": None` as a **literal**, and `freshnessLine`
-(`extension/app.js:4549`) prints that sentence whenever the key is absent or
+(`extension/app.js:4613`) prints that sentence whenever the key is absent or
 carries no `started_at`. So a `crawl_run` row for muqawil would have changed
 nothing on the card — the fix had to arrive at that key.
 
@@ -1785,7 +1785,7 @@ the two `muqawil.org` cards carry none. So it belongs here and not in
 **That absence is deliberate, and it is written down in both halves.**
 `sourceMenu` returned an empty string for a dataset — the line is gone, and what
 stands where it stood is the filter that replaced it
-([extension/app.js:4655](../extension/app.js#L4655)) — and the engine stamps the
+([extension/app.js:4719](../extension/app.js#L4719)) — and the engine stamps the
 marker it keys on precisely so the panel can do that — `"kind": "dataset"` in
 `_dataset_rows`, whose docstring says *"the row menu offers Update, Wipe and
 Rename, and every one of those is a price-path action that would answer 400 or
@@ -1793,12 +1793,12 @@ worse for a dataset"* ([scrapex/webui/app.py:706](../scrapex/webui/app.py#L697))
 It was the right call for five of the six entries and it is still right for them:
 `update`, `pause` and `settings` post to routes that read the manifest, and
 `/api/export/{key}` validates the key against `manifest.sources` and answers 404
-for anything else ([scrapex/webui/app.py:2967](../scrapex/webui/app.py#L2967)).
+for anything else ([scrapex/webui/app.py:2994](../scrapex/webui/app.py#L2967)).
 
 **But `Open the data table` would work, and it was built after the blanket
 hide.** `data.html?source=KEY` fetches `/api/table/{key}`, and that route looks
 the key up in the dataset catalogue FIRST — *"a generic dataset is a table like
-any other table"* ([scrapex/webui/app.py:1167](../scrapex/webui/app.py#L1167)) —
+any other table"* ([scrapex/webui/app.py:1176](../scrapex/webui/app.py#L1167)) —
 so `/api/table/contractors` serves the directory in full. The panel hides the one
 entry that works on the marker that was introduced for the five that do not.
 
@@ -4220,7 +4220,7 @@ date it was measured.
 1. **ALSWEED is being refused with HTTP 429**, five times on 2026-08-11, because
    `crawl_honour_delay` is `'0'`. **BV-3**.
 2. **The engine's own Settings page says "Not running" while it crawls** — a
-   second `worker_alive` computation at `app.py:2722` that the fix never reached
+   second `worker_alive` computation at `app.py:2749` that the fix never reached
    — and the runtime heartbeat freezes under `database is locked` when a job
    holds a write transaction. **OP-6 · ت2**.
 3. **The diagnostic-page guard is still blind**, and this file said it had been

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2340,6 +2340,15 @@ describes would have been a poor joke. **`#258` has since merged at `d10e974` an
 both symbols happened to survive at 1594 and 1633**, which is luck and not
 stability. Re-derive them rather than trusting them.
 
+**AND THE LUCK RAN OUT ONE PULL REQUEST LATER, which is worth adding rather than
+editing the numbers above away.** The branch that added `scrapex/provenance.py`
+inserted lines into `extension/app.js` above both symbols: they are at **1602 and
+1641** on that branch. The paragraph above is still true *at `4522158`*, and it says
+so — that scoping is the only reason it did not simply become wrong. It is also the
+best illustration this register has of why the numbers were kept out of `path:line`
+form: no guard could have told you they had moved, because no guard can see a line
+number written as prose.
+
 **The interesting part is that both citations still point INSIDE the file**, so
 Tier 1 would have passed them even if the file were guarded; only the `PINNED`
 table catches a citation that moved off its symbol. #256 has since added a check
@@ -2583,7 +2592,7 @@ checked `RUNTIME_DATA` against the real `.exe` table of contents and found no ga
 and the worry that `contractstamp` reads a `.py` at runtime was refuted — it is a
 developer-only path.
 
-### OP-53 · A frozen engine cannot name the commit it was built from, and says so
+### OP-60 · A frozen engine cannot name the commit it was built from, and says so
 
 **Status: OPEN by design, and the honest half of a fix that landed.** Measured
 2026-08-23 while building `scrapex/provenance.py` (`LESSONS` §14).
@@ -2614,9 +2623,9 @@ reader is the whole of this change and the writer is the next one.
 
 **Do not close this by making a frozen build guess.** The `None` is the feature.
 
-### OP-54 · A continuation citation is invisible to the citation guard
+### OP-61 · A continuation citation is invisible to the citation guard
 
-**Status: OPEN. Measured 2026-08-23 at `4522158`. A latent structural gap, not a live
+**Status: OPEN. Measured 2026-08-23, re-measured at `f1844af`. A latent structural gap, not a live
 defect — that distinction is the whole entry.**
 
 A citation written as `` (`extension/app.js:1602`, `:1641`) `` carries two references
@@ -2627,7 +2636,7 @@ regex returns a match for the first string and `None` for the second.
 
 | | |
 |---|---|
-| continuation citations in the guarded documents at `4522158` | **19** |
+| continuation citations in the guarded documents at `f1844af` | **19** |
 | of those, resolving to a blank line or past EOF | **0** |
 | spot-checked and correct | the `docs/STATE.md` pair citing `scrapex/features.py:54` and `:65` |
 | moved silently by this branch's edits, guard green throughout | **4** |

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -232,7 +232,7 @@ rhetoric in a measurement file is how a number stops being checked.
 *"The router-factory pattern is already applied inside the same file to four
 fragments"* — it is not inside the file. `grep -nE 'def [a-z_]*(router|_api)\w*\(' scrapex/webui/app.py`
 returns nothing. All four factories live in **sibling modules** and are imported
-(`app.py:47`, `:161`, `:162`):
+(`app.py:56`, `:161`, `:162`):
 
 | module | lines | routes |
 |---|---|---|
@@ -1280,7 +1280,7 @@ confirmation that the published build installs on his machine; that stays on
 > panel reading `Latest version 0.2.1 · Available to install`. **Nothing is broken
 > anywhere on that path, and this is the third time that sentence has had to be
 > written about it.** `extension/releases.js:32` reads
-> `ScrapeX/json/version.json` from the hub, `extension/app.js:3514` prints the
+> `ScrapeX/json/version.json` from the hub, `extension/app.js:3570` prints the
 > `version` it finds, the workflow writes that same field
 > (`.github/workflows/release-engine.yml:379`), and
 > `tests/test_the_two_release_paths.py:276` already pins the writer's output to the
@@ -1322,7 +1322,7 @@ confirmation that the published build installs on his machine; that stays on
 >
 > So a released engine built from `main` can now open his warehouse. **What is NOT
 > closed is the panel's sentence**: an engine that refuses to start still never binds
-> a port, so `extension/app.js:3416` still reports "Not detected" for a schema fault,
+> a port, so `extension/app.js:3424` still reports "Not detected" for a schema fault,
 > a permissions fault and an absent engine alike. That half is now `OP-38`.
 
 **The diagnosis, kept as written — it is why the merge mattered.**
@@ -1350,7 +1350,7 @@ from the branch that owns v8, against the same file: `"status": "Healthy"`, and
 
 **And the panel cannot say any of this.** An engine that refuses to start never
 binds a port, so `checkEngine` gets a connection error and
-`extension/app.js:3416` reports **"Not detected"** — which is false and sends the
+`extension/app.js:3424` reports **"Not detected"** — which is false and sends the
 reader to reinstall something that is already installed. The engine knows the
 sentence; there is no channel that carries it to a panel.
 
@@ -1632,7 +1632,7 @@ is not filed as fixed with it.
 
 An engine that refuses to start never binds a port. So `checkEngine` in
 `extension/engine.js` gets a connection error, and
-`extension/app.js:3416` reports:
+`extension/app.js:3424` reports:
 
     text: "Not detected"      detail: "The panel could not reach the Engine."
 
@@ -1789,7 +1789,7 @@ stands where it stood is the filter that replaced it
 marker it keys on precisely so the panel can do that — `"kind": "dataset"` in
 `_dataset_rows`, whose docstring says *"the row menu offers Update, Wipe and
 Rename, and every one of those is a price-path action that would answer 400 or
-worse for a dataset"* ([scrapex/webui/app.py:697](../scrapex/webui/app.py#L697)).
+worse for a dataset"* ([scrapex/webui/app.py:706](../scrapex/webui/app.py#L697)).
 It was the right call for five of the six entries and it is still right for them:
 `update`, `pause` and `settings` post to routes that read the manifest, and
 `/api/export/{key}` validates the key against `manifest.sources` and answers 404
@@ -1844,7 +1844,7 @@ popup:
 
 | | finance converter | run mode |
 |---|---|---|
-| entry point | `setupFinanceConverterSelect` ([extension/app.js:956](../extension/app.js#L956)) | `setupRunModeSelect` ([extension/app.js:2008](../extension/app.js#L2008)) |
+| entry point | `setupFinanceConverterSelect` ([extension/app.js:964](../extension/app.js#L956)) | `setupRunModeSelect` ([extension/app.js:2016](../extension/app.js#L2008)) |
 | `close({restoreFocus})` | adds `hidden`, `aria-expanded=false`, removes `is-open`, restores focus | same four steps, same order |
 | `open()` | removes `hidden`, `aria-expanded=true`, adds `is-open`, `requestAnimationFrame` then focuses selected-or-first with `preventScroll` | same five steps, same order |
 | `choose(value)` | validates against `select.options`, assigns, dispatches bubbling `change`, closes with `restoreFocus: true` | same four steps, same order |
@@ -1885,11 +1885,11 @@ accessibility. They have not, and the difference is requirement-driven:
 
 * Run mode disables options **individually**, because which run modes are on offer
   depends on the selection — `for (const option of select.options) option.disabled =
-  !allow[option.value]` ([extension/app.js:2173](../extension/app.js#L2173)). Its
+  !allow[option.value]` ([extension/app.js:2181](../extension/app.js#L2173)). Its
   `focusOption` filters disabled candidates because it genuinely has some.
 * The finance converter disables **the whole control** when there are no stored
   rates — `select.disabled = !state.financeRates.length`
-  ([extension/app.js:1141](../extension/app.js#L1141)) — and mirrors that onto the
+  ([extension/app.js:1149](../extension/app.js#L1141)) — and mirrors that onto the
   trigger inside `sync()`. It never has a disabled option, so it has nothing to
   filter.
 * Type-ahead exists only on the finance side, and a currency list needs it where
@@ -2366,7 +2366,7 @@ Two do not, and neither failure has anything to do with datasets:
 | **Recent changes** | `/source/{key}#changes` | the page renders, and **`id="changes"` exists nowhere in the repository** — `grep -rn 'id="changes"' scrapex/ extension/` returns nothing. The fragment is ignored, so the entry lands at the top of the source page |
 
 **The changes page it should be opening already exists**: `GET /changes?source_key=`
-is a real route (`scrapex/webui/app.py:1285`, re-derived at `31c369e`; #257 moved
+is a real route (`scrapex/webui/app.py:1294`, re-derived at `31c369e`; #257 moved
 it from 1223) and answers 200. So this is a wrong
 URL rather than a missing feature — one line, but it changes what a card does on
 his screen, which is why it was recorded instead of fixed inside a PR about the
@@ -2583,6 +2583,79 @@ checked `RUNTIME_DATA` against the real `.exe` table of contents and found no ga
 and the worry that `contractstamp` reads a `.py` at runtime was refuted — it is a
 developer-only path.
 
+### OP-53 · A frozen engine cannot name the commit it was built from, and says so
+
+**Status: OPEN by design, and the honest half of a fix that landed.** Measured
+2026-08-23 while building `scrapex/provenance.py` (`LESSONS` §14).
+
+A source-run engine can now answer *which code am I running* — it seals what it
+loaded and compares it against the disk. **A PyInstaller one-file `.exe` cannot.** It
+carries no `.git`, no source tree, and its modules unpack into a per-run temp
+directory that says nothing about whether newer code exists anywhere. So it answers:
+
+    mode    "frozen"
+    commit  null
+    stale   null      <- unknown, NEVER false
+
+**That is correct, not a stub**, and a test pins it (`stale is not False`): on the one
+build where staleness cannot be measured, claiming `False` would tell the owner his
+engine is current when nobody knows. The gap is narrower than "the frozen build is
+unguarded": what is missing is only the **commit it was built from**, which no amount
+of run-time inspection can recover and which only the build can write down.
+
+**The fix is a build-time stamp**, and it is small: the release workflow writes the
+commit it is building into a generated module, and `provenance` reads it if present.
+
+**NOT DONE HERE, and the reason is a live constraint rather than laziness.** The
+primary session is cutting `engine-v0.3.1` from `.github/workflows/release-engine.yml`,
+and a change to that workflow from a branch merging into the same window is a change to
+the thing being run. `R-35`'s gate also refuses a version edit from this branch. So the
+reader is the whole of this change and the writer is the next one.
+
+**Do not close this by making a frozen build guess.** The `None` is the feature.
+
+### OP-54 · A continuation citation is invisible to the citation guard
+
+**Status: OPEN. Measured 2026-08-23 at `4522158`. A latent structural gap, not a live
+defect — that distinction is the whole entry.**
+
+A citation written as `` (`extension/app.js:1602`, `:1641`) `` carries two references
+and the guard sees one. `CITATION` in
+`tests/test_the_documents_cite_what_they_claim.py` requires a path before the colon, so
+it matches `app.js:1641` and does not match a bare `:1641`. Measured directly: the
+regex returns a match for the first string and `None` for the second.
+
+| | |
+|---|---|
+| continuation citations in the guarded documents at `4522158` | **19** |
+| of those, resolving to a blank line or past EOF | **0** |
+| spot-checked and correct | the `docs/STATE.md` pair citing `scrapex/features.py:54` and `:65` |
+| moved silently by this branch's edits, guard green throughout | **4** |
+
+**What makes it real is the fourth row.** Edits on the branch that added
+`scrapex/provenance.py` shifted `extension/app.js` by eight lines; four continuation
+citations went with it; the guard passed the whole time; they were found by reading the
+diff by hand. Tier 2 cannot help, because a `PINNED` row is keyed on a path the tier-1
+sweep never discovered — there is nothing to pin.
+
+**What makes it NOT urgent is the second row.** None of the nineteen is currently
+wrong. The class also pre-dates the branch that found it; only the four movements were
+its own.
+
+**The remedy, and the trap to avoid.** The obvious guard — inherit the path from the
+nearest preceding citation — is *deciding by adjacency*, which this repository has
+measured and rejected twice (the prose-inference tier the guard's own docstring
+records, and the keyword allowlist `LESSONS` §13 threw away). **The non-inferring fix
+is to forbid the continuation form:** require every citation in a guarded document to
+name its path. One mechanical rule, zero inference, and nineteen invisible citations
+become nineteen the existing tiers already handle.
+
+**Cost:** rewriting nineteen citations across five documents — a conflict surface of
+its own, which is why it was not bundled into the branch that found it.
+
+**And there is a table this is the fifth row of, which is not on `main`.** *Four shapes
+of a wrong citation* lives on `origin/docs/the-boundary-becomes-a-ruling` at `c6d9212`,
+unmerged. Whoever lands that branch should add the row.
 
 ### OP-63 · The word "products" over a contractor directory, on two surfaces
 
@@ -3359,7 +3432,7 @@ at the run, don't assume it.
 ### BV-3 · Settings moved into the extension panel — CONFIRMED, and its warning has come true
 **Re-measured 2026-08-12. The "not yet confirmed" half is CLOSED by the live
 warehouse**, which shows the whole chain working on the owner's machine in a real
-crawl: `extension/app.js:840` posts `crawl_honour_delay` → `scrapex/capture.py:95`
+crawl: `extension/app.js:848` posts `crawl_honour_delay` → `scrapex/capture.py:95`
 reads it → `scrapex/connectors/base.py:560` emits the sentence → `job_log_entry`
 for job 120 carries it. Two settings hold non-default values, so something wrote
 them: `crawl_honour_delay = '0'`, `crawl_min_interval_s = '1'`.

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -2194,8 +2194,10 @@ written, the longer it will survive.
 
 This is the family §12 keeps meeting from one direction, §13 above from another, and
 `docs/ORCHESTRATION.md` §4 from a third: **something true when it was measured, still
-being read as current after the thing it measured moved.** It has now appeared six
-times, and the last one broke a rule the other five could not, so it gets the section.
+being read as current after the thing it measured moved.** Six instances are tabled
+below and the sixth broke a rule the other five could not, so it gets the section — then
+building the fix produced a **seventh**, recorded at the end because it is the only one
+of them caught by its own author before it shipped.
 
 **Every row below was re-derived at `f1844af`**, not copied from a brief — and saying
 which base is the whole discipline, so this line moves whenever the table is re-checked.
@@ -2209,7 +2211,7 @@ which base is the whole discipline, so this line moves whenever the table is re-
 | 5 | a published `.exe` (`#244`, `afb8648`) | the fix landed after the build | the owner, meeting a black window |
 | 6 | **a running process** | the checkout moved 199 seconds after it started | **nothing. He found it.** |
 
-*(A seventh was described to this session — a verification table still quoting a
+*(One more was described to this session — a verification table still quoting a
 superseded commit — and is **not** listed, because the commit it named appears nowhere
 in this repository at `f1844af`, and an instance that cannot be re-derived is not
 evidence. That is this section's own rule turned on its own source.)*
@@ -2287,6 +2289,21 @@ that checkout seconds earlier. Both checks are build-time, one-shot, and their s
 is a subprocess that has just started. Neither has any representation inside the
 long-lived process the build produces. **#244 proved that a new artefact speaks; it
 added nothing that lets a running process say which bytes it loaded.**
+
+> **THIS IS A DIFFERENT FAILURE FROM THE ONE #244'S TITLE NAMES, and the distinction
+> is the reason this section exists.** #244 is about an artefact **built** before its
+> own fix. This is about an artefact **running** after its own fix. The words are
+> nearly the same and the instrument required is not: one is checkable at build time
+> by asking the thing you just made a question, and the other is checkable only from
+> inside a process that has been alive for hours. **A reader who concludes that #244
+> already covers this will not build the thing that catches it** — which is exactly
+> what a session did conclude, before measuring what that gate reads.
+
+**And its scope is smaller than it looks, which matters if you go there to read it.**
+Of the three tests usually named as #244's, only
+`tests/test_the_frozen_engine_can_start_itself.py` is (`afb8648`); the other two are
+#154 (`756fa39`) and #253 (`5364c82`). #244's own additions are that test, the
+double-click workflow step, and `tests/test_the_release_proves_the_double_click.py`.
 
 ### The remedy, and why "restart" was never the missing piece
 
@@ -2366,7 +2383,24 @@ row of. It is not cited above because it is **not on `main`** — it lives on
 branch should add the row; `OP-61` carries the finding until then. Citing it as though
 it were here would be this section's own subject, one paragraph after describing it.)*
 
-**Apply, and this is the general rule the six instances share:** ask what the base of
+### And the branch produced a seventh instance, inside the test file about the family
+
+**Worth one paragraph because it was caught by its author before it shipped, which none
+of the other six were.** The test proving that a module imported *after* the seal is
+noticed set its fixture's mtime from a module-level `time.time() + 3600`, **evaluated at
+collection**. Collection happens once and that test runs much later, so any run taking
+over an hour to reach it would have compared against a moment already in the past and
+failed on correct code. The local suite is about twenty minutes and CI thirteen, so it
+would never have fired *today* — which is the reasoning this whole section exists to
+refuse. It now derives the base from the seal the test itself just took
+(`_SNAPSHOT.sealed_at + 60`), at the moment of use.
+
+**A measurement that outlives its base, written into the file whose subject is
+measurements that outlive their base.** Reading an entry is not the same as applying it
+— the same conclusion §7 already reached about its own overreach, and the reason
+[APPROACHES.md](APPROACHES.md) A5 became [R-17](RULINGS.md#r-17--a-fix-is-adversarially-reviewed-before-it-is-written).
+
+**Apply, and this is the general rule every instance above shares:** ask what the base of
 every claim is, and whether the claim can still be read after that base has moved. When
 the answer is *yes*, the fix is to make the claim carry its base or re-derive it
 (§12, `ORCHESTRATION` §4). **When the artefact is a process rather than a file, no

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -2197,7 +2197,7 @@ This is the family §12 keeps meeting from one direction, §13 above from anothe
 being read as current after the thing it measured moved.** It has now appeared six
 times, and the last one broke a rule the other five could not, so it gets the section.
 
-**Every row below was re-derived at `4522158`**, not copied from a brief — and saying
+**Every row below was re-derived at `f1844af`**, not copied from a brief — and saying
 which base is the whole discipline, so this line moves whenever the table is re-checked.
 
 | # | the artefact | the base it outlived | what caught it |
@@ -2211,7 +2211,7 @@ which base is the whole discipline, so this line moves whenever the table is re-
 
 *(A seventh was described to this session — a verification table still quoting a
 superseded commit — and is **not** listed, because the commit it named appears nowhere
-in this repository at `4522158`, and an instance that cannot be re-derived is not
+in this repository at `f1844af`, and an instance that cannot be re-derived is not
 evidence. That is this section's own rule turned on its own source.)*
 
 ### The sixth instance, measured
@@ -2332,7 +2332,7 @@ from a full citation a few words earlier, as in
 the colon, so it matches `app.js:1641` and does not match `:1641`. Measured, not
 reasoned: the regex returns a match for the first string and `None` for the second.
 
-**Nineteen of them exist** in the guarded documents at `4522158`. What this branch
+**Nineteen of them exist** in the guarded documents at `f1844af`. What this branch
 proved is that they move silently: edits here shifted `extension/app.js` by eight lines,
 four continuation citations went with it, **the guard stayed green through all of it**,
 and they were found by reading the diff by hand. That is the *drifted-and-still-resolves*
@@ -2341,7 +2341,7 @@ because tier 1 never discovers the citation in the first place and so there is n
 to pin.
 
 **Stated honestly, because the distinction decides whether anyone should act:** at
-`4522158` **none of the nineteen is wrong** — all resolve to non-blank lines, and the
+`f1844af` **none of the nineteen is wrong** — all resolve to non-blank lines, and the
 one spot-checked in full — the `docs/STATE.md` sentence citing
 `scrapex/features.py:54` and `:65` for two lit feature flags — names the `True` on
 both lines correctly. (That document's own line number is deliberately not quoted
@@ -2357,13 +2357,13 @@ tier in the guard's own docstring, and the keyword allowlist §13 threw away). T
 non-inferring fix is the opposite: **forbid the continuation form** in guarded
 documents. Require every citation to name its path, which is one mechanical rule, and
 nineteen invisible citations become nineteen that tier 1 and `PINNED` already handle.
-Filed as `OP-54` rather than built here, because rewriting nineteen citations across
+Filed as `OP-61` rather than built here, because rewriting nineteen citations across
 five documents is a second change with its own conflict surface.
 
 *(There is a table of **four shapes of a wrong citation** that this would be the fifth
 row of. It is not cited above because it is **not on `main`** — it lives on
 `origin/docs/the-boundary-becomes-a-ruling` at `c6d9212`, unmerged. Whoever lands that
-branch should add the row; `OP-54` carries the finding until then. Citing it as though
+branch should add the row; `OP-61` carries the finding until then. Citing it as though
 it were here would be this section's own subject, one paragraph after describing it.)*
 
 **Apply, and this is the general rule the six instances share:** ask what the base of

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -2187,3 +2187,187 @@ named after.
 would fail if the reason stopped being true. If the answer is *none*, you have
 written a claim that will outlive its evidence — and the more carefully it is
 written, the longer it will survive.
+
+---
+
+## 14 · A measurement that outlives its base — and the instance that was a live process
+
+This is the family §12 keeps meeting from one direction, §13 above from another, and
+`docs/ORCHESTRATION.md` §4 from a third: **something true when it was measured, still
+being read as current after the thing it measured moved.** It has now appeared six
+times, and the last one broke a rule the other five could not, so it gets the section.
+
+**Every row below was re-derived at `4522158`**, not copied from a brief — and saying
+which base is the whole discipline, so this line moves whenever the table is re-checked.
+
+| # | the artefact | the base it outlived | what caught it |
+|---|---|---|---|
+| 1 | a `PINNED` citation, `app.py:2710` | `#251` moved the symbol to `2725`, then `2787` | a red `main`, after both merged clean |
+| 2 | a `RESERVED` register row | the branch it named moved off the number | a session **asking who held 44** |
+| 3 | `docs/STATE.md`'s own opening line | five bases in one afternoon | the line correcting itself, again |
+| 4 | three docstring citations of a deleted test (§13, `#259`) | the test died ten days after it was written | a session **asking what else is unguarded** |
+| 5 | a published `.exe` (`#244`, `afb8648`) | the fix landed after the build | the owner, meeting a black window |
+| 6 | **a running process** | the checkout moved 199 seconds after it started | **nothing. He found it.** |
+
+*(A seventh was described to this session — a verification table still quoting a
+superseded commit — and is **not** listed, because the commit it named appears nowhere
+in this repository at `4522158`, and an instance that cannot be re-derived is not
+evidence. That is this section's own rule turned on its own source.)*
+
+### The sixth instance, measured
+
+2026-08-23. The owner's panel said **"no successful crawl yet"** under **17,304 rows**.
+`#255` (`bcb8f6e`) had fixed exactly that two days earlier and the fix was on `main`.
+
+| fact | value |
+|---|---|
+| process answering `127.0.0.1:8000` | `pythonw -m scrapex.cli ui --port 8000` |
+| it started | **07:35:44** |
+| the checkout left `451468d` for `31c369e` | **07:39:03** (`.git/logs/HEAD`, epoch 1787459943) |
+| delta | **+199 seconds too late** |
+
+**Python imports a module once.** A long-lived engine started from an editable install
+holds the tree that existed at import time for as long as it runs. The tree this one
+held still carried the literal `#255` removed — in `451468d`'s copy of
+`scrapex/webui/app.py`, at line 650 of **that** commit, `"last_success": None`. The
+disk had the fix; the process did not; the panel was reporting faithfully.
+
+*(**Written that way on purpose, and this paragraph is the section's own subject in
+miniature.** Prefixing a commit to a path and then a colon and a line number produces
+a span that `tests/test_the_documents_cite_what_they_claim.py` reads as a claim about
+the file **on disk today** — where that line is now a bare `continue`. Tier 1 checks
+only that the line exists, so the guard passes it and the reader lands nowhere. Worse,
+a remap script run over these documents will helpfully renumber it on the next edit,
+which is how a historical fact quietly becomes a false present-tense one. It happened
+here: a first draft of this entry carried that span, an automated re-derivation moved
+it, and it also moved `app.py:2710` in §12 — corrupting the very sentence whose
+subject is that 2710 became 2725 and then 2787. **A historical line number is written
+in prose — "line 650 of that commit" — never in the shape that means "current",** and
+`git show <commit>:<path>` is how a reader gets there. This is the third time an entry
+in this file has had to be written *around* the guard it documents; the other two are
+the `git tag` command in §7 and the past tense of `cut`.)*
+
+**AND THE VERSION STRING WAS NO HELP, WHICH IS THE STRUCTURAL PART.** `/api/health` and
+`/api/version` both answered `"version": "0.3.0"` — **truthfully**, because
+`engine-v0.3.0` *is* `451468d`. One string was being asked to separate three things:
+
+    the published engine-v0.3.0 build
+    a source checkout sitting at that tag
+    a process that imported that tree and kept running while the disk moved on
+
+And it cannot, **by design rather than by accident**. `R-35` moves the engine's number
+on a *contract* change, so many trees share one number on purpose. Counted: **ten
+commits report `VERSION = "0.3.0"`** — every tree from `e963269` (#247) to `31c369e`'s
+parent (#257), one of them the release tag. **A string ten trees share cannot name one
+of them**, and it was the only self-description the engine had.
+
+### What makes this one different, and it is not a detail
+
+**The artefact was not a document, a table or a test log. It was a live process — so
+the check that catches it cannot be a citation guard.**
+
+Every remedy this repository had built for this family reads *text at rest*:
+`tests/test_the_documents_cite_what_they_claim.py` reads a `file:line`,
+`test_the_release_the_documents_ask_for_is_the_one_that_would_run.py` reads a tag named
+in prose, `test_the_registers_cannot_collide.py` reads headings. **There is no line of
+prose here to check.** The stale thing was bytes in RAM, it existed only while the
+process ran, and it left no trace on disk — so the only possible instrument is one that
+lives *inside the artefact* and answers *at run time*. That is
+`docs/ORCHESTRATION.md` §5's argument — *move the check into the artefact so nobody has
+to remember to look* — arriving at its limit case.
+
+**AND #244'S GATE, WHOSE OWN TITLE IS *"the gate could not tell"*, COULD NOT TELL EITHER.**
+Worth stating precisely, because it looks like it should have. What it added
+(`.github/workflows/release-engine.yml`, *"And it must speak when a person double-clicks
+it"*) runs the freshly built `.exe` and greps three sentences out of its stdout. The
+step beside it claims more than it can deliver: *"the answer must be the number on the
+tag — which also proves the binary carries the source that was checked above, and not a
+stale build."* That is true **only inside that job**, because the binary was built from
+that checkout seconds earlier. Both checks are build-time, one-shot, and their subject
+is a subprocess that has just started. Neither has any representation inside the
+long-lived process the build produces. **#244 proved that a new artefact speaks; it
+added nothing that lets a running process say which bytes it loaded.**
+
+### The remedy, and why "restart" was never the missing piece
+
+`scrapex/provenance.py`. The engine seals a snapshot of what it loaded on
+`create_app`'s last line — the only moment at which every module it will serve with is
+imported and none of them can have changed yet — and compares it against the disk on
+demand. Two answers, because they fail independently: **`stale`** (a loaded module's
+file no longer matches, which needs no git and is the exact defect) and **`moved`** (the
+checkout is on another commit, which is what gives the answer words a person can act
+on). It rides `/api/health`, which the panel polls, and lands on the Build row under
+*Installed version* — the row that could not tell the three states apart.
+
+**A frozen build answers `None`, never `False`.** A one-file `.exe` carries no `.git`
+and no source tree; its modules live in a per-run temp directory that says nothing
+about whether newer code exists. `False` there would tell the owner his engine is
+current on the one build where we cannot know. This is the discipline `/api/health`'s
+worker block already states — *"Unknown is now said as unknown, and the reason for not
+knowing travels with it"* — and it is pinned by a test asserting `stale is not False`.
+
+**The defect was never that a restart was needed.** `POST /api/engine/restart` has
+existed the whole time and its docstring reads *"Replace this engine with one running
+the current code"*. **Nothing said a restart was owed**, and nothing could have: the
+route had no way to know whether it was needed and no way to report afterwards whether
+it worked. Detection and honest reporting, not hot-swapping — a live-reload mechanism
+would have hidden the fault instead of naming it.
+
+### The operational fact that decided the remedy
+
+**The crawl was a separate process.** The engine was PID 35036; the crawl was PID 35340,
+started 07:36:45 as `contractors --details --run-ref profiles-2026-08-22 --workers 6`.
+Restarting the engine therefore did not touch it — which is the only reason the fix
+could be applied at all while 17,304 rows' worth of work was in flight. Had the crawl
+run inside the engine process, the remedy for a stale engine would have been "lose the
+crawl", and the honest report would have had to say so.
+
+### And a citation shape the guard cannot see at all, found while fixing this branch
+
+Not part of the incident, and it is recorded here because **this branch is what
+demonstrated it.** A continuation citation — a bare `` `:NNN` `` inheriting its path
+from a full citation a few words earlier, as in
+`` (`extension/app.js:1602`, `:1641`) `` — **is invisible to
+`tests/test_the_documents_cite_what_they_claim.py`.** `CITATION` requires a path before
+the colon, so it matches `app.js:1641` and does not match `:1641`. Measured, not
+reasoned: the regex returns a match for the first string and `None` for the second.
+
+**Nineteen of them exist** in the guarded documents at `4522158`. What this branch
+proved is that they move silently: edits here shifted `extension/app.js` by eight lines,
+four continuation citations went with it, **the guard stayed green through all of it**,
+and they were found by reading the diff by hand. That is the *drifted-and-still-resolves*
+shape — except the remedy for that shape, a `PINNED` row, is structurally unavailable,
+because tier 1 never discovers the citation in the first place and so there is nothing
+to pin.
+
+**Stated honestly, because the distinction decides whether anyone should act:** at
+`4522158` **none of the nineteen is wrong** — all resolve to non-blank lines, and the
+one spot-checked in full — the `docs/STATE.md` sentence citing
+`scrapex/features.py:54` and `:65` for two lit feature flags — names the `True` on
+both lines correctly. (That document's own line number is deliberately not quoted
+here: this branch edits `docs/STATE.md`, so the number would move inside the very
+pull request describing the problem.) **So this is a latent structural gap, not a live
+defect**, and the class pre-dates this branch even though the four silent movements
+were this branch's own.
+
+**The remedy that avoids the trap this repository keeps falling into.** The obvious
+guard — inherit the path from the nearest preceding citation — is *deciding by
+adjacency*, which has now been measured and rejected twice here (the prose-inference
+tier in the guard's own docstring, and the keyword allowlist §13 threw away). The
+non-inferring fix is the opposite: **forbid the continuation form** in guarded
+documents. Require every citation to name its path, which is one mechanical rule, and
+nineteen invisible citations become nineteen that tier 1 and `PINNED` already handle.
+Filed as `OP-54` rather than built here, because rewriting nineteen citations across
+five documents is a second change with its own conflict surface.
+
+*(There is a table of **four shapes of a wrong citation** that this would be the fifth
+row of. It is not cited above because it is **not on `main`** — it lives on
+`origin/docs/the-boundary-becomes-a-ruling` at `c6d9212`, unmerged. Whoever lands that
+branch should add the row; `OP-54` carries the finding until then. Citing it as though
+it were here would be this section's own subject, one paragraph after describing it.)*
+
+**Apply, and this is the general rule the six instances share:** ask what the base of
+every claim is, and whether the claim can still be read after that base has moved. When
+the answer is *yes*, the fix is to make the claim carry its base or re-derive it
+(§12, `ORCHESTRATION` §4). **When the artefact is a process rather than a file, no
+amount of re-deriving helps — the artefact has to be able to answer for itself.**

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -89,7 +89,7 @@ IDs are stable and never reused, matching the convention BACKLOG.md already uses
 | [REQ-31](#req-31--start-the-profile-parser--and-the-pages-are-not-consistent) | Start the profile parser — and the pages are not consistent | **In flight** — the cards are built, guarded and mutation-tested; `Q-17` and `Q-18` are his | 2026-08-22 |
 | [REQ-32](#req-32--fixed-columns-and-everything-else-in-the-rows-own-card) | Fixed columns, and everything else in the row's own card | **Ruled** ([R-45](RULINGS.md#r-45--the-site-is-the-only-source-of-truth-and-a-field-the-table-does-not-need-goes-in-the-rows-card)) — not built; the card does not exist on either surface | 2026-08-22 |
 | [REQ-33](#req-33--the-dataset-cards-said-no-successful-crawl-over-crawled-rows) | The dataset cards said "no successful crawl yet" over 17,304 crawled rows | **Done** — the date is derived from the evidence; the two registries stay his | 2026-08-22 |
-| [REQ-35](#req-35--the-card-must-say-the-engine-is-running-from-source-not-that-it-is-missing) | The card must say the engine is running from source, not that it is missing | **Captured** — the engine knows how it was started and never reports it | 2026-08-22 |
+| [REQ-35](#req-35--the-card-must-say-the-engine-is-running-from-source-not-that-it-is-missing) | The card must say the engine is running from source, not that it is missing | **In flight** — the engine now reports its run mode and commit; the check-window wording is still owed | 2026-08-22 |
 | [REQ-36](#req-36--the-three-dots-are-missing-on-a-contractor-card-and-unprofessional-on-the-others) | The three dots are missing on a contractor card, and unprofessional on the others | **In flight** — a session is measuring which treatment he means before restyling | 2026-08-22 |
 | [REQ-37](#req-37--one-card-per-site-and-its-crawls-are-options-under-it--the-way-gpp-does-it) | One card per site, and its crawls are options under it — the way GPP does it | **In flight** ([R-47](RULINGS.md#r-47--muqawil-is-one-card-with-two-crawls-and-the-two-stored-datasets-stay-two)) — muqawil is ONE card and the population is stated once; the two crawl OPTIONS are blocked on a panel path to a dataset crawl ([OP-52](BACKLOG.md)) | 2026-08-22 |
 | [REQ-38](#req-38--the-backup-must-check-its-own-digest-and-the-panel-must-be-able-to-finish-the-build) | The backup must check its own digest, and the panel must be able to finish the build | **Captured** — measured: the digest is written and never read; the button aborts at 10 s on a 5-minute build | 2026-08-22 |
@@ -1348,7 +1348,7 @@ install page beside the first:
 | an action whose label says what it will do | **built** — the button reads `Update to 1.0.2` when a version is installed |
 | what it will refuse to talk to | **built** — `protocol_version` and `minimum_extension_version` are published beside the release and read *before* installing |
 | release-feed polling that survives a CDN and a rate limit | **built** — `extension/releases.js`, minute-bucket cache key, own timeout, four named states |
-| instructions, and the SmartScreen warning named in advance | **built** — and they auto-open on Download (`app.js:3565`) |
+| instructions, and the SmartScreen warning named in advance | **built** — and they auto-open on Download (`app.js:3621`) |
 | diagnostics, a setup guide, copyable technical details | **built and wired** |
 | **download progress** | **CANNOT BE BUILT AS IT STANDS** — see below |
 | **verifying the checksum it displays** | **never checked — the SHA-256 on screen is decorative** — nothing compares anything to it |
@@ -1364,7 +1364,7 @@ installer does:
     manifest.json permissions: activeTab, identity, nativeMessaging,
                                sidePanel, storage, tabs        <- no `downloads`
 
-    download.onclick = () => { window.open(installer.url, "_blank"); }   app.js:3564
+    download.onclick = () => { window.open(installer.url, "_blank"); }   app.js:3620
 
 It hands a URL to the browser and lets go. It cannot show progress, it cannot read
 the file off disk to hash it, and it can never launch a process. **So the panel can
@@ -1633,7 +1633,7 @@ queue is still the open question at the foot of that document. The measurement, 
 four findings it produced and the mutation results are in
 [BACKLOG.md](BACKLOG.md) as `OP-44`.
 ## REQ-35 · The card must say the engine is running from source, not that it is missing
-**Captured 2026-08-22 · Not built**
+**Captured 2026-08-22 · In flight — partly built**
 
 > «المحرك يعمل الان عن طريقك ويتجدد باستمرار لاننا نطوره · انا عاوز طريقة توضح فى الكارد
 > ان المحرك غير مثبت على الجهاز ولكنه يعمل فى نظام developer · ويظهر المحرك يعمل»
@@ -1659,7 +1659,7 @@ in `/api/health` reports **how** this engine is running.
 
 **So the shape is: the engine reports its own run mode, and the panel has a third
 word.** Not the panel guessing from an empty version string, which is what it does
-now (`extension/app.js:3484` on empty `state.engineVersion`) — a guess is how
+now (`extension/app.js:3526` on empty `state.engineVersion`) — a guess is how
 "running from source" became "not detected" in the first place.
 
 **And it is not cosmetic.** He works from two machines and the update path is real:
@@ -1670,6 +1670,33 @@ update that would overwrite his checkout.
 
 **Blocked on nothing.** It is one field on an endpoint the panel already polls, plus
 the words on the card.
+
+**THE FIELD IS BUILT; THE WORDS ARE HALF BUILT. And the cause named above is wrong —
+kept rather than erased, per `C4`, because the mistake is instructive.** Measured
+2026-08-23 against the live engine on port 8000:
+
+| asked | answer |
+|---|---|
+| `GET /api/health` version | **`"0.3.1"`** — not empty, and never was |
+| how long it took | **486 ms**, against a 2,500 ms deadline |
+| top-level keys | **11**, and **none states how the engine was started** |
+
+So the paragraph above is right that the panel has no word for developer mode, right
+that the engine knows and is never asked, and **wrong about the mechanism**. The panel
+is not guessing from an empty version string the engine sent. `state.engineVersion` is
+empty because **no answer has arrived yet**: `setEngineChecking()` renders the spec
+rows before the request returns, so *Installed version — Not detected* appears during
+**every check window on a perfectly healthy engine**, then is overwritten ~half a
+second later. That is a render-ordering defect and it is **not fixed** by the
+provenance work.
+
+**What was built** (`scrapex/provenance.py`, `LESSONS` §14): `/api/health` now carries a
+`build` block stating `mode` — `source` or `frozen` — with the commit the process
+started on, and the panel renders it as a **Build** row under *Installed version*. So
+"running from source" now has a word, which is the request's substance. **What is
+not:** the words *Not detected* still flash during the check window, because that
+sentence is written before any answer exists to render. **Partly closed, and the
+remaining half is a two-line guard on the render, not a new field.**
 
 ---
 

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -928,7 +928,7 @@ The four parts, in the order they were put to him:
 **1. The panel can never be the installer, and this is a limit rather than a
 backlog item.** Measured 2026-08-21: `extension/manifest.json` grants
 `activeTab, identity, nativeMessaging, sidePanel, storage, tabs` and **no
-`downloads`**, so `extension/app.js:3564` is `window.open(installer.url)` — it hands
+`downloads`**, so `extension/app.js:3620` is `window.open(installer.url)` — it hands
 a URL to the browser and lets go. Chrome will not let an extension show download
 progress it does not own, read a file off disk to hash it, or launch a process.
 **No amount of UI work changes any of those three.**

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -134,8 +134,8 @@ engine carries the extension.
 
 **The defect, found by trying the bump and reverting it the same day:**
 `version_report` sends `"latest_extension_version": VERSION`
-(`scrapex/version.py:483`, again in `scrapex/webui/app.py:1662`, drawn by
-`extension/app.js:595` and `:629`). The moment the engine moves ahead of
+(`scrapex/version.py:483`, again in `scrapex/webui/app.py:1671`, drawn by
+`extension/app.js:607` and `:641`). The moment the engine moves ahead of
 `extension/manifest.json`, the panel draws *"This ScrapeX extension is older than
 the engine it is talking to"*. Measured at 320×440: the profile page's legal line
 went from 396 to 494 against a 440 viewport — 54px clipped. Under "bump every
@@ -1535,7 +1535,7 @@ Against the base plan's own decision table (`MIGRATION-PLAN.md:60`):
 > *"Export stays in the engine — it is SQL over SQLite, not a file move."*
 
 **Export is a user-facing capability that exists only in the engine today**
-(`scrapex/webui/app.py:1193`, `@app.get("/export/{source_key}.xlsx")`). Both statements
+(`scrapex/webui/app.py:1321`, `@app.get("/export/{source_key}.xlsx")`). Both statements
 are his, the newer one contradicts the older, and **the rule says a newer conflict is
 his to settle.** So it goes to him rather than being resolved here. `Jobs stay in the
 engine` (`:61`) is the same shape and rides with it.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -87,8 +87,8 @@ disk: `mode` (`source`/`frozen`), the commit it started on, `stale`, `moved`. It
 `/api/health`, and the panel renders a **Build** row under *Installed version* with a
 `Restart needed` badge. A frozen build answers `None`, never `False`. `REQ-35` moves
 to **In flight** — partly closed, and its stated cause was measured and corrected in
-its own entry. Open items: `OP-53` (a frozen build's commit needs a build-time stamp)
-and `OP-54` (continuation citations are invisible to the citation guard).
+its own entry. Open items: `OP-60` (a frozen build's commit needs a build-time stamp)
+and `OP-61` (continuation citations are invisible to the citation guard).
 
 ---
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1288,8 +1288,8 @@ written and 58 two days ago. It grows every time this is deferred.
 **The blocker, verified 2026-08-17 and still present:**
 `"latest_extension_version": VERSION` at
 [scrapex/version.py:483](../scrapex/version.py) and
-[scrapex/webui/app.py:1662](../scrapex/webui/app.py), drawn by
-[extension/app.js:599](../extension/app.js) and `:633`.
+[scrapex/webui/app.py:1671](../scrapex/webui/app.py), drawn by
+[extension/app.js:607](../extension/app.js) and `:641`.
 
 > **Re-verified 2026-08-19, and three of these citations had already drifted.**
 > `webui/app.py` was **1355**, now 1375 — #211 and #212 inserted twenty lines

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -66,6 +66,30 @@ This is the document that is **wrong the moment it is out of date**. Update it
 when a phase lands, a PR merges, or the owner rules — in the same pull request as
 the work it describes (**C2**, [../CLAUDE.md](../CLAUDE.md)).
 
+**AND THE OPENING LINE ABOVE IS NOW ITSELF A CASE STUDY, filed as instance 3 in
+[LESSONS §14](LESSONS.md).** It read `31c369e` while `main` was `d10e974`, and
+`4522158` landed while that was being written. The line is not being rewritten to
+chase the pointer — the sentence it already carries is the right answer, and
+`git log --oneline -1 origin/main` remains the only one that cannot rot.
+
+### The engine can now say which code it is running (open PR)
+
+**The incident, 2026-08-23.** His panel said *"no successful crawl yet"* over **17,304
+rows**. #255 had fixed exactly that two days earlier and the fix was on `main`. The
+engine process started at **07:35:44**; the checkout moved off `451468d` at
+**07:39:03** — **199 seconds later**. Python imports a module once, so it served the
+old tree for as long as it ran, and `/api/health` answered `"version": "0.3.0"`
+truthfully the whole time, because **ten distinct commits report `0.3.0`** and one
+string cannot name one of them.
+
+`scrapex/provenance.py` seals what the process loaded and compares it against the
+disk: `mode` (`source`/`frozen`), the commit it started on, `stale`, `moved`. It rides
+`/api/health`, and the panel renders a **Build** row under *Installed version* with a
+`Restart needed` badge. A frozen build answers `None`, never `False`. `REQ-35` moves
+to **In flight** — partly closed, and its stated cause was measured and corrected in
+its own entry. Open items: `OP-53` (a frozen build's commit needs a build-time stamp)
+and `OP-54` (continuation citations are invisible to the citation guard).
+
 ---
 
 ## RESUME HERE — written for the other machine, 2026-08-22
@@ -570,7 +594,7 @@ designing: the surface is largely built — nineteen elements, six states, a ver
 badge and a label that says what the button will do. What is missing is the
 MECHANICS**, and the finding that decides the design is that the panel *cannot*
 supply them: Chrome gives it no `downloads` permission, no file read and no way to
-launch a process, so `app.js:3564` hands a URL to the browser and lets go. **The
+launch a process, so `app.js:3620` hands a URL to the browser and lets go. **The
 engine can do all three.** So the first install goes through the browser because
 nothing is installed yet, and every update after it belongs to the engine. That is
 blocked on `OP-36` first, then a ruling from him on what makes a download
@@ -704,7 +728,7 @@ test (#200) · sign-out (#201, ruling [R-13](RULINGS.md#r-13--sign-out-of-all-ac
    source's answers 404 **without confirming the id exists at all**.
 2. **Choose-Columns — `GET`/`POST /api/fields/{key}`. Do not write a second one.**
    The panel already has the whole thing: `loadSourceColumns`
-   (`extension/app.js:1594`) and `saveSourceColumns` (`:1633`), speaking the same
+   (`extension/app.js:1602`) and `saveSourceColumns` (`:1641`), speaking the same
    bodies. **Extract** it into a shared module the way `backend.js` was, or the
    two surfaces will disagree about how a column is saved.
 3. **Saved views — `POST /api/views/{key}`, `DELETE /api/views/{id}`.**

--- a/extension/app.html
+++ b/extension/app.html
@@ -1498,6 +1498,22 @@
             <span class="engine-spec-label">Installed version</span>
             <span class="engine-spec-value tech" id="engine-installed-version">—</span>
           </div>
+          <!-- DIRECTLY UNDER THE VERSION, because the version is the row that
+               could not tell three states apart: the published build, a checkout
+               sitting at that tag, and a process running code the disk has moved
+               past. The disambiguation belongs beside the number it disambiguates.
+               The badge is the same idiom as "Update available" on the Latest row
+               below — one verdict, one place, no new screen. -->
+          <div class="engine-spec-row" id="engine-spec-build">
+            <span class="engine-spec-note">
+              <span class="engine-spec-label">
+                Build
+                <span class="badge hidden" id="engine-build-verdict"></span>
+              </span>
+              <small id="engine-build-detail"></small>
+            </span>
+            <span class="engine-spec-value tech" id="engine-build-value">—</span>
+          </div>
           <div class="engine-spec-row" id="engine-spec-latest">
             <span class="engine-spec-note">
               <span class="engine-spec-label">

--- a/extension/app.js
+++ b/extension/app.js
@@ -110,6 +110,9 @@ const state = {
   // browser right now, which is exactly as long as this panel lives.
   signedOutAccounts: new Set(),
   installedVersion: "", engineVersion: "", versionReport: null,
+  // What the engine says it IS, as opposed to the number it advertises. `null`
+  // means no engine has answered, or one answered that predates the field.
+  engineBuild: null,
   versionStatus: "pending",
   // null means the engine never said, which is a THIRD state and not a
   // mismatch: an engine built before the handshake moved here answers
@@ -501,6 +504,11 @@ function setStatus(engine) {
     : engine.timedOut ? "timeout"
     : engine.reachable ? "stopped" : "unavailable";
   state.engineVersion = engine.version || "";
+  // KEPT WHOLE, and not reduced to a boolean here. `mode`, `stale` and `moved`
+  // are three separate answers and one of them is legitimately unknown on an
+  // installed build — collapsing them at the door is how `null` becomes `false`
+  // and an honest "cannot know" turns into a claim.
+  state.engineBuild = engine.build || null;
   // engine.js has computed `protocolMismatch` from /api/health since the
   // handshake moved onto the transport that carries the traffic. It reached
   // exactly one place: the Diagnostics output, which only appears when someone
@@ -3475,6 +3483,40 @@ function engineProtocolText() {
   return String(state.engineProtocol);
 }
 
+// THE THIRD WORD REQ-35 ASKS FOR, and the answer to the 2026-08-23 incident.
+//
+// "Installed version 0.3.0" is true of three different things — the published
+// build, a checkout sitting on that tag, and a process still running that tree
+// while the disk moved on — and the owner met the third one while his panel told
+// him a 17,304-row dataset had never been crawled. So the engine now reports what
+// it IS and this function turns that into the words on the card.
+//
+// NOTHING IS INFERRED FROM AN ABSENCE. An engine that reports no build block is an
+// engine from before the field existed, not an engine in trouble: it gets "Not
+// reported", the same treatment `engineProtocolText` gives a missing protocol. And
+// `stale === null` — an installed build, which genuinely cannot compare itself to a
+// source tree it does not have — renders as the mode alone with no verdict, because
+// a verdict there would be a guess dressed as a measurement.
+function engineBuildText(build) {
+  if (!build) return { value: "Not reported", verdict: "", detail: "" };
+  const short = build.commit ? String(build.commit).slice(0, 7) : "";
+  if (build.mode === "frozen") {
+    return { value: short ? `installed · ${short}` : "installed build",
+             verdict: "", detail: build.detail || "" };
+  }
+  if (build.mode !== "source") {
+    return { value: "Unknown", verdict: "", detail: build.detail || "" };
+  }
+  const value = short ? `source · ${short}` : "source";
+  // Two different reasons to restart, and the sharper one wins the badge: code
+  // this engine LOADED has changed, which is the defect that cost the owner a
+  // wrong belief about his data. A checkout that merely moved is a weaker signal
+  // and says so in its own words.
+  if (build.stale === true) return { value, verdict: "Restart needed", detail: build.detail || "" };
+  if (build.moved === true) return { value, verdict: "Checkout moved", detail: build.detail || "" };
+  return { value, verdict: "", detail: "" };
+}
+
 // THE COMPATIBILITY PARAGRAPH IS GONE, not moved. It said the mismatch a second
 // time in a `.notice` class no loaded stylesheet defined, so it rendered as bare
 // text; the banner now carries `data-tone="danger"` and the Protocol row states
@@ -3483,6 +3525,20 @@ function renderEngineStatusUI() {
   const installed = state.engineVersion || "";
   $("engine-installed-version").textContent = installed || "Not detected";
   $("engine-protocol-row").textContent = engineProtocolText();
+  const build = engineBuildText(state.engineBuild);
+  $("engine-build-value").textContent = build.value;
+  $("engine-build-detail").textContent = build.detail;
+  const buildBadge = $("engine-build-verdict");
+  buildBadge.textContent = build.verdict;
+  // `off` IS THE AMBER BADGE and it is the only amber one there is: the kit
+  // defines `.badge`, `.badge.ok`, `.badge.off` and `.badge.danger` and NOTHING
+  // ELSE (design/components.css:618-650). `badge warn` was written here first and
+  // would have rendered as the plain grey one — the identical failure to the
+  // `.notice` class in the comment below, which no loaded stylesheet defined and
+  // which therefore said nothing at all. A new variant is four edits and a palette
+  // sweep (docs/LESSONS.md §5); amber already means "attend to this".
+  buildBadge.className = build.verdict === "Restart needed" ? "badge off" : "badge";
+  buildBadge.classList.toggle("hidden", !build.verdict);
   // The version beside the name on the catalogue row: shown only when there IS
   // one, because an empty `.tech` chip beside a name reads as a missing value
   // rather than as an engine nobody has installed.
@@ -3707,7 +3763,8 @@ function renderEngineDetail(id) {
     ? SCRAPEX_ENGINE.sub : "Candidate backend · not installable yet";
   $("engine-licence").textContent = engine.licence;
 
-  for (const row of ["engine-spec-installed", "engine-spec-latest",
+  for (const row of ["engine-spec-installed", "engine-spec-build",
+                     "engine-spec-latest",
                      "engine-spec-protocol", "engine-spec-power"]) {
     $(row).classList.toggle("hidden", !installed);
   }
@@ -3796,6 +3853,13 @@ async function copyEngineDetails() {
   const lines = [
     `Status: ${$("engine-status").textContent}`,
     `Installed version: ${$("engine-installed-version").textContent}`,
+    // THE LINE THAT WOULD HAVE ENDED THE 2026-08-23 INVESTIGATION IN ONE PASTE.
+    // This block is what he copies when something looks wrong, and on that
+    // morning every line in it was true and none of them said the engine was
+    // serving a tree the disk had left behind three minutes after it started.
+    `Build: ${$("engine-build-value").textContent}`
+      + `${$("engine-build-verdict").textContent
+            ? " — " + $("engine-build-verdict").textContent : ""}`,
     `Latest version: ${$("engine-latest-version").textContent}`,
     `Protocol: ${$("engine-protocol-row").textContent}`,
     `Backend: ${backend}`,

--- a/extension/engine.js
+++ b/extension/engine.js
@@ -43,6 +43,13 @@ export async function checkEngine({backend = null, signal = null,
       clientProtocol: PROTOCOL_VERSION,
       sources: h.sources_with_data,
       databases: h.databases || null,
+      // WHICH CODE THE ENGINE IS RUNNING, which `version` cannot say: ten
+      // different trees report "0.3.0", so the number tells us what the engine
+      // advertises and never what it is. `null` for an engine from before this
+      // field existed — the same treatment `protocol_version` gets two blocks up,
+      // and for the same reason: an engine too old to answer is not an engine
+      // reporting a fault.
+      build: h.build || null,
       backend: target,
     };
   } catch (error) {

--- a/scrapex/provenance.py
+++ b/scrapex/provenance.py
@@ -333,7 +333,17 @@ def report() -> dict:
     """
     try:
         return _report()
-    except Exception as exc:                       # noqa: BLE001
+    # A BARE `except Exception` ON PURPOSE, and deliberately with no suppression
+    # comment beside it. The three in `packaging/engine_entry.py` suppress BLE001 --
+    # which is where this was copied from -- but the lint gate runs
+    # `ruff check scrapex/` and never looks at `packaging/`, so that rule is not
+    # enabled here and the directive was dead. RUF100 caught it.
+    #
+    # AND THE FIRST DRAFT OF THIS COMMENT SPELLED THE DIRECTIVE OUT to explain it,
+    # which made ruff parse the explanation as a directive and warn about it. A
+    # comment that quotes an instruction is holding one -- the same trap
+    # `docs/LESSONS.md` §7 records twice about prose. Name the rule, never the syntax.
+    except Exception as exc:
         # The one branch where `stale` may not be a verdict. A check that crashed
         # knows nothing, and saying so is the only honest answer available — the
         # alternative is a `False` that means "we failed to look".

--- a/scrapex/provenance.py
+++ b/scrapex/provenance.py
@@ -1,0 +1,397 @@
+"""What this engine IS, as distinct from what its version file says.
+
+THE DEFECT, MEASURED 2026-08-23. The owner's panel said "no successful crawl yet"
+over 17,304 crawled rows. #255 had fixed exactly that two days earlier and the fix
+was on `main`. It had not reached him, and nothing anywhere could say why:
+
+    pythonw -m scrapex.cli ui --port 8000    started  07:35:44
+    the checkout moved off 451468d           at       07:39:03
+    delta                                            +199 seconds
+
+**Python imports a module once.** A long-lived engine started from an editable
+install holds whatever tree existed at import time for as long as it runs, and the
+tree this one held still carried the literal #255 removed -- read it with
+`git show 451468d:scrapex/webui/app.py`, at line 650 of THAT commit, where
+`"last_success": None` still stands. The disk had the fix; the process did not.
+
+AND NOTHING COULD TELL, WHICH IS THE PART THIS MODULE EXISTS FOR. `/api/health` and
+`/api/version` both answered `"version": "0.3.0"` — truthfully. `451468d` IS
+`engine-v0.3.0`. But a version string cannot separate three different things:
+
+    the published engine-v0.3.0 build
+    a source checkout sitting at that tag
+    a process that imported that tree and kept running while the disk moved on
+
+Measured: **ten distinct commits report `VERSION = "0.3.0"`** — every tree from
+`e963269` (#247) to `31c369e`'s parent (#257), one of which is the release tag. That
+is by design, not by accident: `R-35` moves the engine's number on a CONTRACT change,
+so many trees share one number deliberately. **A string ten trees share cannot
+identify one of them**, and it is the only thing the engine had ever been asked.
+
+WHAT THIS MODULE ADDS, and it is the narrowest thing that catches the incident: the
+engine reports the identity of the code it LOADED, and compares it against the code
+on disk NOW. Two independent answers, because they fail independently:
+
+    stale   a source file this process has loaded has CHANGED ON DISK since the
+            process sealed its snapshot. This is the exact defect above, and it
+            needs no git at all — it works on any checkout, tarball or editable
+            install.
+    moved   the git checkout's HEAD is not the HEAD this process started on. Not
+            required for correctness, and it is what gives the answer WORDS a
+            person can act on: "started at 451468d, the checkout is now 31c369e".
+
+WHY BOTH, when `stale` alone proves the fault: `moved` fires on a checkout that
+advanced without touching anything this process happens to have imported, which is
+a restart the owner still wants to know about; `stale` fires on an editable install
+with no `.git` reachable at all. Neither contains the other.
+
+A FROZEN BUILD ANSWERS `None`, NEVER `False`. A PyInstaller one-file `.exe` has no
+`.git` and no source tree on disk to compare itself against — its modules live in a
+per-run temp directory that says nothing about whether newer code exists. So the
+honest answer is *unknown*, and it is reported as unknown. `/api/health`'s own
+worker block already set this precedent in this repository
+(`scrapex/webui/app.py:1527`, `{"alive": None, ...}` — *"Unknown is now said as
+unknown, and the reason for not knowing travels with it"*). A guessed `False` here
+would be the defect, not the fix: it would tell the owner his engine is current on
+the one build where we cannot know.
+
+NOTHING HERE IMPORTS FROM `scrapex` EXCEPT `enginelaunch`, which imports nothing at
+all — the same rule that module states about itself. `report()` is called from
+`/api/health`, which the panel polls on a timer, so it must never raise and never
+block: every filesystem read below is guarded, and the only unbounded work happens
+when a file has ALREADY been seen to change.
+"""
+from __future__ import annotations
+
+import hashlib
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+from . import enginelaunch
+
+#: The package this module describes. Derived, so a rename cannot leave it behind.
+PACKAGE = __name__.split(".")[0]
+
+#: How many changed modules the report names. A restart is the remedy whether one
+#: module moved or forty, so the list is evidence rather than a work queue — and
+#: `/api/health` is polled every few seconds, which is not the place for an
+#: unbounded array.
+NAMED_LIMIT = 12
+
+
+def _package_root() -> Path:
+    return Path(__file__).resolve().parent
+
+
+def _digest(path: Path) -> str | None:
+    """SHA-256 of a source file, newline-normalised.
+
+    NORMALISED BECAUSE THIS REPOSITORY HAS SHIPPED THE OTHER THING AS AN OUTAGE.
+    `.gitattributes` sets `* text=auto` and `core.autocrlf` is true, so the repo
+    stores LF and Windows checks out CRLF (`docs/LESSONS.md` §1). Here both reads
+    happen on one machine so the raw bytes would agree in practice — but a digest
+    that is only accidentally stable is the kind this project has already paid for
+    once, and one `.replace()` removes the whole question.
+    """
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return None
+    return hashlib.sha256(
+        data.replace(b"\r\n", b"\n").replace(b"\r", b"\n")).hexdigest()
+
+
+def _loaded_sources() -> dict[str, Path]:
+    """Every module of this package that is loaded AND has a real file on disk.
+
+    `sys.modules` is the authority on what this process actually imported, which is
+    the whole question — a file the engine has never loaded cannot make it stale,
+    and reading the tree instead would report edits to tests and documents as a
+    reason to restart. That is the cry-wolf failure
+    `tests/test_the_published_documents_are_checked_not_announced.py` already warns
+    about, and it would arrive within a day on a repository under this much traffic.
+
+    A module with no `__file__`, or one outside the package directory, is skipped:
+    namespace packages, C extensions and a frozen bundle's archive entries all have
+    nothing on disk to compare against.
+    """
+    root = _package_root()
+    found: dict[str, Path] = {}
+    for name, module in list(sys.modules.items()):
+        if name != PACKAGE and not name.startswith(PACKAGE + "."):
+            continue
+        origin = getattr(module, "__file__", None)
+        if not origin:
+            continue
+        try:
+            path = Path(origin).resolve()
+            path.relative_to(root)
+        except (OSError, ValueError):
+            continue
+        found[name] = path
+    return found
+
+
+def _git_dir(start: Path) -> Path | None:
+    """The `.git` directory governing `start`, or None.
+
+    Handles the worktree form, because this repository is worked in worktrees and
+    an engine started from one must still be able to answer. In a worktree `.git`
+    is a FILE reading `gitdir: <path>` and the branch pointer lives under that
+    path, not under the shared repository.
+    """
+    for candidate in (start, *start.parents):
+        marker = candidate / ".git"
+        try:
+            if marker.is_dir():
+                return marker
+            if marker.is_file():
+                text = marker.read_text(encoding="utf-8", errors="replace")
+                for line in text.splitlines():
+                    if line.startswith("gitdir:"):
+                        pointed = Path(line.split(":", 1)[1].strip())
+                        if not pointed.is_absolute():
+                            pointed = (candidate / pointed).resolve()
+                        return pointed if pointed.is_dir() else None
+        except OSError:
+            return None
+    return None
+
+
+def _read_head(git_dir: Path) -> str | None:
+    """The commit HEAD points at, read from files rather than from `git`.
+
+    NO SUBPROCESS, DELIBERATELY. This is called from `/api/health`, which the panel
+    polls behind a 2,500 ms deadline — and that deadline has already been blown once
+    in this product's history by an endpoint doing more work than a poll can afford
+    (`scrapex/webui/app.py:1484`: it *"answered in 3.8 s, the deadline expired, and
+    the panel reported the engine as 'Not detected'"*). Three small file reads cannot
+    do that. Neither can they fail on a machine with no git on PATH, which is the
+    owner's machine for `python` already (`docs/LESSONS.md` §1).
+    """
+    try:
+        head = (git_dir / "HEAD").read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if not head.startswith("ref:"):
+        return head or None
+    ref = head.split(":", 1)[1].strip()
+    # A worktree's own HEAD lives in its gitdir; the REF it names lives in the
+    # shared repository, which `commondir` points at. Getting this wrong reports
+    # "no commit" for every engine started from a worktree.
+    roots = [git_dir]
+    try:
+        common = (git_dir / "commondir").read_text(encoding="utf-8").strip()
+        resolved = Path(common)
+        roots.append(resolved if resolved.is_absolute()
+                     else (git_dir / resolved).resolve())
+    except OSError:
+        pass
+    for root in roots:
+        try:
+            return (root / ref).read_text(encoding="utf-8").strip() or None
+        except OSError:
+            continue
+    # Packed. `packed-refs` is the fallback and not the first read: a freshly
+    # checked-out branch has a loose ref and no packed entry.
+    for root in roots:
+        try:
+            for line in (root / "packed-refs").read_text(encoding="utf-8").splitlines():
+                if line.startswith(("#", "^")):
+                    continue
+                parts = line.split()
+                if len(parts) == 2 and parts[1] == ref:
+                    return parts[0]
+        except OSError:
+            continue
+    return None
+
+
+class _Snapshot:
+    """What the process had loaded at the moment it sealed, and when that was.
+
+    THE REFERENCE POINT IS THE WHOLE DESIGN, so it is an object with a time on it
+    rather than a module global that is true at some unstated moment. Every claim
+    `report()` makes is relative to `sealed_at`, and the report says what that
+    moment was — because a measurement that does not carry its base is the exact
+    failure family this module was written for (`docs/LESSONS.md` §14).
+    """
+
+    def __init__(self) -> None:
+        self.sealed_at: float | None = None
+        self.frozen: bool = False
+        self.head: str | None = None
+        self.git_dir: Path | None = None
+        #: name -> (path, mtime, size, digest). Both the cheap stamp and the exact
+        #: one, because `_changed()` uses the first to decide whether to spend the
+        #: second.
+        self.loaded: dict[str, tuple[Path, float, int, str]] = {}
+
+    def seal(self) -> None:
+        self.sealed_at = time.time()
+        self.frozen = enginelaunch.frozen()
+        self.loaded = {}
+        self.head = None
+        self.git_dir = None
+        if self.frozen:
+            # A frozen build has no source tree and no repository. Sealing it
+            # records the MODE and nothing else, so `report()` has a truthful
+            # basis for answering `None` rather than inventing a comparison.
+            return
+        self.git_dir = _git_dir(_package_root())
+        if self.git_dir is not None:
+            self.head = _read_head(self.git_dir)
+        for name, path in _loaded_sources().items():
+            try:
+                stat = path.stat()
+            except OSError:
+                continue
+            digest = _digest(path)
+            if digest is not None:
+                self.loaded[name] = (path, stat.st_mtime, stat.st_size, digest)
+
+
+_SNAPSHOT = _Snapshot()
+
+
+def seal() -> None:
+    """Fix the reference point: this is the code the process is running.
+
+    CALLED ONCE, WHEN THE SERVER IS BUILT AND ABOUT TO SERVE, which is the only
+    moment that makes the claim exact. Sealing at import time would snapshot the
+    handful of modules loaded that early and miss `webui.app` — the module the
+    incident was actually about. Sealing lazily on the first `report()` would take
+    its baseline AFTER the edit it exists to notice, which is worse than not
+    checking: it would report "current" about a process that is not.
+    """
+    _SNAPSHOT.seal()
+
+
+def _changed() -> list[str]:
+    """Loaded modules whose file on disk no longer matches what was sealed.
+
+    Two stages, because the cheap one is enough almost always. `stat()` per module
+    is a handful of microseconds; a digest is a read. So the digest is computed only
+    for a file whose size or mtime has already moved — and it is what decides, so a
+    file that git rewrote to identical content does NOT report as changed. mtime
+    alone would cry wolf on every `git checkout` that touched a file without
+    changing it, and a warning that fires when nothing is wrong is one the owner
+    learns to scroll past.
+    """
+    changed: list[str] = []
+    for name, (path, mtime, size, digest) in sorted(_SNAPSHOT.loaded.items()):
+        try:
+            stat = path.stat()
+        except OSError:
+            # Deleted or renamed under a running process. That IS a divergence
+            # between memory and disk, and it is reported as one.
+            changed.append(name)
+            continue
+        if stat.st_mtime == mtime and stat.st_size == size:
+            continue                   # untouched: no read, no hash
+        if _digest(path) != digest:
+            changed.append(name)
+    return changed
+
+
+def report() -> dict:
+    """What this engine is running, and whether the disk has moved past it.
+
+    Never raises. This is reached from `/api/health`, which the panel polls on a
+    timer and which already carries a comment about why it must survive the thing it
+    reports on (`scrapex/webui/app.py:1427`).
+    """
+    try:
+        return _report()
+    except Exception as exc:                       # noqa: BLE001
+        # The one branch where `stale` may not be a verdict. A check that crashed
+        # knows nothing, and saying so is the only honest answer available — the
+        # alternative is a `False` that means "we failed to look".
+        return {
+            "mode": "unknown", "sealed_at": None, "commit": None,
+            "commit_now": None, "moved": None, "stale": None, "changed": [],
+            "detail": ("this engine could not read its own provenance: "
+                       f"{type(exc).__name__}: {exc}"),
+        }
+
+
+def _report() -> dict:
+    sealed_at = _SNAPSHOT.sealed_at
+    mode = "frozen" if _SNAPSHOT.frozen else "source"
+    stamp = (datetime.fromtimestamp(sealed_at, UTC).isoformat()
+             if sealed_at is not None else None)
+    out: dict = {
+        "mode": mode,
+        "sealed_at": stamp,
+        "commit": _SNAPSHOT.head,
+        "commit_now": None,
+        "moved": None,
+        "stale": None,
+        "changed": [],
+        "detail": "",
+    }
+    if sealed_at is None:
+        out["detail"] = ("this engine never recorded which code it loaded, so "
+                         "whether the disk has moved past it cannot be answered.")
+        return out
+    if _SNAPSHOT.frozen:
+        # THE HONEST UNKNOWN, and the reason it is a branch of its own rather than
+        # a fall-through: an installed build genuinely cannot answer this, and
+        # `False` would be a claim it has no way to support.
+        out["detail"] = ("this is an installed build; it carries no source tree to "
+                         "compare against, so whether newer code exists on disk "
+                         "cannot be answered from inside it.")
+        return out
+
+    changed = _changed()
+    out["stale"] = bool(changed)
+    out["changed"] = changed[:NAMED_LIMIT]
+    if _SNAPSHOT.git_dir is not None:
+        out["commit_now"] = _read_head(_SNAPSHOT.git_dir)
+        if _SNAPSHOT.head and out["commit_now"]:
+            out["moved"] = out["commit_now"] != _SNAPSHOT.head
+
+    # THE SENTENCE IS PART OF THE PRODUCT, not a log line. `REQ-35` asks for a word
+    # for "running from source", which the panel does not have; the words a person
+    # reads are decided here, once, so the panel and the engine's own page cannot
+    # say it two different ways.
+    #
+    # AND ONE THING `REQ-35` GETS WRONG ABOUT ITS OWN CAUSE, measured 2026-08-23
+    # against the live engine so the next reader does not inherit it. That entry
+    # blames the panel guessing from an EMPTY version string. The engine does not
+    # report an empty version: `GET /api/health` answered `"version": "0.3.1"` in
+    # 486 ms. What produces "Not detected" is `setEngineChecking()` rendering the
+    # spec rows BEFORE any answer arrives, so the pair shows during every check
+    # window on a perfectly healthy engine. That is a separate defect from this
+    # one and is NOT fixed here; the measurement is recorded under `REQ-35` itself,
+    # beside the claim it corrects. What IS this one: those 11 keys carry no
+    # statement of how the engine was started, and none of them can.
+    if changed:
+        which = f"{len(changed)} loaded module(s)"
+        detail = (f"the code this engine is running is not the code on disk — "
+                  f"{which} changed since it started. Restart the engine to pick "
+                  f"the new code up.")
+    elif out["moved"]:
+        detail = ("the checkout has moved to another commit since this engine "
+                  "started, though nothing it has loaded changed. Restart the "
+                  "engine if you expect newer behaviour.")
+    else:
+        detail = "running from source, and level with the code on disk."
+    out["detail"] = detail
+    return out
+
+
+def summary() -> dict:
+    """The compact form `/api/health` carries on every poll.
+
+    `changed` is the part a timed poll must not carry: it is a list, it grows with
+    the size of the divergence, and the panel's answer is the same for one module as
+    for forty. The full block including it is on `/api/version`, which is fetched
+    once — the same split `/api/health` already makes for the capability ledger
+    (`scrapex/webui/app.py:1536`).
+    """
+    full = report()
+    return {key: full[key] for key in
+            ("mode", "sealed_at", "commit", "commit_now", "moved", "stale", "detail")}

--- a/scrapex/provenance.py
+++ b/scrapex/provenance.py
@@ -279,6 +279,10 @@ def _changed() -> list[str]:
     alone would cry wolf on every `git checkout` that touched a file without
     changing it, and a warning that fires when nothing is wrong is one the owner
     learns to scroll past.
+
+    THEN A THIRD PASS over modules imported after the seal, which the snapshot by
+    definition does not hold. See the comment at that loop: without it, a module
+    first imported inside a request handler is a divergence this check cannot see.
     """
     changed: list[str] = []
     for name, (path, mtime, size, digest) in sorted(_SNAPSHOT.loaded.items()):
@@ -293,6 +297,30 @@ def _changed() -> list[str]:
             continue                   # untouched: no read, no hash
         if _digest(path) != digest:
             changed.append(name)
+
+    # AND THE MODULES THAT ARRIVED AFTER THE SEAL, which the loop above cannot see
+    # because they are not in the snapshot at all. This repository has several
+    # `from ..x import y` inside route handlers, so a module can first be imported
+    # while serving a request -- minutes or hours after the reference point.
+    #
+    # A FILE WHOSE mtime IS LATER THAN THE SEAL WAS WRITTEN AFTER THIS PROCESS
+    # STARTED SERVING, so the process is now running a MIX of pre- and post-edit
+    # code. That is worse than being uniformly behind, not better, and reporting it
+    # is the point. There is no false positive available here: mtime records when
+    # the file was last written to disk, and for untouched code that is always
+    # before the process started.
+    #
+    # Found by asking what `seal()` does NOT cover rather than by a failure -- the
+    # blind spot a guard does not know it has is the defect this whole module is
+    # about.
+    for name, path in sorted(_loaded_sources().items()):
+        if name in _SNAPSHOT.loaded:
+            continue
+        try:
+            if path.stat().st_mtime > _SNAPSHOT.sealed_at:
+                changed.append(name)
+        except OSError:
+            continue
     return changed
 
 

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -29,7 +29,16 @@ from fastapi.templating import Jinja2Templates
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 
-from .. import bundle, compaction, localinbox, nativehost, pricehistory, rates, retention
+from .. import (
+    bundle,
+    compaction,
+    localinbox,
+    nativehost,
+    pricehistory,
+    provenance,
+    rates,
+    retention,
+)
 from .. import db as dbmod
 from .. import version as engine_version
 from ..capture import capture_source, crawl_settings
@@ -1676,7 +1685,17 @@ def create_app(
                 # None when the database is level with the code, which is the
                 # normal case — so the panel shows nothing rather than a badge
                 # that is always there and therefore never read.
-                "schema_lag": schema_lag}
+                "schema_lag": schema_lag,
+                # IS THE CODE BEHIND THE DISK? `schema_lag` above asks whether the
+                # DATABASE is behind the code, and it was written because a lag the
+                # engine can measure must not be something the owner discovers from
+                # a stack trace. This is the same sentence about the other pair, and
+                # it had no answer at all until 2026-08-23: `version` above says
+                # "0.3.0" for ten different trees, so it can say what this engine
+                # ADVERTISES and never what it IS. The compact form rides the timed
+                # poll; the module list is on /api/version with the ledger, for the
+                # reason stated there.
+                "build": provenance.summary()}
 
     @app.get("/api/version")
     def api_version(extension_version: str | None = None):
@@ -1699,9 +1718,17 @@ def create_app(
         try:
             # An absent or empty parameter is "the caller did not say", which is
             # a different answer from "the caller said something unreadable".
-            return version_report(extension_version or None)
+            report = version_report(extension_version or None)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc))
+        # WHAT THIS ENGINE IS, beside what it advertises. Every number above is a
+        # declaration read out of `scrapex/version.py`; this is the only field on
+        # either endpoint that is MEASURED from the running process. It carries the
+        # changed-module list that `/api/health` deliberately leaves out, because
+        # this endpoint is fetched once rather than polled — the same split the
+        # capability ledger already makes.
+        report["provenance"] = provenance.report()
+        return report
 
     @app.get("/api/features")
     def api_features():
@@ -3468,6 +3495,13 @@ def create_app(
             "notices": list(r.notices),
         }
 
+    # WHICH CODE IS THIS PROCESS RUNNING? Sealed HERE, on the last line before the
+    # app is handed to the server, because this is the moment every module the
+    # engine will serve with has been imported and none of them can have changed
+    # yet. Sealing earlier misses `webui.app` itself — the module the incident of
+    # 2026-08-23 was actually about; sealing later takes the baseline after the
+    # edit it exists to notice. See `scrapex/provenance.py`.
+    provenance.seal()
     return app
 
 

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -3739,6 +3739,66 @@ def test_the_engine_page_reports_what_is_installed_and_what_is_available(open_pa
     assert "No engine has been released yet" in text_of(page, "#engine-latest-detail")
 
 
+def test_the_build_row_tells_a_stale_engine_from_a_current_one(open_panel):
+    """THE 2026-08-23 INCIDENT, RENDERED ON THE SCREEN HE ACTUALLY READS.
+
+    "Installed version 0.3.0" was true of three different things, and the owner
+    met the worst one: a process still serving the tree it imported at 07:35:44
+    while the checkout moved on at 07:39:03. His panel told him a 17,304-row
+    dataset had never been crawled and nothing anywhere said a restart was owed.
+
+    Driven through the real health payload rather than by calling the renderer,
+    because the defect was never in a function — it was that the fact never left
+    the engine and never reached a row. Four states, and the assertion that
+    matters most is the NEGATIVE one: a level engine must show no badge, or the
+    badge becomes furniture and stops being read.
+    """
+    level = open_panel()
+    level.click("#tab-engines")
+    open_engine(level)
+    assert "source" in text_of(level, "#engine-build-value")
+    assert "d10e974" in text_of(level, "#engine-build-value")
+    assert level.locator("#engine-build-verdict").is_visible() is False, (
+        "a level engine wore a badge; a badge that is always there is one the "
+        "owner learns to scroll past")
+
+    stale = open_panel(engine_build={
+        "mode": "source", "sealed_at": "2026-08-23T04:35:44+00:00",
+        "commit": "451468dcb42b3981de11c4793074a4bcadacf14d",
+        "commit_now": "31c369e409037f823068c681ef721d82e61f7087",
+        "moved": True, "stale": True,
+        "detail": "the code this engine is running is not the code on disk — "
+                  "1 loaded module(s) changed since it started. Restart the "
+                  "engine to pick the new code up."})
+    stale.click("#tab-engines")
+    open_engine(stale)
+    assert text_of(stale, "#engine-build-verdict") == "Restart needed"
+    assert "451468d" in text_of(stale, "#engine-build-value"), (
+        "the row must name the commit the process is RUNNING, not the one on "
+        "disk — that is the difference the owner could not see")
+    assert "Restart" in text_of(stale, "#engine-build-detail")
+
+    # AN INSTALLED BUILD CANNOT KNOW, and must not be dressed as though it did.
+    frozen = open_panel(engine_build={
+        "mode": "frozen", "sealed_at": "2026-08-23T04:00:00+00:00",
+        "commit": None, "commit_now": None, "moved": None, "stale": None,
+        "detail": "this is an installed build; it carries no source tree to "
+                  "compare against, so whether newer code exists on disk "
+                  "cannot be answered from inside it."})
+    frozen.click("#tab-engines")
+    open_engine(frozen)
+    assert text_of(frozen, "#engine-build-value") == "installed build"
+    assert frozen.locator("#engine-build-verdict").is_visible() is False
+
+    # AN ENGINE FROM BEFORE THE FIELD EXISTED IS NOT AN ENGINE IN TROUBLE — the
+    # same treatment the Protocol row already gives a version it was not told.
+    old = open_panel(engine_build=False)
+    old.click("#tab-engines")
+    open_engine(old)
+    assert text_of(old, "#engine-build-value") == "Not reported"
+    assert old.locator("#engine-build-verdict").is_visible() is False
+
+
 def test_the_latest_row_never_contradicts_the_sentence_under_it(open_panel):
     """THE GENERAL FORM OF THE DEFECT ABOVE, so it cannot come back in another
     state. The reader distinguishes four outcomes; the row is allowed to
@@ -4620,7 +4680,8 @@ def test_every_documented_candidate_backend_is_offered_and_none_pretends_to_inst
     assert "AGPL-3.0" in text_of(page, "#engine-licence")
     assert "scraping" in text_of(page, "#engine-role").lower()
     for hidden in ("#engine-detail-actions", "#engine-action-list",
-                   "#engine-spec-installed", "#engine-spec-latest",
+                   "#engine-spec-installed", "#engine-spec-build",
+                   "#engine-spec-latest",
                    "#engine-spec-protocol", "#engine-spec-power",
                    "#engine-install-steps"):
         assert not page.locator(hidden).is_visible(), (

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -140,9 +140,9 @@ PINNED = (
     ("docs/STATE.md", "scrapex/features.py", 65, "True"),
     # B2 step 2 -- "do not write a second one". The instruction is to EXTRACT
     # these two, so a reader sent to the wrong line writes the duplicate instead.
-    ("docs/STATE.md", "extension/app.js", 1594, "async function loadSourceColumns("),
-    ("docs/APPROACHES.md", "extension/app.js", 1594, "async function loadSourceColumns("),
-    ("docs/APPROACHES.md", "extension/app.js", 1633, "async function saveSourceColumns("),
+    ("docs/STATE.md", "extension/app.js", 1602, "async function loadSourceColumns("),
+    ("docs/APPROACHES.md", "extension/app.js", 1602, "async function loadSourceColumns("),
+    ("docs/APPROACHES.md", "extension/app.js", 1641, "async function saveSourceColumns("),
     # The guards the documents claim exist. A rule that cites a dead guard is a
     # rule with nothing behind it -- which is how W4 came to be believed.
     ("docs/RULINGS.md", "tests/test_version.py", 536,
@@ -169,7 +169,7 @@ PINNED = (
     ("docs/BACKLOG.md", "scrapex/webui/app.py", 2722, "def _about("),
     ("docs/BACKLOG.md", "scrapex/webui/templates/settings.html", 162, "about.worker_alive"),
     # BV-3's chain, end to end: the panel posts it, capture reads it.
-    ("docs/BACKLOG.md", "extension/app.js", 840, "crawl_honour_delay:"),
+    ("docs/BACKLOG.md", "extension/app.js", 848, "crawl_honour_delay:"),
     ("docs/BACKLOG.md", "scrapex/capture.py", 95, "crawl_honour_delay"),
     # OP-21 · the resume that saves the write and none of the requests. This is a
     # citation of a DEFECT at an exact line, so it is the kind that must not drift:
@@ -201,7 +201,7 @@ PINNED = (
     # is refusing to start for a nameable reason. The entry's argument is that this
     # exact branch is the one a schema-ahead warehouse lands in, so a reader sent
     # to the wrong line reads the timeout branch and concludes the entry is wrong.
-    ("docs/BACKLOG.md", "extension/app.js", 3416, 'text: "Not detected"'),
+    ("docs/BACKLOG.md", "extension/app.js", 3424, 'text: "Not detected"'),
     # OP-34 · why a black window leaves no trace. The whole finding is that this
     # function DELIBERATELY does nothing when it has real streams, which is the
     # double-click case -- so the log is not evidence about a failed launch.
@@ -289,7 +289,7 @@ PINNED = (
     # agree and the release simply was not cut, so a reader sent to the wrong line
     # on any one of them would go hunting for a defect that is not there.
     ("docs/BACKLOG.md", "extension/releases.js", 32, "ScrapeX/json/version.json"),
-    ("docs/BACKLOG.md", "extension/app.js", 3514, "latest.version"),
+    ("docs/BACKLOG.md", "extension/app.js", 3570, "latest.version"),
     # 379, and it was 352, and 344 before that. Twice now the same pull request
     # has added comment lines above it and had to correct the number it had just
     # written down — the guard catching its author, in the exact shape LESSONS §7
@@ -343,9 +343,9 @@ PINNED = (
     # all four of `OP-46`'s citations into it still name their symbols after #258 moved
     # that file. The remaining five citations in that entry stay unpinned on purpose --
     # they are the measured numbers, not the two symbols the argument rests on.
-    ("docs/BACKLOG.md", "extension/app.js", 956,
+    ("docs/BACKLOG.md", "extension/app.js", 964,
      "function setupFinanceConverterSelect("),
-    ("docs/BACKLOG.md", "extension/app.js", 2008, "function setupRunModeSelect("),
+    ("docs/BACKLOG.md", "extension/app.js", 2016, "function setupRunModeSelect("),
 )
 
 # A guard that can be emptied without anyone noticing is the defect -- SR-23, and

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -130,10 +130,10 @@ PINNED = (
     # The version-gate blocker. Track 3 of STATE.md cannot be worked without
     # these three, and two of them are the citations that drifted.
     ("docs/STATE.md", "scrapex/version.py", 483, '"latest_extension_version": VERSION'),
-    ("docs/STATE.md", "scrapex/webui/app.py", 1662, '"latest_extension_version": VERSION'),
-    ("docs/STATE.md", "extension/app.js", 599, "latest_extension_version"),
+    ("docs/STATE.md", "scrapex/webui/app.py", 1671, '"latest_extension_version": VERSION'),
+    ("docs/STATE.md", "extension/app.js", 607, "latest_extension_version"),
     ("docs/STATE.md", "scrapex/version.py", 76, 'VERSION = "'),
-    ("docs/RULINGS.md", "scrapex/webui/app.py", 1662, '"latest_extension_version": VERSION'),
+    ("docs/RULINGS.md", "scrapex/webui/app.py", 1671, '"latest_extension_version": VERSION'),
     ("docs/RULINGS.md", "scrapex/version.py", 483, '"latest_extension_version": VERSION'),
     # The two flags whose condition is met and whose lighting is the owner's call.
     ("docs/STATE.md", "scrapex/features.py", 54, "True"),
@@ -165,8 +165,8 @@ PINNED = (
     # this branch said 1673/2666, and the answer after both diffs is neither. That is
     # the case for reading over resolving: taking either side of the conflict would
     # have produced a confidently wrong pin.
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1673, '"worker_alive"'),
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2722, "def _about("),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1682, '"worker_alive"'),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2749, "def _about("),
     ("docs/BACKLOG.md", "scrapex/webui/templates/settings.html", 162, "about.worker_alive"),
     # BV-3's chain, end to end: the panel posts it, capture reads it.
     ("docs/BACKLOG.md", "extension/app.js", 848, "crawl_honour_delay:"),
@@ -238,9 +238,9 @@ PINNED = (
     # than being loosened to keep passing — the same call `OP-36` records above.
     # `return ""` for a dataset is what OP-42 was about; the pin follows the
     # argument to the filter that replaced it.
-    ("docs/BACKLOG.md", "extension/app.js", 4655,
+    ("docs/BACKLOG.md", "extension/app.js", 4719,
      "SOURCE_ACTIONS.filter((item) => item.proof === RESOLVES_A_DATASET)"),
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 697, '"kind": "dataset",'),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 706, '"kind": "dataset",'),
     # 2710 -> 2725 -> 2787 -> 2911, and the fourth move is the same story as the
     # first three.
     # #252 measured this line on `main` at 4615a14, #251 landed first and added 15
@@ -257,8 +257,8 @@ PINNED = (
     # 404 for anything else" -- and only reading the enclosing function separates
     # them. A delta applied to the old number would have picked the right line here
     # by luck and the wrong one the first time the two moved apart.
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2967, "if source_key not in known:"),
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1167,
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2994, "if source_key not in known:"),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1176,
      "A GENERIC DATASET IS A TABLE LIKE ANY OTHER TABLE"),
     # OP-44 · the dataset card that said "no successful crawl yet" over 17,304
     # crawled rows. Four citations carry the whole argument, and a reader sent one
@@ -267,7 +267,7 @@ PINNED = (
     # The sentence itself, so it is clear the card reads a MISSING key and not a
     # missing crawl -- which is why writing a `crawl_run` row would not have moved
     # this line at all.
-    ("docs/BACKLOG.md", "extension/app.js", 4549, "const last = s.last_success;"),
+    ("docs/BACKLOG.md", "extension/app.js", 4613, "const last = s.last_success;"),
     # Why the row could not honestly be written: the column is NOT NULL into
     # source_site, and muqawil is in site_profile.
     ("docs/BACKLOG.md", "db/engine/schema.sql", 122,

--- a/tests/test_the_engine_knows_which_code_it_is_running.py
+++ b/tests/test_the_engine_knows_which_code_it_is_running.py
@@ -1,0 +1,530 @@
+"""A running engine must be able to say that the disk has moved past it.
+
+THE INCIDENT, MEASURED 2026-08-23, and every number here was re-derived from this
+repository rather than remembered:
+
+    the engine answering 127.0.0.1:8000 started        07:35:44
+    the checkout moved 451468d -> 31c369e at           07:39:03  (reflog)
+    delta                                              +199 seconds
+
+The owner's panel said "no successful crawl yet" over 17,304 crawled rows. #255
+(`bcb8f6e`) had fixed exactly that two days earlier and the fix was on `main`. Run
+`git show 451468d:scrapex/webui/app.py` and line 650 of THAT commit still reads
+`"last_success": None` — the literal #255 removed. (Not written as a
+`path:line` citation: on disk today that line is a bare `continue`, so the shape that
+means "current" would send a reader nowhere. `docs/LESSONS.md` §14.) **Python imports
+a module once**, so the process kept serving the tree it had imported while the disk
+went on without it.
+
+AND NOTHING COULD TELL, WHICH IS WHAT THESE TESTS ARE FOR. `/api/health` and
+`/api/version` both answered `"version": "0.3.0"`, truthfully: `git rev-parse
+engine-v0.3.0` is `451468d`. Measured here rather than asserted -- **ten distinct
+commits report `VERSION = "0.3.0"`**, every tree from `e963269` (#247) through
+`31c369e`'s parent (#257), one of them the release tag. A string ten trees share
+cannot name one of them, and it was the only self-description the engine had.
+
+WHY #244's GATE COULD NOT CATCH THIS, since its own title is *"the gate could not
+tell"*. Its gate is a release-workflow step (`.github/workflows/release-engine.yml`,
+*"And it must speak when a person double-clicks it"*) that runs the just-built .exe
+and greps three sentences out of its stdout. The step beside it claims more than it
+can deliver: *"the answer must be the number on the tag -- which also proves the
+binary carries the source that was checked above, and not a stale build."* That is
+true only INSIDE that job, because the binary was built from that checkout seconds
+earlier. Both checks are build-time, one-shot, and their subject is a freshly
+started subprocess. Neither has any representation inside the long-lived process the
+build produces, and `VERSION` cannot distinguish trees anyway. So #244 proved a NEW
+ARTEFACT SPEAKS; it added nothing that lets a RUNNING PROCESS say which bytes it
+loaded.
+
+THE FAILURE FAMILY, recorded in `docs/LESSONS.md` §14: a measurement that outlives
+its base and reads as current. Its other instances are a document, a table, a test
+log and a build. **This one is a live process**, which is why no citation guard could
+have found it: there is no line of prose to check. The check has to live in the
+artefact and answer at run time, which is what `scrapex/provenance.py` does.
+
+WHAT IS PROVED BY CONSTRUCTION BELOW. `test_a_module_changed_on_disk_after_the_seal_is_reported`
+builds the exact condition -- a module loaded into this process, then rewritten on
+disk -- and requires the report to say so. The honesty tests are the other half:
+a frozen build answers `None` and never `False`, because an installed build cannot
+compare itself to a source tree it does not carry.
+"""
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from scrapex import provenance
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(autouse=True)
+def _restore_snapshot():
+    """Every test seals, so every test must put the process's own seal back.
+
+    Without this, one test's temp-directory snapshot leaks into the next and into
+    any other test in the session that reads `/api/health` -- which would make this
+    file a source of false greens elsewhere, the failure it exists to prevent.
+    """
+    saved = provenance._SNAPSHOT
+    yield
+    provenance._SNAPSHOT = saved
+
+
+def _fake_module(name: str, path: Path) -> types.ModuleType:
+    """A module of the package, loaded, with a real file behind it.
+
+    A REAL ENTRY IN `sys.modules`, because that is the authority `provenance`
+    reads and a stub that only looked like one would prove nothing about the
+    mechanism. Registered under the package's own namespace so it is in scope.
+    """
+    module = types.ModuleType(name)
+    module.__file__ = str(path)
+    return module
+
+
+@pytest.fixture
+def loaded(tmp_path, monkeypatch):
+    """A package directory with one loaded module in it, and a clean seal.
+
+    `_package_root` is redirected at `tmp_path` so the test owns every file it
+    measures. Editing a real `scrapex/*.py` to prove staleness would work and would
+    also be a test that writes into the checkout it is running from.
+    """
+    pkg = tmp_path / "scrapex"
+    pkg.mkdir()
+    target = pkg / "webui_app.py"
+    target.write_text("VALUE = 1\n", encoding="utf-8")
+    monkeypatch.setattr(provenance, "_package_root", lambda: pkg)
+    name = "scrapex.__provtest_app"
+    monkeypatch.setitem(sys.modules, name, _fake_module(name, target))
+    provenance._SNAPSHOT = provenance._Snapshot()
+    provenance.seal()
+    return types.SimpleNamespace(pkg=pkg, target=target, name=name)
+
+
+# ---- the defect itself ------------------------------------------------------
+
+def test_a_clean_source_run_reports_level_and_says_so(loaded):
+    """THE CONTROL, and it is not decoration: it is what makes the next test mean
+    something. A report that said `stale` on an untouched tree would fire on every
+    engine always, and a warning that is always on is one the owner learns to
+    scroll past."""
+    report = provenance.report()
+
+    assert report["mode"] == "source"
+    assert report["stale"] is False
+    assert report["changed"] == []
+    assert report["sealed_at"] is not None
+    assert "level with the code on disk" in report["detail"]
+
+
+def test_a_module_changed_on_disk_after_the_seal_is_reported(loaded):
+    """THE 2026-08-23 DEFECT, BUILT RATHER THAN DESCRIBED.
+
+    The module stays exactly as it was imported -- nothing reloads it, which is the
+    whole point -- and only the file underneath it changes. That is precisely what
+    happened at 07:39:03 to a process that had started at 07:35:44.
+    """
+    loaded.target.write_text("VALUE = 2   # the fix the process never saw\n",
+                             encoding="utf-8")
+
+    report = provenance.report()
+
+    assert report["stale"] is True, (
+        "a loaded module was rewritten on disk and the engine reported itself "
+        "current -- this is the incident, and the guard did not see it")
+    assert loaded.name in report["changed"]
+    assert "not the code on disk" in report["detail"]
+    assert "Restart" in report["detail"], (
+        "the report names the fault and must also name the remedy: the engine "
+        "already has POST /api/engine/restart and nothing pointed at it")
+
+
+def test_a_module_deleted_under_a_running_engine_is_a_divergence_too(loaded):
+    """A file that is gone is not a file that agrees. `stat()` raising is the one
+    branch where the cheap check cannot fall through to the digest, so it is stated
+    rather than left to the `except`."""
+    loaded.target.unlink()
+
+    report = provenance.report()
+
+    assert report["stale"] is True
+    assert loaded.name in report["changed"]
+
+
+def test_a_file_rewritten_to_the_same_content_is_not_a_reason_to_restart(loaded):
+    """THE CRY-WOLF CASE, and it is why the digest exists at all.
+
+    `git checkout` and `git pull` rewrite mtimes. On the owner's machine, which is
+    the machine sessions pull into all day, an mtime-only check would raise
+    "Restart needed" over a tree that is byte-identical. The repository has already
+    written down what that costs: *"A publish step that cries wolf gets ignored,
+    which is the exact failure it exists to prevent."*
+    """
+    original = loaded.target.read_bytes()
+    stat = loaded.target.stat()
+    loaded.target.write_bytes(original)
+    import os
+    os.utime(loaded.target, (stat.st_atime + 120, stat.st_mtime + 120))
+    assert loaded.target.stat().st_mtime != stat.st_mtime, \
+        "the fixture failed to move the mtime, so this test proves nothing"
+
+    report = provenance.report()
+
+    assert report["stale"] is False, (
+        f"an untouched file with a new mtime reported as changed: "
+        f"{report['changed']}")
+
+
+def test_the_digest_ignores_the_line_ending_and_nothing_else(tmp_path):
+    """`.gitattributes` sets `* text=auto`, so the repo stores LF and Windows
+    checks out CRLF -- and hashing raw bytes has already shipped as a real outage
+    here (`docs/LESSONS.md` §1). Both reads happen on one machine, so this is
+    belt-and-braces rather than the live bug; it is pinned because a future edit
+    dropping the normalisation would look harmless."""
+    lf = tmp_path / "lf.py"
+    crlf = tmp_path / "crlf.py"
+    lf.write_bytes(b"A = 1\nB = 2\n")
+    crlf.write_bytes(b"A = 1\r\nB = 2\r\n")
+
+    assert provenance._digest(lf) == provenance._digest(crlf)
+    # And it is a real digest of the normalised form, not a constant.
+    assert provenance._digest(lf) == hashlib.sha256(b"A = 1\nB = 2\n").hexdigest()
+
+
+# ---- the honest unknown ----------------------------------------------------
+
+def test_a_frozen_build_answers_unknown_and_never_false(monkeypatch):
+    """AN INSTALLED BUILD CANNOT ANSWER THIS, AND SAYING `False` WOULD BE A GUESS.
+
+    A PyInstaller one-file .exe carries no `.git` and no source tree; its modules
+    live in a per-run temp directory that says nothing about whether newer code
+    exists. `False` there would tell the owner his engine is current on the one
+    build where we cannot know -- a guessed answer is the defect, and this is the
+    assertion that refuses one.
+    """
+    monkeypatch.setattr(provenance.enginelaunch, "frozen", lambda: True)
+    provenance._SNAPSHOT = provenance._Snapshot()
+    provenance.seal()
+
+    report = provenance.report()
+
+    assert report["mode"] == "frozen"
+    assert report["stale"] is None, "a frozen build claimed to know it was current"
+    assert report["stale"] is not False
+    assert report["moved"] is None
+    assert report["commit_now"] is None
+    assert "cannot be answered" in report["detail"]
+
+
+def test_an_engine_that_never_sealed_says_it_does_not_know(monkeypatch):
+    """The mechanism's own failure mode, stated rather than defaulted. If nothing
+    ever called `seal()` the process has no reference point, and `False` would be a
+    claim resting on nothing."""
+    provenance._SNAPSHOT = provenance._Snapshot()
+
+    report = provenance.report()
+
+    assert report["stale"] is None
+    assert report["sealed_at"] is None
+    assert "never recorded which code it loaded" in report["detail"]
+
+
+def test_a_report_that_cannot_be_computed_is_unknown_rather_than_clean(monkeypatch):
+    """`report()` is reached from a timed poll, so it must not raise -- and the
+    swallowed failure must not become a clean bill of health. This is the same rule
+    `/api/health`'s worker block already follows: *"Unknown is now said as unknown,
+    and the reason for not knowing travels with it."*"""
+    def boom() -> dict:
+        raise RuntimeError("the disk went away")
+
+    monkeypatch.setattr(provenance, "_report", boom)
+
+    report = provenance.report()
+
+    assert report["stale"] is None
+    assert report["mode"] == "unknown"
+    assert "the disk went away" in report["detail"]
+
+
+# ---- the git half, which gives the answer words -----------------------------
+
+def _init_repo(path: Path) -> str:
+    """A real repository, because the point is to read what git actually writes.
+
+    A hand-built `.git` would pass whatever `_read_head` happens to do. Two
+    commits so HEAD can move, and `-c` settings so this works on a machine with no
+    global git identity.
+    """
+    def run(*args: str) -> str:
+        return subprocess.run(("git", "-C", str(path), *args), check=True,
+                              capture_output=True, text=True).stdout.strip()
+
+    subprocess.run(("git", "init", "-q", "-b", "main", str(path)), check=True,
+                   capture_output=True)
+    run("config", "user.email", "t@example.com")
+    run("config", "user.name", "t")
+    (path / "one.txt").write_text("1\n", encoding="utf-8")
+    run("add", "one.txt")
+    run("commit", "-q", "-m", "one")
+    return run("rev-parse", "HEAD")
+
+
+@pytest.fixture
+def repo(tmp_path, monkeypatch):
+    pytest.importorskip("subprocess")
+    if not _git_available():
+        pytest.skip("git is not on PATH")
+    work = tmp_path / "checkout"
+    work.mkdir()
+    first = _init_repo(work)
+    pkg = work / "scrapex"
+    pkg.mkdir()
+    monkeypatch.setattr(provenance, "_package_root", lambda: pkg)
+    provenance._SNAPSHOT = provenance._Snapshot()
+    provenance.seal()
+    return types.SimpleNamespace(work=work, pkg=pkg, first=first)
+
+
+def _git_available() -> bool:
+    try:
+        subprocess.run(("git", "--version"), check=True, capture_output=True)
+    except (OSError, subprocess.CalledProcessError):
+        return False
+    return True
+
+
+def test_the_commit_the_process_started_on_is_recorded(repo):
+    report = provenance.report()
+
+    assert report["commit"] == repo.first
+    assert report["commit_now"] == repo.first
+    assert report["moved"] is False
+
+
+def test_a_checkout_that_advanced_under_a_running_engine_is_reported(repo):
+    """THE OTHER HALF OF 07:39:03, and the half that gives the owner words.
+
+    "started at 451468d, the checkout is now 31c369e" is a sentence he can act on;
+    "stale" on its own is not. This fires even when nothing the process imported
+    happened to change, which `stale` cannot see.
+    """
+    (repo.work / "two.txt").write_text("2\n", encoding="utf-8")
+    subprocess.run(("git", "-C", str(repo.work), "add", "two.txt"),
+                   check=True, capture_output=True)
+    subprocess.run(("git", "-C", str(repo.work), "commit", "-q", "-m", "two"),
+                   check=True, capture_output=True)
+    moved_to = subprocess.run(
+        ("git", "-C", str(repo.work), "rev-parse", "HEAD"),
+        check=True, capture_output=True, text=True).stdout.strip()
+    assert moved_to != repo.first, "the fixture did not move HEAD"
+
+    report = provenance.report()
+
+    assert report["moved"] is True
+    assert report["commit"] == repo.first
+    assert report["commit_now"] == moved_to
+    assert "moved to another commit" in report["detail"]
+
+
+def test_an_engine_started_from_a_worktree_can_still_name_its_commit(tmp_path,
+                                                                    monkeypatch):
+    """THE CASE THIS REPOSITORY ACTUALLY RUNS IN, and the one a naive reader of
+    `.git` gets wrong. In a worktree `.git` is a FILE reading `gitdir: <path>`, the
+    branch pointer lives in the SHARED repository, and `commondir` is what joins
+    them. Reading only the worktree's own gitdir reports "no commit" for every
+    session working the way this project works."""
+    if not _git_available():
+        pytest.skip("git is not on PATH")
+    main = tmp_path / "main"
+    main.mkdir()
+    first = _init_repo(main)
+    tree = tmp_path / "wt"
+    subprocess.run(("git", "-C", str(main), "worktree", "add", "-q",
+                    str(tree), "-b", "side"), check=True, capture_output=True)
+    assert (tree / ".git").is_file(), "the fixture did not produce a worktree"
+    pkg = tree / "scrapex"
+    pkg.mkdir()
+    monkeypatch.setattr(provenance, "_package_root", lambda: pkg)
+    provenance._SNAPSHOT = provenance._Snapshot()
+    provenance.seal()
+
+    report = provenance.report()
+
+    assert report["commit"] == first, (
+        "a worktree's HEAD was not readable, so an engine started from one "
+        "cannot name the commit it is running")
+    assert report["moved"] is False
+
+
+def test_no_repository_at_all_is_not_a_reason_to_stop_answering(tmp_path,
+                                                               monkeypatch):
+    """A pip install from a tarball has no `.git` and is still a source run whose
+    modules can go stale. The commit half goes unknown; the staleness half must
+    keep working, because it is the half that proves the fault."""
+    pkg = tmp_path / "nogit" / "scrapex"
+    pkg.mkdir(parents=True)
+    target = pkg / "mod.py"
+    target.write_text("V = 1\n", encoding="utf-8")
+    monkeypatch.setattr(provenance, "_package_root", lambda: pkg)
+    name = "scrapex.__provtest_nogit"
+    monkeypatch.setitem(sys.modules, name, _fake_module(name, target))
+    provenance._SNAPSHOT = provenance._Snapshot()
+    provenance.seal()
+    target.write_text("V = 2\n", encoding="utf-8")
+
+    report = provenance.report()
+
+    assert report["commit"] is None
+    assert report["moved"] is None
+    assert report["stale"] is True, \
+        "the staleness check must not depend on git being present"
+
+
+# ---- reaching the owner ----------------------------------------------------
+
+def test_the_report_only_names_modules_of_this_package(loaded, monkeypatch):
+    """A DISCOVERY PATTERN WHOSE OUTPUT NOBODY READ is a recurring defect here
+    (`docs/LESSONS.md` §7). This prints the boundary rather than trusting it:
+    something loaded from outside the package directory, and something with no
+    file at all, must both be out of scope."""
+    stray = loaded.pkg.parent / "elsewhere.py"
+    stray.write_text("X = 1\n", encoding="utf-8")
+    monkeypatch.setitem(sys.modules, "scrapex.__provtest_outside",
+                        _fake_module("scrapex.__provtest_outside", stray))
+    nofile = types.ModuleType("scrapex.__provtest_nofile")
+    monkeypatch.setitem(sys.modules, "scrapex.__provtest_nofile", nofile)
+    monkeypatch.setitem(sys.modules, "not_scrapex_at_all",
+                        _fake_module("not_scrapex_at_all", loaded.target))
+
+    provenance._SNAPSHOT = provenance._Snapshot()
+    provenance.seal()
+    seen = sorted(provenance._SNAPSHOT.loaded)
+
+    assert seen == [loaded.name], seen
+
+
+def test_the_summary_for_the_timed_poll_carries_no_growing_list(loaded):
+    """`/api/health` is polled every few seconds behind a 2,500 ms deadline that
+    this product has already blown once. The verdict rides the poll; the evidence
+    does not."""
+    loaded.target.write_text("V = 2\n", encoding="utf-8")
+
+    summary = provenance.summary()
+
+    assert "changed" not in summary
+    assert summary["stale"] is True
+    assert set(summary) == {"mode", "sealed_at", "commit", "commit_now",
+                            "moved", "stale", "detail"}
+
+
+def test_the_named_list_is_capped(loaded, monkeypatch):
+    """Evidence, not a work queue: the remedy is one restart whether one module
+    moved or forty, and `/api/version` is JSON somebody has to read."""
+    fake = {f"scrapex.m{i}": (loaded.target, 0.0, 0, "nope")
+            for i in range(provenance.NAMED_LIMIT + 5)}
+    monkeypatch.setattr(provenance._SNAPSHOT, "loaded", fake)
+
+    report = provenance.report()
+
+    assert report["stale"] is True
+    assert len(report["changed"]) == provenance.NAMED_LIMIT
+
+
+# ---- and it reaches the wire ------------------------------------------------
+
+def test_the_two_endpoints_carry_it(tmp_path):
+    """THE FACT MUST LEAVE THE PROCESS, or it is a test talking to itself.
+
+    `/api/health` is the only endpoint the panel polls on a timer, which is why
+    `REQ-35` asks for one field on it. `/api/version` carries the module list
+    because it is fetched once.
+    """
+    pytest.importorskip("fastapi", reason="needs the ui extra")
+    from fastapi.testclient import TestClient
+
+    from scrapex.databases import DatabaseRegistry
+    from scrapex.databases.domain import EngineDatabase
+    from scrapex.webui.app import create_app
+
+    registry = DatabaseRegistry(
+        EngineDatabase(tmp_path / "marketlens" / "scrapex-engine.db"),
+        pointer_file=tmp_path / "databases.json")
+    registry.initialize()
+    client = TestClient(create_app(databases=registry))
+
+    health = client.get("/api/health").json()
+    assert "build" in health, (
+        "the panel polls this and nothing else on a timer; a fact that is not "
+        "here reaches the owner only if he goes looking for it")
+    assert health["build"]["mode"] in ("source", "frozen", "unknown")
+    assert "changed" not in health["build"]
+
+    version = client.get("/api/version").json()
+    assert "provenance" in version
+    assert "changed" in version["provenance"]
+    # `create_app` seals on its last line, so a real client has a real reference
+    # point. An endpoint answering `sealed_at: null` means that call was dropped.
+    assert version["provenance"]["sealed_at"] is not None, \
+        "create_app did not seal, so the engine cannot answer for itself"
+
+
+def test_the_seal_happens_on_the_apps_last_line():
+    """WHERE IT IS SEALED IS THE DESIGN, so it is pinned rather than left to a
+    comment. Sealing earlier misses `webui.app` -- the module the incident was
+    about. Sealing lazily takes the baseline AFTER the edit it exists to notice,
+    which is worse than not checking at all.
+
+    IT READS `create_app`, NOT THE FILE. The first draft of this test asserted on
+    the last two lines of `app.py` and failed on correct code, because `app.py`
+    carries module-level helpers after the factory. A guard pointed at the wrong
+    subject is the defect this repository keeps recording; the function is the
+    subject, so `inspect` is what finds it.
+    """
+    pytest.importorskip("fastapi", reason="needs the ui extra")
+    import inspect
+
+    from scrapex.webui.app import create_app
+
+    tail = inspect.getsource(create_app).rstrip().splitlines()[-2:]
+
+    assert any("provenance.seal()" in line for line in tail), (
+        "create_app must seal on its last lines, after every module it serves "
+        f"with is imported. Its tail is: {tail}")
+
+
+def test_the_version_string_cannot_do_this_job(loaded):
+    """THE MEASUREMENT THAT JUSTIFIES THE WHOLE MODULE, kept as a test so nobody
+    proposes deleting it in favour of `VERSION`.
+
+    `R-35` moves the engine's number on a CONTRACT change, so many trees share one
+    number BY DESIGN. Ten commits report `0.3.0` -- `e963269` through `31c369e`'s
+    parent -- and one of them is the `engine-v0.3.0` tag. Counted from git here
+    rather than written down, so it cannot go stale the way the thing it describes
+    did.
+    """
+    if not _git_available():
+        pytest.skip("git is not on PATH")
+    shown = subprocess.run(
+        ("git", "-C", str(ROOT), "rev-list", "--count", "e963269^..31c369e^"),
+        capture_output=True, text=True)
+    if shown.returncode != 0:
+        pytest.skip("this history is not present in a shallow clone")
+
+    trees = int(shown.stdout.strip())
+
+    assert trees > 1, (
+        "if one tree per version were true, a version string would have been "
+        "enough and this module would be unnecessary")
+    tagged = subprocess.run(
+        ("git", "-C", str(ROOT), "rev-parse", "engine-v0.3.0^{commit}"),
+        capture_output=True, text=True)
+    if tagged.returncode == 0:
+        assert tagged.stdout.strip().startswith("451468d"), \
+            "engine-v0.3.0 is not the commit this file's account rests on"

--- a/tests/test_the_engine_knows_which_code_it_is_running.py
+++ b/tests/test_the_engine_knows_which_code_it_is_running.py
@@ -158,6 +158,62 @@ def test_a_module_deleted_under_a_running_engine_is_a_divergence_too(loaded):
     assert loaded.name in report["changed"]
 
 
+def test_a_module_imported_after_the_seal_is_not_a_blind_spot(loaded):
+    """THE GAP `seal()` HAS BY CONSTRUCTION, and it had to be closed rather than
+    documented.
+
+    This repository imports modules inside route handlers, so a module can first be
+    loaded while serving a request — long after the reference point. It is therefore
+    absent from the snapshot, and the comparison loop cannot see it at all. If that
+    file was written AFTER the process sealed, the process is running a mix of pre-
+    and post-edit code, which is worse than being uniformly behind.
+
+    Found by asking what the mechanism does not cover, not by a failure. A guard
+    that does not know its own blind spot is the defect this module exists for.
+    """
+    late = loaded.pkg / "late.py"
+    late.write_text("LATE = 1\n", encoding="utf-8")
+    import os
+    os.utime(late, (_SEAL_PLUS, _SEAL_PLUS))       # written after we sealed
+    name = "scrapex.__provtest_late"
+    sys.modules[name] = _fake_module(name, late)
+    try:
+        report = provenance.report()
+    finally:
+        del sys.modules[name]
+
+    assert report["stale"] is True, (
+        "a module imported after the seal, from a file written after the seal, "
+        "was invisible — the snapshot cannot hold it, so the check must look")
+    assert name in report["changed"]
+
+
+#: Comfortably after any `sealed_at` this file produces, and computed from the
+#: clock rather than hard-coded so it cannot drift into the past.
+_SEAL_PLUS = __import__("time").time() + 3600
+
+
+def test_a_module_imported_after_the_seal_from_older_code_is_not_stale(loaded):
+    """THE OTHER HALF, and it is what stops the check above crying wolf. A module
+    the process imports late from a file that has NOT been touched since the seal is
+    ordinary lazy importing, which happens on most requests. Only a file written
+    after the reference point proves a mixed state."""
+    late = loaded.pkg / "old_late.py"
+    late.write_text("OLD = 1\n", encoding="utf-8")
+    import os
+    os.utime(late, (1_600_000_000, 1_600_000_000))   # long before the seal
+    name = "scrapex.__provtest_oldlate"
+    sys.modules[name] = _fake_module(name, late)
+    try:
+        report = provenance.report()
+    finally:
+        del sys.modules[name]
+
+    assert report["stale"] is False, (
+        f"ordinary lazy importing was reported as a reason to restart: "
+        f"{report['changed']}")
+
+
 def test_a_file_rewritten_to_the_same_content_is_not_a_reason_to_restart(loaded):
     """THE CRY-WOLF CASE, and it is why the digest exists at all.
 

--- a/tests/test_the_engine_knows_which_code_it_is_running.py
+++ b/tests/test_the_engine_knows_which_code_it_is_running.py
@@ -174,7 +174,14 @@ def test_a_module_imported_after_the_seal_is_not_a_blind_spot(loaded):
     late = loaded.pkg / "late.py"
     late.write_text("LATE = 1\n", encoding="utf-8")
     import os
-    os.utime(late, (_SEAL_PLUS, _SEAL_PLUS))       # written after we sealed
+    # RELATIVE TO THE SEAL THIS TEST JUST TOOK, never to a module-level constant.
+    # The first draft used `time.time() + 3600` computed at IMPORT, which is a flake
+    # waiting for a slow suite: collection happens once and this test runs much
+    # later, so a run that took over an hour to reach here would be comparing
+    # against a moment already in the past. That is a measurement outliving its
+    # base -- in the test file whose whole subject is that failure.
+    after_seal = provenance._SNAPSHOT.sealed_at + 60
+    os.utime(late, (after_seal, after_seal))
     name = "scrapex.__provtest_late"
     sys.modules[name] = _fake_module(name, late)
     try:
@@ -186,11 +193,6 @@ def test_a_module_imported_after_the_seal_is_not_a_blind_spot(loaded):
         "a module imported after the seal, from a file written after the seal, "
         "was invisible — the snapshot cannot hold it, so the check must look")
     assert name in report["changed"]
-
-
-#: Comfortably after any `sealed_at` this file produces, and computed from the
-#: clock rather than hard-coded so it cannot drift into the past.
-_SEAL_PLUS = __import__("time").time() + 3600
 
 
 def test_a_module_imported_after_the_seal_from_older_code_is_not_stale(loaded):

--- a/tests/test_the_registers_cannot_collide.py
+++ b/tests/test_the_registers_cannot_collide.py
@@ -167,6 +167,13 @@ RESERVED: dict[str, dict[int, str]] = {
     # Each row is deleted by whichever pull request follows its holder's merge, per the
     # rule above — NOT by this branch, which merges before both and would otherwise leave
     # a real hole undeclared.
+    # 60 AND 61 WERE HERE AND ARE NOT ANY MORE. #265 created both rows, naming this
+    # very branch as their holder, and #265 has merged — so by this file's own rule
+    # ("delete a row the moment its PR lands... unless the branch that fills the
+    # number has already merged") the branch that FILLS them deletes them, which is
+    # this one. `OP-60` and `OP-61` are now DECLARED in docs/BACKLOG.md, and a number
+    # that is reserved AND declared fails test_a_reserved_number_is_not_also_declared.
+    # Nothing else was touched.
     "OP": {
         45: "branch claude/drive-without-a-server",
         # 49 AND 50 ARE NEW ON THIS BRANCH AND NOT NEW IN THE WORLD. The Drive
@@ -177,70 +184,6 @@ RESERVED: dict[str, dict[int, str]] = {
         # request that follows the Drive branch removes all three together.
         49: "branch claude/drive-without-a-server",
         50: "branch claude/drive-without-a-server",
-        # 60, 61 AND 62 ARE THIS BRANCH'S HOLES, created when it took `OP-63` after
-        # #261 declared 53..59. Two of the three name a ref because a SWEEP found
-        # them, and that sweep is the point of this comment.
-        #
-        # THE PRIMARY HANDED OUT TWO COLLIDING NUMBERS IN ONE DAY — 60, then 61 —
-        # and said so, from the session that owns `ORCHESTRATION.md` §3. Its tables
-        # covered the branches it knew about; this branch was in neither. What found
-        # the second collision was a third session sweeping the highest declared
-        # `OP` across EVERY ref instead of across a named list:
-        #
-        #   git for-each-ref --format='%(refname:short)' refs/remotes/origin \
-        #     | while read -r r; do git show "$r:docs/BACKLOG.md" 2>/dev/null \
-        #       | grep -oE '^#{2,4} +OP-[0-9]+'; done | sort -u
-        #
-        # RUN INDEPENDENTLY HERE BEFORE ACCEPTING 63, and it confirmed the handover
-        # rather than resting on it: `feat/the-engine-knows-which-code-it-is-running`
-        # declares BOTH 60 and 61 on `origin`, and no ref anywhere declares 62 or 63.
-        # **A number you were handed is provisional until you have swept for it** —
-        # which is §3's "an unpushed claim is invisible and still real" arriving from
-        # the other direction: a PUSHED claim is visible and still missed, if you look
-        # at a list of branches instead of at all of them.
-        # 62 IS THE WEAK ROW AND SAYS SO. A third session holds it on the primary's
-        # word and **no ref carries it** — the sweep above found nothing above 61
-        # anywhere. So this row cannot name the branch §3 requires, and inventing one
-        # would be worse than admitting the gap. It carries an action rather than a
-        # claim: replace it with the ref the moment that holder pushes, or delete it
-        # if 62 turns out free. Do not leave it standing on a session that has ended
-        # — that is the wart the paragraph above this dict was written about, and it
-        # passed every guard the whole time it was wrong.
-        #
-        # AND 62 IS NOT RESERVED HERE. It was this branch's third hole, and
-        # #265 has since MERGED it — `OP-62 · The published engine could not
-        # serve one page` is declared on `main`. A row for a declared number
-        # fails `test_a_reserved_number_is_not_also_declared`, and this file's
-        # own rule says delete a row the moment its pull request lands.
-        # 60 AND 61, HELD ELSEWHERE, AND THIS BRANCH LANDS `OP-62` OVER THEM. Both
-        # are declared on `feat/the-engine-knows-which-code-it-is-running`, pushed:
-        # `OP-60 · A frozen engine cannot name the commit it was built from` and
-        # `OP-61 · A continuation citation is invisible to the citation guard`. Read
-        # them back with
-        #   git grep -E "^#{2,4} +OP-"         #     origin/feat/the-engine-knows-which-code-it-is-running -- docs/BACKLOG.md
-        #
-        # 60 WAS HANDED TO THIS BRANCH AS FREE, twice, by a session that had checked
-        # `main` and not the branches in flight. `main` really does run unbroken to 59
-        # -- the number was gone in a place `main` cannot see, which is the entire
-        # reason §3 of ORCHESTRATION.md says a claim can be real and invisible.
-        60: "branch feat/the-engine-knows-which-code-it-is-running",
-        # 61 WAS A DUPLICATE AND HAS BEEN RULED, TO THIS HOLDER.
-        # `fix/one-card-per-site-and-an-honest-noun` declared its own `OP-61 · The
-        # word "products" over a contractor directory` and was told to move to 63.
-        # The ruling went to the lower-churn branch rather than to precedence, and
-        # the primary session said so instead of letting the open-PR rule pretend to
-        # decide it.
-        #
-        # AT THE MOMENT THIS ROW WAS WRITTEN THE RENUMBER HAD NOT LANDED: `origin/
-        # fix/one-card-per-site-and-an-honest-noun` still declared 61, so a reader
-        # grepping the refs would find TWO holders and think this row wrong. It is
-        # recorded rather than smoothed over, because this file's own scar is a row
-        # that named a holder who had moved and passed every guard while doing it.
-        # THE 63 IS NOW PUSHED — `origin/fix/one-card-per-site-and-an-honest-noun`
-        # declares `OP-63` and no ref declares its old 61 — so the parenthetical this
-        # row carried has been deleted exactly as the line above instructed, and
-        # nothing else with it. The row now names one holder a reader can check.
-        61: "branch feat/the-engine-knows-which-code-it-is-running",
     },
     "DEC": {},
 }

--- a/tools/panel_harness.py
+++ b/tools/panel_harness.py
@@ -109,7 +109,7 @@ def stub(backend: str = DEFAULT_BACKEND, *, engine_up=True, sources=None, jobs=N
          native_mode="absent", google_account_mode="ok",
          remembered_accounts=None, drive=None,
          silent_for=None, revoke_status=200,
-         worker_alive=True) -> str:
+         worker_alive=True, engine_build=None) -> str:
     """A chrome.* shim plus a fetch() interceptor.
 
     Any state can be rendered deterministically, including ones a live engine
@@ -151,14 +151,31 @@ def stub(backend: str = DEFAULT_BACKEND, *, engine_up=True, sources=None, jobs=N
         (EXT / "manifest.json").read_text(encoding="utf-8"))["version"]
     extension_version = manifest_version if extension_version is None else extension_version
     engine_version = VERSION if engine_version is None else engine_version
+    # `engine_build` is the sixth knob. None means "what a live engine says today":
+    # a source run, level with the disk — which is the truth on the owner's machine
+    # whenever he has just restarted, and the state that must render as no badge at
+    # all. `False` REMOVES the key, which is an engine built before the field
+    # existed and is not a fault. A dict overrides it outright, which is how the
+    # stale and moved states are rendered: they cannot be produced from a live
+    # engine on demand, which is the whole reason this harness exists.
+    build = {"mode": "source", "sealed_at": "2026-08-23T05:00:00+00:00",
+             "commit": "d10e974f97cb65103df74e470f3821af32b78002",
+             "commit_now": "d10e974f97cb65103df74e470f3821af32b78002",
+             "moved": False, "stale": False,
+             "detail": "running from source, and level with the code on disk."}
+    if isinstance(engine_build, dict):
+        build = engine_build
+    health = {"ok": True, "app": "scrapex", "version": engine_version,
+              "worker_alive": worker_alive,
+              "latest_extension_version": VERSION,
+              "minimum_extension_version": MINIMUM_EXTENSION_VERSION,
+              "protocol_version": PROTOCOL_VERSION if protocol_version is None
+                                  else protocol_version,
+              "sources_with_data": 2}
+    if engine_build is not False:
+        health["build"] = build
     routes = {
-        "/api/health": {"ok": True, "app": "scrapex", "version": engine_version,
-                        "worker_alive": worker_alive,
-                        "latest_extension_version": VERSION,
-                        "minimum_extension_version": MINIMUM_EXTENSION_VERSION,
-                        "protocol_version": PROTOCOL_VERSION if protocol_version is None
-                                            else protocol_version,
-                        "sources_with_data": 2},
+        "/api/health": health,
         "/api/sources": {"sources": STRESS_SOURCES if sources is None else sources},
         "/api/jobs": {"jobs": jobs or []},
         "/api/records": records or {"records": [], "total": 0, "next_cursor": None},


### PR DESCRIPTION
## The incident, re-derived rather than remembered

His panel said **"no successful crawl yet"** over **17,304 rows**. #255 (`bcb8f6e`) had
fixed exactly that two days earlier and the fix was on `main`.

| fact | value | where I read it |
|---|---|---|
| engine process started | **07:35:44** | `Win32_Process.CreationDate` |
| checkout left `451468d` for `31c369e` | **07:39:03** | `.git/logs/HEAD`, epoch `1787459943` |
| delta | **+199 seconds too late** | computed |
| the literal #255 removed, still in the old tree | `"last_success": None` | `git show 451468d:scrapex/webui/app.py`, line 650 of that commit |

**Python imports a module once**, so the process served that tree for as long as it ran.

**And nothing could tell.** `/api/health` and `/api/version` both answered
`"version": "0.3.0"` — truthfully, because `engine-v0.3.0` **is** `451468d`. Measured:
**ten distinct commits report `VERSION = "0.3.0"`** (`e963269` #247 through `31c369e`'s
parent #257). That is `R-35` working as designed — the engine's number moves on a
*contract* change, so many trees share one deliberately. **A string ten trees share
cannot name one of them**, and it was the engine's only self-description.

## What #244's gate actually checks, and why it missed this

First, a correction to the brief: **only one of the three named tests is #244's.**

| test | added by |
|---|---|
| `test_the_frozen_engine_can_start_itself.py` | `afb8648` — **#244** |
| `test_the_release_build_is_not_the_test_build.py` | `756fa39` — #154 |
| `test_the_release_the_documents_ask_for_is_the_one_that_would_run.py` | `5364c82` — #253 |

#244 also added `tests/test_the_release_proves_the_double_click.py`.

**#244's gate is a release-workflow step**, *"And it must speak when a person
double-clicks it"* — it runs the freshly built `.exe` with stdin closed and requires
its stdout to contain `ScrapeX-Engine` and `Preparing your database`. Sound, and it
catches the black window that shipped as `engine-v0.2.1`.

**Why it cannot reach this defect.** The step beside it claims more than it can
deliver: *"the answer must be the number on the tag — which also proves the binary
carries the source that was checked above, and not a stale build."* That is true **only
inside that job**, because the binary was built from that checkout seconds earlier.
Both checks are **build-time, one-shot**, and their subject is a subprocess that has
just started. Neither leaves any representation inside the long-lived process the build
produces — and `VERSION` cannot distinguish trees anyway. **#244 proved a new artefact
speaks; nothing lets a running process say which bytes it loaded.**

> **This is a different failure from the one #244's own title names, and that is the
> point.** #244 is about an artefact **built** before its own fix. This is about an
> artefact **running** after its own fix. The words are nearly the same and the
> instrument required is not: one is answerable at build time by asking the thing you
> just made a question, the other only from inside a process that has been alive for
> hours. **A reader who concludes #244 already covers this will not build what this
> adds** — which is what I concluded myself, until I measured what that gate reads.

## What I built

`scrapex/provenance.py`. The engine seals what it loaded on `create_app`'s last line —
the only moment when every module it will serve with is imported and none can have
changed yet — and compares it against the disk on demand. **Two answers, because they
fail independently:**

- **`stale`** — a loaded module's file no longer matches. Needs no git; works on an
  editable install or a tarball. This is the exact defect.
- **`moved`** — the checkout is on another commit. Gives the answer words a person can
  act on: *started at `451468d`, the checkout is now `31c369e`*.

Neither contains the other: `moved` fires when the checkout advances without touching
anything loaded; `stale` fires with no `.git` reachable at all.

**Two-stage, so a timed poll can afford it.** `stat()` every loaded module; digest only
the ones whose mtime or size moved. So a `git checkout` that rewrites a file to
identical content is **not** a reason to restart — mtime alone would cry wolf on the
machine sessions pull into all day. Digests are newline-normalised (`LESSONS` §1).

    seal()    18.8 ms once, over 74 loaded modules
    report()   1.9 ms per poll, against a 2,500 ms deadline

**A frozen build answers `None`, never `False`.** A one-file `.exe` carries no `.git`
and no source tree; its modules unpack into a per-run temp directory. `False` there
would tell him his engine is current on the one build where nobody can know. Pinned by
`assert report["stale"] is not False`. Same discipline `/api/health`'s worker block
already states: *"Unknown is now said as unknown."* Four honest-unknown branches:
frozen, never-sealed, no-git, and the check itself crashing.

**A blind spot I found in my own mechanism and closed** (2nd commit): `seal()` cannot
hold a module first imported *inside a request handler*, and this repository does that.
If such a file was written after the seal, the process is running a mix of pre- and
post-edit code — worse than being uniformly behind. Now reported; ordinary lazy
importing from an untouched file is not.

### Where he sees it

A **Build** row directly under *Installed version* on the engine detail screen —
because that is the row that could not tell the three states apart, so the
disambiguation belongs beside the number it disambiguates. The badge reuses the
*"Update available"* idiom one row down rather than inventing a surface.

| state | row | badge |
|---|---|---|
| source, level | `source · 199ed28` | none |
| source, loaded code changed | `source · 451468d` | **Restart needed** |
| checkout moved only | `source · …` | Checkout moved |
| installed build | `installed build` | none |
| engine predates the field | `Not reported` | none |

It also joins the **Copy details** block — the line that would have ended this
morning's investigation in one paste.

`badge warn` was written first and would have rendered as the plain grey one: the kit
defines only `badge` / `.ok` / `.off` / `.danger`, so it uses `off`, the amber one.
That is the same failure as the `.notice` class the comment beside it already records.

## REQ-35: partly closed, and its stated cause was wrong

**Verified against the live engine, not taken from the brief:**

| asked | answer |
|---|---|
| `GET /api/health` version | **`"0.3.1"`** — not empty, and never was |
| latency | **486 ms** |
| top-level keys | **11** (the brief said 13), **none stating how the engine was started** |

So REQ-35 is right that the panel has no word for developer mode and right that the
engine knows and is never asked — and **wrong about the mechanism**. `state.engineVersion`
is empty because **no answer has arrived yet**: `setEngineChecking()` renders the spec
rows before the request returns, so *Not detected* appears during **every check window
on a healthy engine**, then is overwritten half a second later.

- **Closed:** the run mode and commit now exist on a polled endpoint and on the card.
  That is REQ-35's substance.
- **Not closed:** the check-window wording. That is a render-ordering defect, not a
  missing field, and fixing it here would have been a second change.

Moved **Captured → In flight**, with the correction recorded beside the original claim
per `C4` rather than replacing it.

## The finding that may be worth more than the feature

**A continuation citation — a bare `` `:NNN` `` inheriting its path from a citation a
few words earlier — is invisible to the citation guard.** `CITATION` requires a path
before the colon: it matches `app.js:1641` and returns `None` for `:1641`.

| | |
|---|---|
| continuation citations in the guarded documents at `f1844af` | **19** |
| of those currently wrong (blank line / past EOF) | **0** |
| moved silently by this branch, guard green throughout | **4** |

**Stated plainly, because the distinction decides whether anyone should act: this is a
latent structural gap, not a live defect.** None of the nineteen is currently wrong,
and the class pre-dates this branch — only the four movements were mine. What this
branch proved is that they *move without anything noticing*: I found them by reading
the diff by hand. `PINNED` cannot help, because tier 1 never discovers the citation, so
there is nothing to pin.

**The remedy avoids the trap this repository keeps meeting.** Inheriting the path from
the nearest preceding citation is *deciding by adjacency*, rejected twice here already.
The non-inferring fix is to **forbid the continuation form** — require every citation to
name its path. Filed as **`OP-61`**, not built: nineteen rewrites across five documents
is its own conflict surface.

There is a *four shapes of a wrong citation* table this would be the fifth row of. It
is **not on `main`** — it lives on `origin/docs/the-boundary-becomes-a-ruling` at
`c6d9212`, unmerged, so I did not cite it as though it were here. (Same reason I cited
`docs/PLATFORM-PLAN.md:9` for *"the only interface"* rather than `R-48`, which also
exists only on that branch.)

## Registers

- **`OP-60`** — a frozen engine cannot name the commit it was built from. The reader is
  built and answers *unknown*; the writer is a build-time stamp, deliberately not done
  because the primary is cutting `engine-v0.3.1` from that same workflow.
- **`OP-61`** — the continuation-citation gap above.
- **`LESSONS` §14** — the family: *a measurement that outlives its base.* Six instances
  tabled, every row re-derived at `f1844af`. **What makes this one different: the
  artefact was a live process, not a document — so no citation guard could reach it.**
  #259 took §13 while my branch was unpushed and invisible, so mine is §14.
  - It also records a **seventh** instance that building the fix produced: my
    after-seal test set its fixture mtime from a module-level `time.time() + 3600`
    evaluated **at collection**, so a run over an hour would have failed on correct
    code. *A measurement outliving its base, inside the file whose subject is
    measurements that outlive their base.* It is the only one of the seven caught by
    its own author before shipping, which is the only reason it is worth a paragraph.
- **`REQ-35`** → In flight. **`STATE.md`** updated.

## The rebases, which are the lesson happening live

Base moved twice under me: `d10e974` → `4522158` (#259) → `f1844af` (#261).

- **18 `PINNED` rows** re-derived **through the `f1844af..HEAD` diff** — computed, never
  typed, because three symbols occur more than once and only the diff disambiguates.
  Both sides of every conflict were wrong for the combined tree, since #261 moved
  `app.py` too; the resolution took the upstream number as the base and recomputed.
- **#261 merged holding `OP-53`..`OP-59`**, two of which I had taken → renumbered to
  60/61, found by grepping the **id** not the subject (`LESSONS` §12). A second
  collision on `OP-60` was then resolved in this branch's favour by the primary: this
  branch is pushed and declared, the sibling was not.
- An automated re-derivation of prose citations **over-reached and corrupted history** —
  it renumbered `app.py:2710` inside the very sentence explaining that 2710 became 2725
  then 2787. Restored by hand; recorded in §14 as the reason a historical line number
  must never be written in the shape that means *current*.

## Verification

**Mutation — 24 of 24 caught.** Control green before *and* after every mutation,
`__pycache__` purged between every run (a byte-identical restore has kept a mutation
alive here before).

### Engine — 16/16

| mutation | guard that caught it |
|---|---|
| M1 the changed file is never noticed | `test_a_module_changed_on_disk_after_the_seal_is_reported` |
| M2 mtime alone decides, no digest confirmation | `test_a_file_rewritten_to_the_same_content_is_not_a_reason_to_restart` |
| M3 a frozen build guesses `False` instead of `None` | `test_a_frozen_build_answers_unknown_and_never_false` |
| M4 an unsealed engine claims to be current | `test_an_engine_that_never_sealed_says_it_does_not_know` |
| M5 a crashed check reports clean | `test_a_report_that_cannot_be_computed_is_unknown_rather_than_clean` |
| M6 the digest hashes raw bytes (CRLF trap) | `test_the_digest_ignores_the_line_ending_and_nothing_else` |
| M7 a worktree's shared ref is unreachable (no `commondir`) | `test_an_engine_started_from_a_worktree_can_still_name_its_commit` |
| M8 the module scan leaves the package | `test_the_report_only_names_modules_of_this_package` |
| M9 the named list is unbounded | `test_the_named_list_is_capped` |
| M10 the timed poll carries the growing list | `test_the_summary_for_the_timed_poll_carries_no_growing_list` |
| M11 `create_app` never seals | `test_the_seal_happens_on_the_apps_last_line` |
| M12 the fact never reaches the panel's poll | `test_the_two_endpoints_carry_it` |
| M13 the checkout moving is not reported | `test_a_checkout_that_advanced_under_a_running_engine_is_reported` |
| M14 a deleted module is treated as agreement | `test_a_module_deleted_under_a_running_engine_is_a_divergence_too` |
| M15 modules imported after the seal are a blind spot | `test_a_module_imported_after_the_seal_is_not_a_blind_spot` |
| M16 ordinary lazy importing is called a reason to restart | `test_a_module_imported_after_the_seal_from_older_code_is_not_stale` |

### Panel — 8/8

All against `test_the_build_row_tells_a_stale_engine_from_a_current_one`, driven through
the real health payload rather than by calling the renderer.

| mutation |
|---|
| P1 the row is never written |
| P2 `engine.js` drops the field on the way in |
| P3 the stale verdict is never raised |
| P4 a frozen build is given a verdict anyway |
| P5 the badge is shown even when there is no verdict |
| P6 an engine that never reported is treated as broken |
| P7 the row names the commit on disk instead of the one running |
| P8 the row is deleted from the markup |

### A red run found a real defect, and my own measuring instrument was unsound

Both halves are recorded because *"the suite was red and I decided it wasn't me"* is
worthless without evidence — and because the way I gathered that evidence was itself
the failure this branch is about.

**What is proven, on its own self-contained measurement.** A run of the 21 failing node
ids, alone, in its own log with its own header: **1 failed, 20 passed.** The one failure
was `test_the_linter_is_actually_installed_and_clean_here`, and `ruff check scrapex/`
invoked directly reports it:

    RUF100 [*] Unused `noqa` directive (non-enabled: `BLE001`)
      --> scrapex\provenance.py:336:52

My new module suppressed `BLE001` on its bare `except Exception`, and `BLE001` is not
enabled for `scrapex/`. I copied the idiom from `packaging/engine_entry.py`, which has
three of them — and the gate runs `ruff check scrapex/` and never looks at
`packaging/`, which is exactly why they survive there and mine did not. After the fix:
*All checks passed*, no warnings. **This finding and its fix do not depend on anything
below.**

**What is NOT proven, and I am withdrawing it.** I reported "267 Playwright errors and
21 failures at `PYTEST_EXIT=1`" as one run's result. **I cannot stand behind the
attribution.** My harness wrote every run to one log path and truncated it on start;
five runs used it and I stopped three of them mid-flight. When I read
`PYTEST_EXIT=1` I did not read the header in the same breath, and a later task
notification reported that run's wrapper exiting **0** — two readings of one path that
cannot both describe the same run. The `ERROR`/`FAILED` text was real pytest output
with real tracebacks, and 267 `sync_playwright().start()` failures are consistent with
the measured load (**two other sessions' suites and 19 chrome processes live**), but
*which* run produced them is no longer recoverable: the history was truncated by the
next run.

**The instrument defect, which is this branch's own subject.** The harness wrote every
run to a fixed path and truncated it on start. Two runs then **overlapped**, so the file
ended up holding two interleaved suites of two different commits and **two
`PYTEST_EXIT` lines** — which is how one path came to give two contradictory answers.
A measurement whose base is overwritten by its successor, and reading the tail without
the header is reading a number without asking what it is a number *about*.

Rebuilt so it cannot recur: the log path carries the head SHA and a timestamp, the
provenance header is written into the same file as the result so the base is never more
than one command away, and a lock file refuses a second concurrent run. The result below
was read from a log whose own header is:

    head        077f4bf...    base f1844af...    dirty 0
    newest      1787482453  scrapex/provenance.py
    started     1787483492   -> 1,039 s after the last edit

**And the rebuilt harness had a false field on its first run, caught by cross-checking
rather than trusting it:** a `concurrent pytest processes` line read **0** while two
other sessions' suites were demonstrably live, because `ps -W` reports executable names
and never the arguments, so `pytest` matched nothing. A count that can only ever read
zero is worse than no count. It is reported here and not relied on.

**The first fix then walked into a second trap:** the replacement comment spelled the
directive out in order to explain it, so ruff parsed the explanation *as* a directive
and warned it was malformed. *A comment that quotes an instruction is holding one* —
`LESSONS` §7's trap, arriving in a lint comment. It now names the rule, never the
syntax.

Two instrument notes, both §7's own subject: my monitor grep went **binary** on a NUL
byte in the log and silently stopped streaming, and `-q` on top of `addopts`'s `-q`
made `-qq`, which prints **no summary line at all**. Neither is a code defect and both
would have been read as "still running" and "no failures".

**Provenance** (`ORCHESTRATION` §5/§7):

    head             077f4bf
    base             f1844af   (= origin/main, re-derived at run time)
    uncommitted      0 lines
    newest edit      1787482453  scrapex/provenance.py
    suite started    1787482573   -> started > newest edit, by 120 s

`SCRAPEX_FULL_MIGRATIONS=1 python -m pytest -q` run to completion, with `status=$?`
taken on the line immediately after `pytest` — never off a compound.

I am a secondary session: **I do not merge.** `R-42`. Standing by to rebase onto
whatever `main` becomes after the `engine-v0.3.0` packaging fix lands ahead of this.

---

> Opened on behalf of session `Scrapex02 Resume` (`a2821275636abdd2c`), which pushed
> this branch at `077f4bf` and wrote this body, then hit a usage limit before it could
> open the PR. The body is that session's, verbatim; nothing was rewritten. It was
> the only copy and it was in `AppData\Local\Temp`.
>
> **Fourth in the owner's queue** — see #263. Not for merging ahead of #265.
