### PR TITLE
Two records that were owed: OP-69 and REQ-44

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2793,6 +2793,86 @@ for a crawl that never ran.
 
 ## 3. Decided, not yet built
 
+### OP-69 · The release gate proves the engine STARTED, never that it can serve a page
+
+**Found 2026-08-23 by the session that wrote `OP-62`'s fix. Filed 2026-08-26, and the
+three-day gap is the defect worth recording first.**
+
+**THIS ENTRY IS LATE AND THE LATENESS IS THE LESSON.** The session that fixed `OP-62`
+scoped this gap deliberately OUT of that change — correctly, because widening a defect fix
+into a new feature is how a fix stops being reviewable — and then **told the primary
+session about it rather than leaving it.** The primary said it would take it and give it a
+number. **It never wrote it down.** For three days it existed in a chat channel, which is
+the one place `CLAUDE.md` says does not count: *"the repository is the only memory. A note
+that is not committed did not happen."* The finder had to come back and ask for the number
+a second time, having first checked `BACKLOG.md`, `STATE.md`, `REQUESTS.md`, `LESSONS.md`
+and `RULINGS.md` and found nothing.
+
+**So it is filed before the fix rather than with it.** Had it been filed with the fix, and
+had the fix not been authorised, the record would have been lost a second time by the same
+mechanism.
+
+### The gap
+
+`OP-62` was the published engine unable to serve a single page: `packaging/build_engine.py`
+told PyInstaller to carry two data paths and the runtime opens five. It is fixed — all five
+are in `RUNTIME_DATA` and `tests/test_the_frozen_engine_carries_its_own_files.py` guards
+them by enumerating what the source actually opens rather than restating the recipe.
+
+**The release gate, however, still stops one step short of the thing that fails.** Its final
+check runs the built `.exe` and requires four lines of output, the last being `ScrapeX UI`.
+That line is printed by `scrapex/cli.py`'s `_cmd_ui` only once `create_app` **has returned** —
+which is a real and deliberate improvement, because `StaticFiles(check_dir=True)` refuses to
+mount a missing directory and so a bundle without `scrapex/webui/static` cannot reach it.
+
+**But `Jinja2Templates` does NOT check its directory at construction.** `RUNTIME_DATA`'s own
+comment says so in as many words:
+
+> *"Jinja2Templates does NOT check its directory at construction, so a missing templates
+> tree is not a startup error; it is a `TemplateNotFound` on whichever page the owner opens
+> first."*
+
+So a build missing `scrapex/webui/templates` **starts cleanly, prints all four lines,
+passes the gate, reports itself healthy — and answers every page with
+`TemplateNotFound`.** The same is true of `apps_script/StagingAppScript.txt`, whose absence
+is quieter still: the route answers 404 saying the script *"is not bundled"*, which was true
+of every engine ever shipped until `OP-62` closed it.
+
+**This is the same shape as `OP-62` itself, which is why it is worth a number rather than a
+shrug: a gate that proves the step before the one that breaks.** `OP-62`'s own history is
+the argument — the gate had already been widened once, after `0.2.1` shipped a black window,
+and it *still* stopped one line short of the failure `0.3.0` shipped.
+
+### What today's guard does and does not cover
+
+**Covered, and this matters when scoping the work:**
+`tests/test_the_frozen_engine_carries_its_own_files.py` stages a bundle from `RUNTIME_DATA`,
+starts the engine inside it, and asserts every `templates/**/*.html` in the repository is
+present — enumerated from the tree, not restated. It carries its own mutation test, which
+removes the static directory and requires the check to fail.
+
+**Not covered:** nothing anywhere fetches a page from the built artefact. The suite proves
+the *recipe* is complete against today's source; it does not prove the *published binary*
+answers `200`. Those differ the moment a build step, a PyInstaller upgrade or a
+`--exclude-module` changes what actually lands in the archive — and the artefact is the thing
+the owner installs.
+
+### The remedy, which is small
+
+In `.github/workflows/release-engine.yml`, after the existing double-click step: bind a port,
+fetch `/`, require a **200 with real content** rather than merely a status line. It must
+assert something a template produced, or it proves only that uvicorn is listening.
+
+**And it must keep the timeout shape the current step uses.** `ScrapeX UI` is the last thing
+printed before uvicorn takes the process, which is why that step passes on a *timeout* rather
+than an exit code. A fetch step has to start the engine in the background, poll the port, and
+then be sure to kill it — a release job that leaks a listening engine is its own defect.
+
+### Who holds it
+
+Being built on `fix/the-release-gate-fetches-a-page` by the session that found it, base
+`35962cc`. **This entry deliberately does not depend on that branch landing.**
+
 ### DEC-1 · Topology A — the TypeScript extension as the public product
 **Approved 2026-07-18. Zero commits since.** This is the largest gap between what was
 decided and what exists.

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -95,6 +95,7 @@ IDs are stable and never reused, matching the convention BACKLOG.md already uses
 | [REQ-38](#req-38--the-backup-must-check-its-own-digest-and-the-panel-must-be-able-to-finish-the-build) | The backup must check its own digest, and the panel must be able to finish the build | **Captured** — measured: the digest is written and never read; the button aborts at 10 s on a 5-minute build | 2026-08-22 |
 | [REQ-39](#req-39--the-extension-must-report-what-drive-holds-because-nothing-else-can-ask) | The extension must report what Drive holds, because nothing else can ask | **Captured** — the panel is the only holder of the token and it stores no answer | 2026-08-22 |
 | [REQ-40](#req-40--the-extension-is-the-phone-and-the-engines-are-apps-installed-on-it) | The extension is the phone and the engines are apps installed on it — study which of the engine's duties shrink into it | **Captured** — measured: the premise is HALF BUILT since 2026-08-12 and undocumented; three counted holes, chief of them 0 of 18,008 contractors in the offline pack | 2026-08-23 |
+| [REQ-44](#req-44--the-state-gets-its-own-column-and-the-user-never-infers-it) | The state gets its own column, and the user never infers it | **Done** — ruled as `R-27` and built the same day (#235 + migration 0006), and the column it asked for now lies: `OP-68` measures it reporting 17,256 of 17,304 contractors as gone after a crawl that read every one | 2026-08-21 |
 
 ---
 
@@ -2213,3 +2214,78 @@ not before**, per `R-02`.
 verifiers caught it: it dated *text* by each **file's** last commit, which inverts the
 seniority of two documents in one of its headline contradictions. A line's age is not its
 file's age, and this register should not repeat the mistake.
+
+---
+
+## REQ-44 · The state gets its own column, and the user never infers it
+**Captured 2026-08-21 · ruled as `R-27` and built in #235 the same day · reached the board only on 2026-08-26 · Done**
+
+> «ضيف الحالات التى ذكرتها ولا يتم تغطيتها الان وايضا عمود يوضح الحالة الجديدة لا تدع
+> المستخدم يستنتج الحالة»
+
+*Add the states you named that are not covered now, and a column that shows the new state —
+do not leave the user to infer the state.*
+
+**FIVE DAYS LATE, AND THE LATENESS IS WHY THIS ENTRY EXISTS AT ALL.** His instruction was
+**ruled** as [R-27](RULINGS.md#r-27--a-row-never-disappears-from-the-users-view-its-state-becomes-a-column)
+and **built** the same day — migration `0006_a_row_says_when_it_was_last_proved_absent.sql`,
+merged as #235 (`ec53b17`) — and it never reached this board. It survived in the code that
+implements it: quoted in that migration's header, in `scrapex/sightings.py:102` and `:361`,
+in `scrapex/extract/service.py:51` and `:958`, and in
+`tests/test_a_dataset_is_a_table_like_any_other.py:849`. **Six citations in code and
+migrations, zero on the register that tracks what he asked for.**
+
+**It was found by a guard refusing a pull request.**
+`tests/test_a_request_of_his_reaches_the_board.py::test_every_finding_that_quotes_him_is_reachable_from_the_request_board`
+failed on `#267` because `OP-68` quotes him and nothing on the board carried the quote. The
+guard was written after this exact failure happened three times in one afternoon; **the debt
+it caught here is older than the branch it blocked**, and blocking that branch is how it
+surfaced.
+
+### What he asked for, in two halves
+
+| half | state |
+|---|---|
+| **add the states not yet covered** | **Done.** Six were computable from what the schema held — `new`, `updated`, `confirmed`, `absent`, `unsighted`, `retired`. One was not, and migration `0006` is the reason it now is: **`returned`** — absent in an earlier crawl, and here again |
+| **a column that shows the state, so the reader never infers it** | **Built, and now WRONG.** See below |
+
+### The column he asked for is currently telling him the opposite of the truth
+
+**[`OP-68`](BACKLOG.md) measured it read-only on the live warehouse**, and it is the loudest
+false alarm the product can produce:
+
+| | `contractors` | `contractor_profiles` |
+|---|---|---|
+| rows reported **absent** | **17,256 of 17,304** | 17,384 |
+| rows reported **new** | — | **1**, where **121** were first seen that day |
+| `dataset_sighting` rows | 17,417 | **0** |
+
+**The screen tells him 17,256 of his 17,304 contractors have stopped being published — after
+a crawl that read every one of them.** The cause is that `newest` is `MAX(last_seen_at)` **to
+the second**, and a crawl writes its rows over half an hour, so only rows written in the
+final second survive the comparison. The reasoning that fixes it is already in the same file
+eight lines below the defect, where `last_absent_at` uses `>=` *"because both timestamps are
+`strftime(…,'now')` at SECOND resolution"* — and that argument was never carried across.
+
+**So this request is `Done` and its product is lying, which is a worse state than
+`Not built`.** `Not built` shows him nothing; this shows him a number and the number is
+wrong. That is why the board row says **"Done, and the column now lies"** rather than
+**Done**.
+
+### Why it is filed here rather than folded into `OP-68`
+
+**`OP-68` is a finding — we measured it. This is a request — he said it.** `CLAUDE.md`'s
+boundary is exactly that test, and the two must not drift into each other. `OP-68` stays in
+`BACKLOG.md` as the defect; this entry is the instruction the defect betrays.
+
+**And it is filed independently of `#267` deliberately.** That branch has been red for two
+days holding a data recovery. Had this record ridden along with it, it would depend on that
+branch landing — which is the identical mechanism that lost `OP-69` for three days. A record
+that can be lost by a stalled branch is not a record.
+
+### What is owed
+
+The fix is `OP-68`'s to carry. What this entry adds is the standard the fix is measured
+against, in his words: **the user never infers the state.** A state column that is present
+and wrong does not satisfy that; it violates it more completely than a missing column would,
+because it is believed.

--- a/tests/test_the_registers_cannot_collide.py
+++ b/tests/test_the_registers_cannot_collide.py
@@ -122,6 +122,14 @@ RESERVED: dict[str, dict[int, str]] = {
     # hole nobody owns, which is the rule the comment above already states.
     "REQ": {
         34: "branch claude/drive-without-a-server",
+        # 41 AND 42 BELONG TO `docs/two-counts-and-the-gap-between-them` (PR #267) and 43
+        # to `feat/organization-enrichment`. All three became holes HERE the moment this
+        # branch declared `REQ-44`, because the gap check runs from 1 to `max(numbers)`.
+        # #267 has an open pull request and 43's branch is pushed, so both keep their
+        # numbers and this branch steps past them. Delete each row the day its PR lands.
+        41: "branch docs/two-counts-and-the-gap-between-them (PR #267)",
+        42: "branch docs/two-counts-and-the-gap-between-them (PR #267)",
+        43: "branch feat/organization-enrichment",
     },
     # #246 merged on 2026-08-22 and brought its own 39 and 40, so the reservation is
     # gone with it — which is the rule the comment above states: a row left behind is a

--- a/tests/test_the_registers_cannot_collide.py
+++ b/tests/test_the_registers_cannot_collide.py
@@ -176,6 +176,17 @@ RESERVED: dict[str, dict[int, str]] = {
     # Nothing else was touched.
     "OP": {
         45: "branch claude/drive-without-a-server",
+        # 64 THROUGH 68 BELONG TO `docs/two-counts-and-the-gap-between-them` (PR #267,
+        # open). They became holes HERE the moment this branch declared `OP-69`, because
+        # the gap check runs from 1 to `max(numbers)`. #267 has an open pull request and
+        # this branch's own claim came later, so #267 keeps them under the rule that an
+        # open PR outranks a bare branch -- and the five rows are the cost of skipping
+        # past them rather than arguing over them. Delete all five the day #267 merges.
+        64: "branch docs/two-counts-and-the-gap-between-them (PR #267)",
+        65: "branch docs/two-counts-and-the-gap-between-them (PR #267)",
+        66: "branch docs/two-counts-and-the-gap-between-them (PR #267)",
+        67: "branch docs/two-counts-and-the-gap-between-them (PR #267)",
+        68: "branch docs/two-counts-and-the-gap-between-them (PR #267)",
         # 49 AND 50 ARE NEW ON THIS BRANCH AND NOT NEW IN THE WORLD. The Drive
         # branch has held all three of 45, 49 and 50 since before #255; they only
         # became holes HERE when this branch declared `OP-51` and `OP-52`, because


### PR DESCRIPTION
Two records that were owed and not written, plus the reservations they open. No code changes.

## `OP-69` — the release gate proves the engine STARTED, never that it can serve a page

Found on 2026-08-23 by the session that wrote `OP-62`'s fix. It scoped this out of that
change correctly — widening a defect fix into a feature is how a fix stops being reviewable
— and told the primary rather than leaving it. **The primary said it would take it and give
it a number, and never wrote it down.** For three days it lived only in a chat channel,
which is the one place `CLAUDE.md` says does not count. The finder came back and asked a
second time, having already checked `BACKLOG`, `STATE`, `REQUESTS`, `LESSONS` and `RULINGS`.

**The entry's first paragraph is the three-day gap, not the technical gap**, because that is
the more expensive of the two.

The gap itself: the gate's last check requires four lines from the built `.exe`, ending in
`ScrapeX UI`, which `cli.py` prints only once `create_app` has **returned**. That is a real
improvement — `StaticFiles(check_dir=True)` refuses to mount a missing directory, so a
bundle without `scrapex/webui/static` cannot reach that line. But `Jinja2Templates` does
**not** check its directory at construction, and `RUNTIME_DATA`'s own comment says so. A
build missing `templates` starts cleanly, prints all four lines, passes the gate, reports
itself healthy, and answers every page with `TemplateNotFound`.

Scope is stated so the work is not measured twice.
`tests/test_the_frozen_engine_carries_its_own_files.py` already enumerates every
`templates/**/*.html` from the tree and asserts each reaches the staged bundle, with its own
mutation test. **What nothing covers is fetching a page from the published artefact** — the
recipe is guarded against today's source; the binary is not guarded at all, and the binary is
what he installs.

## `REQ-44` — his instruction was ruled and built the same day, and never boarded

**Found because a guard refused #267.** `OP-68` quotes him and nothing on the request board
carried the quote, so `test_every_finding_that_quotes_him_is_reachable_from_the_request_board`
failed. That guard was written after the identical failure happened three times in one
afternoon, and **the debt it caught here is older than the branch it blocked.**

His instruction of 2026-08-21, in full:

> «ضيف الحالات التى ذكرتها ولا يتم تغطيتها الان وايضا عمود يوضح الحالة الجديدة لا تدع
> المستخدم يستنتج الحالة»

It was **ruled** as `R-27` and **built** as migration `0006` in #235 **on the day he said
it** — and reached the board five days later. It survived meanwhile in the code that
implements it: the migration header, `sightings.py:102` and `:361`,
`extract/service.py:51` and `:958`, and a test docstring. **Six citations in code, zero on
the register that tracks what he asked for.**

Both halves are recorded. Adding the uncovered states is **done** — six were computable and
`returned` was not, which is what migration 0006 exists for. The column that shows the state
is **built and wrong**: `OP-68` measures it reporting **17,256 of 17,304** contractors as
absent after a crawl that read every one, because `newest` is `MAX(last_seen_at)` to the
**second** and a crawl writes its rows over half an hour, so only the final second survives
the comparison.

So the board says `Done` and the row says the column now lies. **`Done` whose product is
false is a worse state than `Not built`** — a missing column shows him nothing; this one
shows him a number he will believe.

## Why both were filed independently of the branches that will fix them

`#267` has been red for two days holding a data recovery. A record that rides along with a
stalled branch can be lost by it, which is the identical mechanism that lost `OP-69` for
three days. **`OP-68` is named inside `REQ-44`, so #267 goes green on a rebase with no edit
to its own text** — the guard passes if the finding cites a REQ *or* if `REQUESTS.md` names
the finding.

## Reservations

`OP-64`–`68` to `docs/two-counts-and-the-gap-between-them` (#267); `REQ-41` and `42` to the
same; `REQ-43` to `feat/organization-enrichment`. All eight became holes the moment this
branch declared `OP-69` and `REQ-44`, because the gap check runs from 1 to `max(numbers)`.
Both holders keep their numbers under the rule that an open PR outranks a later claim, and
each row says which merge deletes it.

## Verification

`REQ-44`'s status line is shaped to the guard rather than to prose: `_reached` returns the
**last** state token in the line, so `Done` is last and `ruled` is lowercase to stay out of
`\bRuled\b`'s way, and the board cell is the bare token it is compared against. Both were
checked by reimplementing the guard's own parse before running it.

Every edit script asserts its postconditions **against the file** afterwards, not against
its own intent — `str.replace` returns the original on no match, and a script that silently
did nothing reads perfectly.
