### PR TITLE
Two docstrings cite the ruling that deleted them (LESSONS 29)

### DIFF
--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -3283,3 +3283,43 @@ The tell is not internal consistency, it is whether the tool could see what it w
 Related: section 21's rule about re-deriving citations after an insertion is the same
 discipline applied to line numbers rather than to counts, and `OP-97` is the same failure
 applied to a file LIST — a census scoped to 9 stylesheets when there were 19.
+
+## 29 · Deleting a ruling rewrites the sentences that talk ABOUT it, and four sessions found the same blind spot in one day
+
+`R-77` deleted five rulings and every live citation of them was repointed mechanically.
+That is the right operation for a link. **It is the wrong operation for a sentence that
+recounts what a ruling DID**, and the difference is invisible to grep.
+
+    "R-35 immediately moved the source to 0.3.1"    -> now a claim about a ruling dated today
+    "superseded by R-06 on 2026-08-16"              -> R-77 did not exist on 2026-08-16
+    "R-07 already ruled it must go"                 -> inside a snapshot pinned to 31c369e
+
+**Six were caught. Two were not, and the two say where to look next time.** The six were in
+`LESSONS`, `STATE`, `BACKLOG` and `REQUESTS`; the two that shipped were **test docstrings** --
+`tests/test_the_version_moves_when_the_contract_does.py` came out of `#290` citing `R-77` for
+the criterion `R-77` abolished, and a second test asserting the constant `R-77` retires. The
+review pass read documentation and did not read code comments. **A citation inside a guard is
+the one a reader trusts most**, because a guard is supposed to be the thing that cannot be
+wrong.
+
+**AND A RETIRED GUARD IS NOT A GUARD TO DELETE.** Both tests still enforce the deleted rule
+ON PURPOSE: `R-77` is a ruling and not yet an architecture, so removing them today takes away
+the only protection there is and puts nothing in its place -- the ninety-one-commit silent
+drift that produced them. The fix was to make each docstring say *"this enforces a rule that
+has been replaced, here is what it becomes, and this is the first thing its builder changes"*.
+
+**THE SAME SHAPE, FOUND FOUR TIMES ON 2026-08-30 BY FOUR SESSIONS THAT WERE NOT LOOKING FOR
+IT.** A mechanism that is correct, visible, and load-bearing on nothing:
+
+| found | the mechanism | what it actually held |
+|---|---|---|
+| design review | `assert "THEME_PROPERTIES.forEach" in appearance` | the string occurs TWICE, so deleting `apply()`'s loop leaves it green on `clearTheme` |
+| Drive incident | the panel's *"3 loaded module(s) changed"* row | displayed correctly, gated nothing; the backup ran on stale code |
+| engine page | `schema_lag` published and rendered | `engine.js` never carries the field, so the banner cannot appear in any state |
+| engine page | a guard slicing `app.js` between two markers | the window is ~2,800 lines and `detail` appears ~71 times in unrelated code |
+
+**None of the four is a defect in the guard's logic.** Each is a guard whose SUBJECT stopped
+being what it was written for, and none of them can say so. `LESSONS` §7 is the older half of
+this and §21 is the citation half; what 2026-08-30 added is that **it is not rare**. The test
+that finds them is the one §18 already states: *if the thing it protects were broken right
+now, would this fail?* -- asked of the guard's SUBJECT and not of its assertion.

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -3284,7 +3284,7 @@ Related: section 21's rule about re-deriving citations after an insertion is the
 discipline applied to line numbers rather than to counts, and `OP-97` is the same failure
 applied to a file LIST — a census scoped to 9 stylesheets when there were 19.
 
-## 29 · Deleting a ruling rewrites the sentences that talk ABOUT it, and five sessions found the same blind spot in one day
+## 29 · Deleting a ruling rewrites the sentences that talk ABOUT it, and one blind spot was found five times in a day
 
 `R-77` deleted five rulings and every live citation of them was repointed mechanically.
 That is the right operation for a link. **It is the wrong operation for a sentence that
@@ -3309,7 +3309,7 @@ drift that produced them. The fix was to make each docstring say *"this enforces
 has been replaced, here is what it becomes, and this is the first thing its builder changes"*.
 
 **THE SAME SHAPE, FOUND FIVE TIMES ON 2026-08-30 BY FOUR SESSIONS THAT WERE NOT LOOKING FOR
-IT.** A mechanism that is correct, visible, and load-bearing on nothing:
+IT** -- and two of the five could never have failed at all. A mechanism that is correct, visible, and load-bearing on nothing:
 
 | found | the mechanism | what it actually held |
 |---|---|---|
