### PR TITLE
Device colours reach the user, and the ink is derived rather than trusted (R-79)

### DIFF
--- a/design/appearance.js
+++ b/design/appearance.js
@@ -32,7 +32,14 @@
           surfaceRaised: "#FFFFFF", line: "#E5E5E5", lineStrong: "#959393",
           text: "#0A0A0A", muted: "#666666", textSubtle: "#707070",
           chip: "#F7F5F3", accent: "#35AA65", accentHover: "#2E9D5B",
-          accentActive: "#278F52", accentInk: "#18864B",
+          // #18864B until 2026-08-30, when OD-03's new pair measured it at
+          // 4.180:1 on this palette's own accentWeak (#DBFDD5) against a 4.5
+          // floor -- the one failure the five added pairs found across all eight
+          // shipped states. It was marginal on --surface too, at 4.615. Darkened
+          // until both clear with headroom: 5.077 on accentWeak, 5.604 on white.
+          // accentWeak cannot be raised to meet it -- even #F0FEEE only reaches
+          // 4.421 -- so the ink is the only side that can move.
+          accentActive: "#278F52", accentInk: "#147742",
           accentContrast: "#0A0A0A", accentWeak: "#DBFDD5",
           focus: "#278F52", controlHover: "#F0EEEC",
           buttonBg: "#43D36D", buttonHover: "#1C1E21",

--- a/design/tokens.css
+++ b/design/tokens.css
@@ -296,21 +296,6 @@
 
 }
 
-/* Device colours use the colour preference exposed by the browser/operating
-   system. Browsers do not expose their private new-tab palette to extensions,
-   so the system accent is the truthful automatic colour source. */
-@supports (color: AccentColor) {
-  :root[data-color-mode="device"] {
-    --accent: AccentColor;
-    --accent-hover: color-mix(in srgb, AccentColor 84%, var(--text));
-    --accent-active: color-mix(in srgb, AccentColor 72%, var(--text));
-    --accent-ink: color-mix(in srgb, AccentColor 78%, var(--text));
-    --accent-contrast: AccentColorText;
-    --accent-weak: color-mix(in srgb, AccentColor 14%, var(--surface));
-    --focus: AccentColor;
-  }
-}
-
 :root[data-theme="dark"] {
   color-scheme: dark;
 
@@ -426,6 +411,73 @@
   }
 }
 
