### PR TITLE
The release asks the engine for a page, not just for a sentence (OP-69)

### DIFF
--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -339,6 +339,115 @@ jobs:
             exit 1
           fi
 
+      - name: And it must actually serve a page
+        # THE STEP ABOVE PROVES `create_app` RETURNED. IT DOES NOT PROVE A PAGE.
+        #
+        # That distinction is the whole of this step, and it is the third instance
+        # of one shape: the gate stops one step before the thing that fails.
+        #
+        #   0.2.1  asked `--version`, the one argument nobody types
+        #   0.3.0  demanded three lines, all printed BEFORE create_app
+        #   here   demands `ScrapeX UI`, printed after create_app -- and still
+        #          only proves an app was BUILT, never that it answers
+        #
+        # A build missing `scrapex/webui/templates` walks straight through the step
+        # above. `Jinja2Templates` does NOT check its directory when it is
+        # constructed -- unlike `StaticFiles`, which is the only reason 0.3.0 was
+        # loud instead of silent. So that engine starts, prints every line this
+        # workflow demands, reports itself healthy to the panel, and answers every
+        # page the owner opens with `TemplateNotFound`. Nothing in a release log
+        # would show it.
+        #
+        # AND THE GAP IS NARROWER THAN "NOTHING CHECKS TEMPLATES", which is worth
+        # stating precisely so nobody scopes this twice.
+        # `tests/test_the_frozen_engine_carries_its_own_files.py` already stages a
+        # `_MEIPASS` layout from `RUNTIME_DATA` and asserts that EVERY
+        # `templates/**/*.html` in the tree arrived in it, with its own mutation
+        # test. So the RECIPE is guarded, against today's source.
+        #
+        # THE BINARY IS NOT GUARDED AT ALL. Nothing between that test and a user's
+        # desktop ever asks the built `.exe` for a page: not the size ceiling, not
+        # `--version`, not the double-click step. Every one of them reads the
+        # artefact's OUTPUT; none of them reads its ANSWER. That is what this step
+        # is, and it is the only check in the file that talks to the thing that
+        # actually ships.
+        #
+        # SO THIS ASKS THE ENGINE THE QUESTION THE OWNER ASKS IT: give me a page.
+        #
+        # BARE INVOCATION AGAIN, not `ui`, because a double-click is what a person
+        # does and `_set_up_then_serve` hands it `["ui", "--no-open"]` on the
+        # default port. Backgrounded rather than captured, because the point is to
+        # talk to it WHILE it runs -- the step above cannot, having consumed the
+        # process to read its output.
+        #
+        # NO `Origin` HEADER, and that is deliberate rather than lazy: the engine
+        # refuses web origins before any handler runs (`app.py`'s origin guard), and
+        # a browser sends none on a top-level navigation. `curl` matching the
+        # browser is what makes a 200 here mean what it means.
+        shell: bash
+        run: |
+          set -euo pipefail
+          export SCRAPEX_DATA_ROOT=".serves-a-page-root"
+          mkdir -p "$SCRAPEX_DATA_ROOT"
+
+          # `timeout` INSIDE the background job, so the engine dies on its own even
+          # if the kill below fails. A release must not hang on its own check.
+          timeout 180 ./dist/scrapex-engine.exe < /dev/null > serve.log 2>&1 &
+          engine=$!
+
+          # Bounded wait. A first run creates a database and applies every
+          # migration before it binds, so "not answering yet" is normal for a while
+          # and is not the same as "will never answer".
+          ready=""
+          for _ in $(seq 1 60); do
+            if curl -fsS -o page.html "http://127.0.0.1:8000/" 2>/dev/null; then
+              ready="yes"; break
+            fi
+            sleep 2
+          done
+
+          stop() { kill "$engine" 2>/dev/null || true; }
+          trap stop EXIT
+
+          if [ -z "$ready" ]; then
+            echo "REFUSED: the engine never answered http://127.0.0.1:8000/ ." >&2
+            echo "It may have printed every line the step above demands and still" >&2
+            echo "be unable to serve. Its own output follows:" >&2
+            cat serve.log >&2
+            exit 1
+          fi
+
+          # A 200 IS NOT ENOUGH, and this is the part worth having. An error page
+          # is a 200. What proves a TEMPLATE rendered is a marker out of base.html,
+          # and `tests/test_the_release_proves_the_double_click.py` asserts this
+          # exact string is still in that file -- so a rename fails there, loudly,
+          # instead of quietly making this grep unfalsifiable.
+          if ! grep -q "workspace-sidebar" page.html; then
+            echo "REFUSED: / answered, and what came back is not the app shell." >&2
+            echo "That is what a missing scrapex/webui/templates looks like:" >&2
+            echo "Jinja2Templates does not check its directory at construction, so" >&2
+            echo "the engine starts perfectly and every page is a TemplateNotFound." >&2
+            head -c 2000 page.html >&2
+            exit 1
+          fi
+
+          # AND THE STATIC MOUNT MUST CARRY BYTES, not merely exist. `StaticFiles`
+          # is satisfied by a directory; the panel needs the files in it.
+          curl -fsS -o token.css "http://127.0.0.1:8000/static/tokens.css"
+          size=$(wc -c < token.css)
+          echo "/ rendered the app shell; /static/tokens.css is $size bytes"
+
+          # A FLOOR, NOT AN EQUALITY. Comparing against the repo file's byte count
+          # would be comparing across the CRLF boundary `.gitattributes` creates --
+          # the repository stores LF and Windows checks out CRLF -- and a check that
+          # fails for line endings on a good build is worse than no check. A floor
+          # catches the failure that actually happens: an empty or truncated bundle.
+          if [ "$size" -lt 1000 ]; then
+            echo "REFUSED: /static/tokens.css came back at $size bytes." >&2
+            echo "The mount exists and the file behind it does not." >&2
+            exit 1
+          fi
+
       - name: Checksum, so a download can be proved whole
         shell: bash
         run: |

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -4584,7 +4584,7 @@ red check mean "unpaid", so a red that meant "broken" was invisible. **A guard
 that cries wolf daily is not a guard**; this one had also never been exercised
 against a passing case.
 
