### PR TITLE
A dataset row gets the handle products always had, and three guards that had never failed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,19 @@ jobs:
           # that regressed before and a per-file "at least one" would not have
           # noticed 48 becoming 1.
           test "$(collected tests/test_panel_dom.py)" -ge 40
+          # AND THE SAME REASONING NOW COVERS THE TWO SUITES THAT DRAW THE DATA
+          # PAGE, because the sentence above was true of them and applied to
+          # neither. Counted 2026-08-26 with `--collect-only -q`, not remembered:
+          # test_grid_dom.py 20, test_tab_page_dom.py 10. Both sat on the `-ge 1`
+          # floor, so either could have fallen to a single test and stayed green.
+          #
+          # They are named because the plan that moves the source page into the
+          # extension proves steps 1, 3 and 4 through these two files and no
+          # others, and its own argument for them is that the Data page already
+          # shipped BROKEN once with 2,460 engine and 398 extension tests green
+          # on it. A gate defending against that must not be the loosest one.
+          test "$(collected tests/test_grid_dom.py)" -ge 20
+          test "$(collected tests/test_tab_page_dom.py)" -ge 10
 
       - name: The extension gate must not have emptied
         # The same reasoning as the line above, for the set the split depends

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,15 +250,17 @@ jobs:
           # AND THE SAME REASONING NOW COVERS THE TWO SUITES THAT DRAW THE DATA
           # PAGE, because the sentence above was true of them and applied to
           # neither. Counted 2026-08-26 with `--collect-only -q`, not remembered:
-          # test_grid_dom.py 20, test_tab_page_dom.py 10. Both sat on the `-ge 1`
+          # test_grid_dom.py 24, test_tab_page_dom.py 10. Both sat on the `-ge 1`
           # floor, so either could have fallen to a single test and stayed green.
+          # (grid_dom collected 20 before the four tests that draw the moved-column
+          # card and press the AR|EN toggle landed alongside this.)
           #
           # They are named because the plan that moves the source page into the
           # extension proves steps 1, 3 and 4 through these two files and no
           # others, and its own argument for them is that the Data page already
           # shipped BROKEN once with 2,460 engine and 398 extension tests green
           # on it. A gate defending against that must not be the loosest one.
-          test "$(collected tests/test_grid_dom.py)" -ge 20
+          test "$(collected tests/test_grid_dom.py)" -ge 24
           test "$(collected tests/test_tab_page_dom.py)" -ge 10
 
       - name: The extension gate must not have emptied

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -85,6 +85,245 @@ to `RULINGS.md`; a thing we discovered goes here.
 
 Ordered by consequence.
 
