### PR TITLE
#281 shifted nine citations 53 lines and four tiers of guard said nothing

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -109,7 +109,7 @@ number in it had moved. That `docs/plans/` sits outside the citation guard's `DO
 
 **Found 2026-08-26. Two halves, and the second is what lets the first survive.**
 
-**The collapse.** [scrapex/extract/service.py:915](../scrapex/extract/service.py#L915)
+**The collapse.** [scrapex/extract/service.py:968](../scrapex/extract/service.py#L968)
 resolves the identity field as `identity[0] if len(identity) == 1 else None`. With **two**
 `key_part` fields, or **zero**, that is `None` — so every row's external id is `None`, every
 `dataset_sighting` lookup misses, and `row_state` runs with `sighted_at=None,
@@ -136,7 +136,7 @@ of the three available answers: explicit refusal, a composite key, or silent omi
 
 ### OP-71 · The `MAX(observed_at)` subquery cannot be served by its index, twelve lines under a comment condemning that exact pattern
 
-**Found 2026-08-26.** [scrapex/extract/service.py:940](../scrapex/extract/service.py#L940)
+**Found 2026-08-26.** [scrapex/extract/service.py:993](../scrapex/extract/service.py#L993)
 runs `(SELECT MAX(v.observed_at) FROM generic_record_revision AS v WHERE
 v.generic_record_id = r.generic_record_id)` — once per row.
 
@@ -147,7 +147,7 @@ SQLite can seek a record's revisions from the index and must then read the table
 one to get the timestamp. No covering index, no index-only `MAX`.
 
 **And the trap is named on the same screen.**
-[service.py:954](../scrapex/extract/service.py#L954), twelve lines below, explains that the
+[service.py:1007](../scrapex/extract/service.py#L1007), twelve lines below, explains that the
 sighting side is read in ONE query because joining per row *"would be the
 correlated-subquery defect `OP-27` measured at 49s all over again."* The rule is known,
 written down, and applied to the neighbouring table.
@@ -247,7 +247,7 @@ to `POST` later, alongside `OP-73`.**
 **Found 2026-08-26.** `grep display_name scrapex/reports.py` returns **zero hits**: the
 products payload labels from a module constant only —
 [reports.py:2191](../scrapex/reports.py#L2191), `labels = dict(BROWSE_COLUMNS)`. The dataset
-payload does the opposite at [service.py:1043](../scrapex/extract/service.py#L1043),
+payload does the opposite at [service.py:1096](../scrapex/extract/service.py#L1096),
 preferring his stored `display_name`.
 
 **So renaming a column reaches a contractor table's heading and never a products table's.**
@@ -274,7 +274,7 @@ shapes. Recorded so that a later reader does not "fix" it.
 ### OP-78 · `tree` is produced by both producers, asserted by a test, and read by no consumer anywhere
 
 **Found 2026-08-26.** [reports.py:2255](../scrapex/reports.py#L2255) computes it with
-`_tree_shape`; [service.py:1046](../scrapex/extract/service.py#L1046) hard-codes `{}`. No
+`_tree_shape`; [service.py:1099](../scrapex/extract/service.py#L1099) hard-codes `{}`. No
 consumer reads `payload.tree` — `grid.js`'s `features.tree` is a name collision — and the
 13-key list asserts it regardless.
 
@@ -2318,7 +2318,7 @@ entirely** — `contractors` was not touched by that work, and the skew is older
 
 **`scrapex/sightings.py:398` decides a row is gone by comparing its `last_seen_at` against
 `newest`, and `newest` is `MAX(last_seen_at)` to the SECOND** — a timestamp, not a run
-identifier ([scrapex/extract/service.py:943](../scrapex/extract/service.py#L943)):
+identifier ([scrapex/extract/service.py:996](../scrapex/extract/service.py#L996)):
 
 ```python
 if last_seen_at is None or last_seen_at < newest:
@@ -2353,10 +2353,10 @@ column written row by row cannot.
 
 **Two statements nearby are also false, and both predate `#267`:**
 
-* [scrapex/extract/service.py:613](../scrapex/extract/service.py#L613) says *"`last_seen_at`
+* [scrapex/extract/service.py:666](../scrapex/extract/service.py#L666) says *"`last_seen_at`
   still moved: the upsert above sets it unconditionally, so a confirmation is recorded on
   the RECORD."* The `DEC-10` early `return` at
-  [scrapex/extract/service.py:515](../scrapex/extract/service.py#L515) fires **before** that
+  [scrapex/extract/service.py:560](../scrapex/extract/service.py#L560) fires **before** that
   upsert. Measured: **0** profile rows have a `last_seen_at` on 2026-08-24 with an earlier
   `first_seen_at`; all 17,264 pre-`R-51` rows still read 2026-08-23, after a full
   re-approval that touched every one of them.
@@ -3032,6 +3032,39 @@ the remedy did not survive the incident.
 system honest.** He ruled it is read and reported before anything of it merges.
 
 ---
+
+### OP-91 · The citation guard watches 9 documents of 82, and pins the code rather than the citation
+
+**Found 2026-08-29 by shipping the defect it exists to prevent.** `#281` inserted
+`_confirm_seen` at `scrapex/extract/service.py:303` — **53 lines above nine citations** — and
+every tier stayed green through two pull requests:
+
+| tier | why it passed |
+|---|---|
+| the file exists | it does |
+| the line exists | the file is 1,339 lines long |
+| the line is not blank | a 53-line shift in a file this dense lands on CODE, not on a gap |
+| `PINNED` | none of the nine was in it |
+
+So `BACKLOG.md` sent a reader to `return dataset_id, fields` for a sentence about pagination,
+and `LESSONS.md` did the same. Repaired, and all ten now sit in `PINNED` — a mutation that
+inserts thirteen lines above them turns the suite red and names each subject.
+
+**Two holes remain, and they are why this is open rather than closed:**
+
+1. **`DOCUMENTS` is a nine-item tuple** — `CLAUDE.md`, `ENGINEERING.md` and seven under
+   `docs/`. The repository holds **82** `.md` files. Everything in `docs/plans/`,
+   `MUQAWIL-AUDIT-2026-08-26.md`, `ENGINE-ROLE-MEASURED.md`, `STORAGE.md` and the rest is
+   unchecked, and one of them cites a line of `service.py` that **is** blank today.
+2. **`PINNED` pins the CODE, not the citation.** Measured: changing a document's number
+   from `:996` back to the stale `:943` leaves the suite green, because the row asserts what
+   `service.py:996` says — not that any document cites 996. It catches the code moving
+   under a pin, which is the common case and the one that bit here, but it does not catch a
+   document written with a wrong number in the first place.
+
+**The two are one fix or two.** Widening `DOCUMENTS` needs a way to exclude the documents
+that declare a base commit on purpose — `MUQAWIL-AUDIT` says *"measured against `5722b6f`,
+NOT `main`"* in its second line, so the marker already exists in prose and could be read.
 
 ### OP-90 · A re-approval silently un-retires the rows `OP-64` disowned
 

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -2590,7 +2590,7 @@ assert row["observed_state"] in {"new", "updated", "confirmed", "returned",
 
 `unsighted` is in that set. So a table where **every single row** collapsed to
 `unsighted` is green. And there is a live path that does exactly that:
-[scrapex/extract/service.py:915](../scrapex/extract/service.py#L915) resolves the
+[scrapex/extract/service.py:968](../scrapex/extract/service.py#L968) resolves the
 identity field as `identity[0] if len(identity) == 1 else None`, so a dataset with
 two `key_part` fields — or zero — yields `None`, every row's `external` is `None`,
 every sighting lookup misses, and the whole column is wrong with nothing to say so.
@@ -2862,3 +2862,36 @@ before anything is built on it"*, and the ruling's own measurement section conta
 answer to the question I spent an afternoon measuring from scratch — then published a wrong
 conclusion from, in `STATE.md`, the document every session reads second. Read the ruling
 that names the mechanism before designing the mechanism.
+
+## 21 · Nine citations drifted at once and four tiers of guard said nothing
+
+`#281` added a 53-line function at `scrapex/extract/service.py:303`. Every citation below it
+moved. **Nine of them, across `BACKLOG.md` and `LESSONS.md`, were left pointing 53 lines above
+their subject, and the build was green through two pull requests.**
+
+The failure is not that a guard was missing. Four ran and each was satisfied honestly:
+
+- the file exists — it does;
+- the line exists — the file is 1,339 lines;
+- **the line is not blank** — and this is the one worth staring at. That tier was written
+  after `#255` pushed a cited sentence 38 lines down onto an empty line. A 53-line shift in a
+  file of dense code lands on *another statement*, so the tier that catches drift catches
+  only the drift that happens to land in a gap;
+- `PINNED` — none of the nine was in it.
+
+**The repair, and the measurement that made it trustworthy.** All ten are pinned now, and a
+mutation that inserts thirteen lines above them turns the suite red and names each subject.
+Had those rows existed a day earlier, `#281` could not have shipped.
+
+**And a survivor taught what `PINNED` actually pins.** The first mutation changed a
+DOCUMENT's number from `:996` back to the stale `:943` and the suite stayed green: a pinned
+row asserts what `service.py:996` says, not that anything cites 996. It guards the code
+moving under a citation — the common case — and not a citation written wrong to begin with.
+Knowing which of the two a guard covers is the difference between trusting it and assuming it.
+
+**The cheap rule that follows:** after inserting anything above line ~300 of a long, heavily
+cited module, re-derive every citation into it. `difflib` between the old blob and the new one
+gives the map in one pass — **and read each answer**, because one of the nine was better after
+the drift than before it: `STATE.md:918` had pointed at a docstring's closing quote and the
+shift landed it on the `def` the sentence names. Applying the map blindly would have repaired
+it into being wrong.

--- a/docs/plans/2026-08-24-a-generic-crawl-is-a-run.md
+++ b/docs/plans/2026-08-24-a-generic-crawl-is-a-run.md
@@ -69,7 +69,7 @@ magnitude cheaper and answers a different question. That refusal stands.
    newest one. Decide it in the code with a comment, and test the resume.
 2. **`scrapex/partitioncrawl.py`** — the 93 cells. They must all belong to ONE run row,
    keyed on the base ref, not 93 rows.
-3. **`scrapex/extract/service.py:923`** — `newest` is computed here and handed to
+3. **`scrapex/extract/service.py:996`** — `newest` is computed here and handed to
    `derive_state`. It becomes "the newest `success` run's `started_at` for this dataset",
    read from `dataset_crawl`, and `None` when there is none — which the ladder already
    handles honestly (`STATE_CONFIRMED`).

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -397,6 +397,42 @@ PINNED = (
     # for pinning it rather than trusting a number in prose.
     ("docs/BACKLOG.md", "scrapex/extract/muqawil.py", 1715,
      "arabic_value = arabic.values[lined_up.arabic_of[index]]"),
+    # EVERY `extract/service.py` CITATION IN THE GUARDED DOCUMENTS, pinned together on
+    # 2026-08-29 after nine of them drifted at once and NOTHING here noticed.
+    #
+    # `#281` inserted `_confirm_seen` at line 303 -- 53 lines above all of them. Tier 1
+    # passed because the file is long enough; `test_no_citation_lands_on_a_blank_line`
+    # passed because a 53-line shift in a file this dense lands on CODE, not on a gap;
+    # and tier 2 never looked, because none of the nine was here. So `BACKLOG.md` sent a
+    # reader to `return dataset_id, fields` for a sentence about pagination, and the
+    # build stayed green through two pull requests.
+    #
+    # The lesson the file already states -- "writing a citation that matters means adding
+    # a row here" -- is now applied to the whole family rather than to whichever one
+    # happened to break last.
+    ("docs/BACKLOG.md", "scrapex/extract/service.py", 560,
+     'and recovered["schema_hash"] == schema_hash'),
+    ("docs/BACKLOG.md", "scrapex/extract/service.py", 666,
+     "last_seen_at=strftime"),
+    ("docs/BACKLOG.md", "scrapex/extract/service.py", 968,
+     "Pagination is what saves the render"),
+    ("docs/LESSONS.md", "scrapex/extract/service.py", 968,
+     "Pagination is what saves the render"),
+    ("docs/BACKLOG.md", "scrapex/extract/service.py", 993,
+     "WHEN THE MOST RECENT CRAWL SAW ANYTHING"),
+    ("docs/BACKLOG.md", "scrapex/extract/service.py", 996, "newest = conn.execute("),
+    ("docs/BACKLOG.md", "scrapex/extract/service.py", 1007,
+     "for key, seen, absent in conn.execute("),
+    ("docs/BACKLOG.md", "scrapex/extract/service.py", 1096,
+     'presentation.get(row["field_key"])'),
+    ("docs/BACKLOG.md", "scrapex/extract/service.py", 1099,
+     "His ORDER only once he has actually arranged"),
+    # NOT REMAPPED, AND THAT IS THE POINT OF READING EACH ONE. Before `#281` this pointed
+    # at the closing `\"\"\"` of the docstring; the +53 shift landed it on the `def` that
+    # `STATE.md`'s sentence actually names. Applying difflib blindly would have put it
+    # back on the quote -- a repair that made the citation worse.
+    ("docs/STATE.md", "scrapex/extract/service.py", 918,
+     "def dataset_table_payload"),
 )
 
 # A guard that can be emptied without anyone noticing is the defect -- SR-23, and


### PR DESCRIPTION
A defect I shipped yesterday, and the more useful half is why nothing caught it.

`#281` inserted `_confirm_seen` at `scrapex/extract/service.py:303`. Every citation below it
moved 53 lines. **Nine of them, across `docs/BACKLOG.md` and `docs/LESSONS.md`, were left
pointing 53 lines above their subject — through two green pull requests.**

```
:915  BACKLOG/LESSONS  ->  return dataset_id, fields        subject now at :968
:943  BACKLOG          ->  a sentence about row limits      subject now at :996
:954  BACKLOG          ->  a comment about A8               subject now at :1007
:1043 BACKLOG          ->  rows = []                        subject now at :1096
... and five more, every one +53
```

## Four tiers, each satisfied honestly

| tier | why it passed |
|---|---|
| the file exists | it does |
| the line exists | `service.py` is 1,339 lines |
| **the line is not blank** | a 53-line shift in dense code lands on another *statement*, not in a gap |
| `PINNED` | none of the nine was in it |

The blank-line tier is the one worth staring at. It was written after `#255` pushed a cited
sentence 38 lines down **onto an empty line** — so it catches the drift that happens to land
in a gap, and this one did not.

## Repaired, and every answer read rather than applied

`difflib` between the pre-`#281` blob and the current file gives the map in one pass, and each
destination is asserted against the symbol it must still name.

**One was deliberately NOT remapped.** `STATE.md:918` pointed at the closing `"""` of a
docstring before; the +53 shift landed it on `def dataset_table_payload` — the function that
sentence actually names. Applying the map blindly would have repaired it into being wrong.

The `R-52` plan's `service.py:923` is corrected too — it had been stale since `#272`.

## Ten rows added to `PINNED`, and mutated

Inserting thirteen lines above them turns the suite red and names each subject:

```
FAILED ...::test_a_pinned_citation_still_points_at_its_subject[BACKLOG.md-service.py-560]
FAILED ...::test_a_pinned_citation_still_points_at_its_subject[BACKLOG.md-service.py-666]
FAILED ...::test_a_pinned_citation_still_points_at_its_subject[BACKLOG.md-service.py-968]
```

So `#281` could not have shipped this had the rows existed a day earlier.

**A first mutation survived, and it taught what `PINNED` actually pins.** Changing a
*document's* number from `:996` back to the stale `:943` leaves the suite green — a pinned row
asserts what `service.py:996` says, not that anything cites 996. It guards the code moving
under a citation, which is the case that bit here, and not a citation written wrong to begin
with.

## What stays open

`OP-91`, because two holes remain:

1. **`DOCUMENTS` is a nine-item tuple** and the repository holds **82** `.md` files. Everything
   under `docs/plans/`, plus `MUQAWIL-AUDIT`, `ENGINE-ROLE-MEASURED` and `STORAGE`, is
   unchecked — and one of them cites a line of `service.py` that is blank today. Widening it
   needs a way to exclude the documents that declare a base commit on purpose; that marker
   already exists in their prose.
2. **A citation written wrong in the first place is still invisible**, per the surviving
   mutation above.

`LESSONS` §21 carries the measurement.

## Verification

122 green across every documentation guard. **The register guard caught this branch's own
first number** — `OP-96` left 91–95 empty, which is exactly how two sessions come to write the
same entry; corrected to `OP-91`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)