### PR TITLE
A backup of nothing reached Drive, and the check was disabled by zero (OP-111)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3895,6 +3895,73 @@ under.
 *(An earlier draft of this entry said 35 against 11, and 34 below the floor. Both were
 counted with a line-grep that did not strip comments. Re-counted with a parser: 38, 6, 29.)*
 
+### OP-111 · A backup of nothing reached Drive, and the check that would have caught it was disabled by zero
+
+**Found 2026-08-30, by him, from the Drive folder.** After pressing "Back up to
+Drive" his `ScrapeX backups` folder held `scrapex-bundle-20260830-045416.zip` at **0
+bytes**, `panel.jsonl.gz` at **0 bytes**, and a `latest.json` beside them saying a backup
+existed. **He had no usable backup in Drive.** Two complete 378.7 MB archives were safe on
+local disk, so nothing was lost — but nothing on either side said so.
+
+**The chain, each link measured:**
+
+1. **The running engine was not the code on disk.** It reported `engine_version 0.4.5`
+   while `main` carried `0.4.6`; a running Python process keeps the modules it loaded. So
+   `OP-100`'s build lock was merged and **not active**. Two builds ran 36 seconds apart
+   (stamps `20260830-045340` and `045416`) and three stamps sat in a folder where
+   `BUNDLE_KEEP = 2` would have left two.
+2. **`zipfile.ZipFile(archive, "w")` created the file under its FINAL name immediately**,
+   at zero bytes, and filled it over the ~33 s of the deflate.
+3. **`GET /api/bundle/archive` answers with the newest `.zip` by mtime**
+   ([scrapex/webui/app.py:2923](../scrapex/webui/app.py#L2923)), so it handed the panel the
+   second build's empty, in-progress file.
+4. **Nothing compared what arrived with what the engine had described.** The pointer took
+   `bytes` from the uploaded blob (0) and `sha256` from the manifest of the *complete*
+   378 MB build. Two sources, never reconciled.
+5. **And the restore-side check was written `if (pointer.bytes && …)`.** With `bytes: 0`
+   that is falsy, so it never ran. **The guard was switched off by exactly the value that
+   means the thing it guards against has happened** — a truthiness test on a size is a test
+   that the size is *interesting*, and zero is the least interesting number and the most
+   alarming one. A restore would have reported success on an empty archive.
+
+**Four defects. `OP-100` closed only the first, and D4 is the one that would have
+prevented all of it.**
+
+| | defect | state |
+|---|---|---|
+| **D1** | two builds at once | fixed by `OP-100`'s lock — **which was not loaded** |
+| **D2** | the archive is written in place under its final name, so the route can serve a partial file | **fixed here** |
+| **D3** | nothing verifies the bytes against the manifest, and the restore check disables itself at zero | **fixed here** |
+| **D4** | **the engine knew it was stale, said so, and gated nothing** | **open** |
+
+**D4 is not a deployment accident and should not be read as one.** The panel's build row
+said *"the code this engine is running is not the code on disk — 3 loaded module(s) changed
+since it started"*. That is the system detecting the exact condition that made this
+possible, **displaying it correctly, and letting the button be pressed anyway.** Nothing
+said the button was unsafe. A detected-and-displayed staleness that gates nothing is a
+decorative guard; the Engine page also has no restart control on it, so the sentence names
+an action the page cannot perform.
+
+**Fixed here.** `bundle.pack` writes to `<name>.zip.part` and renames
+([scrapex/bundle.py:388](../scrapex/bundle.py#L388), `PARTIAL_SUFFIX` at
+[:357](../scrapex/bundle.py#L357)); `Path.replace` is atomic on one filesystem, so the real
+name either does not exist or names a complete archive. The panel-pack copy is done the
+same way. On the panel, `expectSize` refuses a part whose length is not the length the
+engine described ([extension/drive.js:405](../extension/drive.js#L405), called at
+[:432](../extension/drive.js#L432)) before a byte leaves the machine, an empty archive is
+refused outright ([:436](../extension/drive.js#L436)), and the download check is a `typeof`
+rather than a truthiness test ([:540](../extension/drive.js#L540)).
+
+**Measured rather than assumed, because the rename could have re-introduced the bug:**
+`Path.replace` carries the **write-completion** mtime across the rename, not the creation
+time. A renamed archive therefore still sorts by when its bytes finished. Had it carried
+the creation time, a fast rebuild could have sorted behind an older complete archive and
+`_newest` would have served the wrong one.
+
+**No version bump.** The regenerated contract baseline moves only its version stamp — no
+migration, route or protocol change — so `R-35`'s engine trigger does not fire, and `0.4.7`
+is held while the `R-06`/`R-35` cadence question is with him.
+
 ### DEC-1 · Topology A — the TypeScript extension as the public product
 **Approved 2026-07-18. Zero commits since.** This is the largest gap between what was
 decided and what exists.

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -3361,3 +3361,18 @@ now, would this fail?* -- asked of the guard's SUBJECT and not of its assertion.
 **The sixth was found the same day, in the Drive incident, and it is the sharpest of them because it names the VALUE at which a guard switches off.** A size, a count, a duration and a checksum all share one property: **zero is the least interesting number and the most alarming one**, and a truthiness test discards exactly it. Ask for PRESENCE — `typeof x === "number"` — which forgives an absent field and refuses a zero one.
 
 **And the two idioms are one character apart, which is why this is worth a paragraph rather than a rule.** Measured across `extension/` before writing it: the `x && …` shape appears five times on a size- or count-like name and **all five are the safe one** — `if (rows.length && …)` asks *is there anything at all*, where zero is a real answer and skipping is correct. `if (pointer.bytes && …)` asks *do I have a measurement* and answers it with a test for whether the measurement is interesting. Same shape, opposite meaning, and only the second is wrong.
+
+**AND ONE COUNTEREXAMPLE, WHICH THIS SECTION NEEDS OR IT READS AS A LIST OF THINGS THAT
+CANNOT WORK.** Every entry above is a guard that could not notice its subject had changed.
+On the rebase that produced this very paragraph, one did. `tests/test_the_registers_cannot_collide.py`
+held ten reservations for `OP-101..110` on behalf of another branch. That branch merged, the
+numbers became DECLARED on `main`, and `test_a_reserved_number_is_not_also_declared` refused
+the rebase and **named all ten** — a reservation for a number that has landed is a
+contradiction, and the table says so about itself.
+
+**What makes it work is the shape of the assertion, not the care of its author.** It compares
+two things that move independently — the reservations and the headings — so a change to
+either side breaks the agreement. The failures above all assert something about ONE side and
+cannot see the other move. That is the buildable version of §18's question: do not ask *"would
+this fail if the thing broke"* and hope; **assert an agreement between two things that are
+maintained separately**, and the guard notices without anybody remembering to ask.

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -3004,6 +3004,16 @@ entries with the SAME key. Python keeps the last. No error, no warning — a gro
 simply stopped being described. Found by the guard above, which is the only reason it is not
 still true.
 
+**IT HAPPENED AGAIN ON 2026-08-30, in `tests/test_the_registers_cannot_collide.py` — the
+guard against register collisions.** `RESERVED` is a long dict literal with a comment block
+before each key, and ten reservations were added as a second `"OP":` near the top without
+noticing an `"OP":` already existed a hundred lines below. Python kept the lower one, the ten
+reservations evaporated, and the register guard failed with the numbers still missing —
+reporting the symptom the new rows had just been written to explain. **The comment blocks are
+what hide it**: they are long enough that the two keys never appear on one screen. Read a dict
+literal for its KEYS before adding one, and prefer `**dict.fromkeys(...)` merged into the
+existing key over a second entry that looks separate.
+
 **The shape of all three:** a test that builds its own database is only as honest as the
 builder it calls. When two builders exist, half the suite is testing a product nobody runs.
 
@@ -3284,7 +3294,7 @@ Related: section 21's rule about re-deriving citations after an insertion is the
 discipline applied to line numbers rather than to counts, and `OP-97` is the same failure
 applied to a file LIST — a census scoped to 9 stylesheets when there were 19.
 
-## 29 · Deleting a ruling rewrites the sentences that talk ABOUT it, and one blind spot was found five times in a day
+## 29 · Deleting a ruling rewrites the sentences that talk ABOUT it, and one blind spot was found six times in a day
 
 `R-77` deleted five rulings and every live citation of them was repointed mechanically.
 That is the right operation for a link. **It is the wrong operation for a sentence that
@@ -3335,7 +3345,7 @@ indistinguishable from a green that earned it, and no count anywhere would diffe
 device half was found by the design-review session while building `R-79`; those words are its
 own.)
 
-**Two in five is a rate, not an anecdote.** "It rotted" is the comfortable reading because it
+**Two of the first five is a rate, not an anecdote** (the sixth below could fail, at any mismatch but zero, so it is not in that count)**.** "It rotted" is the comfortable reading because it
 implies the guard was once correct and time did the damage. **Forty per cent of these were
 never correct** -- which means a reviewer should ask *"could this ever have failed?"* as a
 matter of course, not only when a guard looks stale.
@@ -3345,3 +3355,9 @@ being what it was written for, and none of them can say so. `LESSONS` §7 is the
 this and §21 is the citation half; what 2026-08-30 added is that **it is not rare**. The test
 that finds them is the one §18 already states: *if the thing it protects were broken right
 now, would this fail?* -- asked of the guard's SUBJECT and not of its assertion.
+
+| Drive incident | `if (pointer.bytes && archive.size !== pointer.bytes)` | **nothing, at the only value that matters.** `0 &&` is falsy, so the comparison never ran and a 0-byte backup passed as good |
+
+**The sixth was found the same day, in the Drive incident, and it is the sharpest of them because it names the VALUE at which a guard switches off.** A size, a count, a duration and a checksum all share one property: **zero is the least interesting number and the most alarming one**, and a truthiness test discards exactly it. Ask for PRESENCE — `typeof x === "number"` — which forgives an absent field and refuses a zero one.
+
+**And the two idioms are one character apart, which is why this is worth a paragraph rather than a rule.** Measured across `extension/` before writing it: the `x && …` shape appears five times on a size- or count-like name and **all five are the safe one** — `if (rows.length && …)` asks *is there anything at all*, where zero is a real answer and skipping is correct. `if (pointer.bytes && …)` asks *do I have a measurement* and answers it with a test for whether the measurement is interesting. Same shape, opposite meaning, and only the second is wrong.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -424,6 +424,52 @@ tracks *his requests* through Captured → Ruled → Planned → In flight → D
 
 ## Open pull requests
 
+### A backup of nothing — 2026-08-30 · branch `claude/the-backup-that-uploaded-nothing`, no PR yet
+
+**`OP-111`. No ruling — nothing here was his to decide.** Based on `main` at `25e9dd8`.
+Secondary session; `recursing-shannon-068e63` merges
+([R-42](RULINGS.md#r-42--one-primary-session-merges-every-other-session-is-secondary-and-asks)).
+
+He backed up and Drive received a **0-byte archive, a 0-byte panel pack, and a pointer saying
+a backup existed**. Two complete 378.7 MB archives were safe on local disk. The engine was
+running `0.4.5` while `main` carried `0.4.6` — a running process keeps its loaded modules — so
+`#288`'s build lock was merged and **not active**, two builds overlapped, and the route that
+serves "the newest archive" served the one that had been created and not yet filled.
+
+**Built here:**
+
+| | |
+|---|---|
+| the archive is written to `<name>.zip.part` and renamed | `scrapex/bundle.py:388` |
+| the panel-pack copy, the same way | `scrapex/webui/app.py` |
+| `expectSize` — refuses a part the engine described differently, before a byte leaves | `extension/drive.js:405` |
+| an empty archive or pack refused outright, on upload and on download | `extension/drive.js:436` |
+| the download check is a `typeof`, not a truthiness test | `extension/drive.js:540` |
+
+**Measured, because the fix could have re-introduced the bug:** `Path.replace` carries the
+**write-completion** mtime across the rename, so a renamed archive still sorts by when its
+bytes finished. Had it carried the creation time, a fast rebuild could have sorted behind an
+older complete archive.
+
+**Left open, and named in `OP-111` as D4:** the engine detected its own staleness, displayed
+it correctly — *"3 loaded module(s) changed since it started"* — and gated nothing. The
+Engine page has no restart control on it either, so the sentence names an action the page
+cannot perform. That is a separate track and the owner has asked for it.
+
+**A guard was removed as well as added.** A filter against `.part` was written into `_newest`
+and then taken out: measured, `*.zip` cannot match `*.zip.part`, so the condition could never
+fire — and a condition that can never be true reads as a hazard that is still live. The
+naming enforces it; a test proves the naming.
+
+**No version bump.** The regenerated contract baseline moves only its version stamp, so
+`R-35`'s trigger does not fire, and `0.4.7` is held while the `R-06`/`R-35` cadence question
+is with him.
+
+**Ten `RESERVED` rows added** for `OP-101..110`, held by `claude/design-system-review-d6787a`
+— delete them the day that branch merges.
+
+### ~~The backup that said it failed~~ — MERGED as #288 (`3a745a9`), 2026-08-30
+
 ### Device colours reach the user — 2026-08-30 · branch `claude/device-colours-reach-the-user`, based on `main` at `f920e7d`
 
 **`R-79`, the first two of `REQ-49`'s twelve decisions.** Closes `OP-101` and half of
@@ -503,7 +549,8 @@ pruning and the sweep; all four were mutation-checked (break the guard, watch th
 red) rather than merely written.
 
 **Two citations were repaired on the way past**, both exposed rather than caused by the
-insertions: the pinned `scrapex/webui/app.py:3022` in `tests/test_the_documents_cite_what_they_claim.py`,
+insertions: the pinned citation for `if source_key not in known:` in
+`tests/test_the_documents_cite_what_they_claim.py`,
 and `docs/REQUESTS.md`'s jobs-route citation, which was **already 27 lines stale** —
 Tier 1 only asks that a cited line exist, and a stale line that is not blank still exists.
 

--- a/extension/app.js
+++ b/extension/app.js
@@ -6109,6 +6109,12 @@ async function backUpToDrive(token) {
     ? await (await fetch(base + "/api/bundle/panel-pack")).blob()
     : null;
 
+  // `manifest: built` is not decoration. WHAT THE ENGINE DESCRIBED AND WHAT
+  // ARRIVED ARE TWO DIFFERENT FACTS -- the manifest comes from the POST above,
+  // the bytes from a second request that reads the newest file on disk -- and
+  // on 2026-08-30 those resolved to different builds and a 0-byte archive went
+  // to Drive under a pointer carrying the real one's digest. `backUp` compares
+  // them now, because it is handed both.
   const stored = await backUp(token, {
     archive, name: built.name, panelPack,
     manifest: built, bundleFormat: built.bundle_format,

--- a/extension/drive.js
+++ b/extension/drive.js
@@ -391,10 +391,56 @@ export async function readLatest(token, parent, {fetchImpl = fetch} = {}) {
  * through: this file never opens a bundle, because that is the engine's job and
  * doing it twice is how two readers of one format drift.
  */
+/** Refuse a part whose length is not the length the engine described.
+ *
+ * `typeof`, NEVER truthiness. `if (described && ...)` is the shape that let the
+ * 2026-08-30 backup through: a size of zero is falsy, so the comparison was
+ * skipped, and THE CHECK SWITCHED ITSELF OFF AT EXACTLY THE VALUE THAT MEANS
+ * THE THING IT CHECKS FOR HAS HAPPENED. A missing size is still forgiven — a
+ * caller may legitimately have no manifest — but a size of zero is not missing.
+ *
+ * Exported for its own test. The truthiness bug is invisible in a test that
+ * only ever passes plausible numbers, so it is asserted at zero directly.
+ */
+export function expectSize(what, blob, described) {
+  if (typeof described !== "number") return;
+  const size = blob ? blob.size : 0;
+  if (size === described) return;
+  throw new DriveError(
+    `The engine built a ${what} of ${described} bytes and this panel read ` +
+    `${size}. Nothing was uploaded, and the backup already in Drive is ` +
+    "untouched. Restart the engine from the Engine page, then try again.",
+    null, "mismatched");
+}
+
 export async function backUp(token, {
   archive, name, panelPack = null, manifest = {}, bundleFormat = 1,
   onProgress = null, fetchImpl = fetch,
 } = {}) {
+  // NOTHING COMPARED THE BYTES TO THE DESCRIPTION UNTIL 2026-08-30, and the
+  // manifest was already being passed in when it happened. The engine's POST
+  // reply says how long the archive is; the archive arrives from a SECOND
+  // request that serves the newest file on disk. Two concurrent builds made
+  // those two different things, and a 0-byte archive went to Drive under a
+  // pointer carrying the complete build's digest -- a backup that reported
+  // success and could restore nothing.
+  //
+  // Refused here, before a single byte leaves the machine, and refused twice:
+  // the size must match what the engine described, AND an empty archive is
+  // never a backup whatever anyone described. The second is not redundant --
+  // it holds for a caller that passes no manifest at all.
+  expectSize("archive", archive, manifest.bytes);
+  expectSize("panel pack", panelPack, manifest.panel_pack?.bytes);
+  if (!archive || archive.size === 0) {
+    throw new DriveError(
+      "The archive was empty, so nothing was uploaded. The backup already in " +
+      "Drive is untouched.", null, "empty");
+  }
+  if (panelPack && panelPack.size === 0) {
+    throw new DriveError(
+      "The panel pack was empty, so nothing was uploaded. The backup already " +
+      "in Drive is untouched.", null, "empty");
+  }
   const parent = await folderId(token, {fetchImpl});
 
   const stored = await upload(token, {
@@ -485,10 +531,23 @@ export async function fetchLatest(token, {
       "again. Nothing was restored.", null, "wrong-format");
   }
   const archive = await download(token, pointer.file_id, {onProgress, fetchImpl});
-  if (pointer.bytes && archive.size !== pointer.bytes) {
+  // `typeof`, NOT `pointer.bytes &&`. The truthiness version read a pointer
+  // saying `bytes: 0` as "no size recorded, nothing to compare" and returned an
+  // empty archive as a good one -- THE GUARD WAS DISABLED BY EXACTLY THE VALUE
+  // THAT MEANS THE THING IT GUARDS AGAINST HAS HAPPENED. A pointer with no
+  // `bytes` at all is a genuinely older pointer and is still forgiven; a
+  // pointer that says zero is now the loudest failure here.
+  if (typeof pointer.bytes === "number" && archive.size !== pointer.bytes) {
     throw new DriveError(
       `The download stopped at ${archive.size} of ${pointer.bytes} bytes. ` +
       "Nothing was restored.", null, "truncated");
+  }
+  // Reached when a pointer carries no size at all, so the comparison above had
+  // nothing to compare. An empty archive is unusable whatever the pointer says.
+  if (archive.size === 0) {
+    throw new DriveError(
+      "The backup in Drive is empty, so there is nothing to restore. Take a " +
+      "new backup from this panel.", null, "empty");
   }
   return {archive, pointer};
 }

--- a/extension/tests/drive.test.mjs
+++ b/extension/tests/drive.test.mjs
@@ -11,7 +11,7 @@ import assert from "node:assert/strict";
 import {
   backUp, download, fetchLatest, folderId, listing, prunable, upload,
   fetchPanelPack,
-  BUNDLE_FORMAT, DriveError, KEEP, LATEST, PANEL_PACK,
+  BUNDLE_FORMAT, DriveError, KEEP, LATEST, PANEL_PACK, expectSize,
 } from "../drive.js";
 import {readFileSync} from "node:fs";
 
@@ -541,4 +541,114 @@ test("a truncated pack shows nothing rather than half the rows", async () => {
     assert.match(error.message, /Nothing is shown/);
     return true;
   });
+});
+
+// ---- a backup of nothing, 2026-08-30 (OP-111) --------------------------------
+//
+// Drive ended up holding a 0-byte archive, a 0-byte panel pack and a pointer
+// beside them saying a backup existed. Two engine builds overlapped, the second
+// had created its zip and not yet filled it, and the route that serves "the
+// newest archive" served that. Nothing on this side compared what arrived with
+// what the engine had described, and the download guard was written
+// `if (pointer.bytes && ...)` — so a recorded size of zero disabled it.
+
+test("a size of zero does not disable the size check", () => {
+  // THE WHOLE BUG IN ONE ASSERTION. Under `if (described && ...)` this passed
+  // silently, because zero is falsy and the comparison never ran.
+  assert.throws(() => expectSize("archive", new Blob(["abc"]), 0),
+                (error) => error instanceof DriveError && error.kind === "mismatched");
+  assert.throws(() => expectSize("archive", new Blob([]), 12),
+                (error) => error.kind === "mismatched");
+});
+
+test("a size the engine did not describe is still forgiven", () => {
+  // A caller with no manifest is legitimate; absent is not the same as zero.
+  expectSize("archive", new Blob(["abc"]), undefined);
+  expectSize("archive", new Blob(["abc"]), null);
+  expectSize("panel pack", null, undefined);
+});
+
+test("an archive shorter than the engine described is never uploaded", async () => {
+  const fetchImpl = scripted([[() => true, () => reply(500, {body: {}})]]);
+  await assert.rejects(() => backUp("tok", {
+    archive: new Blob([]), name: "bundle.zip",
+    manifest: {bytes: 378655878}, fetchImpl,
+  }), (error) => {
+    assert.equal(error.kind, "mismatched");
+    assert.match(error.message, /378655878 bytes and this panel read 0/);
+    assert.match(error.message, /backup already in Drive is untouched/,
+                 "the refusal must say the existing backup survived");
+    return true;
+  });
+  // AND NOTHING WAS ASKED OF GOOGLE. The check has to fail before the first
+  // request, or a half-made backup folder is the cheapest thing it costs.
+  assert.equal(fetchImpl.calls.length, 0);
+});
+
+test("an empty archive is refused even when nothing described it", async () => {
+  const fetchImpl = scripted([[() => true, () => reply(500, {body: {}})]]);
+  await assert.rejects(() => backUp("tok", {
+    archive: new Blob([]), name: "bundle.zip", fetchImpl,
+  }), (error) => {
+    assert.equal(error.kind, "empty");
+    return true;
+  });
+  assert.equal(fetchImpl.calls.length, 0);
+});
+
+test("an empty panel pack is refused too", async () => {
+  const fetchImpl = scripted([[() => true, () => reply(500, {body: {}})]]);
+  await assert.rejects(() => backUp("tok", {
+    archive: new Blob(["real"]), panelPack: new Blob([]), name: "bundle.zip",
+    fetchImpl,
+  }), (error) => error.kind === "empty");
+  assert.equal(fetchImpl.calls.length, 0);
+});
+
+/** A Drive whose pointer records `bytes` and whose archive is `archiveBody`. */
+function driveHolding(bytes, archiveBody) {
+  return scripted([
+    [isSearch, (url) => (url.includes("mimeType")
+      ? reply(200, {body: {files: [{id: "folder-1"}]}})
+      : reply(200, {body: {files: [{id: "ptr", name: LATEST}]}}))],
+    [(url) => url.includes("/ptr") && url.includes("alt=media"),
+      () => reply(200, {body: JSON.stringify(
+        {file_id: "arch", bytes, bundle_format: BUNDLE_FORMAT})})],
+    [(url) => url.includes("/arch") && url.includes("alt=media"),
+      () => reply(200, {body: archiveBody})],
+  ]);
+}
+
+test("a pointer recording zero bytes no longer waves the download through", async () => {
+  // EXACTLY THE COMPARISON THE OLD GUARD SKIPPED. `if (pointer.bytes && ...)`
+  // read a recorded zero as "no size to check" and returned whatever arrived.
+  await assert.rejects(
+    () => fetchLatest("tok", {fetchImpl: driveHolding(0, "some bytes")}),
+    (error) => {
+      assert.equal(error.kind, "truncated");
+      assert.match(error.message, /Nothing was restored/);
+      return true;
+    });
+});
+
+test("an empty archive is refused even though it matches its pointer", async () => {
+  // What the owner's Drive actually held on 2026-08-30: a 0-byte archive and a
+  // pointer agreeing it was 0 bytes. The size comparison is SATISFIED -- both
+  // are zero -- so it takes a second guard to say that nothing is not a backup.
+  // Without it a restore reports success and installs an empty bundle.
+  await assert.rejects(
+    () => fetchLatest("tok", {fetchImpl: driveHolding(0, "")}),
+    (error) => {
+      assert.equal(error.kind, "empty");
+      assert.match(error.message, /nothing to restore/);
+      return true;
+    });
+});
+
+test("a pointer with no recorded size at all is still honoured", async () => {
+  // Older pointers predate `bytes`. Absent must stay forgiven, or this fix
+  // turns every backup written before it into an unreadable one.
+  const {archive} = await fetchLatest(
+    "tok", {fetchImpl: driveHolding(undefined, "a real archive")});
+  assert.equal(archive.size, "a real archive".length);
 });

--- a/scrapex/bundle.py
+++ b/scrapex/bundle.py
@@ -352,12 +352,30 @@ def read_dataset(bundle_dir: Path | str, source_key: str,
 # instead of seventy-one.
 
 
+#: What a half-written archive is called while it is being written. Anything
+#: carrying this suffix is a build in progress and is not a backup.
+PARTIAL_SUFFIX = ".part"
+
+
 def pack(bundle_dir: Path | str, archive_path: Path | str) -> dict:
     """Compress a verified bundle into one file, and describe it.
 
     Refuses to pack a bundle that does not verify. The whole point of
     `latest.json` naming only a validated bundle is lost if the validation can
     be skipped by packing first and checking later.
+
+    THE ARCHIVE APPEARS UNDER ITS REAL NAME ONLY WHEN IT IS WHOLE, and that is
+    not tidiness. `zipfile.ZipFile(path, "w")` creates the file the instant it
+    is called and leaves it at zero bytes for the thirty-odd seconds it takes to
+    deflate the owner's warehouse. `GET /api/bundle/archive` answers with
+    `_newest(folder, ".zip")` — newest by mtime — so for that whole window the
+    freshest `.zip` on disk is the emptiest one.
+
+    ON 2026-08-30 THAT WINDOW WAS ENTERED AND A BACKUP OF NOTHING REACHED HIS
+    DRIVE: a 0-byte archive and a 0-byte panel pack, with a pointer beside them
+    saying a backup existed. Writing to `<name>.zip.part` and renaming closes it
+    — `Path.replace` is atomic on one filesystem, so the name either does not
+    exist or names a complete archive, and there is no third state to serve.
     """
     root, archive = Path(bundle_dir), Path(archive_path)
     report = verify(root)
@@ -367,10 +385,20 @@ def pack(bundle_dir: Path | str, archive_path: Path | str) -> dict:
             + "; ".join(f"{f.path}: {f.problem}" for f in report.faults[:3]))
 
     archive.parent.mkdir(parents=True, exist_ok=True)
-    with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED, compresslevel=6) as out:
-        for path in sorted(root.rglob("*")):
-            if path.is_file():
-                out.write(path, path.relative_to(root).as_posix())
+    building = archive.with_name(archive.name + PARTIAL_SUFFIX)
+    try:
+        with zipfile.ZipFile(building, "w", zipfile.ZIP_DEFLATED, compresslevel=6) as out:
+            for path in sorted(root.rglob("*")):
+                if path.is_file():
+                    out.write(path, path.relative_to(root).as_posix())
+        building.replace(archive)
+    except BaseException:
+        # A crash must not leave the half-written file behind to be mistaken for
+        # a backup later. `.part` is already excluded from every reader, so this
+        # is housekeeping rather than correctness -- but a 372 MB remnant per
+        # failed build is the leak this module has just been taught to avoid.
+        building.unlink(missing_ok=True)
+        raise
     return {"path": str(archive), "bytes": archive.stat().st_size,
             "sha256": sha256_of(archive), "files": report.files,
             "uncompressed_bytes": report.bytes}

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -2921,6 +2921,25 @@ def create_app(
         return backup_folder(conn, app.state.db_path)
 
     def _newest(folder: Path, suffix: str) -> Path | None:
+        """The newest COMPLETE artefact of its kind, never one being written.
+
+        THE SECOND HALF OF THAT SENTENCE IS THE WHOLE FUNCTION'S JOB, and it did
+        not used to be. On 2026-08-30 this returned a `.zip` that a concurrent
+        build had created and not yet filled — newest by mtime, zero bytes long —
+        and the panel uploaded it to Drive as the owner's backup.
+
+        WHAT ENFORCES IT IS THE NAMING, not a filter here. `bundle.pack` writes
+        to `<name>.zip.part` and renames, and `*.zip` does not match `*.zip.part`
+        — measured, not assumed. A guard was written here as well and then taken
+        out again: it could not fire, and a condition that can never be true
+        reads as a hazard that is still live.
+
+        Two properties this relies on, both measured 2026-08-30:
+        `Path.replace` is atomic on one filesystem, so this glob sees the name
+        either not at all or complete; and it carries the write-completion mtime
+        across the rename, so a renamed archive still sorts by when its bytes
+        finished rather than by when its name first appeared.
+        """
         made = sorted(folder.glob(f"{BUNDLE_PREFIX}*{suffix}"),
                       key=lambda p: p.stat().st_mtime, reverse=True)
         return made[0] if made else None
@@ -3029,7 +3048,19 @@ def create_app(
             pack_source = staging / bundle.PANEL_PACK
             panel_pack = folder / f"{BUNDLE_PREFIX}{stamp}{PANEL_SUFFIX}"
             if pack_source.is_file():
-                shutil.copy2(pack_source, panel_pack)
+                # COPIED ASIDE AND RENAMED, for the reason `bundle.pack` is now
+                # written the same way: a destination being copied INTO is a
+                # file that exists, is newest by mtime, and is the wrong length,
+                # and `_newest` would hand it to the panel as this backup's pack.
+                # Four megabytes copy fast, but "fast" is not "atomic".
+                building = panel_pack.with_name(
+                    panel_pack.name + bundle.PARTIAL_SUFFIX)
+                try:
+                    shutil.copy2(pack_source, building)
+                    building.replace(panel_pack)
+                except BaseException:
+                    building.unlink(missing_ok=True)
+                    raise
         except ValueError as error:
             raise HTTPException(status_code=400, detail=str(error)) from error
         finally:

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -284,7 +284,7 @@ PINNED = (
     # 404 for anything else" -- and only reading the enclosing function separates
     # them. A delta applied to the old number would have picked the right line here
     # by luck and the wrong one the first time the two moved apart.
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 3115, "if source_key not in known:"),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 3146, "if source_key not in known:"),
     ("docs/BACKLOG.md", "scrapex/webui/app.py", 1204,
      "A GENERIC DATASET IS A TABLE LIKE ANY OTHER TABLE"),
     # OP-44 · the dataset card that said "no successful crawl yet" over 17,304

--- a/tests/test_the_engine_hands_the_bundle_over.py
+++ b/tests/test_the_engine_hands_the_bundle_over.py
@@ -476,3 +476,168 @@ def test_a_failed_build_does_not_take_the_last_good_archive_with_it(client, monk
     survived = {p.name[len("scrapex-bundle-"):][:15]
                 for p in backups.glob("scrapex-bundle-*.zip")}
     assert survived == {"20260101-000000", "20260102-000000", "20260103-000000"}
+
+
+# ---- an archive is only servable when it is whole (OP-111) --------------------
+#
+# On 2026-08-30 a 0-byte archive reached the owner's Drive under a pointer
+# saying a backup existed. Two builds overlapped; the second had CREATED its zip
+# and not yet filled it; and this route answers with the newest `.zip` on disk.
+# `zipfile.ZipFile(path, "w")` makes that window thirty seconds wide on his
+# warehouse. The archive is now written beside its real name and renamed into
+# place, so the name either does not exist or names a complete file.
+
+
+def test_a_finished_build_leaves_no_half_written_file_behind(client):
+    connected, backups = client
+
+    connected.post("/api/bundle")
+
+    leftovers = [p.name for p in backups.glob("*.part")]
+    assert not leftovers, f"the build left a partial file behind: {leftovers}"
+
+
+def test_an_archive_still_being_written_is_never_served(client):
+    """THE INCIDENT, as a test. The partial file is deliberately the NEWEST
+    thing in the folder, because mtime is exactly what the route sorts on."""
+    import os
+    import time
+
+    connected, backups = client
+    connected.post("/api/bundle")
+    whole = next(iter(backups.glob("scrapex-bundle-*.zip")))
+
+    partial = backups / "scrapex-bundle-29991231-235959.zip.part"
+    partial.write_bytes(b"")
+    later = time.time() + 60
+    os.utime(partial, (later, later))
+
+    got = connected.get("/api/bundle/archive")
+
+    assert got.status_code == 200, got.text
+    assert len(got.content) == whole.stat().st_size, (
+        "the route served something other than the complete archive")
+    assert len(got.content) > 0, "the route served an empty archive"
+
+
+def test_a_panel_pack_still_being_copied_is_never_served(client):
+    """Four megabytes copy fast, and `shutil.copy2` is still not atomic."""
+    import os
+    import time
+
+    connected, backups = client
+    connected.post("/api/bundle")
+    whole = next(iter(backups.glob("scrapex-bundle-*-panel.jsonl.gz")))
+
+    partial = backups / "scrapex-bundle-29991231-235959-panel.jsonl.gz.part"
+    partial.write_bytes(b"")
+    later = time.time() + 60
+    os.utime(partial, (later, later))
+
+    got = connected.get("/api/bundle/panel-pack")
+
+    assert got.status_code == 200, got.text
+    assert len(got.content) == whole.stat().st_size
+    assert len(got.content) > 0
+
+
+def test_a_partial_file_left_by_a_crash_is_pruned_with_its_stamp(client):
+    """It carries a stamp like any other file of that backup, so retention
+    reaches it. A crash that leaves 372 MB behind is the leak this closes."""
+    connected, backups = client
+    for stamp in ("20260101-000000", "20260102-000000", "20260103-000000"):
+        _fake_backup(backups, stamp)
+    orphan = backups / "scrapex-bundle-20260101-000000.zip.part"
+    orphan.write_bytes(b"half a zip")
+
+    connected.post("/api/bundle")
+
+    assert not orphan.exists(), "the partial file outlived its own stamp"
+
+
+def test_a_pack_that_dies_leaves_nothing_that_looks_like_a_backup(tmp_path, monkeypatch):
+    """A raise mid-zip must not leave a file the next reader could serve."""
+    from scrapex import bundle as bundlemod
+
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "warehouse.db").write_bytes(b"x" * 32)
+
+    # A bundle that verifies, so `pack` gets past its own refusal and reaches
+    # the zip -- which is where the failure is injected.
+    monkeypatch.setattr(
+        bundlemod, "verify",
+        lambda root: bundlemod.BundleReport(root=Path(root), files=1, bytes=32))
+
+    real_zipfile = bundlemod.zipfile.ZipFile
+
+    class DiesMidWrite:
+        def __init__(self, path, *a, **kw):
+            self._inner = real_zipfile(path, *a, **kw)
+
+        def __enter__(self):
+            self._inner.__enter__()
+            return self
+
+        def write(self, *a, **kw):
+            raise OSError("the disk filled up")
+
+        def __exit__(self, *exc):
+            return self._inner.__exit__(*exc)
+
+    monkeypatch.setattr(bundlemod.zipfile, "ZipFile", DiesMidWrite)
+
+    archive = tmp_path / "scrapex-bundle-20260101-000000.zip"
+    with pytest.raises(OSError):
+        bundlemod.pack(source, archive)
+
+    assert not archive.exists(), "a failed pack published an archive"
+    assert not list(tmp_path.glob("*.part")), "a failed pack left a partial file"
+
+
+def test_the_final_name_appears_only_when_the_archive_is_complete(tmp_path, monkeypatch):
+    """THE DECISIVE ONE. The tests above prove a `.part` is not served; this
+    proves the archive is written as one, which is what makes that true.
+
+    Asserted from INSIDE the zip write, because that is the only moment the old
+    code was wrong: `zipfile.ZipFile(archive, "w")` created the real name up
+    front and left it empty for the length of the deflate.
+    """
+    from scrapex import bundle as bundlemod
+
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "warehouse.db").write_bytes(b"x" * 4096)
+    monkeypatch.setattr(
+        bundlemod, "verify",
+        lambda root: bundlemod.BundleReport(root=Path(root), files=1, bytes=4096))
+
+    archive = tmp_path / "scrapex-bundle-20260101-000000.zip"
+    real_zipfile = bundlemod.zipfile.ZipFile
+    seen = []
+
+    class Watching:
+        def __init__(self, path, *a, **kw):
+            seen.append(("opened", archive.exists()))
+            self._inner = real_zipfile(path, *a, **kw)
+
+        def __enter__(self):
+            self._inner.__enter__()
+            return self
+
+        def write(self, *a, **kw):
+            seen.append(("writing", archive.exists()))
+            return self._inner.write(*a, **kw)
+
+        def __exit__(self, *exc):
+            return self._inner.__exit__(*exc)
+
+    monkeypatch.setattr(bundlemod.zipfile, "ZipFile", Watching)
+    bundlemod.pack(source, archive)
+
+    assert seen, "the zip was never opened; this test proved nothing"
+    for moment, existed in seen:
+        assert not existed, (
+            f"the archive existed under its final name while {moment} — that is "
+            "the window a concurrent reader served 0 bytes out of")
+    assert archive.exists() and archive.stat().st_size > 0

--- a/tests/test_the_registers_cannot_collide.py
+++ b/tests/test_the_registers_cannot_collide.py
@@ -225,6 +225,20 @@ RESERVED: dict[str, dict[int, str]] = {
     # Nothing else was touched.
     "OP": {
         45: "branch claude/drive-without-a-server",
+        # 101 THROUGH 110 WERE RESERVED HERE AND THE ROWS ARE GONE, which is this
+        # table's own rule applied to itself: `claude/design-system-review-d6787a`
+        # merged, so the numbers are declared on `main` and a reservation for a
+        # declared number is a contradiction -- `test_a_reserved_number_is_not_also
+        # _declared` says so, and it is what caught the rows on this rebase.
+        #
+        # WORTH KEEPING FROM THE HOUR THEY EXISTED: `git ls-remote` is the WRONG
+        # check for whether a number is claimed, and it fails in the direction that
+        # hurts. Every worktree under `.claude/worktrees/` shares one ref namespace
+        # with the main checkout, so a sibling session's local-only branch shows up
+        # in `git branch -a` and not in `ls-remote` at all. "Has it been pushed" is
+        # a different question from "has it been claimed"; this table is about the
+        # second, and that advice was given once on 2026-08-30 and would have
+        # reported a held number as free.
         # 64 THROUGH 68 BELONG TO `docs/two-counts-and-the-gap-between-them` (PR #267,
         # open). They became holes HERE the moment this branch declared `OP-69`, because
         # the gap check runs from 1 to `max(numbers)`. #267 has an open pull request and


### PR DESCRIPTION
He pressed **Back up to Drive** and his Drive received a **0-byte archive**, a **0-byte panel pack**, and a `latest.json` beside them saying a backup existed. Two complete 378.7 MB archives were safe on local disk, so no data was lost — but nothing on either side said so, and a restore would have reported success on an empty bundle.

## The chain, each link measured

1. **The running engine was not the code on disk.** It reported `0.4.5` while `main` carried `0.4.6`; a live Python process keeps its loaded modules. So `#288`'s build lock was merged and **not active**, and two builds ran **36 seconds apart**.
2. `zipfile.ZipFile(archive, "w")` **creates the file under its final name immediately**, at zero bytes, and fills it over the ~33 s of the deflate.
3. `GET /api/bundle/archive` answers with the newest `.zip` **by mtime**, so it handed the panel the second build's empty, in-progress file.
4. Nothing compared what arrived with what the engine had described. The pointer took `bytes` from the uploaded blob (0) and `sha256` from the manifest of the *complete* build.
5. And the restore check was `if (pointer.bytes && …)`. At `bytes: 0` that is falsy — **the guard was disabled by exactly the value that means the thing it guards against has happened.**

## What is in this PR

**D2 — an archive appears under its real name only when it is whole.** `bundle.pack` writes to `<name>.zip.part` and renames; `Path.replace` is atomic on one filesystem, so the name either does not exist or names a complete archive. There is no third state to serve. The panel-pack copy is done the same way — `shutil.copy2` is fast and still not atomic.

**D3 — the bytes are checked against the description, before they leave.** `expectSize` refuses a part whose length is not the length the engine described; an empty archive is refused outright on upload *and* on download; and the download check is a `typeof` test, so an **absent** size is still forgiven and a **zero** one no longer is.

**Measured, because the fix could have re-introduced the bug:** `Path.replace` carries the **write-completion** mtime across the rename, so a renamed archive still sorts by when its bytes finished. Had it carried the creation time, a fast rebuild could have sorted behind an older complete archive.

## A guard was removed as well as added

A filter against `.part` was written into `_newest` and then taken out: `*.zip` cannot match `*.zip.part`, so it **could never fire**, and a condition that can never be true reads as a hazard that is still live. The naming enforces the invariant; a test proves the naming, by asserting **from inside the zip write** that the final name does not yet exist.

## Not fixed here

**D4:** the engine detected its own staleness, displayed it correctly — *"3 loaded module(s) changed since it started"* — and **gated nothing**. The Engine page has no restart control on it either, so the sentence names an action the page cannot perform. Recorded in `OP-111`.

## Tests

Five engine cases and eight in `extension/tests/drive.test.mjs`. **All five new guards were mutation-checked** — each reverted to its defect in turn, the matching test went red, and the files were restored byte-for-byte. Both suite modes green with real exit codes.

## On the rebase

The truthiness lesson is folded into **`LESSONS` §29's table** as its sixth instance, plus one paragraph carrying the part a row cannot: `rows.length &&` and `pointer.bytes &&` are one character apart and mean opposite things, and **all five uses of the shape in `extension/` are the safe one**. The ten `RESERVED` rows this branch had added for `OP-101..110` are **deleted** — that branch merged, and a reservation for a declared number is a contradiction. That is the table's own rule applied to itself, and it is what caught them on the rebase.

No version bump: `R-77` moved product identity to the extension and gave the engine a commit SHA and a protocol number.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