+### The twelve below came from ONE review, 2026-08-26 — the source-page plan, read against the code
+
+He asked for `docs/plans/2026-08-22-the-source-page-moves-into-the-extension.md` to be
+reviewed before a line was written, section by section, and ruled a direction on each
+finding. **Sixteen were found; four were built the same day** — the row handle, the payload
+memory, the derived contract guard, and the DOM and CI floors. **These twelve are the ones
+not built**, filed the day they were found, because a finding that lives in a chat channel
+did not happen. That is the mechanism `OP-69` was three days late by.
+
+`OP-70`, `OP-71` and `OP-72` lead because they are the three the primary session separated
+out, and the ordering rule is worth stating: the first has a **scheduled arrival date**, the
+second is a **comment naming a trap sitting above code that walks into it**, and the third
+is the only one that lets a caller **manufacture state**. The remaining nine follow by
+consequence.
+
+**Every citation here was re-derived at `35962cc` and none was carried from the plan.** The
+plan was written at `4522158`, six merges earlier, and every `app.py` and `app.js` line
+number in it had moved. That `docs/plans/` sits outside the citation guard's `DOCUMENTS` is
+`OP-59`'s shape one file over.
+
+### OP-70 · A dataset with a composite identity reports every row as `unsighted`, and the test covering that column cannot see it
+
+**Found 2026-08-26. Two halves, and the second is what lets the first survive.**
+
+**The collapse.** [scrapex/extract/service.py:895](../scrapex/extract/service.py#L895)
+resolves the identity field as `identity[0] if len(identity) == 1 else None`. With **two**
+`key_part` fields, or **zero**, that is `None` — so every row's external id is `None`, every
+`dataset_sighting` lookup misses, and `row_state` runs with `sighted_at=None,
+last_absent_at=None` for the entire table. `observed_state`, the column that exists on his
+instruction in `REQ-44` — «عمود يوضح الحالة الجديدة لا تدع المستخدم يستنتج الحالة» — is then uniformly
+wrong with nothing on screen or in a log to say so.
+
+**It is not hypothetical, because the code names its own trigger two lines above:**
+*"`contractor_id` is muqawil's answer; **Balady's and the UAE's will not be**, and this
+function is the one the panel calls for every generic source."* Both sources are already
+written up — `docs/BALADY-ENG-OFFICES.md` and `docs/UAE-SOURCES.md`. A defect with a
+scheduled arrival date.
+
+**The guard that cannot fire.** `grep -rn "key_part" tests/` returns **zero**: the identity
+resolution has no test at any arity. And the assertion covering the column
+([tests/test_a_dataset_is_a_table_like_any_other.py:869](../tests/test_a_dataset_is_a_table_like_any_other.py#L869))
+tests membership in an eight-value set that **contains `unsighted`**, so a table where every
+row collapsed stays green. General form in `LESSONS` §15.
+
+**His direction, 2026-08-26: build the edge case AND strengthen the assertion.** The `else
+None` swallows an unanswered question — what a two-key dataset *means* — and took the worst
+of the three available answers: explicit refusal, a composite key, or silent omission.
+**Which of the three is his call, not a developer's.**
+
+### OP-71 · The `MAX(observed_at)` subquery cannot be served by its index, twelve lines under a comment condemning that exact pattern
+
+**Found 2026-08-26.** [scrapex/extract/service.py:920](../scrapex/extract/service.py#L920)
+runs `(SELECT MAX(v.observed_at) FROM generic_record_revision AS v WHERE
+v.generic_record_id = r.generic_record_id)` — once per row.
+
+The only index available is [db/engine/schema.sql:849](../db/engine/schema.sql#L849),
+`ix_generic_record_revision_record ON generic_record_revision(generic_record_id,
+record_revision_id)`. **Its second column is `record_revision_id`, not `observed_at`**, so
+SQLite can seek a record's revisions from the index and must then read the table for each
+one to get the timestamp. No covering index, no index-only `MAX`.
+
+**And the trap is named on the same screen.**
+[service.py:934](../scrapex/extract/service.py#L934), twelve lines below, explains that the
+sighting side is read in ONE query because joining per row *"would be the
+correlated-subquery defect `OP-27` measured at 49s all over again."* The rule is known,
+written down, and applied to the neighbouring table.
+
+**His direction: a covering index on `(generic_record_id, observed_at)`, and explicitly NOT
+a cache.** A crawl writes continuously, and a stale cache produces *"why is the new
+contractor not showing?"* — a silent failure worse than a slow query. **The migration number
+is `0012`**, swept across every ref on 2026-08-26: `main` holds `0010`,
+`origin/feat/organization-enrichment` holds `0011`. Ask for it rather than counting it.
+
+### OP-72 · Three write tables key on a bare `TEXT source_key` with no foreign key and no existence check
+
+**Found 2026-08-26, and it is the only one of the twelve that lets a caller manufacture
+state.** `dataset_field` ([db/engine/schema.sql:176](../db/engine/schema.sql#L176)),
+`saved_view` ([:511](../db/engine/schema.sql#L511)) and `source_attribute_promotion`
+([:575](../db/engine/schema.sql#L575)) each declare `source_key TEXT NOT NULL` with **no
+`REFERENCES`**, and `fields.ensure_fields` and `fields.set_promotion` check nothing before
+inserting. A `POST` naming a source that does not exist **creates rows for it**.
+
+Related and separate: `fields.delete_view` is `DELETE FROM saved_view WHERE saved_view_id =
+?` with **no `source_key` scoping**, so the id alone is the whole authority.
+
+### OP-73 · `POST /api/fields` has no catalogue branch, so hiding a contractor column returns 404
+
+**Found 2026-08-26.** Step 0 of the plan gave `GET /api/fields` a dataset branch
+([scrapex/webui/app.py:2269](../scrapex/webui/app.py#L2269)) and **the POST at
+[:2335](../scrapex/webui/app.py#L2335) never got one.** It runs the price machinery
+unconditionally, and its seeding is keyed on `BROWSE_COLUMNS`: `wanted = [key for key, _ in
+BROWSE_COLUMNS if key in present or key == body.get("field_key")]`.
+
+**Measured: `BROWSE_COLUMNS` holds 54 keys and not one is a dataset field** —
+`company_name`, `contractor_id`, `membership_level` and `company_name_ar` are all absent.
+The comprehension iterates `BROWSE_COLUMNS`, so a contractor key never enters `wanted`,
+`ensure_fields` seeds nothing, `set_visibility` updates zero rows and raises `KeyError`, and
+[:2371](../scrapex/webui/app.py#L2371) turns that into **404**.
+
+**Reachable today.** Hiding a column from the grid's three-dot menu is the POST at
+[grid.js:1246](../scrapex/webui/static/grid.js#L1246); the GET that seeds runs only inside
+the Choose-Columns panel builder at
+[grid.js:1205](../scrapex/webui/static/grid.js#L1205). Open the contractors table, hide a
+column from the column menu without opening Choose-Columns → 404. **And the comment at
+[app.py:2340](../scrapex/webui/app.py#L2340) describes this exact failure and says it was
+fixed** — the fix is `BROWSE_COLUMNS`-shaped, so it is products-only.
+
+**Nothing tests it:** every `POST /api/fields` test uses a products key, and all four
+`contractors` HTTP calls in the step-0 suite are `GET`.
+
+**His direction: repair the seam BEFORE the port starts**, so steps 1–4 really are the
+"pure client ports" the plan calls them rather than discovering a server defect mid-way.
+
+### OP-74 · `list(body["order"])` is unguarded: a 500 one way, a forged «this is your arrangement» the other
+
+**Found 2026-08-26.** [scrapex/webui/app.py:2367](../scrapex/webui/app.py#L2367) is
+`reorder(conn, source_key, list(body["order"]))` with no type check. Two failure modes,
+traced through [scrapex/fields.py:153](../scrapex/fields.py#L153):
+
+- `{"order": 5}` → `list(5)` raises `TypeError`. `_write` catches only `DbLockedError`, the
+  outer `try` only `KeyError`, and the app-level handlers only three database errors →
+  **unhandled 500**.
+- `{"order": "abc"}` → `list("abc")` is `['a','b','c']`, which **passes** the `if not
+  ordered_keys: return` guard at [fields.py:160](../scrapex/fields.py#L160), matches no real
+  key, changes no order — and then [fields.py:173](../scrapex/fields.py#L173) stamps
+  `arranged_at` for the whole source **unconditionally**. `order_source` flips from
+  `"agreed"` to `"yours"` with nobody having arranged anything.
+
+The second is worse, and the comment above the stamp says why: *"This is the only path a
+PERSON can reach."* The stamp's whole meaning is *a person arranged this*, and an
+unvalidated cast lets a stray string forge it. `0059` rests on that distinction.
+
+**His direction: reject a non-list `order` with 422, plus tests for `5`, `"abc"`, `[]`, `{}`
+and an unknown key.**
+
+### OP-75 · `GET /api/fields` writes and commits on both branches, outside the write lock every `POST` pays for
+
+**Found 2026-08-26.** The GET commits at
+[app.py:2240](../scrapex/webui/app.py#L2240) — the dataset branch, seeding from the schema —
+and at [app.py:2291](../scrapex/webui/app.py#L2291) on the price branch. A grep over the
+whole `api_fields` region finds **two `conn.commit()` and zero `write_lock`**, while every
+`POST` goes through `_write` ([app.py:2178](../scrapex/webui/app.py#L2178)), which takes the
+lock for the reason it states: *"A crawl in progress holds that lock."*
+
+**The write-on-GET is deliberate, documented and tested** — that is not the finding. The
+finding is that it is **unlocked**, so the protection depends on the HTTP verb rather than
+on what the code does, and a GET can write while a crawl holds the lock.
+
+**This is also what makes read-only connections more than a one-line change.** Neither
+`read_conn` nor `general_read_conn` opens read-only: both reach plain
+`sqlite3.connect(str(path))`
+([databases/domain.py:144](../scrapex/databases/domain.py#L144)), and the only `?mode=ro` in
+the package is in `bundle.py` and `carry_over.py`. Making the read paths read-only breaks
+this GET **immediately**, so every endpoint must first be classified "reads" against "reads
+and seeds". **His direction: put the lock where the write already is, and move the seeding
+to `POST` later, alongside `OP-73`.**
+
+### OP-76 · The two payload producers label columns by different rules, and the difference is visible to him
+
+**Found 2026-08-26.** `grep display_name scrapex/reports.py` returns **zero hits**: the
+products payload labels from a module constant only —
+[reports.py:2191](../scrapex/reports.py#L2191), `labels = dict(BROWSE_COLUMNS)`. The dataset
+payload does the opposite at [service.py:1023](../scrapex/extract/service.py#L1023),
+preferring his stored `display_name`.
+
+**So renaming a column reaches a contractor table's heading and never a products table's.**
+The plan lists *"a rename reaches the heading"* as a met step-0 gate; it holds for datasets
+only, and the plan does not say so.
+
+**His direction, 2026-08-26: unify it — his renames should reach products headings too.**
+Recorded as a decision rather than a cleanup, because it changes what existing product
+tables display.
+
+### OP-77 · `dataset_table_payload` reimplements two `fields.py` helpers inline while the products path calls them
+
+**Found 2026-08-26.** It imports and uses two of the five helpers
+([service.py:16](../scrapex/extract/service.py#L16)) and reimplements `hidden_columns` and
+`column_order` in the function body, where
+[reports.py:2183](../scrapex/reports.py#L2183) calls the helper. Two surfaces answering one
+question two ways — which is what step 2's own gate forbids: *"a grep finds no second copy of
+any of the three bodies."*
+
+**Not inflated beyond what it is:** `fields.list_fields` and `catalog.list_fields` are a
+**name collision, not duplication** — different tables, different keys, different return
+shapes. Recorded so that a later reader does not "fix" it.
+
+### OP-78 · `tree` is produced by both producers, asserted by a test, and read by no consumer anywhere
+
+**Found 2026-08-26.** [reports.py:2255](../scrapex/reports.py#L2255) computes it with
+`_tree_shape`; [service.py:1026](../scrapex/extract/service.py#L1026) hard-codes `{}`. No
+consumer reads `payload.tree` — `grid.js`'s `features.tree` is a name collision — and the
+13-key list asserts it regardless.
+
+**Recorded rather than deleted, on his direction:** removing a key from the contract while a
+third producer is being written against it is two changes at once. It is now **named** in
+`UNREAD_BY_EVERY_READER` in
+[tests/test_the_table_payload_answers_every_key_its_readers_read.py](../tests/test_the_table_payload_answers_every_key_its_readers_read.py),
+so it is a listed decision instead of an accident, and anything that joins it fails that
+test.
+
+### OP-79 · `reorder` reads `dataset_field` unfiltered, so `OP-53`'s eleven inert rows still consume ordering positions
+
+**Found 2026-08-26.** [fields.py:162](../scrapex/fields.py#L162) builds `current` from a bare
+`list_fields`, which is `SELECT ... FROM dataset_field WHERE source_key = ?` with no
+intersection against the dataset's real schema. The intersection that makes `OP-53`'s eleven
+price-path rows inert lives **only on the read path**, at
+[app.py:2243](../scrapex/webui/app.py#L2243). So the eleven are invisible in the chooser and
+still occupy `display_order` slots whenever anything is reordered.
+
+Depends on `OP-58`: whether those rows are deleted at all is his gate, since
+`COMPATIBILITY.md` puts a destructive migration behind his review.
+
+### OP-80 · One uncached `/api/offer` request per selected row, with no cap — and step 3 would port it verbatim
+
+**Found 2026-08-26.** [grid.js:3085](../scrapex/webui/static/grid.js#L3085) is
+`rowsData.forEach((row) => { ... fetch("/api/offer/" + ... + row.offer_id)` — one request per
+selected row, all in parallel, no batching, no cache, and `rowsData` carries no length limit.
+
+These are the multi-row selection cards: 109 lines of the 967-line step-3 cluster, so the
+shape crosses into the panel unchanged, where it also crosses the extension's 5,000 ms
+deadline.
+
+**His direction: a cap that SAYS what it excluded, plus a batch endpoint.** Step 3 builds a
+new endpoint anyway, so making it batch costs about the same and stops the N+1 reaching a
+second surface.
+
+### OP-81 · Nothing on the data path is cached, anywhere
+
+**Found 2026-08-26.** Zero hits for `cache-control|etag|last-modified|max-age` across
+`webui/app.py`, `reports.py`, `extract/service.py` and `fields.py`, and zero for
+`lru_cache|functools.cache|@cache` across **all** of `scrapex/`. None of the three registered
+middlewares ([app.py:565](../scrapex/webui/app.py#L565)) adds a header. Every open of a data
+tab recomputes the whole payload, measured at 24.26 MB over 17,304 rows for `contractors`.
+
+**Recorded as a characteristic rather than a defect to fix, and he ruled against caching
+directly** — see `OP-71`. A crawl writes continuously, and stale data he cannot explain is
+worse than a slow query he can. **The remedy for the cost is the covering index, not a
+cache.**
+
 ### OP-43 · Four written premises about the muqawil profile page were wrong, and one of them hid a price
 **Found 2026-08-22** under `REQ-31`, measured over **2,419 real profile pairs** read
 read-only out of the running crawl, after he warned that the pages are not consistent —

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -2564,3 +2564,95 @@ every claim is, and whether the claim can still be read after that base has move
 the answer is *yes*, the fix is to make the claim carry its base or re-derive it
 (§12, `ORCHESTRATION` §4). **When the artefact is a process rather than a file, no
 amount of re-deriving helps — the artefact has to be able to answer for itself.**
+
+---
+
+## 15 · An assertion that lists the allowed answers passes when every answer is wrong
+
+**Measured 2026-08-26, reviewing the plan that moves the source page into the
+extension.** Three guards were examined and all three were the same defect wearing
+different clothes: *the expectation was retyped beside the thing it guards instead
+of derived from it.* Retyped expectations do not merely go stale — they go stale
+**silently and in the safe-looking direction**, which is why none of the three had
+ever failed.
+
+### The instance that is worst, because the column exists to prevent guessing
+
+`observed_state` exists on his instruction — «عمود يوضح الحالة الجديدة لا تدع
+المستخدم يستنتج الحالة». The test covering it
+([tests/test_a_dataset_is_a_table_like_any_other.py:869](../tests/test_a_dataset_is_a_table_like_any_other.py#L869))
+asserts membership:
+
+```
+assert row["observed_state"] in {"new", "updated", "confirmed", "returned",
+                                 "absent", "unsighted", "retired", "unavailable"}
+```
+
+`unsighted` is in that set. So a table where **every single row** collapsed to
+`unsighted` is green. And there is a live path that does exactly that:
+[scrapex/extract/service.py:895](../scrapex/extract/service.py#L895) resolves the
+identity field as `identity[0] if len(identity) == 1 else None`, so a dataset with
+two `key_part` fields — or zero — yields `None`, every row's `external` is `None`,
+every sighting lookup misses, and the whole column is wrong with nothing to say so.
+
+**Two facts make this a lesson rather than a hypothetical.** `grep -rn "key_part"
+tests/` returns **zero** — the identity resolution has no test at any arity. And the
+comment two lines above the collapse names the trigger: *"`contractor_id` is
+muqawil's answer; Balady's and the UAE's will not be."* The next source is the
+event, and `docs/BALADY-ENG-OFFICES.md` and `docs/UAE-SOURCES.md` are already
+written.
+
+### The general form, and the cheap test for it
+
+**An assertion whose right-hand side is a SET is only as strong as the worst member
+of that set.** Ask of any such assertion: *if the code returned this same value for
+every row, would this still pass?* When the answer is yes, it is measuring that the
+code produced a string, not that it produced the right one.
+
+The fix is not a bigger set. It is asserting the value a **named** fixture must
+produce — one row that is genuinely `confirmed`, one genuinely `unsighted` — so the
+mapping is checked rather than the vocabulary.
+
+### The same shape twice more, both closed the same way
+
+- **The payload contract.** `test_it_answers_every_key_the_grid_reads` asserted
+  thirteen keys typed into the test. `grid.js` reads ten, and three of the thirteen
+  it never reads. Worse, it opens no file, so a **new** `payload.x` read in `grid.js`
+  failed no test — the crash the docstring names was the one case it could not see.
+  Closed by deriving both sides from the artefacts
+  ([tests/test_the_table_payload_answers_every_key_its_readers_read.py](../tests/test_the_table_payload_answers_every_key_its_readers_read.py)),
+  the mechanism `R-15`'s citation guard already established.
+- **CI's browser floor.** `.github/workflows/ci.yml` said it in its own comment —
+  *"a per-file 'at least one' would not have noticed 48 becoming 1"* — and then
+  applied a real number to one suite of ten. `test_grid_dom.py` (20) and
+  `test_tab_page_dom.py` (10), the two suites that draw the Data page, sat on `-ge 1`.
+
+**So the rule generalises past tests:** a guard that states its own reasoning and
+then applies it narrowly is more dangerous than one that never stated it, because
+the stated reasoning reads as coverage.
+
+## 16 · Reading the renderer is not drawing it, and the gap was one word wide
+
+**Same review, and it cost ten minutes rather than an afternoon only because a
+harness existed.** `grid.js` pushes the moved-column card into
+`detailSections.get("specifications")`, so a test written from the source waits for
+`[data-inspector-view="specifications"]`. It times out: the record panel renders
+**exactly two** view buttons, `details` and `history`. "specifications" is a
+*section inside* Details, not a view of its own — a distinction invisible in the
+line that names it.
+
+**And a second one in the same test.** The card's heading is upper-cased by CSS, and
+`innerText` reports the transformed text, so `"Moved out of the table" in panel` is
+false while the card is plainly drawn. A behavioural assertion must not be able to
+fail because a stylesheet changed its mind about capitals.
+
+**Apply:** when a gate says *"the card appears"*, the only thing that can prove it is
+a browser. Both misreadings above were made while looking directly at the correct
+line of source, which is the argument the plan makes for its own harness — the Data
+page shipped **broken** once with 2,460 engine and 398 extension tests green on it —
+arrived at again from the other end.
+
+**And the corollary that is easy to skip:** the negative control must open the same
+view as the positive test. Asserting "no card" against a panel whose section was
+never opened passes for the wrong reason, and an absent card and an unopened section
+are indistinguishable from outside.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -310,6 +310,45 @@ tracks *his requests* through Captured → Ruled → Planned → In flight → D
 
 ## Open pull requests
 
+### The source-page plan was reviewed, and the review found the step-3 blocker is one line — 2026-08-26
+
+**Branch `fix/a-dataset-row-gets-a-handle-and-the-payload-a-guard`, based on `35962cc`.**
+The owner asked for a full review of
+[the plan that moves the source page into the extension](plans/2026-08-22-the-source-page-moves-into-the-extension.md)
+before any code was written, ruled on sixteen findings, and approved a first wave of
+six that change no behaviour. Four commits, and the register entries for the twelve
+findings NOT in this wave are held pending numbers from the primary session (`R-42`).
+
+**THE FINDING THAT MOVES THE PLAN.** Step 3 — the record card, `REQ-32`, the step he
+actually asked for — is priced in the plan at **967 lines** and gated on a new
+endpoint. Measured: `dataset_table_payload` SELECTed `generic_record_id`
+([service.py:918](../scrapex/extract/service.py#L918)) and the emitting loop dropped
+it, so the payload carried **no handle for the row at all**, while `grid.js` opens its
+card from `rows.filter((row) => row.offer_id)` and closes the panel when that is
+empty. **Selecting a contractor could never open anything**, and the fix is one
+assignment. Emitted now as `observed_record_id`, following `offer_id`'s precedent
+exactly: it rides in `rows` and is absent from the column list, so it never draws.
+
+**What else landed, each with the measurement behind it:**
+
+| | |
+|---|---|
+| the payload held itself twice | `.fetchall()` kept every raw `data_json` live through the loop that parses them. `tracemalloc` on a 28-field, 17,304-row fixture: `stored` 60 MB, `stored`+`rows` 160 MB, 307 MB peak against a 43 MB wire payload — **7.2x**, excluding `sighted` as a third. Streaming: **160.0 → 103.8 MB, −35%**. The bound is untouched — `cap=None` still means every row |
+| the payload contract was retyped, not derived | two producers, three readers, no TypedDict/schema/`response_model` anywhere. The one guard asserted 13 hand-typed keys; `grid.js` reads 10, three of the 13 it never reads, and a NEW read would have failed no test. Now derived from both sides, two tiers, mutation-tested three ways |
+| two capabilities had no test on the surface being ported | `grep grid-lang-toggle tests/ tools/` was empty though the toggle renders in the harness; `moved_to_details` was `[]` in every rendered fixture in the repo. Four tests with their controls, mutation-tested |
+| CI's browser floor was `-ge 1` for nine of ten suites | its own comment says *"a per-file 'at least one' would not have noticed 48 becoming 1"*. `test_grid_dom.py` and `test_tab_page_dom.py` — the two that draw this page — now carry numbers |
+
+**AND THE PLAN'S OWN GATE IS STALE, which is not this branch's to fix.** It carries
+steps 3 and 5 as ⛔ blocked on a boundary study it says is *still running*. That study
+landed as [R-50](RULINGS.md#r-50--the-engine-is-a-helper-to-the-extension-and-any-task-the-extension-can-do-moves-to-it)
+in #260 on 2026-08-23. Its structural claim that *"only `/api/table` uses
+`general_read_conn()`"* was falsified by its own step 0 — `GET /api/fields` resolves
+the catalogue first too. And its migration note is doubly stale: `main` holds `0010`
+and `origin/feat/organization-enrichment` holds `0011`, so the next free number is
+**`0012`**, asked for rather than counted. `docs/plans/` sits outside the citation
+guard's `DOCUMENTS`, which is the same unguarded position the plan criticises in
+`OP-59`.
+
 ### muqawil is ONE card, and 17,304 contractors stop being products — 2026-08-23
 
 **`REQ-37` was ruled on 2026-08-22 as `R-47` and was still not built on 2026-08-23**,

--- a/scrapex/extract/service.py
+++ b/scrapex/extract/service.py
@@ -46,6 +46,18 @@ OBSERVED_FIRST_SEEN = "observed_first_seen"
 OBSERVED_LAST_SEEN = "observed_last_seen"
 OBSERVED_CHANGED = "observed_last_changed"
 OBSERVED_STATUS = "observed_status"
+#: THE ROW'S HANDLE, and it is not a column. `offer_id` is what the products payload
+#: carries so `grid.js` can open a card for the row that was selected — it rides in
+#: `rows` and is absent from `BROWSE_COLUMNS`, so it never draws. A dataset row had no
+#: equivalent: `generic_record_id` was SELECTed and then dropped on the floor by the
+#: emitting loop, so `grid.js`'s `rows.filter((row) => row.offer_id)` matched nothing
+#: and selecting a contractor could not open anything at all.
+#:
+#: `observed_` PREFIXED like the rest, for the reason the block above gives: it is a
+#: fact about our storage rather than one the site published, and no site's own label
+#: slugs to it. Deliberately NOT added to `OBSERVED_COLUMNS` — a handle the reader
+#: never sees is the whole point.
+OBSERVED_RECORD_ID = "observed_record_id"
 
 #: THE STATE COLUMN LEADS, on his instruction: «عمود يوضح الحالة الجديدة لا تدع
 #: المستخدم يستنتج الحالة». The dates stay — they are the evidence behind the state and
@@ -905,24 +917,6 @@ def dataset_table_payload(conn: sqlite3.Connection, dataset_key: str,
     total = conn.execute(
         "SELECT count(*) FROM generic_record WHERE dataset_definition_id = ?",
         (dataset_id,)).fetchone()[0]
-    # LIMIT only when a caller asked for one. `LIMIT -1` is SQLite's own idiom
-    # for no limit and is used rather than building two query strings, so the
-    # bounded and unbounded paths cannot drift apart.
-    # EVERY FACT THE STATE NEEDS, IN ONE QUERY. `changed_at` is the newest revision
-    # for this record, which is what makes `updated` knowable — and it is only
-    # meaningful because `R-20` stopped writing a revision when nothing changed.
-    # Before that every row had one every crawl and `updated` would have been every
-    # row. `LEFT JOIN`, because a record whose only revision is its first has none
-    # after it and must not vanish from its own table.
-    stored = conn.execute(
-        "SELECT r.generic_record_id, r.record_key, r.data_json, r.status, "
-        "       r.first_seen_at, r.last_seen_at, "
-        "       (SELECT MAX(v.observed_at) FROM generic_record_revision AS v "
-        "         WHERE v.generic_record_id = r.generic_record_id) AS changed_at "
-        "  FROM generic_record AS r WHERE r.dataset_definition_id = ? "
-        " ORDER BY r.generic_record_id LIMIT ?",
-        (dataset_id, -1 if cap is None else int(cap))).fetchall()
-
     # WHEN THE MOST RECENT CRAWL SAW ANYTHING — one aggregate, not a per-row
     # question. Derived, never stored: written into the row it would be stale the
     # moment the next crawl ran (`R-27`).
@@ -942,6 +936,37 @@ def dataset_table_payload(conn: sqlite3.Connection, dataset_key: str,
                 "  FROM dataset_sighting WHERE dataset_key = ?", (dataset_key,))
         }
 
+    # LIMIT only when a caller asked for one. `LIMIT -1` is SQLite's own idiom
+    # for no limit and is used rather than building two query strings, so the
+    # bounded and unbounded paths cannot drift apart.
+    # EVERY FACT THE STATE NEEDS, IN ONE QUERY. `changed_at` is the newest revision
+    # for this record, which is what makes `updated` knowable — and it is only
+    # meaningful because `R-20` stopped writing a revision when nothing changed.
+    # Before that every row had one every crawl and `updated` would have been every
+    # row. `LEFT JOIN`, because a record whose only revision is its first has none
+    # after it and must not vanish from its own table.
+    #
+    # STREAMED, AND EXECUTED LAST ON PURPOSE. It used to end in `.fetchall()` up
+    # beside the COUNT, which meant every raw `data_json` string stayed live for the
+    # whole of the loop below that parses them — two full-population structures in
+    # memory at once, plus `sighted` as a third. Measured on a 28-field,
+    # 17,304-row fixture: `stored` alone 60 MB, `stored` + `rows` 160 MB, peak with
+    # the serialised body 307 MB against a 43 MB wire payload — 7.2x, and that
+    # figure EXCLUDES `sighted`. Iterating the cursor drops the first of the three.
+    #
+    # It is executed here rather than above `newest` so that nothing runs on this
+    # connection between opening this cursor and draining it. `conn.execute` hands
+    # back a fresh cursor each call and interleaving would in fact be safe, but a
+    # reader should not have to know that to trust the function.
+    stored = conn.execute(
+        "SELECT r.generic_record_id, r.record_key, r.data_json, r.status, "
+        "       r.first_seen_at, r.last_seen_at, "
+        "       (SELECT MAX(v.observed_at) FROM generic_record_revision AS v "
+        "         WHERE v.generic_record_id = r.generic_record_id) AS changed_at "
+        "  FROM generic_record AS r WHERE r.dataset_definition_id = ? "
+        " ORDER BY r.generic_record_id LIMIT ?",
+        (dataset_id, -1 if cap is None else int(cap)))
+
     rows = []
     for row in stored:
         record = json.loads(row["data_json"])
@@ -950,6 +975,7 @@ def dataset_table_payload(conn: sqlite3.Connection, dataset_key: str,
         # BESIDE THE SITE'S FIELDS, NEVER MERGED INTO THEM. These are facts about our
         # OBSERVATION, not facts the site published, and `data_json` is source truth —
         # so they are added to the row the grid renders and never written back.
+        record[OBSERVED_RECORD_ID] = row["generic_record_id"]
         record[OBSERVED_FIRST_SEEN] = row["first_seen_at"]
         record[OBSERVED_LAST_SEEN] = row["last_seen_at"]
         record[OBSERVED_STATUS] = row["status"]

--- a/tests/test_grid_dom.py
+++ b/tests/test_grid_dom.py
@@ -502,3 +502,166 @@ def test_the_record_panels_timestamps_follow_the_display_zone(page_factory):
     finally:
         browser.close()
         ctx.stop()
+
+
+# ---- the two capabilities the extension port is measured by, 2026-08-26 ------
+#
+# The plan that moves the source page into the extension proves its step 1 (the
+# AR|EN toggle) and its step 3 (the record card's "Moved out of the table"
+# section) through a DOM harness. Neither had a behavioural test on THIS surface,
+# so there was no baseline for a port to be measured against:
+#
+#   * `grep -rn "grid-lang-toggle" tests/ tools/` returned nothing. The toggle
+#     renders in this very harness -- `_payload()` has carried a non-empty
+#     `bilingual` since the file was written -- and nobody had ever pressed it.
+#   * `moved_to_details` is `[]` in EVERY rendered fixture in the repo: here at
+#     :69 and twice in tests/test_tab_page_dom.py. The only non-empty assertions
+#     are on the payload in Python, so the card below had never been drawn.
+#
+# A port whose gate is "the panel does what the engine does" needs the engine's
+# half asserted first, or "correct" silently becomes "whatever the port did".
+
+MOVED_OUT_OF_THE_TABLE = [{"key": "sku", "label": "SKU"}]
+
+
+def test_a_column_moved_out_of_the_table_is_drawn_in_the_record_card(page_factory):
+    """`R-45`: hiding a column MOVES it to the card. This draws the move.
+
+    `sku` is the honest fixture for it -- it rides in every row of `_payload()`
+    and is absent from `columns`, which is exactly the shape a hidden column has.
+    """
+    payload = _payload()
+    payload["moved_to_details"] = MOVED_OUT_OF_THE_TABLE
+    page, browser, ctx = page_factory(payload, offer=OFFER_WITH_HISTORY)
+    try:
+        # The card is built only when a row is open: grid.js gates it on
+        # `moved.length && openOfferRow`, so a non-empty list on its own draws
+        # nothing and asserting on the payload could never have caught that.
+        opened = page.evaluate("""() => {
+            const table = Tabulator.findTable('#grid')[0];
+            table.selectRow(table.getRows()[0]);
+            return table.getSelectedRows().length;
+        }""")
+        assert opened == 1, "the row could not be selected, so no record opened"
+
+        # Under DETAILS, and this is the first thing the harness taught that
+        # reading the source did not: grid.js pushes the card into
+        # `detailSections.get("specifications")`, but "specifications" is a
+        # SECTION inside the Details view rather than a view of its own. The
+        # panel renders exactly two buttons -- details and history -- so a test
+        # written from the source alone waits forever for a third.
+        page.click('#offer-panel [data-inspector-view="details"]')
+        page.wait_for_selector("#offer-panel", state="visible", timeout=5000)
+        panel = page.inner_text("#offer-panel")
+
+        # Case-insensitively: the heading is upper-cased by CSS, and `innerText`
+        # reports the transformed text. A behavioural test must not go red
+        # because a stylesheet changed its mind about capitals.
+        assert "moved out of the table" in panel.lower(), (
+            "a column was moved out of the table and the card did not say so; "
+            f"the panel read: {panel[:400]!r}")
+        # The VALUE, not just the heading: the card reads the key off the open
+        # row (`openOfferRow[column.key]`), so a heading with an empty body is
+        # the failure that looks like success. Row 0 carries offer_id 1.
+        assert "SKU1" in panel, (
+            "the moved column's heading drew but its value did not, so the card "
+            f"is empty of the thing it exists to show; panel: {panel[:400]!r}")
+    finally:
+        browser.close()
+        ctx.stop()
+
+
+def test_an_empty_moved_list_draws_no_card_at_all(page_factory):
+    """The control for the test above, and the state every other fixture is in.
+
+    Without this the assertion above would pass just as well against a card that
+    is always drawn, which is a different page from the one `R-45` asked for.
+    """
+    page, browser, ctx = page_factory(offer=OFFER_WITH_HISTORY)
+    try:
+        page.evaluate("""() => {
+            const table = Tabulator.findTable('#grid')[0];
+            table.selectRow(table.getRows()[0]);
+        }""")
+        page.wait_for_selector("#offer-panel", state="visible", timeout=5000)
+        # The SAME view the positive test reads, or this passes for the wrong
+        # reason -- an absent card and an unopened section are indistinguishable
+        # from outside, and asserting on the closed panel would be exactly the
+        # weak assertion this pair of tests exists to replace.
+        page.click('#offer-panel [data-inspector-view="details"]')
+        page.wait_for_timeout(300)
+        assert "moved out of the table" not in page.inner_text("#offer-panel").lower(), (
+            "nothing was moved out of the table and the card drew anyway")
+    finally:
+        browser.close()
+        ctx.stop()
+
+
+def test_the_language_toggle_swaps_which_name_column_is_visible(page):
+    """Step 1's subject: it changes VISIBILITY, and leaves the rows alone.
+
+    The engine's toggle swaps which of the two name columns is shown rather than
+    rewriting one column's contents, and that is the property the port has to
+    keep: sort, filter and export each go on working against the column they
+    name. So this asserts the swap AND that the row order did not move.
+    """
+    def visible():
+        return page.evaluate("""() => {
+            const t = Tabulator.findTable('#grid')[0];
+            return t.getColumns().filter(c => c.isVisible()).map(c => c.getField());
+        }""")
+
+    def order():
+        return page.evaluate(
+            "() => Tabulator.findTable('#grid')[0].getData('active')"
+            "  .map(r => r.offer_id)")
+
+    page.wait_for_selector("#grid-lang-toggle", timeout=5000)
+    before = order()
+    assert "product_name" in visible(), "the table did not open on English names"
+
+    page.click('#grid-lang-toggle .grid-lang-option[aria-label="Show Arabic fields"]')
+    page.wait_for_function(
+        """() => {
+            const t = Tabulator.findTable('#grid')[0];
+            const c = t.getColumn('product_name_ar');
+            return c && c.isVisible();
+        }""", timeout=5000)
+    after = visible()
+    assert "product_name_ar" in after, "AR was pressed and the Arabic column stayed hidden"
+    assert "product_name" not in after, (
+        "AR was pressed and BOTH name columns are visible; the toggle is meant to "
+        "swap them, not add one")
+    assert order() == before, (
+        "the language toggle reordered the table; it swaps a column's visibility "
+        "and must not touch the rows")
+
+    page.click('#grid-lang-toggle .grid-lang-option[aria-label="Show English fields"]')
+    page.wait_for_function(
+        """() => {
+            const t = Tabulator.findTable('#grid')[0];
+            const c = t.getColumn('product_name');
+            return c && c.isVisible();
+        }""", timeout=5000)
+    assert "product_name_ar" not in visible(), "EN was pressed and AR stayed visible"
+    assert order() == before, "returning to English reordered the table"
+
+
+def test_the_toggle_is_absent_rather_than_present_and_lying(page_factory):
+    """No pairs means no control. `grid.js` returns early on an empty `bilingual`.
+
+    Worth asserting because the panel's own `summarise` gets this wrong in the
+    other direction -- it prints the word "bilingual" for `{}`, since an empty
+    object is truthy in JS -- so the two surfaces do not agree today about what
+    an empty pair set means.
+    """
+    payload = _payload()
+    payload["bilingual"] = {}
+    page, browser, ctx = page_factory(payload)
+    try:
+        assert page.locator("#grid-lang-toggle").count() == 0, (
+            "there are no bilingual pairs and the toggle rendered anyway, which "
+            "offers the reader a control that cannot do anything")
+    finally:
+        browser.close()
+        ctx.stop()

--- a/tests/test_the_table_payload_answers_every_key_its_readers_read.py
+++ b/tests/test_the_table_payload_answers_every_key_its_readers_read.py
@@ -1,0 +1,217 @@
+"""The table payload has two producers and three readers, and nothing bound them.
+
+WHY THIS EXISTS. `scrapex/webui/static/grid.js` reads keys off the payload
+unconditionally, and `dataset_table_payload`'s own comment states the consequence:
+*"an absent key would be a crash where a false is a switch the page simply does not
+offer."* So the contract is load-bearing. It was also entirely implicit:
+
+  * TWO producers fill it -- `reports.table_payload` from `price_observation`, and
+    `extract.service.dataset_table_payload` from `generic_record`.
+  * THREE readers consume it -- `grid.js` on the engine page, and
+    `extension/datatable.js` and `extension/data.js` in the panel.
+  * NO TypedDict, no dataclass, no JSON schema, no FastAPI `response_model`. A
+    repo-wide search for all four finds nothing, so the only thing describing the
+    shape was prose.
+
+WHAT WAS GUARDING IT, AND WHY THAT WAS NOT ENOUGH. One test:
+`test_it_answers_every_key_the_grid_reads` in
+`tests/test_a_dataset_is_a_table_like_any_other.py`. Its docstring says *"`grid.js`
+reads these unconditionally"* and its list is a **literal typed into the test**. Two
+consequences were measured before this file was written:
+
+  * It asserts thirteen keys. `grid.js` reads ten. Three of the thirteen --
+    `source_key`, `folded`, `tree` -- it never reads, so the docstring's claim is
+    false for nearly a quarter of the list. (`folded` IS read, but by the panel, a
+    reader that test never looks at.)
+  * It reads nothing off disk, so **adding a new `payload.x` read to `grid.js`
+    tomorrow fails no test at all.** The crash it exists to prevent is exactly the
+    crash it cannot see.
+
+That is the same failure `tests/test_the_documents_cite_what_they_claim.py` was built
+for -- an assertion about a file, written by hand, drifting from the file -- and this
+guard copies its answer: derive the expectation from the artefact instead of retyping
+it. It also copies its TWO TIERS, for the same reason that file gives:
+
+  * **Tier 1** is the crash direction and is mechanical: every key a reader reads,
+    both producers must emit. Zero inference -- a regex over the readers, an `ast`
+    walk over the producers -- and no database, so it cannot flake.
+  * **Tier 2** is the opposite direction and is a LIST, because "nothing reads this"
+    is a judgement rather than a defect. A key emitted for no reader is either dead
+    weight or deliberate headroom, and which one it is has to be said out loud.
+    Adding to `UNREAD_BY_EVERY_READER` is the intended cost.
+
+WHY A REGEX OVER THE READERS RATHER THAN A JS PARSER. The three readers touch the
+payload through exactly one idiom, `payload.key` or `payload?.key`, verified by
+reading all three at 35962cc. A parser would be a dependency and a second thing to
+keep true for one extra form nobody writes. If a reader ever destructures instead --
+`const {rows} = payload` -- this guard goes BLIND rather than loud, so
+`test_the_readers_still_use_the_idiom_this_guard_can_see` fails on that change and
+sends the next session here.
+"""
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+#: Every file that reads the table payload. `grid.js` is the engine's page; the other
+#: two are the panel's, and they are in this list because the plan that moves the
+#: source page into the extension adds readers rather than replacing one -- so the
+#: number of ways to drift goes UP, which is what makes deriving the contract worth a
+#: file of its own.
+READERS = (
+    "scrapex/webui/static/grid.js",
+    "extension/datatable.js",
+    "extension/data.js",
+)
+
+#: Both producers, and the function in each that builds the payload.
+PRODUCERS = (
+    ("scrapex/reports.py", "table_payload"),
+    ("scrapex/extract/service.py", "dataset_table_payload"),
+)
+
+#: Keys BOTH producers emit that NO reader reads. Every entry needs a reason.
+#:
+#: `source_key` -- the readers all learn the source another way: `grid.js` takes it
+#: from the DOM (`const SOURCE = mount.dataset.source`), and the panel already knows
+#: which source it asked about. Harmless, and useful when reading a payload by hand.
+#:
+#: `tree` -- genuinely dead. `reports.table_payload` computes it with `_tree_shape`
+#: and `dataset_table_payload` hard-codes `{}`; `grid.js` has a `features.tree` but
+#: that is a name collision, not a read of this key. Recorded rather than deleted:
+#: removing a key from the contract while a third producer is being written is two
+#: changes at once, and the owner's standing instruction is one step at a time.
+UNREAD_BY_EVERY_READER = frozenset({"source_key", "tree"})
+
+#: `payload.key` and `payload?.key`. Deliberately does NOT match `payload["key"]` --
+#: no reader uses it, and matching it would invite the belief that this regex sees
+#: every access when it sees one idiom. The companion test below is what keeps that
+#: honest.
+_READ = re.compile(r"payload\s*\??\s*\.\s*([A-Za-z_]\w*)")
+
+#: A destructure of the payload would hide reads from `_READ` entirely.
+_DESTRUCTURE = re.compile(r"(?:const|let|var)\s*\{[^}]*\}\s*=\s*payload\b")
+
+
+def _text(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+def _keys_read(relative: str) -> set[str]:
+    return set(_READ.findall(_text(relative)))
+
+
+def _keys_emitted(relative: str, function: str) -> set[str]:
+    """The keys of the payload dict literal `function` returns.
+
+    Returns that are not dict literals are skipped -- `dataset_table_payload`'s
+    `return None` on a catalogue miss is one -- and returns belonging to a NESTED
+    function are skipped too, because `table_payload` defines a `tax_ref` helper
+    inside itself and its return is not the payload.
+    """
+    tree = ast.parse(_text(relative))
+    target = next(
+        (node for node in ast.walk(tree)
+         if isinstance(node, ast.FunctionDef) and node.name == function), None)
+    assert target is not None, f"{relative} no longer defines {function}()"
+
+    nested = {inner for child in target.body for inner in ast.walk(child)
+              if isinstance(inner, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda))
+              and inner is not target}
+    nested_returns = {ret for func in nested for ret in ast.walk(func)
+                      if isinstance(ret, ast.Return)}
+
+    literals = [node for node in ast.walk(target)
+                if isinstance(node, ast.Return)
+                and node not in nested_returns
+                and isinstance(node.value, ast.Dict)]
+    assert len(literals) == 1, (
+        f"{relative}:{function}() returns {len(literals)} dict literals; this guard "
+        "reads the payload off exactly one and cannot tell which is meant")
+    payload = literals[0].value
+    keys = {key.value for key in payload.keys if isinstance(key, ast.Constant)}
+    assert len(keys) == len(payload.keys), (
+        f"{relative}:{function}() builds a key dynamically; this guard can only "
+        "read constant keys and would report a false absence")
+    return keys
+
+
+# ---- tier 1: the crash direction -------------------------------------------------
+
+@pytest.mark.parametrize("reader", READERS)
+@pytest.mark.parametrize(("module", "function"), PRODUCERS)
+def test_every_key_a_reader_reads_is_emitted(reader: str, module: str, function: str):
+    """A key read and not emitted is `undefined` at best and a crash at worst.
+
+    Both producers are held to EVERY reader, not each to its own, because one
+    endpoint answers from either of them: `/api/table/{key}` resolves the catalogue
+    first and falls through to the price path, so a reader cannot know which
+    producer filled the payload it was handed.
+    """
+    emitted = _keys_emitted(module, function)
+    missing = sorted(_keys_read(reader) - emitted)
+
+    assert not missing, (
+        f"{reader} reads {missing} off the payload and {module}:{function}() does "
+        f"not emit {'it' if len(missing) == 1 else 'them'}. Either emit the key or "
+        f"stop reading it -- an absent key reaches the page as undefined.")
+
+
+def test_the_two_producers_agree_on_the_whole_shape():
+    """One page renders both, so a key on one path and not the other is a defect.
+
+    This is the check that would have caught the shape drifting while a third
+    producer -- the dataset record card -- is being written against it.
+    """
+    (price_module, price_fn), (data_module, data_fn) = PRODUCERS
+    price = _keys_emitted(price_module, price_fn)
+    dataset = _keys_emitted(data_module, data_fn)
+
+    assert price == dataset, (
+        f"the two producers disagree: only {price_fn}() emits "
+        f"{sorted(price - dataset)}, only {data_fn}() emits "
+        f"{sorted(dataset - price)}")
+
+
+# ---- tier 2: the stated-out-loud direction ---------------------------------------
+
+def test_a_key_no_reader_reads_is_listed_and_not_merely_present():
+    """Emitted-and-unread is a decision. It has to be written down as one."""
+    emitted = set.intersection(*(_keys_emitted(m, f) for m, f in PRODUCERS))
+    read = set.union(*(_keys_read(reader) for reader in READERS))
+    unread = emitted - read
+
+    assert unread == set(UNREAD_BY_EVERY_READER), (
+        "the emitted-but-unread set moved.\n"
+        f"  now unread and NOT listed : {sorted(unread - UNREAD_BY_EVERY_READER)}\n"
+        f"  listed and no longer unread: {sorted(UNREAD_BY_EVERY_READER - unread)}\n"
+        "If a key stopped being read, say why it is still emitted. If one started "
+        "being read, take it off the list.")
+
+
+# ---- the guard's own assumption --------------------------------------------------
+
+@pytest.mark.parametrize("reader", READERS)
+def test_the_readers_still_use_the_idiom_this_guard_can_see(reader: str):
+    """Destructuring the payload would make tier 1 silently see nothing.
+
+    This is the test that fails LOUD instead, because a guard that has gone blind
+    and a guard that has nothing to report look identical from the outside.
+    """
+    assert not _DESTRUCTURE.search(_text(reader)), (
+        f"{reader} destructures the payload, and this file finds reads by matching "
+        "`payload.key`. Teach `_READ` the new form -- or tier 1 is now asserting "
+        "nothing about this reader.")
+
+
+@pytest.mark.parametrize("reader", READERS)
+def test_every_reader_actually_reads_the_payload(reader: str):
+    """A reader that reads nothing means a stale path in READERS, not a clean bill."""
+    assert _keys_read(reader), (
+        f"{reader} reads no payload key. It was renamed, or it stopped being a "
+        "reader -- either way READERS is out of date and tier 1 lost a surface.")

--- a/tests/test_the_table_payload_answers_every_key_its_readers_read.py
+++ b/tests/test_the_table_payload_answers_every_key_its_readers_read.py
@@ -56,6 +56,13 @@ from pathlib import Path
 
 import pytest
 
+#: MARKED, and the gate that demanded it was right for this file specifically. Two
+#: of the three readers are `extension/` sources, so without the mark this guard
+#: would not run on an extension-only change -- which is precisely the change most
+#: likely to add a `payload.x` read to `datatable.js` or `data.js`. It would have
+#: been blind in the one scope it was written for.
+pytestmark = pytest.mark.extension
+
 ROOT = Path(__file__).resolve().parents[1]
 
 #: Every file that reads the table payload. `grid.js` is the engine's page; the other


### PR DESCRIPTION
He asked for `docs/plans/2026-08-22-the-source-page-moves-into-the-extension.md` to be reviewed **before a line was written** — architecture, code quality, tests, performance, section by section, with his ruling between each. Sixteen findings, sixteen directions ruled. **This is the first wave: the six that change no behaviour, plus the twelve findings that do not.**

Nothing here touches `scrapex/webui/app.py` or `extension/app.js`. Both were contested when this started, and the items that need them are the next branch.

---

## The finding that moves the plan, and it was one line

The plan prices step 3 — the record card, `REQ-32`, *«نفس الشى اريده فى كاتوجرى المقاولون»* — at **967 lines** and gates it on a new endpoint. Measured:

`dataset_table_payload` **SELECTed `generic_record_id` and then dropped it.** The emitting loop wrote only the six `OBSERVED_*` keys, so the payload carried **no handle for the row at all** — while `grid.js` opens its card from `rows.filter((row) => row.offer_id)` and closes the panel when that is empty.

**Selecting a contractor row could never open anything.** Two ids were read off the disk for every row and thrown away.

Emitted now as `observed_record_id`, following `offer_id`'s precedent exactly: it rides in `rows`, it is absent from the column list, so it never draws. The plan says step 3 *"needs a new endpoint keyed on `generic_record_id`"* — true, and it did not say the payload had nothing to pass it.

## The payload was holding itself twice

The row query ended in `.fetchall()` beside the `COUNT`, so every raw `data_json` string stayed live through the loop that parses them into dicts. Measured with `tracemalloc` on a 28-field, 17,304-row fixture:

| | |
|---|---|
| `stored` alone | 60 MB |
| `stored` + `rows`, both live | **160 MB** |
| peak including the serialised body | 307 MB |
| the wire payload | 43 MB |
| **ratio** | **7.2x** — and this *excludes* `sighted`, a third full-population structure |

Streaming the cursor instead: **160.0 → 103.8 MB, −56.3 MB (−35%)**.

**His bound is untouched.** `cap=None` still means every row, on his instruction of 2026-08-20 «اريد تحميل كل الصفوف بلا حد». This lowers what a row costs while it is being shaped, not how many are shaped.

## The payload contract is now derived from its readers instead of retyped beside them

Two producers fill it (`reports.table_payload`, `extract.service.dataset_table_payload`), **three** files read it (`grid.js`, `extension/datatable.js`, `extension/data.js`), and nothing bound the two sides — no TypedDict, no dataclass, no JSON schema, no `response_model` anywhere in the package. `dataset_table_payload`'s own comment states the stakes: *"an absent key would be a crash where a false is a switch the page simply does not offer."*

What guarded it was one test with a hand-typed list, and measuring it found both failures that shape has:

- it asserts **thirteen** keys; `grid.js` reads **ten**, and three of the thirteen it never reads (`folded` *is* read — by the panel, a reader that test never opens);
- it reads nothing off disk, so **a new `payload.x` read in `grid.js` failed no test**. The crash its docstring names was the one case it could not see.

So the new guard derives both sides from the artefacts, the way `test_the_documents_cite_what_they_claim.py` does, and takes its two tiers for the same stated reason:

- **Tier 1** is the crash direction and is mechanical — a regex over the three readers, an `ast` walk over the two producers, no database, no inference.
- **Tier 2** is `UNREAD_BY_EVERY_READER`, because *"no reader reads this"* is a judgement and has to be said out loud: `source_key` because every reader learns the source another way, `tree` because it is genuinely dead and deleting a key while a third producer is being written against the contract is two changes at once.

Both producers are checked against **every** reader rather than each against its own: `/api/table` resolves the catalogue first and falls through to the price path, so a reader cannot know which producer filled what it was handed.

**Mutation tested three ways.** Dropping `"foldable"` from `dataset_table_payload` turns tier 1 red; adding a `payload.brandNew` read to `datatable.js` turns two tests red; destructuring the payload in `data.js` turns the blindness test red. That last one matters most — a guard that has gone blind and a guard with nothing to report look identical from outside.

## The two capabilities the port is measured by had no test on the surface being ported

The plan proves step 1 (the AR|EN toggle) and step 3 (the moved-column card) through a DOM harness. Neither had a behavioural test on the **engine**, so "correct" would quietly have become "whatever the port did".

- `grep -rn "grid-lang-toggle" tests/ tools/` returned **nothing**. The toggle has rendered in this harness since the file was written — `_payload()` has always carried a non-empty `bilingual` — and nobody had pressed it.
- `moved_to_details` is `[]` in **every** rendered fixture in the repo. The only non-empty assertions are on the payload in Python, so the card had never been drawn anywhere.

Four tests, each with its control: the card draws with its **value** and not just its heading, and does not draw when nothing was moved; the toggle swaps which name column is visible while leaving row order untouched, and is **absent** rather than present-and-useless when there are no pairs. Mutation tested — one test red per mutation, no over-triggering.

**And the harness immediately taught something reading the source did not.** `grid.js` pushes the card into `detailSections.get("specifications")`, so a test written from the source waits for `[data-inspector-view="specifications"]` — and the panel renders **exactly two** view buttons, `details` and `history`. "specifications" is a section *inside* Details, not a view. A second one in the same test: the heading is upper-cased by CSS, so an exact-case assertion is false while the card is plainly drawn.

That is the plan's own argument for its harness — the Data page shipped **broken** once with 2,460 engine and 398 extension tests green on it — arrived at again from the other end.

## CI's browser floor was `-ge 1` for nine suites of ten

`.github/workflows/ci.yml` states the reasoning itself: *"a per-file 'at least one' would not have noticed 48 becoming 1"* — and applied a real number to one suite. Counted with CI's own `collected()` helper, not remembered: `test_grid_dom.py` **24** (20 before this branch), `test_tab_page_dom.py` **10**. Both sat on `-ge 1`, so either could have fallen to a single test and stayed green.

These two are named rather than all ten because they are the files the plan proves steps 1, 3 and 4 through. The other seven keep `-ge 1`: ten hard numbers would be ten small CI failures unrelated to this work.

---

## `OP-70` … `OP-81` — the twelve findings NOT built

Filed **the day they were found**, not with their fixes, for the reason `OP-69` records about itself: it lived in a chat channel for three days, and had it been filed with a fix that was never authorised it would have been lost twice by the same mechanism.

Numbers assigned by the primary session and **re-derived before writing** — a sweep of every ref and every tracked document, not `BACKLOG` on `main` alone: highest declared **69**, zero hits for 70–81.

Three lead, and the ordering rule is stated in the file:

| # | finding | why it leads |
|---|---|---|
| `OP-70` | a composite identity collapses every row to `unsighted`, and the assertion covering that column tests membership in an 8-value set that **contains** `unsighted` | a **scheduled arrival date** — the code's own comment says Balady's and the UAE's identity will not key on `contractor_id`, and `grep -rn key_part tests/` returns **zero** |
| `OP-71` | `MAX(observed_at)` cannot be served by `ix_generic_record_revision_record`, whose second column is `record_revision_id` | a **comment naming that exact trap twelve lines above code that walks into it** |
| `OP-72` | three write tables key on bare `TEXT source_key`, no FK, no existence check | the only one that lets a caller **manufacture state** |

Then `OP-73` (`POST /api/fields` has no catalogue branch → a live **404** when hiding a contractor column), `OP-74` (`list(body["order"])` unguarded → a 500 one way, a forged «this is your arrangement» the other), `OP-75` (`GET /api/fields` writes and commits **outside** the lock every POST pays for), `OP-76`, `OP-77`, `OP-78`, `OP-79`, `OP-80`, `OP-81`.

Each records his ruled direction, and **three record that the decision is still his**: which of three answers a composite identity gets (`OP-70`), whether the eleven inert rows are deleted at all (`OP-79`, gated on `OP-58`), and that unifying the label rule **changes what existing product tables display** (`OP-76`).

## Documentation — `C2`, in the same PR as the work

**`LESSONS` §15 — an assertion that lists the allowed answers passes when every answer is wrong.** Three guards examined, all one defect in different clothes. The generalisable test is one question: *if the code returned this same value for every row, would this assertion still pass?* The CI instance carries the sharper form — a guard that states its reasoning and then applies it narrowly is more dangerous than one that never stated it, because the stated reasoning reads as coverage.

**`LESSONS` §16 — reading the renderer is not drawing it**, with the corollary that the negative control must open the same view as the positive test or it passes for the wrong reason.

**`STATE.md`** carries this branch and three things about the plan that are stale and **not this branch's to fix**: its ⛔ gate on steps 3 and 5 cites a boundary study that landed as `R-50` in #260 on 2026-08-23; its claim that only `/api/table` resolves the catalogue was falsified by its own step 0 (`GET /api/fields` does too); and its migration note is doubly stale — `main` holds `0010` and `origin/feat/organization-enrichment` holds `0011`, so the next free number is **`0012`**, asked for rather than counted.

---

## Verification

**Full suite green on this base: `PYTEST_EXIT=0`, zero failures, 3,311 tests collected.**

Read from a log rather than from a pipe, and that mattered twice. `python -m pytest -q | tail` reports the exit code of `tail`: the first "green" here was pytest failing on an unrecognised `--timeout` argument and **never running a single test**, surfacing as exit 0 — the same shape as `gh pr checks --watch` returning 0 with jobs still pending. The inverse also fired: a wrapper ending in `grep -c` reported "failed, exit 1" when the failure count was **zero**.

That first bad green hid a real failure, and the guard that caught it was right: the new payload test reads two `extension/` sources and carried no `pytest.mark.extension`, so it would not have run on an extension-only change — the exact change most likely to add a `payload.x` read. Fixed in its own commit.

Two document guards then caught two of my own citations while the `BACKLOG` entries were being written:

- `service.py:996` had become a **blank line**, and it became one because **this branch** pushed the file down thirteen lines. A citation written correctly during a change can be wrong by the end of it. Corrected to `1023`, derived.
- `OP-70` quotes «لا تدع المستخدم يستنتج الحالة» and cited no `REQ`. It is **`REQ-44`**, now named in the entry.

Rebased onto `a859c31`. #267, #268 and #269 all landed on `docs/LESSONS.md` and `docs/BACKLOG.md`, which this branch also edits — the #251/#252 shape, not disjoint at all — so the check a clean textual merge does *not* perform was run: no duplicate `OP` headings, and `LESSONS.md` has 16 top-level sections with no duplicate numbers.

**Not merged, and not mine to merge — `R-42`.**


🤖 Generated with [Claude Code](https://claude.com/claude-code)
