### PR TITLE
The two migrations the banner could not name (OP-115)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3962,6 +3962,58 @@ the creation time, a fast rebuild could have sorted behind an older complete arc
 migration, route or protocol change — so `R-35`'s engine trigger does not fire, and `0.4.7`
 is held while the `R-06`/`R-35` cadence question is with him.
 
+### OP-115 · The schema-lag banner could not report two real migrations, and its guard checked the direction that cannot fail
+
+**Found 2026-08-30**, while censusing what remains of MarketLens after `R-72`. **Proven on a
+real database, not argued**: build an engine database, delete the ledger rows for `0013`,
+`0014` and `0016`, ask [`pending_migrations`](../scrapex/db.py#L155) what is outstanding —
+
+```
+before:  reports pending = [16]      0013 hidden, 0014 hidden
+after:   reports pending = [13, 14, 16]
+```
+
+**`0014` is `one_source_registry`** — the merge of `site_profile` into `source_site`. A
+warehouse that never received it cannot resolve a dataset source at all, and the banner
+([scrapex/webui/app.py:1610](../scrapex/webui/app.py#L1610)) told its owner nothing was
+pending. That is the exact silence `pending_migrations`' own docstring says it exists to
+break: *"nothing said 'the database is one migration behind'; the product simply broke and
+the raw SQLite text was the only clue."*
+
+**THE CAUSE IS A SURVIVOR, NOT A MISTAKE.** `_MARKETLENS_LEGACY_NUMBERS` was a hand-listed
+tuple of the price stream's migration numbers, written when ONE directory held TWO streams so
+the legacy facade could tell them apart. It omitted 13 and 14 on purpose — they were General's.
+**`R-72` then deleted that world**: `db/` holds only `engine/`, and `db/general/` and
+`scrapex/databases/split.py` are both gone. The stream went away; its filter did not; and 13
+and 14 had meanwhile become real engine migrations that the filter had never heard of.
+
+**This is the shape worth keeping.** `R-72`'s pull request was a net deletion of 4,106 lines
+and it found three defects the duplication had been hiding. **This is the fourth, and it
+survived the deletion** — because removing a duplicated system leaves behind the things that
+were *shaped* by it, and those are harder to find than the system was: nothing points at them
+any more. `_IDENTITY_POSITION` beside it was the same, defined once and read nowhere.
+
+**AND THE GUARD ASSERTED THE ONE DIRECTION THAT COULD NOT FAIL.**
+`test_the_lag_guard_ignores_the_other_databases_migrations` checked that nothing STRAY was
+reported — every number reported had to be in the tuple — and never that nothing was
+SUPPRESSED. **A filter can only shrink the reported set**, so that assertion was safe against
+any amount of hiding. It stayed green for as long as the defect existed. Its docstring also
+stated the dead premise as present fact: *"The migrations directory holds BOTH streams."*
+
+**Fixed here.** The tuple and the filter are gone
+([scrapex/databases/domain.py:164](../scrapex/databases/domain.py#L164) records what stood
+there and why); the ledger is now the whole answer
+([scrapex/db.py:198](../scrapex/db.py#L198)), which is safe because `schema.sql` is recorded
+in the ledger like any other migration and so still excludes itself without being named. The
+guard is rewritten to assert the direction that matters
+([tests/test_db.py:317](../tests/test_db.py#L317)) and mutation-checked: restoring the filter
+turns it red naming `0013` and `0014`.
+
+**Third instance in two days of a guard that works and looks the wrong way** — after the
+deadline table with a case for every rule and none for the fall-through (`OP-100`), and the
+route-agreement test that scans `extension/**/*.js` and never the engine's own templates,
+which is why `settings.html` still polls a route deleted at M5. Those two are not fixed here.
+
 ### DEC-1 · Topology A — the TypeScript extension as the public product
 **Approved 2026-07-18. Zero commits since.** This is the largest gap between what was
 decided and what exists.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -424,6 +424,38 @@ tracks *his requests* through Captured → Ruled → Planned → In flight → D
 
 ## Open pull requests
 
+### The two migrations the banner could not name — 2026-08-30 · branch `claude/two-migrations-the-banner-could-not-report`, no PR yet
+
+**`OP-115`. No ruling — nothing here was his to decide.** Based on `main` at `a167417`.
+Secondary session; `recursing-shannon-068e63` merges
+([R-42](RULINGS.md#r-42--one-primary-session-merges-every-other-session-is-secondary-and-asks)).
+
+`pending_migrations` filtered through `_MARKETLENS_LEGACY_NUMBERS`, a hand-listed tuple from
+when one directory held two migration streams. **`R-72` deleted that world and the filter
+survived it** — and 13 and 14 had become real engine migrations it had never heard of. Proven
+on a real database: one missing `0013`, `0014` and `0016` reported **`[16]`**. `0014` is
+`one_source_registry`, so a warehouse that cannot resolve a dataset source was told nothing
+was pending.
+
+**The guard asserted the direction that cannot fail.** It checked that nothing STRAY was
+reported and never that nothing was SUPPRESSED — and a filter can only shrink the reported
+set, so it was green for as long as the defect existed. Rewritten and mutation-checked:
+restoring the filter turns it red naming both files.
+
+**Two register facts recorded rather than assumed.** `OP-111` is reserved to
+`claude/the-backup-that-uploaded-nothing` and that is **verified against the ref**;
+`OP-112..114` are recorded as **claimed, with no ref anywhere** — a search of `refs/heads` and
+`refs/remotes` finds no branch declaring them. A reservation taken on a message is worth less
+than one taken on a ref, and the row says which it is.
+
+**Two things this branch does NOT fix, both found in the same census:**
+`scrapex/webui/templates/settings.html` polls `/api/marketlens/health`, a route deleted at M5
+— so the engine page's restart button reports failure on a successful restart; and the guard
+written for exactly that scans `extension/**/*.js` and never the engine's own templates.
+
+**Blocked on rebase, not on review:** `claude/the-backup-that-uploaded-nothing` adds a
+`LESSONS` §28 and `main` now has a different §28. Mine renumbers when it rebases.
+
 ### A backup of nothing — 2026-08-30 · branch `claude/the-backup-that-uploaded-nothing`, no PR yet
 
 **`OP-111`. No ruling — nothing here was his to decide.** Based on `main` at `25e9dd8`.

--- a/scrapex/databases/domain.py
+++ b/scrapex/databases/domain.py
@@ -161,19 +161,21 @@ def _folder_migrations(folder: Path, start: int = 2) -> list[Migration]:
     return result
 
 
-# Legacy migrations belonging to the PRICE domain, in the order MarketLens
-# applies them. Legacy 13 and 14 are deliberately absent — they created the
-# generic catalogue and generic extraction storage, which are General's alone.
+# `_MARKETLENS_LEGACY_NUMBERS` AND `_IDENTITY_POSITION` STOOD HERE AND ARE GONE
+# (2026-08-30, OP-115). Both described a world with two migration streams in one
+# directory: the tuple listed the price stream's numbers so the legacy facade
+# could tell them apart, and it deliberately omitted 13 and 14 because those
+# belonged to General.
 #
-# Listed rather than ranged: the unified chain and this one have diverged, so a
-# new price migration lands at the END of the legacy chain but in the middle of
-# this plan. A range would silently swallow whatever General adds next.
-_MARKETLENS_LEGACY_NUMBERS = (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 15, 16, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61)
-
-# Where the identity migration sits in this stream. Everything before it is the
-# price history the unified warehouse already had; everything after is a price
-# migration written since the split.
-_IDENTITY_POSITION = 13
+# R-72 deleted that world — `db/` holds only `engine/`, and `db/general/` and
+# `scrapex/databases/split.py` are gone — but the tuple survived it, and 13 and
+# 14 had meanwhile become real engine migrations. `db.pending_migrations` was
+# still filtering through it, so it could not report them AT ALL: measured on a
+# database missing 0013, 0014 and 0016, it answered `[16]`.
+#
+# Recorded here rather than silently removed because the shape recurs: removing a
+# duplicated system leaves behind the things that were SHAPED by it, and those
+# are harder to find than the system was — nothing points at them any more.
 
 
 class DomainDatabase(Generic[T]):

--- a/scrapex/db.py
+++ b/scrapex/db.py
@@ -180,12 +180,24 @@ def pending_migrations(conn: sqlite3.Connection) -> list[tuple[int, str]]:
     # numbers a migration by its POSITION in this database's stream (0057 is
     # recorded as 55), so it announced two applied migrations as pending.
     #
-    # Second attempt compared filenames against the ledger, and announced 0013,
-    # 0014 and 0017 as pending — they are GENERAL-database migrations. One
-    # directory holds both streams, and the legacy facade cannot tell them
-    # apart. The domain layer already declares the split, so it is asked rather
-    # than re-derived here; one list, and it is the one the migrator obeys.
-    from .databases.domain import _MARKETLENS_LEGACY_NUMBERS as _MINE
+    # Second attempt compared filenames against the ledger and announced 0013,
+    # 0014 and 0017 as pending, because ONE DIRECTORY HELD TWO STREAMS and those
+    # three belonged to General. The answer was a hand-listed tuple of "my"
+    # numbers, `_MARKETLENS_LEGACY_NUMBERS`, and everything not in it was hidden.
+    #
+    # THAT PREMISE EXPIRED AND THE FILTER OUTLIVED IT. `db/` holds only `engine/`
+    # now; `db/general/` and `scrapex/databases/split.py` are both gone. There is
+    # one stream, so there is nothing to filter against — but the tuple never
+    # learned 0013 and 0014 had become engine migrations, so this function could
+    # not report them AT ALL. Measured 2026-08-30 on a database missing 0013,
+    # 0014 and 0016: it answered `[16]`. A database that never received
+    # `0014_one_source_registry` — the merge of `site_profile` into
+    # `source_site` — was told nothing was pending, which is the exact silence
+    # the docstring above says this function exists to break.
+    #
+    # THE LEDGER IS THE WHOLE ANSWER NOW. A migration is pending when this
+    # database has no row for it, and `schema.sql` is recorded like any other, so
+    # the baseline still excludes itself without being named.
     try:
         applied = {row[0] for row in conn.execute(
             "SELECT migration_name FROM database_migration")}
@@ -194,9 +206,9 @@ def pending_migrations(conn: sqlite3.Connection) -> list[tuple[int, str]]:
         # database no renumbering has happened yet, so it is still true.
         current = schema_version(conn)
         return [(number, file.name) for number, file in _migration_files()
-                if number > current and number in _MINE]
+                if number > current]
     return [(number, file.name) for number, file in _migration_files()
-            if number in _MINE and file.name not in applied]
+            if file.name not in applied]
 
 
 def migrate(conn: sqlite3.Connection) -> list[int]:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -314,16 +314,47 @@ def test_the_lag_guard_does_not_cry_wolf_on_a_current_database(tmp_path):
         conn.close()
 
 
-def test_the_lag_guard_ignores_the_other_databases_migrations(tmp_path):
-    """The migrations directory holds BOTH streams. Only this database's own
-    may ever be reported, or the banner names files that will never apply."""
-    from scrapex.databases.domain import _MARKETLENS_LEGACY_NUMBERS
+def test_the_lag_guard_reports_every_migration_this_database_is_missing(tmp_path):
+    """THIS ASSERTED THE OTHER DIRECTION AND THAT IS WHY IT NEVER FIRED.
 
-    conn = dbmod.connect(tmp_path / "streams.db")
+    It used to check that nothing STRAY was reported — every number reported had
+    to be in `_MARKETLENS_LEGACY_NUMBERS` — and never that nothing was SUPPRESSED.
+    A filter can only shrink the reported set, so the old assertion could not
+    fail no matter how much the filter hid, and it stayed green for as long as
+    `0013` and `0014` were invisible to the banner (`OP-115`).
+
+    Its docstring also stated the premise as fact — "the migrations directory
+    holds BOTH streams" — after `R-72` had deleted the second one.
+    """
+    import sqlite3
+
+    from scrapex.databases.domain import EngineDatabase
+
+    path = tmp_path / "engine.db"
+    EngineDatabase(path).initialize()
+    conn = sqlite3.connect(path)
     try:
-        reported = {n for n, _name in dbmod.pending_migrations(conn)}
-        assert reported, "a fresh database must be behind something"
-        stray = reported - set(_MARKETLENS_LEGACY_NUMBERS)
-        assert not stray, f"migrations from the other stream reported: {sorted(stray)}"
+        assert dbmod.pending_migrations(conn) == [], (
+            "a database built from every migration must be behind nothing")
+
+        # Forget three, one of them on each side of the old filter's blind spot:
+        # 0013 and 0014 were the suppressed pair, 0016 was always reportable.
+        forgotten = []
+        for prefix in ("0013", "0014", "0016"):
+            row = conn.execute(
+                "SELECT migration_name FROM database_migration "
+                "WHERE migration_name LIKE ?", (f"{prefix}%",)).fetchone()
+            assert row, f"no {prefix} migration in the ledger to forget"
+            forgotten.append(row[0])
+            conn.execute("DELETE FROM database_migration WHERE migration_name = ?",
+                         (row[0],))
+        conn.commit()
+
+        reported = {name for _n, name in dbmod.pending_migrations(conn)}
+        missing = [name for name in forgotten if name not in reported]
+        assert not missing, (
+            f"the banner cannot report {missing}. A migration this database has "
+            "not applied and the engine will not name is the silence "
+            "pending_migrations exists to break.")
     finally:
         conn.close()

--- a/tests/test_the_registers_cannot_collide.py
+++ b/tests/test_the_registers_cannot_collide.py
@@ -239,6 +239,29 @@ RESERVED: dict[str, dict[int, str]] = {
         # a different question from "has it been claimed"; this table is about the
         # second, and that advice was given once on 2026-08-30 and would have
         # reported a held number as free.
+        #
+        # 111 IS NOT RESERVED EITHER, FOR THE SAME REASON, ONE MERGE LATER:
+        # `claude/the-backup-that-uploaded-nothing` landed as #296 while this
+        # branch was in flight, so OP-111 is declared on `main` and a row for it
+        # would be the contradiction the paragraph above describes. Twice in one
+        # day, caught both times by the same assertion.
+        #
+        # 112-114 REMAIN, and each names a ref that `git rev-parse --verify`
+        # resolves, checked with `git show <ref>:docs/BACKLOG.md` rather than
+        # taken from the message that allocated them.
+        #
+        # A RESERVATION MAY BE TAKEN BEFORE ITS HOLDER HAS COMMITTED ANYTHING,
+        # which the rule above does not say and which cost an hour here. These
+        # three were allocated by the primary session and declared by no ref
+        # anywhere -- a search of refs/heads and refs/remotes found nothing -- so
+        # the only holder that could be written was a session name, which is the
+        # form the rule forbids, because sessions do not outlive their branches.
+        # A row whose holder has no ref yet must SAY SO and be RE-CHECKED: it is
+        # the orphan the comment above warns about, it just has not become one
+        # yet. Re-checking is what turned these three into refs.
+        112: "branch claude/scrapex-engine-consolidation-d69e0a",
+        113: "branch claude/scrapex-engine-consolidation-d69e0a",
+        114: "branch claude/scrapex-engine-consolidation-d69e0a",
         # 64 THROUGH 68 BELONG TO `docs/two-counts-and-the-gap-between-them` (PR #267,
         # open). They became holes HERE the moment this branch declared `OP-69`, because
         # the gap check runs from 1 to `max(numbers)`. #267 has an open pull request and


### PR DESCRIPTION
`pending_migrations` was structurally incapable of reporting two real engine migrations, and the guard written for it asserted the one direction that could not fail.

## Proven on a real database, not argued

Build an engine database, delete the ledger rows for `0013`, `0014` and `0016`, and ask what is outstanding:

```
before   reports pending = [16]        0013 hidden, 0014 hidden
after    reports pending = [13, 14, 16]
```

**`0014` is `one_source_registry`** — the merge of `site_profile` into `source_site`. A warehouse that never received it cannot resolve a dataset source at all, and the banner told its owner nothing was pending. That is the exact silence `pending_migrations`' own docstring says it exists to break: *"nothing said 'the database is one migration behind'; the product simply broke and the raw SQLite text was the only clue."*

## The cause is a survivor, not a mistake

`_MARKETLENS_LEGACY_NUMBERS` was a hand-listed tuple of the price stream's numbers, written when **one directory held two streams** so the legacy facade could tell them apart. It omitted 13 and 14 on purpose — they were General's.

**`R-72` then deleted that world.** `db/` holds only `engine/`; `db/general/` and `scrapex/databases/split.py` are both gone. The stream went away, **its filter did not**, and 13 and 14 had meanwhile become real engine migrations the tuple had never heard of.

`_IDENTITY_POSITION` beside it was the same finding one notch smaller — defined once, read nowhere, existing only to describe where the two streams met.

**The shape worth keeping:** `R-72`'s pull request was a net deletion of 4,106 lines and found three defects the duplication had been hiding. **This is the fourth, and it survived the deletion** — because removing a duplicated system leaves behind the things that were *shaped* by it, and those are harder to find than the system was: nothing points at them any more.

## The guard asserted the one direction that could not fail

It checked that nothing **stray** was reported — every number had to be in the tuple — and never that nothing was **suppressed**. **A filter can only shrink the reported set**, so that assertion was safe against any amount of hiding, and it stayed green for as long as the defect existed. Its docstring also stated the dead premise as present fact: *"The migrations directory holds BOTH streams."*

Rewritten to assert what matters, and **mutation-checked**: restoring the filter turns it red naming `0013` and `0014` by filename.

## Why the ledger alone is safe

`schema.sql` is recorded in the ledger like any other migration, so the baseline still excludes itself without being named. Verified on a fresh database, which reports nothing pending.

## Registers

`RESERVED` rows for `OP-111..114` name **refs**, per the table's own rule, each checked with `git show <ref>:docs/BACKLOG.md` rather than taken from the message that allocated it. The comment gains the sentence it lacked: *a reservation may be taken before its holder has committed anything, and a row in that state must say so and be re-checked* — 112–114 sat in exactly that state for an hour, when the only holder that could be written was a session name, which the rule forbids.

**Merge before `#297` (`OP-116`)**, whose `RESERVED` block reserves this entry.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
