### PR TITLE
crawl_run_ref is not a run identity, and #281 said in STATE.md that it was

### DIFF
--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -2824,3 +2824,41 @@ Measured on SQLite 3.50.4: `UPDATE t SET d = 'new' WHERE k IN ()` is **accepted*
 nothing, and reports `rowcount` 0 — exactly what the guard returned by hand. The guard is
 gone rather than kept behind a corrected comment, and the test now pins the behaviour,
 which holds either way.
+
+## 20 · `generic_page_snapshot.crawl_run_ref` is an operator's label, not a run identity
+
+Worth its own section because the column *looks* exactly like the thing three row states need,
+and because a ruling had already established it was not — which is the part that cost time.
+
+**Measured 2026-08-27** on the finished warehouse:
+
+    distinct values                          141   across 55,313 snapshots
+    listing-2026-08-20                        64   distinct refs -- ONE per cell
+    residual-2026-08-21                       40
+    deficit-2026-08-21b                       33
+    profiles-2026-08-22                        1   -- one ref for 34,834 pages
+    one stored value is literally  'R'         2   snapshots
+    matches against crawl_run.* or crawl_job.job_ref:  0
+
+It is the free-text `--run-ref` a crawl is invoked with. Nothing validates it, nothing joins
+to it, and its granularity is **per partition cell** for a listing crawl and **per crawl** for
+a profile crawl — so "the latest run" means two different sizes of thing depending on which
+dataset is asked.
+
+**What that does if you build the state comparison on it**, simulated before any code was
+written: taking "the run of the most recently captured snapshot this dataset's rows point at"
+gives `deficit-2026-08-21b-region_id_1-company_size_verysmall-a8` with **11 rows** for the
+listing and `gap-2026-08-23` with **1 row** for the profiles — so **17,030 of 17,304** and
+**17,384 of 17,385** rows would read `absent`. That is worse than the defect it replaces.
+
+**And `R-52` had already said so, in the paragraph titled "Why nothing stored could answer
+it".** `crawl_run` is the price path alone; its `source_id` points at `source_site`, where
+muqawil does not exist at all; `dataset_sighting` has `first_run_ref` and
+`last_absent_run_ref` and no `last_run_ref`. He chose **option B — a generic crawl-run
+table** — on 2026-08-24.
+
+**The lesson is `C1` with a price on it.** The plan's step 2 is titled *"Re-rule `R-52`
+before anything is built on it"*, and the ruling's own measurement section contained the
+answer to the question I spent an afternoon measuring from scratch — then published a wrong
+conclusion from, in `STATE.md`, the document every session reads second. Read the ruling
+that names the mechanism before designing the mechanism.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -125,9 +125,30 @@ this session's context nor this warehouse. Everything below is the whole handove
 > 17,221 of 17,304 rows — 99.5%**, because its sighting ledger is already full (17,417) so
 > the `MAX(last_seen_at)` comparison runs, and only the 48 rows written in the crawl's final
 > second survive it. `contractor_profiles` escapes with `unsighted` only because its ledger
-> is empty. **The second pull request replaces that comparison with the RUN**, and needs no
-> migration: `generic_page_snapshot.crawl_run_ref` carries a value on 55,313 of 57,041
-> snapshots, and he ruled the remaining 1,728 read `unsighted`.
+> is empty.
+>
+> **The second pull request needs the table `R-52` already ruled, and my earlier note here
+> > was wrong.** It said the comparison needs no migration because
+> > `generic_page_snapshot.crawl_run_ref` carries a value on 55,313 of 57,041 snapshots. The
+> > column exists; **it is not a run identity.** Measured 2026-08-27:
+> >
+> > - **141 distinct values** across 55,313 snapshots — per CELL for listing crawls
+> >   (`listing-2026-08-20` alone has 64, `residual-2026-08-21` 40, `deficit-2026-08-21b` 33)
+> >   and per crawl for the profile run (`profiles-2026-08-22`, one ref for 34,834 pages).
+> > - It **joins to nothing**: zero matches against any column of `crawl_run` or against
+> >   `crawl_job.job_ref`. It is the free-text `--run-ref` the operator types, and one stored
+> >   value is literally **`R`**, on two snapshots.
+> > - Simulated: comparing against "the run of the most recently captured snapshot" would read
+> >   **`absent` on 17,030 of 17,304** listing rows and **17,384 of 17,385** profile rows —
+> >   worse than today, not better.
+> >
+> > `R-52` had already measured this and he had already chosen the answer: **option B, a generic
+> > crawl-run table**, because `crawl_run` is the price path alone and its `source_id` points at
+> > `source_site`, where muqawil does not exist. So the second half is a migration plus a writer
+> > plus the comparison — and its `source_id` problem is `R-62`'s registry merge, the same thing
+> > that blocks the crawl button.
+>
+> He ruled that rows whose run cannot be established read `unsighted`.
 
 ### The code and the decisions are in the repository. The DATA is not.
 