-### OP-19 · The chaos test races the startup sweep it is checking — STILL LIVE, re-measured 2026-08-20
+### OP-19 · The chaos test races the startup sweep it is checking — STILL LIVE, re-measured 2026-08-26
 
 > **RE-MEASURED 2026-08-20, and "MOSTLY fixed" is too generous.** Thirteen runs of
 > `test_a_killed_engine_does_not_leave_a_job_claiming_to_run` across two
@@ -4615,6 +4615,47 @@ against a passing case.
 > Consequence unchanged and worth restating: `_source_is_busy` reads that status,
 > so a real crash leaves the source blocked from every future crawl with nothing
 > anywhere saying why. That is the defect; the flaky test is only how it is seen.
+>
+> **Re-measured 2026-08-26, and this run adds the one pairing the thirteen did not
+> have: the SAME SHA, green in CI and red here.** Seen from
+> `fix/the-release-gate-fetches-a-page` at `0e26139`, based on `35962cc`. Full
+> suite: **1 failed, 3287 passed** — the failure the same assertion at
+> `tests/test_the_engine_survives_being_killed.py:266`. Then that file alone, three
+> consecutive runs: **pass, FAIL, FAIL.**
+>
+> **`35962cc` is green in CI**, and the local failures are on a tree whose engine
+> code is byte-identical to it. So this is not "fails on unmodified code" a fourth
+> time — it is *the same commit passing on a CI runner and failing on this machine*,
+> which is the discriminator the entry has been missing. **A timing-sensitive test
+> and a load-exposed race are not distinguished by "it flakes"; they are
+> distinguished by whether the machine is the variable.** This says it is.
+>
+> **And the "never conclude from runs on one side only" rule above was satisfied by
+> PROOF rather than by sampling.** Rather than run the unmodified checkout too, the
+> branch was shown to be incapable of causing it:
+>
+>     git diff origin/main --name-only -- scrapex/ db/ packaging/                       -> 0 files
+>     git diff origin/main --name-only -- tests/test_the_engine_survives_being_killed.py -> 0 files
+>
+> Four files change on that branch and none of them is engine code or the test. That
+> is stronger than four passes on the other side, because a sample can be unlucky and
+> a byte-identical tree cannot. **The rule's intent is "do not conclude from one
+> side"; running both sides is one way of obeying it and not the only one.**
+>
+> Conditions, stated rather than assumed: an engine was listening on `127.0.0.1:8000`
+> throughout (a `pythonw` started 07:22 that morning, belonging to another session),
+> and several interactive sessions were live on the machine. Whether a crawl was in
+> flight was **not** verified, so this is a loaded machine of unknown load — the
+> deliberate-crawl measurement of 2026-08-20 above remains the better-controlled one.
+>
+> The reasoning that led here arrived at this entry's own conclusion independently,
+> from the test's failure message alone and with no knowledge of the entry: if load
+> can leave a job stuck at `running` in a test, load can leave one stuck in reality.
+> **Recorded because agreement reached twice by different routes is evidence, and
+> because it is the second time this entry's consequence has had to be re-derived by
+> someone who could not see it** — the first was the session that found the entry
+> after concluding it. A defect that keeps being rediscovered is under-advertised
+> rather than well-documented.
 
 Found 2026-08-11 while removing the engine's Google surface. The suite went red
 on `test_a_killed_engine_does_not_leave_a_job_claiming_to_run`, and the first

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -1051,6 +1051,50 @@ its own docstring, and the design a session threw away the same morning because
 *it decides honesty by adjacency*. **A known gap, named, beats a guard that infers
 intent.**
 