+/* Device colours use the colour preference exposed by the browser/operating
+   system. Browsers do not expose their private new-tab palette to extensions,
+   so the system accent is the truthful automatic colour source.
+ *
+ * IT SITS HERE, AFTER THE DARK BLOCKS, AND THE POSITION IS THE WHOLE POINT.
+ * `@supports` contributes NO specificity, so this selector is (0,2,0) -- exactly
+ * what `:root[data-theme="dark"]` and `:root:not([data-theme="light"])` are. When
+ * it stood above them they won on source order and redeclared all seven of these
+ * properties, so "Device colours" on a dark OS painted Supabase's own #3ecf8e for
+ * every accent, focus ring, button and switch track while the panel's status text
+ * reported the choice it was not painting. Measured in Chromium 149 before the
+ * move: device-dark resolved `--accent` to rgb(62, 207, 142). That is OP-101, and
+ * moving these eleven lines is the whole of its fix.
+ *
+ * KEEP IT BELOW BOTH DARK BLOCKS. A future block added after this one that also
+ * sets an accent will take device back, silently and in one scheme only, which is
+ * the shape that made this defect invisible for as long as it lived. */
+@supports (color: AccentColor) {
+  :root[data-color-mode="device"] {
+    --accent: AccentColor;
+    --accent-hover: color-mix(in srgb, AccentColor 84%, var(--text));
+    --accent-active: color-mix(in srgb, AccentColor 72%, var(--text));
+    /* 60%, not the 78% the other accent tones use. Measured on Chromium 149's
+       accent in dark: at 78% this is rgb(52,144,251) on an --accent-weak of
+       rgb(18,50,87) = 4.031:1, under the 4.5 floor; 66% is the first passing
+       value at 4.698 and 60% is the first with real headroom, 5.123 dark and
+       7.025 light. The other tones keep 78% because nothing pairs them with a
+       tinted weak surface. */
+    --accent-ink: color-mix(in srgb, AccentColor 60%, var(--text));
+    --accent-contrast: AccentColorText;
+    --accent-weak: color-mix(in srgb, AccentColor 14%, var(--surface));
+    --focus: AccentColor;
+  }
+}
+
+/* AND THE OPERATING SYSTEM'S OWN INK IS NOT LEGIBLE ON ITS OWN ACCENT.
+ *
+ * Measured in Chromium 149, whose AccentColor is rgb(0, 117, 255): its
+ * AccentColorText is WHITE, which is 4.21:1 against that accent where the panel
+ * guard needs 4.5. Black on the same accent is 4.99:1. The browser hands us the
+ * worse of the two, and it is the pair a user actually reads a primary button
+ * through.
+ *
+ * SUPABASE'S OWN MECHANISM PICKS THE WRONG ONE TOO, so this is a departure from
+ * the baseline with the number written at the value, the way the other four are.
+ * Their on-colour is a hard step on OKLCH lightness -- oklch(from <fill>
+ * clamp(0.12, calc((0.62 - l) * 100), 0.99) ...) -- and for this accent it
+ * resolves to L 0.99, near-white, because OKLCH lightness and WCAG relative
+ * luminance disagree about saturated blues. `contrast-color()` asks the WCAG
+ * question directly and answers black.
+ *
+ * It is a separate @supports on purpose: `contrast-color()` is newer than
+ * `AccentColor`, so a browser that has the accent and not the function keeps the
+ * declaration above and loses nothing it had. */
+@supports (color: contrast-color(red)) {
+  :root[data-color-mode="device"] {
+    --accent-contrast: contrast-color(AccentColor);
+    /* AND THE HOVER SURFACE NEEDS ITS OWN INK, which is why this token exists.
+       `--accent-hover` moves toward `--text`, so in LIGHT it darkens -- and the
+       ink chosen for the base accent is black, so the two converge: measured
+       3.766:1 against a 4.5 floor. Derived per surface instead, light picks
+       WHITE for the hover (5.576:1) and dark keeps black (6.066:1). One ink
+       cannot serve both ends of an accent the operating system chooses. */
+    --button-hover-text: contrast-color(var(--accent-hover));
+  }
+}
+
 /* Device-derived tonal surfaces
  *
  * When the browser exposes a system accent, it supplies a quiet family of
@@ -475,9 +527,19 @@
     color-mix(in srgb, var(--accent) 16%, #e9e9e9),
     color-mix(in srgb, var(--accent) 18%, #232423)
   );
+  /* THE DARK BASE IS #787878 HERE AND #707070 EVERYWHERE ELSE, deliberately.
+     Device surfaces are tinted with the system accent and therefore LIGHTER than
+     the plain dark surface, so a line that clears 3:1 on the plain one does not
+     clear on this one. Measured on Chromium 149's accent: #707070 gives 2.982:1
+     against a device-dark --surface of rgb(20,40,59), and it stays under the
+     floor across the whole mix range -- 2.982 at 26%, 2.994 at 20%, 3.002 at 14%,
+     2.994 at 8% -- because the line and the surface are mixed with the same
+     accent and move together. #787878 clears at every percentage, 3.249 at the
+     26% used here. This is a measured difference, not the silent drift recorded
+     above it. */
   --line-strong: light-dark(
     color-mix(in srgb, var(--accent) 28%, #8f8f8f),
-    color-mix(in srgb, var(--accent) 26%, #707070)
+    color-mix(in srgb, var(--accent) 26%, #787878)
   );
   --chip: light-dark(
     color-mix(in srgb, var(--accent) 10%, #f3f3f3),

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3582,7 +3582,7 @@ staging tree it finds.
    2026-08-29 row would falsify. **The rule is not that every plan is frozen:** one under
    `## Current` is a live document and `C2` makes a stale one a bug to fix. This one is
    Historical, which is what settles it.
-### OP-101 · "Device colours" paints Supabase's own accent in dark mode
+### OP-101 · ~~"Device colours" paints Supabase's own accent in dark mode~~ — CLOSED 2026-08-30
 
 `design/tokens.css:302` wraps the device block in `@supports (color: AccentColor)`, which
 contributes **no specificity**. The selector is therefore `(0,2,0)` — identical to the two
@@ -3602,6 +3602,18 @@ device-light shows, because `color-mix(in srgb, AccentColor 84%, var(--text))` m
 near-white in dark. The fix does not create the illegibility; it reveals it. So it lands
 with `OP-104`'s device coverage or not at all. Recorded as OD-04 in
 [REQ-49](REQUESTS.md#req-49--review-the-design-system-against-supabases).
+
+**CLOSED 2026-08-30 by [R-79](RULINGS.md#r-79--device-colours-reach-the-user-and-the-ink-is-derived-rather-than-trusted).**
+The block moved below both dark blocks; `test_device_colours_reach_the_user_in_both_schemes`
+asserts the property that broke — device DIFFERS from the baseline in both schemes — rather
+than a value, because the accent belongs to the machine.
+
+**And the price was paid rather than deferred.** The five failures the move revealed are
+fixed here, not registered: the on-colour is derived with `contrast-color()` because the
+system's own `AccentColorText` is 4.21:1 on its own accent; `--button-hover-text` derives per
+surface because one ink cannot serve both ends of an accent we do not choose; `--accent-ink`
+went 78% to 60%; and the dark `--line-strong` base went `#707070` to `#787878`. Device now
+passes 21 of 21 in both schemes.
 
 ### OP-102 · `R-74` is enforced by one unasserted statement, and mutation proves it
 
@@ -3679,6 +3691,34 @@ existing tokens, so `THEME_PROPERTIES` stays at 36. Recorded as OD-03.
 **One reason for deferring this was measured and is false.** The fear was that an alpha or
 system colour would make the guard silently vacuous. It does not: Chromium returns the
 unresolved expression and the parser raises `ValueError`. It fails loudly.
+
+---
+
+**HALF CLOSED 2026-08-30 by [R-79](RULINGS.md#r-79--device-colours-reach-the-user-and-the-ink-is-derived-rather-than-trusted):
+the five pairs are added and `device` is covered. The hand-written pair list remains.**
+
+Coverage goes from **102 executions over 6 states to 168 over 8**. All five new pairs use
+tokens that already exist, so `THEME_PROPERTIES` stays at 36 and no palette gained a cell.
+
+**AND THE DEEPER HALF OF "device HAS NO COVERAGE" WAS NEVER THE PARAMETRIZE.** The guard read
+custom properties as declared, and `getComputedStyle` does not resolve one — so device's
+`AccentColor` and `color-mix(...)` came back as the literal text `ACCENTCOLOR` and
+`COLOR-MIX(IN SRGB, ...)`, and nothing could score them. **Adding device to the parametrize
+without fixing the reader would have measured nothing and passed.** The reader now resolves
+through a probe element, for every palette rather than only for device, so a palette that
+starts using `color-mix` cannot quietly fall out of coverage either; the parser learned
+`rgb()` and `color(srgb ...)` to match.
+
+**The new pairs found their first defect in a shipped palette, not in device.** `brand` light
+painted `--accent-ink` `#18864B`, which is **4.180:1** on that palette's own `--accent-weak`
+and was already marginal at 4.615 on white. `--accent-weak` cannot be raised to meet it —
+even `#F0FEEE` reaches only 4.421 — so the ink moved to `#147742`, at 5.077 and 5.604.
+`R-79` makes that the rule: a failing pair is a defect in the palette, never a reason to
+lower a threshold.
+
+**What is still open here** is the shape the entry opens with: the pair list is still
+hand-written while the palette list is derived, so a token that starts carrying text is
+still invisible until somebody adds a row by hand.
 
 ### OP-105 · The OS Increase-contrast setting reaches one of the four colour choices
 

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -2669,8 +2669,8 @@ including two that had accused the code of breaking a ruling it obeys.
 |---|---|---|---|
 | OD-01 | adopt their numeric ramps `200`-`600`? | 15 tokens across 3 blocks = 45 declarations minimum; `THEME_PROPERTIES` 36 to 51, and the contrast matrix grows with it | **no** to the ramps, **yes** to the four status-border tokens — a quarter of the cost, 14 call sites and nine competing mix percentages behind it |
 | OD-02 | is `--amber` the intended colour or the accident of a clip? | the target is 27.6% outside sRGB; the shipped hex is a naive clip 9.5 degrees off their warning hue; the hue-holding value is `#8d5e00` | switch **or** rule "clip accepted" — the comment is now true either way, and it blocks any future warning ramp |
-| OD-03 | five more contrast pairs, and a `device` state? | 102 to 132 assertions, **zero new tokens**, `THEME_PROPERTIES` unchanged | **yes** — measure first and land green, never land red |
-| OD-04 | fix the device cascade? | a seven-declaration block move, zero tokens — and device-dark goes 0 of 17 to **5 of 17** failing | **yes**, but land it with OD-03. The fix reveals the illegibility, it does not create it |
+| ~~OD-03~~ | ~~five more contrast pairs, and a `device` state?~~ | **Ruled 2026-08-30 as [R-79](RULINGS.md#r-79--device-colours-reach-the-user-and-the-ink-is-derived-rather-than-trusted).** He was offered four routes after the review merged and took this one, coupled with OD-04. Landed at **168 executions over 8 states**, not the 132 estimated here — the estimate counted 6 states because it did not yet know `device` would become two of them | done |
+| ~~OD-04~~ | ~~fix the device cascade?~~ | **Ruled 2026-08-30 as `R-79`.** Landed with OD-03 exactly as recommended. The move revealed **five** failures, not the four the review priced, and all five are fixed rather than registered | done |
 | OD-05 | make `--surface-subtle`, `--chip` and `--line` true alpha? | exact on `--background`, wrong on `--card` and `--popover` by 2/255 light and (5,6,6) dark | **plan it, do not slip it in.** The deferral's stated hazard was measured and is false — the guard fails loudly, not silently |
 | OD-06 | extract a shared table primitive? | two implementations, 101 lines already token-bound and 1,837 of Tabulator override; the extension has **zero** table CSS | extract the 101-line one only. `OP-46` makes a new shared module yours |
 | OD-07 | grow the shared `.empty`? | 3 declarations against 10 surface-local implementations and 19 usage sites | **yes** — the cheapest item in the review, and the local copies exist because the shared one was too thin |
@@ -2681,6 +2681,13 @@ including two that had accused the code of breaking a ruling it obeys.
 | OD-12 | citation guard: bare-path tier, `DOCUMENTS` widening, or both? | `DOCUMENTS` is 9 of 82 tracked `.md`; design citations are 8 and exactly 1 is pinned | **bare-path tier first** — widening alone changes zero verdicts here |
 
 ### What was deliberately not done
+
+> **THE FIRST TWO OF THE TWELVE ARE DECIDED.** OD-03 and OD-04 landed together on 2026-08-30 as
+> [R-79](RULINGS.md#r-79--device-colours-reach-the-user-and-the-ink-is-derived-rather-than-trusted),
+> closing `OP-101` and half of `OP-104`. Ten remain, and a third question was put to him
+> inside that work — whether to drop a contrast assertion no surface renders — which he
+> answered "drop it with the evidence". **The version question every one of these used to
+> raise is gone**: `R-77` gives the engine no version at all.
 
 **No value, no selector and no component rule changed.** Seven comments, six documents, the
 registers and one review. Every defect is filed rather than fixed, per **C1** — and the

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -3227,3 +3227,118 @@ guard that rejects out-of-contract rows stays where it is and keeps doing its jo
 `--approve`, `--coverage`, `--impostors`, and **four of the six make no network request at
 all**. Whatever the panel offers must name the pass; *"Update now"* describes none of them.
 
+---
+
+### R-79 · Device colours reach the user, and the ink is derived rather than trusted
+
+**2026-08-30 · design system · closes [OP-101](BACKLOG.md) and half of [OP-104](BACKLOG.md) ·
+first of [REQ-49](REQUESTS.md#req-49--review-the-design-system-against-supabases)'s twelve
+decisions**
+
+**HE CHOSE FROM OPTIONS RATHER THAN DICTATING, and this entry records the choice and the
+numbers that were in front of him when he made it** — not a quotation, because there is
+none to quote. Asked what should follow the merged review, he was offered four routes: fix
+device and contrast together, rule on all twelve decisions first, run the second wave of
+twenty axes, or fix the twelve silent undeclared properties. **He took the first**, which
+was the one labelled as the recommendation. Asked separately what to do about a contrast
+assertion that a shipped surface does not render, he was offered four and **took "drop it
+with the evidence"**, again the recommendation.
+
+#### 1 · Device colours must reach the user in both schemes
+
+`@supports` contributes **no specificity**. The device block's
+`:root[data-color-mode="device"]` is therefore `(0,2,0)` — exactly what
+`:root[data-theme="dark"]` and `:root:not([data-theme="light"])` are — and while it stood
+above them in `design/tokens.css` they won on source order and redeclared all seven of its
+properties. Measured in Chromium 149: device-dark resolved `--accent` to `rgb(62, 207, 142)`,
+which is Supabase's own `#3ecf8e`, **while the panel's status text reported "Device
+colours"**. One of the four choices `R-74` names by name, unreachable in half its states.
+
+The block moves below both dark blocks. That is the whole fix, and
+`test_device_colours_reach_the_user_in_both_schemes` asserts the property that broke —
+device DIFFERS from the baseline in both schemes — rather than a value, because the accent
+belongs to the machine and not to us.
+
+#### 2 · The fix REVEALS the contrast failures. It does not cause them.
+
+**This sentence exists so that a reader six weeks from now does not conclude the cascade fix
+broke something.** Device-dark was passing 0 of 17 assertions because it was not device: it
+was the default palette wearing device's name. Making it real exposed what the derivation
+actually produces, and five pairs went red the moment they had something true to measure.
+
+That is also why the coverage lands in the same change. Landing the cascade fix alone would
+have closed a visible defect and left an invisible one, with the guard still unable to see
+the mode it was now painting.
+
+#### 3 · The operating system's own ink is not legible on its own accent
+
+Chromium 149's `AccentColor` is `rgb(0, 117, 255)`. Its `AccentColorText` is **white**, which
+is **4.21:1** — under the 4.5 floor this repository enforces. Black on the same accent is
+**4.99:1**. The browser hands over the worse of the two, and it is the pair a user reads a
+primary button through.
+
+**Supabase's own mechanism picks the wrong one too**, which makes this the fifth departure
+from the baseline and it is written at the value like the other four. Their on-colour is a
+hard step on OKLCH lightness; for this accent it resolves to L 0.99, near-white, because
+OKLCH lightness and WCAG relative luminance disagree about saturated blues.
+`contrast-color()` asks the WCAG question directly and answers black.
+
+**And one ink cannot serve both ends of an accent the operating system chooses.**
+`--accent-hover` moves toward `--text`, so in light it darkens and converges on the black
+ink: 3.766:1. Derived per surface, light picks white for the hover (5.576) and dark keeps
+black (6.066). `--button-hover-text` already existed as a separate token; this is the system
+anticipating the problem before it was measured.
+
+#### 4 · A palette entry may carry only colour, and every value here does
+
+Nothing in this ruling touches shape, typography, spacing, elevation or motion.
+[R-74](#r-74--the-design-system-is-supabases-always-and-a-palette-may-change-nothing-but-colour)
+holds unchanged, and `tests/test_a_palette_may_change_nothing_but_colour.py` still passes.
+The four device values that moved — the ink derivation, the hover ink, `--accent-ink` at 60%
+instead of 78%, and the dark `--line-strong` base at `#787878` instead of `#707070` — are all
+inside device-scoped blocks in `design/tokens.css`, and the three registered palettes are
+untouched by them.
+
+The dark `--line-strong` base is the one that deserves its own line: device surfaces are
+tinted with the system accent and therefore **lighter** than the plain dark surface, so a
+border that clears 3:1 on the plain one does not clear on this one. `#707070` measured
+2.982:1 and stayed under the floor **across the entire mix range** — 2.982 at 26%, 2.994 at
+20%, 3.002 at 14%, 2.994 at 8% — because line and surface are mixed with the same accent and
+move together. That is a measured difference, not the silent drift recorded above it.
+
+#### 5 · An assertion that no surface renders is removed, with its evidence
+
+`("accentContrast", "accentHover")` is gone from the pair list. **`--accent-hover` has no
+consumer anywhere outside `design/tokens.css`** — the only thing that reads it is
+`--button-hover` — and the surface it becomes is inked with `--button-hover-text`, which
+`("buttonHoverText", "buttonHover")` covers. While the two inks were the same token the pair
+was a duplicate; once device derived them separately it became a duplicate that was also
+false.
+
+**Removing an assertion is the move this repository is most suspicious of**, and it was put
+to him as its own question with the alternatives priced: keep it and flatten the hover to
+94% of the accent, which passes at 4.489 and costs the hover its visible affordance; or
+repoint it at the tokens that actually render, which reproduces a pair already in the list.
+He chose removal with the evidence recorded. **No floor was lowered and no surface a reader
+meets went uncovered.**
+
+#### 6 · What the coverage now is, and the one thing it found that was not device
+
+The matrix goes from **102 executions over 6 states to 168 over 8** — three palettes plus
+device, two schemes each, 21 assertions apiece. Five pairs were added, all using tokens that
+already exist, so `THEME_PROPERTIES` stays at 36 and no palette gained a cell.
+
+**The deeper half of `device` having no coverage was never the parametrize.** The guard read
+custom properties as declared, and `getComputedStyle` does not resolve them — so device's
+`AccentColor` and `color-mix(...)` came back as the literal text `ACCENTCOLOR` and
+`COLOR-MIX(IN SRGB, ...)` and nothing could score them. **Pointing the old reader at device
+would have measured nothing.** It now resolves through a probe element, for every palette and
+not only for device, so a palette that starts using `color-mix` cannot quietly fall out of
+coverage either.
+
+**And the five new pairs found their first defect in a shipped palette, not in device.**
+`brand` light painted `--accent-ink` `#18864B`, which is **4.180:1** on that palette's own
+`--accent-weak` — and was already marginal at 4.615 on white. `--accent-weak` cannot be
+raised to meet it: even `#F0FEEE` only reaches 4.421, so the ink was the only side that could
+move. It is `#147742` now, at 5.077 and 5.604. **Per this ruling a failing pair is a defect
+in the palette, never a reason to lower a threshold.**

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -424,6 +424,51 @@ tracks *his requests* through Captured → Ruled → Planned → In flight → D
 
 ## Open pull requests
 
+### Device colours reach the user — 2026-08-30 · branch `claude/device-colours-reach-the-user`, based on `main` at `f920e7d`
+
+**`R-79`, the first two of `REQ-49`'s twelve decisions.** Closes `OP-101` and half of
+`OP-104`. He was offered four routes after the review merged and took "fix device and
+contrast together"; a second question inside the work — whether to drop a contrast assertion
+no surface renders — he answered "drop it with the evidence".
+
+**THE CASCADE WAS THE WHOLE DEFECT AND ELEVEN LINES WERE THE WHOLE FIX.** `@supports`
+contributes no specificity, so the device block was `(0,2,0)` — exactly what the two dark
+blocks are — and they came after it and redeclared all seven of its properties. Measured in
+Chromium 149: device-dark resolved `--accent` to `rgb(62, 207, 142)`, Supabase's own
+`#3ecf8e`, while the panel's status text said "Device colours".
+
+**THE FIX REVEALS THE CONTRAST FAILURES, IT DOES NOT CAUSE THEM.** device-dark was passing
+17 of 17 because it was not device: it was the default palette wearing device's name. Five
+pairs went red the moment they had something true to measure, and all five are fixed here
+rather than registered:
+
+| what moved | the number |
+|---|---|
+| the on-colour, `AccentColorText` → `contrast-color(AccentColor)` | the system's own ink is **4.21:1** on its own accent; black is **4.99** |
+| `--button-hover-text`, derived per surface | **3.766** → **5.576** light, 6.066 dark |
+| `--accent-ink` for device, 78% → 60% | **4.031** → 5.123 dark, 7.025 light |
+| dark `--line-strong` base, `#707070` → `#787878` | under 3:1 across the **entire** mix range: 2.982 / 2.994 / 3.002 / 2.994 |
+
+**And Supabase's own mechanism picks the wrong ink too** — their OKLCH-lightness step
+resolves to near-white for this accent, because OKLCH lightness and WCAG luminance disagree
+about saturated blues. Fifth departure from the baseline, written at the value like the
+other four.
+
+**THE GUARD'S READER WAS THE DEEPER HALF OF "device HAS NO COVERAGE".** `getComputedStyle`
+does not resolve a custom property, so device's `AccentColor` and `color-mix(...)` came back
+as literal text — **adding device to the parametrize without fixing the reader would have
+measured nothing and passed.** It resolves through a probe element now, for every palette.
+Coverage: **102 executions over 6 states → 168 over 8**, `THEME_PROPERTIES` still 36.
+
+**The five new pairs found their first defect in a shipped palette, not in device.** `brand`
+light painted `--accent-ink` `#18864B` at **4.180:1** on its own `--accent-weak`, already
+marginal at 4.615 on white; `--accent-weak` cannot be raised to meet it, so the ink moved to
+`#147742`.
+
+**No version bump, and under `R-77` there is no longer a question to ask** — the engine
+carries no version at all.
+
+
 ### The backup that said it failed — 2026-08-29 · branch `claude/request-deadline-exceeded-3b1cad`, no PR yet
 
 **`OP-100`, ruled the same day as

--- a/extension/appearance.js
+++ b/extension/appearance.js
@@ -32,7 +32,14 @@
           surfaceRaised: "#FFFFFF", line: "#E5E5E5", lineStrong: "#959393",
           text: "#0A0A0A", muted: "#666666", textSubtle: "#707070",
           chip: "#F7F5F3", accent: "#35AA65", accentHover: "#2E9D5B",
-          accentActive: "#278F52", accentInk: "#18864B",
+          // #18864B until 2026-08-30, when OD-03's new pair measured it at
+          // 4.180:1 on this palette's own accentWeak (#DBFDD5) against a 4.5
+          // floor -- the one failure the five added pairs found across all eight
+          // shipped states. It was marginal on --surface too, at 4.615. Darkened
+          // until both clear with headroom: 5.077 on accentWeak, 5.604 on white.
+          // accentWeak cannot be raised to meet it -- even #F0FEEE only reaches
+          // 4.421 -- so the ink is the only side that can move.
+          accentActive: "#278F52", accentInk: "#147742",
           accentContrast: "#0A0A0A", accentWeak: "#DBFDD5",
           focus: "#278F52", controlHover: "#F0EEEC",
           buttonBg: "#43D36D", buttonHover: "#1C1E21",

--- a/extension/tokens.css
+++ b/extension/tokens.css
@@ -296,21 +296,6 @@
 
 }
 
-/* Device colours use the colour preference exposed by the browser/operating
-   system. Browsers do not expose their private new-tab palette to extensions,
-   so the system accent is the truthful automatic colour source. */
-@supports (color: AccentColor) {
-  :root[data-color-mode="device"] {
-    --accent: AccentColor;
-    --accent-hover: color-mix(in srgb, AccentColor 84%, var(--text));
-    --accent-active: color-mix(in srgb, AccentColor 72%, var(--text));
-    --accent-ink: color-mix(in srgb, AccentColor 78%, var(--text));
-    --accent-contrast: AccentColorText;
-    --accent-weak: color-mix(in srgb, AccentColor 14%, var(--surface));
-    --focus: AccentColor;
-  }
-}
-
 :root[data-theme="dark"] {
   color-scheme: dark;
 
@@ -426,6 +411,73 @@
   }
 }
 
+/* Device colours use the colour preference exposed by the browser/operating
+   system. Browsers do not expose their private new-tab palette to extensions,
+   so the system accent is the truthful automatic colour source.
+ *
+ * IT SITS HERE, AFTER THE DARK BLOCKS, AND THE POSITION IS THE WHOLE POINT.
+ * `@supports` contributes NO specificity, so this selector is (0,2,0) -- exactly
+ * what `:root[data-theme="dark"]` and `:root:not([data-theme="light"])` are. When
+ * it stood above them they won on source order and redeclared all seven of these
+ * properties, so "Device colours" on a dark OS painted Supabase's own #3ecf8e for
+ * every accent, focus ring, button and switch track while the panel's status text
+ * reported the choice it was not painting. Measured in Chromium 149 before the
+ * move: device-dark resolved `--accent` to rgb(62, 207, 142). That is OP-101, and
+ * moving these eleven lines is the whole of its fix.
+ *
+ * KEEP IT BELOW BOTH DARK BLOCKS. A future block added after this one that also
+ * sets an accent will take device back, silently and in one scheme only, which is
+ * the shape that made this defect invisible for as long as it lived. */
+@supports (color: AccentColor) {
+  :root[data-color-mode="device"] {
+    --accent: AccentColor;
+    --accent-hover: color-mix(in srgb, AccentColor 84%, var(--text));
+    --accent-active: color-mix(in srgb, AccentColor 72%, var(--text));
+    /* 60%, not the 78% the other accent tones use. Measured on Chromium 149's
+       accent in dark: at 78% this is rgb(52,144,251) on an --accent-weak of
+       rgb(18,50,87) = 4.031:1, under the 4.5 floor; 66% is the first passing
+       value at 4.698 and 60% is the first with real headroom, 5.123 dark and
+       7.025 light. The other tones keep 78% because nothing pairs them with a
+       tinted weak surface. */
+    --accent-ink: color-mix(in srgb, AccentColor 60%, var(--text));
+    --accent-contrast: AccentColorText;
+    --accent-weak: color-mix(in srgb, AccentColor 14%, var(--surface));
+    --focus: AccentColor;
+  }
+}
+
+/* AND THE OPERATING SYSTEM'S OWN INK IS NOT LEGIBLE ON ITS OWN ACCENT.
+ *
+ * Measured in Chromium 149, whose AccentColor is rgb(0, 117, 255): its
+ * AccentColorText is WHITE, which is 4.21:1 against that accent where the panel
+ * guard needs 4.5. Black on the same accent is 4.99:1. The browser hands us the
+ * worse of the two, and it is the pair a user actually reads a primary button
+ * through.
+ *
+ * SUPABASE'S OWN MECHANISM PICKS THE WRONG ONE TOO, so this is a departure from
+ * the baseline with the number written at the value, the way the other four are.
+ * Their on-colour is a hard step on OKLCH lightness -- oklch(from <fill>
+ * clamp(0.12, calc((0.62 - l) * 100), 0.99) ...) -- and for this accent it
+ * resolves to L 0.99, near-white, because OKLCH lightness and WCAG relative
+ * luminance disagree about saturated blues. `contrast-color()` asks the WCAG
+ * question directly and answers black.
+ *
+ * It is a separate @supports on purpose: `contrast-color()` is newer than
+ * `AccentColor`, so a browser that has the accent and not the function keeps the
+ * declaration above and loses nothing it had. */
+@supports (color: contrast-color(red)) {
+  :root[data-color-mode="device"] {
+    --accent-contrast: contrast-color(AccentColor);
+    /* AND THE HOVER SURFACE NEEDS ITS OWN INK, which is why this token exists.
+       `--accent-hover` moves toward `--text`, so in LIGHT it darkens -- and the
+       ink chosen for the base accent is black, so the two converge: measured
+       3.766:1 against a 4.5 floor. Derived per surface instead, light picks
+       WHITE for the hover (5.576:1) and dark keeps black (6.066:1). One ink
+       cannot serve both ends of an accent the operating system chooses. */
+    --button-hover-text: contrast-color(var(--accent-hover));
+  }
+}
+
 /* Device-derived tonal surfaces
  *
  * When the browser exposes a system accent, it supplies a quiet family of
@@ -475,9 +527,19 @@
     color-mix(in srgb, var(--accent) 16%, #e9e9e9),
     color-mix(in srgb, var(--accent) 18%, #232423)
   );
+  /* THE DARK BASE IS #787878 HERE AND #707070 EVERYWHERE ELSE, deliberately.
+     Device surfaces are tinted with the system accent and therefore LIGHTER than
+     the plain dark surface, so a line that clears 3:1 on the plain one does not
+     clear on this one. Measured on Chromium 149's accent: #707070 gives 2.982:1
+     against a device-dark --surface of rgb(20,40,59), and it stays under the
+     floor across the whole mix range -- 2.982 at 26%, 2.994 at 20%, 3.002 at 14%,
+     2.994 at 8% -- because the line and the surface are mixed with the same
+     accent and move together. #787878 clears at every percentage, 3.249 at the
+     26% used here. This is a measured difference, not the silent drift recorded
+     above it. */
   --line-strong: light-dark(
     color-mix(in srgb, var(--accent) 28%, #8f8f8f),
-    color-mix(in srgb, var(--accent) 26%, #707070)
+    color-mix(in srgb, var(--accent) 26%, #787878)
   );
   --chip: light-dark(
     color-mix(in srgb, var(--accent) 10%, #f3f3f3),

--- a/scrapex/webui/static/appearance.js
+++ b/scrapex/webui/static/appearance.js
@@ -32,7 +32,14 @@
           surfaceRaised: "#FFFFFF", line: "#E5E5E5", lineStrong: "#959393",
           text: "#0A0A0A", muted: "#666666", textSubtle: "#707070",
           chip: "#F7F5F3", accent: "#35AA65", accentHover: "#2E9D5B",
-          accentActive: "#278F52", accentInk: "#18864B",
+          // #18864B until 2026-08-30, when OD-03's new pair measured it at
+          // 4.180:1 on this palette's own accentWeak (#DBFDD5) against a 4.5
+          // floor -- the one failure the five added pairs found across all eight
+          // shipped states. It was marginal on --surface too, at 4.615. Darkened
+          // until both clear with headroom: 5.077 on accentWeak, 5.604 on white.
+          // accentWeak cannot be raised to meet it -- even #F0FEEE only reaches
+          // 4.421 -- so the ink is the only side that can move.
+          accentActive: "#278F52", accentInk: "#147742",
           accentContrast: "#0A0A0A", accentWeak: "#DBFDD5",
           focus: "#278F52", controlHover: "#F0EEEC",
           buttonBg: "#43D36D", buttonHover: "#1C1E21",

--- a/scrapex/webui/static/tokens.css
+++ b/scrapex/webui/static/tokens.css
@@ -296,21 +296,6 @@
 
 }
 
-/* Device colours use the colour preference exposed by the browser/operating
-   system. Browsers do not expose their private new-tab palette to extensions,
-   so the system accent is the truthful automatic colour source. */
-@supports (color: AccentColor) {
-  :root[data-color-mode="device"] {
-    --accent: AccentColor;
-    --accent-hover: color-mix(in srgb, AccentColor 84%, var(--text));
-    --accent-active: color-mix(in srgb, AccentColor 72%, var(--text));
-    --accent-ink: color-mix(in srgb, AccentColor 78%, var(--text));
-    --accent-contrast: AccentColorText;
-    --accent-weak: color-mix(in srgb, AccentColor 14%, var(--surface));
-    --focus: AccentColor;
-  }
-}
-
 :root[data-theme="dark"] {
   color-scheme: dark;
 
@@ -426,6 +411,73 @@
   }
 }
 
+/* Device colours use the colour preference exposed by the browser/operating
+   system. Browsers do not expose their private new-tab palette to extensions,
+   so the system accent is the truthful automatic colour source.
+ *
+ * IT SITS HERE, AFTER THE DARK BLOCKS, AND THE POSITION IS THE WHOLE POINT.
+ * `@supports` contributes NO specificity, so this selector is (0,2,0) -- exactly
+ * what `:root[data-theme="dark"]` and `:root:not([data-theme="light"])` are. When
+ * it stood above them they won on source order and redeclared all seven of these
+ * properties, so "Device colours" on a dark OS painted Supabase's own #3ecf8e for
+ * every accent, focus ring, button and switch track while the panel's status text
+ * reported the choice it was not painting. Measured in Chromium 149 before the
+ * move: device-dark resolved `--accent` to rgb(62, 207, 142). That is OP-101, and
+ * moving these eleven lines is the whole of its fix.
+ *
+ * KEEP IT BELOW BOTH DARK BLOCKS. A future block added after this one that also
+ * sets an accent will take device back, silently and in one scheme only, which is
+ * the shape that made this defect invisible for as long as it lived. */
+@supports (color: AccentColor) {
+  :root[data-color-mode="device"] {
+    --accent: AccentColor;
+    --accent-hover: color-mix(in srgb, AccentColor 84%, var(--text));
+    --accent-active: color-mix(in srgb, AccentColor 72%, var(--text));
+    /* 60%, not the 78% the other accent tones use. Measured on Chromium 149's
+       accent in dark: at 78% this is rgb(52,144,251) on an --accent-weak of
+       rgb(18,50,87) = 4.031:1, under the 4.5 floor; 66% is the first passing
+       value at 4.698 and 60% is the first with real headroom, 5.123 dark and
+       7.025 light. The other tones keep 78% because nothing pairs them with a
+       tinted weak surface. */
+    --accent-ink: color-mix(in srgb, AccentColor 60%, var(--text));
+    --accent-contrast: AccentColorText;
+    --accent-weak: color-mix(in srgb, AccentColor 14%, var(--surface));
+    --focus: AccentColor;
+  }
+}
+
+/* AND THE OPERATING SYSTEM'S OWN INK IS NOT LEGIBLE ON ITS OWN ACCENT.
+ *
+ * Measured in Chromium 149, whose AccentColor is rgb(0, 117, 255): its
+ * AccentColorText is WHITE, which is 4.21:1 against that accent where the panel
+ * guard needs 4.5. Black on the same accent is 4.99:1. The browser hands us the
+ * worse of the two, and it is the pair a user actually reads a primary button
+ * through.
+ *
+ * SUPABASE'S OWN MECHANISM PICKS THE WRONG ONE TOO, so this is a departure from
+ * the baseline with the number written at the value, the way the other four are.
+ * Their on-colour is a hard step on OKLCH lightness -- oklch(from <fill>
+ * clamp(0.12, calc((0.62 - l) * 100), 0.99) ...) -- and for this accent it
+ * resolves to L 0.99, near-white, because OKLCH lightness and WCAG relative
+ * luminance disagree about saturated blues. `contrast-color()` asks the WCAG
+ * question directly and answers black.
+ *
+ * It is a separate @supports on purpose: `contrast-color()` is newer than
+ * `AccentColor`, so a browser that has the accent and not the function keeps the
+ * declaration above and loses nothing it had. */
+@supports (color: contrast-color(red)) {
+  :root[data-color-mode="device"] {
+    --accent-contrast: contrast-color(AccentColor);
+    /* AND THE HOVER SURFACE NEEDS ITS OWN INK, which is why this token exists.
+       `--accent-hover` moves toward `--text`, so in LIGHT it darkens -- and the
+       ink chosen for the base accent is black, so the two converge: measured
+       3.766:1 against a 4.5 floor. Derived per surface instead, light picks
+       WHITE for the hover (5.576:1) and dark keeps black (6.066:1). One ink
+       cannot serve both ends of an accent the operating system chooses. */
+    --button-hover-text: contrast-color(var(--accent-hover));
+  }
+}
+
 /* Device-derived tonal surfaces
  *
  * When the browser exposes a system accent, it supplies a quiet family of
@@ -475,9 +527,19 @@
     color-mix(in srgb, var(--accent) 16%, #e9e9e9),
     color-mix(in srgb, var(--accent) 18%, #232423)
   );
+  /* THE DARK BASE IS #787878 HERE AND #707070 EVERYWHERE ELSE, deliberately.
+     Device surfaces are tinted with the system accent and therefore LIGHTER than
+     the plain dark surface, so a line that clears 3:1 on the plain one does not
+     clear on this one. Measured on Chromium 149's accent: #707070 gives 2.982:1
+     against a device-dark --surface of rgb(20,40,59), and it stays under the
+     floor across the whole mix range -- 2.982 at 26%, 2.994 at 20%, 3.002 at 14%,
+     2.994 at 8% -- because the line and the surface are mixed with the same
+     accent and move together. #787878 clears at every percentage, 3.249 at the
+     26% used here. This is a measured difference, not the silent drift recorded
+     above it. */
   --line-strong: light-dark(
     color-mix(in srgb, var(--accent) 28%, #8f8f8f),
-    color-mix(in srgb, var(--accent) 26%, #707070)
+    color-mix(in srgb, var(--accent) 26%, #787878)
   );
   --chip: light-dark(
     color-mix(in srgb, var(--accent) 10%, #f3f3f3),

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -485,9 +485,39 @@ def test_appearance_is_a_complete_android_style_destination(open_panel):
     assert page.locator("html").get_attribute("data-palette") is None
 
 
+def _channels(colour: str) -> list[float]:
+    """0..1 sRGB channels from every form the browser actually hands back.
+
+    THE HEX-ONLY PARSER IS WHY `device` HAD NO COVERAGE, and the reason is one
+    layer below its absence from the parametrize. A palette writes concrete hexes
+    as inline style, so reading the custom property returned `#RRGGBB` and hex was
+    enough. `device` writes `AccentColor` and `color-mix(...)`, and a custom
+    property is NOT resolved by `getComputedStyle` -- it hands back the SPECIFIED
+    value, so those came back as the literal text `ACCENTCOLOR` and
+    `COLOR-MIX(IN SRGB, ...)`. Nothing could score them. The page-side reader now
+    resolves through a probe element (see `_read_theme_colours`), which returns
+    `rgb(...)` and `color(srgb ...)`, and this parses both.
+    """
+    value = colour.strip()
+    if value.startswith("#"):
+        if len(value) == 4:
+            value = "#" + "".join(char * 2 for char in value[1:])
+        return [int(value[index:index + 2], 16) / 255 for index in (1, 3, 5)]
+    lowered = value.lower()
+    if lowered.startswith("rgb"):
+        numbers = value[value.index("(") + 1:value.index(")")]
+        parts = numbers.replace("/", " ").replace(",", " ").split()
+        return [float(part) / 255 for part in parts[:3]]
+    if lowered.startswith("color(srgb"):
+        numbers = value[len("color(srgb"):value.rindex(")")]
+        return [min(1.0, max(0.0, float(part)))
+                for part in numbers.replace("/", " ").split()[:3]]
+    raise ValueError(f"cannot read a colour out of {colour!r}")
+
+
 def _contrast(first: str, second: str) -> float:
     def luminance(colour: str) -> float:
-        channels = [int(colour[index:index + 2], 16) / 255 for index in (1, 3, 5)]
+        channels = _channels(colour)
         linear = [
             value / 12.92 if value <= 0.04045 else ((value + 0.055) / 1.055) ** 2.4
             for value in channels
@@ -522,63 +552,190 @@ def _registered_palette_ids() -> list[str]:
     return ids
 
 
+#: Read every themed colour the guard scores, RESOLVED rather than as declared.
+#:
+#: `getComputedStyle(root).getPropertyValue('--x')` returns the SPECIFIED value of
+#: a custom property, so `AccentColor` and `color-mix(...)` come back as text and
+#: cannot be scored -- which is the real reason `device` was never contrast-tested,
+#: one layer below its absence from the parametrize. Painting the token onto a
+#: probe element's `color` and reading THAT back gives the used value, resolved by
+#: the engine to `rgb(...)` or `color(srgb ...)`.
+#:
+#: It resolves for the three palettes too, and that is deliberate: one reader means
+#: a palette that starts using `color-mix` cannot quietly fall out of coverage.
+_THEME_COLOURS_JS = """() => {
+    const probe = document.createElement('span');
+    probe.style.cssText = 'position:absolute;visibility:hidden;pointer-events:none';
+    document.documentElement.appendChild(probe);
+    const read = (name) => {
+      probe.style.color = '';
+      probe.style.color = `var(${name})`;
+      return getComputedStyle(probe).color;
+    };
+    const out = {
+      text: read("--text"), muted: read("--muted"),
+      subtle: read("--text-subtle"), surface: read("--surface"),
+      bg: read("--bg"), accent: read("--accent"),
+      accentHover: read("--accent-hover"),
+      accentInk: read("--accent-ink"),
+      accentContrast: read("--accent-contrast"),
+      accentWeak: read("--accent-weak"),
+      chip: read("--chip"),
+      surfaceSubtle: read("--surface-subtle"),
+      surfaceRaised: read("--surface-raised"),
+      buttonBg: read("--button-bg"),
+      buttonHover: read("--button-hover"),
+      buttonText: read("--button-text"),
+      buttonHoverText: read("--button-hover-text"),
+      lineStrong: read("--line-strong"), focus: read("--focus"),
+      amber: read("--amber"), amberWeak: read("--amber-weak"),
+      red: read("--red"), redHover: read("--red-hover"),
+      redWeak: read("--red-weak"),
+      dangerContrast: read("--danger-contrast"),
+      switchTrack: read("--switch-track"),
+      switchTrackHover: read("--switch-track-hover"),
+      switchTrackOff: read("--switch-track-off"),
+      switchThumb: read("--switch-thumb"),
+      switchThumbOff: read("--switch-thumb-off"),
+    };
+    probe.remove();
+    return out;
+}"""
+
+#: The pairs a reader actually meets, and the floors they must clear.
+#:
+#: `("accentContrast", "accentHover")` WAS HERE AND IS NOT ANY MORE, on his ruling
+#: of 2026-08-30. It asserted a combination the product does not render:
+#: `--accent-hover` has no consumer anywhere outside `design/tokens.css` -- the only
+#: thing that reads it is `--button-hover` -- and the surface it becomes is inked
+#: with `--button-hover-text`, which `("buttonHoverText", "buttonHover")` below
+#: covers. While the two inks were the same token the pair was a duplicate; once
+#: `device` derived them separately it became a duplicate that was also false.
+#: Removing it is not a lowered floor: every surface a reader meets is still scored.
+_TEXT_PAIRS = (
+    ("text", "bg"),
+    ("text", "surface"),
+    ("muted", "surface"),
+    ("subtle", "surface"),
+    ("accentInk", "surface"),
+    ("accentContrast", "accent"),
+    ("buttonText", "buttonBg"),
+    ("buttonHoverText", "buttonHover"),
+    ("amber", "amberWeak"),
+    ("red", "redWeak"),
+    ("dangerContrast", "red"),
+    # Added 2026-08-30 (OD-03). Four of the five are text on a surface that carries
+    # secondary text and was never measured; the fifth is accent text on the accent
+    # tint. All five use tokens that already exist, so THEME_PROPERTIES stays at 36.
+    ("muted", "chip"),
+    ("text", "chip"),
+    ("text", "surfaceSubtle"),
+    ("text", "surfaceRaised"),
+    ("accentInk", "accentWeak"),
+)
+
+#: Non-text pairs and their own floors, which are lower on purpose: a border and a
+#: switch track carry meaning without carrying words.
+_SHAPE_PAIRS = (
+    ("lineStrong", "surface", 3.0),
+    ("focus", "bg", 3.0),
+    ("switchThumb", "switchTrack", 2.9),
+    ("switchThumb", "switchTrackHover", 3.0),
+    ("switchThumbOff", "switchTrackOff", 2.9),
+)
+
+
+def _assert_legible(values: dict, label: str) -> None:
+    for foreground, background in _TEXT_PAIRS:
+        assert _contrast(values[foreground], values[background]) >= 4.5, (
+            f"{label}: {foreground} on {background} is not WCAG AA "
+            f"({_contrast(values[foreground], values[background]):.3f})")
+    for foreground, background, floor in _SHAPE_PAIRS:
+        assert _contrast(values[foreground], values[background]) >= floor, (
+            f"{label}: {foreground} on {background} is under {floor} "
+            f"({_contrast(values[foreground], values[background]):.3f})")
+
+
 @pytest.mark.parametrize("palette", _registered_palette_ids())
 @pytest.mark.parametrize("scheme", ["light", "dark"])
 def test_every_manual_theme_keeps_text_controls_and_focus_legible(
         open_panel, palette, scheme):
     page = open_panel()
-    values = page.evaluate("""([palette, scheme]) => {
+    page.evaluate("""([palette, scheme]) => {
         window.ScrapeXAppearance.set({
           mode: "manual", scheme, palette, deviceColors: false,
         });
-        const style = getComputedStyle(document.documentElement);
-        const read = (name) => style.getPropertyValue(name).trim().toUpperCase();
-        return {
-          text: read("--text"), muted: read("--muted"),
-          subtle: read("--text-subtle"), surface: read("--surface"),
-          bg: read("--bg"), accent: read("--accent"),
-          accentHover: read("--accent-hover"),
-          accentInk: read("--accent-ink"),
-          accentContrast: read("--accent-contrast"),
-          buttonBg: read("--button-bg"),
-          buttonHover: read("--button-hover"),
-          buttonText: read("--button-text"),
-          buttonHoverText: read("--button-hover-text"),
-          lineStrong: read("--line-strong"), focus: read("--focus"),
-          amber: read("--amber"), amberWeak: read("--amber-weak"),
-          red: read("--red"), redHover: read("--red-hover"),
-          redWeak: read("--red-weak"),
-          dangerContrast: read("--danger-contrast"),
-          switchTrack: read("--switch-track"),
-          switchTrackHover: read("--switch-track-hover"),
-          switchTrackOff: read("--switch-track-off"),
-          switchThumb: read("--switch-thumb"),
-          switchThumbOff: read("--switch-thumb-off"),
-        };
     }""", [palette, scheme])
+    _assert_legible(page.evaluate(_THEME_COLOURS_JS), f"{palette} {scheme}")
 
-    text_pairs = (
-        ("text", "bg"),
-        ("text", "surface"),
-        ("muted", "surface"),
-        ("subtle", "surface"),
-        ("accentInk", "surface"),
-        ("accentContrast", "accent"),
-        ("accentContrast", "accentHover"),
-        ("buttonText", "buttonBg"),
-        ("buttonHoverText", "buttonHover"),
-        ("amber", "amberWeak"),
-        ("red", "redWeak"),
-        ("dangerContrast", "red"),
-    )
-    for foreground, background in text_pairs:
-        assert _contrast(values[foreground], values[background]) >= 4.5, (
-            f"{palette} {scheme}: {foreground} on {background} is not WCAG AA")
-    assert _contrast(values["lineStrong"], values["surface"]) >= 3
-    assert _contrast(values["focus"], values["bg"]) >= 3
-    assert _contrast(values["switchThumb"], values["switchTrack"]) >= 2.9
-    assert _contrast(values["switchThumb"], values["switchTrackHover"]) >= 3
-    assert _contrast(values["switchThumbOff"], values["switchTrackOff"]) >= 2.9
+
+@pytest.mark.parametrize("scheme", ["light", "dark"])
+def test_device_colours_are_legible_in_both_schemes(open_panel, scheme):
+    """THE FOURTH COLOUR CHOICE, AND IT HAD NO COVERAGE OF ANY KIND.
+
+    `device` is not a palette -- `design/appearance.js` removes it from the theme
+    entirely -- so `_registered_palette_ids()` can never yield it and the sweep
+    beside this one is structurally unable to reach it. It is also the choice
+    `R-74` names fourth and the one a fresh install used to get before the
+    `deviceColors` flip, which made it the least measured and the most reachable
+    at the same time.
+
+    IT DID NOT MERELY LACK A ROW IN THE PARAMETRIZE. The guard read custom
+    properties as declared, and device declares `AccentColor` and `color-mix(...)`,
+    which a custom property read never resolves -- so even pointed at device the
+    old reader had nothing it could score. Both halves are fixed here.
+
+    WHAT IT COSTS TO OWN THIS: the accent is the operating system's, not ours, so
+    these assertions are about the DERIVATION holding for whatever accent arrives
+    rather than about a value we chose. Chromium's own accent is rgb(0, 117, 255),
+    whose `AccentColorText` is white at 4.21:1 -- under the floor -- which is why
+    `design/tokens.css` derives the ink with `contrast-color()` instead of trusting
+    the system's. A machine with a different accent exercises a different point of
+    the same derivation, and that is the intent.
+    """
+    page = open_panel()
+    page.evaluate("""([scheme]) => {
+        window.ScrapeXAppearance.set({
+          mode: "manual", scheme, deviceColors: true,
+        });
+    }""", [scheme])
+    assert page.evaluate("() => CSS.supports('color', 'AccentColor')"), (
+        "this browser has no AccentColor, so the device block never applied and "
+        "this test measured the baseline instead -- which is exactly the false "
+        "green it exists to prevent")
+    assert page.locator("html").get_attribute("data-color-mode") == "device"
+    _assert_legible(page.evaluate(_THEME_COLOURS_JS), f"device {scheme}")
+
+
+def test_device_colours_reach_the_user_in_both_schemes(open_panel):
+    """OP-101. The cascade, not the colours -- and it is a source-order fact.
+
+    `@supports` contributes no specificity, so the device block's
+    `:root[data-color-mode="device"]` is (0,2,0) -- exactly what
+    `:root[data-theme="dark"]` and `:root:not([data-theme="light"])` are. While it
+    stood ABOVE them they won on source order and redeclared all seven of its
+    properties, so a user on a dark OS who chose "Device colours" was painted
+    Supabase's own #3ecf8e while the panel's status text reported otherwise.
+
+    The assertion is deliberately not a value: the accent belongs to the machine.
+    What must hold is that device DIFFERS from the palette it would otherwise fall
+    back to, in BOTH schemes. That is what source order broke and nothing caught.
+    """
+    page = open_panel()
+    assert page.evaluate("() => CSS.supports('color', 'AccentColor')")
+
+    def accent(**appearance):
+        page.evaluate("([a]) => window.ScrapeXAppearance.set(a)", [appearance])
+        return page.evaluate(_THEME_COLOURS_JS)["accent"]
+
+    for scheme in ("light", "dark"):
+        device = accent(mode="manual", scheme=scheme, deviceColors=True)
+        baseline = accent(mode="manual", scheme=scheme, palette="supabase",
+                          deviceColors=False)
+        assert device != baseline, (
+            f"device {scheme} paints {device}, which is the {scheme} baseline. "
+            "The device block is being outranked by source order again -- keep it "
+            "below both dark blocks in design/tokens.css.")
 
 
 def test_whatsapp_theme_matches_the_current_application_palette(open_panel):
@@ -663,7 +820,12 @@ def test_whatsapp_extension_layers_navigation_and_primary_hover(open_panel):
         "main": "rgb(255, 255, 255)",
         "rail": "rgb(247, 245, 243)",
         "indicator": "rgb(53, 170, 101)",
-        "active": "rgb(24, 134, 75)",
+        # rgb(20, 119, 66) since 2026-08-30, was rgb(24, 134, 75). The active rail
+        # tab is painted with `--accent-ink`, and this palette's ink was darkened
+        # because OD-03's new `accentInk on accentWeak` pair measured the old one
+        # at 4.180:1 against a 4.5 floor. This pin follows what is painted; the
+        # reason lives at the value in `design/appearance.js`.
+        "active": "rgb(20, 119, 66)",
         "button": "rgb(67, 211, 109)",
         "buttonText": "rgb(10, 10, 10)",
     }


### PR DESCRIPTION
The first two of `REQ-49`'s twelve decisions, ruled as **[R-79]** and landed together because they do not separate. Closes `OP-101` and half of `OP-104`.

## The cascade was the whole defect and eleven lines were the whole fix

`@supports` contributes **no specificity**. The device block's `:root[data-color-mode="device"]` is `(0,2,0)` — exactly what `:root[data-theme="dark"]` and `:root:not([data-theme="light"])` are — and they came *after* it and redeclared all seven of its properties.

Measured in Chromium 149: device-dark resolved `--accent` to `rgb(62, 207, 142)`, which is Supabase's own `#3ecf8e`, **while the panel's status text said "Device colours"**. One of the four colour choices `R-74` names by name, unreachable in half its states.

## The fix REVEALS the contrast failures. It does not cause them.

This is the sentence to read before the diff. **device-dark was passing 17 of 17 because it was not device** — it was the default palette wearing device's name. Five pairs went red the moment they had something true to measure, and all five are fixed here rather than registered.

| what moved | the number that moved it |
|---|---|
| the on-colour, `AccentColorText` → `contrast-color(AccentColor)` | the system's own ink is **4.21:1** on its own accent; black is **4.99** |
| `--button-hover-text`, derived per surface | **3.766** → **5.576** light, 6.066 dark |
| `--accent-ink` for device, 78% → 60% | **4.031** on `--accent-weak` → 5.123 dark, 7.025 light |
| dark `--line-strong` base, `#707070` → `#787878` | under 3:1 across the **entire** mix range — 2.982 / 2.994 / 3.002 / 2.994 |

All four are device-scoped. The three registered palettes are untouched by them.

**And Supabase's own mechanism picks the wrong ink too.** Their on-colour is a hard step on OKLCH lightness; for this accent it resolves to L 0.99, near-white, because OKLCH lightness and WCAG relative luminance disagree about saturated blues. `contrast-color()` asks the WCAG question directly and answers black. Fifth departure from the baseline, written at the value like the other four.

One ink cannot serve both ends of an accent the operating system chooses: `--accent-hover` moves toward `--text`, so in light it converges on the black ink. `--button-hover-text` already existed as a separate token — the system anticipating the problem before it was measured.

## The guard's reader was the deeper half of "device has no coverage"

One layer below its absence from the parametrize. `getComputedStyle` does **not** resolve a custom property, so device's `AccentColor` and `color-mix(...)` came back as the literal text `ACCENTCOLOR` and `COLOR-MIX(IN SRGB, ...)`. **Adding device to the parametrize without fixing the reader would have measured nothing and passed.**

It resolves through a probe element now, for every palette rather than only for device, so a palette that starts using `color-mix` cannot quietly fall out of coverage either. The parser learned `rgb()` and `color(srgb ...)`.

**Coverage: 102 executions over 6 states → 168 over 8.** Five pairs added, all using tokens that already exist, so `THEME_PROPERTIES` stays at 36 and no palette gained a cell.

## The new pairs found their first defect in a shipped palette, not in device

`brand` light painted `--accent-ink` `#18864B`, which is **4.180:1** on that palette's own `--accent-weak` — and was already marginal at 4.615 on white. `--accent-weak` cannot be raised to meet it (even `#F0FEEE` reaches only 4.421), so the ink moved to `#147742`, at 5.077 and 5.604.

`R-79` makes that the rule: **a failing pair is a defect in the palette, never a reason to lower a threshold.**

## One assertion removed, with its evidence

`("accentContrast", "accentHover")` asserts a pairing no surface renders: `--accent-hover` has **no consumer anywhere outside `design/tokens.css`**, and the surface it becomes is inked with `--button-hover-text`, which is covered.

Removing an assertion is the move this repository is most suspicious of, so it was put to him as its own question with the alternatives priced — flatten the hover to 94% of the accent and lose its affordance (4.489), or repoint at a pair already in the list. He chose removal with the evidence recorded. **No floor was lowered and no surface a reader meets went uncovered.**

## Verification

```
TEMPLATE_MODE_EXIT=0
FULL_MIGRATIONS_EXIT=0
```

pytest's own exit code, captured to a file rather than read off a pipe.

**No version bump.** Under `R-77` the engine carries no version at all, so the question these changes used to raise does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
