### PR TITLE
R-74 holds in the built product and is guarded by almost nothing (REQ-49)

### DIFF
--- a/design/tokens.css
+++ b/design/tokens.css
@@ -53,8 +53,14 @@
   --surface-subtle: #f6f6f6;  /* --muted */
   --surface-raised: #ffffff;  /* --popover */
   --line: #e9e9e9;            /* --border */
-  /* Their --border-stronger is #cecece, which is 1.57:1 on their own --card
-     where the panel guard needs 3:1. Derived to clear it: 3.23:1. */
+  /* Their --border-stronger is an alpha overlay, so it has no single value: it
+     composites to #cecece over --background and #d0d0d0 over --card. The 1.57:1
+     recorded here was the --background composite measured against --card, so the
+     plate and the value did not match; on its own plate it is 1.574:1. Both are
+     under the panel guard's 3:1, so the substitution stands and only the
+     arithmetic behind it was wrong. What replaces it is not derived: #8f8f8f is
+     Supabase's own gray-light-900 (hsl 0 0% 56.1%, in their build css source),
+     and it clears the floor at 3.23:1. PUBLISHED. */
   --line-strong: #8f8f8f;
   --text: #030303;            /* --foreground */
   --muted: #464646;           /* --muted-foreground */
@@ -74,8 +80,16 @@
   --accent-contrast: #030303;
   --accent-weak: #d3f8e4;     /* brand-200 light       PUBLISHED */
   /* Their --warning is oklch(0.68 0.14 75) = #ca8a10, which is 2.68:1 on their
-     own published warning-300 tint below where the guard needs 4.5:1. Their hue
-     and chroma held, lightness moved to 0.52: 5.14:1. */
+     own published warning-300 tint below where the guard needs 4.5:1, so it had
+     to move. WHAT MOVED IS NOT WHAT THIS COMMENT USED TO SAY. The target
+     oklch(0.52 0.14 75) does not exist in sRGB -- maximum in-gamut chroma at that
+     lightness and hue is 0.1097, so it sat 27.6% past the boundary -- and the
+     value below is a naive per-channel clip of it. Measured back out of the hex:
+     LIGHTNESS held (0.5218), chroma fell 16.7%, and hue moved 75 -> 65.53
+     degrees. So the shipped warning sits 9.5 degrees off Supabase's warning hue.
+     It clears the guard at 5.14:1, and it is not the colour the old comment
+     described. The gamut-mapped value that would hold hue 75 is #8d5e00;
+     switching to it is the owner's call and until he rules this stands. */
   --amber: #965900;
   --amber-weak: #fff4d5;      /* warning-300 light     PUBLISHED */
   --red: #ab413e;             /* --destructive light   derived */
@@ -144,8 +158,13 @@
   /* Elevation — and Supabase's position on it is "almost none". They define ZERO
      shadow tokens: depth is a surface-colour ladder plus a 1px border, their
      Dialog is `border shadow-md dark:shadow-xs` so the border is unconditional
-     and the shadow is what gets dropped, `shadow-none` appears in more of their
-     files than `shadow-md`, and even their box-shadow utilities draw a 1px line
+     and the shadow is what gets dropped. (An earlier line here claimed
+     `shadow-none` appears in more of their files than `shadow-md`. Measured over
+     packages/ui and packages/ui-patterns it is the other way round: shadow-none
+     in 7 files / 13 uses, shadow-md in 11 files / 13 uses. The position is still
+     "almost none" -- they author ZERO shadow tokens, which is the part that
+     matters -- but the count said something untrue.) Even their box-shadow
+     utilities draw a 1px line
      at zero blur. So these are deliberately flat, and flatter again in the dark
      blocks below. OP-95: --shadow-lg's colour was a literal while its two
      siblings derived from --shadow-color, so no appearance could re-tone it;
@@ -178,10 +197,18 @@
   --font-mono: "Source Code Pro", ui-monospace, "Cascadia Code", Consolas,
     monospace;
   /* Their scale is shifted about 2px down from stock Tailwind, under their own
-     comment "font sizing and weights optimized for Inter". Measured against the
-     ramp this file already had, SEVEN of the eight steps agreed already --
-     12/13/16/18/22/28 are identical. The one real move is the body size:
-     their text-base is 15px where --fs was 14px. */
+     comment "font sizing and weights optimized for Inter". The VALUES below match
+     theirs exactly from 13px up -- 13/15/16/18/22/28 -- and the one real move was
+     the body size: their text-base is 15px where --fs was 14px.
+     THE NAMES DO NOT MATCH, AND THAT IS A TRAP FOR ANY PORT. This ramp carries an
+     `md` step Tailwind has no name for, so from --fs-md upward every rung sits one
+     place BELOW theirs: --fs-md 16px is their --text-lg, --fs-lg 18px is their
+     --text-xl, --fs-xl 22px is their --text-2xl. Porting one of their class names
+     onto the same-sounding token here silently resizes the text. Do not renumber
+     to fix it -- these names are load-bearing across 19 stylesheets.
+     One thing of theirs this ramp does not have: they reset the whole scale to
+     stock Tailwind inside code/pre/kbd/.font-mono, so their mono context runs a
+     different size ramp AND a different normal weight (400, not 450). */
   --fs-2xs: 0.6875rem;
   --fs-xs: 0.75rem;
   --fs-sm: 0.8125rem;
@@ -190,10 +217,16 @@
   --fs-lg: 1.125rem;
   --fs-xl: 1.375rem;
   --fs-2xl: 1.75rem;
-  /* --font-weight-normal is 450, not 400, and there is NO BOLD anywhere in their
-     system: `strong` is downgraded to 500 and the ceiling is Manrope 600 on
-     headings. So --fw-heavy drops 700 -> 600 -- deliberately removing a weight
-     rather than adding one, which is why --fw-bold and --fw-heavy now agree. */
+  /* --font-weight-normal is 450, not 400, and their COMPONENT LIBRARY carries no
+     bold at all: packages/ui and packages/ui-patterns measure 0 font-bold and 0
+     font-extrabold, `strong` is downgraded to 500, and the ceiling is Manrope 600
+     on headings. So --fw-heavy drops 700 -> 600 -- deliberately removing a weight
+     rather than adding one, which is why --fw-bold and --fw-heavy now agree.
+     BE PRECISE ABOUT THE SCOPE. An earlier version of this comment said there is
+     no bold ANYWHERE in their system, and that is false of their repository: the
+     docs chrome and the imported shadcn demos carry 11 font-bold and 2
+     font-extrabold. The claim holds for the library these components come from,
+     which is what this ramp copies, and it holds nowhere wider. */
   --fw-regular: 450;
   --fw-medium: 500;
   --fw-bold: 600;
@@ -202,9 +235,16 @@
   --lh: 1.5;
   --lh-relaxed: 1.65;
 
-  /* Motion and layering — Supabase's vocabulary is 100/150/200/250/300ms and
-     exactly TWO curves, chosen by meaning rather than by size: one for things
-     that APPEAR and one for things that TRAVEL. */
+  /* Motion and layering. THE DURATIONS BELOW ARE NOT THEIR RAMP, and an earlier
+     version of this comment said they were. Measured over packages/ui and
+     packages/ui-patterns their ramp is 75/100/150/200/300/400/500/700/1000ms,
+     dominated by 200 (14 uses) and 100 (6). `duration-250` is used ZERO times,
+     and 200 -- their de-facto control transition -- has no token here at all.
+     THE TWO CURVES ARE OURS, NOT THEIRS. Neither cubic-bezier below appears
+     anywhere in their source; their components use Tailwind stock easing. Pairing
+     the curves by meaning -- one for things that APPEAR, one for things that
+     TRAVEL -- is this repository's own idea and worth keeping, but it is an
+     addition on top of the baseline, not a transcription of it. */
   --dur-fast: 0.1s;
   --dur: 0.15s;
   --dur-slow: 0.25s;
@@ -401,9 +441,18 @@
  * WHY THE NEUTRALS ARE SPELLED AGAIN HERE. A custom property cannot be mixed
  * against its own cascaded value -- `--bg: color-mix(..., var(--bg)))` is a
  * cycle and computes to nothing -- so the base has to be named literally at the