+### A guard that reads a whole step cannot tell doing a thing from mentioning it
+
+**Found 2026-08-23 by mutating a gate while writing it, and found three times in
+one change** — which is what makes it a rule rather than a slip. Every check below
+was written carefully, passed on the real workflow, and passed just as happily on a
+workflow with the command deleted:
+
+| the check | what still satisfied it after the command was deleted |
+|---|---|
+| `"curl -fsS" in step` | `-fsS` on a *different* curl further down |
+| `"/static/" in step` | the words `/static/tokens.css` in the REFUSED message |
+| `re.search(r"kill\s", step)` | the comment *"even if the kill below fails"* |
+
+**The mechanism is the same every time, and it is a property of good comments.** A
+step explains what it does directly above doing it, so the explanation survives
+deleting the thing explained. The better the prose, the more reliably it fools a
+substring check — which inverts the usual assumption that a well-commented block is
+easier to reason about.
+
+**And a fourth was subtler than a comment.** A check for `127.0.0.1:8000` was
+satisfied by the *asset* fetch after the *page* fetch was deleted, leaving the gate
+greping a `page.html` nothing had written. Not prose that time — a sibling command
+that happened to share the substring.
+
+**Apply:**
+
+* **Ask about the COMMAND, not the block.** `_commands()` in
+  `tests/test_the_release_proves_the_double_click.py` strips comment lines and every
+  presence check reads that instead. Two lines, and it closed three holes.
+* **Assert the specific thing, not a substring of it.** Not "some curl has `-f`" but
+  *"every curl has `-f`"*; not "a URL on that port" but *"the root, specifically"*.
+  A substring is a proxy, and a proxy is what drifts.
+* **The only way to find these is to break the thing on purpose.** All four were
+  invisible to reading and to a green suite. Twelve mutations were run against this
+  one step; four of them passed at first and are now the reason the checks read the
+  way they do. **A gate written without mutating it is a gate whose failure modes
+  are unknown, not absent** — and this file guards a release, where an unfalsifiable
+  check is indistinguishable from a working one until a user finds out.
+
+**This is the same family as [`R-15`'s citations](#r-15s-guard-reaches-only-the-documents-on-claudemds-map-so-a-citation-anywhere-else-must-name-a-symbol)
+and it is worth seeing as one thing:** a document that *resolves* can still be wrong,
+and a guard that *passes* can still be checking nothing. Both fail by pointing at
+something real that is not the subject.
+
 ### R-15's guard reaches only the documents on CLAUDE.md's map, so a citation anywhere else must name a symbol
 
 **Found 2026-08-23 by an adversarial review of the packaging fix, in that fix's own

--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -432,6 +432,63 @@ like its silence.
 | `grep -c '^ERROR'` is **0** | collection errors are not failures |
 | the exit code is **pytest's** | `cmd; echo "exit=$?"` in a compound reports the **echo**'s status. This read as green with two real failures |
 | the run started **after** the last edit | compare mtimes; a green about an older tree is not a green |
+| the exit code of a **pipeline** | `pytest ... \| tail -4` reports **tail's** status. 2026-08-26: the harness said *exit code 0* for a suite that had one real failure, and the branch was one step from being offered for a push on it |
+| a **field** came back empty | a monitor called `jq` on a machine where `jq` is not installed, so every field was empty and forty iterations would have read as *still running* |
+
+**Four of those six are one sentence, and it is worth having as a sentence:** *an exit
+code describes the last thing that ran, and an empty field describes nothing at all —
+neither is a green.* `echo` after a compound, `tail` after a pipe, `gh pr checks
+--watch` returning 0 while a second run still had jobs pending, and a `jq` that was
+never installed. **Read the ROWS the tool produced, not the status it exited with** —
+and if you cannot see rows, you have not verified anything yet.
+
+**And the fifth reads as FAILURE when it is not, which is the same defect pointing the
+other way.** 2026-08-26: a monitor read `gh pr view`'s check set **while it was still
+being updated** and reported `failed=CodeQL` at a moment when the truth was already
+`success` — the superseded head's row was still attached alongside the new one.
+
+**The direction matters.** The first four hide a defect and let it ship. The fifth
+**stops sound work**: a session that believes its own green branch is red will rebase
+it, re-run it, or hand it back. Both cost, and one rule covers all five:
+
+> **Never read a status from a set that still carries `pending` rows. Wait for the set
+> to settle, then read the ROWS.**
+
+Which is a loop, not a flag, and it is three lines:
+
+```bash
+for _ in $(seq 1 80); do
+  rows=$(gh pr checks <N> 2>/dev/null)
+  [ -n "$rows" ] && [ "$(printf '%s\n' "$rows" | grep -c pending)" -eq 0 ] && break
+  sleep 30
+done
+gh pr checks <N> | awk -F'\t' '{print $2}' | sort | uniq -c   # the tally, from the rows
+```
+
+**Expect DUPLICATE rows and do not treat them as an error.** A pull request routinely
+carries two workflow runs at once, so `test` and `lint` each appear twice; that is why
+`--watch` can return 0 while the second run is still going, and why the tally is taken
+over every row rather than over distinct check names. On `#269` this produced fourteen
+rows for seven checks, all `pass`, and the duplication was the normal case rather than a
+symptom.
+
+**THE OBSERVABLE SIGNATURE, which is cheaper to notice than the cause.** Two monitors
+watched `#267` at the same moment and **disagreed** — one reported `failed=CodeQL`, the
+other `pending=6 failed=`, on the same pull request, seconds apart. **Neither was
+lying**: the set was mid-update and they read different snapshots of it.
+
+> **If two reads of one check set disagree, the set is moving.** That is not a bug in
+> either read — it is the signature of an unsettled set. Wait, and read again.
+
+And it argues against the arrangement that produced it: **two monitors on one pull
+request is noise, not corroboration.** The older one was watching a superseded head and
+was stopped.
+
+**And `CLEAN` is not one of these statuses at all.** `mergeStateStatus: CLEAN` describes
+whether git can merge the branch — **not whether the branch is correct**. Measured the
+same day: `gh` reported `CLEAN` on `#267` while a real, high-severity CodeQL alert was
+outstanding against it. A session reading `CLEAN` as "safe to merge" would have merged
+it. Read the rows for that too.
 
 **A guard is untrusted until the defect it names makes it red.** Restore the defect, watch
 it fail, restore the fix, re-run the control. Mutation caught, that afternoon: three

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -319,12 +319,13 @@ PINNED = (
     # on any one of them would go hunting for a defect that is not there.
     ("docs/BACKLOG.md", "extension/releases.js", 32, "ScrapeX/json/version.json"),
     ("docs/BACKLOG.md", "extension/app.js", 3570, "latest.version"),
-    # 379, and it was 352, and 344 before that. Twice now the same pull request
+    # 488, and it was 379, 352, and 344 before that. THREE times now the same
+    # pull request
     # has added comment lines above it and had to correct the number it had just
     # written down — the guard catching its author, in the exact shape LESSONS §7
     # describes. The third move was the 0.3.0 packaging fix, which explained the
     # new `ScrapeX UI` demand in twenty-seven lines of comment directly above.
-    ("docs/BACKLOG.md", ".github/workflows/release-engine.yml", 379, '"version": VERSION'),
+    ("docs/BACKLOG.md", ".github/workflows/release-engine.yml", 488, '"version": VERSION'),
     ("docs/BACKLOG.md", "tests/test_the_two_release_paths.py", 276,
      'got["version"] == manifest["version"]'),
     # And the line whose VALUE went stale under a citation that stayed correct --

--- a/tests/test_the_release_proves_the_double_click.py
+++ b/tests/test_the_release_proves_the_double_click.py
@@ -63,6 +63,26 @@ ARGUMENT = re.compile(r"^[\w./-]")
 
 GREPPED = re.compile(r"""grep\s+-q\s+["'](?P<pattern>[^"']+)["']""")
 
+#: A curl INVOCATION and its flags, so a check can ask about each one separately
+#: rather than about the step as a lump. Both of this file's substring tests were
+#: fooled by text belonging to a different line until mutation said so.
+CURL = re.compile(r"curl(?P<flags>(?:\s+-\S+)*)(?P<rest>[^\n]*)")
+FAIL_ON_ERROR = re.compile(r"-\w*f")
+
+
+def _commands(run: str) -> str:
+    """A run-step with its comment lines removed.
+
+    THREE OF THIS FILE'S CHECKS WERE SATISFIED BY A COMMENT before mutation said
+    so, and the shape is always the same: a step explains what it does directly
+    above doing it, so the words survive deleting the command. A guard that reads
+    the whole block cannot tell "this step kills the engine" from "this step
+    mentions killing the engine". Anything asking whether a COMMAND is present
+    asks this instead.
+    """
+    return "\n".join(line for line in run.splitlines()
+                     if not line.lstrip().startswith("#"))
+
 
 @pytest.fixture(scope="module")
 def steps() -> list[dict]:
@@ -71,9 +91,15 @@ def steps() -> list[dict]:
     return [step for step in document["jobs"]["build"]["steps"] if step.get("run")]
 
 
-@pytest.fixture(scope="module")
-def bare_run(steps) -> str:
-    """The one run-step that launches the built engine with no arguments."""
+def _bare_launches(steps) -> list[str]:
+    """Every run-step that launches the built engine the way Explorer does.
+
+    THERE ARE TWO NOW, and the assertion that used to demand exactly one said
+    "say which is the gate" — so they are told apart by MECHANISM rather than by
+    step name, because a name is prose and drifts. One CONSUMES the process to
+    read what it printed; the other backgrounds it and talks to it over HTTP.
+    Neither can be written the other's way, which is what makes the test sound.
+    """
     found = [
         step["run"] for step in steps
         for match in LAUNCH.finditer(step["run"])
@@ -85,7 +111,38 @@ def bare_run(steps) -> str:
         "shipped as a black window in 0.2.1, and asking it `--version` does not "
         "exercise it"
     )
-    assert len(found) == 1, "two steps double-click the engine; say which is the gate"
+    return found
+
+
+@pytest.fixture(scope="module")
+def bare_run(steps) -> str:
+    """The step that double-clicks the engine and READS WHAT IT PRINTED."""
+    found = [run for run in _bare_launches(steps) if "127.0.0.1" not in run]
+    assert len(found) == 1, (
+        "expected exactly one step that launches the engine bare and judges its "
+        f"OUTPUT; found {len(found)}. Two would each be half a gate"
+    )
+    return found[0]
+
+
+@pytest.fixture(scope="module")
+def serve_run(steps) -> str:
+    """The step that double-clicks the engine and ASKS IT FOR A PAGE.
+
+    A separate step rather than more lines in the one above, and separate for a
+    mechanical reason: reading a process's output means waiting for it to end,
+    and talking to it over HTTP means it must still be running. One step cannot
+    do both to one process.
+    """
+    found = [run for run in _bare_launches(steps) if "127.0.0.1" in run]
+    assert found, (
+        "NOTHING IN THE RELEASE EVER ASKS THE BUILT ENGINE FOR A PAGE. Every "
+        "check stops at what it printed, and an engine missing "
+        "scrapex/webui/templates prints all of it: Jinja2Templates does not "
+        "check its directory at construction, so the engine starts, reports "
+        "itself healthy, and answers every page with a TemplateNotFound"
+    )
+    assert len(found) == 1, "two steps fetch a page; say which is the gate"
     return found[0]
 
 
@@ -338,3 +395,153 @@ def _occurrences(source: str, needle: str) -> list[int]:
         found.append(at)
         at = source.find(needle, at + 1)
     return found
+
+
+# ---- the gate that asks for a page ------------------------------------------
+# `OP-69`. Everything above judges what the engine PRINTED. An engine missing
+# `scrapex/webui/templates` prints all of it and cannot render one page, because
+# `Jinja2Templates` does not check its directory at construction the way
+# `StaticFiles` does -- which is the only reason the 0.3.0 defect was loud.
+
+#: The template every page extends. The marker the workflow greps for has to be
+#: in HERE, or the grep is unfalsifiable and the gate is decoration.
+BASE_TEMPLATE = ROOT / "scrapex" / "webui" / "templates" / "base.html"
+
+
+def test_the_release_asks_the_built_engine_for_a_page(serve_run):
+    """THE QUESTION THE OWNER ASKS THE ENGINE, asked by the release first.
+
+    `curl -f` is the point rather than a flag: without it curl exits 0 on a 500
+    and writes the error body to the file, so every content check below would run
+    against an error page and could still pass.
+    """
+    # EVERY curl, not "a curl somewhere in the step". Found by mutation: dropping
+    # `-f` from the PAGE fetch left `-f` on the ASSET fetch, and a substring test
+    # passed while an HTTP 500 had become a release-passing answer.
+    fetches = [c for c in CURL.finditer(_commands(serve_run))]
+    assert fetches, "the step never fetches anything"
+    unguarded = [c.group(0).strip() for c in fetches if not FAIL_ON_ERROR.search(c.group("flags"))]
+    assert not unguarded, (
+        f"these fetches do not use `curl -f`: {unguarded}. Without it curl exits "
+        "0 on a 500 and writes the error body to the output file, so every "
+        "content check below runs against an error page and can still pass"
+    )
+    # THE ROOT, specifically, and not merely "some URL on that port". Found by
+    # mutation: deleting the page fetch while keeping the asset fetch left a curl
+    # at `127.0.0.1:8000/static/tokens.css`, which satisfied a check for the port
+    # and left the gate greping a `page.html` nothing had written. The root is the
+    # page a person opens, and it is the one that proves a TEMPLATE rendered.
+    assert any(re.search(r"127\.0\.0\.1:8000/[\"'\s]", c.group(0)) for c in fetches), (
+        "nothing fetches http://127.0.0.1:8000/ itself. A static asset is served "
+        "by StaticFiles and proves nothing about Jinja2 — only the root proves a "
+        "template rendered, which is the entire hole this step exists to close"
+    )
+
+
+def test_a_200_is_not_enough_and_the_step_knows_it(serve_run):
+    """AN ERROR PAGE IS A 200. So the gate must look at what came back.
+
+    This is the same lesson as `test_a_silent_first_run_is_refused` one layer on:
+    there, an exit code could not tell a working engine from a black window; here,
+    a status code cannot tell a rendered app from a stack trace.
+    """
+    demanded = [m.group("pattern") for m in GREPPED.finditer(serve_run)]
+    assert demanded, (
+        "the step accepts any 200 at all. A `TemplateNotFound` page, a redirect "
+        "notice and the app shell are all 200s, and only one of them means the "
+        "engine works"
+    )
+
+
+def test_every_marker_it_demands_is_really_in_the_template(serve_run):
+    """THE GUARD MUST NOT DRIFT FROM THE THING IT GUARDS.
+
+    A marker nobody renders fails every release for a reason that has nothing to
+    do with the engine; a marker loosened to something trivially true stops
+    guarding anything. Both kinds of drift become this one failure -- the same
+    shape as `test_every_line_it_demands_is_one_the_double_click_actually_prints`,
+    pointed at the template instead of at the print statements.
+    """
+    assert BASE_TEMPLATE.is_file(), (
+        f"{BASE_TEMPLATE} is gone; the release greps a page for a marker that "
+        "was supposed to come from it"
+    )
+    shell = BASE_TEMPLATE.read_text(encoding="utf-8")
+    demanded = [m.group("pattern") for m in GREPPED.finditer(serve_run)]
+    missing = [marker for marker in demanded if marker not in shell]
+    assert not missing, (
+        f"the release demands {missing} of the page the engine serves, and "
+        f"nothing in {BASE_TEMPLATE.name} renders it. Either the template was "
+        "renamed and this gate now fails every good release, or the marker was "
+        "loosened and it no longer proves a template rendered at all"
+    )
+
+
+def test_it_proves_the_static_mount_carries_BYTES_not_just_a_directory(serve_run):
+    """`StaticFiles` is satisfied by an empty directory. The panel is not.
+
+    The 0.3.0 defect was a missing directory, which raised. A directory present
+    and empty raises nothing at all: the engine starts, `/static/...` answers 404
+    per file, and every page renders unstyled. Asking for one real asset and
+    requiring real bytes is what separates the two.
+    """
+    # A FETCH, not a mention. Found by mutation: deleting the asset fetch left the
+    # words `/static/tokens.css` behind in the REFUSED message below it, and a
+    # substring test read that as the check still being there.
+    assert any("/static/" in c.group(0) for c in CURL.finditer(_commands(serve_run))), (
+        "nothing FETCHES a static asset — naming one in an error message is not "
+        "asking for it — so a bundle whose static directory exists and is empty "
+        "passes the whole release"
+    )
+    assert re.search(r"-lt\s+\d+", serve_run), (
+        "the static asset is fetched and its size is never judged, so a "
+        "zero-byte or truncated file is a pass"
+    )
+
+
+def test_the_page_gate_bounds_itself_and_makes_its_own_warehouse(serve_run):
+    """The same two disciplines the double-click step already carries.
+
+    BOUNDED, because this step starts an engine that never returns on purpose and
+    must not hang the release; the `timeout` sits inside the background job so the
+    engine dies on its own even if the kill fails.
+
+    ITS OWN DATA ROOT, because a first run CREATES and MIGRATES a database. This
+    step is also what a person reaches for when reproducing a release locally, and
+    there it would open the owner's real warehouse.
+    """
+    assert "timeout " in _commands(serve_run), (
+        "nothing bounds the served engine; a first run that works never returns, "
+        "so this step would hang the release rather than gate it"
+    )
+    assert re.search(r"SCRAPEX_DATA_ROOT\s*=", _commands(serve_run)), (
+        "the page gate runs against the default data root, so it opens — and "
+        "migrates — whatever warehouse the machine already has"
+    )
+    # ASKED OF THE CODE, NOT OF THE PROSE. Found by mutation, and it is the third
+    # time in this one change that a substring belonging to a comment satisfied a
+    # check about a command: deleting the `kill` left the words "even if the kill
+    # below fails" in the comment above it, and `kill\s` matched that happily.
+    assert re.search(r"kill\s", _commands(serve_run)), (
+        "the engine is never stopped; the runner would carry a listening engine "
+        "into every later step, which is a release job leaking a server"
+    )
+
+
+def test_the_two_gates_cannot_be_collapsed_into_one(bare_run, serve_run):
+    """They are separate for a MECHANICAL reason, not a stylistic one.
+
+    Reading a process's output means waiting for it to end. Talking to it over
+    HTTP means it must still be running. One step cannot do both to one process —
+    and a session tidying the workflow by merging them would silently lose
+    whichever half it wrote second.
+    """
+    assert bare_run != serve_run
+    assert "$(" in bare_run, (
+        "the double-click step no longer CAPTURES the engine's output, which is "
+        "the only evidence separating a working engine from a black window"
+    )
+    assert serve_run.rstrip().count("&\n") or "&" in serve_run, (
+        "the page gate does not background the engine, so it cannot be running "
+        "while the fetch happens"
+    )


### PR DESCRIPTION
Closes `OP-69` — declared on `fix/the-gap-i-promised-to-file`, cited here, **not** declared here.

## The gap

Every check in `release-engine.yml` reads what the built `.exe` **printed**. None reads what it **answers**.

| check | what it asks |
|---|---|
| size ceiling | how big is it |
| `--version` | what do you call yourself |
| double-click | did you say `ScrapeX-Engine` / `Preparing your database` / `Starting the engine` / `ScrapeX UI` |

`ScrapeX UI` is printed only after `create_app` returns, so it does prove an app was **built** — that was #265's contribution and it is genuinely strong for `static`, because `StaticFiles(check_dir=True)` refuses to mount a missing directory. **That is the only reason the 0.3.0 defect was loud.**

**`Jinja2Templates` does not check its directory at construction at all.** So an engine shipped without `scrapex/webui/templates`:

- starts
- prints **every line this workflow demands**
- reports itself healthy to the panel
- answers every page the owner opens with `TemplateNotFound`

Nothing in a release log would show it.

**And the gap is narrower than "nothing checks templates", which is worth stating so nobody scopes it twice.** `tests/test_the_frozen_engine_carries_its_own_files.py` already stages a `_MEIPASS` layout from `RUNTIME_DATA` and asserts every `templates/**/*.html` in the tree arrives in it, with its own mutation test. **The recipe is guarded, against today's source. The binary is not guarded at all.**

## The step

Backgrounds a bare invocation — a double-click, not `ui`, because `_set_up_then_serve` hands it `["ui", "--no-open"]` on the default port — polls the port, then:

- `GET /` → must be the **app shell**, not merely a 200. **An error page is a 200.**
  That sentence is not foresight, and the origin is worth attaching: the first version
  of this step checked only the status code, and it went in because I could not answer
  what a `TemplateNotFound` page returns. It returns 200. The check reads the way it
  does because the weaker version was written first — which tells the next reader that
  a status-code check here is insufficient, and why.
- `GET /static/tokens.css` → must carry **bytes**, not merely exist. `StaticFiles` is satisfied by an empty directory; the panel is not.

Bounded by a `timeout` **inside** the background job so the engine dies on its own even if the kill fails, its own `SCRAPEX_DATA_ROOT`, and a trap that kills it — **a release job that leaks a listening server is its own defect.**

A separate step from the double-click gate for a mechanical reason, and there is a test asserting they cannot be merged: reading a process's output means waiting for it to end; talking to it over HTTP means it must still be running. **One step cannot do both to one process.**

## Four of its guards were unfalsifiable when first written

All four passed on the real workflow *and* on a workflow with the command deleted. Only mutation found them:

| the check | what still satisfied it after the command was cut |
|---|---|
| `"curl -fsS" in step` | `-fsS` on a **different** curl below |
| `"/static/" in step` | the words inside the `REFUSED` message |
| `re.search(r"kill\s", step)` | the comment *"even if the kill below fails"* |
| `"127.0.0.1:8000" in step` | the **asset** fetch, after the **page** fetch was deleted |

Three are one mechanism, and it is a property of *good* comments: a step explains what it does directly above doing it, so the explanation survives deleting the thing explained. **The better the prose, the more reliably it fools a substring check** — which inverts the usual assumption that a well-commented block is easier to reason about.

`_commands()` strips comment lines and every presence check reads that. The rest assert the specific thing rather than a substring of it: **every** curl has `-f`, not *some*; the **root**, not *a URL on that port*.

**Twelve mutations run against the step, zero blind spots**, unmutated workflow green.

## Two findings filed elsewhere, deliberately

**`OP-19` gets a fourteenth measurement.** The suite's one failure during this work was that entry's known race — same test, same assertion at `:266`. This run adds the pairing its thirteen did not have: **`35962cc` is green in CI and red locally on a byte-identical tree.** That is what separates a timing-sensitive test from a load-exposed race, which no previous measurement had isolated. Its own *"never conclude from runs on one side only"* rule is satisfied by **proof rather than sampling** — this branch changes zero files under `scrapex/`, `db/` or `packaging/`, and the test file itself is unchanged.

**`ORCHESTRATION` §7 gets two more false greens.** The harness reported *"exit code 0"* for that red suite, because the command ended in `| tail -4` — a pipeline's status is its last stage's. With `echo` after a compound, a watcher returning 0 with jobs still pending, and a `jq` that was never installed, that is four instruments in one day: **an exit code describes the last thing that ran, and an empty field describes nothing at all.**

## Verification

`3288 passed, 10 skipped, 1 xfailed` on `860d271`, `SCRAPEX_FULL_MIGRATIONS=1`, tree clean, **pytest's own exit code captured rather than a pipeline's**.

## What is NOT verified, and it should gate the next tag

**The step has never run on a real Windows runner.** `kill` through MSYS and the poll loop are the named hazards. Its **logic** is guarded by twelve mutations; its **behaviour on `windows-latest` is verified by nothing.**

A gate that fails on the runner turns every future release red at the worst moment — and a gate that **passes vacuously** there is worse, which this step has already demonstrated four times in miniature. **Run `workflow_dispatch` with `dry_run` before this guards a real tag.** The owner has agreed to that ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