@@ -3319,14 +3319,26 @@ IT.** A mechanism that is correct, visible, and load-bearing on nothing:
 | engine page | a guard slicing `app.js` between two markers | the window is ~2,800 lines and `detail` appears ~71 times in unrelated code |
 | design review | `getComputedStyle` read against the `device` palette | **nothing.** It does not resolve a custom property, so `AccentColor` and `color-mix(...)` come back as literal TEXT and there is nothing to score |
 
-**THE FIFTH IS THE WORST AND IT IS A DIFFERENT KIND.** The other four ROTTED. That one
-would have been **born** rotten, and born from the fix for the finding: a session closing
-`OP-104` the obvious way adds `device` to the parametrize, watches **17 of 17 pass**, and
-records coverage that does not exist. The tell was that device-dark was passing 17 of 17
-**because it was not device** -- it was the default palette wearing device's name. **A green
-that arrives without the thing under test having run is indistinguishable from a green that
-earned it, and no count anywhere would differ.** (Found by the design-review session while
-building `R-79`; the words are its own.)
+**TWO OF THE FIVE WERE BORN ROTTEN, NOT ONE, AND THAT IS THE FINDING.** Rows 2, 3 and 4
+rotted -- they held something once and their subject moved. **Rows 1 and 5 never held
+anything.**
+
+The `forEach` assertion was written on **2026-08-29** (`208d829`) against a file that had
+carried **two** occurrences since **2026-07-27** (`6779573`) -- checked with `git log -S`, and
+`git show 208d829^:design/appearance.js` counts 2. **So it could not distinguish them on any
+day of its life.** And the device reader would have been born rotten **from the fix for the
+finding**: a session closing `OP-104` the obvious way adds `device` to the parametrize,
+watches **17 of 17 pass**, and records coverage that does not exist. The tell was that
+device-dark was passing 17 of 17 **because it was not device** -- it was the default palette
+wearing device's name. **A green that arrives without the thing under test having run is
+indistinguishable from a green that earned it, and no count anywhere would differ.** (The
+device half was found by the design-review session while building `R-79`; those words are its
+own.)
+
+**Two in five is a rate, not an anecdote.** "It rotted" is the comfortable reading because it
+implies the guard was once correct and time did the damage. **Forty per cent of these were
+never correct** -- which means a reviewer should ask *"could this ever have failed?"* as a
+matter of course, not only when a guard looks stale.
 
 **None of the five is a defect in the guard's logic.** Each is a guard whose SUBJECT stopped
 being what it was written for, and none of them can say so. `LESSONS` §7 is the older half of

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -3284,7 +3284,7 @@ Related: section 21's rule about re-deriving citations after an insertion is the
 discipline applied to line numbers rather than to counts, and `OP-97` is the same failure
 applied to a file LIST — a census scoped to 9 stylesheets when there were 19.
 
-## 29 · Deleting a ruling rewrites the sentences that talk ABOUT it, and four sessions found the same blind spot in one day
+## 29 · Deleting a ruling rewrites the sentences that talk ABOUT it, and five sessions found the same blind spot in one day
 
 `R-77` deleted five rulings and every live citation of them was repointed mechanically.
 That is the right operation for a link. **It is the wrong operation for a sentence that
@@ -3308,7 +3308,7 @@ the only protection there is and puts nothing in its place -- the ninety-one-com
 drift that produced them. The fix was to make each docstring say *"this enforces a rule that
 has been replaced, here is what it becomes, and this is the first thing its builder changes"*.
 
-**THE SAME SHAPE, FOUND FOUR TIMES ON 2026-08-30 BY FOUR SESSIONS THAT WERE NOT LOOKING FOR
+**THE SAME SHAPE, FOUND FIVE TIMES ON 2026-08-30 BY FOUR SESSIONS THAT WERE NOT LOOKING FOR
 IT.** A mechanism that is correct, visible, and load-bearing on nothing:
 
 | found | the mechanism | what it actually held |
@@ -3317,8 +3317,18 @@ IT.** A mechanism that is correct, visible, and load-bearing on nothing:
 | Drive incident | the panel's *"3 loaded module(s) changed"* row | displayed correctly, gated nothing; the backup ran on stale code |
 | engine page | `schema_lag` published and rendered | `engine.js` never carries the field, so the banner cannot appear in any state |
 | engine page | a guard slicing `app.js` between two markers | the window is ~2,800 lines and `detail` appears ~71 times in unrelated code |
+| design review | `getComputedStyle` read against the `device` palette | **nothing.** It does not resolve a custom property, so `AccentColor` and `color-mix(...)` come back as literal TEXT and there is nothing to score |
 
