### PR TITLE
R-54, the root half: a confirming pass moves the record's own last_seen_at

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3033,6 +3033,32 @@ system honest.** He ruled it is read and reported before anything of it merges.
 
 ---
 
+### OP-90 · A re-approval silently un-retires the rows `OP-64` disowned
+
+**Found 2026-08-27 while building `R-54`'s root half**, and deliberately NOT fixed there —
+it is outside that ruling and it is his call whether a confirmation may reactivate a row.
+
+`approve_candidate`'s upsert ends
+`last_seen_at=strftime(...), status='active'` — **unconditionally**. So the next
+re-approval of the fourteen profile pages `OP-64` retired writes `status='active'` back over
+them, and the disowning disappears with nothing raised. Those rows are the ones whose
+membership number disagrees with their own listing card: the site answered a dead id with the
+contractors listing at HTTP 200, so their address, city and coordinates came from nowhere.
+
+**What makes it live rather than theoretical:** `OP-64`'s own open half is that *"no command
+targets specific ids today"*, so the honest repair is a re-fetch of those pages — which is
+exactly the operation that would resurrect them.
+
+**The confirming path added for `R-54` does not do this**, and its docstring says why: a
+withdrawal somebody decided outranks an observation, which is `sightings.row_state`'s first
+precedence rule. A mutation that adds `status='active'` to it is killed by
+`test_a_confirmation_does_not_resurrect_a_retired_row`. So this entry is about the ONE place
+that still does it.
+
+**The question underneath is his:** should the upsert leave `status` alone when the stored
+row is `retired`, or should a re-fetch that produces the same wrong number be refused
+earlier — at `OP-64`'s layer 2, where the mismatch is already detected?
+
 ### OP-89 · `STATE.md`'s "Open pull requests" is 535 lines in which nothing is open
 
 **Measured 2026-08-27.** The section runs from the heading to `## Track 1`, and **every pull

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -2779,3 +2779,48 @@ else runs, is the only form that survives.
 process**, so it perpetuates whichever checkout the engine was born in. His engine had been
 serving from an unmerged worktree for hours. Full measurement in `OP-88`; the reason it
 belongs here too is that the route answers `ok: true` with a new pid, which reads as success.
+
+## 19 · Three ways a mutation run lied about itself, all in one afternoon
+
+A guard is untrusted until the defect it names makes it red. That rule is only as good as
+the harness, and this harness reported three different falsehoods before it reported a
+number worth quoting.
+
+### 1 · CRLF: every single-line anchor matched and every multi-line one silently did not
+
+The harness read the file, searched for an anchor, replaced it, ran the suite. Nine
+mutations; three reported killed and six reported *"anchor appears 0 times"*. The three
+that worked were the three whose `old` text was a **single line**.
+
+`.gitattributes` sets `* text=auto`, so the repository stores LF and Windows checks out
+CRLF — trap 2 of `CLAUDE.md`, which is written there about **hashing** and bit a mutation
+harness instead. Normalise `\r\n` → `\n` after `read_bytes()` and restore from the
+captured bytes, never from the normalised text.
+
+**What made this recoverable rather than a false 3/3:** the harness distinguishes *"the
+suite stayed green"* from *"the anchor never matched"* and calls only the first a survivor.
+A harness that just ran the suite and checked for red would have reported three kills out
+of three attempted and been believed.
+
+### 2 · A syntactically invalid mutation goes red for the wrong reason
+
+One mutation deleted `return int(` from the head of a multi-line expression and left the
+closing `).rowcount)` behind. The module stopped importing, **every** test in the file
+errored, and the run was red — so a harness checking only the exit code would have counted
+it as a kill. The named test was not among the failures, which is the only reason it was
+caught.
+
+**So a mutation needs two assertions, not one:** the suite must go red, *and* the specific
+test that names the defect must be among the failures.
+
+### 3 · `IN ()` is legal SQLite, so a guard against it cannot fail
+
+`_confirm_seen` was written with `if not record_keys: return 0` and a comment saying an
+empty `IN ()` would be a syntax error. Deleting that guard left every test green, which is
+the signature `_rows_unchanged` already records one screen above — *"a line that read like
+protection and could not fail."*
+
+Measured on SQLite 3.50.4: `UPDATE t SET d = 'new' WHERE k IN ()` is **accepted**, matches
+nothing, and reports `rowcount` 0 — exactly what the guard returned by hand. The guard is
+gone rather than kept behind a corrected comment, and the test now pins the behaviour,
+which holds either way.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -115,7 +115,19 @@ this session's context nor this warehouse. Everything below is the whole handove
 > process's own `__file__`. Measured in [OP-88](BACKLOG.md). It now runs `0.4.2` from the main
 > checkout, started through `ScrapeX Engine.vbs`.
 >
