### PR TITLE
The panel called a backup failed 94 seconds before it finished (OP-100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ work predates this file, the commit that built it — evidence read out of
 record of what was done; this file answers a narrower question: which version
 has it.
 
-## 0.4.5
+## 0.4.6
 
 Minimum supported extension: `0.2.2`.
 

--- a/contracts/capability-baseline.json
+++ b/contracts/capability-baseline.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.5",
+  "version": "0.4.6",
   "minimum_extension_version": "0.2.2",
   "capabilities": {
     "crawl_pace": "0.2.0",

--- a/contracts/contract-baseline.json
+++ b/contracts/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.5",
+  "version": "0.4.6",
   "schema": [
     "0002_the_price_source_key_is_named_for_what_it_is.sql",
     "0003_a_source_says_how_deep_its_crawl_goes.sql",

--- a/contracts/version-vectors.json
+++ b/contracts/version-vectors.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.5",
+  "version": "0.4.6",
   "minimum_extension_version": "0.2.2",
   "capability_reporting_since": "0.2.0",
   "note": "Both copies of capabilityProblem must reproduce every `problem` string exactly. Python: scrapex/version.py. JavaScript: extension/version.js.",
@@ -7,8 +7,8 @@
     {
       "name": "in step — the engine deploys it and the extension is new enough",
       "key": "crawl_parallel_sources",
-      "extension_version": "0.4.5",
-      "engine_version": "0.4.5",
+      "extension_version": "0.4.6",
+      "engine_version": "0.4.6",
       "deployed": {
         "crawl_pace": {
           "since": "0.2.0",
@@ -50,7 +50,7 @@
       "name": "the extension is behind the engine",
       "key": "crawl_parallel_sources",
       "extension_version": "0.1.0",
-      "engine_version": "0.4.5",
+      "engine_version": "0.4.6",
       "deployed": {
         "crawl_pace": {
           "since": "0.2.0",
@@ -86,12 +86,12 @@
         }
       },
       "update_instructions": "Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards.",
-      "problem": "«Crawl several different sites at the same time. Two sources on the SAME site still take turns, so no site is asked for more than before.» needs ScrapeX extension 0.2.0; this extension is 0.1.0 and the engine is 0.4.5. Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards."
+      "problem": "«Crawl several different sites at the same time. Two sources on the SAME site still take turns, so no site is asked for more than before.» needs ScrapeX extension 0.2.0; this extension is 0.1.0 and the engine is 0.4.6. Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards."
     },
     {
       "name": "the engine is behind and says so",
       "key": "crawl_parallel_sources",
-      "extension_version": "0.4.5",
+      "extension_version": "0.4.6",
       "engine_version": "0.1.0",
       "deployed": {
         "crawl_pace": {
@@ -124,22 +124,22 @@
         }
       },
       "update_instructions": "Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards.",
-      "problem": "«crawl_parallel_sources» is not deployed by this ScrapeX engine (0.1.0); this extension is 0.4.5. Update the engine to 0.4.5 or newer."
+      "problem": "«crawl_parallel_sources» is not deployed by this ScrapeX engine (0.1.0); this extension is 0.4.6. Update the engine to 0.4.6 or newer."
     },
     {
       "name": "the engine is too old to say anything",
       "key": "crawl_parallel_sources",
-      "extension_version": "0.4.5",
+      "extension_version": "0.4.6",
       "engine_version": "0.1.0",
       "deployed": null,
       "update_instructions": "Update the engine first (it carries the new extension with it), then open chrome://extensions, turn on Developer mode and press Reload on ScrapeX. Close and reopen the side panel afterwards.",
-      "problem": "«crawl_parallel_sources» cannot be confirmed: the ScrapeX engine reports version 0.1.0 and is too old to say which features it deploys. This extension is 0.4.5. Update the engine to 0.4.5."
+      "problem": "«crawl_parallel_sources» cannot be confirmed: the ScrapeX engine reports version 0.1.0 and is too old to say which features it deploys. This extension is 0.4.6. Update the engine to 0.4.6."
     },
     {
       "name": "an extension newer than the requirement is not refused for being newer",
       "key": "crawl_parallel_sources",
       "extension_version": "9.9.9",
-      "engine_version": "0.4.5",
+      "engine_version": "0.4.6",
       "deployed": {
         "crawl_pace": {
           "since": "0.2.0",

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3468,6 +3468,105 @@ one lifecycle is what `R-72` is about, and the second copy is the one that decid
 behind it and no test that currently fails, so it is recorded rather than slipped into a
 pull request about something else.
 
+### OP-100 · "Back up to Drive" reported failure on a backup that had succeeded
+
+**Found 2026-08-29, by him, pressing the button.** The panel said *"The request exceeded
+its 10000 ms deadline."* The backup had worked.
+
+`POST /api/bundle` matched no rule in `LOCAL_POLICIES`, so it fell through to the default
+for a mutation — [extension/startup.js:14](../extension/startup.js#L14), `localMutation:
+10000`. The route answers only when the whole job is finished: it copies the warehouse,
+exports every dataset, hashes each file, zips the lot and hashes that before writing a
+first byte. A deadline that bounds time-to-first-byte therefore bounds the entire build.
+
+**Measured on his disk the same hour**, from the artefacts the run left behind:
+
+| | |
+|---|---|
+| warehouse | **1,490 MB** |
+| build phase (start → `panel.jsonl.gz` written) | **71 s** |
+| pack (→ archive closed) | **104 s** total |
+| archive produced | **372.6 MB** |
+| budget it was given | **10 s** |
+
+**The engine finished. Only the panel gave up.** The archive was closed 94 seconds after
+the abort, complete, and the staging tree was removed — so the route reached its `finally`.
+Aborting a `fetch` cancels nothing on the far side of it.
+
+**What the bundle actually is**, read from the archive's own index rather than by
+extracting it: `warehouse.db` is **93.6%** of the 1,592 MB packed (360 of 372.6 MB
+compressed). The 72 export files are 97.7 MB, 6.1%. So build time tracks warehouse size,
+and the exports are noise — which is why the 2026-08-12 sizing note below no longer
+predicts anything.
+
+**A correction to that note, and it matters for how this entry is read.** The
+*Measured: what a backup bundle actually weighs* note records "22.4s to build" at a 113.6 MB
+database. Putting that beside the 10 s bound shows the route was already over budget on the
+day it was measured — **but that is this session's inference, not something the note
+reported.** It is a sizing measurement about why the bundle is zipped; it never mentions a
+deadline, and nothing was watching the two numbers together. Its baseline is also stale:
+113.6 MB then, 1,490 MB now, **13× in 17 days**.
+
+**Three consequences outlived the deadline itself**, all now fixed:
+
+* **The double click.** The panel re-enables its button the moment a request fails
+  (`extension/app.js:6092`), so a failure at ten seconds invited a second click while the
+  first build was still packing — two warehouse copies, two staging trees, and `_newest`
+  free to hand the panel an archive from one build beside the manifest of the other.
+* **Nothing pruned local bundles, ever.** 372.6 MB per successful backup, kept for good.
+  Only Drive was pruned (`extension/drive.js:65`, `KEEP = 3`).
+* **A killed engine leaks its staging tree.** The `rmtree` is in a `finally`
+  ([scrapex/webui/app.py:3038](../scrapex/webui/app.py#L3038)), so a process that dies
+  skips it and leaves the bundle expanded — 1.5 GB. This, not a second build, is what
+  actually survives a crash: the build is a thread inside the engine and cannot outlive it.
+
+**Fixed here** under [R-76](RULINGS.md#r-76--the-backup-deadline-is-raised-from-a-measurement-and-the-rebuild-that-would-end-it-is-deferred):
+`bundleBuild: 600000` ([extension/startup.js:33](../extension/startup.js#L33)) with a rule
+that deliberately excludes the two streaming sub-paths
+([extension/startup.js:52](../extension/startup.js#L52)); a non-blocking
+`threading.Lock` ([scrapex/webui/app.py:2915](../scrapex/webui/app.py#L2915)) refusing a
+concurrent build with the house 409; `BUNDLE_KEEP = 2`
+([scrapex/webui/app.py:2896](../scrapex/webui/app.py#L2896)) pruning **by stamp** so the
+two files of one backup cannot be split; and an age-guarded sweep
+([scrapex/webui/app.py:2952](../scrapex/webui/app.py#L2952)) for orphaned staging.
+
+**Residual, named rather than closed.** The lock is in-process, which is correct here —
+`start_engine` refuses to spawn a second engine on a held port
+([scrapex/native.py:297](../scrapex/native.py#L297)), and a crashed build leaves no
+survivor to race. An engine started by hand on another port would share the folder and
+defeat it; that is why the sweep keeps a 6-hour age guard
+([scrapex/webui/app.py:2903](../scrapex/webui/app.py#L2903)) rather than deleting any
+staging tree it finds.
+
+**Two things this measurement exposed that belong to other tracks.**
+
+1. **Disk.** 7.9 GB free while a build needs ~3 GB of transient peak. Bounded retention was
+   housekeeping when it was written and is closer to urgent now.
+2. **The retention gap is already recorded — this only prices it.** It is
+   [docs/plans/2026-08-21-the-platform-not-a-price-tracker.md:159](plans/2026-08-21-the-platform-not-a-price-tracker.md#L159)
+   §4, out of `R-32`, and `CLAUDE.md` states it in its opening. **Nothing new is claimed
+   here.** What is new is the SHARE, measured 2026-08-29: `generic_page_snapshot` is
+   **932.9 MB** of row payload, **75.8%** of the database, against **25.6 MB / 2.1%** for
+   `price_observation` — the only table `retention.py` and `compaction.py` touch. The
+   exports moved 90.2 MB → 97.7 MB across the same 17 days in which the database went 13×,
+   because the contractor datasets export **0.00 MB**.
+
+   **A DISAGREEMENT WITH THE PLAN'S ORDERING, not a correction of it — the plan is his and
+   so is the order.** §4 puts retention last on the grounds that it *"can wait, because
+   nothing is deleting contractor rows today"*. That is true, and it is about deletion. The
+   share adds a second cost the ordering could not have weighed: retention is now also why a
+   backup takes 104 seconds, through a chain nobody had traced — the bundle is 93.6% the
+   database, and the database is three-quarters the one table nothing tends. Recorded under
+   `C5` for him to re-rank or not.
+
+   **Why the number is here and not in the plan.** That plan is listed under `## Historical`
+   (`docs/plans/README.md:83`), and historical records are kept verbatim because *"a plan
+   edited after the fact stops being evidence of what was decided when"*
+   (`docs/plans/README.md:9`) — §4's own table is stamped *"measured 2026-08-21"*, which a
+   2026-08-29 row would falsify. **The rule is not that every plan is frozen:** one under
+   `## Current` is a live document and `C2` makes a stale one a bug to fix. This one is
+   Historical, which is what settles it.
+
 ### DEC-1 · Topology A — the TypeScript extension as the public product
 **Approved 2026-07-18. Zero commits since.** This is the largest gap between what was
 decided and what exists.

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -3166,3 +3166,39 @@ their fixture had registered the site from a slightly different URL. A crawl dec
 source it does not know; it does not re-assert the identity of one somebody already
 registered. The corrected shape asks first (`runs.open_run`, catching `UnknownSource`) and
 registers only on the way through.
+
+## 27 · A table of deadlines cannot report the route it stopped covering, and a cancelled fetch cancels nothing
+
+**2026-08-29, `OP-100`.** `POST /api/bundle` matched no rule in `LOCAL_POLICIES`, so it took
+the fall-through default `localMutation: 10000` for a job measured at **104 seconds**. Three
+properties made this invisible, and each is the general lesson.
+
+**1 · A plausible default is worse than no default.** Ten seconds is a *reasonable* number
+for a mutation, so nothing looked wrong at the point of failure or in review. A table like
+this has no moment at which it says "a route has outgrown me" — the fall-through is silent
+by construction. The existing test had a case for **every rule in the table and none for a
+path that matched no rule**, which is precisely the shape of the hole. A guard on a policy
+table must name the routes it does *not* cover, or it only tests the rules that already work.
+
+**2 · The bound was time-to-first-byte, and nobody had asked which routes that flatters.**
+`fetchWithDeadline` clears its timer in a `finally` the moment `fetch` resolves — and `fetch`
+resolves on **headers**, not on the body. For a streaming route that makes the number a
+connect bound and the body unbounded. For a route that does all its work before replying, the
+same number bounds the entire job. One constant, two completely different meanings, decided
+by whether the handler streams. That is why the fix's rule deliberately excludes
+`/api/bundle/archive` and `/api/bundle/panel-pack`: widening it to the shared prefix would
+have removed a real guard from two fast routes while repairing one slow one.
+
+**3 · Aborting a `fetch` cancels the client's wait, not the server's work.** The archive was
+closed **94 seconds after** the panel gave up, complete, and the staging tree was removed —
+the route ran to its `finally`. So the failure the owner saw was a *lie about a success*, and
+the button he pressed again started a **second** full build beside the first. When a timeout
+fires on a mutation, ask what the far side is still doing; the answer is usually "all of it".
+
+**And the arithmetic that was sitting in this repository the whole time.**
+`docs/BACKLOG.md`'s 2026-08-12 sizing note recorded *"22.4s to build"* while
+`extension/startup.js` granted 10 s. Both numbers were correct, both were committed, and
+**neither document was about the other** — one was measuring why a bundle is zipped, the
+other bounding a request. No guard compares a documented duration against a coded timeout,
+and none is proposed here; what is worth keeping is that the evidence for a defect can be
+fully present in the repository, in two files, and still be nobody's finding.

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -2421,7 +2421,7 @@ reason is four links long, every one measured on the live engine rather than arg
 | link | evidence |
 |---|---|
 | 1 | the panel's crawl action sends `POST /api/jobs` with `source_keys` — `extension/app.js:4064` |
-| 2 | that route validates the key against `app.state.manifest` — `scrapex/webui/app.py:3392-3396`, whose own comment reads *"fail before queueing, not mid-crawl"* (re-derived at `72ca371`: `GET /api/dry/{source_key}` was inserted above it in #274 and moved it 43 lines. The quoted comment, not the number, is what made it findable) |
+| 2 | that route validates the key against `app.state.manifest` — `scrapex/webui/app.py:3513-3517`, whose own comment reads *"fail before queueing, not mid-crawl"* (re-derived twice by the quoted comment rather than the number: `GET /api/dry/{source_key}` moved it 43 lines in #274, and the bundle-build lock moved it again here. It was 27 lines stale before that second move — Tier 1 only asks that a cited line exist, and a stale line that is not blank still exists) |
 | 3 | the manifest is `sources.yaml` — **12 price sources, and neither `muqawil` nor `contractors` is in it.** muqawil lives in `site_profile`, not `source_site` |
 | 4 | `scrapex/jobs.py`, which is what the button drives, contains **zero** references to `muqawil`, `generic_record`, `partitioncrawl`, `snapshotcrawl`, `contractors` or `dataset` |
 

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -3232,3 +3232,43 @@ load-bearing rather than stylistic. A listing sweep stores no profile page, so
 `MAX(run_id)` for the source would call every profile row `absent` the moment a listing
 crawl finished — while the site still lists every one of them. `runs.latest_run_for` asks
 for the newest run among the snapshots this dataset's records actually point at.
+
+### R-76 · The backup deadline is raised from a measurement, and the rebuild that would end it is deferred
+
+**2026-08-29 · the panel/engine seam · `OP-100`**
+
+He pressed "Back up to Drive", was told the request had exceeded a 10-second deadline, and
+asked for the problem to be analysed. Shown the cause and three options, he chose **(b) and
+(c) now** and **deferred (a)**:
+
+| option | his call |
+|---|---|
+| **(a)** make the build asynchronous — `POST` returns at once, the panel polls for progress | **deferred** — named as the real fix, not done here |
+| **(b)** a named deadline policy for `POST /api/bundle` | **now** |
+| **(c)** a lock against concurrent builds, bounded local retention, orphan-staging sweep | **now** |
+
+**THE DEFERRAL IS THE HALF THAT HAD TO BE WRITTEN DOWN** (`C4`, `C5`). A raised deadline on
+a still-synchronous route reads like a solved problem, and the next session that finds a
+named `bundleBuild` policy will assume it was sized correctly. It was sized from a
+measurement **and that measurement expires**:
+
+* 104 s measured at a 1,490 MB warehouse, 2026-08-29. `600000` is **5.8×** that, covering a
+  warehouse near 8.5 GB — more than the machine has free, so the disk runs out before the
+  deadline does.
+* The warehouse grew **13× in 17 days**. Whatever number is chosen, the growth curve eats
+  it; (b) is a stopgap with a computable shelf life, not a fix.
+* **WHAT (b) ACTUALLY BUYS, said plainly: a false failure is replaced by a long silence.**
+  The route yields no bytes until it is finished, so the panel can now sit blocked for ten
+  minutes showing no progress. That is strictly better than telling him a backup failed
+  when it succeeded — he can at least trust the answer — and it is not a good screen. This
+  is the sharpest argument for (a): only an asynchronous build can report progress at all.
+
+**Why (b) was still worth doing today rather than waiting for (a).** The panel was reporting
+failure on a backup that had completed — the archive was closed 94 seconds after the abort,
+whole. An owner who is told his backup failed has no way to know he has one, and the honest
+reading of that screen is "ScrapeX cannot back up", which is false.
+
+**The bound is deliberately narrow.** `/api/bundle/archive` and `/api/bundle/panel-pack`
+stream a `FileResponse` whose headers arrive at once, so their existing 5-second bound is a
+real guard on a fast route. The rule is written `(?:\?|$)` rather than the usual
+`(?:[/?]|$)` precisely so the fix cannot take a guard off two routes while repairing one.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,18 +1,17 @@
 # State — where the work stands
 
-**Last updated: 2026-08-23.** `main` is at `759a9df` (#264). #246 through #264 are
-all merged — **eighteen merges** landed after this line last said `afb8648` (#244),
-across two days, and the count here was measured with
-`git log --oneline afb8648..origin/main` rather than carried. **And this conflict is
+**Last updated: 2026-08-29.** `main` is at `ef86a19` (#287). **Twenty-three merges**
+landed after this line last said `759a9df` (#264), and the count was measured with
+`git log --oneline 759a9df..origin/main` rather than carried. **And this conflict is
 the argument itself:** resolving it, one side said `f1844af` (#261) with "fifteen"
 and the other `d10e974` (#258) with "thirteen", and both were already wrong before
 either could be read. A commit pointer written into prose is stale by the time it is
 read: `git log --oneline -1 origin/main` is the answer that cannot be — **and this
-very line has now proved it seven times across two days**, reading `4615a14` with
-#251 and #252 already in, then `5f63bb0` with #254 in, then `451468d` with #255 in,
-then `31c369e` with #258 in, then `f1844af`, then `467a3ac` with #265 in, and now
-this. Each correction is the argument for the sentence rather than a counter-example
-to it.
+very line has now proved it eight times**, reading `4615a14` with #251 and #252
+already in, then `5f63bb0` with #254 in, then `451468d` with #255 in, then
+`31c369e` with #258 in, then `f1844af`, then `467a3ac` with #265 in, then `759a9df`
+with #287 in, and now this. Each correction is the argument for the sentence rather
+than a counter-example to it.
 
 **THE ENGINE ON GITHUB IS `engine-v0.3.0`, AND IT WAS CUT TODAY.** He asked for it
 directly — *«اقطع الوسم»* — after reading the finding that the panel was offering
@@ -424,6 +423,44 @@ tracks *his requests* through Captured → Ruled → Planned → In flight → D
 ---
 
 ## Open pull requests
+
+### The backup that said it failed — 2026-08-29 · branch `claude/request-deadline-exceeded-3b1cad`, no PR yet
+
+**`OP-100`, ruled the same day as
+[R-76](RULINGS.md#r-76--the-backup-deadline-is-raised-from-a-measurement-and-the-rebuild-that-would-end-it-is-deferred).
+Based on `main` at `ef86a19`.** Secondary session; `recursing-shannon-068e63` merges
+([R-42](RULINGS.md#r-42--one-primary-session-merges-every-other-session-is-secondary-and-asks)).
+
+He pressed "Back up to Drive" and was told *"The request exceeded its 10000 ms deadline."*
+**The backup had succeeded** — the archive was closed 94 seconds after the panel gave up,
+and the engine cleaned its staging tree. `POST /api/bundle` matched no rule in
+`LOCAL_POLICIES` and fell through to `localMutation: 10000`, while the route builds, packs
+and hashes 1,490 MB before it writes a first byte.
+
+**Built here — (b) and (c) of the three he was offered:**
+
+| | |
+|---|---|
+| `bundleBuild: 600000`, derived from 104 s measured at 1,490 MB | `extension/startup.js:33` |
+| a rule that does **not** re-time `/api/bundle/archive` or `/api/bundle/panel-pack` | `extension/startup.js:52` |
+| non-blocking `threading.Lock`, house 409 | `scrapex/webui/app.py:2915` |
+| `BUNDLE_KEEP = 2`, pruned **by stamp** so a backup's two files cannot be split | `scrapex/webui/app.py:2896` |
+| age-guarded sweep of staging left by a killed engine | `scrapex/webui/app.py:2952` |
+
+**Deferred, and this is the load-bearing half:** (a), making the build asynchronous with
+progress polling. `R-76` records why the raise has a shelf life — the warehouse grew **13×
+in 17 days**, and no fixed number survives that.
+
+**Tests.** `extension/tests/startup.test.mjs` gains the two cases the table never had — the
+build's own rule, and the negative one proving the two streaming sub-paths keep their fast
+bound. Seven cases in `tests/test_the_engine_hands_the_bundle_over.py` cover the lock,
+pruning and the sweep; all four were mutation-checked (break the guard, watch the test go
+red) rather than merely written.
+
+**Two citations were repaired on the way past**, both exposed rather than caused by the
+insertions: the pinned `scrapex/webui/app.py:3022` in `tests/test_the_documents_cite_what_they_claim.py`,
+and `docs/REQUESTS.md`'s jobs-route citation, which was **already 27 lines stale** —
+Tier 1 only asks that a cited line exist, and a stale line that is not blank still exists.
 
 ### The supabase appearance — 2026-08-28 · branch `feat/the-supabase-appearance-is-a-design-system`, no PR yet
 

--- a/extension/startup.js
+++ b/extension/startup.js
@@ -14,6 +14,23 @@ export const STARTUP_DEADLINES = Object.freeze({
   localMutation: 10000,
   engineRepair: 15000,
   localGeneric: 5000,
+  // THE ONLY DEADLINE HERE DERIVED FROM A MEASUREMENT INSTEAD OF CHOSEN, because
+  // POST /api/bundle does not stream. The engine copies the warehouse, exports
+  // every dataset, hashes each file, zips the lot and hashes that -- all before
+  // it writes a first byte -- so this bound is the WHOLE JOB, not the time to
+  // answer. Every other rule below bounds a reply that starts arriving at once.
+  //
+  // MEASURED on the owner's machine 2026-08-29: warehouse 1,490 MB, build 71 s,
+  // pack 33 s, 104 s in total, archive 372.6 MB. It was running under
+  // `localMutation: 10000`, so the panel reported failure on a backup that had
+  // SUCCEEDED -- the engine finished 94 seconds after the panel gave up, because
+  // aborting a fetch cancels nothing on the far side of it.
+  //
+  // 600000 is 5.8x that measurement and covers a warehouse near 8.5 GB, more than
+  // this machine has free -- so the disk runs out before the deadline does. THAT
+  // DERIVATION IS ALSO ITS EXPIRY DATE: the warehouse grew 13x in 17 days, and the
+  // real fix is to stop making a browser wait for a synchronous build (R-76).
+  bundleBuild: 600000,
 });
 
 // A new Side Panel document can exist before Chrome considers it active enough
@@ -28,6 +45,11 @@ const LOCAL_POLICIES = [
   [/^\/api\/(?:appearance|timezone)(?:[/?]|$)/, STARTUP_DEADLINES.preferences],
   [/^\/api\/(?:engine\/restart|databases\/upgrade)(?:[/?]|$)/,
     STARTUP_DEADLINES.engineRepair],
+  // `(?:\?|$)` and NOT `(?:[/?]|$)` like every other rule, which is the whole
+  // point of writing it out: /api/bundle/archive and /api/bundle/panel-pack are
+  // FileResponse streams whose headers arrive immediately, and they must keep the
+  // fast generic bound. Only the build is slow, so only the build is matched.
+  [/^\/api\/bundle(?:\?|$)/, STARTUP_DEADLINES.bundleBuild],
   [/^\/api\/(?:sources|outputs|jobs|resolve|records|changes|schedules|storage|settings|fields|rates)(?:[/?]|$)/,
     STARTUP_DEADLINES.destinationData],
 ];

--- a/extension/tests/startup.test.mjs
+++ b/extension/tests/startup.test.mjs
@@ -31,6 +31,47 @@ test("local endpoints receive purpose-specific deadlines", () => {
                STARTUP_DEADLINES.localMutation);
   assert.equal(deadlineForLocalRequest("/api/engine/restart", "POST"),
                STARTUP_DEADLINES.engineRepair);
+  assert.equal(deadlineForLocalRequest("/api/bundle", "POST"),
+               STARTUP_DEADLINES.bundleBuild);
+});
+
+// WHAT WAS MISSING HERE ON 2026-08-29, and the shape of the hole is the lesson.
+// The case above had a row for every rule in the table and none for a path that
+// matched no rule at all -- so `POST /api/bundle` collected `localMutation:
+// 10000` for a job that takes 104 seconds on the owner's warehouse, and the
+// panel told him a backup had FAILED while the engine went on to finish it. The
+// abort cancelled nothing: the archive was closed 94 seconds later, complete.
+//
+// The fall-through is a plausible number for a mutation, which is exactly why
+// nothing went red. A table like this cannot announce that it has stopped
+// covering a route; only a case naming the route can.
+test("the bundle build is bounded by the job, and its sub-paths are not", () => {
+  assert.equal(deadlineForLocalRequest("/api/bundle", "POST"),
+               STARTUP_DEADLINES.bundleBuild);
+  assert.equal(deadlineForLocalRequest("/api/bundle?force=1", "POST"),
+               STARTUP_DEADLINES.bundleBuild);
+
+  // THE OVER-MATCH, which is the way this fix could have made things worse.
+  // Both of these stream a FileResponse whose headers arrive at once, so the
+  // deadline they carry is a real guard on a fast route. Writing the rule with
+  // `(?:\?|$)` instead of the usual `(?:[/?]|$)` is what keeps them out of it.
+  assert.equal(deadlineForLocalRequest("/api/bundle/archive"),
+               STARTUP_DEADLINES.localGeneric);
+  assert.equal(deadlineForLocalRequest("/api/bundle/panel-pack"),
+               STARTUP_DEADLINES.localGeneric);
+  assert.notEqual(STARTUP_DEADLINES.bundleBuild, STARTUP_DEADLINES.localMutation);
+});
+
+// A floor, not an equality: the number is expected to be revisited, and what is
+// worth refusing is a revision that puts it back under the job it bounds. The
+// ceiling is here because a bound this long is a STOPGAP -- the panel shows no
+// progress for its whole duration, and R-76 records that the real fix is to stop
+// making a browser wait on a synchronous build at all.
+test("the bundle deadline still clears the measurement it was derived from", () => {
+  assert.ok(STARTUP_DEADLINES.bundleBuild >= 300000,
+            `bundleBuild is ${STARTUP_DEADLINES.bundleBuild} ms; the build was ` +
+            "measured at 104000 ms on 2026-08-29 with a 1,490 MB warehouse");
+  assert.ok(STARTUP_DEADLINES.bundleBuild <= 900000);
 });
 
 test("a nonresponsive request ends at its declared deadline", async () => {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "scrapex"
 # A MIRROR of scrapex/version.py:VERSION — setuptools cannot import the package
 # to ask. tests/test_version.py reads this line back and fails when they drift.
-version = "0.4.5"
+version = "0.4.6"
 description = "ScrapeX ecosystem: contract-driven web data collection into a SQLite warehouse. Categories: products, contractors"
 requires-python = ">=3.12"
 dependencies = [

--- a/scrapex/version.py
+++ b/scrapex/version.py
@@ -73,7 +73,7 @@ from enum import StrEnum
 # The release stamp. Bump it for a functional, architectural or behavioural
 # change (issue 32 section 1.1), and regenerate the baseline + CHANGELOG in the
 # same commit: python -m scrapex.cli export-version
-VERSION = "0.4.5"
+VERSION = "0.4.6"
 
 
 class Surface(StrEnum):

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -2888,6 +2888,35 @@ def create_app(
     #: backup share a stamp and sort together.
     PANEL_SUFFIX = "-panel.jsonl.gz"
 
+    #: How many built bundles stay on disk. NOTHING pruned these before
+    #: 2026-08-29 and each one is now 372.6 MB, so they accumulated for as long
+    #: as the feature has existed. Two, not one: `/api/bundle/archive` serves the
+    #: newest, and the predecessor survives so that rebuilding while the previous
+    #: upload is still running does not delete the file that upload was named for.
+    BUNDLE_KEEP = 2
+
+    #: A staging directory younger than this may belong to a build still running,
+    #: so the sweep leaves it alone. `start_engine` (scrapex/native.py) refuses to
+    #: spawn a second engine on a held port, so within one port there is never a
+    #: second builder -- but an engine started by hand elsewhere would share this
+    #: folder, and deleting a live foreign build is worse than the leak it fixes.
+    STAGING_ORPHAN_AGE_S = 6 * 3600
+
+    #: Serialises the build. The panel re-enables its button the moment a request
+    #: fails, so the 10-second deadline that used to fire mid-build invited a
+    #: second click while the first was still packing -- two copies of the
+    #: warehouse, two staging trees, and `_newest` free to hand the panel an
+    #: archive from one build while it holds the manifest of the other.
+    #:
+    #: IN-PROCESS ON PURPOSE, and per app rather than per module so tests do not
+    #: share one. A build is a thread inside this process; it cannot outlive a
+    #: crash, so there is never a survivor to lock against. An on-disk lock would
+    #: only add a stale one to clear.
+    _bundle_build_lock = threading.Lock()
+
+    #: `%Y%m%d-%H%M%S`, the stamp both files of a backup share.
+    _BUNDLE_STAMP = re.compile(rf"^{re.escape(BUNDLE_PREFIX)}(\d{{8}}-\d{{6}})")
+
     def _bundle_folder(conn) -> Path:
         return backup_folder(conn, app.state.db_path)
 
@@ -2895,6 +2924,49 @@ def create_app(
         made = sorted(folder.glob(f"{BUNDLE_PREFIX}*{suffix}"),
                       key=lambda p: p.stat().st_mtime, reverse=True)
         return made[0] if made else None
+
+    def _prune_old_bundles(folder: Path, keep: int = BUNDLE_KEEP) -> None:
+        """Keep the newest `keep` backups; delete every file of the older ones.
+
+        BY STAMP RATHER THAN BY MTIME, because the two files of one backup do not
+        share an mtime: `shutil.copy2` gives the panel pack the timestamp of the
+        staged file it was copied from, minutes before the archive beside it is
+        closed. Pruning each suffix on its own could therefore keep an archive
+        from one build and a panel pack from another, and the panel uploads the
+        pair as though they described the same warehouse.
+        """
+        stamps: dict[str, list[Path]] = {}
+        for path in folder.glob(f"{BUNDLE_PREFIX}*"):
+            found = _BUNDLE_STAMP.match(path.name)
+            if path.is_file() and found:
+                stamps.setdefault(found.group(1), []).append(path)
+        for stamp in sorted(stamps, reverse=True)[keep:]:
+            for path in stamps[stamp]:
+                try:
+                    path.unlink()
+                except OSError:
+                    # Windows refuses to unlink a file another process holds
+                    # open. Housekeeping must never fail a backup that worked.
+                    pass
+
+    def _sweep_orphan_staging(folder: Path) -> None:
+        """Remove staging trees left by a build that never reached its `finally`.
+
+        The rmtree below runs in a `finally`, so an engine killed mid-build skips
+        it and leaves the bundle expanded on disk -- a second full copy of the
+        warehouse, 1.5 GB on the owner's machine. That is what actually survives
+        a crash here; the build itself cannot.
+        """
+        cutoff = time.time() - STAGING_ORPHAN_AGE_S
+        for path in folder.glob(f"{BUNDLE_PREFIX}*"):
+            if not path.is_dir() or not _BUNDLE_STAMP.match(path.name):
+                continue
+            try:
+                if path.stat().st_mtime > cutoff:
+                    continue
+            except OSError:
+                continue
+            shutil.rmtree(path, ignore_errors=True)
 
     @app.post("/api/bundle")
     def api_bundle_build():
@@ -2904,12 +2976,30 @@ def create_app(
         promise that what the panel is about to upload reads back correctly.
         The alternative — pack now, check later — is how `latest.json` ends up
         naming an archive nobody can open.
+
+        ONE AT A TIME. This route answers only when the whole job is done -- it
+        does not stream, so on the owner's warehouse the panel waits 104 seconds
+        for a first byte. Anything that makes him press the button twice used to
+        start a second build over the top of the first.
         """
+        if not _bundle_build_lock.acquire(blocking=False):
+            raise HTTPException(status_code=409, detail=(
+                "a backup is already being built — try again shortly"))
+        try:
+            return _build_one_bundle()
+        finally:
+            _bundle_build_lock.release()
+
+    def _build_one_bundle() -> dict:
         conn = read_conn()
         try:
             folder = _bundle_folder(conn)
         finally:
             conn.close()
+
+        # Under the lock, so the only staging trees old enough to match are the
+        # ones no build in this process is using.
+        _sweep_orphan_staging(folder)
 
         stamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
         staging = folder / f"{BUNDLE_PREFIX}{stamp}"
@@ -2946,6 +3036,10 @@ def create_app(
             # The staging directory is the bundle expanded; once packed it is a
             # second full copy of the warehouse sitting on the owner's disk.
             shutil.rmtree(staging, ignore_errors=True)
+
+        # AFTER the build succeeded, never before: a build that fails must not
+        # take the last archive that worked with it.
+        _prune_old_bundles(folder)
 
         return {
             "name": archive.name,

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -284,7 +284,7 @@ PINNED = (
     # 404 for anything else" -- and only reading the enclosing function separates
     # them. A delta applied to the old number would have picked the right line here
     # by luck and the wrong one the first time the two moved apart.
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 3022, "if source_key not in known:"),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 3115, "if source_key not in known:"),
     ("docs/BACKLOG.md", "scrapex/webui/app.py", 1204,
      "A GENERIC DATASET IS A TABLE LIKE ANY OTHER TABLE"),
     # OP-44 · the dataset card that said "no successful crawl yet" over 17,304

--- a/tests/test_the_engine_hands_the_bundle_over.py
+++ b/tests/test_the_engine_hands_the_bundle_over.py
@@ -305,3 +305,174 @@ def test_the_row_ceiling_is_the_same_number_in_all_three_places():
     assert panel_limit, "MAX_EXPORT_ROWS is gone from extension/sheets.js"
     assert int(route_limit.group(1).replace("_", "")) == engine_default
     assert int(panel_limit.group(1).replace("_", "")) == engine_default
+
+
+# ---- one build at a time, and no rubbish left behind -------------------------
+#
+# ALL OF THIS IS ABOUT A ROUTE THAT ANSWERS ONLY WHEN IT IS FINISHED. On the
+# owner's warehouse the build takes 104 seconds, the panel used to abort at ten
+# and re-enable its button, and nothing stopped the next click from starting a
+# second build over the top of the first. The deadline is fixed in
+# extension/startup.js; these are the consequences that outlived it.
+
+
+def _fake_backup(folder, stamp: str, *, staging: bool = False):
+    """A backup that some earlier build left in the folder."""
+    if staging:
+        made = folder / f"scrapex-bundle-{stamp}"
+        made.mkdir()
+        (made / "warehouse.db").write_bytes(b"not really")
+        return made
+    archive = folder / f"scrapex-bundle-{stamp}.zip"
+    archive.write_bytes(b"not really a zip")
+    (folder / f"scrapex-bundle-{stamp}-panel.jsonl.gz").write_bytes(b"not really gzip")
+    return archive
+
+
+def test_a_second_build_is_refused_while_the_first_is_still_running(client, monkeypatch):
+    """THE DOUBLE CLICK. Two builds share a folder, a stamp format and `_newest`,
+    so the second does not merely waste 104 seconds of disk — it can leave the
+    panel holding the manifest of one build and the archive of the other."""
+    import threading
+
+    import scrapex.webui.app as module
+
+    connected, _ = client
+    real = module.bundle.build
+    inside, may_finish = threading.Event(), threading.Event()
+
+    def slow_build(db_path, staging, **kw):
+        inside.set()
+        may_finish.wait(timeout=10)
+        return real(db_path, staging, **kw)
+
+    monkeypatch.setattr(module.bundle, "build", slow_build)
+
+    first: dict = {}
+    worker = threading.Thread(
+        target=lambda: first.update(status=connected.post("/api/bundle").status_code))
+    worker.start()
+    try:
+        assert inside.wait(timeout=10), "the first build never started"
+        refused = connected.post("/api/bundle")
+    finally:
+        may_finish.set()
+        worker.join(timeout=30)
+
+    assert refused.status_code == 409, refused.text
+    assert "already being built" in refused.json()["detail"]
+    assert first["status"] == 200, "refusing the second must not disturb the first"
+
+
+def test_the_lock_is_released_when_a_build_fails(client, monkeypatch):
+    """A refusal that outlives its cause is worse than the collision it prevents:
+    every later backup would answer 409 until the engine was restarted."""
+    import scrapex.webui.app as module
+
+    connected, _ = client
+
+    def broken_build(*a, **kw):
+        raise ValueError("nope")
+
+    monkeypatch.setattr(module.bundle, "build", broken_build)
+    assert connected.post("/api/bundle").status_code == 400
+
+    monkeypatch.undo()
+    assert connected.post("/api/bundle").status_code == 200, (
+        "the lock was not released after a failed build")
+
+
+def test_only_the_newest_backups_survive_a_build(client):
+    """NOTHING PRUNED THESE UNTIL 2026-08-29. The archive is 372.6 MB on the
+    owner's machine and every successful backup left one behind for good."""
+    connected, backups = client
+    for stamp in ("20260101-000000", "20260102-000000", "20260103-000000"):
+        _fake_backup(backups, stamp)
+
+    connected.post("/api/bundle")
+
+    stamps = sorted({p.name[len("scrapex-bundle-"):][:15]
+                     for p in backups.glob("scrapex-bundle-*") if p.is_file()})
+    assert len(stamps) == module_keep(), stamps
+    assert "20260101-000000" not in stamps, "the oldest should have gone first"
+    assert "20260103-000000" in stamps, "the newest predecessor should survive"
+
+
+def module_keep() -> int:
+    """`BUNDLE_KEEP` is a closure inside `create_app`, so it is read from source
+    rather than imported — the alternative is hard-coding 2 in this file and
+    having the test disagree silently with the code the day it changes."""
+    import re
+    from pathlib import Path
+    source = (Path(__file__).resolve().parents[1] / "scrapex" / "webui" / "app.py")
+    found = re.search(r"^\s*BUNDLE_KEEP = (\d+)", source.read_text(encoding="utf-8"),
+                      re.MULTILINE)
+    assert found, "BUNDLE_KEEP is no longer in scrapex/webui/app.py"
+    return int(found.group(1))
+
+
+def test_both_files_of_a_backup_are_pruned_together(client):
+    """The two files of one backup do NOT share an mtime — `shutil.copy2` gives
+    the panel pack the timestamp of the staged file it came from, minutes before
+    the archive beside it is closed. Pruning each suffix independently could keep
+    an archive from one build and a pack from another, and the panel uploads the
+    pair as one description of one warehouse."""
+    connected, backups = client
+    for stamp in ("20260101-000000", "20260102-000000", "20260103-000000"):
+        _fake_backup(backups, stamp)
+
+    connected.post("/api/bundle")
+
+    for path in backups.glob("scrapex-bundle-*.zip"):
+        stamp = path.name[len("scrapex-bundle-"):][:15]
+        assert (backups / f"scrapex-bundle-{stamp}-panel.jsonl.gz").is_file(), (
+            f"{path.name} survived without its panel pack")
+
+
+def test_a_staging_tree_left_by_a_killed_engine_is_swept(client):
+    """WHAT ACTUALLY SURVIVES A CRASH. The build itself cannot — it is a thread
+    inside the engine — but the staging directory it was writing does, because
+    the `rmtree` that removes it runs in a `finally` the process never reached.
+    That tree is the bundle expanded: 1.5 GB on the owner's machine."""
+    import os
+    import time
+
+    connected, backups = client
+    orphan = _fake_backup(backups, "20260101-000000", staging=True)
+    old = time.time() - (7 * 3600)
+    os.utime(orphan, (old, old))
+
+    connected.post("/api/bundle")
+
+    assert not orphan.exists(), "the orphaned staging tree was left on disk"
+
+
+def test_a_staging_tree_that_may_still_be_in_use_is_left_alone(client):
+    """The age guard. `start_engine` refuses to spawn a second engine on a held
+    port (scrapex/native.py), so within one port there is never a second builder
+    — but an engine started by hand elsewhere would share this folder, and
+    deleting a live foreign build is a worse failure than the leak it fixes."""
+    connected, backups = client
+    fresh = _fake_backup(backups, "20260101-000000", staging=True)
+
+    connected.post("/api/bundle")
+
+    assert fresh.is_dir(), "a staging tree young enough to be live was deleted"
+
+
+def test_a_failed_build_does_not_take_the_last_good_archive_with_it(client, monkeypatch):
+    """Pruning runs only after a build that verified and packed. A build that
+    dies must not be able to delete the backup the owner still has."""
+    import scrapex.webui.app as module
+
+    connected, backups = client
+    for stamp in ("20260101-000000", "20260102-000000", "20260103-000000"):
+        _fake_backup(backups, stamp)
+
+    monkeypatch.setattr(module.bundle, "build",
+                        lambda *a, **kw: (_ for _ in ()).throw(ValueError("nope")))
+    assert connected.post("/api/bundle").status_code == 400
+
+    survived = {p.name[len("scrapex-bundle-"):][:15]
+                for p in backups.glob("scrapex-bundle-*.zip")}
+    assert survived == {"20260101-000000", "20260102-000000", "20260103-000000"}


### PR DESCRIPTION

`POST /api/bundle` matched no rule in `LOCAL_POLICIES`, so it fell through to
`localMutation: 10000`. The route builds, verifies, packs and hashes the whole
warehouse before writing a first byte, and the deadline bounds time-to-first-
byte -- so ten seconds bounded a job measured at 104 on the owner's machine.

The backup had SUCCEEDED. The archive was closed 94 seconds after the panel
aborted, complete, and the staging tree was removed, so the route reached its
`finally`. Aborting a fetch cancels nothing on the far side.

(b) `bundleBuild: 600000`, derived rather than chosen: 104 s measured at a
1,490 MB warehouse, 5.8x headroom, covering ~8.5 GB -- more than the machine
has free, so the disk runs out before the deadline does. The rule is written
`(?:\?|$)` rather than the usual `(?:[/?]|$)` so it does NOT re-time
`/api/bundle/archive` or `/api/bundle/panel-pack`; both stream a FileResponse
whose headers arrive at once, and widening to the shared prefix would take a
real guard off two fast routes to repair one slow one.

(c) A non-blocking `threading.Lock` refusing a concurrent build with the house
409 -- the panel re-enables its button on failure, so the old deadline invited
a second build over the top of the first. `BUNDLE_KEEP = 2`, pruned BY STAMP
because `shutil.copy2` gives the panel pack the staged file's mtime and pruning
each suffix alone could keep an archive from one build beside a pack from
another. An age-guarded sweep for staging trees left by a killed engine, which
is what actually survives a crash: the build is a thread and cannot.

(a), the asynchronous rebuild, is deferred by him and recorded in R-76 with the
reason -- the raise has a computable shelf life, the warehouse grew 13x in 17
days, and what (b) buys is a false failure replaced by a long silence.

Measured from the finished archive's own zip index rather than by rebuilding it,
which would have cost ~3 GB of transient disk on a machine with 7.9 GB free:
the bundle is 93.6% `warehouse.db`, and the 72 exports are 6.1%.

Tests: two cases in extension/tests/startup.test.mjs against the real
`deadlineForLocalRequest`, including the negative one on the sub-paths; seven in
tests/test_the_engine_hands_the_bundle_over.py for the lock, pruning and sweep.
All four engine guards were mutation-checked. Two citations repaired -- the
pinned app.py:3022, and REQUESTS.md's jobs-route citation, already 27 lines
stale before this branch.

VERSION 0.4.5 -> 0.4.6 under R-06's per-PR cadence, NOT as a contract change:
the regenerated contract-baseline moves only its version stamp, leaving 15
migrations, 96 routes and protocol 1 untouched, so R-35's trigger did not fire.
The two rulings disagree about whether this commit needed a bump at all; he
chose to bump and the question is his to settle.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


---

Opened by the primary session on the owner's instruction: the authoring session (`eager-robinson-1d8a3a-e2`) had `gh pr create` refused by its own permission classifier and correctly declined to route around it. Branch, commits and verification are entirely its work.