-**None of the four is a defect in the guard's logic.** Each is a guard whose SUBJECT stopped
+**THE FIFTH IS THE WORST AND IT IS A DIFFERENT KIND.** The other four ROTTED. That one
+would have been **born** rotten, and born from the fix for the finding: a session closing
+`OP-104` the obvious way adds `device` to the parametrize, watches **17 of 17 pass**, and
+records coverage that does not exist. The tell was that device-dark was passing 17 of 17
+**because it was not device** -- it was the default palette wearing device's name. **A green
+that arrives without the thing under test having run is indistinguishable from a green that
+earned it, and no count anywhere would differ.** (Found by the design-review session while
+building `R-79`; the words are its own.)
+
+**None of the five is a defect in the guard's logic.** Each is a guard whose SUBJECT stopped
 being what it was written for, and none of them can say so. `LESSONS` §7 is the older half of
 this and §21 is the citation half; what 2026-08-30 added is that **it is not rare**. The test
 that finds them is the one §18 already states: *if the thing it protects were broken right

--- a/tests/test_the_version_moves_when_the_contract_does.py
+++ b/tests/test_the_version_moves_when_the_contract_does.py
@@ -1,4 +1,8 @@
-"""The engine's version moves when its CONTRACT moves, and the extension's when the panel's behaviour does.
+"""The gate that holds the version rule until `R-77` replaces the rule with an architecture.
+
+Its title is the rule it enforces -- the engine's version moves when its CONTRACT moves,
+the extension's when the panel's behaviour does -- and that rule was deleted on
+2026-08-30. Read the next paragraph before changing anything here.
 
 WHY THIS FILE EXISTS. `VERSION` sat at `0.2.2` for **91 commits** — last moved
 `adf31b2` on 2026-08-10 — and the owner could no longer answer a simple question
@@ -12,11 +16,43 @@ changed in those 91 commits — so the gate stayed quiet while **three engine
 migrations landed in a single day**, each of them a change an older build cannot
 read.
 
-He ruled the criterion rather than the number (`R-77`):
+**THIS FILE ENFORCES A RULE THAT HAS BEEN REPLACED, AND IT STAYS UNTIL ITS REPLACEMENT
+IS BUILT.** The criterion below is `R-35`'s, and `R-35` was DELETED on 2026-08-30 by
+`R-77` along with `R-05`, `R-06`, `R-07` and `R-61`:
 
     engine     moves on a CONTRACT change — schema, protocol, or endpoint
     extension  moves on a USER-VISIBLE change — which this codebase already
                models as a capability whose `Surface` is the panel
+
+**`R-77` says the engine has no version at all** — a `protocol` number for compatibility,
+a build SHA for identity, and the product version is the extension's alone. Under it, "is
+a new endpoint a bump?" stops being a question.
+
+**SO WHY IS THIS STILL HERE.** `R-77` is a ruling and not yet an architecture: `VERSION`
+is still hand-edited, and nothing yet reads `protocol` as the compatibility authority.
+**Deleting this gate today would remove the only protection there is and put nothing in
+its place** — a contract could move silently again, which is the ninety-one-commit
+failure that produced it. So it enforces the old rule on purpose, and it is the FIRST
+thing `R-77`'s builder must change:
+
+    test_the_contract_has_not_moved_without_the_version_moving
+        -> asks `endpoints`; becomes a check that `protocol` moved
+    test_the_minimum_extension_version_is_still_the_engines_to_own
+        -> asserts what `R-77` retires; becomes a MINIMUM PROTOCOL
+
+**AND UNTIL THEN A NEW ROUTE CANNOT LAND WITHOUT A DECISION.** `contractstamp._ROUTE`
+matches `@app.<verb>("...")`, so one new endpoint puts an entry in `endpoints["added"]`
+and reddens the gate unless `VERSION` is bumped by hand — which is the churn `R-77`
+ended. Measured 2026-08-30, this blocked `POST /api/engine/stop` and the work was split
+around it rather than spending a version number on a rule that had been deleted.
+
+**HOW THIS DOCSTRING CAME TO CITE THE RULING THAT DELETED IT**, recorded because it is
+the failure this file is about, one level up: `#290` repointed every citation of the five
+deleted rulings to `R-77` mechanically. Four sentences in `LESSONS`, `STATE`, `BACKLOG`
+and `REQUESTS` were caught and rewritten — prose that RECOUNTS what a ruling did reads
+as a claim about the ruling it now names. **These two were missed because they are test
+docstrings and the review pass read prose.** A citation inside a guard is the one a reader
+trusts most.
 
 WHY THESE TWO AND NOT ONE RULE FOR BOTH. A contract break stops another program
 working, and that is what an engine consumer needs warned about. Chrome shows the
@@ -181,9 +217,17 @@ def test_the_panel_surface_is_what_the_extension_version_answers_to():
 
 
 def test_the_minimum_extension_version_is_still_the_engines_to_own():
