### PR TITLE
Step 1 is applied to his warehouse, and the engine was reading an unmerged branch

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3033,6 +3033,56 @@ system honest.** He ruled it is read and reported before anything of it merges.
 
 ---
 
+### OP-89 · `STATE.md`'s "Open pull requests" is 535 lines in which nothing is open
+
+**Measured 2026-08-27.** The section runs from the heading to `## Track 1`, and **every pull
+request in it has merged** — #274, #244 and the rest. The heading is present tense and the
+document is the one every session is sent to second, after `CLAUDE.md`.
+
+It is not deletable as it stands: the entries carry measurements other documents rely on, and
+`tests/test_the_documents_cite_what_they_claim.py` pins citations inside them. Folding it means
+moving each measurement to the track it belongs to and leaving a one-line merged row behind —
+the same operation that took the `.md` corpus from 42,592 lines to 32,702 earlier the same day.
+
+**A dated banner was added instead**, which makes the section honest without moving anything.
+That is a stopgap and this entry says so.
+
+### OP-88 · His engine was serving from an unmerged branch's worktree, and the restart button cannot move it
+
+**Measured 2026-08-27, immediately after `#279` merged**, while checking whether `0013` had
+reached his warehouse.
+
+His engine on port 8000 was `pythonw -m scrapex.cli ui` with its **cwd in
+`C:\tmp\ScrapeX-organization-enrichment`** — the `feat/organization-enrichment` worktree,
+`VERSION 0.3.4`, migration ceiling `0012`. `-m` puts cwd ahead of site-packages, so the
+branch's package won even though the editable install resolves to the main checkout.
+
+**The proof was a route, not a path:** `/api/dry/contractors` from the live engine returned
+**zero** matches for `reapprove_schema`, the pass `scrapex/passes.py` declares.
+
+**This is how the warehouse reached `user_version 12` while `0011`/`0012` were on no merged
+branch** — the sequence [R-64](RULINGS.md#r-64--a-migration-reaches-his-warehouse-only-after-it-is-on-main)
+now forbids, done before `R-64` existed.
+
+**`POST /api/engine/restart` cannot repair it, and this was tried.** `relaunch.repo_root()` is
+`Path(__file__).resolve().parent.parent` **of the running process**, so the helper relaunches
+whichever checkout the old engine was born in. It answered `ok: true` with a fresh pid and
+came back on `0.3.4` — the route's own docstring names this fault («a database written by a
+NEWER build than the process reading it») and cannot cure the case where the *process* is the
+old build from another directory.
+
+**The Startup entry is correct** — `ScrapeX Engine.vbs` runs from
+`C:\Users\User01\source\repos\ScrapeX`. So a logon fixes this and the button does not.
+
+**Fixed by hand here**, with `0 running` and `0 queued` jobs confirmed first: stop the
+process, then `wscript "ScrapeX Engine.vbs"`. The engine came up on `0.4.2`, found the
+warehouse behind, backed it up to
+`scrapex-engine.pre-upgrade-20260827T125628Z.backup.db` and applied `[13]`.
+
+**Open:** should the restart route refuse when its own package is not the installed one, or
+relaunch from the console script instead of from `__file__`? That is a design question, and it
+is the only reason this entry is open rather than done.
+
 ### OP-87 · `feat/organization-enrichment` reviewed before merge — four blockers, and the architecture is sound
 
 **Reviewed 2026-08-27 on his ruling** («أقرأُه وأُبلِغُك قبلَ أىّ دمج»). 7,832 lines, 44 files,
@@ -3892,6 +3942,28 @@ And the readiness level is **neither a column nor discarded**: fixed columns in 
 table, everything else in the **row's own card**, because contractors will have several
 sources and a column is a promise every source must keep. The question is kept below,
 unedited, because the answer is only legible beside what was asked (**C4**).
