### PR TITLE
A dry route for every source type, and a hover that says what each pass costs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ work predates this file, the commit that built it — evidence read out of
 record of what was done; this file answers a narrower question: which version
 has it.
 
-## 0.3.2
+## 0.4.0
 
 Minimum supported extension: `0.2.2`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ work predates this file, the commit that built it — evidence read out of
 record of what was done; this file answers a narrower question: which version
 has it.
 
-## 0.3.1
+## 0.3.2
 
 Minimum supported extension: `0.2.2`.
 

--- a/contracts/capability-baseline.json
+++ b/contracts/capability-baseline.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.2",
+  "version": "0.4.0",
   "minimum_extension_version": "0.2.2",
   "capabilities": {
     "crawl_pace": "0.2.0",

--- a/contracts/capability-baseline.json
+++ b/contracts/capability-baseline.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.1",
+  "version": "0.3.2",
   "minimum_extension_version": "0.2.2",
   "capabilities": {
     "crawl_pace": "0.2.0",

--- a/contracts/contract-baseline.json
+++ b/contracts/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.1",
+  "version": "0.3.2",
   "schema": [
     "0002_the_price_source_key_is_named_for_what_it_is.sql",
     "0003_a_source_says_how_deep_its_crawl_goes.sql",
@@ -20,6 +20,7 @@
     "GET /api/bundle/archive",
     "GET /api/bundle/panel-pack",
     "GET /api/changes",
+    "GET /api/dry/{source_key}",
     "GET /api/export/{source_key}",
     "GET /api/features",
     "GET /api/fields/{source_key}",

--- a/contracts/contract-baseline.json
+++ b/contracts/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.2",
+  "version": "0.4.0",
   "schema": [
     "0002_the_price_source_key_is_named_for_what_it_is.sql",
     "0003_a_source_says_how_deep_its_crawl_goes.sql",

--- a/contracts/version-vectors.json
+++ b/contracts/version-vectors.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.1",
+  "version": "0.3.2",
   "minimum_extension_version": "0.2.2",
   "capability_reporting_since": "0.2.0",
   "note": "Both copies of capabilityProblem must reproduce every `problem` string exactly. Python: scrapex/version.py. JavaScript: extension/version.js.",
@@ -7,8 +7,8 @@
     {
       "name": "in step — the engine deploys it and the extension is new enough",
       "key": "crawl_parallel_sources",
-      "extension_version": "0.3.1",
-      "engine_version": "0.3.1",
+      "extension_version": "0.3.2",
+      "engine_version": "0.3.2",
       "deployed": {
         "crawl_pace": {
           "since": "0.2.0",
@@ -50,7 +50,7 @@
       "name": "the extension is behind the engine",
       "key": "crawl_parallel_sources",
       "extension_version": "0.1.0",
-      "engine_version": "0.3.1",
+      "engine_version": "0.3.2",
       "deployed": {
         "crawl_pace": {
           "since": "0.2.0",
@@ -86,12 +86,12 @@
         }
       },
       "update_instructions": "Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards.",
-      "problem": "«Crawl several different sites at the same time. Two sources on the SAME site still take turns, so no site is asked for more than before.» needs ScrapeX extension 0.2.0; this extension is 0.1.0 and the engine is 0.3.1. Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards."
+      "problem": "«Crawl several different sites at the same time. Two sources on the SAME site still take turns, so no site is asked for more than before.» needs ScrapeX extension 0.2.0; this extension is 0.1.0 and the engine is 0.3.2. Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards."
     },
     {
       "name": "the engine is behind and says so",
       "key": "crawl_parallel_sources",
-      "extension_version": "0.3.1",
+      "extension_version": "0.3.2",
       "engine_version": "0.1.0",
       "deployed": {
         "crawl_pace": {
@@ -124,22 +124,22 @@
         }
       },
       "update_instructions": "Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards.",
-      "problem": "«crawl_parallel_sources» is not deployed by this ScrapeX engine (0.1.0); this extension is 0.3.1. Update the engine to 0.3.1 or newer."
+      "problem": "«crawl_parallel_sources» is not deployed by this ScrapeX engine (0.1.0); this extension is 0.3.2. Update the engine to 0.3.2 or newer."
     },
     {
       "name": "the engine is too old to say anything",
       "key": "crawl_parallel_sources",
-      "extension_version": "0.3.1",
+      "extension_version": "0.3.2",
       "engine_version": "0.1.0",
       "deployed": null,
       "update_instructions": "Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards.",
-      "problem": "«crawl_parallel_sources» cannot be confirmed: the ScrapeX engine reports version 0.1.0 and is too old to say which features it deploys. This extension is 0.3.1. Update the engine to 0.3.1."
+      "problem": "«crawl_parallel_sources» cannot be confirmed: the ScrapeX engine reports version 0.1.0 and is too old to say which features it deploys. This extension is 0.3.2. Update the engine to 0.3.2."
     },
     {
       "name": "an extension newer than the requirement is not refused for being newer",
       "key": "crawl_parallel_sources",
       "extension_version": "9.9.9",
-      "engine_version": "0.3.1",
+      "engine_version": "0.3.2",
       "deployed": {
         "crawl_pace": {
           "since": "0.2.0",

--- a/contracts/version-vectors.json
+++ b/contracts/version-vectors.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.2",
+  "version": "0.4.0",
   "minimum_extension_version": "0.2.2",
   "capability_reporting_since": "0.2.0",
   "note": "Both copies of capabilityProblem must reproduce every `problem` string exactly. Python: scrapex/version.py. JavaScript: extension/version.js.",
@@ -7,8 +7,8 @@
     {
       "name": "in step — the engine deploys it and the extension is new enough",
       "key": "crawl_parallel_sources",
-      "extension_version": "0.3.2",
-      "engine_version": "0.3.2",
+      "extension_version": "0.4.0",
+      "engine_version": "0.4.0",
       "deployed": {
         "crawl_pace": {
           "since": "0.2.0",
@@ -50,7 +50,7 @@
       "name": "the extension is behind the engine",
       "key": "crawl_parallel_sources",
       "extension_version": "0.1.0",
-      "engine_version": "0.3.2",
+      "engine_version": "0.4.0",
       "deployed": {
         "crawl_pace": {
           "since": "0.2.0",
@@ -86,12 +86,12 @@
         }
       },
       "update_instructions": "Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards.",
-      "problem": "«Crawl several different sites at the same time. Two sources on the SAME site still take turns, so no site is asked for more than before.» needs ScrapeX extension 0.2.0; this extension is 0.1.0 and the engine is 0.3.2. Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards."
+      "problem": "«Crawl several different sites at the same time. Two sources on the SAME site still take turns, so no site is asked for more than before.» needs ScrapeX extension 0.2.0; this extension is 0.1.0 and the engine is 0.4.0. Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards."
     },
     {
       "name": "the engine is behind and says so",
       "key": "crawl_parallel_sources",
-      "extension_version": "0.3.2",
+      "extension_version": "0.4.0",
       "engine_version": "0.1.0",
       "deployed": {
         "crawl_pace": {
@@ -124,22 +124,22 @@
         }
       },
       "update_instructions": "Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards.",
-      "problem": "«crawl_parallel_sources» is not deployed by this ScrapeX engine (0.1.0); this extension is 0.3.2. Update the engine to 0.3.2 or newer."
+      "problem": "«crawl_parallel_sources» is not deployed by this ScrapeX engine (0.1.0); this extension is 0.4.0. Update the engine to 0.4.0 or newer."
     },
     {
       "name": "the engine is too old to say anything",
       "key": "crawl_parallel_sources",
-      "extension_version": "0.3.2",
+      "extension_version": "0.4.0",
       "engine_version": "0.1.0",
       "deployed": null,
       "update_instructions": "Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards.",
-      "problem": "«crawl_parallel_sources» cannot be confirmed: the ScrapeX engine reports version 0.1.0 and is too old to say which features it deploys. This extension is 0.3.2. Update the engine to 0.3.2."
+      "problem": "«crawl_parallel_sources» cannot be confirmed: the ScrapeX engine reports version 0.1.0 and is too old to say which features it deploys. This extension is 0.4.0. Update the engine to 0.4.0."
     },
     {
       "name": "an extension newer than the requirement is not refused for being newer",
       "key": "crawl_parallel_sources",
       "extension_version": "9.9.9",
-      "engine_version": "0.3.2",
+      "engine_version": "0.4.0",
       "deployed": {
         "crawl_pace": {
           "since": "0.2.0",

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -2416,7 +2416,7 @@ reason is four links long, every one measured on the live engine rather than arg
 | link | evidence |
 |---|---|
 | 1 | the panel's crawl action sends `POST /api/jobs` with `source_keys` — `extension/app.js:4064` |
-| 2 | that route validates the key against `app.state.manifest` — `scrapex/webui/app.py:3349-3353`, whose own comment reads *"fail before queueing, not mid-crawl"* |
+| 2 | that route validates the key against `app.state.manifest` — `scrapex/webui/app.py:3392-3396`, whose own comment reads *"fail before queueing, not mid-crawl"* (re-derived at `72ca371`: `GET /api/dry/{source_key}` was inserted above it in #274 and moved it 43 lines. The quoted comment, not the number, is what made it findable) |
 | 3 | the manifest is `sources.yaml` — **12 price sources, and neither `muqawil` nor `contractors` is in it.** muqawil lives in `site_profile`, not `source_site` |
 | 4 | `scrapex/jobs.py`, which is what the button drives, contains **zero** references to `muqawil`, `generic_record`, `partitioncrawl`, `snapshotcrawl`, `contractors` or `dataset` |
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -310,6 +310,31 @@ tracks *his requests* through Captured → Ruled → Planned → In flight → D
 
 ## Open pull requests
 
+### A dry route for every source type — 2026-08-27 · [#274](https://github.com/muhammadbayoumi/ScrapeX/pull/274)
+
+> «اعمل مسار dry لكل المصادر مهما اختلفت نوعها» · «ابنى المسار الجاف للثلاثة وخلى hover
+> الى يبان يكون واضح بدقة للمستخدم»
+
+`GET /api/dry/{source_key}` resolves a key in **both** registries. Measured against the
+same three keys `POST /api/jobs` was measured on:
+
+| key | registry | `POST /api/jobs` | `GET /api/dry/{key}` |
+|---|---|---|---|
+| `ADVANCEDCASTLE` | `sources.yaml` | 200 | 200 |
+| `contractors` | `dataset_definition` | **404** | **200** |
+| `muqawil_org` | `site_profile` | **404** | **200** |
+
+Zero requests and zero writes are guarded: a SQLite authorizer (`dryrun.refuse_writes`)
+denies every statement able to change the warehouse, which matters on the one call —
+`disown_impostors` deletes when `dry_run=False`. 16 mutations, 16 reds.
+
+The passes, their cost, what they write and the hover are declared once in
+`scrapex/passes.py`; `contractors.validate` gates on the same tuple, and `--plan`'s 114
+requests are derived as `2 x (cells + 1)`. **`extension/app.js` is untouched** — the
+engine declares and serves the hover, the panel does not yet render it.
+
+**Awaiting the primary:** a `REQ` number (`REQ-46` was free across all 419 refs on
+2026-08-27), and whether `VERSION` moves.
 ### The source-page plan was reviewed, and the review found the step-3 blocker is one line — 2026-08-26
 
 **Branch `fix/a-dataset-row-gets-a-handle-and-the-payload-a-guard`, based on `35962cc`.**

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -335,6 +335,7 @@ engine declares and serves the hover, the panel does not yet render it.
 
 **Awaiting the primary:** a `REQ` number (`REQ-46` was free across all 419 refs on
 2026-08-27), and whether `VERSION` moves.
+
 ### The source-page plan was reviewed, and the review found the step-3 blocker is one line — 2026-08-26
 
 **Branch `fix/a-dataset-row-gets-a-handle-and-the-payload-a-guard`, based on `35962cc`.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "scrapex"
 # A MIRROR of scrapex/version.py:VERSION — setuptools cannot import the package
 # to ask. tests/test_version.py reads this line back and fails when they drift.
-version = "0.3.2"
+version = "0.4.0"
 description = "ScrapeX ecosystem: contract-driven web data collection into a SQLite warehouse. Categories: products, contractors"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "scrapex"
 # A MIRROR of scrapex/version.py:VERSION — setuptools cannot import the package
 # to ask. tests/test_version.py reads this line back and fails when they drift.
-version = "0.3.1"
+version = "0.3.2"
 description = "ScrapeX ecosystem: contract-driven web data collection into a SQLite warehouse. Categories: products, contractors"
 requires-python = ">=3.12"
 dependencies = [

--- a/scrapex/contractors.py
+++ b/scrapex/contractors.py
@@ -62,6 +62,7 @@ from .partitioncrawl import (
     crawl_partition,
     size_cell,
 )
+from .passes import DIRECTORY_PASSES
 from .sightings import (
     coverage,
     departures,
@@ -652,6 +653,27 @@ def details(conn, directory: Directory, fetch, fetcher, run_ref: str,
 
 # ---- --coverage: what the warehouse knows about its own gaps ------------------
 
+#: How many sighted-and-never-stored ids the answer carries. One number, two readers:
+#: this printer and `GET /api/dry/{key}`.
+COVERAGE_SAMPLE = 20
+
+
+def default_window(conn, dataset_key: str) -> str:
+    """The window `--coverage` measures departures against, when nobody names one.
+
+    THE LEDGER'S OWN NEWEST SIGHTING, so running coverage straight after a crawl asks
+    "who did THAT crawl not show us" without anyone typing a timestamp — and a
+    mistyped one silently reports every contractor as departed. Empty when nothing has
+    ever been sighted, which is a real answer and not a zero.
+
+    A FUNCTION SO THE ROUTE CANNOT PICK A DIFFERENT WINDOW. It was inline in `run`,
+    which put it out of reach of every other caller.
+    """
+    return conn.execute(
+        "SELECT MAX(last_seen_at) FROM dataset_sighting WHERE dataset_key = ?",
+        (dataset_key,)).fetchone()[0] or ""
+
+
 def report_coverage(conn, directory: Directory, not_seen_since: str) -> None:
     """Every coverage question this warehouse can answer, in one place.
 
@@ -683,7 +705,7 @@ def report_coverage(conn, directory: Directory, not_seen_since: str) -> None:
             "module does not pick a school.)")
         say("")
 
-    gap = missing_ids(conn, directory.dataset_key, limit=20)
+    gap = missing_ids(conn, directory.dataset_key, limit=COVERAGE_SAMPLE)
     say(f"sighted and never stored: {len(gap)} shown (ordered by how often the site "
         "showed it — one seen six times and still unstored is a stronger signal "
         "than one glimpsed once)")
@@ -1365,9 +1387,12 @@ def validate(args: argparse.Namespace) -> None:
     that would have to raise it, and a usage error printed by the wrong parser
     prints the wrong usage line.
     """
-    if not (args.plan or args.crawl or args.details or args.approve
-            or args.coverage or args.impostors):
-        _refuse("choose one of --plan, --crawl, --details, --approve, --coverage or --impostors")
+    # THE SIX ARE DECLARED IN `scrapex/passes.py`, which is also what
+    # `GET /api/dry/{key}` builds the panel's menu from — so the command line and the
+    # panel cannot come to offer different sets.
+    if not any(getattr(args, name) for name in DIRECTORY_PASSES):
+        _refuse("choose one of "
+                + ", ".join(f"--{name}" for name in DIRECTORY_PASSES))
     if (args.crawl or args.details or args.approve) and not args.run_ref:
         _refuse("--crawl, --details and --approve need --run-ref: it is what makes an "
                 "interrupted crawl resumable and what --approve reads")
@@ -1475,13 +1500,7 @@ def run(args: argparse.Namespace) -> int:
         if args.impostors:
             disown_impostors(conn, directory, dry_run=not args.repair)
         if args.coverage:
-            # THE DEFAULT WINDOW IS THE LEDGER'S OWN NEWEST SIGHTING, so running this
-            # straight after a crawl asks "who did THAT crawl not show us" without
-            # anyone having to type a timestamp — and a mistyped one silently reports
-            # every contractor as departed.
-            since = args.not_seen_since or (conn.execute(
-                "SELECT MAX(last_seen_at) FROM dataset_sighting WHERE dataset_key = ?",
-                (directory.dataset_key,)).fetchone()[0] or "")
+            since = args.not_seen_since or default_window(conn, directory.dataset_key)
             if not since:
                 say("no sightings recorded for this dataset, so there is no window "
                     "to measure departures against. Crawl first.")

--- a/scrapex/dryrun.py
+++ b/scrapex/dryrun.py
@@ -1,0 +1,327 @@
+"""What a source WOULD do, answered for every source type without doing any of it.
+
+`REQ-45`, measured live: `POST /api/jobs` validates its key against
+`app.state.manifest` — the twelve price sources of `sources.yaml` — and muqawil lives
+in `site_profile`, so the crawl button answered
+`404 {"detail": "unknown source_key 'contractors'"}`. `GET /api/table` and
+`GET /api/fields` both learned to ask the dataset catalogue first; `POST /api/jobs`
+never did.
+
+So this route resolves a key in BOTH registries and a key known to either answers
+200. It makes no request and no write, and both are GUARDED rather than promised:
+`refuse_writes` installs a SQLite authorizer that denies every statement able to
+change the warehouse, and the fetchers are never constructed.
+
+WHAT IT DOES NOT DO. `--plan` is ADVERTISED with its request count and never run —
+a route called "dry" that quietly made 114 requests is the naming defect this
+repository keeps finding.
+"""
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+
+from . import contractors, passes
+from .crawlscope import CrawlScope
+from .directories import Directory
+from .directories import get as get_directory
+from .features import FeatureKey, is_enabled
+from .sightings import coverage, departures, missing_ids, sighting_frequencies
+
+#: Every authorizer action able to change the warehouse file. Temp objects are left
+#: alone: they live in the temp database and cannot reach his data.
+_DENIED = frozenset({
+    sqlite3.SQLITE_INSERT, sqlite3.SQLITE_UPDATE, sqlite3.SQLITE_DELETE,
+    sqlite3.SQLITE_CREATE_TABLE, sqlite3.SQLITE_CREATE_INDEX,
+    sqlite3.SQLITE_CREATE_TRIGGER, sqlite3.SQLITE_CREATE_VIEW,
+    sqlite3.SQLITE_CREATE_VTABLE,
+    sqlite3.SQLITE_DROP_TABLE, sqlite3.SQLITE_DROP_INDEX,
+    sqlite3.SQLITE_DROP_TRIGGER, sqlite3.SQLITE_DROP_VIEW,
+    sqlite3.SQLITE_DROP_VTABLE,
+    sqlite3.SQLITE_ALTER_TABLE, sqlite3.SQLITE_REINDEX, sqlite3.SQLITE_ANALYZE,
+    sqlite3.SQLITE_ATTACH, sqlite3.SQLITE_DETACH,
+    sqlite3.SQLITE_TRANSACTION, sqlite3.SQLITE_SAVEPOINT,
+})
+
+
+def refuse_writes(conn: sqlite3.Connection) -> None:
+    """Make a write on this connection RAISE instead of happening.
+
+    A comment saying "this path does not write" is not a guard: `disown_impostors`
+    deletes when `dry_run=False`, so one wrong keyword on this path is destructive.
+    The authorizer runs when a statement is PREPARED, so a denied write never
+    executes at all — and it fails loudly, which is what turns the claim into a
+    check.
+
+    Installed after the connection is open, so the pragmas `db.connect` sets on the
+    way in are untouched.
+    """
+    def authorize(action: int, arg1, arg2, database, trigger) -> int:
+        return sqlite3.SQLITE_DENY if action in _DENIED else sqlite3.SQLITE_OK
+
+    conn.set_authorizer(authorize)
+
+
+@dataclass(frozen=True)
+class Target:
+    """The key, resolved. `kind` decides which half of the payload gets built."""
+
+    source_key: str
+    kind: str            # "price" | "dataset"
+    registry: str        # which register knew the key
+    display_name: str
+    #: price only — the manifest entry.
+    entry: object | None = None
+    #: dataset only.
+    site_key: str = ""
+    dataset_keys: tuple[str, ...] = ()
+    scope: CrawlScope | None = None
+    crawl_slice: str = ""
+
+
+def resolve(source_key: str, *, general: sqlite3.Connection, manifest) -> Target | None:
+    """The key in both registries, or None when neither knows it.
+
+    THE MANIFEST FIRST because it needs no query, and the two sets cannot collide:
+    a price key is `^[A-Z][A-Z0-9_]{2,63}$` and a dataset key is lower-case with
+    underscores — the same reasoning `/api/table` gives for asking the other way
+    round.
+
+    `site_profile` IS ASKED TOO, and not only `dataset_definition`. `scrapex
+    contractors --source` names a SITE key (`muqawil_org`) while the panel's card
+    carries a DATASET key (`contractors`); refusing one of the two would leave the
+    same 404 the route exists to end.
+    """
+    try:
+        entry = manifest.get(source_key)
+    except KeyError:
+        entry = None
+    if entry is not None:
+        return Target(source_key=source_key, kind="price", registry="sources.yaml",
+                      display_name=entry.source_name, entry=entry)
+
+    dataset = general.execute(
+        "SELECT d.dataset_key, d.display_name, d.original_name, s.site_key, "
+        "       s.crawl_scope, s.crawl_slice "
+        "  FROM dataset_definition AS d "
+        "  JOIN site_profile AS s ON s.site_profile_id = d.site_profile_id "
+        " WHERE d.dataset_key = ? AND d.valid_to IS NULL LIMIT 1",
+        (source_key,)).fetchone()
+    if dataset is not None:
+        return Target(
+            source_key=source_key, kind="dataset", registry="dataset_definition",
+            display_name=dataset[1] or dataset[2], site_key=dataset[3],
+            dataset_keys=(dataset[0],), scope=CrawlScope(dataset[4]),
+            crawl_slice=dataset[5] or "")
+
+    site = general.execute(
+        "SELECT site_profile_id, site_key, display_name, crawl_scope, crawl_slice "
+        "  FROM site_profile WHERE site_key = ? AND valid_to IS NULL LIMIT 1",
+        (source_key,)).fetchone()
+    if site is None:
+        return None
+    owned = tuple(row[0] for row in general.execute(
+        "SELECT dataset_key FROM dataset_definition "
+        " WHERE site_profile_id = ? AND valid_to IS NULL ORDER BY dataset_key",
+        (site[0],)))
+    return Target(source_key=source_key, kind="dataset", registry="site_profile",
+                  display_name=site[2], site_key=site[1], dataset_keys=owned,
+                  scope=CrawlScope(site[3]), crawl_slice=site[4] or "")
+
+
+def unknown_key_detail(source_key: str, *, manifest) -> str:
+    """The 404's words. It names BOTH registries, because "unknown" was the whole
+    complaint: the old message said `unknown source_key 'contractors'` about a key
+    the warehouse held 17,304 rows for."""
+    return (f"unknown source_key {source_key!r} — not in sources.yaml "
+            f"({len(manifest.sources)} price sources), and not a dataset_key in "
+            "dataset_definition or a site_key in site_profile")
+
+
+def _directory_for(target: Target) -> Directory | None:
+    try:
+        return get_directory(target.site_key)
+    except KeyError:
+        return None
+
+
+def _coverage(general: sqlite3.Connection, dataset_key: str) -> dict:
+    """`scrapex/sightings.py`, called. NOT reimplemented.
+
+    The same four functions `contractors.report_coverage` prints, so the route and
+    the CLI cannot come to disagree about what coverage means — including the
+    window, which is `contractors.default_window` for both. The audit's own finding
+    was `dataset_table_payload` reimplementing `fields.hidden_columns` inline.
+    """
+    figure = coverage(general, dataset_key)
+    window = contractors.default_window(general, dataset_key)
+    body: dict = {
+        "dataset_key": dataset_key,
+        "seen": figure.seen, "stored": figure.stored, "missing": figure.missing,
+        "fraction": figure.fraction, "sentence": str(figure),
+        "frequencies": {str(times): count
+                        for times, count in sighting_frequencies(
+                            general, dataset_key).items()},
+        "missing_sample": list(missing_ids(general, dataset_key,
+                                           limit=contractors.COVERAGE_SAMPLE)),
+    }
+    if not window:
+        body["departures"] = None
+        body["departures_note"] = (
+            "no sightings recorded for this dataset, so there is no window to "
+            "measure departures against")
+        return body
+    left = departures(general, dataset_key, not_seen_since=window)
+    body["departures"] = {"not_seen_since": window, "gone": len(left.gone),
+                          "unsighted": len(left.unsighted), "sentence": str(left)}
+    return body
+
+
+def _impostors(general: sqlite3.Connection, directory: Directory | None) -> dict:
+    """`contractors.disown_impostors(..., dry_run=True)`, which counts and returns.
+
+    IT APPENDS ITS FINDING TO `~/.scrapex/contractors.log`, because `say` is how
+    that module reports. That is the one side effect this route has and it touches
+    no database.
+    """
+    if directory is None:
+        # NOT THE SAME REASON as "no profile reader", and saying so cost a measurement:
+        # site_key `muqawil` has a `site_profile` row and no `Directory`, and the first
+        # draft told the owner it declares no profile reader — about a site nothing can
+        # crawl at all.
+        return {"count": None, "dataset_key": None, "dry_run": True,
+                "reason": "no directory builder for this site (scrapex/directories.py), "
+                          "so nothing can be checked against it"}
+    if directory.profiles is None:
+        return {"count": None, "dataset_key": None, "dry_run": True,
+                "reason": "this site declares no profile reader, so it has no "
+                          "profile rows to check"}
+    return {"count": contractors.disown_impostors(general, directory, dry_run=True),
+            "dataset_key": directory.profiles.dataset_key, "dry_run": True,
+            "reason": None}
+
+
+#: `generic_page_snapshot` carries no dataset column, and scoping through
+#: `generic_ingestion` would miss exactly the pages `--details` stores and never
+#: ingests. So the run is the warehouse's newest, and the payload says so.
+_RUN_SCOPE = ("generic_page_snapshot has no dataset column, so this is the newest run "
+              "in the warehouse rather than this dataset's own")
+
+#: `R-52` ruled a generic crawl-run table (option B) and it is not built, so nothing
+#: stored says whether a generic run finished. `R-55`: absence beats a placeholder — a
+#: `false` here would read as "this run completed", which is `OP-68`'s false sentence.
+_NO_RUN_STATUS = ("no stored fact says whether a generic run finished — R-52 ruled a "
+                  "generic crawl-run table and it is not built")
+
+
+def _dataset_last_run(general: sqlite3.Connection) -> dict:
+    """The newest `crawl_run_ref` in `generic_page_snapshot`, and what it holds.
+
+    `runs_recorded` and `pages_stored` are here because the newest run is often a
+    stub: measured on the live warehouse 2026-08-27, the newest ref is `R` with **2
+    pages** while the warehouse holds **57,041** pages over **141** refs. Without the
+    two totals the block reads as "the last crawl stored 2 pages".
+    """
+    totals = general.execute(
+        "SELECT COUNT(*), COUNT(DISTINCT crawl_run_ref) FROM generic_page_snapshot"
+    ).fetchone()
+    row = general.execute(
+        "SELECT crawl_run_ref, COUNT(*), MIN(captured_at), MAX(captured_at) "
+        "  FROM generic_page_snapshot WHERE crawl_run_ref IS NOT NULL "
+        " GROUP BY crawl_run_ref ORDER BY MAX(captured_at) DESC LIMIT 1"
+    ).fetchone()
+    body = {"pages_stored": totals[0], "runs_recorded": totals[1],
+            "scope_basis": _RUN_SCOPE, "partial": None}
+    if row is None:
+        body.update({"run_ref": None, "pages": 0, "captured_from": None,
+                     "captured_to": None,
+                     "partial_basis": "no crawl has stored a page under a run ref"})
+        return body
+    body.update({"run_ref": row[0], "pages": row[1], "captured_from": row[2],
+                 "captured_to": row[3], "partial_basis": _NO_RUN_STATUS})
+    return body
+
+
+def _price_last_run(price: sqlite3.Connection, source_key: str) -> dict:
+    """`crawl_run` for this source. `partial` is a real column here."""
+    row = price.execute(
+        "SELECT r.run_id, r.started_at, r.finished_at, r.status, r.requests_count, "
+        "       r.rows_seen, r.errors_count "
+        "  FROM crawl_run AS r JOIN source_site AS s ON s.source_id = r.source_id "
+        " WHERE s.source_key = ? ORDER BY r.started_at DESC, r.run_id DESC LIMIT 1",
+        (source_key,)).fetchone()
+    if row is None:
+        return {"run_ref": None, "started_at": None, "finished_at": None,
+                "status": None, "requests": None, "rows_seen": None,
+                "errors": None, "partial": None,
+                "partial_basis": "this source has no crawl_run row yet"}
+    return {"run_ref": str(row[0]), "started_at": row[1], "finished_at": row[2],
+            "status": row[3], "requests": row[4], "rows_seen": row[5],
+            "errors": row[6], "partial": row[3] == "partial",
+            "partial_basis": "crawl_run.status"}
+
+
+def _scope(target: Target) -> dict:
+    """The scope, and the one refusal it causes, IN THE PAYLOAD.
+
+    Measured: `crawl_scope` appears nowhere in `scrapex/webui/app.py` and nowhere in
+    any `extension/*.js`, so it is settable only by editing the database — and
+    `--details` refuses under `listing_only` and tells the owner in words to change
+    it. Showing the value is not the setter; the setter is a separate item.
+    """
+    return {
+        "site_key": target.site_key,
+        "value": target.scope.value if target.scope else None,
+        "values": [one.value for one in CrawlScope],
+        "slice": target.crawl_slice,
+        "settable_here": False,
+        "note": "site_profile.crawl_scope is settable only in the database today. "
+                "Under listing_only the profile-page pass refuses.",
+    }
+
+
+def dry_payload(source_key: str, *, general: sqlite3.Connection,
+                price: sqlite3.Connection, manifest) -> dict | None:
+    """Four blocks, and the fourth is the one the panel's menu is built from.
+
+    None when neither registry knows the key — the caller turns that into a 404 with
+    `unknown_key_detail`.
+    """
+    target = resolve(source_key, general=general, manifest=manifest)
+    if target is None:
+        return None
+
+    body: dict = {
+        "source_key": target.source_key,
+        "kind": target.kind,
+        "registry": target.registry,
+        "display_name": target.display_name,
+        # The route's OWN cost, stated so "dry" can be checked rather than trusted.
+        "network_requests": 0,
+        "writes": [],
+    }
+    if target.kind == "price":
+        last = _price_last_run(price, target.source_key)
+        body["scope"] = None
+        body["coverage"] = []
+        body["coverage_note"] = ("coverage is sighted-against-stored, which the "
+                                 "sighting ledger holds for datasets only")
+        body["impostors"] = {"count": None, "dataset_key": None, "dry_run": True,
+                             "reason": "the impostor check compares a profile row "
+                                       "against its listing card, which a price "
+                                       "source has neither of"}
+        body["last_run"] = last
+        body["passes"] = [one.as_dict() for one in passes.price_passes(
+            target.entry, last_requests=last["requests"])]
+        return body
+
+    directory = _directory_for(target)
+    body["scope"] = _scope(target)
+    body["coverage"] = [_coverage(general, key) for key in target.dataset_keys]
+    body["impostors"] = _impostors(general, directory)
+    body["last_run"] = _dataset_last_run(general)
+    body["passes"] = [one.as_dict() for one in passes.directory_passes(
+        directory, scope=target.scope, crawl_slice=target.crawl_slice,
+        site_key=target.site_key,
+        extraction_enabled=is_enabled(FeatureKey.GENERIC_EXTRACTION))]
+    return body

--- a/scrapex/dryrun.py
+++ b/scrapex/dryrun.py
@@ -186,6 +186,15 @@ def _coverage(general: sqlite3.Connection, dataset_key: str) -> dict:
 def _impostors(general: sqlite3.Connection, directory: Directory | None) -> dict:
     """`contractors.disown_impostors(..., dry_run=True)`, which counts and returns.
 
+    ZERO IS THE RIGHT ANSWER TODAY AND THE AUDIT SAYS FOURTEEN, so a reader who has
+    read `MUQAWIL-AUDIT-2026-08-26.md` will think this is broken. It is not: `OP-64`'s
+    `--repair` has already run, and `disown_impostors` reads `r.status = 'active'`.
+    Measured on the live warehouse 2026-08-27 — `contractor_profiles` holds **17,371
+    active and 14 retired**; **14 of 14 retired** rows disagree with their listing
+    card and **0 of 17,371 active** ones do. The fourteen are exactly the audit's,
+    withdrawn rather than deleted (`status`, never a DELETE), so the dry pass has
+    nothing left to find.
+
     IT APPENDS ITS FINDING TO `~/.scrapex/contractors.log`, because `say` is how
     that module reports. That is the one side effect this route has and it touches
     no database.

--- a/scrapex/dryrun.py
+++ b/scrapex/dryrun.py
@@ -158,7 +158,13 @@ def _coverage(general: sqlite3.Connection, dataset_key: str) -> dict:
     body: dict = {
         "dataset_key": dataset_key,
         "seen": figure.seen, "stored": figure.stored, "missing": figure.missing,
-        "fraction": figure.fraction, "sentence": str(figure),
+        # NULL RATHER THAN 1.0 WHEN NOTHING HAS BEEN SIGHTED. `Coverage.fraction`
+        # returns 1.0 there while `Coverage.__str__` says coverage "cannot be stated.
+        # That is not the same as complete" — so publishing the number would print
+        # 100% over the sentence denying it. Live: `contractor_profiles` has 0
+        # sightings, so this is the ordinary case and not an edge. `R-55`.
+        "fraction": figure.fraction if figure.seen else None,
+        "sentence": str(figure),
         "frequencies": {str(times): count
                         for times, count in sighting_frequencies(
                             general, dataset_key).items()},
@@ -317,6 +323,10 @@ def dry_payload(source_key: str, *, general: sqlite3.Connection,
 
     directory = _directory_for(target)
     body["scope"] = _scope(target)
+    # THE SAME TOP-LEVEL KEYS FOR BOTH KINDS, so the panel reads one shape. A key
+    # present on one kind and absent on the other is how a reader learns to guard
+    # every access, and then stops noticing which guards mean something.
+    body["coverage_note"] = None
     body["coverage"] = [_coverage(general, key) for key in target.dataset_keys]
     body["impostors"] = _impostors(general, directory)
     body["last_run"] = _dataset_last_run(general)

--- a/scrapex/passes.py
+++ b/scrapex/passes.py
@@ -99,7 +99,7 @@ _DIRECTORY: dict[str, Pass] = {
     "coverage": Pass(
         key="coverage", label="What we are missing",
         does="Stored against sighted, the frequency sample, sighted-and-never-stored, "
-             "and departures",
+             "and departures measured against the ledger's newest sighting",
         writes=(), network=0,
         network_phrase="zero requests, read from the warehouse"),
     "impostors": Pass(

--- a/scrapex/passes.py
+++ b/scrapex/passes.py
@@ -1,0 +1,219 @@
+"""What a source can be asked to do — ONE declaration, read by the engine and the panel.
+
+`REQ-45`: five of the panel's six source actions answered 404 for muqawil, because
+`extension/app.js` carried its own retyped list of what a source can do. A retyped
+list goes stale in the safe-looking direction, so the passes, their cost, what they
+write and the hover line the user reads are declared here and served by
+`GET /api/dry/{source_key}`.
+
+THE HOVER IS COMPOSED, NEVER WRITTEN. `Pass.hover` is built from the same fields the
+payload carries, so a hover cannot promise one cost while `network` states another.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+from .connectors.factory import _BUILDERS, supports_history
+from .crawlscope import CrawlScope
+from .directories import Directory
+from .vocab import RunMode
+
+#: The passes a DIRECTORY source has. `contractors.validate` reads this tuple, so a
+#: seventh pass cannot reach the command line without appearing here.
+DIRECTORY_PASSES: tuple[str, ...] = (
+    "plan", "crawl", "details", "approve", "coverage", "impostors")
+
+
+@dataclass(frozen=True)
+class Pass:
+    """One thing a source can be asked to do, and what it costs to ask.
+
+    `network` is a count where the code fixes one and `None` where it depends on a
+    frontier only a run can size; `network_phrase` is what the user reads either way.
+    """
+
+    key: str
+    label: str
+    #: What it does, one clause, no trailing stop. The first half of the hover.
+    does: str
+    #: The tables it writes, or empty for a pass that writes nothing.
+    writes: tuple[str, ...] = ()
+    network: int | None = 0
+    network_phrase: str = "zero requests"
+    #: Why it cannot run now, in words the user can act on, or None.
+    blocked_by: str | None = None
+
+    @property
+    def hover(self) -> str:
+        wrote = ("writes nothing" if not self.writes
+                 else "writes " + ", ".join(self.writes))
+        line = f"{self.does} — {self.network_phrase}, {wrote}."
+        if self.blocked_by:
+            line += f" BLOCKED: {self.blocked_by}"
+        return line
+
+    def as_dict(self) -> dict:
+        return {"key": self.key, "label": self.label, "writes": list(self.writes),
+                "network": self.network, "blocked_by": self.blocked_by,
+                "hover": self.hover}
+
+
+# ---- directory sources ------------------------------------------------------
+
+#: `--approve` also writes the SCHEMA tables — `dataset_definition`,
+#: `dataset_schema_version`, `field_definition`, `schema_version_field` — but only
+#: when the parse adds a field, which `extract.service._retire_or_refuse` decides.
+#: The five below move on every approve.
+_APPROVE_WRITES = ("generic_record", "generic_record_revision", "generic_ingestion",
+                   "generic_record_node", "classification_node")
+
+_DIRECTORY: dict[str, Pass] = {
+    "plan": Pass(
+        key="plan", label="Price the crawl",
+        does="Sizes every cell of the partition and prices the full crawl against "
+             "the live directory",
+        # `contractors.run` calls `plan()` and returns BEFORE `open_engine()`, so it
+        # cannot write even on error.
+        writes=(), network=None,
+        network_phrase="sizing requests against the live site"),
+    "crawl": Pass(
+        key="crawl", label="Crawl the listing",
+        does="Fetches every listing page the partition proves it must read, storing "
+             "each unparsed",
+        writes=("generic_page_snapshot", "dataset_sighting", "fetch_validator",
+                "generic_record"),
+        network=None,
+        network_phrase="one request per listing page — 56 cells, 47 proven on the "
+                       "first run"),
+    "details": Pass(
+        key="details", label="Fetch the profile pages",
+        does="Fetches the profile page of every row the registered scope asks for",
+        writes=("generic_page_snapshot",), network=None,
+        network_phrase="one request per profile page in the frontier — last measured "
+                       "34,834 pages at 1.007 s each, 9.75 h"),
+    "approve": Pass(
+        key="approve", label="Interpret the stored pages",
+        does="Interprets the pages already on disk into rows, re-fetching nothing",
+        writes=_APPROVE_WRITES, network=0,
+        network_phrase="zero requests — last measured 121 rows in 83.9 min"),
+    "coverage": Pass(
+        key="coverage", label="What we are missing",
+        does="Stored against sighted, the frequency sample, sighted-and-never-stored, "
+             "and departures",
+        writes=(), network=0,
+        network_phrase="zero requests, read from the warehouse"),
+    "impostors": Pass(
+        key="impostors", label="Rows written from the wrong page",
+        does="Lists profile rows whose membership number disagrees with their listing "
+             "card; --repair is what retires them",
+        writes=(), network=0,
+        network_phrase="zero requests, read from the warehouse"),
+}
+
+
+def directory_passes(directory: Directory | None, *, scope: CrawlScope | None,
+                     crawl_slice: str = "", site_key: str = "",
+                     extraction_enabled: bool = True) -> tuple[Pass, ...]:
+    """The six, with the cost filled in and every block named.
+
+    Every block below is one of `contractors.validate`'s own refusals, or the early
+    return in `contractors.details` — stated here so the panel can grey a control
+    instead of the user meeting the refusal after the click.
+    """
+    if directory is None:
+        unknown = (f"no directory builder for site {site_key!r} "
+                   "(scrapex/directories.py), so no pass can be run against it")
+        return tuple(replace(_DIRECTORY[key], blocked_by=unknown)
+                     for key in DIRECTORY_PASSES)
+
+    cells = len(directory.partition().cells())
+    built: list[Pass] = []
+    for key in DIRECTORY_PASSES:
+        one = _DIRECTORY[key]
+        if key == "plan":
+            # `size_cell` costs 2 requests, or 1 for a cell that is a single page —
+            # so this is the ceiling, and it is derived rather than carried.
+            one = replace(
+                one, network=2 * (cells + 1),
+                network_phrase=f"up to {2 * (cells + 1)} requests — 2 per cell over "
+                               f"{cells} cells, plus the whole listing")
+        elif key == "details":
+            if scope is CrawlScope.LISTING_ONLY:
+                one = replace(one, blocked_by=(
+                    "site_profile.crawl_scope is listing_only, under which this pass "
+                    "refuses and asks you to change the scope"))
+            elif scope is CrawlScope.LISTING_PLUS_SLICE and not crawl_slice.strip():
+                one = replace(one, blocked_by=(
+                    "site_profile.crawl_scope is listing_plus_slice and "
+                    "crawl_slice names no slice, so there is nothing to select"))
+        elif key == "approve" and not extraction_enabled:
+            one = replace(one, blocked_by=(
+                "generic extraction is disabled in this build "
+                "(scrapex/features.py)"))
+        elif key == "impostors" and directory.profiles is None:
+            one = replace(one, blocked_by=(
+                f"{directory.key} declares no profile reader, so it has no profile "
+                "rows to check"))
+        built.append(one)
+    return tuple(built)
+
+
+# ---- price sources ----------------------------------------------------------
+
+#: Every table `scrapex/ingest.py` writes. Guarded against that file, so a run mode
+#: cannot come to write a table this list does not name.
+_INGEST_WRITES = ("crawl_run", "currency_rate", "offer_state", "price_observation",
+                  "price_period", "source_offer", "source_product",
+                  "source_product_attribute", "source_site", "source_variant")
+
+_PRICE: dict[str, Pass] = {
+    RunMode.INITIAL_CRAWL.value: Pass(
+        key=RunMode.INITIAL_CRAWL.value, label="First full collection",
+        does="Walks the whole catalogue for the first time and stores every price it "
+             "reads",
+        writes=_INGEST_WRITES, network=None),
+    RunMode.UPDATE.value: Pass(
+        key=RunMode.UPDATE.value, label="Update now",
+        does="Re-reads the catalogue and appends an observation only where the price "
+             "moved",
+        writes=_INGEST_WRITES, network=None),
+    RunMode.FULL_REBUILD.value: Pass(
+        key=RunMode.FULL_REBUILD.value, label="Rebuild from scratch",
+        does="Archives what is held, then collects the catalogue again from the top",
+        writes=_INGEST_WRITES, network=None),
+    RunMode.HISTORY_BACKFILL.value: Pass(
+        key=RunMode.HISTORY_BACKFILL.value, label="Collect the published history",
+        does="Collects the history the source publishes itself, as dated rows",
+        writes=_INGEST_WRITES, network=None),
+}
+
+
+def price_passes(entry, *, last_requests: int | None = None) -> tuple[Pass, ...]:
+    """The run modes `POST /api/jobs` accepts, per source.
+
+    The cost is the source's OWN last run — `crawl_run.requests_count` — because a
+    number retyped from another shop's catalogue is not this shop's cost.
+    """
+    phrase = (f"last run made {last_requests:,} requests"
+              if last_requests else
+              "no finished run has measured this source's request count yet")
+    # EVERY REASON, NOT THE FIRST ONE. ELBUROJ is both switched off and on a family
+    # with no published history; naming one of the two sends the owner to fix a
+    # setting that will not make the control work.
+    common: list[str] = []
+    if entry.family not in _BUILDERS:
+        common.append(f"family {entry.family.value!r} has no connector in "
+                      "scrapex/connectors/factory.py, so nothing can collect it")
+    if not entry.active:
+        common.append("the source is switched off in sources.yaml")
+
+    built: list[Pass] = []
+    for key in (mode.value for mode in RunMode):
+        reasons = list(common)
+        if key == RunMode.HISTORY_BACKFILL.value and not supports_history(entry.family):
+            reasons.append(
+                f"family {entry.family.value!r} does not publish its own history")
+        built.append(replace(_PRICE[key], network=last_requests,
+                             network_phrase=phrase,
+                             blocked_by="; ".join(reasons) or None))
+    return tuple(built)

--- a/scrapex/version.py
+++ b/scrapex/version.py
@@ -73,7 +73,7 @@ from enum import StrEnum
 # The release stamp. Bump it for a functional, architectural or behavioural
 # change (issue 32 section 1.1), and regenerate the baseline + CHANGELOG in the
 # same commit: python -m scrapex.cli export-version
-VERSION = "0.3.2"
+VERSION = "0.4.0"
 
 
 class Surface(StrEnum):

--- a/scrapex/version.py
+++ b/scrapex/version.py
@@ -73,7 +73,7 @@ from enum import StrEnum
 # The release stamp. Bump it for a functional, architectural or behavioural
 # change (issue 32 section 1.1), and regenerate the baseline + CHANGELOG in the
 # same commit: python -m scrapex.cli export-version
-VERSION = "0.3.1"
+VERSION = "0.3.2"
 
 
 class Surface(StrEnum):

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -53,7 +53,6 @@ from ..databases import (
     DatabaseUnavailableError,
     EngineDatabase,
 )
-from ..dryrun import dry_payload, refuse_writes, unknown_key_detail
 from ..extract import service as extract_service
 from ..extract.api import create_extraction_router
 from ..features import FeatureKey, is_enabled
@@ -3351,7 +3350,17 @@ def create_app(
         BOTH CONNECTIONS ARE SEALED BEFORE ANY PAYLOAD WORK. `refuse_writes` denies
         every statement able to change the warehouse, which matters on exactly one
         call: `disown_impostors` deletes when `dry_run=False`.
+
+        IMPORTED HERE AND NOT AT MODULE SCOPE, and the reason is measured rather than
+        stylistic: one import line at the top of this 3,800-line module renumbers
+        every line below it, and 26 citations across six of the nine documents
+        `tests/test_the_documents_cite_what_they_claim.py` guards point into this
+        file. Adding it there moved 36 documented lines, six of them RECORDS of past
+        drift that must not be renumbered. This route sits below every cited line, so
+        the import belongs where the route is.
         """
+        from ..dryrun import dry_payload, refuse_writes, unknown_key_detail
+
         general = general_read_conn()
         price = read_conn()
         try:

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -53,6 +53,7 @@ from ..databases import (
     DatabaseUnavailableError,
     EngineDatabase,
 )
+from ..dryrun import dry_payload, refuse_writes, unknown_key_detail
 from ..extract import service as extract_service
 from ..extract.api import create_extraction_router
 from ..features import FeatureKey, is_enabled
@@ -3335,6 +3336,36 @@ def create_app(
         finally:
             conn.close()
         return {"source_key": source_key, "summary": summary, "changes": feed}
+
+    # ---- the dry route: what a source WOULD do, for every source type ---------
+
+    @app.get("/api/dry/{source_key}")
+    def api_dry(source_key: str):
+        """«اعمل مسار dry لكل المصادر مهما اختلفت نوعها» — one route, both registries.
+
+        `POST /api/jobs` below validates against `app.state.manifest` alone, so
+        muqawil answered `404 unknown source_key 'contractors'` while
+        `/api/table/contractors` served 11,059 rows. This route asks both, and a key
+        either register knows answers 200.
+
+        BOTH CONNECTIONS ARE SEALED BEFORE ANY PAYLOAD WORK. `refuse_writes` denies
+        every statement able to change the warehouse, which matters on exactly one
+        call: `disown_impostors` deletes when `dry_run=False`.
+        """
+        general = general_read_conn()
+        price = read_conn()
+        try:
+            refuse_writes(general)
+            refuse_writes(price)
+            payload = dry_payload(source_key, general=general, price=price,
+                                  manifest=app.state.manifest)
+        finally:
+            general.close()
+            price.close()
+        if payload is None:
+            raise HTTPException(status_code=404, detail=unknown_key_detail(
+                source_key, manifest=app.state.manifest))
+        return payload
 
     # ---- jobs (spec 4/23/24: the panel enqueues and polls, never executes) ---
 

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -3359,6 +3359,9 @@ def create_app(
         drift that must not be renumbered. This route sits below every cited line, so
         the import belongs where the route is.
         """
+        # DO NOT MOVE THIS TO MODULE SCOPE. It is deliberate, it is measured, and the
+        # primary session ruled on 2026-08-27 that the trade is not worth a style
+        # point: see the paragraph above for the 36 documented lines it would shift.
         from ..dryrun import dry_payload, refuse_writes, unknown_key_detail
 
         general = general_read_conn()

--- a/tests/test_a_dry_route_for_every_source_type.py
+++ b/tests/test_a_dry_route_for_every_source_type.py
@@ -118,7 +118,13 @@ def log_elsewhere(tmp_path, monkeypatch):
     monkeypatch.setattr(contractors, "LOG", tmp_path / "contractors.log")
 
 
-pytestmark = pytest.mark.usefixtures("log_elsewhere")
+#: `extension` IS LOAD-BEARING, and CI caught its absence rather than this session.
+#: `test_the_panel_does_not_retype_a_single_hover_string` reads every `extension/*.js`,
+#: and an extension-only change runs `pytest -m extension` — so without the mark the one
+#: guard that stops the panel retyping a hover would stop running on exactly the pull
+#: requests most likely to break it. `tests/test_the_extension_gate_is_complete.py`.
+pytestmark = [pytest.mark.extension,
+              pytest.mark.usefixtures("log_elsewhere")]
 
 
 # ---- the premise: without this every assertion below is vacuous --------------

--- a/tests/test_a_dry_route_for_every_source_type.py
+++ b/tests/test_a_dry_route_for_every_source_type.py
@@ -1,0 +1,519 @@
+"""One dry route, both registries, and the four claims it makes about itself.
+
+«اعمل مسار dry لكل المصادر مهما اختلفت نوعها» — a dry route for ALL sources, whatever
+their type. `REQ-45`: `POST /api/jobs` validates against `app.state.manifest` alone, so
+muqawil answered `404 unknown source_key 'contractors'` while `/api/table/contractors`
+served 11,059 rows.
+
+WHAT IS ASSERTED HERE RATHER THAN TRUSTED:
+
+  * a key EITHER register knows answers 200 — price key, dataset key and site key;
+  * zero requests, with the sockets taken away rather than a comment saying so;
+  * zero writes, with the authorizer PROVEN to fire and the row counts held;
+  * the passes and their hover come from ONE declaration the panel cannot retype.
+"""
+from __future__ import annotations
+
+import shutil
+import socket
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from scrapex import contractors, dryrun, passes
+from scrapex.config import MANIFEST_FILE, load_manifest
+from scrapex.connectors.factory import _BUILDERS
+from scrapex.crawlscope import CrawlScope
+from scrapex.databases import DatabaseRegistry, EngineDatabase
+from scrapex.extract import service
+from scrapex.extract.models import ApprovalField, CandidateApproval, SnapshotCreate
+from scrapex.extract.muqawil import listing_candidate
+from scrapex.sightings import record_sightings
+from scrapex.vocab import RunMode
+from scrapex.webui.app import create_app
+
+ROOT = Path(__file__).resolve().parent.parent
+LISTING = (ROOT / "tests" / "fixtures" / "muqawil" / "listing-en.html").read_text(
+    encoding="utf-8")
+
+DATASET = "contractors"
+SITE = "muqawil_org"
+#: An id no page approved, so `coverage.missing` is not zero and the block is not
+#: vacuous.
+NEVER_STORED = "99999901"
+
+
+def _price_key() -> str:
+    """An ACTIVE, IMPLEMENTED source from the shipped manifest, chosen by the file.
+
+    Not typed in: a key that stops being in `sources.yaml` must fail here as a
+    missing fixture rather than as a mysterious 404.
+    """
+    entries = sorted((one for one in load_manifest(MANIFEST_FILE).sources
+                      if one.active and one.family in _BUILDERS),
+                     key=lambda one: one.source_key)
+    assert entries, "sources.yaml has no active implemented source to test against"
+    return entries[0].source_key
+
+
+PRICE = _price_key()
+
+
+@pytest.fixture(scope="module")
+def engine(tmp_path_factory):
+    """One approved dataset, its sightings, and one price source with a finished run."""
+    tmp = tmp_path_factory.mktemp("dry-route")
+    registry = DatabaseRegistry(EngineDatabase(tmp / "scrapex-engine.db"),
+                               pointer_file=tmp / "databases.json")
+    registry.initialize()
+    conn = registry.engine.connect()
+    try:
+        snapshot = service.save_snapshot(conn, SnapshotCreate(
+            source_url="https://muqawil.org/en/contractors?page=1",
+            html_content=LISTING, crawl_run_ref="listing-test"))
+        candidate = listing_candidate(LISTING)
+        service.approve_candidate(
+            conn, int(snapshot["page_snapshot_id"]),
+            CandidateApproval(
+                table_index=0, site_key=SITE, site_display_name="SCA",
+                dataset_key=DATASET, dataset_name="Contractors",
+                fields=[ApprovalField(field_key=f.field_key,
+                                      display_name=f.source_name, data_type="text",
+                                      identity=(f.field_key == "contractor_id"))
+                        for f in candidate.fields]),
+            candidate=candidate)
+        stored_ids = [str(row["contractor_id"]) for row in candidate.rows]
+        record_sightings(conn, DATASET, [*stored_ids, NEVER_STORED],
+                         run_ref="listing-test")
+        conn.execute(
+            "INSERT INTO source_site (source_id, source_key, source_name_ar, "
+            " source_name, base_url, platform, currency, timezone, authority, active) "
+            "VALUES (1,?,'س','S','http://s','custom_json','SAR','UTC','shop',1)",
+            (PRICE,))
+        conn.execute(
+            "INSERT INTO crawl_run (run_id, source_id, started_at, finished_at, "
+            " status, requests_count, rows_seen, errors_count) "
+            "VALUES (1,1,'2026-08-01T00:00:00Z','2026-08-01T00:04:00Z','success',"
+            " 812, 4001, 0)")
+        conn.commit()
+    finally:
+        conn.close()
+    manifest = tmp / "sources.yaml"     # a COPY, so no test can edit the real one
+    shutil.copy(MANIFEST_FILE, manifest)
+    return registry, manifest
+
+
+@pytest.fixture(scope="module")
+def client(engine) -> TestClient:
+    registry, manifest = engine
+    return TestClient(create_app(databases=registry, manifest_path=manifest))
+
+
+@pytest.fixture()
+def log_elsewhere(tmp_path, monkeypatch):
+    """`disown_impostors` reports through `contractors.say`, which appends to
+    `~/.scrapex/contractors.log`. Kept out of a real home directory here."""
+    monkeypatch.setattr(contractors, "LOG", tmp_path / "contractors.log")
+
+
+pytestmark = pytest.mark.usefixtures("log_elsewhere")
+
+
+# ---- the premise: without this every assertion below is vacuous --------------
+
+def test_the_warehouse_really_holds_both_kinds(client):
+    rows = client.get("/api/sources").json()["sources"]
+    kinds = {row["source_key"]: row.get("kind") for row in rows}
+
+    assert kinds.get(DATASET) == "dataset", "no dataset is being served"
+    assert PRICE in kinds, f"{PRICE} is not in the manifest this app loaded"
+
+
+# ---- a key EITHER register knows answers 200 --------------------------------
+
+@pytest.mark.parametrize("key,kind,registry", [
+    (PRICE, "price", "sources.yaml"),
+    (DATASET, "dataset", "dataset_definition"),
+    (SITE, "dataset", "site_profile"),
+])
+def test_a_key_either_register_knows_answers_200(client, key, kind, registry):
+    """THE WHOLE POINT OF 'every source type'. `POST /api/jobs` answers 404 for two
+    of these three."""
+    response = client.get(f"/api/dry/{key}")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["kind"] == kind
+    assert body["registry"] == registry
+    assert body["passes"], "a source with no passes is a menu with no entries"
+
+
+def test_an_unknown_key_is_404_and_names_both_registries(client):
+    response = client.get("/api/dry/NOT_A_SOURCE")
+
+    assert response.status_code == 404
+    detail = response.json()["detail"]
+    assert "sources.yaml" in detail
+    assert "dataset_definition" in detail and "site_profile" in detail
+
+
+def test_the_route_answers_a_dataset_key_that_post_api_jobs_still_refuses(client):
+    """The defect, both halves, in one test — so a fix to one cannot hide the other."""
+    assert client.get(f"/api/dry/{DATASET}").status_code == 200
+    refused = client.post("/api/jobs", json={"source_keys": [DATASET]})
+    assert refused.status_code == 404, (
+        "POST /api/jobs now resolves a dataset key; this route's reason for existing "
+        "has changed and REQ-45 should be re-read")
+
+
+# ---- zero requests, guarded --------------------------------------------------
+
+def _refuse(*args, **kwargs):
+    raise AssertionError("the dry route reached the network")
+
+
+def _cut_the_wire(monkeypatch) -> None:
+    """Every way this code base can reach a host, taken away.
+
+    NOT `socket.socket` ITSELF, and that was measured rather than assumed:
+    `TestClient` drives the app through an asyncio loop whose `ProactorEventLoop`
+    builds a self-pipe with `socket.socketpair()`, so patching the constructor fails
+    the HARNESS and reports a network call that never happened — an instrument
+    failure wearing the costume of a defect. `getaddrinfo` is the chokepoint every
+    outbound request by hostname must pass and the loopback self-pipe does not.
+    """
+    monkeypatch.setattr(socket, "getaddrinfo", _refuse)
+    monkeypatch.setattr(socket, "create_connection", _refuse)
+    monkeypatch.setattr("httpx.HTTPTransport.handle_request", _refuse)
+    monkeypatch.setattr("urllib.request.urlopen", _refuse)
+    monkeypatch.setattr("scrapex.connectors.base.HttpFetcher.__init__", _refuse)
+
+
+def test_the_route_makes_no_request(client, monkeypatch):
+    """THE WIRE IS CUT. `--plan` costs ~114 requests and is ADVERTISED by this
+    payload, never run — so the guard has to be able to catch a call rather than
+    trust that none is written."""
+    _cut_the_wire(monkeypatch)
+
+    for key in (PRICE, DATASET, SITE):
+        assert client.get(f"/api/dry/{key}").status_code == 200, key
+
+
+def test_the_network_guard_would_catch_the_pass_it_advertises(client, monkeypatch):
+    """NON-VACUITY, AND AGAINST THE REAL CALL. Three guards shipped here passing
+    under their own defect. This runs the sizing request `--plan` would make, with
+    the same wire cut, and requires it to be caught."""
+    _cut_the_wire(monkeypatch)
+
+    with pytest.raises(AssertionError, match="reached the network"):
+        contractors.make_fetch(1.0)
+
+
+# ---- zero writes, guarded ---------------------------------------------------
+
+def _row_counts(conn: sqlite3.Connection) -> dict[str, int]:
+    tables = [row[0] for row in conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' "
+        " AND name NOT LIKE 'sqlite_%'")]
+    return {name: conn.execute(f"SELECT COUNT(*) FROM \"{name}\"").fetchone()[0]
+            for name in tables}
+
+
+def test_not_one_row_moves(client, engine):
+    """Every table in the warehouse, counted either side of all three requests."""
+    registry, _ = engine
+    conn = registry.engine.connect()
+    try:
+        before = _row_counts(conn)
+    finally:
+        conn.close()
+
+    for key in (PRICE, DATASET, SITE):
+        assert client.get(f"/api/dry/{key}").status_code == 200
+
+    conn = registry.engine.connect()
+    try:
+        after = _row_counts(conn)
+    finally:
+        conn.close()
+    moved = {name: (before[name], after[name])
+             for name in before if before[name] != after[name]}
+    assert not moved, f"the dry route wrote rows: {moved}"
+
+
+def test_the_seal_is_live_so_a_write_on_the_route_would_raise(client, monkeypatch):
+    """THE GUARD THAT MAKES 'zero writes' A CHECK AND NOT A PROMISE.
+
+    `disown_impostors` DELETES when `dry_run=False`, so the destructive case is one
+    wrong keyword away. Here the impostor step is replaced by one that tries an
+    INSERT on the very connection the route opened: if `refuse_writes` were removed,
+    this test would pass and the route would be writing."""
+    def write_instead(conn, directory, *, dry_run=True):
+        conn.execute("INSERT INTO dataset_sighting (dataset_key, external_id) "
+                     "VALUES ('x','y')")
+        return 0
+
+    monkeypatch.setattr(dryrun.contractors, "disown_impostors", write_instead)
+    with pytest.raises(sqlite3.DatabaseError, match="not authorized"):
+        client.get(f"/api/dry/{DATASET}")
+
+
+@pytest.mark.parametrize("statement", [
+    "INSERT INTO dataset_sighting (dataset_key, external_id) VALUES ('a','b')",
+    "UPDATE dataset_sighting SET seen_count = 9",
+    "DELETE FROM dataset_sighting",
+    "DROP TABLE dataset_sighting",
+    "CREATE TABLE sneaky (a TEXT)",
+    "ALTER TABLE dataset_sighting ADD COLUMN sneaky TEXT",
+    "REINDEX",
+    "ANALYZE",
+])
+def test_refuse_writes_denies_every_shape_of_write(engine, statement):
+    registry, _ = engine
+    conn = registry.engine.connect()
+    try:
+        dryrun.refuse_writes(conn)
+        with pytest.raises(sqlite3.DatabaseError, match="not authorized"):
+            conn.execute(statement)
+        # AND STILL READS, or the seal would be a closed door rather than a filter.
+        assert conn.execute("SELECT COUNT(*) FROM dataset_sighting").fetchone()[0] >= 0
+    finally:
+        conn.close()
+
+
+# ---- the passes are DERIVED, not retyped ------------------------------------
+
+def test_the_directory_passes_are_the_command_line_s_own_flags():
+    """Each declared pass is a real `--flag`, and no action flag is undeclared."""
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    contractors.add_arguments(parser)
+    flags = {action.dest for action in parser._actions
+             if isinstance(action, argparse._StoreTrueAction)}
+
+    assert set(passes.DIRECTORY_PASSES) <= flags, (
+        "a declared pass has no flag on `scrapex contractors`")
+    # `--repair` is a MODIFIER of `--impostors`, not a pass of its own: it is the
+    # only store_true flag that is not one.
+    assert flags - set(passes.DIRECTORY_PASSES) == {"repair"}, (
+        "a store_true flag exists that is neither a declared pass nor --repair; "
+        "declare it in scrapex/passes.py or this menu goes stale silently")
+
+
+def test_validate_reads_the_declaration_and_names_every_pass(capsys):
+    """PROVES THE TUPLE IS THE ONE THE CLI GATES ON. If `validate` grew its own list
+    the refusal would stop naming what `passes.py` declares."""
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    contractors.add_arguments(parser)
+    with pytest.raises(SystemExit) as raised:
+        contractors.validate(parser.parse_args([]))
+
+    assert raised.value.code == 2
+    message = capsys.readouterr().err
+    for name in passes.DIRECTORY_PASSES:
+        assert f"--{name}" in message
+
+
+def test_the_price_passes_are_exactly_the_run_modes(client):
+    body = client.get(f"/api/dry/{PRICE}").json()
+
+    assert [one["key"] for one in body["passes"]] == [one.value for one in RunMode], (
+        "POST /api/jobs accepts RunMode; a pass list that is not RunMode is retyped")
+
+
+def test_the_price_writes_are_exactly_what_ingest_writes():
+    """Read off `scrapex/ingest.py`, so a new table it learns to write goes red here
+    instead of being missing from a hover that promises what a run costs."""
+    import re
+
+    source = (ROOT / "scrapex" / "ingest.py").read_text(encoding="utf-8")
+    written = set(re.findall(r"INSERT (?:OR [A-Z]+ )?INTO ([a-z_]+)", source))
+    written |= set(re.findall(r"UPDATE ([a-z_]+) SET", source))
+
+    declared = set(passes._INGEST_WRITES)
+    assert declared == written, (
+        f"ingest.py writes {sorted(written - declared)} that no pass declares, and "
+        f"the declaration claims {sorted(declared - written)} it does not")
+
+
+def test_every_table_a_pass_claims_to_write_exists():
+    """A renamed table would otherwise leave a hover naming a table that is gone."""
+    schema = (ROOT / "db" / "engine" / "schema.sql").read_text(encoding="utf-8")
+    for folder in ("db/engine/migrations", "db/migrations"):
+        for path in sorted((ROOT / folder).glob("*.sql")):
+            schema += path.read_text(encoding="utf-8")
+
+    claimed = {name for one in (*passes._DIRECTORY.values(), *passes._PRICE.values())
+               for name in one.writes}
+    assert claimed, "no pass declares a write; the field has stopped being filled"
+    for name in sorted(claimed):
+        assert f"TABLE {name} " in schema or f"TABLE IF NOT EXISTS {name} " in schema, (
+            f"a pass says it writes {name!r} and no schema file creates it")
+
+
+# ---- the hover: his explicit instruction ------------------------------------
+
+def test_every_hover_says_what_it_does_what_it_writes_and_what_it_costs():
+    every = [*passes.directory_passes(
+                 contractors.get_directory(SITE), scope=CrawlScope.FULL_THEN_LISTING),
+             *passes._PRICE.values()]
+    for one in every:
+        assert one.does in one.hover, one.key
+        assert one.network_phrase in one.hover, one.key
+        if one.writes:
+            for name in one.writes:
+                assert name in one.hover, f"{one.key} hides that it writes {name}"
+        else:
+            assert "writes nothing" in one.hover, one.key
+
+
+def test_the_route_serves_the_declared_hover_verbatim(client):
+    """ONE PLACE. If the route composed its own sentence there would be two."""
+    body = client.get(f"/api/dry/{DATASET}").json()
+    declared = {one.key: one for one in passes.directory_passes(
+        contractors.get_directory(SITE), scope=CrawlScope.LISTING_ONLY)}
+
+    for served in body["passes"]:
+        assert served["hover"] == declared[served["key"]].hover
+        assert served["writes"] == list(declared[served["key"]].writes)
+
+
+def test_the_panel_does_not_retype_a_single_hover_string():
+    """THE DRIFT THIS FEATURE EXISTS TO END. `extension/app.js` carried its own list
+    of what a source can do and five of its six actions 404'd (`REQ-45`). A retyped
+    sentence goes stale in the safe-looking direction — `LESSONS` §15."""
+    surfaces = [*(ROOT / "extension").rglob("*.js"),
+                *(ROOT / "scrapex" / "webui" / "static").rglob("*.js"),
+                *(ROOT / "scrapex" / "webui" / "templates").rglob("*.html")]
+    text = "\n".join(path.read_text(encoding="utf-8", errors="ignore")
+                     for path in surfaces)
+
+    for one in (*passes._DIRECTORY.values(), *passes._PRICE.values()):
+        assert one.does not in text, (
+            f"{one.key}'s description is retyped in a panel or page file; read it "
+            "from GET /api/dry/{source_key} instead")
+        assert one.network_phrase not in text, f"{one.key}'s cost is retyped"
+
+
+# ---- the scope is visible, and the setter is deliberately not built ---------
+
+def test_a_dataset_payload_shows_the_scope_and_the_refusal_it_causes(client):
+    body = client.get(f"/api/dry/{DATASET}").json()
+    scope = body["scope"]
+
+    assert scope["value"] == CrawlScope.LISTING_ONLY.value
+    assert scope["values"] == [one.value for one in CrawlScope]
+    assert scope["settable_here"] is False
+    assert "database" in scope["note"]
+
+    details = next(one for one in body["passes"] if one["key"] == "details")
+    assert details["blocked_by"] and "listing_only" in details["blocked_by"], (
+        "the scope refuses --details and the payload does not say so")
+    assert "change the scope" in details["blocked_by"]
+
+
+def test_the_refusal_lifts_when_the_scope_asks_for_profiles(client, engine):
+    """NON-VACUITY FOR THE BLOCK. A `blocked_by` that is always set says nothing."""
+    registry, _ = engine
+    conn = registry.engine.connect()
+    try:
+        conn.execute("UPDATE site_profile SET crawl_scope = ? WHERE site_key = ?",
+                     (CrawlScope.FULL_THEN_LISTING.value, SITE))
+        conn.commit()
+        body = client.get(f"/api/dry/{DATASET}").json()
+        details = next(one for one in body["passes"] if one["key"] == "details")
+        assert details["blocked_by"] is None
+        assert body["scope"]["value"] == CrawlScope.FULL_THEN_LISTING.value
+    finally:
+        conn.execute("UPDATE site_profile SET crawl_scope = ? WHERE site_key = ?",
+                     (CrawlScope.LISTING_ONLY.value, SITE))
+        conn.commit()
+        conn.close()
+
+
+def test_plan_is_advertised_with_its_cost_and_derived_from_the_partition(client):
+    """~114 IS DERIVED, NOT CARRIED. `size_cell` costs at most 2 requests, so the
+    ceiling is 2 x (cells + 1) — 114 over muqawil's 56 cells."""
+    body = client.get(f"/api/dry/{DATASET}").json()
+    plan = next(one for one in body["passes"] if one["key"] == "plan")
+    cells = len(contractors.get_directory(SITE).partition().cells())
+
+    assert plan["network"] == 2 * (cells + 1)
+    assert plan["writes"] == [], (
+        "plan() returns before open_engine(), so it cannot write even on error")
+    assert body["network_requests"] == 0, (
+        "the ROUTE advertises plan's cost and must not pay it")
+
+
+# ---- the payload calls sightings rather than reimplementing it --------------
+
+def test_coverage_comes_from_the_sightings_module(client, monkeypatch):
+    """The audit's own finding was `dataset_table_payload` reimplementing
+    `fields.hidden_columns` inline. If this payload grew its own SQL the sentinel
+    below would never appear."""
+    calls: list[str] = []
+
+    real = dryrun.coverage
+
+    def spy(conn, dataset_key):
+        calls.append(dataset_key)
+        return real(conn, dataset_key)
+
+    monkeypatch.setattr(dryrun, "coverage", spy)
+    body = client.get(f"/api/dry/{DATASET}").json()
+
+    assert calls == [DATASET]
+    assert body["coverage"][0]["sentence"].startswith(DATASET)
+    assert body["coverage"][0]["missing"] >= 1, (
+        f"{NEVER_STORED} was sighted and never stored; coverage says nothing is "
+        "missing, so the block is vacuous")
+
+
+def test_the_route_and_the_cli_share_one_departure_window(client, engine):
+    """`contractors.default_window` — the same function `--coverage` uses. Two copies
+    of `MAX(last_seen_at)` is how a route and a printer come to disagree."""
+    registry, _ = engine
+    conn = registry.engine.connect()
+    try:
+        expected = contractors.default_window(conn, DATASET)
+    finally:
+        conn.close()
+    block = client.get(f"/api/dry/{DATASET}").json()["coverage"][0]
+
+    assert expected, "the ledger has no sightings, so this asserts nothing"
+    assert block["departures"]["not_seen_since"] == expected
+    assert len(block["missing_sample"]) <= contractors.COVERAGE_SAMPLE
+
+
+def test_the_impostor_check_runs_dry_and_says_which_dataset(client):
+    body = client.get(f"/api/dry/{SITE}").json()
+
+    assert body["impostors"]["dry_run"] is True
+    assert body["impostors"]["dataset_key"] == "contractor_profiles"
+
+
+def test_a_generic_run_does_not_claim_it_finished(client):
+    """`R-52` ruled a generic crawl-run table and it is not built, so `partial` is
+    NULL with its basis named — `R-55`: absence beats a placeholder."""
+    body = client.get(f"/api/dry/{DATASET}").json()
+
+    assert body["last_run"]["partial"] is None
+    assert "R-52" in body["last_run"]["partial_basis"]
+    assert body["last_run"]["run_ref"] == "listing-test"
+
+
+def test_a_price_run_does_state_whether_it_was_partial(client):
+    """The other side: `crawl_run.status` is a real column, so this is not NULL."""
+    body = client.get(f"/api/dry/{PRICE}").json()
+
+    assert body["last_run"]["partial"] is False
+    assert body["last_run"]["partial_basis"] == "crawl_run.status"
+    assert body["last_run"]["requests"] == 812
+    assert all(one["network"] == 812 for one in body["passes"]), (
+        "a price pass must cost this source's own measured requests, not a number "
+        "borrowed from another shop")

--- a/tests/test_a_dry_route_for_every_source_type.py
+++ b/tests/test_a_dry_route_for_every_source_type.py
@@ -150,6 +150,16 @@ def test_a_key_either_register_knows_answers_200(client, key, kind, registry):
     assert body["passes"], "a source with no passes is a menu with no entries"
 
 
+def test_both_kinds_answer_the_same_top_level_keys(client):
+    """ONE SHAPE FOR THE PANEL. A key present on one kind and absent on the other
+    teaches a reader to guard every access, and then to stop noticing which guards
+    mean something."""
+    price = set(client.get(f"/api/dry/{PRICE}").json())
+    dataset = set(client.get(f"/api/dry/{DATASET}").json())
+
+    assert price == dataset, f"only on price: {price - dataset}; only on dataset: {dataset - price}"
+
+
 def test_an_unknown_key_is_404_and_names_both_registries(client):
     response = client.get("/api/dry/NOT_A_SOURCE")
 
@@ -482,6 +492,25 @@ def test_coverage_comes_from_the_sightings_module(client, monkeypatch):
     assert body["coverage"][0]["missing"] >= 1, (
         f"{NEVER_STORED} was sighted and never stored; coverage says nothing is "
         "missing, so the block is vacuous")
+
+
+def test_a_never_sighted_dataset_does_not_publish_100_percent_coverage(engine):
+    """`Coverage.fraction` is **1.0** when nothing has been sighted, while the same
+    object's sentence says coverage *"cannot be stated. That is not the same as
+    complete."* Publishing the number would print 100% over the sentence denying it.
+
+    Live, 2026-08-27: `contractor_profiles` carries **0** sightings, so this is the
+    ordinary case for a dataset built from profile pages — not an edge."""
+    registry, _ = engine
+    conn = registry.engine.connect()
+    try:
+        block = dryrun._coverage(conn, "a_dataset_nothing_has_sighted")
+    finally:
+        conn.close()
+
+    assert block["seen"] == 0, "the ledger has sightings for this key, so nothing is proved"
+    assert block["fraction"] is None
+    assert "cannot be stated" in block["sentence"]
 
 
 def test_the_route_and_the_cli_share_one_departure_window(client, engine):

--- a/tests/test_a_dry_route_for_every_source_type.py
+++ b/tests/test_a_dry_route_for_every_source_type.py
@@ -373,14 +373,24 @@ def test_every_hover_says_what_it_does_what_it_writes_and_what_it_costs():
 
 
 def test_the_route_serves_the_declared_hover_verbatim(client):
-    """ONE PLACE. If the route composed its own sentence there would be two."""
-    body = client.get(f"/api/dry/{DATASET}").json()
-    declared = {one.key: one for one in passes.directory_passes(
-        contractors.get_directory(SITE), scope=CrawlScope.LISTING_ONLY)}
+    """ONE PLACE. If the route composed its own sentence there would be two.
 
-    for served in body["passes"]:
-        assert served["hover"] == declared[served["key"]].hover
-        assert served["writes"] == list(declared[served["key"]].writes)
+    BOTH KINDS, and that is not symmetry for its own sake: the first version of this
+    test checked the dataset payload only, and a mutation that replaced the PRICE
+    hover with the label passed it — the guard held for one of the two halves it
+    was written for.
+    """
+    entry = load_manifest(MANIFEST_FILE).get(PRICE)
+    expected = {
+        DATASET: {one.key: one for one in passes.directory_passes(
+            contractors.get_directory(SITE), scope=CrawlScope.LISTING_ONLY)},
+        PRICE: {one.key: one for one in passes.price_passes(entry,
+                                                           last_requests=812)},
+    }
+    for key, declared in expected.items():
+        for served in client.get(f"/api/dry/{key}").json()["passes"]:
+            assert served["hover"] == declared[served["key"]].hover, key
+            assert served["writes"] == list(declared[served["key"]].writes), key
 
 
 def test_the_panel_does_not_retype_a_single_hover_string():


### PR DESCRIPTION
## What he asked for

> «اعمل مسار dry لكل المصادر مهما اختلفت نوعها»
>
> «ابنى المسار الجاف للثلاثة وخلى hover الى يبان يكون واضح بدقة للمستخدم»

**No register number is claimed.** Sweep of all 419 refs: highest declared `REQ-45`
(`req/the-crawl-button-for-muqawil`, pushed), `OP-81`, `R-58`. `REQ-46` is the next free
`REQ` — the primary assigns it.

## The route

`GET /api/dry/{source_key}` — resolves the key in **both** registries, and a key either
one knows answers 200.

| key | registry | `POST /api/jobs` | `GET /api/dry/{key}` |
|---|---|---|---|
| `ADVANCEDCASTLE` | `sources.yaml` | 200 | **200** |
| `contractors` | `dataset_definition` | **404** | **200** |
| `muqawil_org` | `site_profile` | **404** | **200** |
| `NOT_A_SOURCE` | neither | 404 | **404**, naming both registries |

`site_profile` is asked as well as `dataset_definition` because `scrapex contractors
--source` names a SITE key while the panel's card carries a DATASET key.

Measured on the live 1.2 GB warehouse, read-only: **0.69 s** for `contractors`, **0.79 s**
for `muqawil_org` (three datasets), **0.00 s** for a price key.

## Zero requests and zero writes are guarded, not asserted

`dryrun.refuse_writes` installs a SQLite authorizer denying every action able to change
the warehouse — INSERT/UPDATE/DELETE, every CREATE/DROP of a non-temp object,
ALTER/REINDEX/ANALYZE/ATTACH/DETACH/TRANSACTION/SAVEPOINT. It matters on exactly one
call: `disown_impostors` deletes when `dry_run=False`.

The network guard cuts `socket.getaddrinfo`, `socket.create_connection`,
`httpx.HTTPTransport.handle_request`, `urllib.request.urlopen` and
`HttpFetcher.__init__`. **Not `socket.socket` itself** — that was tried and it fails the
HARNESS: `TestClient`'s `ProactorEventLoop` builds its self-pipe with
`socket.socketpair()`, so the first version reported a network call that never happened.

**One side effect, named:** `disown_impostors` reports through `contractors.say`, which
appends ~12 lines to `~/.scrapex/contractors.log` and prints them. No database is touched.

## The four blocks

1. **Coverage** — `scrapex/sightings.py` **called**, not reimplemented: `coverage`,
   `sighting_frequencies`, `missing_ids`, `departures`. The window is
   `contractors.default_window`, extracted from `contractors.run` so the route and
   `report_coverage` cannot pick different ones; the sample size is
   `contractors.COVERAGE_SAMPLE`, extracted from the same printer.
2. **Impostors, dry** — `disown_impostors(conn, directory, dry_run=True)`. **Live: 0**,
   not the audit's 14.
3. **Last-run state** — for a dataset, from `generic_page_snapshot` by `crawl_run_ref`;
   for a price source, from `crawl_run`. `partial` is a real column on the price side and
   **NULL with its basis named** on the dataset side: `R-52` ruled a generic crawl-run
   table and it is not built, and `R-55` says absence beats a placeholder. A `false` there
   is `OP-68`'s false sentence.
   `runs_recorded` and `pages_stored` are in the block because the newest run is often a
   stub — live, the newest ref is `R` with **2 pages** against **57,041** over **141** refs.
   `generic_page_snapshot` has no dataset column, so the run is the warehouse's newest and
   the payload says so.
4. **The passes** — declared in `scrapex/passes.py`, derived rather than retyped:
   - directory passes are keyed on `DIRECTORY_PASSES`, and `contractors.validate` now
     gates on that same tuple;
   - price passes are keyed on `RunMode`, which is what `POST /api/jobs` accepts;
   - `--plan`'s cost is `2 x (cells + 1)` from the partition — **114** over muqawil's 56
     cells — and not the number 114;
   - price cost is the source's **own** `crawl_run.requests_count`;
   - `blocked_by` names **every** reason, not the first: ELBUROJ is both switched off and
     on a family with no published history.

## The hover

`Pass.hover` is **composed** from `does` + `network_phrase` + `writes`, so it cannot
promise one cost while `network` states another. The route serves it verbatim.

```
Interprets the pages already on disk into rows, re-fetching nothing — zero requests —
last measured 121 rows in 83.9 min, writes generic_record, generic_record_revision,
generic_ingestion, generic_record_node, classification_node.

Fetches the profile page of every row the registered scope asks for — one request per
profile page in the frontier — last measured 34,834 pages at 1.007 s each, 9.75 h,
writes generic_page_snapshot. BLOCKED: site_profile.crawl_scope is listing_only, under
which this pass refuses and asks you to change the scope.
```

The scope block carries the current value, all three `CrawlScope` values, the slice,
`settable_here: false` and the note that it is settable only in the database.
**The setter is not built here** — that is a separate approved item.

## `--plan` is advertised, never run

`payload.network_requests` is `0` and `plan`'s own `network` is `114`. A route called
"dry" that quietly made 114 requests is the naming defect this repository keeps finding.

## The mutation table — 18 defects restored, 18 reds

| defect restored | mutated | restored |
|---|---|---|
| the write seal is installed | 1 | 0 |
| no row moves | 1 | 0 |
| zero network | 1 | 0 |
| `site_profile` is a registry too | 1 | 0 |
| the manifest is a registry too | 1 | 0 |
| a new CLI flag must be declared | 1 | 0 |
| `validate` reads the declaration | 1 | 0 |
| the panel may not retype a hover | 1 | 0 |
| the route serves the declared hover | 1 | 0 |
| price writes match `ingest.py` | 1 | 0 |
| a declared table must exist | 1 | 0 |
| `listing_only` blocks the profile pass | 1 | 0 |
| one departure window | 1 | 0 |
| `sightings` is called, not reimplemented | 1 | 0 |
| a generic run does not claim it finished | 1 | 0 |
| `--plan`'s cost is derived from the partition | 1 | 0 |
| both kinds answer the same top-level keys | 1 | 0 |
| a never-sighted dataset is not 100% covered | 1 | 0 |

`__pycache__` purged between every run; tree verified clean after all restores.

**One hole the mutation found, and the second commit closes it:**
`test_the_route_serves_the_declared_hover_verbatim` read the DATASET payload only, so
replacing the PRICE hover with the label left it green. Both kinds are asserted now.

## Three things reading the payload back caught

1. **A never-sighted dataset published 100% coverage.** `Coverage.fraction` returns `1.0`
   when nothing has been sighted while the same object's sentence says coverage *"cannot
   be stated. That is not the same as complete."* Live, `contractor_profiles` carries **0**
   sightings — the ordinary case for a dataset built from profile pages, not an edge. NULL
   now, per `R-55`. **`Coverage.fraction` itself is unchanged** (the CLI printer never
   shows it) and is worth a `BACKLOG` line the primary numbers.
2. **The two kinds answered different top-level keys** — `coverage_note` was on price and
   absent on a dataset. One shape now, guarded both ways.
3. **The coverage hover did not say where its window comes from.** It does.

## Why the import is inside the route

One import line at the top of this 3,800-line module renumbers every line below it. **26
citations across six of the nine documents the citation guard checks point into
`scrapex/webui/app.py`; adding the import at module scope moved 36 documented lines, six
of them RECORDS of past drift** (`ORCHESTRATION` §4's own `app.py:2710 → 2725 → 2787`)
that must not be renumbered. The route sits below every cited line, so the import sits
with the route. Reversible — say the word and it moves up with the 36 re-derivations.

## Not done here, deliberately

- **`extension/app.js` is untouched.** The engine declares and serves the hover; the panel
  renders it. Another session has queued work near that file — say when it is free.
- **No register entry written.** See the sweep above.

## Two things CI caught that no local run of mine had

I ran the files I wrote and the guards I expected, and not the guards that watch the
repository. Both were red on the first push and are fixed:

1. **`pytest.mark.extension` was missing.** `test_the_panel_does_not_retype_a_single_hover_string`
   reads every `extension/*.js`, and an extension-only change runs `pytest -m extension` —
   so the one guard stopping the panel retyping a hover would have stopped running on
   exactly the pull requests most likely to break it. `pytestmark` was a bare
   `usefixtures`, which crowded the mark out.
2. **`VERSION` had to move, and I had written in this body that it did not.** `R-35`: the
   engine moves on a CONTRACT change — schema, protocol, or endpoint — and
   `GET /api/dry/{source_key}` is an endpoint. **95 routes → 96.**

**HE RULED 0.4.0**, not the 0.3.2 I had picked. `scrapex/version.py` and its
`pyproject.toml` mirror moved, baselines and `CHANGELOG` regenerated by
`python -m scrapex.cli export-version` (9 migrations, 96 routes, protocol 1).
`MINIMUM_EXTENSION_VERSION` stays **`0.2.2`** — no capability was added and nothing in the
panel needs the route yet, so nobody is sent to reload a browser. The `0.3.2` literal was
swept: 14 occurrences, all in the two sources and the four generated files, none in prose.
`tests/test_the_release_the_documents_ask_for_is_the_one_that_would_run.py` was run
explicitly — the guard `OP-32` cost twelve days for — and is green.

## Why the impostor count is 0 and the audit says 14

A reader of `MUQAWIL-AUDIT-2026-08-26.md` would conclude the route is broken. It is not,
and `dryrun._impostors`'s docstring now says so. `OP-64`'s `--repair` has run, and
`disown_impostors` reads `r.status = 'active'`. Measured read-only on the live warehouse
2026-08-27:

| `contractor_profiles` | rows | disagree with their listing card |
|---|---|---|
| `active` | 17,371 | **0** |
| `retired` | 14 | **14** |
| `unavailable` | 0 | 0 |

The fourteen are exactly the audit's, withdrawn rather than deleted (`status`, never a
`DELETE`), so the dry pass has nothing left to find.

## Rebased onto `fd450cf`

`main` moved three times during this session (`#272`, `#270`, `#273`). `docs/STATE.md`
conflicted once and was resolved by keeping both sections; the second rebase auto-merged.

**`#273` landed `REQ-45`'s own entry on `main`, and this route had moved the line it
cites.** `scrapex/webui/app.py:3349-3353` — the manifest validation `REQ-45` rests its
whole argument on — is now `3392-3396`, because `GET /api/dry/{source_key}` was inserted
immediately above `POST /api/jobs`. Re-derived. Swept all nine documents the citation
guard checks: it is the **only** guarded citation past the insertion point. The entry
quotes the comment *"fail before queueing, not mid-crawl"*, and that sentence — not the
number — is what located it, which is `ORCHESTRATION` §4's rule earning its place.

| fact | value |
|---|---|
| head | `de959aa` |
| base | `fd450cf` (== `origin/main`, re-derived after) |
| worktree | **0** uncommitted lines |
| newest edit | `1787812991` `scrapex/dryrun.py` |
| started | `1787813013` — **22 s after** the newest edit |

`SCRAPEX_FULL_MIGRATIONS=1 python -m pytest -q`: **3,432 passed, 10 skipped, 1 xfail, 0
failed, 0 errors** — 3,443 outcomes counted off the progress characters, because `addopts`
already carries `-q` so pytest prints no summary line at all (`ORCHESTRATION` §7). 100%
reached, `PYTEST_EXIT=0` taken on the line immediately after pytest. The 18-mutation table
was re-run on this exact tree: 18 OK, tree clean after.

**One run was discarded rather than reported.** An earlier local suite was stopped with
`TaskStop`, which — as `ORCHESTRATION` §7 rule 1 says — did not kill `pytest`; the killed
wrapper took the Playwright driver's process group with it and the run reported **284
errors and 25 failures**, every error body reading
`AttributeError: 'PlaywrightContextManager' object has no attribute '_playwright'`. That
is the documented instrument failure, not a result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