-> **Next is step 2**, the State column — `R-54`, and `R-69` sets the order 1 → 2 → 5 → 3.
+> **Step 2's ROOT HALF is built** — `R-54`, on his order 1 → 2 → 5 → 3 (`R-69`). A
+> confirming pass now moves the record's own `last_seen_at`, which is the field the state
+> comparison rests on; `approve_candidate` returned seventy lines above the only write that
+> moved it. Nine mutations, nine killed, 993 tests green across 45 suites.
+>
+> **And the State column is already wrong on screen, not merely predicted.** Computed with
+> the panel's own `sightings.row_state` on 2026-08-27: `contractors` reads **`absent` on
+> 17,221 of 17,304 rows — 99.5%**, because its sighting ledger is already full (17,417) so
+> the `MAX(last_seen_at)` comparison runs, and only the 48 rows written in the crawl's final
+> second survive it. `contractor_profiles` escapes with `unsighted` only because its ledger
+> is empty. **The second pull request replaces that comparison with the RUN**, and needs no
+> migration: `generic_page_snapshot.crawl_run_ref` carries a value on 55,313 of 57,041
+> snapshots, and he ruled the remaining 1,728 read `unsighted`.
 
 ### The code and the decisions are in the repository. The DATA is not.
 

--- a/docs/plans/2026-08-26-what-remains-of-muqawil.md
+++ b/docs/plans/2026-08-26-what-remains-of-muqawil.md
@@ -18,7 +18,7 @@ order is argued rather than preferred.
 |---|---|---|---|
 | 0 | The crawl, the workers, the storage | **DONE** | 34,834 of 34,834; 9.75 h at 1.007 s/page = 100.7% of the politeness floor; 4.40 GB in 80,676,567 bytes |
 | 1 | **The poisoned profile schema** | ✅ **RULED 2026-08-26 — [R-53](../RULINGS.md#r-53--the-profile-schema-is-re-approved-onto-a-clean-version-not-reopened)**: re-approve all 17,371 rows onto a clean 27-field v4, not reopen v2. **DONE 2026-08-27** — [#279](https://github.com/muhammadbayoumi/ScrapeX/pull/279), and applied to his warehouse the same day | no live row is bound to a `retired` version, and a new site field is RECORDED rather than refusing the page |
-| 2 | **`R-52` re-ruled, then the State column fixed** | ✅ **RULED 2026-08-26 — [R-54](../RULINGS.md#r-54--the-state-column-is-fixed-at-its-root-first-a-confirmation-moves-last_seen_at)**: the root first — a confirming pass moves `last_seen_at`, then state is computed against the RUN. `R-52` amended, not erased. **Buildable now** | `absent`/`new`/`updated` computed per RUN, and a confirming pass moves `last_seen_at` on the record |
+| 2 | **`R-52` re-ruled, then the State column fixed** | ✅ **RULED 2026-08-26 — [R-54](../RULINGS.md#r-54--the-state-column-is-fixed-at-its-root-first-a-confirmation-moves-last_seen_at)**: the root first — a confirming pass moves `last_seen_at`, then state is computed against the RUN. `R-52` amended, not erased. **ROOT HALF DONE 2026-08-27** — a confirming pass now moves `last_seen_at`; the comparison against the RUN is its own pull request on his ruling | `absent`/`new`/`updated` computed per RUN, and a confirming pass moves `last_seen_at` on the record |
 | 3 | The 263 stranded listing rows | ✅ **RULED 2026-08-26 — [R-56](../RULINGS.md#r-56--the-263-stranded-listing-rows-are-fixed-by-a-fresh-listing-crawl)**: a fresh listing crawl, 58 min at concurrency 4. **NOT** a re-approve — `ExtractionConflict` refuses that and writes nothing | all 263 on schema v2 with `profile_url` and the City/Region split |
 | 4 | The two-directional gap: 148 + 81 | ✅ **RULED 2026-08-27 — [R-68](../RULINGS.md#r-68--the-two-crawls-reconcile-themselves-at-the-end-of-every-crawl-in-both-directions)**: automatic at the end of every crawl, **both directions**. **Buildable now** | bounded, and reported inside the crawl's own report; 148 need zero network |
 | 5 | The placeholder pair: map pin + `logo_url` | ✅ **RULED 2026-08-26 — [R-55](../RULINGS.md#r-55--absence-is-more-honest-than-a-placeholder-and-one-ruling-covers-both-fields)**: one ruling for both — store absence. Coverage becomes an honest 24% and 16%. **Buildable now** | one ruling covering both, or two explicit refusals |
@@ -75,7 +75,33 @@ a clean 27-field v4** is the one that also leaves a correct version history, and
 
 ## Tier 2 — values we publish that are false
 
-### Step 2 · Re-rule `R-52` before anything is built on it
+### Step 2 · Re-rule `R-52` before anything is built on it — ROOT HALF DONE 2026-08-27
+
+> **The root is built and the comparison is not, which is the order he set.** A confirming
+> pass now moves the record's own `last_seen_at`
+> (`extract.service._confirm_seen`), so the field the state comparison rests on finally
+> moves. Nine mutations, nine killed; 993 tests green across the 45 suites that touch it.
+>
+> **AND THE DEFECT IS ALREADY VISIBLE, not merely predicted.** Computed on his warehouse
+> on 2026-08-27 with the panel's own `sightings.row_state`:
+>
+> | dataset | rows | what the State column says today |
+> |---|---|---|
+> | `contractors` | 17,304 | **`absent` on 17,221 — 99.5%** · `confirmed` 48 · `unsighted` 35 |
+> | `contractor_profiles` | 17,385 | `unsighted` 17,371 · `retired` 14 |
+>
+> The ruling predicted this for the profiles **if** their ledger were filled. The listing's
+> ledger is ALREADY filled — 17,417 rows — so the comparison runs on it, and only the 48
+> rows written in the crawl's final second survive it. `absent` claims the site stopped
+> publishing a contractor, and `publish.py` carries payload columns into his Sheet.
+>
+> **What is left for the second pull request:** `newest` stops being
+> `MAX(last_seen_at)` and becomes the RUN. That needs no migration —
+> `generic_page_snapshot.crawl_run_ref` already exists and carries a value on **55,313 of
+> 57,041** snapshots, reachable from `generic_record.source_snapshot_id`. He ruled that the
+> **1,728** snapshots without one read `unsighted`, the state that claims nothing about the
+> site.
+
 
 **`R-52` is on `main` as of `19ea359`, and the evidence says its plan will not fix the
 defect it was written for.** That disagreement is recorded under `C5` rather than acted on,

--- a/scrapex/contractors.py
+++ b/scrapex/contractors.py
@@ -1205,6 +1205,10 @@ def approve(conn, directory: Directory, run_ref: str) -> None:
     recovered = 0
     reparsed = 0
     lonely = 0
+    # `R-54`: rows whose date a confirmation moved. Counted separately from `recovered`
+    # because one confirmed PAGE carries many rows, and the number that answers "did the
+    # confirmation reach the records" is the row count, not the page count.
+    confirmed_rows = 0
     mismatched = 0
     #: Profile pages the cross-check could not judge because no listing row
     #: carried a number for them. Reported, never inferred from silence.
@@ -1319,18 +1323,23 @@ def approve(conn, directory: Directory, run_ref: str) -> None:
         conn.commit()
         made += 1
         if result.get("recovered"):
-            # ALREADY APPROVED AND IDENTICAL, so it wrote nothing — and since `R-40`
-            # that is a claim about the ROWS and not just the request. The digest of
-            # what the parser produced is compared against the digest the previous
-            # ingestion stored, so this count now means "nothing had changed" rather
-            # than the old "we did not look".
+            # ALREADY APPROVED AND IDENTICAL — and since `R-40` that is a claim about the
+            # ROWS and not just the request. The digest of what the parser produced is
+            # compared against the digest the previous ingestion stored, so this count
+            # means "nothing had changed" rather than the old "we did not look".
+            #
+            # IT NO LONGER MEANS "WROTE NOTHING". `R-54`: confirming a row moves its
+            # `last_seen_at`, because a pass that refreshed a row's memberships and left
+            # its own date behind is what put 17,259 records behind their memberships.
             recovered += 1
+            confirmed_rows += int(result.get("confirmed") or 0)
         elif result.get("reparsed"):
             # THE CASE DEC-10 EXISTED FOR. Same page, same schema, DIFFERENT values —
             # a parser that was corrected. It used to be indistinguishable from the
             # line above and wrote nothing at all.
             reparsed += 1
-    say(f"approved {made} page(s): {recovered} unchanged and wrote nothing, "
+    say(f"approved {made} page(s): {recovered} unchanged and confirmed "
+        f"({confirmed_rows:,} row date(s) moved, no revision written), "
         f"{reparsed} re-parsed with new values (DEC-10 / R-40); "
         f"{lonely} page(s) missing a locale half")
     if unwitnessed:

--- a/scrapex/extract/service.py
+++ b/scrapex/extract/service.py
@@ -300,6 +300,51 @@ def _rows_unchanged(conn: sqlite3.Connection, dataset_id: int,
                for row, key in zip(rows, record_keys, strict=True))
 
 
+def _confirm_seen(conn: sqlite3.Connection, dataset_id: int,
+                  record_keys: list[str]) -> int:
+    """`R-54`: a confirming pass moves the record's own `last_seen_at`, and NOTHING else.
+
+    THE ROOT, AND HE RULED IT FIRST. `approve_candidate` returns seventy lines above its
+    upsert when every row on the page is unchanged, so the one write that moved
+    `last_seen_at` was never reached — while `taxonomy.py:181` refreshed the row's
+    MEMBERSHIPS on the same pass. Measured on his warehouse: **17,259 records older than
+    their own memberships**, 17,264 profile rows still reading 2026-08-23.
+
+    THREE COLUMNS THIS DELIBERATELY DOES NOT TOUCH, each for its own reason:
+
+      - NO REVISION. `R-20` / `SR-6`: an unchanged value is confirmed, not appended, and
+        `generic_record_revision` is UNIQUE on `(record, snapshot, content_hash)` anyway.
+        A confirmation is a fact about our observation, not about the site's data.
+      - NO `status`. A confirmation must not resurrect a row somebody withdrew.
+        `OP-64` retired 14 impostor rows, and the upsert below sets `status='active'`
+        UNCONDITIONALLY -- which would un-retire them on the next re-approval of those
+        pages. That is recorded as a finding rather than fixed here; what matters is that
+        this path does not become a second place doing it.
+      - NO `source_snapshot_id`. That is the RUN link the other half of `R-54` needs, and
+        moving it here would change which snapshot is cited as a row's source without the
+        state computation that justifies it.
+
+    The `IN (...)` list is the one `_rows_unchanged` just built from the same page, so no
+    parameter-count limit appears here that was not already being respected.
+
+    AN EMPTY PAGE NEEDS NO GUARD, and a mutation is what settled that. `if not
+    record_keys: return 0` stood here first and deleting it left every test green --
+    the same shape `_rows_unchanged` records above, a line that reads like protection
+    and cannot fail. Measured on SQLite 3.50.4: `WHERE k IN ()` is ACCEPTED, matches
+    nothing and reports `rowcount` 0, which is the answer the guard was returning by
+    hand. So the guard is gone rather than kept with a comment defending it.
+
+    Returns the number of rows moved, so the caller can say it out loud instead of
+    printing "wrote nothing" -- which is what it used to print, truthfully.
+    """
+    holes = ",".join("?" * len(record_keys))
+    return int(conn.execute(
+        "UPDATE generic_record "
+        "   SET last_seen_at = strftime('%Y-%m-%dT%H:%M:%SZ','now') "
+        f" WHERE dataset_definition_id = ? AND record_key IN ({holes})",
+        (dataset_id, *record_keys)).rowcount)
+
+
 def _retire_or_refuse(conn: sqlite3.Connection, active_version_id: int,
                       approval: CandidateApproval) -> None:
     """A GROWN schema opens a new version; a SHRUNK one is still refused.
@@ -534,11 +579,19 @@ def approve_candidate(
         # holds exactly this fact per row, and the write path below already reads it.
         if _rows_unchanged(conn, int(recovered["dataset_definition_id"]),
                            rows, record_keys):
+            # `R-54`, AND THIS RETURN IS THE DEFECT. Confirming a page is an OBSERVATION
+            # and it has to be recorded as one: the upsert seventy lines below moves
+            # `last_seen_at` unconditionally and this branch never reaches it, so a
+            # confirmed row kept an older date than the memberships written beside it on
+            # the same pass. `_confirm_seen` says why it moves that column and no other.
+            confirmed = _confirm_seen(
+                conn, int(recovered["dataset_definition_id"]), record_keys)
             result = _dataset_public(conn, int(recovered["dataset_definition_id"]))
             result.update({
                 "schema_version_id": int(recovered["schema_version_id"]),
                 "generic_ingestion_id": int(recovered["generic_ingestion_id"]),
                 "recovered": True,
+                "confirmed": confirmed,
             })
             return result
 

--- a/tests/test_a_confirmation_moves_the_records_own_date.py
+++ b/tests/test_a_confirmation_moves_the_records_own_date.py
@@ -1,0 +1,345 @@
+"""`R-54`, the root half: a confirming pass moves the record's own `last_seen_at`.
+
+WHAT WAS WRONG. `approve_candidate` returns seventy lines above its upsert when every row
+on the page is unchanged (`_rows_unchanged`, the `DEC-10`/`R-40` short-circuit). That
+return is correct about the ROWS — nothing changed, so nothing should be rewritten — and
+wrong about the OBSERVATION: the upsert it skips is the only write that moved
+`last_seen_at`, so a pass that confirmed a row left the row's own date behind.
+
+Meanwhile `taxonomy.py` refreshed the same row's MEMBERSHIPS on that very pass. Measured
+read-only on the owner's warehouse on 2026-08-27:
+
+    profile records whose last_seen_at reads 2026-08-23    17,264
+    records reading 2026-08-24                                121
+    their memberships dated 2026-08-24                    397,526 -- every one
+    records OLDER THAN THEIR OWN MEMBERSHIPS               17,259
+
+WHY THIS IS THE ROOT AND NOT THE SYMPTOM, which is his ruling `R-54`. The visible defect is
+the State column, and the obvious fix is the sighting ledger — but state is compared against
+`MAX(last_seen_at)`, so a fix that starts from the ledger builds on a field that does not
+move. He was offered the ledger-first route with its cost stated and took the root instead.
+
+**The comparison is deliberately NOT changed here.** He ruled the root first and the
+comparison second, in its own pull request, so that a failing mutation names one of the two
+rather than either (`OP-18`).
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scrapex.databases import DatabaseRegistry, EngineDatabase
+from scrapex.extract import service
+from scrapex.extract.models import ApprovalField, CandidateApproval, SnapshotCreate
+from scrapex.extract.muqawil import listing_candidate
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "muqawil"
+LISTING = (FIXTURES / "listing-en.html").read_text(encoding="utf-8")
+URL = "https://muqawil.org/en/contractors?page=1"
+
+#: Any timestamp older than "now" would do. A real one from before the warehouse existed
+#: makes a failure read as "the date did not move" rather than "the date is odd".
+LONG_AGO = "2020-01-01T00:00:00Z"
+
+
+@pytest.fixture()
+def conn(tmp_path: Path):
+    registry = DatabaseRegistry(EngineDatabase(tmp_path / "scrapex-engine.db"),
+                                pointer_file=tmp_path / "databases.json")
+    registry.initialize()
+    connection = registry.engine.connect()
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def _snapshot(conn) -> int:
+    """THROUGH THE PRODUCTION WRITER. `LESSONS` records seventeen tests that passed both
+    before and after a real defect because none of them stored a compressed page."""
+    saved = service.save_snapshot(
+        conn, SnapshotCreate(source_url=URL, html_content=LISTING))
+    return int(saved["page_snapshot_id"])
+
+
+def _approval(candidate) -> CandidateApproval:
+    return CandidateApproval(
+        table_index=0, site_key="muqawil_org",
+        site_display_name="Saudi Contractors Authority",
+        dataset_key="contractors", dataset_name="Contractors",
+        fields=[ApprovalField(field_key=f.field_key, display_name=f.source_name,
+                              data_type="text",
+                              identity=(f.field_key == "contractor_id"))
+                for f in candidate.fields])
+
+
+def _approved_once(conn) -> tuple[int, int]:
+    """The state this whole file is about: one page approved, and approving it again is a
+    confirmation because nothing on it changed. Returns `(snapshot_id, dataset_id)`."""
+    snapshot_id = _snapshot(conn)
+    candidate = listing_candidate(LISTING)
+    result = service.approve_candidate(
+        conn, snapshot_id, _approval(candidate), candidate=candidate)
+    assert not result.get("recovered"), "the FIRST approval is not a confirmation"
+    return snapshot_id, int(result["dataset_definition_id"])
+
+
+def _confirm_again(conn, snapshot_id: int) -> dict:
+    candidate = listing_candidate(LISTING)
+    return service.approve_candidate(
+        conn, snapshot_id, _approval(candidate), candidate=candidate)
+
+
+def _age_every_row(conn, dataset_id: int) -> int:
+    """Push every row's date into the past so a move is visible.
+
+    NECESSARY RATHER THAN CONVENIENT: `last_seen_at` is `strftime(...,'now')` at SECOND
+    resolution, so two approvals inside one second write the same string and a test that
+    merely re-approved would pass whether or not the fix exists. That is the shape of
+    false green this suite is built to avoid.
+    """
+    return int(conn.execute(
+        "UPDATE generic_record SET last_seen_at = ? WHERE dataset_definition_id = ?",
+        (LONG_AGO, dataset_id)).rowcount)
+
+
+def _dates(conn, dataset_id: int) -> list[str]:
+    return [row[0] for row in conn.execute(
+        "SELECT last_seen_at FROM generic_record WHERE dataset_definition_id = ? "
+        "ORDER BY generic_record_id", (dataset_id,))]
+
+
+# --------------------------------------------------------------------- the defect itself
+
+def test_a_confirming_reapproval_moves_the_records_own_date(conn):
+    """THE DEFECT, in one assertion. Before the fix every date stayed at `LONG_AGO`."""
+    snapshot_id, dataset_id = _approved_once(conn)
+    aged = _age_every_row(conn, dataset_id)
+    assert aged > 0, "the fixture stored no rows, so nothing below proves anything"
+
+    result = _confirm_again(conn, snapshot_id)
+
+    assert result.get("recovered") is True, (
+        "the second approval must still take the short-circuit — this file is about what "
+        "that branch writes, not about removing it")
+    assert all(date != LONG_AGO for date in _dates(conn, dataset_id)), (
+        "a confirmed row kept the date it had before the confirmation")
+
+
+def test_the_confirmation_reaches_every_row_on_the_page(conn):
+    """Not just the first. The `IN (...)` list is built from the whole page."""
+    snapshot_id, dataset_id = _approved_once(conn)
+    aged = _age_every_row(conn, dataset_id)
+    _confirm_again(conn, snapshot_id)
+    moved = sum(1 for date in _dates(conn, dataset_id) if date != LONG_AGO)
+    assert moved == aged, f"{moved} of {aged} row(s) moved"
+
+
+def test_the_result_says_how_many_rows_it_confirmed(conn):
+    """A count the caller can print. `contractors.approve` used to say "wrote nothing"."""
+    snapshot_id, dataset_id = _approved_once(conn)
+    aged = _age_every_row(conn, dataset_id)
+    result = _confirm_again(conn, snapshot_id)
+    assert result.get("confirmed") == aged, (
+        f"result says {result.get('confirmed')!r}, {aged} row(s) were on the page")
+
+
+# ----------------------------------------------------- the three columns it must not move
+
+def test_a_confirmation_writes_no_revision(conn):
+    """`R-20` / `SR-6`: an unchanged value is confirmed, not appended.
+
+    The revision table is also UNIQUE on `(record, snapshot, content_hash)`, so a
+    revision per confirmation would not merely be noise — it would raise on the second
+    confirmation of the same page.
+    """
+    snapshot_id, dataset_id = _approved_once(conn)
+    before = conn.execute(
+        "SELECT COUNT(*) FROM generic_record_revision").fetchone()[0]
+    _age_every_row(conn, dataset_id)
+    _confirm_again(conn, snapshot_id)
+    after = conn.execute("SELECT COUNT(*) FROM generic_record_revision").fetchone()[0]
+    assert after == before, f"{after - before} revision(s) written by a confirmation"
+
+
+def test_a_confirmation_does_not_resurrect_a_retired_row(conn):
+    """`OP-64` retired 14 impostor rows on the owner's warehouse by setting `status`.
+
+    The upsert this branch skips sets `status='active'` UNCONDITIONALLY, so the confirming
+    path must not copy that: a withdrawal somebody decided outranks an observation, which
+    is `sightings.row_state`'s first precedence rule.
+    """
+    snapshot_id, dataset_id = _approved_once(conn)
+    victim = conn.execute(
+        "SELECT generic_record_id FROM generic_record "
+        " WHERE dataset_definition_id = ? ORDER BY generic_record_id LIMIT 1",
+        (dataset_id,)).fetchone()[0]
+    conn.execute("UPDATE generic_record SET status = 'retired' "
+                 " WHERE generic_record_id = ?", (victim,))
+    _age_every_row(conn, dataset_id)
+
+    _confirm_again(conn, snapshot_id)
+
+    assert conn.execute("SELECT status FROM generic_record WHERE generic_record_id = ?",
+                        (victim,)).fetchone()[0] == "retired", (
+        "a confirmation un-retired a row that had been withdrawn")
+
+
+def test_a_confirmation_does_not_move_the_source_snapshot(conn):
+    """That column is the RUN link the other half of `R-54` needs, and moving it here
+    would change which snapshot is cited as a row's source before the state computation
+    that justifies it exists."""
+    snapshot_id, dataset_id = _approved_once(conn)
+    before = [row[0] for row in conn.execute(
+        "SELECT source_snapshot_id FROM generic_record "
+        " WHERE dataset_definition_id = ? ORDER BY generic_record_id", (dataset_id,))]
+    _age_every_row(conn, dataset_id)
+    _confirm_again(conn, snapshot_id)
+    after = [row[0] for row in conn.execute(
+        "SELECT source_snapshot_id FROM generic_record "
+        " WHERE dataset_definition_id = ? ORDER BY generic_record_id", (dataset_id,))]
+    assert after == before, "a confirmation repointed a row at a different snapshot"
+
+
+def test_a_confirmation_does_not_move_first_seen_at(conn):
+    """`first_seen_at` answers "when did this contractor appear", and `row_state` reads it
+    to decide `new`. A confirmation that moved it would make every row new for ever."""
+    snapshot_id, dataset_id = _approved_once(conn)
+    conn.execute("UPDATE generic_record SET first_seen_at = ? "
+                 " WHERE dataset_definition_id = ?", (LONG_AGO, dataset_id))
+    _age_every_row(conn, dataset_id)
+    _confirm_again(conn, snapshot_id)
+    firsts = {row[0] for row in conn.execute(
+        "SELECT first_seen_at FROM generic_record WHERE dataset_definition_id = ?",
+        (dataset_id,))}
+    assert firsts == {LONG_AGO}, f"first_seen_at moved: {sorted(firsts)}"
+
+
+# ------------------------------------------------------------------- the helper's own edges
+
+def test_confirm_seen_with_no_keys_writes_nothing(conn):
+    """A page that parsed to zero rows is a real case: `_rows_unchanged` answers True for
+    it, so this runs with an empty list.
+
+    AND THE REASON FIRST WRITTEN HERE WAS WRONG. It said "an `IN ()` would be a syntax
+    error", so the function carried a `if not record_keys: return 0` guard. A mutation
+    deleted that guard and this test stayed green, which sent me to measure it: SQLite
+    3.50.4 ACCEPTS `WHERE k IN ()`, matches nothing, and reports `rowcount` 0. The guard
+    was returning by hand what SQLite already returns, so it is gone — and what this test
+    pins is the BEHAVIOUR, which holds either way.
+    """
+    _, dataset_id = _approved_once(conn)
+    _age_every_row(conn, dataset_id)
+    assert service._confirm_seen(conn, dataset_id, []) == 0
+    assert set(_dates(conn, dataset_id)) == {LONG_AGO}, (
+        "an empty confirmation moved a date")
+
+
+def test_confirm_seen_touches_only_the_dataset_it_was_given(conn):
+    """`record_key` is unique per dataset, NOT globally — `UNIQUE (dataset_definition_id,
+    record_key)`. A confirmation of one dataset must not move a colliding key in another,
+    which is what the missing `dataset_definition_id` predicate would have done."""
+    snapshot_id, dataset_id = _approved_once(conn)
+    keys = [row[0] for row in conn.execute(
+        "SELECT record_key FROM generic_record WHERE dataset_definition_id = ?",
+        (dataset_id,))]
+    # A second dataset carrying the SAME record_key, built by copying the stored rows.
+    other = int(conn.execute(
+        "INSERT INTO dataset_definition (site_profile_id, dataset_key, original_name, "
+        "dataset_kind, discovery_method) "
+        "SELECT site_profile_id, 'other_dataset', original_name, dataset_kind, "
+        "       discovery_method "
+        "  FROM dataset_definition WHERE dataset_definition_id = ?",
+        (dataset_id,)).lastrowid)
+    version = int(conn.execute(
+        "INSERT INTO dataset_schema_version (dataset_definition_id, version_number, "
+        "schema_hash) VALUES (?, 1, 'other-shape')", (other,)).lastrowid)
+    conn.execute(
+        "INSERT INTO generic_record (dataset_definition_id, record_key, "
+        "schema_version_id, data_json, source_snapshot_id, source_locator, "
+        "content_hash, last_seen_at) "
+        "SELECT ?, record_key, ?, data_json, source_snapshot_id, source_locator, "
+        "       content_hash, ? "
+        "  FROM generic_record WHERE dataset_definition_id = ?",
+        (other, version, LONG_AGO, dataset_id))
+
+    _age_every_row(conn, dataset_id)
+    moved = service._confirm_seen(conn, dataset_id, keys)
+
+    assert moved == len(keys)
+    intact = {row[0] for row in conn.execute(
+        "SELECT last_seen_at FROM generic_record WHERE dataset_definition_id = ?",
+        (other,))}
+    assert intact == {LONG_AGO}, (
+        f"the other dataset's dates moved too: {sorted(intact)}")
+
+
+def test_the_confirmation_is_not_committed_by_the_service(conn, tmp_path: Path):
+    """`extract/service.py` is transaction-neutral BY CONVENTION and the caller commits.
+
+    Asserted rather than assumed, because the convention is what makes the callers correct:
+    `contractors.approve` commits after the membership write so a row and its groups land
+    together, and `extract/api.py` goes through `EngineDatabase.write`. A service that
+    committed here would break the first of those.
+    """
+    snapshot_id, dataset_id = _approved_once(conn)
+    conn.commit()
+    _age_every_row(conn, dataset_id)
+    conn.commit()
+
+    _confirm_again(conn, snapshot_id)          # deliberately NOT committed
+
+    second = sqlite3.connect(f"file:{tmp_path / 'scrapex-engine.db'}?mode=ro", uri=True)
+    try:
+        outside = {row[0] for row in second.execute(
+            "SELECT last_seen_at FROM generic_record WHERE dataset_definition_id = ?",
+            (dataset_id,))}
+    finally:
+        second.close()
+    assert outside == {LONG_AGO}, (
+        "the service committed on its own, so a caller can no longer roll a failed "
+        "membership write back together with the row it belongs to")
+
+    conn.commit()
+    third = sqlite3.connect(f"file:{tmp_path / 'scrapex-engine.db'}?mode=ro", uri=True)
+    try:
+        after = {row[0] for row in third.execute(
+            "SELECT last_seen_at FROM generic_record WHERE dataset_definition_id = ?",
+            (dataset_id,))}
+    finally:
+        third.close()
+    assert after != {LONG_AGO}, "the caller's commit did not persist the confirmation"
+
+
+def test_confirming_twice_is_not_an_error_and_stays_current(conn):
+    """Idempotent, and the reason it must be is `--run-ref`: a resumed crawl re-approves
+    pages it already approved, and 34,834 of them would each hit this branch."""
+    snapshot_id, dataset_id = _approved_once(conn)
+    _age_every_row(conn, dataset_id)
+    first = _confirm_again(conn, snapshot_id)
+    second = _confirm_again(conn, snapshot_id)
+    assert first.get("recovered") is True and second.get("recovered") is True
+    assert second.get("confirmed") == first.get("confirmed")
+    assert all(date != LONG_AGO for date in _dates(conn, dataset_id))
+
+
+# --------------------------------------------------------------- what the caller now says
+
+def test_the_crawl_no_longer_reports_that_a_confirmation_wrote_nothing(conn):
+    """The printed sentence was `"{recovered} unchanged and wrote nothing"`, and after this
+    change that is false rather than merely terse.
+
+    READ OFF THE SOURCE, and the reason is that the alternative is worse: driving
+    `contractors.approve` needs both locale halves, a directory and a frontier, and a test
+    that builds all of it to check one sentence would fail for a dozen reasons that have
+    nothing to do with the sentence. What matters is that the claim is gone and that the
+    count the service returns is actually read.
+    """
+    source = (Path(__file__).resolve().parents[1]
+              / "scrapex" / "contractors.py").read_text(encoding="utf-8")
+    assert "unchanged and wrote nothing" not in source, (
+        "the crawl still prints that a confirmation wrote nothing")
+    assert 'result.get("confirmed")' in source, (
+        "the count the service returns is never read, so the printed number cannot move")


### PR DESCRIPTION
Step 2 of the muqawil plan, root half. `R-54` — his ruling, and its own words: *the root
first.* The comparison is a second pull request because he ordered it that way.

## What was wrong

`approve_candidate` returns seventy lines above its upsert when every row on the page is
unchanged — the `DEC-10`/`R-40` short-circuit. That return is **right about the rows** and
**wrong about the observation**: the upsert it skips is the only write that moved
`last_seen_at`, so a pass that confirmed a row left the row's own date behind while
`taxonomy.py:181` refreshed its memberships on the same pass.

    profile records whose last_seen_at reads 2026-08-23    17,264
    records reading 2026-08-24                                121
    their memberships dated 2026-08-24                    397,526 -- every one
    records OLDER THAN THEIR OWN MEMBERSHIPS               17,259

## And the State column is already wrong on screen, not merely predicted

Computed on his warehouse with the panel's own `sightings.row_state`:

| dataset | rows | what the State column says today |
|---|---|---|
| `contractors` | 17,304 | **`absent` on 17,221 — 99.5%** · `confirmed` 48 · `unsighted` 35 |
| `contractor_profiles` | 17,385 | `unsighted` 17,371 · `retired` 14 |

`R-54` predicted this for the profiles **if** their sighting ledger were filled. The
listing's ledger is **already filled — 17,417 rows** — so the `MAX(last_seen_at)`
comparison runs on it, and only the 48 rows written in the crawl's final second survive.
`absent` claims the site stopped publishing a contractor, on 17,221 real companies, and
`publish.py` carries payload columns into the Sheet the add-in reads.

That measurement is why the root could not wait for the comparison: the field the comparison
rests on had to start moving first, or the fix would be built on a column that does not move.

## What changed, and the three columns it deliberately does not touch

`extract.service._confirm_seen` moves `last_seen_at` on exactly the keys the page carried —
the same `IN (...)` list `_rows_unchanged` just built, so no parameter limit appears that was
not already respected.

- **No revision.** `R-20`/`SR-6`: an unchanged value is confirmed, not appended — and
  `generic_record_revision` is UNIQUE on `(record, snapshot, content_hash)`, so a revision
  per confirmation would raise on the second confirmation of the same page.
- **No `status`.** A withdrawal somebody decided outranks an observation, which is
  `row_state`'s first precedence rule. The upsert sets `status='active'` **unconditionally**
  and would un-retire `OP-64`'s 14 impostor rows — filed as **`OP-90`** rather than copied
  into a second place, with the question it raises left to him.
- **No `source_snapshot_id`.** That is the RUN link the other half of `R-54` needs, and
  moving it here would repoint a row's cited source before the state computation that
  justifies it exists.

`contractors.approve` stops printing *"unchanged and wrote nothing"* — after this that is
false rather than merely terse — and reports the row count instead.

## What the second pull request needs, measured now so it is not guessed later

`newest` stops being `MAX(last_seen_at)` and becomes the run. **No migration:**
`generic_page_snapshot.crawl_run_ref` already exists and carries a value on **55,313 of
57,041** snapshots (`'profiles-2026-08-22'` on 34,834 of them), reachable from
`generic_record.source_snapshot_id`. He ruled the remaining **1,728** read `unsighted` — the
state that claims nothing about the site.

## Verification

12 tests · **9 of 9 mutations killed** · **993 green** across the 45 suites that touch this
code · 112 green across the documentation guards · the version gate says no `VERSION` move
is owed · full suite with `SCRAPEX_FULL_MIGRATIONS=1` before merge.

**Three things the mutation run got wrong before it produced a number worth quoting**, all
recorded in `LESSONS` §19:

1. **CRLF.** Every single-line anchor matched and every multi-line one silently did not —
   three mutations looked killed and six looked unapplied. `* text=auto` means the repo
   stores LF and Windows checks out CRLF; that trap is written down about hashing and bit a
   mutation harness instead. It was only recoverable because the harness distinguishes *"the
   suite stayed green"* from *"the anchor never matched"*.
2. **An invalid mutation went red for the wrong reason.** Deleting `return int(` left an
   unbalanced `)`, the module stopped importing, every test errored — and a harness checking
   only the exit code would have counted it as a kill. A mutation needs both assertions: the
   suite goes red, *and* the test that names the defect is among the failures.
3. **`IN ()` is legal SQLite.** `if not record_keys: return 0` was a guard against a syntax
   error that does not exist — measured on 3.50.4, `WHERE k IN ()` is accepted, matches
   nothing and reports `rowcount` 0. Deleted, because a line that reads like protection and
   cannot fail is exactly what `_rows_unchanged` records one screen above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