+
+### Q-27 · `/api/health` says the databases are `ok` while it also lists two migrations pending
+
+**Asked 2026-08-27 · measured on his live engine, both before and after the `0.4.2` restart**
+
+The same response carries both:
+
+```
+"databases": {"ok": true, ...}
+"schema_lag": {"pending": ["0002_contract_meta.sql", ...],
+               "message": "2 migration(s) on disk are not applied to this database"}
+```
+
+`ok` comes from `EngineDatabase.health`, which compares `PRAGMA user_version` against the
+`db/engine/migrations` ceiling — and that agrees now (both 13). `schema_lag` is reading a
+**second stream**, the one whose names are `0002_contract_meta.sql`, `0010_view_region.sql`,
+`0013_marketlens_database_identity.sql`. The two streams share numbers, which is also what
+made a `LIKE '0013%'` check report a migration as applied when it was not (`LESSONS` §18).
+
+> *Is `schema_lag` still meaningful, or is it reading a stream this warehouse retired? The
+> panel shows one of these two and they disagree — and a warning that is always on is a
+> warning nobody reads.*
 
 ### Q-26 · For a dataset, does the overview keep four tiles or show two?
 

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -2736,3 +2736,46 @@ production code** — a test edited into passing would have survived those.
 hardcoded 2026 timestamp pass every value to `row_state()` explicitly, so no `now` is
 involved, and **no future-dated literal exists anywhere in `tests/`** that would arm the
 same bomb for a later date. Every such literal is a date on which the suite changes its mind.
+
+## 18 · Three checks of my own that reported the wrong thing, on live data
+
+All three passed. All three were measuring something other than what their label said, and
+two of them were about the warehouse the owner actually uses.
+
+### 1 · Two migration streams share numbers, so `LIKE '0013%'` is a false positive
+
+Checking whether `0013_two_versions_may_share_a_shape_across_time.sql` had reached his
+warehouse, `SELECT 1 FROM database_migration WHERE migration_name LIKE '0013%'` returned a
+row. It was **`0013_marketlens_database_identity.sql`** — a different stream, with
+`0010_view_region.sql`, `0011_retention.sql` and `0012_pins_must_match_an_observation.sql`
+sitting beside their engine namesakes in the same ledger.
+
+The contradiction is what saved it: `user_version` said 12 while the prefix check said
+applied. **Compare a migration by its full filename, never by its number** — and when two
+readings disagree, neither is the answer until one is explained.
+
+### 2 · A count that ignores `generic_record.status` measures a population nobody asked about
+
+Verifying step 1, a query counted rows joined to a retired `dataset_schema_version` and
+printed *"live rows bound to a RETIRED version: 14 — must be 0"*. All fourteen were
+`status='retired'` — `OP-64`'s impostor pages, which the design deliberately leaves on `v3`.
+The number that matters adds `AND g.status = 'active'`, and it was 0.
+
+**A retired row and a live row are not distinguished by which version they point at.** Any
+count over `generic_record` that omits `status` is counting history as if it were current.
+
+### 3 · A pipe swallowed a real exit code again, in the same session that wrote the rule down
+
+`scrapex contractors … | tail -30; echo "DRY_EXIT=$?"` printed `DRY_EXIT=0` for a command that
+had not run at all — `scrapex` was not on that shell's `PATH`. `$?` was `tail`'s.
+
+This is `§8`'s false-green wearing a third face, and it appeared **after** the guards for the
+first two were merged. `status=$?` on the line immediately after the command, before anything
+else runs, is the only form that survives.
+
+### And the one that was not mine: the restart button cannot move the engine to newer code
+
+`POST /api/engine/restart` relaunches from `Path(__file__).parent.parent` **of the running
+process**, so it perpetuates whichever checkout the engine was born in. His engine had been
+serving from an unmerged worktree for hours. Full measurement in `OP-88`; the reason it
+belongs here too is that the route answers `ok: true` with a new pid, which reads as success.

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -2891,3 +2891,33 @@ tables have **no reader on `main` at all**, so no capability became reachable. *
 `0.5.0` exactly where he put it** — on `feat/organization-enrichment` — rather than renumbering
 his own ruling as a side effect of a fix. He was offered `0.5.0` here with `0.6.0` for the
 branch and kept `0.4.1`.
