### PR TITLE
The run is the clock: state is computed against the crawl that wrote the row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ work predates this file, the commit that built it — evidence read out of
 record of what was done; this file answers a narrower question: which version
 has it.
 
-## 0.4.3
+## 0.4.4
 
 Minimum supported extension: `0.2.2`.
 

--- a/contracts/capability-baseline.json
+++ b/contracts/capability-baseline.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.3",
+  "version": "0.4.4",
   "minimum_extension_version": "0.2.2",
   "capabilities": {
     "crawl_pace": "0.2.0",

--- a/contracts/contract-baseline.json
+++ b/contracts/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.3",
+  "version": "0.4.4",
   "schema": [
     "0002_the_price_source_key_is_named_for_what_it_is.sql",
     "0003_a_source_says_how_deep_its_crawl_goes.sql",
@@ -14,7 +14,8 @@
     "0012_enrichment_runs_observe_before_they_replace.sql",
     "0013_two_versions_may_share_a_shape_across_time.sql",
     "0014_one_source_registry.sql",
-    "0015_the_shipped_retention_default.sql"
+    "0015_the_shipped_retention_default.sql",
+    "0016_a_snapshot_names_the_run_that_fetched_it.sql"
   ],
   "protocol": "1",
   "endpoints": [

--- a/contracts/version-vectors.json
+++ b/contracts/version-vectors.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.3",
+  "version": "0.4.4",
   "minimum_extension_version": "0.2.2",
   "capability_reporting_since": "0.2.0",
   "note": "Both copies of capabilityProblem must reproduce every `problem` string exactly. Python: scrapex/version.py. JavaScript: extension/version.js.",
@@ -7,8 +7,8 @@
     {
       "name": "in step — the engine deploys it and the extension is new enough",
       "key": "crawl_parallel_sources",
-      "extension_version": "0.4.3",
-      "engine_version": "0.4.3",
+      "extension_version": "0.4.4",
+      "engine_version": "0.4.4",
       "deployed": {
         "crawl_pace": {
           "since": "0.2.0",
@@ -50,7 +50,7 @@
       "name": "the extension is behind the engine",
       "key": "crawl_parallel_sources",
       "extension_version": "0.1.0",
-      "engine_version": "0.4.3",
+      "engine_version": "0.4.4",
       "deployed": {
         "crawl_pace": {
           "since": "0.2.0",
@@ -86,12 +86,12 @@
         }
       },
       "update_instructions": "Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards.",
-      "problem": "«Crawl several different sites at the same time. Two sources on the SAME site still take turns, so no site is asked for more than before.» needs ScrapeX extension 0.2.0; this extension is 0.1.0 and the engine is 0.4.3. Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards."
+      "problem": "«Crawl several different sites at the same time. Two sources on the SAME site still take turns, so no site is asked for more than before.» needs ScrapeX extension 0.2.0; this extension is 0.1.0 and the engine is 0.4.4. Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards."
     },
     {
       "name": "the engine is behind and says so",
       "key": "crawl_parallel_sources",
-      "extension_version": "0.4.3",
+      "extension_version": "0.4.4",
       "engine_version": "0.1.0",
       "deployed": {
         "crawl_pace": {
@@ -124,22 +124,22 @@
         }
       },
       "update_instructions": "Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards.",
-      "problem": "«crawl_parallel_sources» is not deployed by this ScrapeX engine (0.1.0); this extension is 0.4.3. Update the engine to 0.4.3 or newer."
+      "problem": "«crawl_parallel_sources» is not deployed by this ScrapeX engine (0.1.0); this extension is 0.4.4. Update the engine to 0.4.4 or newer."
     },
     {
       "name": "the engine is too old to say anything",
       "key": "crawl_parallel_sources",
-      "extension_version": "0.4.3",
+      "extension_version": "0.4.4",
       "engine_version": "0.1.0",
       "deployed": null,
       "update_instructions": "Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards.",
-      "problem": "«crawl_parallel_sources» cannot be confirmed: the ScrapeX engine reports version 0.1.0 and is too old to say which features it deploys. This extension is 0.4.3. Update the engine to 0.4.3."
+      "problem": "«crawl_parallel_sources» cannot be confirmed: the ScrapeX engine reports version 0.1.0 and is too old to say which features it deploys. This extension is 0.4.4. Update the engine to 0.4.4."
     },
     {
       "name": "an extension newer than the requirement is not refused for being newer",
       "key": "crawl_parallel_sources",
       "extension_version": "9.9.9",
-      "engine_version": "0.4.3",
+      "engine_version": "0.4.4",
       "deployed": {
         "crawl_pace": {
           "since": "0.2.0",

--- a/db/engine/migrations/0016_a_snapshot_names_the_run_that_fetched_it.sql
+++ b/db/engine/migrations/0016_a_snapshot_names_the_run_that_fetched_it.sql
@@ -1,0 +1,56 @@
+-- A SNAPSHOT NAMES THE RUN THAT FETCHED IT, WITH AN ID RATHER THAN A LABEL.
+--
+-- `R-54`'s second half: state is computed against the RUN that wrote a row, not against
+-- `MAX(last_seen_at)`. The root half shipped in `#281` — a confirming pass now moves the
+-- record's own date — and this is the field that half was waiting for.
+--
+-- WHY `crawl_run_ref` COULD NOT BE IT, measured on his warehouse on 2026-08-29 before a
+-- line of this was written:
+--
+--     distinct values                          141   across 55,313 snapshots
+--     listing-2026-08-20                        64   distinct refs -- ONE PER CELL
+--     residual-2026-08-21                       40
+--     profiles-2026-08-22                        1   -- one ref for 34,834 pages
+--     one stored value is literally  'R'         2   snapshots
+--     matches against crawl_run.* or crawl_job.job_ref:  0
+--
+-- It is the free-text `--run-ref` an operator types. Nothing validates it, nothing joins to
+-- it, and its granularity is per PARTITION CELL for a listing crawl and per CRAWL for a
+-- profile crawl — so "the latest run" would mean two different sizes of thing depending on
+-- which dataset asked. Simulated: comparing against it would have read `absent` on 17,030
+-- of 17,304 listing rows and 17,384 of 17,385 profile rows. Worse than the defect.
+--
+-- AND `R-52` CHOSE A NEW TABLE FOR A REASON THAT HAS SINCE EXPIRED. Its own words: "crawl_run
+-- is the price path alone — its `source_id` points at a price source, nothing for a dataset."
+-- That was true on 2026-08-24. `R-62`'s registry merge (`0014`) put `muqawil_org` in
+-- `source_site` at `source_id = 14`, so `crawl_run.source_id` now resolves for a dataset
+-- source like any other. He was shown the measurement and ruled: **one run table for
+-- everything**, which is `R-72`'s own reasoning applied one layer down — two concepts for one
+-- thing is what the second migration stream cost all day.
+--
+-- SO THIS ADDS A COLUMN AND NOT A TABLE.
+--
+-- `ADD COLUMN` rather than a rebuild, deliberately: `generic_page_snapshot` holds 57,041 rows
+-- and 1.4 GB of compressed bodies, and adding a nullable column with no default is a
+-- metadata-only change in SQLite — it does not rewrite a page of that. A rebuild would copy
+-- every stored body to add one integer.
+--
+-- NULL IS A REAL ANSWER AND NOT A GAP. 1,728 snapshots predate run identity entirely, and
+-- every snapshot stored before this migration has no run to name. His ruling for those rows
+-- is `unsighted` — the state that says "stored before the ledger existed" and claims nothing
+-- about the site — rather than `absent`, which would claim the site stopped publishing a
+-- contractor it still lists.
+--
+-- `crawl_run_ref` STAYS. It is what the operator typed and it is how `--run-ref` resumes an
+-- interrupted crawl (`contractors.py` matches on it to build the skip set). This column
+-- answers a different question — WHICH RUN, provably — and the two are not substitutes.
+
+PRAGMA user_version = 16;
+
+ALTER TABLE generic_page_snapshot
+    ADD COLUMN run_id INTEGER REFERENCES crawl_run(run_id);
+
+-- The state computation asks "which run wrote this row" once per row and "which run is the
+-- latest for this dataset" once per dataset. Both go through this column, and without an
+-- index the first is a scan of 57,041 rows per dataset render.
+CREATE INDEX ix_generic_page_snapshot_run ON generic_page_snapshot(run_id);

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -109,7 +109,7 @@ number in it had moved. That `docs/plans/` sits outside the citation guard's `DO
 
 **Found 2026-08-26. Two halves, and the second is what lets the first survive.**
 
-**The collapse.** [scrapex/extract/service.py:968](../scrapex/extract/service.py#L968)
+**The collapse.** [scrapex/extract/service.py:972](../scrapex/extract/service.py#L972)
 resolves the identity field as `identity[0] if len(identity) == 1 else None`. With **two**
 `key_part` fields, or **zero**, that is `None` — so every row's external id is `None`, every
 `dataset_sighting` lookup misses, and `row_state` runs with `sighted_at=None,
@@ -136,7 +136,7 @@ of the three available answers: explicit refusal, a composite key, or silent omi
 
 ### OP-71 · The `MAX(observed_at)` subquery cannot be served by its index, twelve lines under a comment condemning that exact pattern
 
-**Found 2026-08-26.** [scrapex/extract/service.py:993](../scrapex/extract/service.py#L993)
+**Found 2026-08-26.** [scrapex/extract/service.py:1046](../scrapex/extract/service.py#L1046)
 runs `(SELECT MAX(v.observed_at) FROM generic_record_revision AS v WHERE
 v.generic_record_id = r.generic_record_id)` — once per row.
 
@@ -147,7 +147,7 @@ SQLite can seek a record's revisions from the index and must then read the table
 one to get the timestamp. No covering index, no index-only `MAX`.
 
 **And the trap is named on the same screen.**
-[service.py:1007](../scrapex/extract/service.py#L1007), twelve lines below, explains that the
+[service.py:1016](../scrapex/extract/service.py#L1016), twelve lines below, explains that the
 sighting side is read in ONE query because joining per row *"would be the
 correlated-subquery defect `OP-27` measured at 49s all over again."* The rule is known,
 written down, and applied to the neighbouring table.
@@ -247,7 +247,7 @@ to `POST` later, alongside `OP-73`.**
 **Found 2026-08-26.** `grep display_name scrapex/reports.py` returns **zero hits**: the
 products payload labels from a module constant only —
 [reports.py:2191](../scrapex/reports.py#L2191), `labels = dict(BROWSE_COLUMNS)`. The dataset
-payload does the opposite at [service.py:1096](../scrapex/extract/service.py#L1096),
+payload does the opposite at [service.py:1113](../scrapex/extract/service.py#L1113),
 preferring his stored `display_name`.
 
 **So renaming a column reaches a contractor table's heading and never a products table's.**
@@ -274,7 +274,7 @@ shapes. Recorded so that a later reader does not "fix" it.
 ### OP-78 · `tree` is produced by both producers, asserted by a test, and read by no consumer anywhere
 
 **Found 2026-08-26.** [reports.py:2255](../scrapex/reports.py#L2255) computes it with
-`_tree_shape`; [service.py:1099](../scrapex/extract/service.py#L1099) hard-codes `{}`. No
+`_tree_shape`; [service.py:1116](../scrapex/extract/service.py#L1116) hard-codes `{}`. No
 consumer reads `payload.tree` — `grid.js`'s `features.tree` is a name collision — and the
 13-key list asserts it regardless.
 
@@ -703,7 +703,7 @@ anyway is not a resume."* The implementation checks the resume in the wrong plac
 
 ```
 scrapex/snapshotcrawl.py:154   def store(page: FetchedPage) -> None:
-scrapex/snapshotcrawl.py:164       if page.url in seen:
+scrapex/snapshotcrawl.py:169       if page.url in seen:
 ```
 
 `store` is the walker's `on_page`, and `PageWalker.walk` calls it **after**
@@ -2316,9 +2316,12 @@ unmerged. Whoever lands that branch should add the row.
 entirely** — `contractors` was not touched by that work, and the skew is older than the
 `R-51` recovery run.
 
-**`scrapex/sightings.py:398` decides a row is gone by comparing its `last_seen_at` against
+~~**`sightings.row_state` decides a row is gone by comparing its `last_seen_at` against
 `newest`, and `newest` is `MAX(last_seen_at)` to the SECOND** — a timestamp, not a run
-identifier ([scrapex/extract/service.py:996](../scrapex/extract/service.py#L996)):
+identifier.~~ **FIXED 2026-08-29 by `R-54`'s second half**: the comparison is against the
+RUN now, `newest` is gone from the codebase entirely, and the line quoted below no longer
+exists — which is why this citation names no file. The mechanism that replaced it is
+`runs.latest_run_for` and `generic_page_snapshot.run_id` (`0016`).
 
 ```python
 if last_seen_at is None or last_seen_at < newest:
@@ -2353,10 +2356,10 @@ column written row by row cannot.
 
 **Two statements nearby are also false, and both predate `#267`:**
 
-* [scrapex/extract/service.py:666](../scrapex/extract/service.py#L666) says *"`last_seen_at`
+* [scrapex/extract/service.py:667](../scrapex/extract/service.py#L667) says *"`last_seen_at`
   still moved: the upsert above sets it unconditionally, so a confirmation is recorded on
   the RECORD."* The `DEC-10` early `return` at
-  [scrapex/extract/service.py:560](../scrapex/extract/service.py#L560) fires **before** that
+  [scrapex/extract/service.py:561](../scrapex/extract/service.py#L561) fires **before** that
   upsert. Measured: **0** profile rows have a `last_seen_at` on 2026-08-24 with an earlier
   `first_seen_at`; all 17,264 pre-`R-51` rows still read 2026-08-23, after a full
   re-approval that touched every one of them.
@@ -3068,7 +3071,7 @@ door.
 ### OP-91 · The citation guard watches 9 documents of 82, and pins the code rather than the citation
 
 **Found 2026-08-29 by shipping the defect it exists to prevent.** `#281` inserted
-`_confirm_seen` at `scrapex/extract/service.py:303` — **53 lines above nine citations** — and
+`_confirm_seen` at `scrapex/extract/service.py:304` — **53 lines above nine citations** — and
 every tier stayed green through two pull requests:
 
 | tier | why it passed |
@@ -3090,7 +3093,7 @@ inserts thirteen lines above them turns the suite red and names each subject.
    unchecked, and one of them cites a line of `service.py` that **is** blank today.
 2. **`PINNED` pins the CODE, not the citation.** Measured: changing a document's number
    from `:996` back to the stale `:943` leaves the suite green, because the row asserts what
-   `service.py:996` says — not that any document cites 996. It catches the code moving
+   `service.py` line 996 said — not that any document cited it. It catches the code moving
    under a pin, which is the common case and the one that bit here, but it does not catch a
    document written with a wrong number in the first place.
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3456,6 +3456,18 @@ the repository has, on the only platform the owner uses.
 
 ## 3. Decided, not yet built
 
+### OP-99 · The price path still keeps its own copy of the run lifecycle
+
+`R-75` put every crawl on one run table, and the generic path now goes through
+`scrapex/runs.py`. The price path does not: `scrapex/ingest.py` still opens and closes a
+`crawl_run` inline, around its own `_insert(conn, "crawl_run", ...)` call. Two copies of
+one lifecycle is what `R-72` is about, and the second copy is the one that decides whether
+`finished_at` and `status` can ever disagree.
+
+**Not done on the way past, deliberately.** It is a change to working code with no defect
+behind it and no test that currently fails, so it is recorded rather than slipped into a
+pull request about something else.
+
 ### DEC-1 · Topology A — the TypeScript extension as the public product
 **Approved 2026-07-18. Zero commits since.** This is the largest gap between what was
 decided and what exists.

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -959,7 +959,7 @@ resume is explained in its module docstring in terms of **requests**:
 > anyway is not a resume.
 
 Every word of that is the right intent. The check sits in `store`
-([scrapex/snapshotcrawl.py:164](../scrapex/snapshotcrawl.py)), which is the
+([scrapex/snapshotcrawl.py:169](../scrapex/snapshotcrawl.py)), which is the
 walker's `on_page` — called **after** the fetch. So the resume saves the INSERT and
 saves no request at all, and the docstring's own justification is the one thing it
 does not deliver. Recorded as [OP-21](BACKLOG.md).
@@ -2590,7 +2590,7 @@ assert row["observed_state"] in {"new", "updated", "confirmed", "returned",
 
 `unsighted` is in that set. So a table where **every single row** collapsed to
 `unsighted` is green. And there is a live path that does exactly that:
-[scrapex/extract/service.py:968](../scrapex/extract/service.py#L968) resolves the
+[scrapex/extract/service.py:972](../scrapex/extract/service.py#L972) resolves the
 identity field as `identity[0] if len(identity) == 1 else None`, so a dataset with
 two `key_part` fields — or zero — yields `None`, every row's `external` is `None`,
 every sighting lookup misses, and the whole column is wrong with nothing to say so.
@@ -2865,7 +2865,7 @@ that names the mechanism before designing the mechanism.
 
 ## 21 · Nine citations drifted at once and four tiers of guard said nothing
 
-`#281` added a 53-line function at `scrapex/extract/service.py:303`. Every citation below it
+`#281` added a 53-line function at `scrapex/extract/service.py:304`. Every citation below it
 moved. **Nine of them, across `BACKLOG.md` and `LESSONS.md`, were left pointing 53 lines above
 their subject, and the build was green through two pull requests.**
 
@@ -2885,7 +2885,7 @@ Had those rows existed a day earlier, `#281` could not have shipped.
 
 **And a survivor taught what `PINNED` actually pins.** The first mutation changed a
 DOCUMENT's number from `:996` back to the stale `:943` and the suite stayed green: a pinned
-row asserts what `service.py:996` says, not that anything cites 996. It guards the code
+row asserts what that line of `service.py` says, not that anything cites it. It guards the code
 moving under a citation — the common case — and not a citation written wrong to begin with.
 Knowing which of the two a guard covers is the difference between trusting it and assuming it.
 

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -3129,3 +3129,40 @@ palette through it *before* writing it into the source found two failures and co
 The scratch script asserts on `REQ-48` in `docs/REQUESTS.md` — a string added in this
 session — rather than on `__file__`, per the trap in `CLAUDE.md`: `__file__` catches a
 misdirected import and never a misdirected read.
+
+## 26 · A function that always answers plausibly cannot fail loudly, and three ways that bit in one afternoon
+
+`R-54`'s second half replaced `MAX(last_seen_at)` with the run that wrote a row. The defect
+being replaced had lived for weeks in plain sight, and the reason is worth keeping.
+
+**1 · The wrong answer and the right answer are the same SHAPE.** `row_state` returns one of
+eight strings. The old comparison returned one of them for every row, always -- never NULL,
+never an exception, never a log line. On his warehouse it read **`absent` on 17,221 of 17,304
+contractors**, which is a catastrophic answer that no test, no type checker and no eye
+scanning the panel could distinguish from a correct one. Nothing here fails loudly on its
+own: **the only thing that can is an assertion naming a specific row, a specific pair of
+runs, and the state it must get.** That is the whole design of
+`tests/test_a_run_is_the_clock_that_states_are_read_against.py`, and it is why fifteen small
+assertions beat one integration test.
+
+**2 · The obvious column that looked like the answer.** `crawl_run_ref` sits on 55,313 of
+57,041 snapshots and is *named* like a run identity. It is a free-text label an operator
+types; §20 has the measurement. Two design notes in this repository had already assumed it
+would do, and both were written by someone who had read the column name and not the data.
+
+**3 · `MAX(run_id)` FOR THE SOURCE is the version of the fix that passes almost every test.**
+It is one word different from `latest_run_for` and it is wrong in exactly one situation: a
+listing sweep stores no profile page, so the moment a listing crawl finishes, every profile
+row reads `absent` -- while the site still lists all of them. The question has to be asked
+THROUGH the rows: the newest run among the snapshots this dataset's records point at. A
+guard for this has to build two runs of the same source where only one wrote rows the
+dataset can see; anything simpler passes under both implementations.
+
+**And a smaller one, from the same change.** A crawl that opens a run needs its source
+registered -- so the first crawl of a new site must register it. The first draft called
+`catalog.register_site` unconditionally, and `register_site` **refuses a key that already
+exists under a different `base_url`**: ten tests went red with `CatalogConflict` because
+their fixture had registered the site from a slightly different URL. A crawl declares a
+source it does not know; it does not re-assert the identity of one somebody already
+registered. The corrected shape asks first (`runs.open_run`, catching `UnknownSource`) and
+registers only on the way through.

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -2320,6 +2320,14 @@ that class of error and this is an instance of it.
 
 ### R-52 · A generic crawl is a RUN with an identity, not the maximum of a timestamp column
 
+> **SUPERSEDED IN PART on 2026-08-29 by [R-75](#r-75--one-run-table-for-everything-and-a-row-is-read-against-the-run-that-wrote-it),
+> and the part that stands is the larger part.** Its principle -- a run has an IDENTITY and a
+> maximum timestamp is not one -- is what `R-75` executes. What expired is its *table*
+> choice, and it expired on a measurement rather than a change of mind: `crawl_run.source_id`
+> pointed at `source_site`, where muqawil did not exist, so a second table was the only way
+> to have run identity at all. `R-62`'s merge (`0014`) put `muqawil_org` into `source_site`
+> on 2026-08-29, and a second run table became two concepts for one thing -- `R-72`.
+
 **Ruled 2026-08-24.** Shown that three of the eight row states rest on `newest` — the
 maximum of `generic_record.last_seen_at` — and offered three ways out, he chose the
 second: **«نفذ ب»**, a generic crawl-run table.
@@ -3099,6 +3107,12 @@ from the next session to ask.
 ---
 
 ### R-74 · The design system is Supabase's, always, and a palette may change nothing but colour
+
+> **THE COMMIT THAT SHIPPED THIS SAYS `R-72`.** `#283`'s merged title carries the wrong
+> ruling number -- the branch was opened while `R-72` was the newest ruling and the title
+> was never corrected before merge. The content is `R-73` and `R-74`. Recorded rather than
+> rewritten: history stays as it happened, and a reader searching git for `R-74` who finds
+> nothing needs to be told why.
 **2026-08-28 · design system · GENERAL — «واى تعارض معاها يلغى» · amends
 [R-73](#r-73--an-appearance-is-a-whole-design-system-and-supabase-is-the-default-one) §2 and
 discharges [R-59](#r-59--the-palette-registry-brand-is-default-alternatives-is-extensible-teal-is-debt)
@@ -3179,3 +3193,42 @@ The three Sign-in-with-Google values and that button's fixed type size stay outs
 appearance's reach — Google's branding rules, and their own guard. `--sp-*`,
 `--control-height*` and `--touch-target` keep the panel's 48px floor. `R-59` decision 4 still
 governs: components consume semantic roles, never a palette identifier.
+
+### R-75 · One run table for everything, and a row is read against the run that wrote it
+
+**2026-08-29 · data model · `R-54`'s second half, and the decision `R-52` made on a
+measurement that has since expired**
+
+`R-54` said state must be computed against the crawl that wrote a row, not against
+`MAX(last_seen_at)` over the whole dataset. Its root half shipped in `#281`. This is the
+other half, and it needed a field that did not exist. Three questions had no computable
+answer and he ruled on each:
+
+| question | his answer |
+|---|---|
+| a new run table for generic crawls, as `R-52` chose, or `crawl_run` | **«استعمِل crawl_run نفسَه — شوطٌ واحدٌ للكلّ»** — one run table for everything |
+| what state does a row stored before run identity existed get | **`unsighted`** — a standing state meaning "stored before the ledger", not `absent` |
+| the migration and the state column together, or separately | **one request** |
+
+**`R-52` IS NOT WRONG; ITS MEASUREMENT EXPIRED** (`C4` — its text stays). Its own words
+were *"`crawl_run` is the price path alone — its `source_id` points at a price source,
+nothing for a dataset."* That was true on 2026-08-24. `R-62`'s registry merge (`0014`) put
+`muqawil_org` into `source_site`, so `crawl_run.source_id` resolves for a dataset source
+like any other — and a second run table would then be exactly what `R-72` forbids: two
+concepts for one thing, which is what the duplicated migration stream cost all day.
+
+**AND THE OBVIOUS SHORTCUT WAS MEASURED AND REFUSED.** `crawl_run_ref` already sits on
+every snapshot and looks like a run identity. Measured on his warehouse before a line was
+written: 141 distinct values across 55,313 snapshots, granularity **per partition cell**
+for a listing crawl and **per crawl** for a profile crawl, one stored value literally
+`'R'`, and **zero** of them join to `crawl_run` or `crawl_job`. Simulated against it, the
+State column would have read `absent` on 17,030 of 17,304 listing rows and 17,384 of
+17,385 profile rows — worse than the defect. `#282` recorded that; `0016` adds a typed
+`run_id` beside the label rather than overloading it, and the label stays because
+`--run-ref` is how an interrupted crawl resumes.
+
+**THE LATEST RUN IS ASKED THROUGH THE ROWS, NOT OFF THE SOURCE**, and the difference is
+load-bearing rather than stylistic. A listing sweep stores no profile page, so
+`MAX(run_id)` for the source would call every profile row `absent` the moment a listing
+crawl finished — while the site still lists every one of them. `runs.latest_run_for` asks
+for the newest run among the snapshots this dataset's records actually point at.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -433,7 +433,7 @@ findings NOT in this wave are held pending numbers from the primary session (`R-
 **THE FINDING THAT MOVES THE PLAN.** Step 3 — the record card, `REQ-32`, the step he
 actually asked for — is priced in the plan at **967 lines** and gated on a new
 endpoint. Measured: `dataset_table_payload` SELECTed `generic_record_id`
-([service.py:918](../scrapex/extract/service.py#L918)) and the emitting loop dropped
+([service.py:922](../scrapex/extract/service.py#L922)) and the emitting loop dropped
 it, so the payload carried **no handle for the row at all**, while `grid.js` opens its
 card from `rows.filter((row) => row.offer_id)` and closes the panel when that is
 empty. **Selecting a contractor could never open anything**, and the fix is one

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -131,10 +131,28 @@ this session's context nor this warehouse. Everything below is the whole handove
 > seed row lived in the retired stream and the schema derivation carried `CREATE` and not
 > `INSERT`. His own warehouse has the row and was checked first; `0015` is the repair.
 >
-> `VERSION` → **0.4.3**, which understates it: `R-69` reserves `0.5.0` for
-> `feat/organization-enrichment` and that ruling was not overridden here.
+> `VERSION` → **0.4.4**. `R-69` reserves `0.5.0` for `feat/organization-enrichment`
+> and that ruling was not overridden here.
 >
-> **Step 2's ROOT HALF is built** — `R-54`, on his order 1 → 2 → 5 → 3 (`R-69`). A
+> **STEP 2 IS BUILT, BOTH HALVES.** The root half shipped in `#281`; the second half is
+> `0016` plus `scrapex/runs.py`, and he ruled `R-75` for it: **one run table for
+> everything.** A snapshot now names the run that fetched it with a typed `run_id`, and
+> `row_state` reads a row against THAT run instead of against `MAX(last_seen_at)`. The
+> latest run is asked THROUGH THE ROWS -- `MAX(run_id)` for the source would call every
+> profile row `absent` the moment a listing sweep finished, while the site still lists
+> every one of them. Fifteen new guards, three mutations, three killed.
+>
+> **`R-52` IS SUPERSEDED BY `R-75`, and its text stays** (`C4`). Its measurement --
+> *"`crawl_run` is the price path alone"* -- was true on 2026-08-24 and expired when
+> `R-62`'s merge (`0014`) put `muqawil_org` into `source_site`. A second run table would
+> then be exactly what `R-72` forbids.
+>
+> **`OP-99` is the honest remainder:** the price path still opens and closes its own
+> `crawl_run` inline in `ingest.py`, not through `runs.py`. Recorded, not slipped in.
+>
+> **Next in his order is step 5, then step 3** (`R-69`), then `R-68`'s reconciliation.
+>
+> The root half, for the record — `R-54`, on his order 1 → 2 → 5 → 3 (`R-69`). A
 > confirming pass now moves the record's own `last_seen_at`, which is the field the state
 > comparison rests on; `approve_candidate` returned seventy lines above the only write that
 > moved it. Nine mutations, nine killed, 993 tests green across 45 suites.
@@ -146,7 +164,7 @@ this session's context nor this warehouse. Everything below is the whole handove
 > second survive it. `contractor_profiles` escapes with `unsighted` only because its ledger
 > is empty.
 >
-> **The second pull request needs the table `R-52` already ruled, and my earlier note here
+> **The second pull request needed a table, and my earlier note here
 > > was wrong.** It said the comparison needs no migration because
 > > `generic_page_snapshot.crawl_run_ref` carries a value on 55,313 of 57,041 snapshots. The
 > > column exists; **it is not a run identity.** Measured 2026-08-27:
@@ -167,7 +185,13 @@ this session's context nor this warehouse. Everything below is the whole handove
 > > plus the comparison — and its `source_id` problem is `R-62`'s registry merge, the same thing
 > > that blocks the crawl button.
 >
-> He ruled that rows whose run cannot be established read `unsighted`.
+> He ruled that rows whose run cannot be established read `unsighted` -- a standing state
+> meaning "stored before the ledger existed", not `absent`, which would claim the site
+> stopped publishing a contractor it still lists. 1,728 snapshots on his warehouse are in
+> exactly that position.
+>
+> **AND `crawl_run_ref` STAYS.** It is what `--run-ref` resumes an interrupted crawl on.
+> `0016` adds a typed `run_id` beside it rather than overloading a free-text label.
 
 ### The code and the decisions are in the repository. The DATA is not.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "scrapex"
 # A MIRROR of scrapex/version.py:VERSION — setuptools cannot import the package
 # to ask. tests/test_version.py reads this line back and fails when they drift.
-version = "0.4.3"
+version = "0.4.4"
 description = "ScrapeX ecosystem: contract-driven web data collection into a SQLite warehouse. Categories: products, contractors"
 requires-python = ">=3.12"
 dependencies = [

--- a/scrapex/contractors.py
+++ b/scrapex/contractors.py
@@ -51,6 +51,8 @@ from .databases import DatabaseRegistry
 from .directories import Directory
 from .directories import get as get_directory
 from .extract import service
+from . import catalog
+from .catalog_models import SiteCreate
 from .extract.models import ApprovalField, CandidateApproval
 from .extract.service import SnapshotCreate, _canonical, _digest
 from .features import FeatureKey, is_enabled
@@ -63,6 +65,8 @@ from .partitioncrawl import (
     size_cell,
 )
 from .passes import DIRECTORY_PASSES
+from . import runs
+from .vocab import RunStatus
 from .sightings import (
     coverage,
     departures,
@@ -200,6 +204,36 @@ def plan(directory: Directory, fetch, started: float) -> None:
 
 # ---- --crawl: the partition, witnessed --------------------------------------
 
+def _run_for(conn, directory: Directory, kind: str) -> int:
+    """Open a run for this directory, registering the site first if it is not there.
+
+    THE ORDER IS THE POINT, and it was found by the crawl driver's own tests refusing to
+    start. A site reaches `source_site` through `catalog.register_site`, which runs during
+    APPROVAL -- and approval happens after pages are stored. So the first crawl of a new
+    source runs before that source exists, and a run that demanded registration would
+    refuse the one crawl that most needs to be recorded.
+
+    Registering here rather than relaxing `open_run` is deliberate. `register_site` is
+    idempotent by contract, so for muqawil this is a no-op every time; and a crawl that
+    declares the site it is about to read is a truthful thing to do, where a run quietly
+    set to None would leave a completed crawl looking, for ever, like one that never
+    named itself.
+    """
+    try:
+        return runs.open_run(conn, directory.key, kind=kind)
+    except runs.UnknownSource:
+        pass
+    # ONLY WHEN IT IS ABSENT, and the first draft got this wrong. It registered
+    # unconditionally, and `register_site` REFUSES a key that already exists under a
+    # different `base_url` -- so a crawl of a site registered from a slightly different
+    # URL raised `CatalogConflict` and never started. A crawl declares a site it does not
+    # know; it does not re-assert the identity of one somebody already registered.
+    catalog.register_site(conn, SiteCreate(
+        site_key=directory.key, display_name=directory.display_name,
+        base_url=directory.base_url))
+    return runs.open_run(conn, directory.key, kind=kind)
+
+
 def crawl(conn, directory: Directory, fetch, fetcher, run_ref: str,
           max_attempts: int, only: str = "", heavy_attempts: int = HEAVY_ATTEMPTS,
           workers: int = 1, connect=None) -> None:
@@ -253,8 +287,15 @@ def crawl(conn, directory: Directory, fetch, fetcher, run_ref: str,
             "answers 304 with no body")
 
     say(f"crawl {run_ref} starting")
+    # `R-54`: A RUN WITH AN IDENTITY, opened before the first fetch so every page this
+    # crawl stores names it. `run_ref` above is the operator's label and is derived per
+    # cell and attempt; this is one id for the whole sweep, and it is what the State
+    # column compares against instead of `MAX(last_seen_at)` — a timestamp to the second
+    # that only the crawl's final second could ever equal.
+    run_id = _run_for(conn, directory, "listing")
+    conn.commit()          # the workers open their own connections and must see it
     outcome = crawl_partition(conn, partition, directory.base_url, fetch=fetch,
-                              run_ref=run_ref,
+                              run_ref=run_ref, run_id=run_id,
                               dataset_key=directory.dataset_key,
                               max_attempts=max_attempts,
                               heavy_attempts=heavy_attempts, cells=chosen,
@@ -272,7 +313,14 @@ def crawl(conn, directory: Directory, fetch, fetcher, run_ref: str,
         say(f"kept {written:,} validator(s) for the next crawl; this one was "
             f"answered 304 for {saved:,} page(s)")
     say("")
+    # CLOSED AFTER THE DEPARTURES ARE MARKED, not before: the run is not finished
+    # while something is still writing under it, and `finished_at` is what a reader
+    # takes as "this sweep is over".
     mark_departures(conn, directory, outcome, run_ref)
+    runs.close_run(conn, run_id, status=RunStatus.SUCCESS,
+                   rows_seen=len(getattr(outcome, "ids", ()) or ()),
+                   requests=int(getattr(fetcher, "requests_count", 0) or 0))
+    conn.commit()
     say(str(coverage(conn, directory.dataset_key)))
 
 
@@ -582,6 +630,13 @@ def details(conn, directory: Directory, fetch, fetcher, run_ref: str,
     if ceiling and len(todo) > ceiling:
         todo = todo[:ceiling]
         say(f"  stopping at the {ceiling:,}-page ceiling, so this run is PARTIAL")
+    # `R-54`: ONE RUN FOR THE WHOLE SWEEP, opened before the first fetch and named by
+    # every page it stores. It is opened AFTER the frontier is settled so a run that
+    # turns out to have nothing to do is never opened at all — an empty `running` row
+    # left behind by a no-op crawl is the kind of debris a State column then has to
+    # explain.
+    run_id = _run_for(conn, directory, "profiles")
+    conn.commit()          # the workers open their own connections and must see it
     declare_frontier(fetcher, len(todo))
 
     # ONE PAGE, WHOLE, AND THE SAME CODE WHATEVER THE WORKER COUNT. The single-worker
@@ -599,6 +654,7 @@ def details(conn, directory: Directory, fetch, fetcher, run_ref: str,
         try:
             service.save_snapshot(writer, SnapshotCreate(
                 source_url=url, html_content=html, crawl_run_ref=run_ref,
+                run_id=run_id,
                 body_class=label_for(url, PageKind.DETAIL)))
             writer.commit()
             return True, ""
@@ -647,6 +703,16 @@ def details(conn, directory: Directory, fetch, fetcher, run_ref: str,
     for note in notes:
         say(note)
     say("")
+    # CLOSED WITH WHAT ACTUALLY HAPPENED, and `partial` is a real status rather than a
+    # kindness: a ceiling stopped this sweep short, so a later reader must not take it
+    # as "the site was fully read on this run". The State column's whole worth is that
+    # distinction.
+    runs.close_run(
+        conn, run_id,
+        status=RunStatus.PARTIAL if len(todo) < len(frontier) else RunStatus.SUCCESS,
+        rows_seen=stored, errors=failed,
+        requests=int(getattr(fetcher, "requests_count", 0) or 0))
+    conn.commit()
     say(f"profiles stored {stored:,}, failed {failed}, resumed {resumed:,}")
     if len(todo) + resumed < len(frontier):
         say("PARTIAL: the ceiling stopped this run. The same --run-ref continues it.")

--- a/scrapex/contractors.py
+++ b/scrapex/contractors.py
@@ -43,16 +43,15 @@ from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
-from . import taxonomy
+from . import catalog, runs, taxonomy
 from . import validators as validator_store
+from .catalog_models import SiteCreate
 from .connectors.base import HttpFetcher, declare_frontier
 from .crawlscope import CrawlScope
 from .databases import DatabaseRegistry
 from .directories import Directory
 from .directories import get as get_directory
 from .extract import service
-from . import catalog
-from .catalog_models import SiteCreate
 from .extract.models import ApprovalField, CandidateApproval
 from .extract.service import SnapshotCreate, _canonical, _digest
 from .features import FeatureKey, is_enabled
@@ -65,8 +64,6 @@ from .partitioncrawl import (
     size_cell,
 )
 from .passes import DIRECTORY_PASSES
-from . import runs
-from .vocab import RunStatus
 from .sightings import (
     coverage,
     departures,
@@ -79,6 +76,7 @@ from .sightings import (
 from .sites.muqawil import MuqawilPageSource
 from .snapshotbody import decode, label_for
 from .snapshotcrawl import already_stored, read_scope
+from .vocab import RunStatus
 
 # THE FOUR CONSTANTS THAT USED TO BE HERE were `BASE`, `DATASET`, `SITE_NAME` and
 # a `MuqawilPartition()`, and they are why a second contractor directory would have

--- a/scrapex/directories.py
+++ b/scrapex/directories.py
@@ -52,8 +52,8 @@ class Directory:
     of accidental sharing that becomes a bug the first time one carries state.
     """
 
-    #: Matches `source_site.site_key`, which is how a crawl finds its scope, and is
-    #: what `--source` names on the command line.
+    #: Matches `source_site.source_key` — one registry since `0014` — which is how a
+    #: crawl finds its scope, and is what `--source` names on the command line.
     key: str
     display_name: str
     base_url: str

--- a/scrapex/extract/models.py
+++ b/scrapex/extract/models.py
@@ -35,6 +35,15 @@ class SnapshotCreate(BaseModel):
     #: moment of capture. None for a crawl that does not name itself, and for
     #: the 1,728 snapshots stored before runs had names.
     crawl_run_ref: str | None = None
+    #: WHICH RUN, PROVABLY -- the typed companion to the label above, added by `0016`
+    #: for `R-54`'s second half. `crawl_run_ref` is what an operator typed and it is
+    #: what `--run-ref` resumes on; this is a foreign key into `crawl_run`, and it is
+    #: what the State column compares against. Measured before the two were separated:
+    #: the label has 141 distinct values across 55,313 snapshots, one per PARTITION
+    #: CELL for a listing crawl and one per CRAWL for a profile crawl, and one stored
+    #: value is literally `R`. None for every snapshot taken before `0016`, and his
+    #: ruling for those rows is `unsighted`.
+    run_id: int | None = None
     #: Which compression dictionary this page belongs with -- `host/kind`, from
     #: `snapshotbody.label_for`. None means STORE IT AS IT ARRIVED, and that is
     #: the default on purpose: the engine's save-a-page endpoint saves one page

--- a/scrapex/extract/service.py
+++ b/scrapex/extract/service.py
@@ -11,6 +11,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 from .. import catalog
+from .. import runs
 from ..catalog_models import DatasetCreate, FieldCreate, SiteCreate
 from ..fields import arranged, list_fields
 from ..sightings import STATE_MEANING, row_state
@@ -133,9 +134,9 @@ def save_snapshot(conn: sqlite3.Connection, request: SnapshotCreate) -> dict[str
     cursor = conn.execute(
         "INSERT INTO generic_page_snapshot "
         "(source_url, html_content, content_hash, crawl_run_ref, html_codec, "
-        " html_dict_id) VALUES (?,?,?,?,?,?)",
+        " html_dict_id, run_id) VALUES (?,?,?,?,?,?,?)",
         (source_url, body, _digest(request.html_content),
-         request.crawl_run_ref, codec, dict_id),
+         request.crawl_run_ref, codec, dict_id, request.run_id),
     )
     return _snapshot_public(_snapshot_row(conn, int(cursor.lastrowid)))
 
@@ -993,12 +994,17 @@ def dataset_table_payload(conn: sqlite3.Connection, dataset_key: str,
     total = conn.execute(
         "SELECT count(*) FROM generic_record WHERE dataset_definition_id = ?",
         (dataset_id,)).fetchone()[0]
-    # WHEN THE MOST RECENT CRAWL SAW ANYTHING — one aggregate, not a per-row
-    # question. Derived, never stored: written into the row it would be stale the
-    # moment the next crawl ran (`R-27`).
-    newest = conn.execute(
-        "SELECT MAX(last_seen_at) FROM generic_record WHERE dataset_definition_id = ?",
-        (dataset_id,)).fetchone()[0]
+    # WHICH RUN LAST WROTE INTO THIS DATASET — one question, not a per-row one.
+    # Derived, never stored: written into the row it would be stale the moment the next
+    # crawl ran (`R-27`).
+    #
+    # IT USED TO BE `MAX(last_seen_at)`, and that is the defect `R-54` names. A crawl
+    # writes for half an hour and that column is `strftime(...,'now')` at SECOND
+    # resolution, so only the rows written in the final second ever compared equal --
+    # 17,221 of 17,304 listing rows read `absent` on his warehouse after a crawl that
+    # had read every one of them.
+    latest_run = runs.latest_run_for(conn, dataset_key) if dataset_key else None
+    run_started_at = runs.started_at_of(conn, latest_run)
 
     # THE SIGHTING SIDE, READ ONCE. `unsighted` and `returned` are the two states that
     # cannot be answered from `generic_record` alone, and joining per row would be the
@@ -1036,10 +1042,16 @@ def dataset_table_payload(conn: sqlite3.Connection, dataset_key: str,
     # reader should not have to know that to trust the function.
     stored = conn.execute(
         "SELECT r.generic_record_id, r.record_key, r.data_json, r.status, "
-        "       r.first_seen_at, r.last_seen_at, "
+        "       r.first_seen_at, r.last_seen_at, s.run_id AS row_run, "
         "       (SELECT MAX(v.observed_at) FROM generic_record_revision AS v "
         "         WHERE v.generic_record_id = r.generic_record_id) AS changed_at "
-        "  FROM generic_record AS r WHERE r.dataset_definition_id = ? "
+        "  FROM generic_record AS r "
+        # LEFT, not INNER: a record whose snapshot predates `0016` has no run, and it
+        # must still reach the loop below -- `R-27` says a row stays on screen whatever
+        # the crawl saw, and dropping it here would be the vanishing that ruling forbids.
+        "  LEFT JOIN generic_page_snapshot AS s "
+        "    ON s.page_snapshot_id = r.source_snapshot_id "
+        " WHERE r.dataset_definition_id = ? "
         " ORDER BY r.generic_record_id LIMIT ?",
         (dataset_id, -1 if cap is None else int(cap)))
 
@@ -1061,7 +1073,9 @@ def dataset_table_payload(conn: sqlite3.Connection, dataset_key: str,
         # dates will infer differently, with one of them wrong.
         state = row_state(
             status=row["status"], first_seen_at=row["first_seen_at"],
-            last_seen_at=row["last_seen_at"], newest=newest,
+            last_seen_at=row["last_seen_at"],
+            row_run=row["row_run"], latest_run=latest_run,
+            run_started_at=run_started_at,
             changed_at=row["changed_at"], sighted_at=seen_at,
             last_absent_at=absent_at)
         record[OBSERVED_STATE] = state

--- a/scrapex/extract/service.py
+++ b/scrapex/extract/service.py
@@ -10,8 +10,7 @@ from decimal import Decimal, InvalidOperation
 from typing import Any
 from urllib.parse import urlparse
 
-from .. import catalog
-from .. import runs
+from .. import catalog, runs
 from ..catalog_models import DatasetCreate, FieldCreate, SiteCreate
 from ..fields import arranged, list_fields
 from ..sightings import STATE_MEANING, row_state

--- a/scrapex/partitioncrawl.py
+++ b/scrapex/partitioncrawl.py
@@ -768,6 +768,7 @@ def witness(fetch: Fetch, partition: PartitionedListing, base_url: str,
 
 def _read_cell(conn: sqlite3.Connection, partition: PartitionedListing,
                base_url: str, size: CellSize, *, fetch: Fetch, run_ref: str,
+               run_id: int | None = None,
                ) -> Attempt:
     """One attempt at one cell: read every page, then witness it."""
     cell = size.cell
@@ -805,7 +806,7 @@ def _read_cell(conn: sqlite3.Connection, partition: PartitionedListing,
         # PACED BY THE FETCHER AND NOWHERE ELSE — see the module docstring. And
         # `fetcher=None` so the frontier is declared ONCE for the whole
         # partition rather than reset fifty-six times.
-        pace_s=0, fetcher=None, run_ref=run_ref,
+        pace_s=0, fetcher=None, run_ref=run_ref, run_id=run_id,
         # THE LISTING PHASE, DECLARED. This crawl's whole product is a proof about the
         # LISTING — the witness compares id sequences and the count compares distinct
         # against declared — and a detail page takes part in neither. Without saying so,
@@ -845,7 +846,7 @@ def _read_cell(conn: sqlite3.Connection, partition: PartitionedListing,
 def _crawl_one_cell(size: CellSize, *, conn: sqlite3.Connection,
                     partition: PartitionedListing, base_url: str, fetch: Fetch,
                     run_ref: str, dataset_key: str, max_attempts: int,
-                    heavy_attempts: int, dry_attempts: int,
+                    heavy_attempts: int, dry_attempts: int, run_id: int | None = None,
                     retry_page_ceiling: int, resize_cells: bool
                     ) -> tuple[CellOutcome, int]:
     """One cell, read until it is proven, counted out, or dry.
@@ -875,7 +876,7 @@ def _crawl_one_cell(size: CellSize, *, conn: sqlite3.Connection,
     for number in range(1, allowed + 1):
         attempt = _read_cell(
             conn, partition, base_url, size, fetch=fetch,
-            run_ref=f"{run_ref}-{size.cell.label}-a{number}")
+            run_ref=f"{run_ref}-{size.cell.label}-a{number}", run_id=run_id)
         attempts.append(attempt)
         # WRITTEN PER ATTEMPT, not once at the end — the same reasoning
         # `snapshotcrawl` applies to a page and `sweep_muqawil` to a pass. A
@@ -937,7 +938,8 @@ def _run_and_close(body, index, size, connect) -> None:
 
 def crawl_partition(conn: sqlite3.Connection, partition: PartitionedListing,
                     base_url: str, *, fetch: Fetch, run_ref: str,
-                    dataset_key: str, cells: Sequence[Cell] | None = None,
+                    dataset_key: str, run_id: int | None = None,
+                    cells: Sequence[Cell] | None = None,
                     parent: Cell = WHOLE,
                     max_attempts: int = 2,
                     heavy_attempts: int = HEAVY_ATTEMPTS,
@@ -1041,7 +1043,7 @@ def crawl_partition(conn: sqlite3.Connection, partition: PartitionedListing,
 
     per_cell = {
         "partition": partition, "base_url": base_url, "fetch": fetch,
-        "run_ref": run_ref, "dataset_key": dataset_key,
+        "run_ref": run_ref, "dataset_key": dataset_key, "run_id": run_id,
         "max_attempts": max_attempts, "heavy_attempts": heavy_attempts,
         "dry_attempts": dry_attempts, "retry_page_ceiling": retry_page_ceiling,
         "resize_cells": resize_cells}

--- a/scrapex/runs.py
+++ b/scrapex/runs.py
@@ -1,0 +1,102 @@
+"""Opening and closing a crawl run, for any kind of source.
+
+WHY THIS MODULE EXISTS AND WHY IT IS NOT A SECOND RUN TABLE. `R-52` chose a new table for
+generic crawls, on a measurement it recorded honestly: *"`crawl_run` is the price path alone
+— its `source_id` points at a price source, nothing for a dataset."* That was true on
+2026-08-24. `R-62`'s registry merge (`0014`) put `muqawil_org` into `source_site`, so
+`crawl_run.source_id` now resolves for a dataset source like any other, and he ruled on
+2026-08-29: **one run table for everything.** It is `R-72`'s reasoning one layer down — two
+concepts for one thing is what the duplicated migration stream cost all day.
+
+WHAT A GENERIC RUN LEAVES EMPTY, said out loud rather than discovered later.
+`products_discovered` and `variants_discovered` mean nothing for a directory and stay 0;
+`rows_seen` carries the number that does. `extractor_version` names the crawl kind, which is
+the only place a reader can tell a listing sweep from a profile sweep after the fact.
+
+THE PRICE PATH STILL HAS ITS OWN COPY of this lifecycle, inline in `ingest.py` around the
+`_insert(conn, "crawl_run", …)` call. It is not routed through here yet — that is a change to
+working code with no defect behind it, and it is recorded as `OP-99` rather than done
+quietly on the way past.
+"""
+from __future__ import annotations
+
+import sqlite3
+
+from .vocab import RunStatus
+
+
+class UnknownSource(LookupError):
+    """The source key names nothing in the registry, so no run can belong to it."""
+
+
+def open_run(conn: sqlite3.Connection, source_key: str, *,
+             kind: str, job_id: int | None = None) -> int:
+    """Start a run for `source_key` and return its id.
+
+    THE SOURCE IS RESOLVED HERE AND NOT PASSED IN, because a caller holding a `source_id`
+    has already had to know which registry to ask — and since `0014` there is only one, so
+    the lookup is a single statement and the caller has one less thing to be wrong about.
+
+    IT DOES NOT COMMIT. Every writer in this codebase leaves the transaction to its caller
+    (`extract/service.py` says so explicitly), and a run that committed itself would survive
+    a crawl that then rolled back — a row saying `running` for ever with nothing behind it.
+    """
+    row = conn.execute(
+        "SELECT source_id FROM source_site WHERE source_key = ? AND valid_to IS NULL",
+        (source_key,)).fetchone()
+    if row is None:
+        raise UnknownSource(
+            f"no active source is registered as {source_key!r}, so a run cannot be opened "
+            "for it; register the source first")
+    return int(conn.execute(
+        "INSERT INTO crawl_run (source_id, status, extractor_version, job_id) "
+        "VALUES (?,?,?,?)",
+        (int(row[0]), RunStatus.RUNNING.value, kind, job_id)).lastrowid)
+
+
+def close_run(conn: sqlite3.Connection, run_id: int, *, status: RunStatus,
+              rows_seen: int = 0, requests: int = 0, errors: int = 0) -> None:
+    """Finish a run. Anything the caller does not know stays at its default of 0.
+
+    `finished_at` is written HERE rather than by the caller, so "when did this run end" can
+    never disagree with "is this run still running" — the two are set in one statement.
+    """
+    conn.execute(
+        "UPDATE crawl_run SET finished_at = strftime('%Y-%m-%dT%H:%M:%SZ','now'), "
+        "       status = ?, rows_seen = ?, requests_count = ?, errors_count = ? "
+        " WHERE run_id = ?",
+        (status.value, int(rows_seen), int(requests), int(errors), int(run_id)))
+
+
+def started_at_of(conn: sqlite3.Connection, run_id: int | None) -> str | None:
+    """When a run began. `new` and `updated` are asked against this rather than against
+    a row's own date, so a revision written any time during a nine-hour sweep belongs to
+    that sweep -- which is precisely what one timestamp could not express."""
+    if run_id is None:
+        return None
+    row = conn.execute("SELECT started_at FROM crawl_run WHERE run_id = ?",
+                       (int(run_id),)).fetchone()
+    return None if row is None else row[0]
+
+
+def latest_run_for(conn: sqlite3.Connection, dataset_key: str) -> int | None:
+    """The newest run that actually wrote a page this dataset's rows came from.
+
+    NOT `MAX(run_id)` FOR THE SOURCE, and the difference is the whole point. A source can
+    have runs that wrote nothing this dataset can see — a listing sweep leaves no profile
+    page — and comparing a profile row against a listing run would call every profile
+    `absent` the moment a listing crawl finished. So the question is asked THROUGH the rows:
+    the latest run among the snapshots this dataset's records actually point at.
+
+    None when no record of this dataset names a run, which is every dataset until a crawl
+    has run since `0016`. His ruling for that state is `unsighted`.
+    """
+    row = conn.execute(
+        "SELECT MAX(s.run_id) "
+        "  FROM generic_record AS r "
+        "  JOIN dataset_definition AS d "
+        "    ON d.dataset_definition_id = r.dataset_definition_id "
+        "  JOIN generic_page_snapshot AS s ON s.page_snapshot_id = r.source_snapshot_id "
+        " WHERE d.dataset_key = ? AND d.valid_to IS NULL",
+        (dataset_key,)).fetchone()
+    return None if row is None or row[0] is None else int(row[0])

--- a/scrapex/sightings.py
+++ b/scrapex/sightings.py
@@ -351,7 +351,9 @@ def departures(conn: sqlite3.Connection, dataset_key: str, *,
 
 
 def row_state(*, status: str, first_seen_at: str | None,
-              last_seen_at: str | None, newest: str | None,
+              last_seen_at: str | None,
+              row_run: int | None = None, latest_run: int | None = None,
+              run_started_at: str | None = None,
               changed_at: str | None = None,
               sighted_at: str | None = None,
               last_absent_at: str | None = None) -> str:
@@ -391,13 +393,22 @@ def row_state(*, status: str, first_seen_at: str | None,
         return STATE_UNAVAILABLE
     if sighted_at is None:
         return STATE_UNSIGHTED
-    if newest is None:
-        # Nothing has been crawled, so "the last crawl" does not exist and no
-        # comparison against it is honest.
-        return STATE_CONFIRMED
-    if last_seen_at is None or last_seen_at < newest:
+    # WHICH RUN, NOT WHICH SECOND. `R-54`, and the defect it replaces is measured:
+    # `newest` used to be `MAX(last_seen_at)` for the dataset, a timestamp at SECOND
+    # resolution, while a crawl writes its rows over half an hour. Only the rows written
+    # in the crawl's final second could ever compare equal to it, so on his warehouse
+    # 17,221 of 17,304 listing rows read `absent` after a crawl that had read every one
+    # of them -- and `absent` says the site stopped publishing a real company.
+    if latest_run is None or row_run is None:
+        # A row whose run cannot be established, which is every row stored before `0016`.
+        # HIS RULING: `unsighted`, because it claims nothing about the site. `absent`
+        # would invent a departure out of our own history, and `confirmed` -- what this
+        # returned before -- would claim the last crawl saw a row nobody can show it saw.
+        return STATE_UNSIGHTED
+    if row_run != latest_run:
         return STATE_ABSENT
-    if first_seen_at is not None and first_seen_at >= newest:
+    if (first_seen_at is not None and run_started_at is not None
+            and first_seen_at >= run_started_at):
         return STATE_NEW
     if last_absent_at is not None and last_seen_at >= last_absent_at:
         # `>=` AND NOT `>`, because both timestamps are `strftime(...,'now')` at
@@ -410,7 +421,11 @@ def row_state(*, status: str, first_seen_at: str | None,
         # latest crawl was already caught as `absent` two checks above, so reaching
         # this line means it IS present now and has a recorded absence behind it.
         return STATE_RETURNED
-    if changed_at is not None and changed_at >= newest:
+    if (changed_at is not None and run_started_at is not None
+            and changed_at >= run_started_at):
+        # AGAINST THE RUN'S START, not against a row's own date. A revision written
+        # while this run was in flight belongs to it however long the run took, which
+        # is exactly what comparing against one timestamp could not express.
         return STATE_UPDATED
     return STATE_CONFIRMED
 

--- a/scrapex/snapshotcrawl.py
+++ b/scrapex/snapshotcrawl.py
@@ -119,6 +119,11 @@ def crawl_to_snapshots(conn: sqlite3.Connection, source: PageSource,
                        max_requests: int | None = None,
                        fetcher: object | None = None,
                        run_ref: str | None = None,
+                       # `R-54`: the typed run this crawl belongs to. `run_ref` is
+                       # the operator's label and is derived per cell; this is one
+                       # id for the whole crawl and it is what the State column
+                       # compares against.
+                       run_id: int | None = None,
                        listing_phase_only: bool = False) -> CrawlOutcome:
     """Walk this site at its registered scope, storing every page as evidence.
 
@@ -181,7 +186,7 @@ def crawl_to_snapshots(conn: sqlite3.Connection, source: PageSource,
             # it is the path that had to learn it: 4.55 GB becomes about 90 MB.
             saved = save_snapshot(conn, SnapshotCreate(
                 source_url=page.url, html_content=page.html,
-                crawl_run_ref=run_ref,
+                crawl_run_ref=run_ref, run_id=run_id,
                 body_class=label_for(page.url, page.kind)))
             conn.commit()
         except Exception as exc:

--- a/scrapex/version.py
+++ b/scrapex/version.py
@@ -73,7 +73,7 @@ from enum import StrEnum
 # The release stamp. Bump it for a functional, architectural or behavioural
 # change (issue 32 section 1.1), and regenerate the baseline + CHANGELOG in the
 # same commit: python -m scrapex.cli export-version
-VERSION = "0.4.3"
+VERSION = "0.4.4"
 
 
 class Surface(StrEnum):

--- a/tests/test_a_crawl_says_what_it_saw.py
+++ b/tests/test_a_crawl_says_what_it_saw.py
@@ -336,7 +336,13 @@ def test_a_row_absent_then_seen_again_reads_returned(conn):
 
     assert row["last_absent_at"] is not None, "the absence was recorded"
     assert row_state(status="active", first_seen_at="2026-08-20T00:00:00Z",
-                     last_seen_at=row["last_seen_at"], newest=row["last_seen_at"],
+                     last_seen_at=row["last_seen_at"],
+                     row_run=7, latest_run=7,
+                     # AFTER `first_seen_at`, deliberately: `new` is checked before
+                     # `returned` and a run that began the moment the row first
+                     # appeared would make it new rather than returned. The precedence
+                     # is right; the fixture had to say which crawl this is.
+                     run_started_at="2026-08-21T00:00:00Z",
                      sighted_at=row["last_seen_at"],
                      last_absent_at=row["last_absent_at"]) == STATE_RETURNED
 
@@ -370,7 +376,8 @@ def test_a_marked_row_outranks_an_observation(conn):
 
     assert row_state(status="retired", first_seen_at="2026-01-01T00:00:00Z",
                      last_seen_at="2026-01-01T00:00:00Z",
-                     newest="2026-08-21T00:00:00Z",
+                     row_run=1, latest_run=9,
+                     run_started_at="2026-08-21T00:00:00Z",
                      sighted_at="2026-01-01T00:00:00Z") == STATE_RETIRED
 
 
@@ -381,21 +388,37 @@ def test_a_new_row_is_not_called_updated_or_returned(conn):
 
     assert row_state(status="active", first_seen_at="2026-08-21T12:00:00Z",
                      last_seen_at="2026-08-21T12:00:00Z",
-                     newest="2026-08-21T12:00:00Z",
+                     row_run=4, latest_run=4,
+                     run_started_at="2026-08-21T12:00:00Z",
                      changed_at="2026-08-21T12:00:00Z",
                      sighted_at="2026-08-21T12:00:00Z",
                      last_absent_at="2026-01-01T00:00:00Z") == STATE_NEW
 
 
-def test_nothing_crawled_yet_is_not_reported_as_absent(conn):
-    """`newest` is None when nothing has been crawled, so there is no "last crawl" to
-    be missing from. Calling every row absent would be an artefact of an empty
-    ledger."""
-    from scrapex.sightings import STATE_CONFIRMED, row_state
+def test_a_row_whose_run_is_unknown_is_not_reported_as_absent(conn):
+    """There is no "last run" to be missing from when nothing names one, and calling
+    every row absent would be an artefact of our own history rather than a fact about
+    the site.
 
+    IT READS `unsighted` AND NOT `confirmed`, WHICH IS HIS RULING OF 2026-08-29 and a
+    change from what this test asserted before. `confirmed` claims the last crawl saw
+    the row; nobody can show that it did. `unsighted` says "stored before the ledger
+    existed" and claims nothing about the site — which is the honest answer for the
+    57,041 snapshots taken before `0016` gave a run an id.
+    """
+    from scrapex.sightings import STATE_UNSIGHTED, row_state
+
+    # nothing anywhere names a run
     assert row_state(status="active", first_seen_at="2026-08-20T00:00:00Z",
-                     last_seen_at="2026-08-20T00:00:00Z", newest=None,
-                     sighted_at="2026-08-20T00:00:00Z") == STATE_CONFIRMED
+                     last_seen_at="2026-08-20T00:00:00Z",
+                     row_run=None, latest_run=None,
+                     sighted_at="2026-08-20T00:00:00Z") == STATE_UNSIGHTED
+    # the dataset has a latest run, but THIS row predates run identity
+    assert row_state(status="active", first_seen_at="2026-08-20T00:00:00Z",
+                     last_seen_at="2026-08-20T00:00:00Z",
+                     row_run=None, latest_run=5,
+                     run_started_at="2026-08-29T00:00:00Z",
+                     sighted_at="2026-08-20T00:00:00Z") == STATE_UNSIGHTED
 
 
 def test_a_changed_row_reads_updated_and_not_confirmed():
@@ -413,7 +436,8 @@ def test_a_changed_row_reads_updated_and_not_confirmed():
 
     crawl = "2026-08-21T12:00:00Z"
     common = {"status": "active", "first_seen_at": "2026-01-01T00:00:00Z",
-              "last_seen_at": crawl, "newest": crawl, "sighted_at": crawl}
+              "last_seen_at": crawl, "row_run": 3, "latest_run": 3,
+              "run_started_at": crawl, "sighted_at": crawl}
 
     # A revision written by THAT crawl: the row changed.
     assert row_state(**common, changed_at=crawl) == STATE_UPDATED
@@ -435,13 +459,20 @@ def test_updated_outranks_confirmed_but_not_new_or_absent():
     )
 
     crawl = "2026-08-21T12:00:00Z"
+    # new: written by the latest run, and first seen once it had started
     assert row_state(status="active", first_seen_at=crawl, last_seen_at=crawl,
-                     newest=crawl, changed_at=crawl,
-                     sighted_at=crawl) == STATE_NEW
+                     row_run=2, latest_run=2, run_started_at=crawl,
+                     changed_at=crawl, sighted_at=crawl) == STATE_NEW
+    # absent: a DIFFERENT run wrote this row, so the latest one did not see it. It is
+    # the run that decides now, not a timestamp comparison the crawl's own duration
+    # could break.
     assert row_state(status="active", first_seen_at="2026-01-01T00:00:00Z",
-                     last_seen_at="2026-08-01T00:00:00Z", newest=crawl,
+                     last_seen_at="2026-08-01T00:00:00Z",
+                     row_run=1, latest_run=2, run_started_at=crawl,
                      changed_at="2026-08-01T00:00:00Z",
                      sighted_at="2026-08-01T00:00:00Z") == STATE_ABSENT
+    # updated: the latest run wrote it and a revision landed while it ran
     assert row_state(status="active", first_seen_at="2026-01-01T00:00:00Z",
-                     last_seen_at=crawl, newest=crawl, changed_at=crawl,
+                     last_seen_at=crawl, row_run=2, latest_run=2,
+                     run_started_at=crawl, changed_at=crawl,
                      sighted_at=crawl) == STATE_UPDATED

--- a/tests/test_a_dataset_is_a_table_like_any_other.py
+++ b/tests/test_a_dataset_is_a_table_like_any_other.py
@@ -900,11 +900,37 @@ def test_gone_and_new_are_measured_against_the_most_recent_crawl(conn):
     record_sightings(conn, "contractors", held)
     ids = [row[0] for row in conn.execute(
         "SELECT generic_record_id FROM generic_record ORDER BY generic_record_id")]
-    # One row last seen long ago; the rest seen in the newest crawl.
-    conn.execute("UPDATE generic_record SET last_seen_at = '2026-01-01T00:00:00Z' "
-                 " WHERE generic_record_id = ?", (ids[0],))
-    conn.execute("UPDATE generic_record SET last_seen_at = '2026-08-21T12:00:00Z' "
-                 " WHERE generic_record_id != ?", (ids[0],))
+    # WHICH RUN, NOT WHICH SECOND — `R-54`, and this fixture had to change with it.
+    # It used to move `last_seen_at` on one row and leave the rest, because `absent`
+    # was `last_seen_at < MAX(last_seen_at)`. The state is decided by the RUN now, so
+    # the rows have to come from different runs to be in different states.
+    #
+    # A SNAPSHOT'S RUN CANNOT BE PATCHED AFTERWARDS: `generic_page_snapshot` is
+    # immutable by trigger in BOTH directions, which is why the second snapshot is
+    # created rather than the first one edited.
+    # ALREADY REGISTERED by the approval inside `stored()`: since `0014` a site and a
+    # price source share one table, and approving a candidate is what puts it there.
+    old_run = conn.execute(
+        "INSERT INTO crawl_run (source_id, status, started_at) "
+        "SELECT source_id, 'success', '2026-01-01T00:00:00Z' FROM source_site "
+        " WHERE source_key = 'muqawil_org'").lastrowid
+    new_run = conn.execute(
+        "INSERT INTO crawl_run (source_id, status, started_at) "
+        "SELECT source_id, 'success', '2026-08-21T12:00:00Z' FROM source_site "
+        " WHERE source_key = 'muqawil_org'").lastrowid
+    stale = service.save_snapshot(conn, SnapshotCreate(
+        source_url="https://muqawil.org/en/contractors?page=99",
+        html_content=LISTING, run_id=old_run))["page_snapshot_id"]
+    fresh = service.save_snapshot(conn, SnapshotCreate(
+        source_url="https://muqawil.org/en/contractors?page=98",
+        html_content=LISTING, run_id=new_run))["page_snapshot_id"]
+    # One row still points at the run that has been superseded; the rest at the newest.
+    conn.execute("UPDATE generic_record SET source_snapshot_id = ?, "
+                 "       last_seen_at = '2026-01-01T00:00:00Z' "
+                 " WHERE generic_record_id = ?", (stale, ids[0]))
+    conn.execute("UPDATE generic_record SET source_snapshot_id = ?, "
+                 "       last_seen_at = '2026-08-21T12:00:00Z' "
+                 " WHERE generic_record_id != ?", (fresh, ids[0]))
     # EVERY ROW'S `first_seen_at` IS PINNED, and only one used to be.
     #
     # `stored()` writes `first_seen_at` as NOW and `row_state` calls a row `new`

--- a/tests/test_a_delisted_contractor_is_marked_and_a_returning_one_is_not.py
+++ b/tests/test_a_delisted_contractor_is_marked_and_a_returning_one_is_not.py
@@ -259,7 +259,11 @@ def test_the_mark_is_taken_back_or_returned_is_unreachable(conn):
     marked_and_back = {
         "first_seen_at": "2026-08-01T00:00:00Z",
         "last_seen_at": "2026-08-21T13:00:00Z",
-        "newest": "2026-08-21T13:00:00Z",
+        # WHICH RUN, NOT WHICH SECOND (`R-54`). The row was written by the latest run
+        # and that run began after it first appeared, so `new` does not outrank the
+        # `returned` this test is about.
+        "row_run": 5, "latest_run": 5,
+        "run_started_at": "2026-08-21T13:00:00Z",
         "sighted_at": "2026-08-01T00:00:00Z",
         "last_absent_at": "2026-08-21T11:00:00Z",
     }
@@ -288,7 +292,11 @@ def test_the_boundary_is_the_one_row_state_uses(conn):
     assert mark_unavailable(conn, "contractors").marked == ()
 
     assert row_state(status="active", first_seen_at="2026-08-01T00:00:00Z",
-                     last_seen_at=same, newest=same, sighted_at="2026-08-01T00:00:00Z",
+                     last_seen_at=same, row_run=2, latest_run=2,
+                     # AFTER `first_seen_at`, so `new` does not outrank `returned`:
+                     # the precedence is the subject of the sibling test, not this one.
+                     run_started_at="2026-08-02T00:00:00Z",
+                     sighted_at="2026-08-01T00:00:00Z",
                      last_absent_at=same) == STATE_RETURNED
 
 

--- a/tests/test_a_run_is_the_clock_that_states_are_read_against.py
+++ b/tests/test_a_run_is_the_clock_that_states_are_read_against.py
@@ -1,0 +1,226 @@
+"""The run is the clock. `R-54`'s second half, guarded.
+
+WHY A GUARD AND NOT A REVIEW. The defect this replaces was invisible for a reason worth
+keeping: `MAX(last_seen_at)` over the whole dataset ANSWERED for every row, always, and
+answered plausibly. Nothing was ever NULL, nothing ever raised, and the wrong answer
+looked exactly like the right one. The only way that fails loudly is if something asserts
+the state a specific row gets from a specific pair of runs -- which is what this file is.
+
+The states these tests name are his, ruled on 2026-08-29: a row the latest run did not
+touch is `absent`; a row stored before run identity existed is `unsighted` and NOT
+`absent`, because `absent` claims the site stopped publishing a contractor it still lists.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scrapex import runs
+from scrapex.catalog import register_site
+from scrapex.catalog_models import SiteCreate
+from scrapex.databases import DatabaseRegistry, EngineDatabase
+from scrapex.sightings import row_state
+from scrapex.vocab import RunStatus
+
+
+@pytest.fixture()
+def conn(tmp_path: Path):
+    registry = DatabaseRegistry(EngineDatabase(tmp_path / "scrapex-engine.db"),
+                               pointer_file=tmp_path / "databases.json")
+    registry.initialize()
+    connection = registry.engine.connect()
+    try:
+        register_site(connection, SiteCreate(site_key="a_site", display_name="A site",
+                                             base_url="https://example.test"))
+        yield connection
+    finally:
+        connection.close()
+
+
+def test_a_run_cannot_be_opened_for_a_source_nobody_registered(conn):
+    """The alternative is a run whose `source_id` points at nothing, and `crawl_run` would
+    take it -- SQLite does not enforce a foreign key unless it is asked to."""
+    with pytest.raises(runs.UnknownSource):
+        runs.open_run(conn, "a_source_that_was_never_registered", kind="listing")
+
+
+def test_an_open_run_is_running_and_a_closed_one_is_not(conn):
+    run_id = runs.open_run(conn, "a_site", kind="listing")
+    status, finished = conn.execute(
+        "SELECT status, finished_at FROM crawl_run WHERE run_id = ?", (run_id,)).fetchone()
+    assert (status, finished) == (RunStatus.RUNNING.value, None)
+
+    runs.close_run(conn, run_id, status=RunStatus.SUCCESS, rows_seen=7)
+    status, finished, seen = conn.execute(
+        "SELECT status, finished_at, rows_seen FROM crawl_run WHERE run_id = ?",
+        (run_id,)).fetchone()
+    assert status == RunStatus.SUCCESS.value and seen == 7
+    # THE PAIR MOVES TOGETHER OR NOT AT ALL. `finished_at` is written in the same
+    # statement as `status` precisely so "when did it end" cannot disagree with "is it
+    # still running", which two separate UPDATEs would allow between them.
+    assert finished is not None
+
+
+def test_a_run_does_not_commit_itself(tmp_path: Path):
+    """A run that committed would survive a crawl that then rolled back -- a row saying
+    `running` for ever with nothing behind it. Every writer here leaves the transaction
+    to its caller, and this asserts `open_run` is not the exception."""
+    registry = DatabaseRegistry(EngineDatabase(tmp_path / "scrapex-engine.db"),
+                               pointer_file=tmp_path / "databases.json")
+    registry.initialize()
+    writer = registry.engine.connect()
+    try:
+        register_site(writer, SiteCreate(site_key="a_site", display_name="A site",
+                                         base_url="https://example.test"))
+        writer.commit()
+        runs.open_run(writer, "a_site", kind="listing")
+        writer.rollback()
+    finally:
+        writer.close()
+    reader = registry.engine.connect()
+    try:
+        assert reader.execute("SELECT COUNT(*) FROM crawl_run").fetchone()[0] == 0
+    finally:
+        reader.close()
+
+
+def test_the_latest_run_is_asked_through_the_rows_and_not_off_the_source(conn):
+    """THE DIFFERENCE IS THE WHOLE POINT, and `MAX(run_id)` for the source would pass every
+    other test in this file. A listing sweep stores no profile page, so if the profile
+    dataset compared its rows against the newest run OF THE SOURCE, every profile row
+    would read `absent` the moment a listing crawl finished -- while the site still lists
+    every one of them."""
+    dataset = _a_dataset(conn, "profiles")
+    profile_run = runs.open_run(conn, "a_site", kind="profiles")
+    _a_row(conn, dataset, run_id=profile_run, url="https://example.test/p/1")
+
+    # A LATER run of the same source that wrote nothing this dataset can see.
+    listing_run = runs.open_run(conn, "a_site", kind="listing")
+    assert listing_run > profile_run
+
+    assert runs.latest_run_for(conn, "profiles") == profile_run
+
+
+def test_a_dataset_no_run_has_written_has_no_latest_run(conn):
+    """Every dataset is in this state until a crawl has run since `0016`, and his ruling
+    for it is `unsighted` rather than a guess."""
+    _a_dataset(conn, "untouched")
+    assert runs.latest_run_for(conn, "untouched") is None
+
+
+def test_started_at_is_none_for_a_run_that_does_not_exist(conn):
+    assert runs.started_at_of(conn, None) is None
+    assert runs.started_at_of(conn, 999_999) is None
+
+
+# --- the states, read against the run ------------------------------------------------
+
+WAS = "2026-08-01T00:00:00Z"
+RUN_BEGAN = "2026-08-29T00:00:00Z"
+DURING = "2026-08-29T04:00:00Z"
+
+
+def _state(**over):
+    base = {"status": "active", "first_seen_at": WAS, "last_seen_at": DURING,
+            "sighted_at": DURING, "row_run": 5, "latest_run": 5,
+            "run_started_at": RUN_BEGAN, "changed_at": WAS}
+    return row_state(**{**base, **over})
+
+
+def test_a_row_the_latest_run_did_not_touch_is_absent():
+    assert _state(row_run=4) == "absent"
+
+
+def test_a_row_stored_before_run_identity_existed_is_unsighted_not_absent():
+    """1,728 snapshots on his warehouse predate `0016` and name no run. Calling them
+    `absent` would claim the site stopped publishing a contractor it still lists."""
+    assert _state(row_run=None) == "unsighted"
+
+
+def test_a_dataset_with_no_run_at_all_is_unsighted_rather_than_confirmed():
+    """The nastier half: were `latest_run is None` to fall through to `confirmed`, every
+    row of an un-crawled dataset would claim to have been seen by this run."""
+    assert _state(latest_run=None) == "unsighted"
+
+
+def test_a_row_first_seen_during_this_run_is_new():
+    assert _state(first_seen_at=DURING) == "new"
+
+
+def test_a_row_changed_during_this_run_is_updated():
+    assert _state(changed_at=DURING) == "updated"
+
+
+def test_a_revision_written_any_time_during_a_long_sweep_belongs_to_that_sweep():
+    """The reason the comparison is against the RUN'S START and not a row's own date. His
+    profile crawl ran nine hours; a row revised in hour eight is `updated` for that sweep,
+    and comparing two row timestamps to each other would have called it merely seen."""
+    nine_hours_in = "2026-08-29T09:00:00Z"
+    assert _state(changed_at=nine_hours_in, last_seen_at=nine_hours_in,
+                  sighted_at=nine_hours_in) == "updated"
+
+
+def test_retired_and_unavailable_still_win_over_everything_the_run_says():
+    assert _state(status="retired", row_run=4) == "retired"
+    assert _state(status="unavailable", row_run=4) == "unavailable"
+
+
+def test_a_row_never_sighted_is_unsighted_whatever_the_runs_say():
+    assert _state(sighted_at=None) == "unsighted"
+
+
+# --- fixtures ------------------------------------------------------------------------
+
+def _a_dataset(conn, key: str) -> int:
+    """RAW, and deliberately so for THIS pair of tests. `latest_run_for` is one SELECT
+    across three tables, and what it must get right is the JOIN -- so the fixture's job is
+    to place rows on both sides of it, not to exercise the writer. The writer is asserted
+    separately, below, through `save_snapshot` itself; the lesson that raw fixtures once
+    hid a real defect is why BOTH exist rather than either alone."""
+    return int(conn.execute(
+        "INSERT INTO dataset_definition "
+        "(source_id, dataset_key, original_name, dataset_kind, discovery_method, "
+        " locator_json) "
+        "VALUES ((SELECT source_id FROM source_site WHERE source_key='a_site'),"
+        "        ?,?, 'table', 'manual', '{}')",
+        (key, key)).lastrowid)
+
+
+def _a_row(conn, dataset_id: int, *, run_id: int, url: str) -> None:
+    snapshot = conn.execute(
+        "INSERT INTO generic_page_snapshot "
+        "(source_url, content_type, html_content, content_hash, html_codec, run_id) "
+        "VALUES (?, 'text/html', '<html/>', ?, 'utf-8', ?)",
+        (url, f"hash-{url}", run_id)).lastrowid
+    version = conn.execute(
+        "INSERT INTO dataset_schema_version (dataset_definition_id, version_number, "
+        " schema_hash, status) VALUES (?, 1, ?, 'approved')",
+        (dataset_id, f"schema-{dataset_id}")).lastrowid
+    conn.execute(
+        "INSERT INTO generic_record "
+        "(dataset_definition_id, record_key, schema_version_id, data_json, "
+        " source_snapshot_id, source_locator, content_hash) "
+        "VALUES (?,?,?,'{}',?,'row[0]',?)",
+        (dataset_id, url, version, snapshot, f"row-{url}"))
+
+
+def test_the_writer_actually_stores_the_run_on_the_page_it_saved(conn):
+    """THE HALF A RAW FIXTURE CANNOT SEE. Every test above can pass while `save_snapshot`
+    quietly drops `run_id` on the floor -- and then every row in production reads
+    `unsighted` for ever, which is a state the code is entitled to return, so nothing
+    raises and nothing looks wrong. `generic_page_snapshot` is immutable by trigger, so a
+    dropped `run_id` cannot be backfilled either: it is wrong permanently or it is right
+    at INSERT.
+    """
+    from scrapex.extract import service
+    from scrapex.extract.models import SnapshotCreate
+
+    run_id = runs.open_run(conn, "a_site", kind="profiles")
+    saved = service.save_snapshot(conn, SnapshotCreate(
+        source_url="https://example.test/p/9",
+        html_content="<html><body>a page</body></html>",
+        run_id=run_id))
+    stored = conn.execute("SELECT run_id FROM generic_page_snapshot WHERE page_snapshot_id = ?",
+                          (saved["page_snapshot_id"],)).fetchone()[0]
+    assert stored == run_id

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -205,8 +205,8 @@ PINNED = (
     # a reader sent one line off reads `store`'s docstring, agrees with it, and
     # concludes the entry is wrong. If someone moves this check into the walk, the
     # entry is answered and this row should go with it.
-    ("docs/BACKLOG.md", "scrapex/snapshotcrawl.py", 164, "if page.url in seen:"),
-    ("docs/LESSONS.md", "scrapex/snapshotcrawl.py", 164, "if page.url in seen:"),
+    ("docs/BACKLOG.md", "scrapex/snapshotcrawl.py", 169, "if page.url in seen:"),
+    ("docs/LESSONS.md", "scrapex/snapshotcrawl.py", 169, "if page.url in seen:"),
     # OP-22 / LESSONS §2 · one database, and where it is. That section described
     # the pre-collapse split layout in the present tense until 2026-08-20, so the
     # line naming the single file is worth holding still.
@@ -408,28 +408,35 @@ PINNED = (
     # The lesson the file already states -- "writing a citation that matters means adding
     # a row here" -- is now applied to the whole family rather than to whichever one
     # happened to break last.
-    ("docs/BACKLOG.md", "scrapex/extract/service.py", 560,
+    ("docs/BACKLOG.md", "scrapex/extract/service.py", 561,
      'and recovered["schema_hash"] == schema_hash'),
-    ("docs/BACKLOG.md", "scrapex/extract/service.py", 666,
+    ("docs/BACKLOG.md", "scrapex/extract/service.py", 667,
      "last_seen_at=strftime"),
-    ("docs/BACKLOG.md", "scrapex/extract/service.py", 968,
+    ("docs/BACKLOG.md", "scrapex/extract/service.py", 972,
      "Pagination is what saves the render"),
-    ("docs/LESSONS.md", "scrapex/extract/service.py", 968,
+    ("docs/LESSONS.md", "scrapex/extract/service.py", 972,
      "Pagination is what saves the render"),
-    ("docs/BACKLOG.md", "scrapex/extract/service.py", 993,
-     "WHEN THE MOST RECENT CRAWL SAW ANYTHING"),
-    ("docs/BACKLOG.md", "scrapex/extract/service.py", 996, "newest = conn.execute("),
-    ("docs/BACKLOG.md", "scrapex/extract/service.py", 1007,
+    # THESE TWO WERE REPLACED, NOT DELETED, on 2026-08-29. They pinned
+    # `WHEN THE MOST RECENT CRAWL SAW ANYTHING` and `newest = conn.execute(` -- the
+    # `MAX(last_seen_at)` comparison `R-54` was written against. Its second half removed
+    # both from the codebase, so the pins move to what took their place rather than
+    # leaving the new mechanism unpinned; deleting a row to make a red build green is
+    # what `PINNED_FLOOR` exists to refuse.
+    ("docs/BACKLOG.md", "scrapex/extract/service.py", 997,
+     "WHICH RUN LAST WROTE INTO THIS DATASET"),
+    ("docs/BACKLOG.md", "scrapex/extract/service.py", 1006,
+     "latest_run = runs.latest_run_for("),
+    ("docs/BACKLOG.md", "scrapex/extract/service.py", 1016,
      "for key, seen, absent in conn.execute("),
-    ("docs/BACKLOG.md", "scrapex/extract/service.py", 1096,
+    ("docs/BACKLOG.md", "scrapex/extract/service.py", 1113,
      'presentation.get(row["field_key"])'),
-    ("docs/BACKLOG.md", "scrapex/extract/service.py", 1099,
+    ("docs/BACKLOG.md", "scrapex/extract/service.py", 1116,
      "His ORDER only once he has actually arranged"),
     # NOT REMAPPED, AND THAT IS THE POINT OF READING EACH ONE. Before `#281` this pointed
     # at the closing `\"\"\"` of the docstring; the +53 shift landed it on the `def` that
     # `STATE.md`'s sentence actually names. Applying difflib blindly would have put it
     # back on the quote -- a repair that made the citation worse.
-    ("docs/STATE.md", "scrapex/extract/service.py", 918,
+    ("docs/STATE.md", "scrapex/extract/service.py", 922,
      "def dataset_table_payload"),
 )
 


### PR DESCRIPTION
`R-54`'s second half. The root half shipped in `#281` — a confirming pass now moves the
record's own `last_seen_at` — and this is the field that half was waiting for.

## The defect, on his own screen

Computed with the panel's own `sightings.row_state`: `contractors` read **`absent` on
17,221 of 17,304 rows — 99.5%**, while the site still lists every one of them. The old
comparison was `MAX(last_seen_at)` over the whole dataset, so only the rows written in the
crawl's final second survived it.

**Why it lived for weeks in plain sight.** `row_state` returns one of eight strings. The
wrong answer and the right answer are the same shape — never `NULL`, never an exception,
never a log line. Nothing here fails loudly on its own; the only thing that can is an
assertion naming a specific row, a specific pair of runs, and the state it must get.

## `R-75` — one run table for everything

Shown the measurement and asked whether to build the generic run table `R-52` chose, he
ruled: **«استعمِل crawl_run نفسَه — شوطٌ واحدٌ للكلّ»**.

**`R-52` is not wrong; its measurement expired**, and its text stays (`C4`). Its own words
were *"`crawl_run` is the price path alone — its `source_id` points at a price source,
nothing for a dataset."* True on 2026-08-24. `R-62`'s registry merge (`0014`) put
`muqawil_org` into `source_site` on 2026-08-29, so `crawl_run.source_id` resolves for a
dataset source like any other — and a second run table would then be exactly what `R-72`
forbids: two concepts for one thing.

He also ruled the state for rows whose run cannot be established: **`unsighted`**, meaning
"stored before the ledger existed", not `absent`, which would claim the site stopped
publishing a contractor it still lists. 1,728 snapshots on his warehouse are in that
position.

## The shortcut that was measured and refused

`crawl_run_ref` sits on 55,313 of 57,041 snapshots and is *named* like a run identity.
Measured on his warehouse before a line was written:

    distinct values                          141   across 55,313 snapshots
    listing-2026-08-20                        64   distinct refs -- ONE PER CELL
    profiles-2026-08-22                        1   -- one ref for 34,834 pages
    one stored value is literally  'R'         2   snapshots
    matches against crawl_run.* or crawl_job.job_ref:  0

Simulated against it, the State column would have read `absent` on 17,030 of 17,304 listing
rows and 17,384 of 17,385 profile rows — worse than the defect. `#282` recorded that.
`0016` adds a typed `run_id` **beside** the label rather than overloading it, and the label
stays because `--run-ref` is how an interrupted crawl resumes.

## What ships

- **`0016`** — `run_id INTEGER REFERENCES crawl_run(run_id)` on `generic_page_snapshot`,
  plus its index. `ADD COLUMN` and not a rebuild, deliberately: that table holds 57,041 rows
  and 1.4 GB of compressed bodies, and a nullable column with no default is metadata-only in
  SQLite. A rebuild would copy every stored body to add one integer. `generic_page_snapshot`
  is immutable by trigger, so `run_id` is right at INSERT or wrong permanently.
- **`scrapex/runs.py`** — `open_run` / `close_run` / `started_at_of` / `latest_run_for`,
  for any kind of source. It does not commit: a run that committed itself would survive a
  crawl that then rolled back, leaving a row saying `running` for ever.
- **`row_state`** reads a row against the run that wrote it. `new` and `updated` are asked
  against the RUN'S START, so a revision written in hour eight of a nine-hour sweep belongs
  to that sweep.
- The crawl paths open and close runs — `contractors.py`, `partitioncrawl.py`,
  `snapshotcrawl.py`, `extract/service.py`.

## `latest_run_for` asks THROUGH the rows, and that is load-bearing

`MAX(run_id)` for the source is one word different and passes almost every test. It is
wrong in exactly one situation: a listing sweep stores no profile page, so the moment a
listing crawl finishes, every profile row reads `absent`. The guard for this builds two
runs of the same source where only one wrote rows the dataset can see.

## Verification

**Both run modes, from a purged tree, after every edit was final** — `LESSONS` §24, the
rule CI taught us on `#285`: the two modes are two products, and each turns off a guard the
other needs.

Fifteen new guards in `tests/test_a_run_is_the_clock_that_states_are_read_against.py`.
**Three mutations, three killed**, each named its expected test:

| mutation | test that went red |
|---|---|
| `latest_run_for` → `MAX(run_id)` for the source | `..._asked_through_the_rows_and_not_off_the_source` |
| `row_state` stops checking for a missing run | `..._stored_before_run_identity_existed_is_unsighted_not_absent` |
| `save_snapshot` drops `run_id` | `..._writer_actually_stores_the_run_on_the_page_it_saved` |

The third is the one a raw fixture cannot see: every other test passes while the writer
drops `run_id`, and then every row reads `unsighted` for ever — a state the code is
entitled to return, so nothing raises.

## Two things recorded rather than done

- **`OP-99`** — the price path still opens and closes its own `crawl_run` inline in
  `ingest.py`, not through `runs.py`. Two copies of one lifecycle is what `R-72` is about,
  but it is working code with no defect behind it and no failing test, so it is recorded
  rather than slipped into a pull request about something else.
- **`#283`'s merged title says `R-72`** while its content is `R-73`/`R-74` — the branch was
  opened when `R-72` was newest and the title was never corrected. Noted on `R-74` itself so
  a reader searching git for `R-74` is told why they find nothing. History stays as it
  happened.

## Two failures CI would have caught, caught here instead

Both from the version bump and both invisible to a single suite run:

1. **The version has five homes, not one.** `pyproject.toml` still said `0.4.3`
   ("bump both or neither"), and `version-vectors.json`, `capability-baseline.json` and
   `CHANGELOG.md` are generated — `python -m scrapex.cli export-version` wrote them. No new
   capability is declared: this is an internal correctness fix, as `0.4.3` was.
2. **`ruff` was red on `scrapex/`** — import ordering in `contractors.py` and
   `service.py`, from this branch's own new imports.

`VERSION` → **0.4.4**. `R-69` reserves `0.5.0` for `feat/organization-enrichment` and that
ruling was not overridden here.

Two citations in `docs/BACKLOG.md` were **repointed, not deleted**: they pinned
`newest = conn.execute(` and the comment above it, both removed by this change, so they now
name the mechanism that replaced them. Deleting a pinned row to make a red build green is
what `PINNED_FLOOR` exists to refuse.

Docs: `R-75` recorded, `R-52` marked superseded in part with its text kept (`C4`),
`LESSONS` §26, `STATE.md`, `OP-99`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