- * point of the mix. `tests/test_vendor.py` asserts these bases match the `:root`
- * and dark-block values they are copies of, which is what stops them drifting
- * apart the way the old ones silently had.
+ * point of the mix.
+ *
+ * NOTHING GUARDS THESE BASES, AND ONE HAS ALREADY DRIFTED. An earlier version of
+ * this comment said `tests/test_vendor.py` asserts the bases match the `:root`
+ * and dark-block values they copy. It does not: the named test checks that nine
+ * token NAMES appear in this block and that the strings `light-dark(` and
+ * `color-mix(in srgb, var(--accent)` are present, and it compares no literal at
+ * all -- grep the whole test suite for any of these hexes and it returns nothing.
+ * Measured 2026-08-29: the light `--control-hover` base here is #f3f3f3, which is
+ * `--chip`, while `:root` declares `--control-hover: var(--surface-subtle)` =
+ * #f6f6f6. The dark base still agrees. So the drift this comment claimed to
+ * prevent is present in the file the comment is written in.
  */
 :root[data-color-mode="device"] {
   --bg: light-dark(

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1933,7 +1933,7 @@ fire after a regression has been written:
   `.workspace-menu-button` in `webui.css`, which is how the third row of the table above
   was found. That is exactly the rule `docs/LESSONS.md` now states in prose (*"The
   extension's layers are three tokens …; a fourth number invented at a call site is the
-  next instance of this bug"*, [docs/LESSONS.md:831](LESSONS.md#L831)) and nothing
+  next instance of this bug"*, [docs/LESSONS.md:840](LESSONS.md#L840)) and nothing
   enforces. It is also cheap: the three substitutions below are the whole of today's
   violation set, so the guard goes green the moment they land.
 * **Behavioural, for `.modal-veil`:** open the confirmation and hit-test a point over the
@@ -3398,7 +3398,8 @@ zero remain.
 
 A design system a rule does not consume is decoration: `--radius` moving from 9px to 6px
 changes nothing at a rule that spells `border-radius: 9px` by hand. Every such site was
-counted across the 9 non-generated stylesheets and split by what it would take to fix:
+counted across **9 of the 19** authored stylesheets — see the correction at the end of this
+entry — and split by what it would take to fix:
 
 | bucket | count | verdict |
 |---|---|---|
@@ -3416,6 +3417,20 @@ reason written at the value.
 **Not urgent.** Buckets B and C are cosmetic drift, not breakage, and closing either is a
 decision about the scale rather than a fix. Registered so the next session does not
 re-measure it.
+
+**RE-MEASURED 2026-08-29 BY [REQ-49](REQUESTS.md#req-49--review-the-design-system-against-supabases),
+AND THE SCOPE WAS HALF THE FILES.** This entry says "the 9 non-generated stylesheets".
+**There are 19.** The ten `scrapex/webui/static/pages/*.css` were never opened — they were
+added five weeks before this entry was measured. A like-for-like bucket-A census over all
+19 finds **140 exact-duplicate sites: 47 in the nine originally scanned, and 93 (66%) in
+the ten that were not** — data-workspace 37, schedules 29, datasets 11, settings 11.
+
+**140 and this entry's 138 are different quantities, not a restatement.** The 138 above is
+B+C, the buckets deliberately left. The 140 is bucket A, the one this entry reports as
+swept. Do not read the near-match as agreement.
+
+The 47 reproduces exactly, so nothing here was wrong — it was scoped to a file list that
+had gone stale, which is the same failure the `9`-of-`19` phrasing made invisible.
 
 ---
 
@@ -3566,6 +3581,278 @@ staging tree it finds.
    2026-08-29 row would falsify. **The rule is not that every plan is frozen:** one under
    `## Current` is a live document and `C2` makes a stale one a bug to fix. This one is
    Historical, which is what settles it.
+### OP-101 · "Device colours" paints Supabase's own accent in dark mode
+
+`design/tokens.css:302` wraps the device block in `@supports (color: AccentColor)`, which
+contributes **no specificity**. The selector is therefore `(0,2,0)` — identical to the two
+dark blocks that come *after* it and redeclare all seven of its properties. Source order
+decides and the dark blocks win, so a user on a dark OS who selects Device colours gets
+`#3ecf8e` for every accent, focus ring, button and switch track while the panel's status
+text reports the choice it is not painting. Measured in Chromium 149 by counterfactual —
+device-dark differs from supabase-dark in **9 of 36** theme properties against **24 of 36**
+in light.
+
+**One of the four colour choices `R-74` names by name, unreachable in half its states.**
+
+**THE FIX IS NOT FREE, AND THAT IS THE WHOLE DECISION.** Moving the seven declarations
+below the dark blocks costs zero tokens and no palette cells — and takes device-dark from
+0 of 17 to **5 of 17** failing contrast assertions, two of them worse than anything
+device-light shows, because `color-mix(in srgb, AccentColor 84%, var(--text))` mixes toward
+near-white in dark. The fix does not create the illegibility; it reveals it. So it lands
+with `OP-104`'s device coverage or not at all. Recorded as OD-04 in
+[REQ-49](REQUESTS.md#req-49--review-the-design-system-against-supabases).
+
+### OP-102 · `R-74` is enforced by one unasserted statement, and mutation proves it
+
+The allowlist loop at `design/appearance.js:347` is what makes *"a palette may change
+nothing but colour"* true at runtime. Its only guard is the substring assertion at
+`tests/test_vendor.py:289` — and `clearTheme` at `design/appearance.js:310` contains the
+same substring, so **the assertion is satisfied whether or not the loop in `apply()`
+exists.**
+
+Mutation testing on a byte-verified mirror, restored and `git status` asserted clean after
+each: replacing the loop with `Object.keys(theme).forEach` put `--fs`, `--font-body` and
+`--lh` into a palette; a second mutation put **11 of the 13 forbidden families** into a
+surface stylesheet. **91 static guards and all 218 browser tests stayed green for both.**
+The architecture `R-74` abolished is reachable today and no gate would say a word.
+
+`--radius` and `--fw-regular` *are* pinned, at `tests/test_panel_dom.py:468` and `:471` —
+two values, hand-written, which is why the gap is 11 families and not 13.
+
+**Entangled with a false docstring.** `tests/test_a_palette_may_change_nothing_but_colour.py:10`
+justifies the shape rule by saying `themeFor` dashes every key into a custom property so a
+`radius` key becomes a real `--radius`. Measured false: `apply()` writes only the 36
+allowlisted names and drops the rest. The docstring argues from a mechanism the allowlist
+already prevents, and correcting it belongs in the same change as the guard.
+
+### OP-103 · Twelve declarations read custom properties that nothing declares
+
+Every one is invalid at computed-value time, none has a fallback, and none errors.
+
+- **`--sticky-tabs` — nine references, zero declarations.** All nine sit inside `calc()`,
+  so the whole declaration is dropped and `top` falls back to `auto`: **the settings
+  sidebar and the exports sidebar are `position: sticky` and never stick**, and two
+  data-workspace popovers lose their offset.
+- **`--control-active`** at `design/components.css:1530`. `background` is a shorthand, so
+  an invalid `var()` computes to `unset`: a pressed split-button option shows the
+  container's background while only its border darkens — a press that half-registers.
+  `docs/LESSONS.md` already proposes `var(--chip)`; whether it enters `THEME_PROPERTIES`
+  or stays a derived alias decides whether a palette can override it, and `R-59` decision 4
+  argues for the alias.
+- **`--fg`** in the extension, a typo for `--text`. `color` is inherited, so the hover and
+  focus rule resolves to the colour the base already inherits: the hover changes nothing
+  but the underline, and keyboard focus is that much weaker.
+- **`--green`** in the console. `border-inline-start-color` is not inherited, so a
+  completed build step loses its colour entirely.
+
+**Why no guard caught them.** `docs/LESSONS.md` cites
+`test_every_custom_property_a_stylesheet_reads_is_one_something_defines` as the guard for
+exactly this class. **That test has never existed** — a grep for the name returns the
+citation and nothing else. The near-miss is real: `tests/test_the_tests_name_tests_that_exist.py`
+guards backticked test names but reads only `tests/*.py`, and the citation guard reads
+`docs/` but checks only `file:line`. The claim fell in the seam between the two.
+
+### OP-104 · A palette can ship text at 1.00:1, and `device` is never measured at all
+
+Two holes in one guard, and `STATE.md` records the first half of it as already fixed.
+
+**The token pairs are still hand-written while the palette list is derived.** The
+parametrize takes its palettes from the registry — which is the fix that landed — but the
+pairs it asserts are a literal list of 12. Mutation: setting `brand`'s `chip`,
+`surfaceSubtle` and `surfaceRaised` each to that palette's own `--text` gives three
+text-bearing backgrounds at **exactly 1.00:1**, and 91 static guards plus all 218 browser
+tests pass. A quarter of what a palette controls carries text and is never read.
+
+**`device` has zero coverage in either scheme.** `_registered_palette_ids()` parses the
+`PALETTES` map, and `device` is removed as a palette entirely by `design/appearance.js`, so
+it can never appear in the parametrize; the fixture then hard-codes `deviceColors: false`.
+Structurally uncoverable, not merely uncovered. Run by hand, **device-light fails two of
+the seventeen assertions at 4.21:1**, on the primary button using the browser's own
+`AccentColor` — a value that varies per machine, which makes an unguarded state worse than
+an unguarded palette.
+
+Five pairs would close the first half — muted-on-chip, text-on-chip, text-on-surfaceSubtle,
+text-on-surfaceRaised, accentInk-on-accentWeak — taking 102 assertions to 132 using only
+existing tokens, so `THEME_PROPERTIES` stays at 36. Recorded as OD-03.
+
+**One reason for deferring this was measured and is false.** The fear was that an alpha or
+system colour would make the guard silently vacuous. It does not: Chromium returns the
+unresolved expression and the parser raises `ValueError`. It fails loudly.
+
+### OP-105 · The OS Increase-contrast setting reaches one of the four colour choices
+
+`design/tokens.css` implements `prefers-contrast: more` at specificity `(0,1,0)`. `apply()`
+writes the 36 theme properties as **inline style**, which outranks it. Measured under
+`page.emulate_media(contrast="more")` with `matchMedia` matching: the two palettes that
+declare a full colour set get nothing.
+
+Silent in both directions — the OS setting is on, the CSS rule is present, no test reads
+it, and a screenshot looks correct. **The accommodation works only for the colour choice
+that declares the fewest colours.**
+
+### OP-106 · An untyped `.banner` reads as a warning
+
+`design/components.css:365` paints `--amber-weak` as the **default**, with `.info`,
+`.promise` and `.danger` as modifiers. Supabase's untyped `Alert` is neutral and its
+`destructive` and `warning` are opt-ins.
+
+Five untyped sites ship. **Four of them are not warnings** — including a database-failure
+alert that is under-coloured by the same rule — and one is `design/gallery.html`'s own
+example, labelled "a statement of fact". The design system's documentation contradicts
+itself in a single viewport, which is how a wrong default gets copied.
+
+### OP-107 · Two guards that look like assertions and are gates
+
+**The sprite check is disabled by renaming a comment.** `tools/sync_design_assets.py`
+regenerates the gallery's sprite block only `if` the marker string is present. Tampering
+with the block is caught; tampering with the block **and** renaming the marker passes, and
+the tool then reports the catalogue current forever. `docs/UI-KIT.md` calls the gallery
+"the catalogue that cannot go stale".
+
+**A colour baked into a shipped SVG is invisible.** The colour-literal guard's suffix
+filter is `{".css", ".js", ".html"}` — no `.svg`. An edit made at `design/material-icons.svg`
+and synced to both copies, which is how anyone would actually introduce one, passes
+`test_vendor.py`, `test_design_system.py`, `test_ui_kit.py` and `sync --check`. Only an
+*inconsistent* edit is caught, and only by the byte-drift guard. An icon with a baked fill
+would ignore the palette in both schemes.
+
+**AND A THIRD, WHICH IS A BELIEF RATHER THAN A GUARD.** Added 2026-08-29 while #289 was in
+CI, because the belief was actively circulating between three sessions at the time.
+
+**The claim:** a branch that touches `design/` runs extra design workflows, so it gets
+**19** CI checks and reading 14 as settled is a false green.
+
+**Measured from `.github/workflows/`, not from a run: fourteen is the complete set, for
+every branch.** `ci.yml` declares five jobs — `lint`, `scope`, `test`, `migration-authority`,
+`contract-parity` — its trigger block is `on: push:` / `pull_request:` with **no `paths:`
+filter**, so it fires twice per pull request: 5 x 2 = 10. CodeQL adds three `Analyze` jobs
+plus its umbrella: 4. Total **14**, and `gh pr checks` on #289 returns exactly that shape.
+
+**There is no design workflow at all.** Grepping the directory for `design`, `tokens.css`,
+`components.css` or `gallery` returns three incidental hits — two comments, and
+`release-engine.yml` curling `/static/tokens.css` as a post-tag smoke check. The only real
+`paths:` filter in the whole directory is `publish-docs.yml` on `docs/privacy-policy.md` and
+`docs/support.md`.
+
+**AND THE BELIEF DID NOT REQUIRE A MISSING WORKFLOW — IT REQUIRED ONE THAT CANNOT EXIST.**
+`ci.yml:60-66` is not a note about the `scope` job; it is a general prohibition on
+conditional checks anywhere in this repository, with the failure mode written out:
+
+> *"A workflow- or job-level `paths:` filter makes the consuming job not exist, and a
+> required check that does not exist stays pending forever — the pull request can never
+> merge. A job that always runs, plus step-level `if:` on the expensive steps, leaves every
+> check reporting on every change, which is what branch protection needs."*
+
+A design-gated workflow is exactly the shape that comment forbids. So "19 on a design
+branch" was never merely unverified: it described an architecture this repository had
+already reasoned through and ruled out **in writing, with the reason attached** — and the
+belief grew anyway, in a repository whose first rule is that the repository is the memory.
+
+**`design/tokens.css` is covered anyway**, because `test` runs the whole suite and the
+`scope` job's rule is one-sided: `docs` requires that EVERY changed file be documentation,
+and a change to `design/`, `extension/` or `tests/` falls through to "run everything". So
+nothing is unguarded. **What is wrong is the belief, and its cost is symmetrical.** Someone
+waiting for 19 waits forever. Someone told "19" who sees 14 reads a complete run as partial
+and holds a mergeable pull request.
+
+**THE PROVENANCE, AND IT IS NOT HYPOTHETICAL.** The session holding the belief passed it to
+two other sessions in one afternoon and then built a CI monitor whose floor was
+`[ "$n" -ge 14 ]`. **Had that floor matched its author's own stated belief of 19, the monitor
+would have waited out its full hour on every design branch and reported `TIMED OUT` on a
+green pull request.** The tooling was correct only because it disagreed with the prose of the
+session that wrote it.
+
+**Why this belongs beside the other two in this entry.** All three are the same shape: a
+mechanism that reports something weaker than what a reader takes it to mean. The sprite check
+is a gate read as an assertion; the colour guard is a suffix list read as complete coverage;
+and a check count is a fixed property of the workflow files read as a property of the
+branch. `ci.yml:60-66` already anticipates the family — it explains that `scope` is a job
+output rather than a `paths:` filter precisely because *"a required check that does not exist
+stays pending forever — the pull request can never merge."* The architecture is deliberately
+fixed-count, which is what makes the 19 unsupportable rather than merely unverified.
+
+**Nothing to fix in CI. The discharge is one line, and it must carry the DERIVATION rather
+than the number** — "it is 14" rots the moment a job is added, silently, exactly the way
+"19" did:
+
+> The CI check count is a property of `.github/workflows/`, never of the diff. It is the
+> jobs declared across those files, times two for the push/pull-request pair, plus CodeQL's
+> analyses and its umbrella. Recompute it; do not carry it.
+
+A reader who knows the derivation can recompute it in ten seconds and can never be stale. A
+reader handed "14" is holding a number with an expiry date nobody wrote on it — which is the
+same argument this repository already makes about deriving a deadline rather than picking
+one, and about `MINIMUM_EXTENSION_VERSION` being derived from the ledger and never typed.
+
+### OP-108 · Values traceable to Supabase ship with no attribution
+
+`github.com/supabase/supabase` is Apache-2.0 at the root (`Copyright 2024 Supabase`), and
+`packages/ui` — the package holding the theme files these values came from — declares
+**MIT**. There is no `NOTICE` file on their side.
+
+`design/tokens.css` carries fifteen byte-exact published values and nineteen more that
+reproduce their OKLCH expressions, and `design/*.css`, `*.js` and `*.html` carry **zero**
+Apache-2.0 or MIT notice. Apache-2.0 §4 requires retaining attribution, shipping the
+licence with the derivative, and **stating prominently that files were changed**; MIT
+requires the notice in all copies or substantial portions.
+
+The same repository discharges the identical obligation **three times over** for a smaller
+borrowing — the Material icons Apache-2.0 text exists in three places and two of them are
+guarded. Discharging both licences is cheaper than deciding which applies. Recorded as
+OD-08.
+
+### OP-109 · The design documents are guarded by nothing, and one guarded claim is false
+
+Neither `docs/DESIGN-SYSTEM.md` nor `docs/UI-KIT.md` is in the citation guard's `DOCUMENTS`
+tuple, and **adding them today would change no verdict**: neither contains a citation of
+the shape the guard can see, and no tier resolves a bare backticked path. Two documents
+governing 12,060 lines of authored CSS have the weakest guarantee in the repository —
+weaker than `docs/plans/`, which is at least deliberately excluded and says so.
+
+Four live stale facts survived because of it, all corrected in this pull request: a licence
+path that does not exist, a `.source-row` primitive that is not in the shared sheet, icon
+markup in a form the repository does not use, and a canonical-file list that is 3 of 10.
+
+**And the same class of hole is inside `design/tokens.css` itself.** Its device block
+claimed `tests/test_vendor.py` asserts the tonal bases match `:root`. That test asserts
+nine token **names** and two substrings and compares no literal — grep the suite for any of
+those hexes and it returns nothing. **The drift it claimed to prevent has happened**: the
+light `--control-hover` base is `#f3f3f3` (`--chip`) where `:root` declares
+`var(--surface-subtle)` = `#f6f6f6`. The comment is corrected; the drift is not.
+
+Order matters: the **bare-path tier first**, the `DOCUMENTS` widening second. Widening
+alone is a green no-op here.
+
+**AND TIER 1 CANNOT TELL A DELIBERATE SNAPSHOT PIN FROM ROT.** Sweeping every citation into
+the five documents this review edited turned up three that point at **blank lines**, and all
+three were already doing so at `ef86a19`, before anything was touched: two in
+`docs/ENGINE-ROLE-MEASURED.md` and one in `docs/MUQAWIL-AUDIT-2026-08-26.md`. Both files are
+snapshots pinned to `31c369e` and `5722b6f` and say so in their headers, so their citations
+are correct **against those commits** and wrong against `HEAD` by design. Tier 1 checks only
+that a line exists, so it passes either way and can distinguish neither. Left alone
+deliberately — repairing them would falsify two frozen records — but a reader sweeping
+citations will keep rediscovering them, so a snapshot document needs a way to declare its
+pin to the guard rather than only to a human.
+
+### OP-110 · The layering scale is 6 tokenised declarations against 38 bare ones
+
+`extension/app.css` declares `nav.side-rail { z-index: 30 }` against `--z-modal: 30`. The
+collision is stated in a comment on the screen that had to route around it and resolved
+nowhere: a modal and a persistent navigation rail sit in one stacking band with the winner
+decided by stylesheet order.
+
+The wider shape, measured over the 19 authored stylesheets with comments stripped:
+**38 bare numeric `z-index` declarations against 6 that use a token**, values sprawling
+`0, 1, 2, 3, 4, 6, 8, 9, 10, 20, 25, 30, 100, 120, 130, 10020`. **29 of the 38 sit BELOW
+the scale's floor** (`--z-sticky: 10`), so they are not bypasses of the scale at all — they
+are local stacking inside a context, a different problem, and a census that files them as
+"literals bypassing tokens" reports the wrong diagnosis. The 9 at or above the floor are the
+real candidates. Two of the three tokens are live (`--z-overlay` five times, `--z-modal`
+once inside a `calc`); **`--z-sticky` is dead**, and it is the one whose value the 29 sit
+under.
+
+*(An earlier draft of this entry said 35 against 11, and 34 below the floor. Both were
+counted with a line-grep that did not strip comments. Re-counted with a parser: 38, 6, 29.)*
 
 ### DEC-1 · Topology A — the TypeScript extension as the public product
 **Approved 2026-07-18. Zero commits since.** This is the largest gap between what was

--- a/docs/DESIGN-SYSTEM.md
+++ b/docs/DESIGN-SYSTEM.md
@@ -1,13 +1,51 @@
 # ScrapeX Design System
 
+## 0 · The design system is Supabase's, and a palette carries colour only
+
+**This is the first thing to read here, and this document did not say it for 37 days.**
+It was last edited on 2026-07-23; `R-73` and `R-74` were ruled on 2026-08-28 and shipped in
+`208d829`, and the word "Supabase" appeared nowhere below. Corrected 2026-08-29 by
+[REQ-49](REQUESTS.md#req-49--review-the-design-system-against-supabases).
+
+[R-74](RULINGS.md#r-74--the-design-system-is-supabases-always-and-a-palette-may-change-nothing-but-colour)
+— *«design system هو supabase ولكن قد ضفنا له استثناء 3 palette الوان»*, and *«واى تعارض
+معاها يلغى»*:
+
+1. **`design/tokens.css` IS the Supabase design system.** Shape, typography, spacing,
+   elevation, motion and focus geometry are Supabase's, always, and they live in the
+   baseline so that every colour choice sits on them.
+2. **A user chooses COLOUR and nothing else.** Four choices: `supabase` (the default),
+   `whatsapp`/`brand`, `github`/`blue`, and `device`.
+3. **A palette entry may contain nothing but colour**, enforced by
+   `tests/test_a_palette_may_change_nothing_but_colour.py`. `whatsapp` and `github` do not
+   represent the brand — they are colour exceptions on top of the system.
+4. [R-59](RULINGS.md#r-59--the-palette-registry-brand-is-default-alternatives-is-extensible-teal-is-debt)
+   decision 4 still governs: components consume semantic roles, **never** a palette
+   identifier.
+
+**Measured 2026-08-29 and worth knowing before you trust the guard:** rule 3 holds in the
+built product across all eight shipped states, and is enforced by one unasserted statement.
+See `OP-102`, and read it before adding a palette.
+
+---
+
 ScrapeX has one authored visual system shared by the browser extension and the
-local web workspace. The canonical files are:
+local web workspace. `tools/sync_design_assets.py` is the single source of the copy map —
+nine sources into eighteen destinations — and it is the file to read rather than any list
+restated here, because a restated list goes stale. The three that carry the rules:
 
 - `design/tokens.css` — semantic colour, type, spacing, shape, elevation,
-  control, motion, and layering tokens.
+  control, motion, and layering tokens. **This is the file `R-74` rules on**, and it is
+  copied byte-for-byte to `extension/tokens.css` and
+  `scrapex/webui/static/tokens.css`.
 - `design/components.css` — reusable controls, cards, banners, lists, badges,
-  layout helpers, icon sizing, focus treatment, and accessibility utilities.
+  layout helpers, icon sizing, focus treatment, and accessibility utilities. Copied to
+  `extension/components.css` and `scrapex/webui/static/components.css`.
 - `design/material-icons.svg` — the curated Google Material Icons sprite.
+
+`design/` holds ten files, not three; the other seven are `appearance.js` (the palette
+engine), `gallery.html` (the catalogue), `split-button.js`, `timezone.js`, the Material
+licence text, `google-g.png` and `x-mark.svg`.
 
 The extension and the Python package need physical copies of these files
 because they ship independently. Never edit those generated copies directly:
@@ -57,8 +95,9 @@ semantic token to the canonical file. Do not create a page-local colour system.
 - Inputs: text controls, selects, textareas, checkboxes, radios, invalid and
   disabled states.
 - Containers: `.card`, `.banner`, `.empty`, `.stack`, `.cluster`, and `.grid`.
-- Status and data: `.chip`, `.badge`, `.dot`, `.source-row`, `.content`, and
-  `.num`.
+- Status and data: `.chip`, `.badge`, `.dot`, `.srow`, `.content`, and `.num`.
+  (**This list said `.source-row`, which is not a shared primitive** — it resolves only in
+  the extension's own stylesheets. The shared name is `.srow`. Corrected 2026-08-29.)
 - Accessibility: `.visually-hidden`, consistent `:focus-visible`, coarse
   pointer sizing, reduced-motion fallbacks, and forced-colour fallbacks.
 
@@ -70,15 +109,34 @@ through `static/grid-theme.css`; renderer-specific overrides stay there.
 The sprite is sourced from
 [`google/material-design-icons`](https://github.com/google/material-design-icons)
 and retains its Apache 2.0 notice in
-`scrapex/webui/static/material-icons/LICENSE.txt`.
+`scrapex/webui/static/material-icons/material-icons.LICENSE.txt`. **The path in this
+sentence used to read `LICENSE.txt`, which does not exist**; all three copies do
+(`design/`, `extension/icons/`, `scrapex/webui/static/material-icons/`) and two of the
+three are guarded. Corrected 2026-08-29 by `REQ-49`.
+
+**Nothing here discharges the Supabase obligation.** `design/tokens.css` carries values
+traceable to `github.com/supabase/supabase` — Apache-2.0 at the root, MIT for the
+`packages/ui` these came from — and `design/` carries no notice of either. That is
+`OP-108`, and it is the one licence gap this repository has not already answered.
 
 Use an icon decoratively with an adjacent visible label:
 
+There are **two** real forms, and the difference is not cosmetic — the extension has no
+`/static/` root, so an absolute path there resolves to nothing.
+
 ```html
-<svg class="material-icon" aria-hidden="true">
-  <use href="/static/material-icons/material-icons.svg#settings"></use>
+{# web workspace: the macro carries the cache-buster #}
+{{ icon('settings') }}
+
+<!-- extension: relative, and the class is sx-icon -->
+<svg class="sx-icon" aria-hidden="true">
+  <use href="icons/material-icons.svg#settings"></use>
 </svg>
 ```
+
+**The authoring class is `sx-icon`, not `material-icon`.** This block previously showed
+`class="material-icon"` on an absolute path — a form neither surface uses. Corrected
+2026-08-29 by `REQ-49`.
 
 An icon-only button must also have an `aria-label`. Add a symbol to the
 canonical sprite only when the repository contains no suitable symbol already.
@@ -91,7 +149,20 @@ canonical sprite only when the repository contains no suitable symbol already.
 - Native and Tabulator tables: `table-theme.css` and `grid-theme.css`.
 - Extension panel and onboarding layout: `extension/app.css` and
   `extension/onboarding.css`.
+- Extension console and data pages: `extension/console.css` and
+  `extension/data.css`. (**780 lines that this table left with no owner named**, while
+  the 33-line `onboarding.css` beside them was named. Added 2026-08-29 by `REQ-49`.)
+
+**The proportion is the thing to keep in mind here.** The shared layer is 2,093 lines and
+it governs 9,967 lines of authored CSS outside it — a ratio of roughly 1 to 4.8, and
+`extension/app.css` alone is 3,818, nearly twice the whole system.
 
 The guard in `tests/test_design_system.py` rejects stale generated assets,
 inline style attributes, embedded SVG paths, and a missing Material icon
 license.
+
+**Two things that guard does NOT do, measured 2026-08-29.** It never opens a `.svg`, so a
+colour baked into the sprite at source and synced to both copies passes every check
+(`OP-107`). And **this document and `docs/UI-KIT.md` are guarded by nothing at all** —
+neither is in the citation guard's `DOCUMENTS`, and no tier resolves a bare backticked
+path, which is why the four stale facts corrected above survived (`OP-109`).

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -780,8 +780,17 @@ nothing looks broken enough to notice.
 (`--control-active: var(--chip)`) — that needs no palette work and follows device
 tones for free. Reach for a raw hex per palette only when the hue itself must be
 fixed. **`--accent` is not a safe state colour**: device mode resolves it to the
-OS `AccentColor`, so it can collide with the fixed `--amber`. Guarded by
-`test_every_custom_property_a_stylesheet_reads_is_one_something_defines`.
+OS `AccentColor`, so it can collide with the fixed `--amber`.
+
+**THE GUARD THIS PARAGRAPH USED TO NAME HAS NEVER EXISTED.** It cited
+`test_every_custom_property_a_stylesheet_reads_is_one_something_defines`; a grep for that
+name returns this line and nothing else. Measured 2026-08-29: **twelve declarations across
+six files read a custom property nothing declares**, including the `--control-active` this
+very paragraph proposes a fix for — so the citation was covering the exact defect it named.
+`OP-103` carries them. The near-miss is worth the space: `tests/test_the_tests_name_tests_that_exist.py`
+guards backticked test names but reads only `tests/*.py`, and the citation guard reads
+`docs/` but checks only `file:line`. **A backticked test name inside a document falls in the
+seam between the two**, and that seam is `OP-109`.
 
 ### Half a composite component is dressed for the half that is missing
 
@@ -1869,7 +1878,11 @@ adds no *completeness* the count does not.
 **What made it hard to see is worth more than the fix.** The module docstring stated
 the opposite as settled fact — *"the union can reach N by luck across two generations
 and that proves nothing"* — and a test was named
-`test_a_union_across_two_generations_is_not_a_proof` and asserted it. Nine guards and
+`test_a_union_across_two_generations_is_not_a_proof` and asserted it. (**The live test is
+`test_a_union_across_two_generations_IS_a_proof`** — the opposite polarity, at
+`tests/test_a_crawl_that_can_prove_it_read_everything.py:363`. This lesson had gone on
+citing the pre-correction name of the very test whose rule it inverted; corrected
+2026-08-29 by `REQ-49`.) Nine guards and
 twenty-one killed mutations all agreed with each other, because they were all
 checking the same wrong rule. **Mutation testing cannot find a mistake in what you
 decided to prove**; it only checks that you still prove it. The error surfaced only
@@ -2892,9 +2905,44 @@ Knowing which of the two a guard covers is the difference between trusting it an
 **The cheap rule that follows:** after inserting anything above line ~300 of a long, heavily
 cited module, re-derive every citation into it. `difflib` between the old blob and the new one
 gives the map in one pass — **and read each answer**, because one of the nine was better after
-the drift than before it: `STATE.md:918` had pointed at a docstring's closing quote and the
-shift landed it on the `def` the sentence names. Applying the map blindly would have repaired
-it into being wrong.
+the drift than before it: the citation then sitting at line 918 of `STATE.md` had pointed at a
+docstring's closing quote, and the shift landed it on the `def` the sentence names. Applying
+the map blindly would have repaired it into being wrong.
+
+**AND THAT SENTENCE HAS NOW PROVED ITSELF TWICE.** It used to write "918" in `file:line`
+form, so the citation guard read a RECOUNTING of a past drift as a live citation — and on
+2026-08-29 the line drifted again, twice in one afternoon, until it landed on a blank line
+and went red. **A number quoted as history is indistinguishable from a number offered as a
+destination**, and this file cannot tell a reader which it meant. So prose about a line
+number is written without the colon form, and only a citation meant to be FOLLOWED gets it.
+
+**Three independent instances the same afternoon, in three different documents, found by two
+sessions who did not know the other was looking.** This one; a sentence in `docs/REQUESTS.md`
+whose whole subject was that its quoted line is *dated, therefore history rather than rot* —
+written in the form reserved for destinations; and a bulk repoint into
+`docs/ENGINE-ROLE-MEASURED.md` that had to be reverted, because that file is a snapshot at a
+named commit and rewriting a reference inside it makes the snapshot say something it did not
+say. Add the fourth already known: a backticked TEST name in a document, which
+`tests/test_the_tests_name_tests_that_exist.py` cannot see because it reads only `tests/*.py`.
+
+**The shape under all four is that a guard cannot see INTENT.** It can check that a
+destination resolves; it cannot ask whether the writer meant a destination at all. That is
+not a defect to fix in the guard — a guard that guessed intent would be worse — it is a
+constraint on how we write. **Signal the intent in the FORM: the colon form means "go here",
+and anything else means "this is what it said".**
+
+### The merge rule that came out of the same afternoon
+
+Three sessions were writing these documents at once, and resolving a rebase conflict by
+keeping BOTH sides silently produced a stale heading with no body under it. The mechanism:
+one side's hunk ENDED with an untouched heading as trailing context, and that same heading
+was the OTHER side's edit target. Concatenating kept the original and the correction.
+
+**"Keep both" is safe for two appends at one anchor. It is NOT safe when one side's trailing
+context is the other side's edit target** — and a conflict hunk does not distinguish the two,
+because trailing context and edited content look identical inside it. **After any
+keep-both resolution, read the seam**, not just the ends: the duplicate is at the join, and
+nothing in the register or citation guards will catch a heading that merely repeats.
 
 ## 22 · Rebuilding a table drops every trigger on it, and only a count says so
 
@@ -3202,3 +3250,35 @@ fires on a mutation, ask what the far side is still doing; the answer is usually
 other bounding a request. No guard compares a documented duration against a coded timeout,
 and none is proposed here; what is worth keeping is that the evidence for a defect can be
 fully present in the repository, in two files, and still be nobody's finding.
+## 28 · A counting tool is fooled by the documentation of the thing it counts
+
+Two sessions hit this from opposite ends on 2026-08-29, within two hours, and neither was
+looking for it.
+
+**Here.** `REQ-49` reported into `OP-110` that the authored stylesheets carry *"35 bare
+numeric `z-index` declarations against 11 tokenised, 34 of them below the token floor"*. All
+three numbers were wrong. Re-counted with a parser that strips `/* ... */` before scanning:
+**38 bare, 6 tokenised, 29 below the floor.** The line-grep had counted `z-index` mentioned
+inside comments — including the comment in `extension/app.css` that *explains the
+`--z-modal` collision*, which is to say the census counted the prose written about the
+defect as further instances of the defect. `calc(var(--z-modal) + 10)` fooled it the other
+way, reading as bare because the digits were there.
+
+**And in the panel, the same hour.** A parser written to read `LOCAL_POLICIES` out of
+`extension/startup.js` broke on a `[/?]` sequence sitting inside the `//` comment written to
+explain the rule that uses `[/?]`. Fixed with a `_without_comments` pass before scanning.
+
+**THE RULE: strip comments before counting anything, and treat a grep-based census of a
+commented file as an estimate.** A file's comments are exactly where its syntax gets quoted,
+so the denser the documentation the worse the count — and this repository documents its
+values at the value on purpose.
+
+**THE PART THAT IS EASY TO MISS.** All three of the numbers moved in the same direction, so
+they stayed consistent with each other and read as trustworthy. **A miscount that shifts one
+figure looks like a typo; a miscount that shifts every figure looks like a measurement.**
+The tell is not internal consistency, it is whether the tool could see what it was counting
+— and the answer here was written into the same file, four lines above.
+
+Related: section 21's rule about re-deriving citations after an insertion is the same
+discipline applied to line numbers rather than to counts, and `OP-97` is the same failure
+applied to a file LIST — a census scoped to 9 stylesheets when there were 19.

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -100,6 +100,7 @@ IDs are stable and never reused, matching the convention BACKLOG.md already uses
 | [REQ-44](#req-44--the-state-gets-its-own-column-and-the-user-never-infers-it) | The state gets its own column, and the user never infers it | **Done** — ruled as `R-27` and built the same day (#235 + migration 0006), and the column it asked for now lies: `OP-68` measures it reporting 17,256 of 17,304 contractors as gone after a crawl that read every one | 2026-08-21 |
 | [REQ-45](#req-45--the-crawl-button-does-not-work-for-muqawil) | The crawl button does not work for muqawil | **Captured** — root cause proven on the live engine: `POST /api/jobs` validates against `sources.yaml` and muqawil lives in `site_profile`, so the route answers 404 and the panel hides the button deliberately. The fix needs `REQ-25`; **four parts do not** and he approved all four | 2026-08-26 |
 | [REQ-48](#req-48--a-supabase-appearance-that-is-a-whole-design-system-and-the-default) | A `supabase` appearance that is a whole design system, not a palette — and the default | **In flight** — ruled 2026-08-28 as [R-73](RULINGS.md#r-73--an-appearance-is-a-whole-design-system-and-supabase-is-the-default-one) (the ruling *was* the plan), built on `feat/the-supabase-appearance-is-a-design-system`, no PR yet. Measured before a line was written: the appearance engine carries **36 theme properties and every one is a colour**, so "a design system" needs an axis that does not exist; and `DEFAULTS.palette` is **unreachable for a fresh user** because `deviceColors` defaults to `true`, so `github` has never been the default anybody saw. He chose the deepest scope (tokens **and** component rules), the `supabase` spelling, and clearing the `R-59` conflict; the `deviceColors` flip is **open** pending numbers he asked for. Closes [OP-82](BACKLOG.md) | 2026-08-28 |
+| [REQ-49](#req-49--review-the-design-system-against-supabases) | Review the design system against Supabase's | **In flight** — measured 2026-08-29; he set the scope first («اولا تحديد كل محاور المراجعة»), then pointed at the SOURCE rather than the site, then chose six axes of twenty-six («ابدأ بالستة»). `R-74` **holds in the built product** (8 states x 118 properties in Chromium 149: 62 move, all colour) **and is guarded by almost nothing** — mutation put the type scale into a palette with 91 static and 218 browser guards green. `device` does not reach the user in dark. 21 findings were refuted by the verify pass. Filed as [OP-101](BACKLOG.md)–[OP-110](BACKLOG.md); **twelve decisions open, all his** | 2026-08-29 |
 
 ---
 
@@ -2564,8 +2565,10 @@ the operating system's `AccentColor` where the browser exposes one.
   engine before the panel ever renders it. OP-82's own note — *"no third palette exists to
   add"* — stops being true with this request.
 - **[tests/test_vendor.py](../tests/test_vendor.py)**'s
-  `test_only_the_two_reviewed_application_palettes_are_available` asserts
-  `appearance.count('description: "') == 2`. That is a **review decision encoded as a
+  `test_only_the_three_reviewed_application_palettes_are_available` asserts
+  `appearance.count('description: "') == 3`. (**Both were `two` and `2` when this was
+  written**, and `R-74` made them three by adding the `supabase` entry; corrected
+  2026-08-29 by `REQ-49`.) That is a **review decision encoded as a
   guard**: a third palette is meant to cost a written justification, not an edited number.
 
 > **The four items above describe the tree AS IT WAS ON 2026-08-28 at capture, and three of
@@ -2606,3 +2609,72 @@ He answered all four questions:
 
 A worktree exists — `feat/the-supabase-appearance-is-a-design-system`, based on `main` at
 `b836de3`.
+
+---
+
+## REQ-49 · Review the design system against Supabase's
+
+**Captured 2026-08-29 · measured the same day · In flight — branch `claude/design-system-review-d6787a`, PR to open. Twelve decisions await his ruling**
+
+> «عاوز اراجع design SYSTEM · https://supabase.com/design-system · اولا تحديد كل محاور
+> المراجعة»
+> — then, on being shown the scope: «لو عاوز تشغل AGENTS
+> https://github.com/supabase/supabase/tree/master/apps/design-system لمزيد من التفاصيل»
+> — then, on being offered twenty-six axes with a recommendation of six: «ابدأ بالستة»
+
+He asked for the axes **before** any finding, which is what made the review scopeable: the
+scoping pass produced twenty-six, a completeness critic found seven that were missing and
+refused eleven measurement steps as unexecutable, and he chose the six that the rest stand
+on. The report is
+[docs/reviews/2026-08-29-the-design-system-against-supabase.md](reviews/2026-08-29-the-design-system-against-supabase.md).
+
+**His second message changed the review's foundation.** `docs/STATE.md` recorded that
+*"Supabase publishes token names with no values"*, and the whole palette had therefore been
+derived by inference and marked `PUBLISHED` or `derived` at each value. Reading the source
+he pointed at shows **the values are published** — `packages/ui/build/css/` carries the
+scalar inputs, the OKLCH derivation and the literal ramps. The premise was false.
+
+**And the inference was right anyway.** Re-derived against the real source: 15 values are
+byte-exact, 19 more reproduce their expressions, light scalars match 9 of 10 and dark 10 of
+10, including `--elevation-step` solved independently at two elevation ratios. What the
+false premise cost was not accuracy — it was six comments that argue from things that are
+not true, now corrected.
+
+### What the review found, in one line each
+
+`R-74` **holds in the built product** — 8 states by 118 properties in Chromium 149, 62 move
+and all 62 are colours — **and is enforced by almost nothing**: mutation put the type scale
+and the body face into a palette with 91 static and 218 browser guards green. One of the
+four colour choices `R-74` names does not reach the user in dark. Twelve declarations read
+properties nothing declares, and two sidebars marked `sticky` never stick. Sixteen comments
+and documents argue from something untrue. Attribution to Supabase is absent entirely.
+
+Filed as [OP-101](BACKLOG.md) through [OP-110](BACKLOG.md).
+
+**Twenty-one findings were refuted by the verify pass** and are listed rather than buried —
+including two that had accused the code of breaking a ruling it obeys.
+
+### The twelve decisions, none of which a reviewer may take
+
+| | question | the number that decides it | recommendation |
+|---|---|---|---|
+| OD-01 | adopt their numeric ramps `200`-`600`? | 15 tokens across 3 blocks = 45 declarations minimum; `THEME_PROPERTIES` 36 to 51, and the contrast matrix grows with it | **no** to the ramps, **yes** to the four status-border tokens — a quarter of the cost, 14 call sites and nine competing mix percentages behind it |
+| OD-02 | is `--amber` the intended colour or the accident of a clip? | the target is 27.6% outside sRGB; the shipped hex is a naive clip 9.5 degrees off their warning hue; the hue-holding value is `#8d5e00` | switch **or** rule "clip accepted" — the comment is now true either way, and it blocks any future warning ramp |
+| OD-03 | five more contrast pairs, and a `device` state? | 102 to 132 assertions, **zero new tokens**, `THEME_PROPERTIES` unchanged | **yes** — measure first and land green, never land red |
+| OD-04 | fix the device cascade? | a seven-declaration block move, zero tokens — and device-dark goes 0 of 17 to **5 of 17** failing | **yes**, but land it with OD-03. The fix reveals the illegibility, it does not create it |
+| OD-05 | make `--surface-subtle`, `--chip` and `--line` true alpha? | exact on `--background`, wrong on `--card` and `--popover` by 2/255 light and (5,6,6) dark | **plan it, do not slip it in.** The deferral's stated hazard was measured and is false — the guard fails loudly, not silently |
+| OD-06 | extract a shared table primitive? | two implementations, 101 lines already token-bound and 1,837 of Tabulator override; the extension has **zero** table CSS | extract the 101-line one only. `OP-46` makes a new shared module yours |
+| OD-07 | grow the shared `.empty`? | 3 declarations against 10 surface-local implementations and 19 usage sites | **yes** — the cheapest item in the review, and the local copies exist because the shared one was too thin |
+| OD-08 | discharge attribution under Apache-2.0 or MIT? | their root is Apache-2.0, `packages/ui` is MIT, and this repository already discharges the same obligation three times for Google | **both** — cheaper than deciding, and Apache-2.0 §4(b) also wants the statement of change |
+| OD-09 | sanction the panel's control-height override? | 2 tokens of 111, documented in a comment, asserted by no test | sanction it, and make it `OP-102`'s guard's only allowlist row — that turns a comment into a mechanism |
+| OD-10 | exempt `design/gallery.html`'s inline styles, or convert them? | 22 attributes, 21 of them pure `var(--token)` | **exempt explicitly**, asserting they are token-only — the catalogue must keep demonstrating tokens |
+| OD-11 | fold `STATE.md`'s "Open pull requests" section? | 642 lines with nothing open; `OP-89` measured it at 535 two days ago and chose a banner, and it has grown 107 lines **above** the banner since | **fold it.** The stopgap was overtaken by the exact mechanism it did not defend against |
+| OD-12 | citation guard: bare-path tier, `DOCUMENTS` widening, or both? | `DOCUMENTS` is 9 of 82 tracked `.md`; design citations are 8 and exactly 1 is pinned | **bare-path tier first** — widening alone changes zero verdicts here |
+
+### What was deliberately not done
+
+**No value, no selector and no component rule changed.** Seven comments, six documents, the
+registers and one review. Every defect is filed rather than fixed, per **C1** — and the
+twelve above are open because each one either grows `THEME_PROPERTIES`, changes what a
+shipped colour choice paints, or creates a shared module, and `R-59` decision 4, `OP-46`
+and `LESSONS` section 5 all put those with him.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -462,11 +462,62 @@ insertions: the pinned `scrapex/webui/app.py:3022` in `tests/test_the_documents_
 and `docs/REQUESTS.md`'s jobs-route citation, which was **already 27 lines stale** —
 Tier 1 only asks that a cited line exist, and a stale line that is not blank still exists.
 
-### The supabase appearance — 2026-08-28 · branch `feat/the-supabase-appearance-is-a-design-system`, no PR yet
+### The design system reviewed against Supabase's — 2026-08-29 · branch `claude/design-system-review-d6787a`, based on `main` at `ef86a19`
+
+**`REQ-49`. A review, not a change: no value, no selector and no component rule moved.**
+Seven comments in `design/tokens.css`, six documents, the registers, and one report at
+[docs/reviews/2026-08-29-the-design-system-against-supabase.md](reviews/2026-08-29-the-design-system-against-supabase.md).
+
+He set the scope before any finding — *«اولا تحديد كل محاور المراجعة»* — chose six axes of
+twenty-six, and pointed the review at Supabase's **source** rather than its website, which
+is what made the token half of it verifiable at all.
+
+**The headline, measured in Chromium 149 across the 8 shipped colour states:** `R-74`
+holds — 62 of 118 root properties move and every one is a colour — **and is enforced by
+almost nothing.** Mutation on a byte-verified mirror put `--fs`, `--font-body` and `--lh`
+into a palette and 11 of the 13 forbidden families into a surface stylesheet, and 91 static
+guards plus all 218 browser tests stayed green. That is `OP-102`.
+
+**And the inference behind the palette was right.** `STATE.md` recorded that Supabase
+publishes names without values, so the colours were derived; the source publishes both, and
+re-derived against it **15 values are byte-exact, 19 more reproduce their expressions, and
+the scalars match 9 of 10 in light and 10 of 10 in dark**. What the false premise cost was
+six comments arguing from things that are not true, now corrected.
+
+**Filed:** `OP-101`–`OP-110`. **Refuted by the verify pass and NOT filed: 21 findings**,
+two of which had accused the code of breaking a ruling it obeys. **Twelve decisions are
+open and all of them are his** — each either grows `THEME_PROPERTIES`, changes what a
+shipped colour choice paints, or creates a shared module.
+
+**`OP-100` and `R-76` are reserved to `claude/request-deadline-exceeded-3b1cad`** — a
+LOCAL-ONLY branch, visible from any worktree because they share one ref namespace and
+invisible to `git ls-remote`. The reservation row says so.
+
+**VERSION deliberately not bumped.** `scrapex/version.py` moves on a functional,
+architectural or behavioural change and this is none of the three; `ENGINEERING.md` W4 says
+every merged pull request. The primary reserved **0.4.7** if the wider rule wins — an open
+question, not an omission.
+
+
+### The supabase appearance — MERGED 2026-08-29 as #283 (`208d829`)
+
+> **This entry said "no PR yet" for a day after it had merged.** Corrected 2026-08-29 by
+> the design-system review ([REQ-49](REQUESTS.md#req-49--review-the-design-system-against-supabases)):
+> `208d829` landed 37 files, +2858/-524, and `gh pr list --state open` returns nothing. The
+> `deviceColors` flip this entry calls "open" is also settled and shipped — `design/appearance.js`
+> reads `deviceColors: false`. This is `OP-89` in miniature: a present-tense heading over
+> merged work, which is what tells the next session the work never landed.
 
 **`REQ-48`, ruled the same day as
-[R-73](RULINGS.md#r-73--an-appearance-is-a-whole-design-system-and-supabase-is-the-default-one).
-Based on `main` at `b836de3`.**
+[R-73](RULINGS.md#r-73--an-appearance-is-a-whole-design-system-and-supabase-is-the-default-one),
+and amended hours later by [R-74](RULINGS.md#r-74--the-design-system-is-supabases-always-and-a-palette-may-change-nothing-but-colour).
+Branched from `main` at `b836de3`; merged into `main` at `208d829`.**
+
+> **The commit subject says `R-72` and that is the wrong number.** The branch was opened
+> when `R-72` was newest and the subject was never corrected, so `git log --grep='R-73'` and
+> `--grep='R-74'` both return **zero rows** and the two rulings this section is about are
+> unfindable by the sweep `ORCHESTRATION.md` demonstrates. `R-72` itself belongs to `81edc02`
+> (#285). Read `docs/RULINGS.md`, not the log.
 
 > «اريد عمل apperance جديد اسميه supbase ويصبح default · ولكن لن يكون الوان فقط بل design
 > system كامل»
@@ -533,8 +584,11 @@ are fixed.
 stepped ramps are HSL literals and every semantic colour is computed at runtime in OKLCH
 from ten scalar inputs, so each one is marked `PUBLISHED` or `derived` at the value. **All 34
 contrast assertions were computed against the guard's own formula before the palette was
-written** — playwright is not installed on this machine, so CI would otherwise have been the
-first to know. That found two light-mode failures, and three Supabase values that fail
+written** — playwright was not installed on the machine that wrote this, so CI would
+otherwise have been the first to know. (**It is installed on the other one.** Measured
+2026-08-29: Chromium 149.0.7827.55 launches and the browser suite runs. A capability
+sentence has to name its machine — `CLAUDE.md` makes two machines the governing fact of
+this repository.) That found two light-mode failures, and three Supabase values that fail
 thresholds this repository already enforces:
 
 | their value | measured | the guard needs |
@@ -549,9 +603,12 @@ the literal `["whatsapp", "github"]`, so a new palette was never contrast-tested
 under `R-73` the **default** would have been the untested one. Derived from the registry it
 goes from 68 assertions to 102. Same fix for the hover sweep's four hard-coded pairs.
 
-**Not verifiable on this machine:** everything in `tests/test_panel_dom.py` and
-`tests/test_panel_startup.py` needs playwright, which `importorskip` skips here. The rest of
-the suite is green.
+**~~Not verifiable on this machine~~ — VERIFIED 2026-08-29 on the other machine.**
+`tests/test_panel_dom.py` and `tests/test_panel_startup.py` collect **218 tests and all 218
+pass**; playwright imports and Chromium 149.0.7827.55 launches. The original sentence was
+true where it was written and named no machine, which is how it became a false general
+claim — and it mattered: it is why `OP-102`'s mutation gap went unmeasured for a day, since
+the guards that would have caught it are in exactly these two files.
 
 ---
 

--- a/docs/UI-KIT.md
+++ b/docs/UI-KIT.md
@@ -73,10 +73,17 @@ are invisible to it. That gap is real. It is not closed by pretending otherwise.
 | Belongs to one screen of the panel | `extension/app.css` | one view |
 | Belongs to one page of the web UI | `scrapex/webui/static/pages/<page>.css` | one page |
 
-`design/` is **canonical**. `extension/components.css`, `extension/icons/`,
-`scrapex/webui/static/components.css` and `.../material-icons/` are **distributed
-copies**, published by `tools/sync_design_assets.py` and asserted byte-equal by
-`tests/test_vendor.py` and `tests/test_design_system.py`.
+`design/` is **canonical**, and `tools/sync_design_assets.py` is the single source of the
+copy map — **nine sources into eighteen destinations**. Read the tool rather than a list
+restated here; a restated list goes stale, and this one had.
+
+**The two copies this sentence used to omit are the ones that matter most.**
+`design/tokens.css` is the file [R-74](RULINGS.md#r-74--the-design-system-is-supabases-always-and-a-palette-may-change-nothing-but-colour)
+rules on, and it is published to `extension/tokens.css` and
+`scrapex/webui/static/tokens.css`; neither was named. `appearance.js`, `split-button.js`
+and `timezone.js` are copied too. All are asserted byte-equal by `tests/test_vendor.py`
+and `tests/test_design_system.py`. Corrected 2026-08-29 by
+[REQ-49](REQUESTS.md#req-49--review-the-design-system-against-supabases).
 
 **Editing a copy is the second mistake I made on 2026-08-05.** Edit `design/`,
 then run:
@@ -172,6 +179,15 @@ in any order without silently regressing.
 `design/gallery.html`, opened by double-clicking it. Every shared component as a
 live example with its markup, both themes, and a guard that fails when a
 component is in the sheet and not on the page.
+
+> **"Cannot go stale" is stronger than the mechanism.** Measured 2026-08-29 by
+> [REQ-49](REQUESTS.md#req-49--review-the-design-system-against-supabases): the sprite half
+> of it is a **gate, not an assertion** — `tools/sync_design_assets.py` regenerates the
+> block only `if` its marker comment is present, so tampering with the block is caught and
+> tampering with the block *and* renaming the marker passes, after which the tool reports
+> the catalogue current forever. And the component check is name-level, not compound-level:
+> a variant that exists only as a compound selector has no live example and nothing says so.
+> `OP-107`. The claim is true of the common case and it is not a guarantee.
 
 **Building it found four things reading the CSS never would have.** Each is now
 written on the page beside the component it belongs to:

--- a/docs/reviews/2026-08-29-the-design-system-against-supabase.md
+++ b/docs/reviews/2026-08-29-the-design-system-against-supabase.md
@@ -1,0 +1,281 @@
+# The design system, measured against Supabase's — 2026-08-29
+
+**Snapshot at `ef86a19`.** Every citation below was checked against that commit, not
+against `HEAD`. Supabase's side was read from `github.com/supabase/supabase` at `master`,
+sparse-checked-out to `apps/design-system`, `packages/ui` and `packages/ui-patterns` — the
+source, not the website, because the website publishes token names without values and the
+source publishes both.
+
+He asked for it as [REQ-49](../REQUESTS.md#req-49--review-the-design-system-against-supabases),
+and approved six of the twenty-six axes the scoping pass produced. This reports those six.
+
+| axis | what it measured |
+|---|---|
+| A1 | token vocabulary, values, provenance |
+| A2 | non-colour scales, and the literals that bypass them |
+| A3 | the theming cascade, in a browser, across all eight shipped states |
+| B1 | component coverage, atoms and fragments |
+| E3 | what the guards actually measure |
+| E4 | what the registers claim versus what is true |
+
+**Approach (C6):** measurement first, adversarial verification second. Every axis was
+measured, then handed to a second pass whose instruction was to *refute* it and whose
+default on an unreproducible number was REFUTED. **Twenty-one findings did not survive**,
+including three the first pass had led with. That list is section 5, and it is the most
+useful section here.
+
+---
+
+## The verdict
+
+**`R-74` holds in the built product, and is enforced by almost nothing.**
+
+Measured in Chromium 149 across 8 shipped states by 118 root custom properties: 62
+properties move and every one is a colour. But that conformance rests on one unasserted
+statement — the allowlist loop at `design/appearance.js:347` — whose only guard is the
+substring assertion at `tests/test_vendor.py:289`, and **`clearTheme` at
+`design/appearance.js:310` satisfies that substring on its own.** Mutation testing on a
+byte-verified mirror put `--fs`, `--font-body` and `--lh` into a palette and 11 of the 13
+forbidden families into a surface stylesheet, and **91 static guards and 218 browser tests
+stayed green.** The architecture `R-74` abolished is reachable today.
+
+**The colour mathematics is excellent and the bookkeeping around it is not.** Fifteen
+values are byte-exact against Supabase's published literals, nineteen more reproduce their
+OKLCH expressions, and the 102-assertion contrast gate has no Supabase counterpart at all.
+Against that: sixteen comments and documents argue from something untrue, twelve
+declarations reference properties nothing declares, and one of the four colour choices
+`R-74` names by name does not reach the user in half its states.
+
+**The largest product-level gap is not a token.** On a warehouse admin tool the table is
+the one component the shared layer does not touch: `design/components.css` contributes a
+single table rule, a sibling margin at `design/components.css:1351`, against Supabase's
+nine sub-parts.
+
+---
+
+## 1 · Defects
+
+**D-01 · "Device colours" paints Supabase's own accent in dark mode.**
+`design/tokens.css:302` wraps the device block in `@supports (color: AccentColor)`, which
+contributes no specificity. The selector is therefore `(0,2,0)` — the same as the two dark
+blocks that come *after* it and redeclare all seven of its properties. Source order
+decides, and the dark blocks win. A user on a dark OS who picks Device colours gets
+`#3ecf8e` for every accent, focus ring, button and switch track, while the panel's status
+text reports the choice it is not painting. Proven by counterfactual, not inferred.
+**One of `R-74`'s four named colour choices, unreachable in half its states.** Filed as
+`OP-101`.
+
+**D-02 · `R-74` is guarded by a substring that a different function satisfies.** Above.
+Filed as `OP-102`.
+
+**D-03 · `--sticky-tabs` is read nine times and declared nowhere.** Nine references across
+four stylesheets, every one inside `calc()` and none with a fallback, so the whole
+declaration is invalid at computed-value time and `top` falls back to `auto`. **The
+settings sidebar and the exports sidebar are `position: sticky` and never stick.** Two
+data-workspace popovers lose their offset with them. Filed as `OP-103`.
+
+**D-04 · A palette can ship text at 1.00:1 with every test green.** The contrast
+parametrize derives its *palette* list from the registry but its *token pairs* are still
+hand-written. Setting `brand`'s `chip`, `surfaceSubtle` and `surfaceRaised` each to that
+palette's own `--text` passes 91 static guards and all 218 browser tests. A quarter of what
+a palette controls carries text and is never measured. Filed as `OP-104`.
+
+**D-05 / D-06 · Three more undeclared properties, all silent.** `--control-active`
+(`design/components.css:1530`) so a pressed split-button option paints no background;
+`--fg` in the extension, a typo for `--text`, so a hover changes nothing but the underline;
+`--green` in the console, so a completed build step loses its colour. `background` and
+`border-*-color` are not inherited, so these compute to nothing rather than erroring.
+Filed with D-03 as `OP-103`.
+
+**D-07 · Three surface tokens are Supabase alpha tokens flattened against the wrong
+plate.** `--surface-subtle`, `--chip` and `--line` are exact over `--background` and wrong
+over `--card` and `--popover` — by 2/255 in light and (5,6,6) per channel in dark. That is
+where borders and chips actually sit. This is OD-05, not a defect to fix in passing.
+
+**D-08 · The operating system's Increase-contrast setting reaches one of the four colour
+choices.** `apply()` writes the 36 theme properties as **inline style**, which outranks the
+stylesheet rule implementing `prefers-contrast: more`. Silent in both directions: the OS
+setting is on, the rule is present, and no test reads it. Filed as `OP-105`.
+
+**D-09 · `.banner` has no neutral default.** `design/components.css:365` paints
+`--amber-weak`, so an untyped banner reads as a warning. Supabase's untyped `Alert` is
+neutral. Five untyped sites exist; four are not warnings, and one is the gallery's own
+example labelled "a statement of fact". Filed as `OP-106`.
+
+**D-10 · `device` has zero contrast coverage.** The parametrize iterates registered
+palettes and `device` is removed as a palette entirely, so it can never appear. Run by
+hand, device-light fails two of the seventeen assertions at 4.21:1. Filed with D-04 as
+`OP-104`.
+
+**D-11 · The catalogue's sprite check is a gate, not an assertion.** Renaming one comment
+marker disables it, and the regeneration tool then reports the catalogue current forever.
+`docs/UI-KIT.md` calls the gallery "the catalogue that cannot go stale". Filed as `OP-107`.
+
+**D-12 · A colour baked into a shipped SVG is invisible to every guard.** The
+colour-literal guard's suffix filter has no `.svg`. An edit made at source and synced to
+both copies — the way anyone would actually introduce one — passes everything. Filed with
+D-11 as `OP-107`.
+
+**D-13 · No Supabase attribution anywhere.** Their root is Apache-2.0 (`Copyright 2024
+Supabase`) and `packages/ui`, the package the values came from, declares MIT. `design/`
+carries no notice of either. The same repository discharges the identical obligation three
+times over for a smaller borrowing from Google. Filed as `OP-108`.
+
+**D-14 · The two documents that govern the design system are guarded by nothing.** Neither
+`docs/DESIGN-SYSTEM.md` nor `docs/UI-KIT.md` is in the citation guard's `DOCUMENTS`, and
+adding them today would change no verdict, because neither contains a citation of the shape
+the guard can see. Four live stale facts in them survived because of it. Filed as `OP-109`.
+
+**D-15 · The side rail and `--z-modal` are both 30.** Recorded in a comment, resolved
+nowhere; a modal and a persistent nav rail share a stacking band and source order decides.
+The wider shape, comments stripped: **38 bare numeric `z-index` declarations against 6
+tokenised**, values sprawling from 0 to 10020, and **29 of the 38 sitting below the scale's
+floor** of `--z-sticky: 10` — which is itself dead. Those 29 are local stacking, not
+bypasses. Filed as `OP-110`.
+
+**D-16 · `.code` renders three properties differently on the two surfaces** under one class
+name, with no override intent declared. Recorded here; not filed.
+
+**D-17 · The device tonal bases have no guard, and one has already drifted.** The comment
+claimed `tests/test_vendor.py` compares them against `:root`; it compares nine token
+*names* and two substrings and no literal at all. Measured: the light `--control-hover`
+base is `#f3f3f3` (`--chip`) where `:root` declares `var(--surface-subtle)` = `#f6f6f6`.
+**The drift the comment claimed to prevent is present in the file the comment is in.**
+The comment is corrected in this pull request; the drift is filed as `OP-109`.
+
+---
+
+## 2 · Divergences that should STAND
+
+Supabase publishes nothing on any of these. They are additions above the baseline, and
+they need a recorded rationale rather than a fix.
+
+- **Contrast.** No numeric target exists anywhere in their 101 authored `.mdx` files —
+  three qualitative claims only. This repository runs a real gate over every registered
+  palette and both schemes, and overrode four Supabase values to meet it.
+- **Accessibility.** `aria-live` / `role=status` 89 here against 3 there; reduced-motion
+  blocks 14 against 3; a `forced-colors` block here against none there; a
+  `prefers-contrast` accommodation against none.
+- **Bidirectionality.** 200 logical directional declarations against 21 physical here — a
+  9.5:1 ratio. Theirs is 279 physical against 6 logical, the inverse, and their system
+  carries an explicit LTR lock. **This repository renders Arabic data inside English
+  chrome, so this is the axis where it must diverge, and it already has.** The 21
+  remaining physical declarations are the finish line, and five of them are defensible.
+- **Checkboxes and radios follow the palette** through one declaration,
+  `design/components.css:22`. `R-74` conformance achieved more cheaply than Supabase
+  achieves it — not a gap.
+- **Control heights** do not intersect their scale at all, because the panel runs a 48px
+  Android touch floor. Deliberate; sanction it rather than close it (OD-09).
+
+Two that should stand but be recorded as **ours rather than theirs**: the two easing curves
+(neither appears in their source) and the `md` type rung, which shifts every name above it
+one place below theirs — a trap for any port, and not worth renumbering across 19
+stylesheets.
+
+---
+
+## 3 · Absences
+
+Table primitive · floating-panel primitive (popover / dropdown / tooltip / menu) · a usable
+empty state · the four status-border tokens · border-width tokens · fourteen of their 34
+semantic roles, of which `--info`, `--field` and `--control-raised` are load-bearing · a
+loading vocabulary · `font-synthesis-weight: none` and the mono-context weight reset · a
+breakpoint vocabulary, noting that they publish none either.
+
+Component coverage, counted from their source rather than their website: **12 of 28 atoms
+present in any form, 4 first-class, 0 at full parity; 3 of 23 fragments.** Sixteen atoms
+have no ScrapeX selector of any kind.
+
+---
+
+## 4 · False premises
+
+The most dangerous category, because the next session will argue from them.
+
+**Corrected in this pull request**, all in `design/tokens.css`, all comments — **no value
+moved**:
+
+1. `--amber` — the comment said hue and chroma held and lightness moved. The opposite:
+   lightness held, the target was 27.6% outside sRGB, and the shipped hex is a naive clip
+   that lost 9.5 degrees of hue and 16.7% of chroma.
+2. `--line-strong` — "1.57:1 on their own `--card`" measured the `--background` composite
+   against `--card`. And the replacement is not derived: `#8f8f8f` is their own
+   `gray-light-900`. Sixteen values are PUBLISHED, not thirteen.
+3. "`shadow-none` appears in more of their files than `shadow-md`" — 7 files against 11.
+4. "SEVEN of the eight steps agreed" listed six numbers, and was silently untrue of the
+   name-to-value mapping.
+5. "There is NO BOLD anywhere in their system" — true of their component library, false of
+   their repository, which carries 11 `font-bold` and 2 `font-extrabold`.
+6. "Their vocabulary is 100/150/200/250/300ms and exactly TWO curves" — `duration-250` is
+   used zero times, their most-used duration (200ms, 14 uses) has no token here, and
+   neither curve is theirs.
+7. The device block's claim that a test compares its bases against `:root`. See D-17.
+
+**Corrected in the registers by this pull request:** `docs/STATE.md`'s "no PR yet" and its
+"playwright is not installed on this machine"; `docs/LESSONS.md`'s citation of a guard that
+has never existed and of an inverted test name; `docs/REQUESTS.md`'s two-palette test name;
+`docs/DESIGN-SYSTEM.md`'s licence path, `.source-row` and icon markup; `docs/BACKLOG.md`'s
+"9 non-generated stylesheets", which is 19.
+
+**Left standing deliberately:** the docstring at
+`tests/test_a_palette_may_change_nothing_but_colour.py:10` says `themeFor` dashes every key
+into a custom property, so a `radius` key becomes a real `--radius`. **Measured false** —
+`apply()` writes only the 36 allowlisted names and drops the rest. The docstring justifies
+the shape rule with a mechanism the allowlist already prevents. Correcting it is entangled
+with `OP-102`'s fix and belongs in the same change.
+
+---
+
+## 5 · What did not survive verification
+
+Twenty-one findings were refuted. The ones that matter:
+
+- **Checkboxes and radios DO follow the palette.** The claim that native checked controls
+  ignore it — filed by the first pass as an `R-74` violation — is false.
+  `design/components.css:22` sets `accent-color`, which is why no `appearance: none` was
+  needed. Browser-proven twice, independently.
+- **"Zero non-colour properties move" is wrong as stated:** four shadow composites change
+  blur and offset between light and dark. The `R-74` conclusion survives because the change
+  is palette-invariant within a scheme and is a declared scheme decision.
+- **`.code` is monospace on both surfaces.** CSS overrides per declaration and the second
+  sheet never declares `font-family`.
+- **The device cascade fix is not free.** Priced as a block move; measured, device-dark goes
+  from 0/17 to 5/17 failing contrast assertions, because the mix runs toward near-white in
+  dark. **The fix does not create the illegibility, it reveals it.**
+- **Four censuses were contaminated by the generated byte copies** — proven by reproducing
+  the wrong number with the copies included. `var(--ease)` is 55 not 77; `--ease-travel` is
+  **1 not 3**, a single declaration tripled by the copies.
+- **One census swallowed the Sign-in-with-Google region**, which is excluded by ruling. The
+  six-families share is 47.4%, not 48.5%.
+- **`OP-97`'s 138 and this review's 140 are different quantities**, not a restatement.
+  `OP-97`'s figure is the buckets it deliberately left; the new one is exact duplicates. The
+  scope gap is real: **93 of the 140 live in ten stylesheets the census never opened.**
+- **The 117-row component matrix was hand-authored, not derived**, and omitted four members
+  of its own stated universe — including Supabase's own `Button` wrapper.
+- **`PINNED` has 66 rows, not 26.** The finding that rests on it — zero rows for either
+  design document — survives; the number did not.
+
+**Why this section exists.** Six of the nine above would have shipped as findings without
+the verify pass, and two of them would have accused the code of violating a ruling it
+obeys. A review without an adversarial stage is a list of plausible claims.
+
+---
+
+## 6 · Twelve decisions, and none of them is a reviewer's
+
+Recorded in full as `REQ-49`'s open questions. The four that gate the rest:
+
+| | question | the number | recommendation |
+|---|---|---|---|
+| OD-01 | adopt their numeric ramps 200-600? | 15 tokens across 3 blocks = 45 declarations minimum; `THEME_PROPERTIES` 36 to 51 | **no** to the ramps, **yes** to the four status-border tokens — a quarter of the cost, 14 call sites behind it |
+| OD-02 | is `--amber` the intended colour, or the accident of a clip? | 9.5 degrees off their warning hue; the hue-holding value is `#8d5e00` | switch, **or** rule "clip accepted" — either way the comment is now true |
+| OD-03 | five more contrast pairs, and a `device` state? | 102 to 132 assertions, **zero new tokens** | **yes**, measured before landing rather than landed red |
+| OD-04 | fix the device cascade? | a seven-declaration block move — and 5 of 17 newly failing | **yes**, but land it with OD-03, not before |
+
+---
+
+## 7 · What this pull request did not do
+
+It changed **no value, no selector and no component rule.** Seven comments, six documents,
+the registers, and one review. The twelve decisions are open and every defect above is
+filed rather than fixed, per **C1**: diagnose, confirm, then fix.

--- a/extension/tokens.css
+++ b/extension/tokens.css
@@ -53,8 +53,14 @@
   --surface-subtle: #f6f6f6;  /* --muted */
   --surface-raised: #ffffff;  /* --popover */
   --line: #e9e9e9;            /* --border */
-  /* Their --border-stronger is #cecece, which is 1.57:1 on their own --card
-     where the panel guard needs 3:1. Derived to clear it: 3.23:1. */
+  /* Their --border-stronger is an alpha overlay, so it has no single value: it
+     composites to #cecece over --background and #d0d0d0 over --card. The 1.57:1
+     recorded here was the --background composite measured against --card, so the
+     plate and the value did not match; on its own plate it is 1.574:1. Both are
+     under the panel guard's 3:1, so the substitution stands and only the
+     arithmetic behind it was wrong. What replaces it is not derived: #8f8f8f is
+     Supabase's own gray-light-900 (hsl 0 0% 56.1%, in their build css source),
+     and it clears the floor at 3.23:1. PUBLISHED. */
   --line-strong: #8f8f8f;
   --text: #030303;            /* --foreground */
   --muted: #464646;           /* --muted-foreground */
@@ -74,8 +80,16 @@
   --accent-contrast: #030303;
   --accent-weak: #d3f8e4;     /* brand-200 light       PUBLISHED */
   /* Their --warning is oklch(0.68 0.14 75) = #ca8a10, which is 2.68:1 on their
-     own published warning-300 tint below where the guard needs 4.5:1. Their hue
-     and chroma held, lightness moved to 0.52: 5.14:1. */
+     own published warning-300 tint below where the guard needs 4.5:1, so it had
+     to move. WHAT MOVED IS NOT WHAT THIS COMMENT USED TO SAY. The target
+     oklch(0.52 0.14 75) does not exist in sRGB -- maximum in-gamut chroma at that
+     lightness and hue is 0.1097, so it sat 27.6% past the boundary -- and the
+     value below is a naive per-channel clip of it. Measured back out of the hex:
+     LIGHTNESS held (0.5218), chroma fell 16.7%, and hue moved 75 -> 65.53
+     degrees. So the shipped warning sits 9.5 degrees off Supabase's warning hue.
+     It clears the guard at 5.14:1, and it is not the colour the old comment
+     described. The gamut-mapped value that would hold hue 75 is #8d5e00;
+     switching to it is the owner's call and until he rules this stands. */
   --amber: #965900;
   --amber-weak: #fff4d5;      /* warning-300 light     PUBLISHED */
   --red: #ab413e;             /* --destructive light   derived */
@@ -144,8 +158,13 @@
   /* Elevation — and Supabase's position on it is "almost none". They define ZERO
      shadow tokens: depth is a surface-colour ladder plus a 1px border, their
      Dialog is `border shadow-md dark:shadow-xs` so the border is unconditional
-     and the shadow is what gets dropped, `shadow-none` appears in more of their
-     files than `shadow-md`, and even their box-shadow utilities draw a 1px line
+     and the shadow is what gets dropped. (An earlier line here claimed
+     `shadow-none` appears in more of their files than `shadow-md`. Measured over
+     packages/ui and packages/ui-patterns it is the other way round: shadow-none
+     in 7 files / 13 uses, shadow-md in 11 files / 13 uses. The position is still
+     "almost none" -- they author ZERO shadow tokens, which is the part that
+     matters -- but the count said something untrue.) Even their box-shadow
+     utilities draw a 1px line
      at zero blur. So these are deliberately flat, and flatter again in the dark
      blocks below. OP-95: --shadow-lg's colour was a literal while its two
      siblings derived from --shadow-color, so no appearance could re-tone it;
@@ -178,10 +197,18 @@
   --font-mono: "Source Code Pro", ui-monospace, "Cascadia Code", Consolas,
     monospace;
   /* Their scale is shifted about 2px down from stock Tailwind, under their own
-     comment "font sizing and weights optimized for Inter". Measured against the
-     ramp this file already had, SEVEN of the eight steps agreed already --
-     12/13/16/18/22/28 are identical. The one real move is the body size:
-     their text-base is 15px where --fs was 14px. */
+     comment "font sizing and weights optimized for Inter". The VALUES below match
+     theirs exactly from 13px up -- 13/15/16/18/22/28 -- and the one real move was
+     the body size: their text-base is 15px where --fs was 14px.
+     THE NAMES DO NOT MATCH, AND THAT IS A TRAP FOR ANY PORT. This ramp carries an
+     `md` step Tailwind has no name for, so from --fs-md upward every rung sits one
+     place BELOW theirs: --fs-md 16px is their --text-lg, --fs-lg 18px is their
+     --text-xl, --fs-xl 22px is their --text-2xl. Porting one of their class names
+     onto the same-sounding token here silently resizes the text. Do not renumber
+     to fix it -- these names are load-bearing across 19 stylesheets.
+     One thing of theirs this ramp does not have: they reset the whole scale to
+     stock Tailwind inside code/pre/kbd/.font-mono, so their mono context runs a
+     different size ramp AND a different normal weight (400, not 450). */
   --fs-2xs: 0.6875rem;
   --fs-xs: 0.75rem;
   --fs-sm: 0.8125rem;
@@ -190,10 +217,16 @@
   --fs-lg: 1.125rem;
   --fs-xl: 1.375rem;
   --fs-2xl: 1.75rem;
-  /* --font-weight-normal is 450, not 400, and there is NO BOLD anywhere in their
-     system: `strong` is downgraded to 500 and the ceiling is Manrope 600 on
-     headings. So --fw-heavy drops 700 -> 600 -- deliberately removing a weight
-     rather than adding one, which is why --fw-bold and --fw-heavy now agree. */
+  /* --font-weight-normal is 450, not 400, and their COMPONENT LIBRARY carries no
+     bold at all: packages/ui and packages/ui-patterns measure 0 font-bold and 0
+     font-extrabold, `strong` is downgraded to 500, and the ceiling is Manrope 600
+     on headings. So --fw-heavy drops 700 -> 600 -- deliberately removing a weight
+     rather than adding one, which is why --fw-bold and --fw-heavy now agree.
+     BE PRECISE ABOUT THE SCOPE. An earlier version of this comment said there is
+     no bold ANYWHERE in their system, and that is false of their repository: the
+     docs chrome and the imported shadcn demos carry 11 font-bold and 2
+     font-extrabold. The claim holds for the library these components come from,
+     which is what this ramp copies, and it holds nowhere wider. */
   --fw-regular: 450;
   --fw-medium: 500;
   --fw-bold: 600;
@@ -202,9 +235,16 @@
   --lh: 1.5;
   --lh-relaxed: 1.65;
 
-  /* Motion and layering — Supabase's vocabulary is 100/150/200/250/300ms and
-     exactly TWO curves, chosen by meaning rather than by size: one for things
-     that APPEAR and one for things that TRAVEL. */
+  /* Motion and layering. THE DURATIONS BELOW ARE NOT THEIR RAMP, and an earlier
+     version of this comment said they were. Measured over packages/ui and
+     packages/ui-patterns their ramp is 75/100/150/200/300/400/500/700/1000ms,
+     dominated by 200 (14 uses) and 100 (6). `duration-250` is used ZERO times,
+     and 200 -- their de-facto control transition -- has no token here at all.
+     THE TWO CURVES ARE OURS, NOT THEIRS. Neither cubic-bezier below appears
+     anywhere in their source; their components use Tailwind stock easing. Pairing
+     the curves by meaning -- one for things that APPEAR, one for things that
+     TRAVEL -- is this repository's own idea and worth keeping, but it is an
+     addition on top of the baseline, not a transcription of it. */
   --dur-fast: 0.1s;
   --dur: 0.15s;
   --dur-slow: 0.25s;
@@ -401,9 +441,18 @@
  * WHY THE NEUTRALS ARE SPELLED AGAIN HERE. A custom property cannot be mixed
  * against its own cascaded value -- `--bg: color-mix(..., var(--bg)))` is a
  * cycle and computes to nothing -- so the base has to be named literally at the
- * point of the mix. `tests/test_vendor.py` asserts these bases match the `:root`
- * and dark-block values they are copies of, which is what stops them drifting
- * apart the way the old ones silently had.
+ * point of the mix.
+ *
+ * NOTHING GUARDS THESE BASES, AND ONE HAS ALREADY DRIFTED. An earlier version of
+ * this comment said `tests/test_vendor.py` asserts the bases match the `:root`
+ * and dark-block values they copy. It does not: the named test checks that nine
+ * token NAMES appear in this block and that the strings `light-dark(` and
+ * `color-mix(in srgb, var(--accent)` are present, and it compares no literal at
+ * all -- grep the whole test suite for any of these hexes and it returns nothing.
+ * Measured 2026-08-29: the light `--control-hover` base here is #f3f3f3, which is
+ * `--chip`, while `:root` declares `--control-hover: var(--surface-subtle)` =
+ * #f6f6f6. The dark base still agrees. So the drift this comment claimed to
+ * prevent is present in the file the comment is written in.
  */
 :root[data-color-mode="device"] {
   --bg: light-dark(

--- a/scrapex/webui/static/tokens.css
+++ b/scrapex/webui/static/tokens.css
@@ -53,8 +53,14 @@
   --surface-subtle: #f6f6f6;  /* --muted */
   --surface-raised: #ffffff;  /* --popover */
   --line: #e9e9e9;            /* --border */
-  /* Their --border-stronger is #cecece, which is 1.57:1 on their own --card
-     where the panel guard needs 3:1. Derived to clear it: 3.23:1. */
+  /* Their --border-stronger is an alpha overlay, so it has no single value: it
+     composites to #cecece over --background and #d0d0d0 over --card. The 1.57:1
+     recorded here was the --background composite measured against --card, so the
+     plate and the value did not match; on its own plate it is 1.574:1. Both are
+     under the panel guard's 3:1, so the substitution stands and only the
+     arithmetic behind it was wrong. What replaces it is not derived: #8f8f8f is
+     Supabase's own gray-light-900 (hsl 0 0% 56.1%, in their build css source),
+     and it clears the floor at 3.23:1. PUBLISHED. */
   --line-strong: #8f8f8f;
   --text: #030303;            /* --foreground */
   --muted: #464646;           /* --muted-foreground */
@@ -74,8 +80,16 @@
   --accent-contrast: #030303;
   --accent-weak: #d3f8e4;     /* brand-200 light       PUBLISHED */
   /* Their --warning is oklch(0.68 0.14 75) = #ca8a10, which is 2.68:1 on their
-     own published warning-300 tint below where the guard needs 4.5:1. Their hue
-     and chroma held, lightness moved to 0.52: 5.14:1. */
+     own published warning-300 tint below where the guard needs 4.5:1, so it had
+     to move. WHAT MOVED IS NOT WHAT THIS COMMENT USED TO SAY. The target
+     oklch(0.52 0.14 75) does not exist in sRGB -- maximum in-gamut chroma at that
+     lightness and hue is 0.1097, so it sat 27.6% past the boundary -- and the
+     value below is a naive per-channel clip of it. Measured back out of the hex:
+     LIGHTNESS held (0.5218), chroma fell 16.7%, and hue moved 75 -> 65.53
+     degrees. So the shipped warning sits 9.5 degrees off Supabase's warning hue.
+     It clears the guard at 5.14:1, and it is not the colour the old comment
+     described. The gamut-mapped value that would hold hue 75 is #8d5e00;
+     switching to it is the owner's call and until he rules this stands. */
   --amber: #965900;
   --amber-weak: #fff4d5;      /* warning-300 light     PUBLISHED */
   --red: #ab413e;             /* --destructive light   derived */
@@ -144,8 +158,13 @@
   /* Elevation — and Supabase's position on it is "almost none". They define ZERO
      shadow tokens: depth is a surface-colour ladder plus a 1px border, their
      Dialog is `border shadow-md dark:shadow-xs` so the border is unconditional
-     and the shadow is what gets dropped, `shadow-none` appears in more of their
-     files than `shadow-md`, and even their box-shadow utilities draw a 1px line
+     and the shadow is what gets dropped. (An earlier line here claimed
+     `shadow-none` appears in more of their files than `shadow-md`. Measured over
+     packages/ui and packages/ui-patterns it is the other way round: shadow-none
+     in 7 files / 13 uses, shadow-md in 11 files / 13 uses. The position is still
+     "almost none" -- they author ZERO shadow tokens, which is the part that
+     matters -- but the count said something untrue.) Even their box-shadow
+     utilities draw a 1px line
      at zero blur. So these are deliberately flat, and flatter again in the dark
      blocks below. OP-95: --shadow-lg's colour was a literal while its two
      siblings derived from --shadow-color, so no appearance could re-tone it;
@@ -178,10 +197,18 @@
   --font-mono: "Source Code Pro", ui-monospace, "Cascadia Code", Consolas,
     monospace;
   /* Their scale is shifted about 2px down from stock Tailwind, under their own
-     comment "font sizing and weights optimized for Inter". Measured against the
-     ramp this file already had, SEVEN of the eight steps agreed already --
-     12/13/16/18/22/28 are identical. The one real move is the body size:
-     their text-base is 15px where --fs was 14px. */
+     comment "font sizing and weights optimized for Inter". The VALUES below match
+     theirs exactly from 13px up -- 13/15/16/18/22/28 -- and the one real move was
+     the body size: their text-base is 15px where --fs was 14px.
+     THE NAMES DO NOT MATCH, AND THAT IS A TRAP FOR ANY PORT. This ramp carries an
+     `md` step Tailwind has no name for, so from --fs-md upward every rung sits one
+     place BELOW theirs: --fs-md 16px is their --text-lg, --fs-lg 18px is their
+     --text-xl, --fs-xl 22px is their --text-2xl. Porting one of their class names
+     onto the same-sounding token here silently resizes the text. Do not renumber
+     to fix it -- these names are load-bearing across 19 stylesheets.
+     One thing of theirs this ramp does not have: they reset the whole scale to
+     stock Tailwind inside code/pre/kbd/.font-mono, so their mono context runs a
+     different size ramp AND a different normal weight (400, not 450). */
   --fs-2xs: 0.6875rem;
   --fs-xs: 0.75rem;
   --fs-sm: 0.8125rem;
@@ -190,10 +217,16 @@
   --fs-lg: 1.125rem;
   --fs-xl: 1.375rem;
   --fs-2xl: 1.75rem;
-  /* --font-weight-normal is 450, not 400, and there is NO BOLD anywhere in their
-     system: `strong` is downgraded to 500 and the ceiling is Manrope 600 on
-     headings. So --fw-heavy drops 700 -> 600 -- deliberately removing a weight
-     rather than adding one, which is why --fw-bold and --fw-heavy now agree. */
+  /* --font-weight-normal is 450, not 400, and their COMPONENT LIBRARY carries no
+     bold at all: packages/ui and packages/ui-patterns measure 0 font-bold and 0
+     font-extrabold, `strong` is downgraded to 500, and the ceiling is Manrope 600
+     on headings. So --fw-heavy drops 700 -> 600 -- deliberately removing a weight
+     rather than adding one, which is why --fw-bold and --fw-heavy now agree.
+     BE PRECISE ABOUT THE SCOPE. An earlier version of this comment said there is
+     no bold ANYWHERE in their system, and that is false of their repository: the
+     docs chrome and the imported shadcn demos carry 11 font-bold and 2
+     font-extrabold. The claim holds for the library these components come from,
+     which is what this ramp copies, and it holds nowhere wider. */
   --fw-regular: 450;
   --fw-medium: 500;
   --fw-bold: 600;
@@ -202,9 +235,16 @@
   --lh: 1.5;
   --lh-relaxed: 1.65;
 
-  /* Motion and layering — Supabase's vocabulary is 100/150/200/250/300ms and
-     exactly TWO curves, chosen by meaning rather than by size: one for things
-     that APPEAR and one for things that TRAVEL. */
+  /* Motion and layering. THE DURATIONS BELOW ARE NOT THEIR RAMP, and an earlier
+     version of this comment said they were. Measured over packages/ui and
+     packages/ui-patterns their ramp is 75/100/150/200/300/400/500/700/1000ms,
+     dominated by 200 (14 uses) and 100 (6). `duration-250` is used ZERO times,
+     and 200 -- their de-facto control transition -- has no token here at all.
+     THE TWO CURVES ARE OURS, NOT THEIRS. Neither cubic-bezier below appears
+     anywhere in their source; their components use Tailwind stock easing. Pairing
+     the curves by meaning -- one for things that APPEAR, one for things that
+     TRAVEL -- is this repository's own idea and worth keeping, but it is an
+     addition on top of the baseline, not a transcription of it. */
   --dur-fast: 0.1s;
   --dur: 0.15s;
   --dur-slow: 0.25s;
@@ -401,9 +441,18 @@
  * WHY THE NEUTRALS ARE SPELLED AGAIN HERE. A custom property cannot be mixed
  * against its own cascaded value -- `--bg: color-mix(..., var(--bg)))` is a
  * cycle and computes to nothing -- so the base has to be named literally at the
- * point of the mix. `tests/test_vendor.py` asserts these bases match the `:root`
- * and dark-block values they are copies of, which is what stops them drifting
- * apart the way the old ones silently had.
+ * point of the mix.
+ *
+ * NOTHING GUARDS THESE BASES, AND ONE HAS ALREADY DRIFTED. An earlier version of
+ * this comment said `tests/test_vendor.py` asserts the bases match the `:root`
+ * and dark-block values they copy. It does not: the named test checks that nine
+ * token NAMES appear in this block and that the strings `light-dark(` and
+ * `color-mix(in srgb, var(--accent)` are present, and it compares no literal at
+ * all -- grep the whole test suite for any of these hexes and it returns nothing.
+ * Measured 2026-08-29: the light `--control-hover` base here is #f3f3f3, which is
+ * `--chip`, while `:root` declares `--control-hover: var(--surface-subtle)` =
+ * #f6f6f6. The dark base still agrees. So the drift this comment claimed to
+ * prevent is present in the file the comment is written in.
  */
 :root[data-color-mode="device"] {
   --bg: light-dark(

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -238,7 +238,7 @@ PINNED = (
     # that tier 1 and tier 2 both accepted. A citation of prose needs pinning more
     # than a citation of code does -- code has a symbol a reader can grep for, and a
     # paragraph about palette tokens reads exactly as plausibly as one about layers.
-    ("docs/BACKLOG.md", "docs/LESSONS.md", 831, "The extension's layers are three"),
+    ("docs/BACKLOG.md", "docs/LESSONS.md", 840, "The extension's layers are three"),
     # OP-35 · the hand-maintained command set that drifted to half the CLI.
     # The entry says "do not extend the literal, derive it", which only makes
     # sense standing at the literal.


### PR DESCRIPTION
He asked for the design system to be reviewed against Supabase's, and set the scope before any finding — «اولا تحديد كل محاور المراجعة». A scoping pass produced twenty-six axes, a completeness critic found seven missing and refused eleven measurement steps as unexecutable, and he chose six: «ابدأ بالستة».

Then he pointed the review at Supabase's **source** rather than its website. That instruction is what made the token half verifiable at all.

## Nothing shipped changed, and it is proved rather than asserted

**193 token declarations before, 193 after, identical**, with both generated copies byte-equal to the source. Seven comments in `design/tokens.css`, six documents, two guards, and one report. Every defect is filed rather than fixed and twelve decisions are open, per **C1**.

## The headline

**`R-74` holds in the built product and is enforced by almost nothing.**

Measured in Chromium 149 across the 8 shipped colour states by 118 root custom properties: 62 move and every one is a colour. That rests on one unasserted statement — the allowlist loop at `design/appearance.js:347` — guarded only by `assert "THEME_PROPERTIES.forEach" in appearance` at `tests/test_vendor.py:289`. **`clearTheme` at `design/appearance.js:310` contains that same substring**, so the assertion is satisfied whether or not the loop in `apply()` exists.

Mutation on a byte-verified mirror put `--fs`, `--font-body` and `--lh` into a palette, and 11 of the 13 forbidden families into a surface stylesheet. **91 static guards and all 218 browser tests stayed green for both.** `OP-102`.

## The premise was false and the work built on it was right

`docs/STATE.md` recorded that Supabase publishes token names without values, so the palette had been derived by inference. `packages/ui/build/css/` publishes both. Re-derived against it: **15 values byte-exact, 19 more reproducing their OKLCH expressions, scalars matching 9 of 10 in light and 10 of 10 in dark** — including `--elevation-step` solved independently at two elevation ratios.

What the false premise cost was six comments arguing from things that are not true. Those are corrected here.

## Filed as OP-101..110

- **`OP-101`** — "Device colours" paints Supabase's own accent in dark. `@supports` adds no specificity, so the device block ties with the two later dark blocks and loses on source order. One of `R-74`'s four named choices, unreachable in half its states. **The fix is not free:** it takes device-dark from 0 of 17 to 5 of 17 failing contrast assertions. It reveals the illegibility rather than creating it.
- **`OP-103`** — twelve declarations read properties nothing declares. `--sticky-tabs` is read nine times and declared zero, all inside `calc()` without a fallback, so **the settings and exports sidebars are `position: sticky` and never stick**.
- **`OP-104`** — the contrast matrix's palette list is derived and its token pairs are not, so a palette can ship three text-bearing backgrounds at **1.00:1** with 218 tests green. And `device` is structurally uncoverable; run by hand it fails two of seventeen at 4.21:1.
- **`OP-108`** — no Supabase attribution anywhere, while this repository discharges the identical obligation three times over for a smaller borrowing from Google.

Plus `OP-102`, `OP-105`, `OP-106`, `OP-107`, `OP-109`, `OP-110`.

## Twenty-one findings did NOT survive verification

Listed in section 5 of the report rather than buried, because six of the nine that matter would have shipped as findings without the verify pass, and **two had accused the code of breaking a ruling it obeys**:

- **Checkboxes and radios DO follow the palette**, through `accent-color` at `design/components.css:22` — which is why no `appearance: none` was needed.
- **Four censuses were contaminated by the generated byte copies.** `--ease-travel` is **1 use, not 3** — a single declaration tripled by the copies.
- **One census swallowed the Sign-in-with-Google region**, which is excluded by ruling.

## Registers

`REQ-49` and `OP-101..110` allocated by the primary session under `R-42`. **`OP-100` is reserved** to `claude/request-deadline-exceeded-3b1cad`, with the reason written into the row: it was local-only when reserved, so `git ls-remote` would have reported the number free. Delete the row the day that PR lands.

## LESSONS 27 is new

**A counting tool is fooled by the documentation of the thing it counts.** Two sessions hit it independently within two hours. Here a line-grep counted the comment *explaining* the `--z-modal` collision as further instances of it — and all three published numbers moved in the same direction, so they stayed consistent with each other and read as trustworthy. Corrected to 38 / 6 / 29 with a parser that strips comments.

## Verification

Both migration modes green, with **pytest's own exit code captured rather than a pipe's** — the first run reported `0` from `tail` while pytest had failed.

```
TEMPLATE_MODE_EXIT=0
FULL_MIGRATIONS_EXIT=0
```

`VERSION` deliberately not bumped: `scrapex/version.py` moves on a functional, architectural or behavioural change and this is none of the three, while `ENGINEERING.md` W4 says every merged pull request. Two sessions reached that same conflict from opposite directions today; it is his to rule and `0.4.7` stays unassigned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