+
+### R-70 · `0013` reaches his warehouse through the engine's own upgrade path, and step 1 is applied after he reads the dry run
+
+**2026-08-27 · two decisions recorded together because the second waited on the first**
+
+**How the migration arrives: move the main checkout to `main`, then restart the engine.** He
+was shown that his warehouse sat at `user_version 12` while `main` was at `13`, and was
+offered three routes. He took the one that uses **his own designed path** — `scrapex ui` finds
+a warehouse that is only *behind*, copies it first, then migrates
+([cli.py:779](../scrapex/cli.py:779), his decision of 2026-08-05). It ran exactly as written:
+
+```
+backed up the engine database to scrapex-engine.pre-upgrade-20260827T125628Z.backup.db
+  before upgrading
+upgraded the engine database: applied [13]
+```
+
+He was offered, and refused, applying `0013` from a worktree by hand — because that leaves the
+warehouse ahead of the checkout the engine reads, which is the same fault one version wider.
+
+**What the offer got wrong, recorded per `C5`.** It said the main checkout was why the engine
+could not restart. The engine was not reading the main checkout at all — it was serving from
+an unmerged worktree (`OP-88`). Moving the checkout was still required for the next launch to
+be correct, but the reason given for it was not the reason.
+
+**Step 1: dry first, then `--repair`.** He read the dry run against his own warehouse — 12
+`x_*` fields dropped, 17,371 records moving, 0 revisions — and then said run it. Applied and
+verified on a second read-only connection: `v4` approved with 27 fields and 17,371 `active`
+rows, **zero active rows on a retired version**, `OP-64`'s 14 impostors still on `v3` and still
+`status='retired'`, 74,574 revisions unchanged, `foreign_key_check` clean.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -97,6 +97,26 @@ and `OP-61` (continuation citations are invisible to the citation guard).
 He works from two machines and asked to continue from the other one, which has neither
 this session's context nor this warehouse. Everything below is the whole handover.
 
