### PR TITLE
Absence is more honest than a placeholder: the bare directory and the default pin (R-55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ work predates this file, the commit that built it — evidence read out of
 record of what was done; this file answers a narrower question: which version
 has it.
 
-## 0.4.4
+## 0.4.5
 
 Minimum supported extension: `0.2.2`.
 

--- a/contracts/capability-baseline.json
+++ b/contracts/capability-baseline.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.4",
+  "version": "0.4.5",
   "minimum_extension_version": "0.2.2",
   "capabilities": {
     "crawl_pace": "0.2.0",

--- a/contracts/contract-baseline.json
+++ b/contracts/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.4",
+  "version": "0.4.5",
   "schema": [
     "0002_the_price_source_key_is_named_for_what_it_is.sql",
     "0003_a_source_says_how_deep_its_crawl_goes.sql",

--- a/contracts/version-vectors.json
+++ b/contracts/version-vectors.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.4",
+  "version": "0.4.5",
   "minimum_extension_version": "0.2.2",
   "capability_reporting_since": "0.2.0",
   "note": "Both copies of capabilityProblem must reproduce every `problem` string exactly. Python: scrapex/version.py. JavaScript: extension/version.js.",
@@ -7,8 +7,8 @@
     {
       "name": "in step — the engine deploys it and the extension is new enough",
       "key": "crawl_parallel_sources",
-      "extension_version": "0.4.4",
-      "engine_version": "0.4.4",
+      "extension_version": "0.4.5",
+      "engine_version": "0.4.5",
       "deployed": {
         "crawl_pace": {
           "since": "0.2.0",
@@ -50,7 +50,7 @@
       "name": "the extension is behind the engine",
       "key": "crawl_parallel_sources",
       "extension_version": "0.1.0",
-      "engine_version": "0.4.4",
+      "engine_version": "0.4.5",
       "deployed": {
         "crawl_pace": {
           "since": "0.2.0",
@@ -86,12 +86,12 @@
         }
       },
       "update_instructions": "Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards.",
-      "problem": "«Crawl several different sites at the same time. Two sources on the SAME site still take turns, so no site is asked for more than before.» needs ScrapeX extension 0.2.0; this extension is 0.1.0 and the engine is 0.4.4. Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards."
+      "problem": "«Crawl several different sites at the same time. Two sources on the SAME site still take turns, so no site is asked for more than before.» needs ScrapeX extension 0.2.0; this extension is 0.1.0 and the engine is 0.4.5. Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards."
     },
     {
       "name": "the engine is behind and says so",
       "key": "crawl_parallel_sources",
-      "extension_version": "0.4.4",
+      "extension_version": "0.4.5",
       "engine_version": "0.1.0",
       "deployed": {
         "crawl_pace": {
@@ -124,22 +124,22 @@
         }
       },
       "update_instructions": "Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards.",
-      "problem": "«crawl_parallel_sources» is not deployed by this ScrapeX engine (0.1.0); this extension is 0.4.4. Update the engine to 0.4.4 or newer."
+      "problem": "«crawl_parallel_sources» is not deployed by this ScrapeX engine (0.1.0); this extension is 0.4.5. Update the engine to 0.4.5 or newer."
     },
     {
       "name": "the engine is too old to say anything",
       "key": "crawl_parallel_sources",
-      "extension_version": "0.4.4",
+      "extension_version": "0.4.5",
       "engine_version": "0.1.0",
       "deployed": null,
       "update_instructions": "Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards.",
-      "problem": "«crawl_parallel_sources» cannot be confirmed: the ScrapeX engine reports version 0.1.0 and is too old to say which features it deploys. This extension is 0.4.4. Update the engine to 0.4.4."
+      "problem": "«crawl_parallel_sources» cannot be confirmed: the ScrapeX engine reports version 0.1.0 and is too old to say which features it deploys. This extension is 0.4.5. Update the engine to 0.4.5."
     },
     {
       "name": "an extension newer than the requirement is not refused for being newer",
       "key": "crawl_parallel_sources",
       "extension_version": "9.9.9",
-      "engine_version": "0.4.4",
+      "engine_version": "0.4.5",
       "deployed": {
         "crawl_pace": {
           "since": "0.2.0",

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2552,7 +2552,7 @@ dict whose insertion order is not the page's, because `read_profile` adds
 `organization_email` and `commercial_registration` after the info-box loop.
 `merge_locales` reads `english.labels[index]` and — since `R-51` — the Arabic value at
 the position `align_locales` works out
-([scrapex/extract/muqawil.py:1715](../scrapex/extract/muqawil.py#L1715)). Re-measured
+([scrapex/extract/muqawil.py:1749](../scrapex/extract/muqawil.py#L1749)). Re-measured
 against **those**:
 
 | pages | shape | the last label on each side | is the odd box at the END? |

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -150,7 +150,26 @@ this session's context nor this warehouse. Everything below is the whole handove
 > **`OP-99` is the honest remainder:** the price path still opens and closes its own
 > `crawl_run` inline in `ingest.py`, not through `runs.py`. Recorded, not slipped in.
 >
-> **Next in his order is step 5, then step 3** (`R-69`), then `R-68`'s reconciliation.
+> **STEP 5 IS BUILT IN THE PARSER** — `R-55`, absence rather than a placeholder. Two rules,
+> both re-measured on his warehouse on 2026-08-29 before a line was written:
+>
+> | field | the placeholder | measured now |
+> |---|---|---|
+> | `logo_url` (`contractors`) | the bare directory `.../companyLogo/`, no filename | **13,042 of 17,304 — 75.4%**, against 4,262 distinct real filenames. `default.jpg`, the string the document asks for, appears **zero** times |
+> | `latitude`/`longitude` (`contractor_profiles`) | the site's default pin `24.4493518, 46.6220053` | **14,621 of the 17,352 rows that carry a coordinate — 84.3%** |
+>
+> Nineteen guards, **four mutations, four killed** — including the OVER-correction, a
+> radius instead of the exact pair, which would eat the 30 rows on `(24.7135517, 46.6753)`
+> that are ordinary real data.
+>
+> **`R-45` IS UNTOUCHED and a guard proves it**: `read_coordinates` still reports the
+> default pin faithfully. What changed is only whether it is promoted to a column.
+>
+> **HIS EXISTING 27,663 ROWS STILL CARRY THE PLACEHOLDER**, and that is a separate
+> decision because it writes to his warehouse. The parser is honest from the next parse
+> onward; the stored rows are not. Measured cost of each route is in the pull request.
+>
+> **Next after this is step 3** (`R-69`), then `R-68`'s reconciliation.
 >
 > The root half, for the record — `R-54`, on his order 1 → 2 → 5 → 3 (`R-69`). A
 > confirming pass now moves the record's own `last_seen_at`, which is the field the state
@@ -1366,12 +1385,17 @@ measurement forced, and what it still cannot see.
 110 MB, does not carry the generic tables at all, and will mislead anyone who
 opens it looking for this data.
 
-**Not in, and named so it is not mistaken for done:** the detail files
-(coordinates, email, licences, interests) — a second crawl of ~22,000 requests ·
-the ~6,344 contractors the sweep counted and nothing has fetched · the
-compression migration DEC-9 asks for · the row-aware idempotency key DEC-10 asks
-for, without which a corrected parser cannot be re-run over stored snapshots at
-all.
+**Not in, and named so it is not mistaken for done:** the compression migration `DEC-9`
+asks for.
+
+> **THIS PARAGRAPH LISTED THREE MORE AND ALL THREE ARE DONE** — re-measured 2026-08-29
+> rather than re-read. The detail files were crawled (`profiles-2026-08-22`, 34,834
+> pages); the contractors the sweep counted were fetched, and the union is complete at
+> 17,452 with nothing left; and **`DEC-10`'s row-aware key IS built** — `_rows_unchanged`
+> asks `generic_record.content_hash` per row in `extract/service.py`, so a corrected
+> parser re-run over stored snapshots now writes, with revisions. That last one is not a
+> detail: it is what makes `R-55`'s repair a re-parse rather than an 11-hour re-crawl,
+> which is the whole reason `R-40` ordered it built BEFORE the profile crawl.
 
 **He ruled, and both flags are lit.** `FeatureKey.GENERIC_DATASET_CATALOG` and
 `FeatureKey.GENERIC_EXTRACTION` are `True` at

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "scrapex"
 # A MIRROR of scrapex/version.py:VERSION — setuptools cannot import the package
 # to ask. tests/test_version.py reads this line back and fails when they drift.
-version = "0.4.4"
+version = "0.4.5"
 description = "ScrapeX ecosystem: contract-driven web data collection into a SQLite warehouse. Categories: products, contractors"
 requires-python = ">=3.12"
 dependencies = [

--- a/scrapex/extract/muqawil.py
+++ b/scrapex/extract/muqawil.py
@@ -1201,6 +1201,44 @@ def read_profile(html: str, *, contractor_id: str | None = None) -> Reading:
                    latitude=latitude, longitude=longitude)
 
 
+
+#: THE SITE'S DEFAULT PIN, WHICH IS NOT A PLACE. Measured on his warehouse 2026-08-29:
+#: **14,621 of 17,352 profiles that carry a coordinate at all -- 84.3% -- publish this
+#: exact pair.** It is the centre of Riyadh, and it puts every contractor in Jizan and
+#: Tabuk on one point 1,000 km from where they are. `R-55`: a site-wide constant dressed
+#: as a per-record value is an ABSENCE.
+#:
+#: HARD-CODED, AND NOT "the most common pair". The next pair down has 30 rows
+#: (24.7135517, 46.6753) and is perfectly plausible as real data -- several contractors
+#: in one district. `R-55` draws that boundary itself: a value that DIFFERS between
+#: records is data, however strange it looks. A frequency heuristic would eventually eat
+#: a real address; a named constant can only ever be wrong about one pair, in public.
+#:
+#: Exact float equality is safe here and nowhere near a general rule: both sides are
+#: `float()` of the SAME decimal literal the page prints, so they are the same double.
+DEFAULT_MAP_PIN = (24.4493518, 46.6220053)
+
+
+def _is_placeholder_logo(source: str) -> bool:
+    """A URL that names no file is not a logo.
+
+    THE DOCUMENTED STRING IS NOT IN THE DATA, and this is the second time that shape has
+    cost something (`LESSONS` §7). `CONTRACTOR-SOURCE.md` asks for `default.jpg` to be
+    stored as NULL, and the site's own `onerror` really does name it -- but measured
+    across all 17,304 stored listing rows on 2026-08-29, `default.jpg` appears **zero**
+    times. The real placeholder is the bare directory
+    `https://muqawil.org/public/contractor/companyLogo/` on **13,042 of 17,304 rows
+    (75.4%)**, against 4,262 distinct real filenames.
+
+    So the rule is written against the shape rather than the string: a `src` that ends at
+    a directory separator has no filename, therefore no image. The `default.jpg` test
+    stays beside it because the page's `onerror` can still produce it and it costs one
+    comparison -- but it is second, and it is no longer the whole rule.
+    """
+    src = source.strip()
+    return not src or src.endswith(("/", "companies/default.jpg"))
+
+
 def read_listing(html: str) -> list[dict[str, str]]:
     """Every contractor a listing page names, with what the card publishes.
 
@@ -1223,11 +1261,7 @@ def read_listing(html: str) -> list[dict[str, str]]:
 
         logo = card.select_one("img.card-img")
         source = (logo.get("src") or "") if logo else ""
-        # THE PLACEHOLDER IS NOT A LOGO. The site's own `onerror` names
-        # `default.jpg`; a card already showing it has no logo, and storing the
-        # placeholder URL would make every logo-less contractor look like one
-        # that has a picture nobody can tell apart from the others.
-        row["logo_url"] = "" if source.endswith("companies/default.jpg") else source
+        row["logo_url"] = "" if _is_placeholder_logo(source) else source
 
         rater = card.select_one(".rater")
         row["customer_rating_score"] = (rater.get("data-rate-value") or "") if rater else ""
@@ -1762,7 +1796,16 @@ def merge_locales(english: Reading, arabic: Reading) -> dict[str, str]:
     # coordinate says "this contractor never placed a pin"; a zero says "this contractor
     # is in the Gulf of Guinea", and a table whose purpose is to be believed cannot say
     # the second.
-    if english.latitude is not None and english.latitude and english.longitude:
+    #
+    # AND THE DEFAULT PIN IS THE SAME THING ONE SCALE LARGER. The zero above was two
+    # pages; `DEFAULT_MAP_PIN` is 14,621 of them, all claiming the centre of Riyadh. The
+    # reasoning is not "this looks wrong" -- it is that a value the site emits IDENTICALLY
+    # for 84.3% of contractors carries no information about any of them, so recording it
+    # is claiming knowledge we never had. `R-45` is untouched: we still never edit what
+    # the site published about a contractor, and `read_coordinates` still reports the pair
+    # faithfully. Refusing to promote it to a coordinate column is not a correction.
+    if (english.latitude is not None and english.latitude and english.longitude
+            and (english.latitude, english.longitude) != DEFAULT_MAP_PIN):
         merged["latitude"] = str(english.latitude)
         merged["longitude"] = str(english.longitude)
     return merged

--- a/scrapex/version.py
+++ b/scrapex/version.py
@@ -73,7 +73,7 @@ from enum import StrEnum
 # The release stamp. Bump it for a functional, architectural or behavioural
 # change (issue 32 section 1.1), and regenerate the baseline + CHANGELOG in the
 # same commit: python -m scrapex.cli export-version
-VERSION = "0.4.4"
+VERSION = "0.4.5"
 
 
 class Surface(StrEnum):

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -393,7 +393,7 @@ PINNED = (
     # AND IT DRIFTED AGAIN BEFORE THE INK WAS DRY, thirteen lines, from correcting
     # the module header above it in the same commit -- which is the whole argument
     # for pinning it rather than trusting a number in prose.
-    ("docs/BACKLOG.md", "scrapex/extract/muqawil.py", 1715,
+    ("docs/BACKLOG.md", "scrapex/extract/muqawil.py", 1749,
      "arabic_value = arabic.values[lined_up.arabic_of[index]]"),
     # EVERY `extract/service.py` CITATION IN THE GUARDED DOCUMENTS, pinned together on
     # 2026-08-29 after nine of them drifted at once and NOTHING here noticed.

--- a/tests/test_the_sites_own_gaps_do_not_become_false_facts.py
+++ b/tests/test_the_sites_own_gaps_do_not_become_false_facts.py
@@ -22,10 +22,13 @@ from pathlib import Path
 import pytest
 
 from scrapex.extract.muqawil import (
+    DEFAULT_MAP_PIN,
     PROFILE_FIELDS,
+    _is_placeholder_logo,
     _slug,
     merge_locales,
     read_coordinates,
+    read_listing,
     read_profile,
 )
 
@@ -180,3 +183,99 @@ def test_the_declared_english_labels_still_map_where_they_did():
     assert PROFILE_FIELDS["Organization Email"] == "organization_email"
     assert PROFILE_FIELDS["Member Since"] == "member_since"
     assert PROFILE_FIELDS["Address"] == "address"
+
+
+# ---- R-55 · the two placeholders that are not values --------------------------
+
+LAT, LNG = DEFAULT_MAP_PIN
+BARE_DIRECTORY = "https://muqawil.org/public/contractor/companyLogo/"
+
+
+def _pinned(lat: float, lng: float) -> str:
+    return f"<html><script>var latlang = {{ lat: {lat!r}, lng: {lng!r} }};</script></html>"
+
+
+def test_the_site_wide_default_pin_is_not_promoted_to_a_coordinate_column():
+    """MEASURED ON HIS WAREHOUSE 2026-08-29: **14,621 of the 17,352 profiles that carry a
+    coordinate at all -- 84.3% -- publish this one pair.** It is the centre of Riyadh, so
+    the column places every contractor in Jizan and Tabuk on a point about 1,000 km from
+    where they are. A value the site emits identically for six contractors in seven says
+    nothing about any of them."""
+    english = read_profile(_pinned(LAT, LNG))
+
+    merged = merge_locales(english, english)
+
+    assert "latitude" not in merged
+    assert "longitude" not in merged
+
+
+def test_the_reader_still_reports_the_default_pin_faithfully():
+    """`R-45` IS NOT OVERRIDDEN, and this is where that is proved rather than asserted.
+    The page says this pair and `read_coordinates` still says it back. What changes is
+    only whether we promote it to a column -- refusing to claim knowledge is not editing
+    what the site published."""
+    assert read_coordinates(_pinned(LAT, LNG)) == (LAT, LNG)
+
+
+def test_a_pair_that_merely_resembles_the_default_pin_is_still_stored():
+    """THE CONSTANT IS EXACT, NOT FUZZY, and the next pair down in the data is why: 30
+    rows share `(24.7135517, 46.6753)`, which is a perfectly ordinary thing for several
+    contractors in one district to do. `R-55` draws the boundary itself -- a value that
+    DIFFERS between records is data, however strange it looks -- so a radius or a
+    frequency threshold would eventually eat a real address."""
+    english = read_profile(_pinned(LAT + 0.0000001, LNG))
+
+    merged = merge_locales(english, english)
+
+    assert merged["latitude"].startswith("24.449351")
+    assert merged["longitude"] == str(LNG)
+
+
+def test_half_the_default_pin_is_not_the_default_pin():
+    """A contractor genuinely on the default LATITUDE with their own longitude keeps
+    both. Only the pair is the placeholder."""
+    english = read_profile(_pinned(LAT, 39.1434676))
+
+    merged = merge_locales(english, english)
+
+    assert merged["longitude"] == "39.1434676"
+
+
+def test_a_logo_url_that_names_no_file_is_not_a_logo():
+    """THE DOCUMENTED STRING IS NOT IN THE DATA. `CONTRACTOR-SOURCE.md` asks for
+    `default.jpg` to be stored as NULL; measured across all 17,304 stored listing rows on
+    2026-08-29, `default.jpg` appears **zero** times, while the bare directory appears on
+    **13,042 (75.4%)**. A guard written against the documented string would never once
+    fire -- `LESSONS` \u00a77."""
+    assert _is_placeholder_logo(BARE_DIRECTORY) is True
+    assert _is_placeholder_logo("") is True
+    assert _is_placeholder_logo("   ") is True
+    # kept because the page's own `onerror` still names it, not because it was measured
+    assert _is_placeholder_logo(
+        "https://muqawil.org/public_assets/img/companies/default.jpg") is True
+    assert _is_placeholder_logo(BARE_DIRECTORY + "CompanyLogo-1710325829_x.jpg") is False
+
+
+def test_the_bare_directory_is_emptied_through_the_real_card_shape():
+    """BUILT FROM A REAL CARD, with only the `src` substituted. The fixture's four cards
+    all carry genuine filenames, so the placeholder has to be introduced -- and doing it
+    by editing one attribute of real HTML is the difference between testing the parser
+    and testing a hand-written string that no longer resembles the page."""
+    html = (FIXTURES / "listing-en.html").read_text(encoding="utf-8")
+    real = read_listing(html)[0]["logo_url"]
+    assert real.startswith(BARE_DIRECTORY) and real != BARE_DIRECTORY
+
+    swapped = html.replace(f'src="{real}"', f'src="{BARE_DIRECTORY}"', 1)
+
+    assert read_listing(swapped)[0]["logo_url"] == ""
+
+
+def test_the_fix_does_not_delete_the_logos_that_exist():
+    """Or it would be a feature that empties a column. All four fixture cards publish a
+    real filename and all four must survive -- the 4,262 distinct real values on his
+    warehouse are what this is protecting."""
+    rows = read_listing((FIXTURES / "listing-en.html").read_text(encoding="utf-8"))
+
+    assert len(rows) == 4
+    assert all(r["logo_url"].startswith(BARE_DIRECTORY) for r in rows)
+    assert all(r["logo_url"] != BARE_DIRECTORY for r in rows)


### PR DESCRIPTION
Step 5 of `R-69`'s order, executing [`R-55`](../blob/main/docs/RULINGS.md): two fields
store a value the site emits for *everyone*, so the column reports coverage it does not
have. Both were **re-measured on his warehouse on 2026-08-29 before a line was written**,
and both matched the ruling.

| field | the placeholder | measured now |
|---|---|---|
| `logo_url` (`contractors`) | the bare directory `.../companyLogo/` — no filename | **13,042 of 17,304 — 75.4%**, against 4,262 distinct real filenames |
| `latitude`/`longitude` (`contractor_profiles`) | the site's default pin `24.4493518, 46.6220053` | **14,621 of the 17,352 rows carrying a coordinate — 84.3%** |

Coverage becomes an honest **24.6%** on the logo and **15.7%** on coordinates, against
100% and 99.8%.

## The rule is written against the shape, because the documented string is not in the data

`CONTRACTOR-SOURCE.md` asks for `default.jpg` to be stored as NULL, and the site's own
`onerror` really does name it. Measured across all 17,304 stored listing rows:
**`default.jpg` appears zero times.** A guard written against the documented string would
never once fire — `LESSONS` §7, the same shape as everything else in that section.

So `_is_placeholder_logo` asks whether the URL names a file at all. The `default.jpg` test
stays beside it because the page's `onerror` can still produce it and it costs one
comparison — but it is second now, and it is no longer the whole rule.

## The coordinate constant is exact, and that is deliberate

`DEFAULT_MAP_PIN` is hard-coded, not "the most common pair". The next pair down has **30
rows** — `(24.7135517, 46.6753)` — and is perfectly ordinary for several contractors in one
district. `R-55` draws that boundary itself: *a value that differs between records is data,
however strange it looks.* A radius or a frequency threshold would eventually eat a real
address; a named constant can only ever be wrong about one pair, in public.

**`R-45` is not overridden, and a guard proves it rather than asserting it.**
`read_coordinates` still reports the default pin faithfully — `test_the_reader_still_
reports_the_default_pin_faithfully`. What changed is only whether it is promoted to a
column. Refusing to claim knowledge we never had is not a correction of the site.

## Verification

Both run modes from a purged tree (`LESSONS` §24). Nineteen guards in
`tests/test_the_sites_own_gaps_do_not_become_false_facts.py` — the file that already owns
this subject. **Four mutations, four killed**, each naming its expected test:

| mutation | test that went red |
|---|---|
| only the DOCUMENTED string is a placeholder (the defect as it shipped) | `..._bare_directory_is_emptied_through_the_real_card_shape` |
| the default pin promoted like any pair | `..._site_wide_default_pin_is_not_promoted_to_a_coordinate_column` |
| **a radius instead of the exact pair** — the over-correction | `..._pair_that_merely_resembles_the_default_pin_is_still_stored` |
| empty the whole logo column | `..._fix_does_not_delete_the_logos_that_exist` |

The third is the one worth having: it fails only if the fix starts eating real data, which
is the failure mode a placeholder rule actually has.

**The placeholder card is built from a real card**, with only `src` substituted — the
fixture's four cards all carry genuine filenames, and editing one attribute of real HTML is
the difference between testing the parser and testing a hand-written string that no longer
resembles the page.

## And a stale paragraph in `STATE.md`, corrected by measurement

It listed three things as "not in, and named so it is not mistaken for done" and **all three
are done**. The one that matters: **`DEC-10`'s row-aware idempotency key IS built** —
`_rows_unchanged` asks `generic_record.content_hash` per row — so a corrected parser re-run
over stored snapshots now writes, with revisions. That is what makes this ruling's repair a
**re-parse rather than an 11-hour re-crawl**, which is exactly why `R-40` ordered it built
BEFORE the profile crawl.

## What this does NOT do

**His 27,663 stored rows still carry the placeholder.** The parser is honest from the next
parse onward; the stored data is not, and changing it writes to his warehouse. He was given
three routes with their measured costs and chose the re-parse — 53 ms/page on profiles and
103 ms/page on listings, measured on his own stored pages, across six run refs. It runs
after this is on `main`, per `R-64`'s reasoning: his warehouse is never moved by code that
is not merged.

`VERSION` → **0.4.5**, with `pyproject.toml` and the three generated ledger files. No new
capability: this is an internal correctness fix. `R-69` still reserves `0.5.0`.

One pinned citation was repointed — `muqawil.py:1715` → `:1749` — where inserting the
helper moved its subject, label and link anchor both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