--- a/docs/plans/2026-08-26-what-remains-of-muqawil.md
+++ b/docs/plans/2026-08-26-what-remains-of-muqawil.md
@@ -95,12 +95,28 @@ a clean 27-field v4** is the one that also leaves a correct version history, and
 > rows written in the crawl's final second survive it. `absent` claims the site stopped
 > publishing a contractor, and `publish.py` carries payload columns into his Sheet.
 >
-> **What is left for the second pull request:** `newest` stops being
-> `MAX(last_seen_at)` and becomes the RUN. That needs no migration —
-> `generic_page_snapshot.crawl_run_ref` already exists and carries a value on **55,313 of
-> 57,041** snapshots, reachable from `generic_record.source_snapshot_id`. He ruled that the
-> **1,728** snapshots without one read `unsighted`, the state that claims nothing about the
-> site.
+> **The second pull request needs the table `R-52` already ruled, and my earlier note here
+> > was wrong.** It said the comparison needs no migration because
+> > `generic_page_snapshot.crawl_run_ref` carries a value on 55,313 of 57,041 snapshots. The
+> > column exists; **it is not a run identity.** Measured 2026-08-27:
+> >
+> > - **141 distinct values** across 55,313 snapshots — per CELL for listing crawls
+> >   (`listing-2026-08-20` alone has 64, `residual-2026-08-21` 40, `deficit-2026-08-21b` 33)
+> >   and per crawl for the profile run (`profiles-2026-08-22`, one ref for 34,834 pages).
+> > - It **joins to nothing**: zero matches against any column of `crawl_run` or against
+> >   `crawl_job.job_ref`. It is the free-text `--run-ref` the operator types, and one stored
+> >   value is literally **`R`**, on two snapshots.
+> > - Simulated: comparing against "the run of the most recently captured snapshot" would read
+> >   **`absent` on 17,030 of 17,304** listing rows and **17,384 of 17,385** profile rows —
+> >   worse than today, not better.
+> >
+> > `R-52` had already measured this and he had already chosen the answer: **option B, a generic
+> > crawl-run table**, because `crawl_run` is the price path alone and its `source_id` points at
+> > `source_site`, where muqawil does not exist. So the second half is a migration plus a writer
+> > plus the comparison — and its `source_id` problem is `R-62`'s registry merge, the same thing
+> > that blocks the crawl button.
+>
+> He ruled that rows whose run cannot be established read `unsighted`.
 
 
 **`R-52` is on `main` as of `19ea359`, and the evidence says its plan will not fix the


### PR DESCRIPTION
A correction, and it is the kind `CLAUDE.md` exists to catch: **#281 left a wrong sentence in
`STATE.md` and in the live plan**, the two documents a session reads first.

It said the second half of `R-54` needs no migration, because
`generic_page_snapshot.crawl_run_ref` carries a value on 55,313 of 57,041 snapshots. The
column exists. **It is not a run identity.**

## Measured, 2026-08-27

```
distinct values                          141   across 55,313 snapshots
listing-2026-08-20                        64   distinct refs -- ONE PER CELL
residual-2026-08-21                       40
deficit-2026-08-21b                       33
profiles-2026-08-22                        1   -- one ref for 34,834 pages
one stored value is literally  'R'         2   snapshots
matches against crawl_run.* or crawl_job.job_ref:  0
```

It is the free-text `--run-ref` the crawl is invoked with. Nothing validates it, nothing joins
to it, and its granularity is **per partition cell** for a listing crawl and **per crawl** for
a profile crawl — so "the latest run" means two different sizes of thing depending on the
dataset.

**Simulated before a line of code was written**, taking "the run of the most recently captured
snapshot this dataset's rows point at":

| dataset | latest run by that rule | rows it wrote | rows that would read `absent` |
|---|---|---|---|
| `contractors` | `deficit-2026-08-21b-…-a8` | 11 | **17,030 of 17,304** |
| `contractor_profiles` | `gap-2026-08-23` | 1 | **17,384 of 17,385** |

Worse than the defect it was meant to replace.

## And the ruling had already answered it

`R-52`'s own section — *"Why nothing stored could answer it"* — records that `crawl_run` is the
price path alone, that its `source_id` points at `source_site` **where muqawil does not exist
at all**, and that `dataset_sighting` carries `first_run_ref` and `last_absent_run_ref` and no
`last_run_ref`. He chose **option B, a generic crawl-run table**, on 2026-08-24.

So the second half of step 2 is a migration plus a writer plus the comparison — and the
`source_id` problem inside it is **`R-62`'s registry merge**, the same thing that blocks the
crawl button (`REQ-45`). That is a change to the build order `R-69` set, so it is recorded
here rather than acted on.

## What this does not touch

**#281's code is unaffected and stays.** The root half — a confirming pass moving
`last_seen_at` — was measured, mutated 9 of 9, and is correct. Only the sentence about what
comes next was wrong.

## Verification

99 green across the documentation guards. `LESSONS` §20 carries the measurement and the
process failure: the plan's step 2 is titled *"Re-rule `R-52` before anything is built on
it"*, and the answer was inside the ruling I was re-measuring from scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)