+> ### 2026-08-27, end of day — the newest three facts, because everything under this
+> ### heading was written five days earlier
+>
+> **Step 1 of the muqawil plan is applied to his live warehouse.** `#279` merged at
+> `11773ab`; `0013` reached the warehouse through the engine's own backup-then-migrate path
+> and `--reapprove-schema --repair` moved the rows. Verified on a second read-only
+> connection: `v4` approved with **27 fields and 17,371 `active` rows**, **zero active rows
+> on a retired version**, `OP-64`'s 14 impostors still `status='retired'` on `v3`, 74,574
+> revisions unchanged, `foreign_key_check` clean. Through the engine,
+> `/api/table/contractor_profiles` serves **33 columns and zero `x_*` keys**.
+>
+> **His engine had been serving from an unmerged branch's worktree** —
+> `C:\tmp\ScrapeX-organization-enrichment`, `0.3.4`, migration ceiling `0012`. That is how
+> the warehouse reached `user_version 12` before `0011`/`0012` were on any merged branch, and
+> **`POST /api/engine/restart` cannot repair it** because it relaunches from the running
+> process's own `__file__`. Measured in [OP-88](BACKLOG.md). It now runs `0.4.2` from the main
+> checkout, started through `ScrapeX Engine.vbs`.
+>
+> **Next is step 2**, the State column — `R-54`, and `R-69` sets the order 1 → 2 → 5 → 3.
+
 ### The code and the decisions are in the repository. The DATA is not.
 
 **Merged and done:** the six muqawil engineering items (#245), four rulings of his
@@ -112,7 +132,7 @@ executed (`R-38`…`R-41`), and the engine release gate (#244).
 | `classification_node` | **243** nodes, levels `{1: 12, 2: 39, 3: 192}` |
 | `generic_record_node` | **391,761** memberships — `R-38` proved on real data |
 | datasets | `contractors` and `contractor_profiles` |
-| schema | **v9** (`0009` = the link table) |
+| schema | **v13**, 2026-08-27 — `0013` lifted `UNIQUE (dataset_definition_id, schema_hash)` so two versions may share a shape across time ([R-70](RULINGS.md#r-70--0013-reaches-his-warehouse-through-the-engines-own-upgrade-path-and-step-1-is-applied-after-he-reads-the-dry-run)). It read **v9** when this table was written |
 
 ### And the crawl is finished — asked and answered 2026-08-24
 
@@ -309,6 +329,19 @@ tracks *his requests* through Captured → Ruled → Planned → In flight → D
 ---
 
 ## Open pull requests
+
+> **Measured 2026-08-27: exactly one is open, and it should not be merged.**
+> [#278](https://github.com/muhammadbayoumi/ScrapeX/pull/278) is green and `CLEAN`, and its
+> whole substance — `R-68`, `R-69`, the plan's status table, `REQUESTS.md` — **is already on
+> `main`** through later pull requests. The only difference left between the two is eight
+> citation line numbers into `scrapex/extract/service.py`, and the branch holds the
+> **stale** ones — line 895 where `main` says 915, and seven more twenty lines apart.
+> Merging it would regress them. (Written without the `file:line` form on purpose: the
+> citation guard reads that shape as a real citation, and it caught this paragraph.)
+>
+> **Every entry below this banner has merged.** They are kept for the measurements in them,
+> not because anything is in flight; the section is 535 lines of history under a
+> present-tense heading, which is `OP-89`.
 
 ### A dry route for every source type — 2026-08-27 · [#274](https://github.com/muhammadbayoumi/ScrapeX/pull/274)
 

--- a/docs/plans/2026-08-26-what-remains-of-muqawil.md
+++ b/docs/plans/2026-08-26-what-remains-of-muqawil.md
@@ -17,7 +17,7 @@ order is argued rather than preferred.
 | # | step | state | gate |
 |---|---|---|---|
 | 0 | The crawl, the workers, the storage | **DONE** | 34,834 of 34,834; 9.75 h at 1.007 s/page = 100.7% of the politeness floor; 4.40 GB in 80,676,567 bytes |
-| 1 | **The poisoned profile schema** | ✅ **RULED 2026-08-26 — [R-53](../RULINGS.md#r-53--the-profile-schema-is-re-approved-onto-a-clean-version-not-reopened)**: re-approve all 17,371 rows onto a clean 27-field v4, not reopen v2. **Buildable now** | no live row is bound to a `retired` version, and a new site field is RECORDED rather than refusing the page |
+| 1 | **The poisoned profile schema** | ✅ **RULED 2026-08-26 — [R-53](../RULINGS.md#r-53--the-profile-schema-is-re-approved-onto-a-clean-version-not-reopened)**: re-approve all 17,371 rows onto a clean 27-field v4, not reopen v2. **DONE 2026-08-27** — [#279](https://github.com/muhammadbayoumi/ScrapeX/pull/279), and applied to his warehouse the same day | no live row is bound to a `retired` version, and a new site field is RECORDED rather than refusing the page |
 | 2 | **`R-52` re-ruled, then the State column fixed** | ✅ **RULED 2026-08-26 — [R-54](../RULINGS.md#r-54--the-state-column-is-fixed-at-its-root-first-a-confirmation-moves-last_seen_at)**: the root first — a confirming pass moves `last_seen_at`, then state is computed against the RUN. `R-52` amended, not erased. **Buildable now** | `absent`/`new`/`updated` computed per RUN, and a confirming pass moves `last_seen_at` on the record |
 | 3 | The 263 stranded listing rows | ✅ **RULED 2026-08-26 — [R-56](../RULINGS.md#r-56--the-263-stranded-listing-rows-are-fixed-by-a-fresh-listing-crawl)**: a fresh listing crawl, 58 min at concurrency 4. **NOT** a re-approve — `ExtractionConflict` refuses that and writes nothing | all 263 on schema v2 with `profile_url` and the City/Region split |
 | 4 | The two-directional gap: 148 + 81 | ✅ **RULED 2026-08-27 — [R-68](../RULINGS.md#r-68--the-two-crawls-reconcile-themselves-at-the-end-of-every-crawl-in-both-directions)**: automatic at the end of every crawl, **both directions**. **Buildable now** | bounded, and reported inside the crawl's own report; 148 need zero network |
@@ -32,7 +32,23 @@ order is argued rather than preferred.
 
 ## Tier 1 — the only step with a deadline we do not set
 
-### Step 1 · The poisoned profile schema
+### Step 1 · The poisoned profile schema — DONE 2026-08-27
+
+> **DONE, and applied to his live warehouse on his ruling.** `#279` merged at `11773ab`;
+> migration `0013` reached the warehouse through the engine's own backup-then-migrate path,
+> and `--reapprove-schema --repair` moved the rows. **Measured afterwards on a second,
+> read-only connection** — the only thing that tells a commit from a convincing return value:
+>
+> ```
+> v2 retired  27 fields       0 rows      v4 APPROVED  27 fields  17,371 active rows
+> v3 retired  39 fields      14 rows, every one status='retired' -- OP-64's impostors
+> ACTIVE rows bound to a retired version: 0
+> revisions 74,574 unchanged      foreign_key_check clean      quick_check ok
+> ```
+>
+> And through the engine: `/api/table/contractor_profiles` serves **33 columns and zero
+> `x_*` keys**, `total 17,385`, `truncated false`.
+
 
 **Why it is first and nothing else is.** Every other defect is wrong today and stays
 equally wrong. This one **refuses the next page that carries a field the site has not


### PR DESCRIPTION
Documentation only, and it records the two things this session did to his live warehouse plus
the finding that turned up on the way.

## `R-70` — both decisions of 2026-08-27, and both carried out

**`0013` reaches the warehouse through the engine's own path.** He was offered three routes and
took the one already built for it: `scrapex ui` finds a warehouse that is only *behind*, copies
it first, then migrates — his own decision of 2026-08-05.

```
backed up the engine database to scrapex-engine.pre-upgrade-20260827T125628Z.backup.db
  before upgrading
upgraded the engine database: applied [13]
```

**Step 1 runs after he reads the dry run.** He read it against his own data — 12 `x_*` fields
dropped, 17,371 records moving, 0 revisions — then said run it.

```
v2 retired  27 fields       0 rows      v4 APPROVED  27 fields  17,371 active rows
v3 retired  39 fields      14 rows, every one status='retired' -- OP-64's impostors
ACTIVE rows bound to a retired version: 0
revisions 74,574 unchanged      foreign_key_check clean      quick_check ok
```

**Measured on a second read-only connection**, because the defect this pass shipped with once
was a printed *"APPLIED: 17,371 moved"* that committed nothing. Through the engine,
`/api/table/contractor_profiles` serves **33 columns and zero `x_*` keys**, `total 17,385`.

And a `C5` note inside `R-70`: the offer told him the main checkout was why the engine could
not restart. **That was wrong** — the engine was not reading the main checkout at all. Moving
it was still required for the next launch to be correct; the reason given was not the reason.

## `OP-88` — his engine was serving an unmerged branch, and the restart button cannot move it

Port 8000 was running with its cwd in `C:\tmp\ScrapeX-organization-enrichment`:
`feat/organization-enrichment`, `VERSION 0.3.4`, migration ceiling `0012`. `-m` puts cwd ahead
of site-packages, so the branch's package won even though the editable install resolves to the
main checkout.

**The proof was a route, not a path:** `/api/dry/contractors` from the live engine returned
**zero** matches for `reapprove_schema`.

**This is how the warehouse reached `user_version 12` while `0011`/`0012` were on no merged
branch** — the sequence `R-64` now forbids, done before `R-64` existed.

**`POST /api/engine/restart` cannot repair it, and it was tried.** `relaunch.repo_root()` is
`Path(__file__).resolve().parent.parent` **of the running process**, so the helper relaunches
whichever checkout the engine was born in — it answered `ok: true` with a fresh pid and came
back on `0.3.4`. The route's docstring names this exact fault and cannot cure the case where
the *process* is the old build from another directory. The Startup entry was correct all along,
so a logon fixes this and the button does not. Left open because "should it refuse, or
relaunch from the console script?" is a design question.

## `LESSONS` §18 — three checks of mine that reported the wrong thing, on live data

- **`LIKE '0013%'` was a false positive.** Two migration streams share numbers and the ledger
  holds `0013_marketlens_database_identity.sql` beside `0010_view_region.sql`,
  `0011_retention.sql` and `0012_pins_must_match_an_observation.sql`. The contradiction is
  what saved it — `user_version` said 12 while the prefix check said applied.
- **A count that ignored `generic_record.status`** printed *"live rows bound to a RETIRED
  version: 14 — must be 0"*. All fourteen were `status='retired'`, `OP-64`'s impostors, which
  the design deliberately leaves on `v3`. Add `status = 'active'` and it is 0.
- **A pipe swallowed a real exit code again**, in the same session that wrote the rule down:
  `DRY_EXIT=0` for a command that never ran, because `scrapex` was not on that shell's `PATH`
  and `$?` was `tail`'s.

## `#278` should be closed, not merged — and `OP-89`

Its whole substance is already on `main`. The only difference left is eight citation line
numbers, and the branch holds the **stale** ones. `OP-89` records the other half of that
banner: `STATE.md`'s "Open pull requests" is 535 lines in which nothing is open, kept only for
the measurements inside it.

## Verification

**112 green across every documentation guard** — citations, the docs gate, the register
collision guard, the request board, both source boards, the ruling-matches-code guard, and the
published-documents guard. The version gate agrees no `VERSION` move is owed.

**The citation guard caught this pull request's own prose.** A paragraph quoting a stale
`file:line` as an *example* was read as a real citation and failed on a blank target line. It
is rephrased, and the text now says why it avoids that shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
