### PR TITLE
His ten decisions of 2026-08-27, and a release blocker proved by running the engine

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2990,6 +2990,51 @@ Being built on `fix/the-release-gate-fetches-a-page` by the session that found i
 
 ---
 
+### OP-84 · The warehouse is ahead of `main` again, and `OP-33`'s remedy was a merge rather than a guard
+
+**Found 2026-08-27 · proved by running · [R-64](RULINGS.md#r-64--a-migration-reaches-his-warehouse-only-after-it-is-on-main-and-no-tag-is-cut-while-his-warehouse-is-ahead) rules it**
+
+| | |
+|---|---|
+| his live warehouse | `PRAGMA user_version` = **12** |
+| `main` | migrations stop at **`0010`**, so a build from it reads **v10** |
+| `database-status` from `main`'s level | `"ok": false` · *"Needs a newer ScrapeX (schema v12; this build reads v10)"* |
+| where `0011`/`0012` live | `feat/organization-enrichment` — pushed, **no PR ever opened**, 3 ahead and **8 behind** |
+
+**So a `0.4.0` release built from `main` would refuse to start on his machine** — which is
+`OP-33` exactly, five days later, with a different pair of migrations. `R-24` forbids the
+shortcut, and the gate's own message says *"do not downgrade the database."*
+
+**Nothing guards the class.** `migration-authority` in CI reads the branch's own diff; it
+cannot see another branch and cannot see his machine. `OP-33` was closed by merging #243, so
+the remedy did not survive the incident.
+
+**And the branch is not a small thing to merge for the sake of the gap:** 7,832 lines across
+44 files, 415 lines of SQL, absent from `REQUESTS.md` entirely, and it edits
+`tests/test_the_documents_cite_what_they_claim.py` and
+`tests/test_the_registers_cannot_collide.py` — **the two guards that keep this documentation
+system honest.** He ruled it is read and reported before anything of it merges.
+
+---
+
+### OP-85 · `Coverage.fraction` returns 1.0 when nothing has ever been sighted
+
+**Found 2026-08-27 while building `#274`'s dry route**
+
+`Coverage.fraction` answers **1.0** for a dataset with an empty sighting ledger, while its own
+sentence says coverage *"cannot be stated"* in that case. So a dataset nobody has ever crawled
+reports **100% covered**, and `contractor_profiles` held zero `dataset_sighting` rows until
+recently — the exact case.
+
+`#274`'s route emits **NULL** rather than 1.0, so the surface is honest today. **The dataclass
+is unchanged**, which means the next caller gets 1.0 again.
+
+**Not urgent, and the reason is specific:** the only two readers are the route (correct now)
+and `report_coverage`'s printer, which prints the count beside the fraction so a reader sees
+`0 of 0`. It becomes urgent the moment a third caller compares the fraction to a threshold.
+
+---
+
 ### OP-83 · 1,728 snapshots were never compressed — 69% of the stored bytes, 623 MB recoverable
 
 **Found 2026-08-27 by counting the warehouse instead of quoting the study.**
@@ -3763,7 +3808,9 @@ unedited, because the answer is only legible beside what was asked (**C4**).
 
 ### Q-26 · For a dataset, does the overview keep four tiles or show two?
 
-**Asked 2026-08-23 · his to answer · evidence in `OP-63`, whose panel half is closed**
+**Asked 2026-08-23 · ANSWERED 2026-08-27 · evidence in `OP-63`, whose panel half is closed**
+
+> **HIS ANSWER: (c) — the tile set follows the kind.** A dataset shows its row count and how much has been fetched; a price source keeps all four. Ruled as [R-63](RULINGS.md#r-63--a-datasets-overview-shows-the-tiles-its-kind-has).
 
 `/source/contractors` prints a **`Products 17,304`** tile over a contractor directory, and
 three of its four tiles say nothing about a directory at all. The panel half of that noun is
@@ -3790,7 +3837,9 @@ would leave two of the three wrong tiles standing while reading as done.
 
 ### Q-24 · Which of the two `site_profile` rows for muqawil is canonical?
 
-**Asked 2026-08-26 · his to answer · found while diagnosing [REQ-45](REQUESTS.md#req-45--the-crawl-button-does-not-work-for-muqawil)**
+**Asked 2026-08-26 · ANSWERED 2026-08-27 · found while diagnosing [REQ-45](REQUESTS.md#req-45--the-crawl-button-does-not-work-for-muqawil)**
+
+> **HIS ANSWER: id 2 (`muqawil_org`) is canonical; id 1 closes with `valid_to`.** And it is not a tidy-up on its own — it happens inside [R-62](RULINGS.md#r-62--one-source-registry-site_profile-merges-into-source_site--and-q-24-is-answered-by-that-migration)'s migration, which merges `site_profile` into `source_site` altogether. **One fact the merge must decide rather than copy:** both rows read `lifecycle = 'draft'`, so neither is `active` today.
 
 Measured read-only on the live warehouse:
 
@@ -3900,7 +3949,9 @@ reason this is a question and not a commit.
 *No recommendation on (a) versus (c), because it depends on how often he intends to
 release. But (b) is now argued against rather than merely listed.*
 
-**Q-15 · May a session run an unmerged migration against his LIVE warehouse?**
+**Q-15 · ~~May a session run an unmerged migration against his LIVE warehouse?~~ — ANSWERED 2026-08-27: NO.**
+
+> **It happened twice while this question sat unanswered** — `0007`/`0008` on 2026-08-21 (`OP-33`) and `0011`/`0012` today (`OP-84`), and both times his warehouse ended up ahead of any engine `main` could build. A migration reaches it only after it is on `main`; a session testing one uses a copy. **A backup is not the protection** — both incidents left backups on disk and neither prevented this. He also approved both guards. [R-64](RULINGS.md#r-64--a-migration-reaches-his-warehouse-only-after-it-is-on-main-and-no-tag-is-cut-while-his-warehouse-is-ahead).
 Three times on 2026-08-21 his engine database moved ahead of `main` — v8 against v6
 in the morning (`OP-33`, closed by #243), and **v9 against v8** in the afternoon
 (`OP-40`). Each instance closes by merging; the class does not.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3017,6 +3017,25 @@ system honest.** He ruled it is read and reported before anything of it merges.
 
 ---
 
+### OP-86 · `crawl_obey_disallow` is a robots setting with no surface on either side
+
+**Found 2026-08-27 while enumerating the keys [R-66](RULINGS.md#r-66--every-outbound-request-knob-is-a-setting-the-user-controls-and-robots-is-one-of-them) names**
+
+`crawl_obey_disallow` is read in code and appears in **neither** `extension/app.html` nor
+`scrapex/webui/templates/settings.html` — measured by grep on both. Its four siblings are on
+both surfaces (`crawl_min_interval_s`, `crawl_honour_delay`, `crawl_timeout_s`,
+`crawl_user_agent`) and `crawl_parallel_sources` is in the extension only.
+
+**So the one robots knob that decides whether a `Disallow` is obeyed is settable only by
+editing the database by hand** — the same shape as `crawl_scope`, which `REQ-45` recorded
+and which `--details` refuses under while telling the owner to change a setting that has no
+place to be changed.
+
+**It is `R-66`'s first item**, and it is registered separately because it is true today and
+independent of the enrichment branch landing.
+
+---
+
 ### OP-85 · `Coverage.fraction` returns 1.0 when nothing has ever been sighted
 
 **Found 2026-08-27 while building `#274`'s dry route**

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -80,7 +80,7 @@ IDs are stable and never reused, matching the convention BACKLOG.md already uses
 | [REQ-22](#req-22--what-happens-on-a-new-contractor-a-vanished-one-a-changed-one-and-on-update) | What happens on a new / vanished / changed contractor, and on "update" | **Captured** — answered by measurement; 3 of 4 are gaps ([OP-26](BACKLOG.md)) | 2026-08-21 |
 | [REQ-23](#req-23--test-my-own-ruling-before-building-it-with-strict-review-criteria) | Test my own ruling before building it, with strict review criteria | **Done** — [R19-CHILD-TABLES-MEASURED.md](R19-CHILD-TABLES-MEASURED.md); ruling upheld, a refinement proposed as `Q-13` | 2026-08-21 |
 | [REQ-24](#req-24--a-shipped-command-so-a-new-user-can-crawl-the-directory-at-all) | A shipped command, so a new user can crawl the directory at all | **Done** — `scrapex contractors`; the panel path is still missing | 2026-08-21 |
-| [REQ-25](#req-25--one-source-registry-with-a-category-visible-to-every-user) | One source registry, with a category, visible to every user | **Planned** — half exists (`active: false`, `TBD-probe`); the category and the single registry do not | 2026-08-21 |
+| [REQ-25](#req-25--one-source-registry-with-a-category-visible-to-every-user) | One source registry, with a category, visible to every user | **Planned** — ruled 2026-08-27 as [R-62](RULINGS.md#r-62--one-source-registry-site_profile-merges-into-source_site--and-q-24-is-answered-by-that-migration): he chose the migration, `site_profile` into `source_site`. Measured: **2 rows to move, 2 tables to repoint, `price_observation` untouched**. Answers `Q-24` inside it and unblocks the crawl button | 2026-08-21 |
 | [REQ-26](#req-26--a-database-per-account-not-per-machine) | A database per account, not per machine | **In flight** — `Q-14` answered (`R-34`): the account is the signed-in address, and his warehouse records it; the per-account layout remains | 2026-08-21 |
 | [REQ-27](#req-27--a-second-source-of-a-category-reuses-the-firsts-machinery) | A second source of a category reuses the first's machinery | **Done** — `scrapex/directories.py`; `--source`, and the crawl is inherited | 2026-08-21 |
 | [REQ-28](#req-28--the-engine-would-not-install-and-showed-a-black-screen) | The Engine would not install — a black screen, and no way to install it | **In flight** — cause proven, gate closed, and `engine-v0.3.0` published 2026-08-22 after he raised it a second time; his confirmation that it installs is what remains | 2026-08-21 |
@@ -1128,7 +1128,9 @@ own interface. That is the next item, and it is separate.
 ---
 
 ## REQ-25 · One source registry, with a category, visible to every user
-**Captured 2026-08-21 · Planned**
+**Captured 2026-08-21 · Ruled 2026-08-27 · Planned**
+
+> **Ruled 2026-08-27 as [R-62](RULINGS.md#r-62--one-source-registry-site_profile-merges-into-source_site--and-q-24-is-answered-by-that-migration): one registry.** He chose to merge `site_profile` into `source_site` rather than teach `POST /api/jobs` the other two registries, which is what I recommended. **Measuring it for the ruling showed my cost estimate was too high**: 2 rows to move, 2 tables to repoint (`dataset_definition`, `dataset_relationship`), and `price_observation`'s 94,664 rows are untouched because they do not reference `source_site`. It answers `Q-24` inside the same migration — id 1 (`muqawil`) closes, id 2 (`muqawil_org`) survives — and it is what unblocks [REQ-45](#req-45--the-crawl-button-does-not-work-for-muqawil), the crawl button.
 
 > «اى مصدر اعطيه لك ونشتغل عليه لازم يظهر ضمن المصادر المسجلة لاى مستخدم ويستطيع
 > عمل زحف عليه · اى مصدر ادتهولك ولم ناسس له زحف يحفظ فقط فى قائمة مصادر حتى ياتى

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -2761,3 +2761,81 @@ guard — **is read and reported before anything of it merges.** Registered as `
 **This does not soften `R-02`:** an un-computable mapping is still his call, and he may refuse
 to rule until studies are measured. What changes is that the asking is not optional and not
 deferred.
+
+---
+
+### R-66 · Every outbound-request knob is a setting the user controls, and robots is one of them
+
+**2026-08-27 · architecture · he refused all three options I offered and gave a wider rule**
+
+> «اريد ربطهم باعدادات بحيث يكون المستخدم متحكم تحكما كاملا فى هذا النقطة بالاضافة الى
+> robot.txt معهم · اريد توفير كل المفاتيح للمستخدم وولمستخدم القرار»
+
+I asked *which component should own outbound requests* — accept the second owner, route it
+through `pacegovernor`, or route both. **He answered a different question: it does not matter
+who owns the request, it matters that the user owns the knob.** Which is `R-21` arriving from
+the other side, and it is consistent with his standing rule that every setting moves to the
+extension.
+
+**The current state, measured — two owners, and they do not obey the same things:**
+
+| | `HttpFetcher` (`connectors/base.py:216`) — prices **and** muqawil | the enrichment website provider |
+|---|---|---|
+| pace per host | `crawl_min_interval_s`, default **1.0 s** | `SCRAPEX_WEBSITE_MIN_INTERVAL_MS`, default **250 ms** — four times faster |
+| reads his settings | **yes** | **no — environment variables only** |
+| robots | `crawl_honour_delay`, `crawl_obey_disallow` | its own `RobotFileParser`, no setting |
+| user agent | `crawl_user_agent` | not configurable |
+| SSRF / private peers | **none** | refuses private peers, off-domain redirects, HTTPS downgrades |
+
+**The ten keys his ruling names.** One exists and is hidden, three are environment variables,
+and the rest are literals with no key at all:
+
+| key | today | after |
+|---|---|---|
+| `crawl_obey_disallow` | **exists in code, no surface on either side** — `OP-86` | a setting |
+| `SCRAPEX_WEBSITE_MIN_INTERVAL_MS` (250) | env var | a setting |
+| `SCRAPEX_DNS_TIMEOUT_SECONDS` (3) | env var | a setting |
+| `SCRAPEX_GOOGLE_PLACES_QPS` (5) | env var | a setting |
+| `httpx.Timeout(12.0, connect=6.0)` | literal | a setting, or `crawl_timeout_s` |
+| `max_bytes` 2,000,000 / 512,000 | literals | a setting |
+| `max_keepalive_connections=0` | literal | a setting, or documented as fixed with its reason |
+| `crawl_honour_delay` · `crawl_obey_disallow` · `crawl_user_agent` | the provider ignores all three | the provider reads them |
+
+**Four are already surfaced on both sides** — `crawl_min_interval_s`, `crawl_honour_delay`,
+`crawl_timeout_s`, `crawl_user_agent` — and `crawl_parallel_sources` in the extension only.
+So the work is smaller than the rule sounds: **the shape exists, and the second owner is
+outside it.**
+
+**What this does NOT settle:** whether `pacegovernor.py` is ever wired. It is written in full
+— `Strain`, `HostPace`, `pace_for`, `concurrency`, `owed_wait_s`, `record` — with **zero
+callers in production**, so `R-21`'s adaptive half is still dead code and still owed. Binding
+the knobs does not build the adaptive governor; it makes the fixed values honest first.
+
+**And one thing a setting must not become:** a knob that lets a user turn politeness off
+silently. `capture.py:88` already records the shape — *"absent reads as HONOUR — silence must
+mean the polite thing"* — and every new key follows it. `SR-8` and `R-21` are not weakened by
+being configurable; they are weakened by a default that is not the polite one.
+
+---
+
+### R-67 · `HttpFetcher` gains the SSRF protections the newer provider already has
+
+**2026-08-27 · security · he took the recommendation**
+
+**Measured, and it is the surprise that reframed the ownership question:** `HttpFetcher` —
+the old owner, driving the price connectors and muqawil — has **zero** references to
+`ipaddress`, `is_private` or a peer check. The enrichment provider has all of them, and its
+live run refused **64** off-domain redirects and **10** HTTPS downgrades in 98 minutes.
+
+**So unifying downward would have LOST protection**, which is why this is a separate ruling
+rather than a consequence of the ownership one: the old owner is upgraded to the new one's
+level whatever is decided about who owns the request.
+
+**What ports across:** refuse a private or loopback peer, refuse a redirect that leaves the
+target's own domain, refuse an HTTPS→HTTP downgrade, cap the response body.
+
+**Why it is worth doing even though the price sources are known.** They are listed in
+`sources.yaml` and low risk. **The risk is not the listed host — it is a link on a page the
+crawl already fetched**, which is exactly how the enrichment provider found 64 of them.
+`HttpFetcher` follows redirects for hosts it was pointed at by stored HTML, and nothing
+checks where they land.

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -2622,3 +2622,142 @@ And a document that shipping code or a test reads is not prose: `docs/reviews/mb
 is 1,709 lines and stays, because `contract/addin-contract.json`, four `extension/*-rules.js`
 files and `tests/test_the_addin_contract_cannot_drift.py` read it. **The test is whether
 something reads it, not how long it is.**
+
+---
+
+### R-61 · A new engine endpoint is a MINOR version, not a patch
+
+**2026-08-27 · release · he chose 0.4.0 over the 0.3.2 I recommended**
+
+`#274` adds `GET /api/dry/{source_key}` — 95 routes to 96 — and `R-35` makes that a contract
+change, so CI forced the version. It was built as **0.3.1 → 0.3.2**, reasoning that the
+addition is additive, `MINIMUM_EXTENSION_VERSION` stays `0.2.2`, and the panel does not render
+the route yet, so nothing a user can reach moved.
+
+**HIS CHOICE: 0.4.0.** A new endpoint is a new capability and the number says so.
+
+**What the argument I lost was, kept because it is the one to answer next time:** a MINOR
+announces a capability nobody can reach, and `OP-32` is what an announcement without a
+reachable feature costs. His answer settles that the version describes **what the engine can
+do**, not what the panel currently shows — which is consistent with `R-48`: the engine
+executes and reports, and the panel is a separate release.
+
+---
+
+### R-62 · One source registry: `site_profile` merges into `source_site` — and `Q-24` is answered by that migration
+
+**2026-08-27 · data model · he chose the merge over teaching `POST /api/jobs` two registries, which is what I recommended · answers [REQ-25](REQUESTS.md#req-25--one-source-registry-with-a-category-visible-to-every-user) and `Q-24`**
+
+**The defect it closes:** `POST /api/jobs` validates a key against `sources.yaml` — 12 price
+sources — and muqawil lives in `site_profile`, so the crawl button answers 404 and the panel
+hides it. **Every read route already resolves both**: `/api/table`, `/api/fields`, and now
+`/api/dry/{source_key}`.
+
+**HIS CHOICE: one registry.** I recommended teaching `POST /api/jobs` the other two, riding
+on `R-52`'s `dataset_crawl`; he took the migration instead.
+
+**And measuring it for this entry showed my cost estimate was too high, which is worth
+recording because it changes the schedule:**
+
+| | |
+|---|---|
+| rows to move | **2** — `site_profile` holds two, `source_site` twelve |
+| tables pointing at `site_profile` | **2** — `dataset_definition.site_profile_id`, `dataset_relationship.site_profile_id` |
+| rows to repoint | **3** in `dataset_definition`, plus `dataset_relationship` |
+| columns to carry across | `crawl_scope`, `crawl_slice` (migration `0003`), `price_source_key`, `lifecycle` |
+| **`price_observation`** | **untouched — 94,664 rows and it does not reference `source_site`** |
+
+I had said it *"touches the working price path"*. It does not: `crawl_run`,
+`feed_assignment` and `source_product` reference `source_site` and none of them gains or
+loses a row by adding two.
+
+**`Q-24` is answered inside it: id 1 (`muqawil`) closes, id 2 (`muqawil_org`) survives.** The
+data is on id 2 — 34,675 active rows against zero — `scrapex contractors` names it, and
+`#274`'s dry route resolves it. Closed with `valid_to`, never deleted.
+
+**One fact the merge must carry, found while measuring:** both rows read
+`lifecycle = 'draft'`. **Neither registry row is `active`**, so whatever the merge writes must
+decide that too rather than copying `draft` into the new table and calling it done.
+
+---
+
+### R-63 · A dataset's overview shows the tiles its kind has
+
+**2026-08-27 · surface · answers `Q-26`, and he took the recommendation**
+
+`/source/contractors` prints `Products 4 · Variants 0 · Data rows 4 · Matched 0` — measured on
+a real render. **Three of the four are price-path concepts a company has none of, and the
+fourth repeats the first.**
+
+**HIS CHOICE: the tile SET follows the kind.** A dataset shows its row count and how much has
+been fetched; a price source keeps all four. Half a day.
+
+**Why not the one-line rename, which was offered:** `Products` → `Rows` reads as finished and
+leaves two wrong tiles standing. **And `0` is the specific harm** — it reads as a measured
+zero rather than *"not a thing this source has"*, which is the distinction
+`last_successful_run` already documents for a crawl that never ran.
+
+`CLAUDE.md` names two more categories coming (`jobs`, `tenders`), so a set that follows the
+kind is not a premature abstraction.
+
+---
+
+### R-64 · A migration reaches his warehouse only after it is on `main`, and no tag is cut while his warehouse is ahead
+
+**2026-08-27 · process · answers `Q-15`, open since it was asked · both guards approved**
+
+**It happened twice before he ruled.** `0007`/`0008` on 2026-08-21 (`OP-33`) and `0011`/`0012`
+today, both applied to his live warehouse from an unmerged branch. **Proved by running, not
+by reading:**
+
+```
+$ python -m scrapex.cli database-status
+"ok": false,
+"status": "Needs a newer ScrapeX",
+"action": "This database was written by a later version (schema v12; this build reads v10)."
+```
+
+**HIS RULING: no.** A migration reaches his warehouse only after it is on `main`. A session
+testing one uses a copy.
+
+**And a backup is not the protection**, which is why the weaker option was refused: the
+`pre-ledger-repair` and `pre-reapprove` backups exist on disk from both incidents. **A backup
+protects the data; it does nothing about the warehouse getting ahead of the engine.**
+
+**HE APPROVED BOTH GUARDS**, because `OP-33` was closed by a merge and not by a guard, and
+that is exactly why the class returned:
+
+1. **In CI** — `release-engine.yml` asks GitHub for branches whose migration ceiling exceeds
+   `main`'s and **refuses, naming them**. It is the only place that can see across branches,
+   and the workflow already makes network calls. Mutation: a fake higher branch must turn it red.
+2. **At runtime** — refuse to cut a tag while the local warehouse is ahead of the code. It
+   catches the same fault late, on his machine, where CI cannot see.
+
+**And the immediate consequence he ruled on:** `#274` merges, **no tag is cut** until
+`0011`/`0012` are on `main`, and `feat/organization-enrichment` — 7,832 lines in 44 files,
+no pull request ever opened, and it edits both the citation guard and the register-collision
+guard — **is read and reported before anything of it merges.** Registered as `OP-84`.
+
+---
+
+### R-65 · Every open question is put to him with what he needs to decide, and the recommendation goes first
+
+**2026-08-27 · process · his instruction**
+
+> «انا اريد الرد على كل الاسئلة ولا اريد تعليق اسئلة مرة اخرى دائما اعرض عليا السؤال موضح
+> بالتفاصيل اللازمة لاتخاذ القرار وضع الاختيار الموصى من وجهة نظرك اول اختيار»
+
+**Three obligations, and the third is the one that was being failed:**
+
+1. **No question is left hanging.** A question filed and not put to him is not asked. `REQ-04`
+   sat ruled and unbuilt for sixteen days; `Q-15` was asked and unanswered while the thing it
+   asks about happened **twice**.
+2. **The question carries what the decision needs** — the measured numbers, the cost of each
+   option, and what each one forecloses. Not a summary that makes him ask for the numbers.
+3. **The recommendation is first, and it is mine, stated as mine.** He overruled two of four
+   on the day he gave this instruction, which is the point: a recommendation he can reject is
+   worth more than a neutral list, and it must be labelled so rejecting it is one word.
+
+**This does not soften `R-02`:** an un-computable mapping is still his call, and he may refuse
+to rule until studies are measured. What changes is that the asking is not optional and not
+deferred.


### PR DESCRIPTION
Ten decisions he made on 2026-08-27, recorded the session he made them (`C3`), plus the
release blocker that surfaced while measuring one of them.

## The blocker, proved by running rather than by reading

    $ python -m scrapex.cli database-status
    "ok": false,
    "status": "Needs a newer ScrapeX",
    "action": "This database was written by a later version (schema v12; this build reads v10)."

His warehouse is at `user_version` **12**; `main`'s migrations stop at **`0010`**. `0011` and
`0012` live on `feat/organization-enrichment` — pushed, **no PR ever opened** — and had already
been applied to his live warehouse. **This is `OP-33` five days later**, and it returned
because `OP-33` was closed by a merge rather than by a guard.

**And measuring it found a live run nobody had told him about:** job
`job_f0f269d7336a`, `organization_enrichment`, **4,046 of 17,304**, **12,138 provider
observations and 3,609 outbound requests** to company websites, 76,000+ rows across 12 new
tables, with ~15 hours and ~33,000 requests still to go. He ruled it stops; cancelled cleanly
through the engine's own `POST /api/jobs/{ref}/control`, verified frozen by two identical
reads. Nothing gathered is lost — the observations are stored and `item_status='pending'` is a
resume ledger.

## The ten

| | his choice | mine |
|---|---|---|
| `R-61` engine version for a new endpoint | **0.4.0**, MINOR | 0.3.2 — **overruled** |
| `R-62` `REQ-25`, which registry owns a generic crawl | **merge `site_profile` into `source_site`** | teach `POST /api/jobs` both — **overruled** |
| `R-62` second half, `Q-24` | id 2 `muqawil_org` canonical, id 1 closes | same |
| `R-63` `Q-26`, a dataset's overview | the tile set follows the kind | same |
| `R-64` `Q-15`, unmerged migrations | **no** — and both guards approved | same |
| `R-65` how questions are put to him | his instruction | — |
| `R-66` who owns an outbound request | **refused all three options** — bind every knob to a setting | — |
| `R-67` SSRF | port the provider's checks into `HttpFetcher` | same |

`OP-84` the recurrence · `OP-85` `Coverage.fraction` returns 1.0 on an empty ledger ·
`OP-86` `crawl_obey_disallow` is a robots setting with no surface on either side.

## Two corrections of mine, because they change what gets scheduled

**`R-62` was cheaper than I priced it.** I said the registry merge *"touches the working price
path"*. Measured: **2 rows to move**, 2 tables to repoint, and `price_observation`'s 94,664
rows are untouched because they do not reference `source_site`.

**And the ownership question I asked was the wrong one.** `HttpFetcher` — the old owner
driving prices and muqawil — has **zero** SSRF protection, and the newer provider has all of
it. Unifying downward would have lost protection, which is why `R-67` upgrades the old owner
regardless of who ends up owning the request.

## Verification

`test_the_documents_cite_what_they_claim.py`, `test_the_request_board_matches_its_entries.py`
and `test_the_registers_cannot_collide.py` green (82 tests). **The board guard refused three
of my drafts in a row** — a row missing its fourth cell, a board that contradicted its entry,
and a shouted `RULED` with a status line whose last token contradicted the declared pipeline
(`Captured → Ruled → Planned → In flight → Done`, so a request both ruled and planned sits at
`Planned`). All three were real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