-    """`R-77`: the engine keeps the GATE and drops the ADVERT. A dynamic version
-    must not quietly turn the minimum into a moving target — it is derived from the
-    ledger, so it moves when a panel capability's `since` does, and not otherwise."""
+    """THE RULE THIS ASSERTS IS RETIRED BY `R-77`, AND THE ASSERTION STAYS UNTIL IT IS
+    BUILT. The sentence it was written for -- "the engine keeps the GATE and drops the
+    ADVERT" -- was `R-07`'s, deleted on 2026-08-30. `R-77` replaces
+    `MINIMUM_EXTENSION_VERSION` with a minimum PROTOCOL, so this test asserts something the
+    ruling retires and will fail the day somebody builds it correctly. **That is the
+    intended signal, not a regression**: whoever removes the constant must remove this with
+    it, and a green suite either side would mean nobody noticed.
+
+    What it still buys today: a dynamic version must not quietly turn the minimum into a
+    moving target -- it is derived from the ledger, so it moves when a panel capability's
+    `since` does, and not otherwise."""
     assert MINIMUM_EXTENSION_VERSION
     assert MINIMUM_EXTENSION_VERSION <= VERSION, (
         f"the engine requires an extension newer than itself "


### PR DESCRIPTION
My own defect from `#290`, found by a peer session an hour after it merged.

`#290` deleted five version rulings and repointed every citation of them to `R-77`
mechanically. **That is the right operation for a link and the wrong one for a sentence that
recounts what a ruling DID.** Six sentences of that shape were caught and rewritten in
`LESSONS`, `STATE`, `BACKLOG` and `REQUESTS`. **Two were missed, and where they were missed
is the finding:**

    tests/test_the_version_moves_when_the_contract_does.py:15
        "He ruled the criterion rather than the number (R-77):
             engine moves on a CONTRACT change -- schema, protocol, or endpoint"
        That is R-35's rule, attributed to the ruling that deleted it.

    the same file, test_the_minimum_extension_version_is_still_the_engines_to_own
        "R-77: the engine keeps the GATE and drops the ADVERT"
        That is R-07's sentence, and the test asserts MINIMUM_EXTENSION_VERSION is the
        engine's to own -- precisely what R-77 retires.

The review pass read documentation and did not read **test docstrings**. A citation inside a
guard is the one a reader trusts most, because a guard is supposed to be the thing that
cannot be wrong.

## Neither test changes what it enforces, and that is deliberate

`R-77` is a ruling and not yet an architecture: `VERSION` is still hand-edited and nothing
reads `protocol` as the compatibility authority. **Deleting these gates today removes the only
protection there is and puts nothing in its place** — the ninety-one-commit silent drift that
produced them. So each docstring now says three things instead of one: the rule it enforces
has been replaced, here is what it becomes, and it is the first thing `R-77`'s builder
changes.

    test_the_contract_has_not_moved_without_the_version_moving
        -> asks `endpoints`; becomes a check that `protocol` moved
    test_the_minimum_extension_version_is_still_the_engines_to_own
        -> asserts what R-77 retires; becomes a MINIMUM PROTOCOL

**And the file's title line asserted the deleted rule as current**, so it is rewritten too —
it now names itself as the gate that holds until the replacement is built.

**A named precondition falls out of this, and a session is already blocked on it.**
`contractstamp._ROUTE` matches `@app.<verb>("...")`, so one new endpoint reddens the gate
unless `VERSION` is bumped by hand — the churn `R-77` ended. Measured today, that blocked
`POST /api/engine/stop`; the engine-page session split its work around it rather than spend a
version number on a deleted rule. The docstring now says so, so the next session does not have
to re-derive it.

## `LESSONS` §29 — the shape, found four times in one day by four sessions

None of the four is a defect in a guard's logic. Each is a guard whose **subject** stopped
being what it was written for, and none of them can say so:

| found by | the mechanism | what it actually held |
|---|---|---|
| design review | `assert "THEME_PROPERTIES.forEach" in appearance` | the string occurs **twice**, so deleting `apply()`'s loop leaves it green on `clearTheme` |
| the Drive incident | the panel's *"3 loaded module(s) changed"* row | displayed correctly, gated nothing; the backup ran on stale code |
| engine page | `schema_lag` published and rendered | `engine.js` never carries the field, so the banner cannot appear in **any** state |
| engine page | a guard slicing `app.js` between two markers | the window is ~2,800 lines and `detail` appears ~71 times in unrelated code |

`LESSONS` §7 is the older half of this and §21 is the citation half. What today added is that
**it is not rare** — and the test for it is the one §18 already states, asked of the guard's
SUBJECT rather than of its assertion: *if the thing it protects were broken right now, would
this fail?*

## Verification

Both run modes from a purged tree, `TEMPLATE_EXIT=0` and `FULL_EXIT=0`, zero failures in
either. `ruff` clean. No version bump: `R-77` removes the engine's version, and this pull
request is about a docstring that misquoted it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
