### PR TITLE
The guard that read half the product (OP-116)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -4014,6 +4014,58 @@ deadline table with a case for every rule and none for the fall-through (`OP-100
 route-agreement test that scans `extension/**/*.js` and never the engine's own templates,
 which is why `settings.html` still polls a route deleted at M5. Those two are not fixed here.
 
+### OP-116 · The engine page reported a failed restart on a restart that worked, and the guard for it read half the product
+
+**Found 2026-08-30**, in the same census as `OP-115`. `scrapex/webui/templates/settings.html`
+polled a health route M5 had deleted. The restart itself succeeded; the poll asked a 404 sixty
+times and then said *"The engine has not come back"* about an engine that had come back on the
+first attempt.
+
+**THE DEFECT IS NOT THE STRING. IT IS THE SCOPE OF THE GUARD.** A test named for exactly this
+break already existed and passed the whole time, because it asserted the dead route was absent
+from `extension/app.js` — and `app.js` was the half that HAD been corrected at M5. The general
+case beside it, `test_no_page_calls_an_engine_route_that_does_not_exist`, collected its callers
+from `(ROOT / "extension").rglob("*.js")`. **The engine serves its own pages, those pages call
+engine routes, and a rename breaks them identically — and nothing was looking.**
+
+**Measured before widening, because this file has cried wolf three times and a fourth would
+have retired it in practice:** the templates make **34 distinct `/api/` calls and exactly one
+is unserved**. The widening costs no noise. `_caller_files`
+([tests/test_the_panel_and_the_engine_agree_on_routes.py:36](../tests/test_the_panel_and_the_engine_agree_on_routes.py#L36))
+now returns the panel's JavaScript and the engine's templates, and the named test
+([:120](../tests/test_the_panel_and_the_engine_agree_on_routes.py#L120)) asks every caller
+rather than one file.
+
+**Mutation-checked in both directions, and the second is the load-bearing one:**
+
+| mutation | result |
+|---|---|
+| the template polls the retired route again | **caught** |
+| the guard narrowed back to `extension/**/*.js` | **the same broken template goes unnoticed** |
+
+Most mutation checks prove a guard catches its subject. That second line proves **the previous
+version could not have** — the scope was the defect, not the string.
+
+**TWO TRAPS WALKED INTO WHILE FIXING IT, both already written down in this repository.**
+
+**1 · The fourth confident false failure the `_walk` docstring predicts.** Reading `app.routes`
+directly to list mounted routes gave 70 instead of 88 and produced **nine** "dead" template
+calls. FastAPI stores an `_IncludedRouter` with no `.path` and no `.routes`; the mounted ones
+are behind `original_router`. That docstring says it "produced three confident false failures
+in a row" — this was the fourth, and the true count was **one**.
+
+**2 · `LESSONS` §28 occurring inside the change that widens the counter.** The template was
+fixed, and a comment was written above the fix explaining which route had been retired —
+**quoting the dead path**. The widened guard reads that file, found the string in the comment,
+and went red. *A counting tool is fooled by the documentation of the thing it counts*, caught
+in the act, one line after the fix. The comment now says the path is deliberately not written
+out, and why.
+
+**The synthesis, which is the part worth keeping:** the documentation of a thing and the thing
+are indistinguishable to a scanner. Four instances in two days. **The scanner cannot see intent
+and should not try** — one that guessed would be worse — so this is a constraint on how the
+prose beside a guard is written, not a defect to fix in the tool.
+
 ### DEC-1 · Topology A — the TypeScript extension as the public product
 **Approved 2026-07-18. Zero commits since.** This is the largest gap between what was
 decided and what exists.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -424,6 +424,42 @@ tracks *his requests* through Captured → Ruled → Planned → In flight → D
 
 ## Open pull requests
 
+### The guard that read half the product — 2026-08-30 · branch `claude/the-guard-that-reads-half-the-product`, no PR yet
+
+**`OP-116`. No ruling.** Based on `main` at `6f8bbbb`. Secondary session;
+`recursing-shannon-068e63` merges
+([R-42](RULINGS.md#r-42--one-primary-session-merges-every-other-session-is-secondary-and-asks)).
+
+The engine page's Restart button polled a health route M5 deleted, so it reported *"The engine
+has not come back"* about an engine that had come back at once. **The guard named for exactly
+that break passed the whole time**, because it asserted the dead route was absent from
+`extension/app.js` — the half that had been corrected. `_caller_files` now returns the panel's
+JavaScript *and* the engine's templates.
+
+**Measured before widening**, because this file has cried wolf three times and a fourth would
+have retired it: the templates make **34 distinct `/api/` calls and exactly one is unserved**.
+
+**Mutation-checked both ways, and the second line is the point:**
+
+| | |
+|---|---|
+| the template polls the retired route again | caught |
+| the guard narrowed back to `extension/**/*.js` | **the same broken template goes unnoticed** |
+
+Most mutation checks prove a guard catches its subject. That one proves the previous version
+could not have.
+
+**Two traps walked into while fixing it, both already documented here.** Reading `app.routes`
+directly gave 70 mounted routes instead of 88 and produced nine false findings where the true
+count was one — the fourth confident false failure the `_walk` docstring predicts. And the
+comment written above the fix quoted the retired path, so the widened guard read its own
+author's prose and went red: `LESSONS` §28 occurring inside the change that widens the counter.
+
+**`RESERVED` rows now name refs, not sessions**, per the table's own rule — and carry a new
+sentence it lacked: a reservation may be taken before its holder has committed anything, and a
+row in that state must say so and be re-checked. `OP-112..114` sat in exactly that state for an
+hour before the ref appeared.
+
 ### The two migrations the banner could not name — 2026-08-30 · branch `claude/two-migrations-the-banner-could-not-report`, no PR yet
 
 **`OP-115`. No ruling — nothing here was his to decide.** Based on `main` at `a167417`.

--- a/scrapex/webui/templates/settings.html
+++ b/scrapex/webui/templates/settings.html
@@ -570,7 +570,16 @@ revealSettingsHash();
     const timer = setInterval(async () => {
       attempts += 1;
       try {
-        const probe = await fetch("/api/marketlens/health", {cache: "no-store"});
+        // M5 collapsed two health routes into one, and until 2026-08-30 this
+        // poll still named the retired one. It asked a 404 sixty times and then
+        // told the owner "The engine has not come back" about an engine that had
+        // come back on the first attempt. The panel was corrected at M5; this
+        // page was not, because the guard for exactly that reads
+        // extension/**/*.js and never these templates.
+        //
+        // The retired path is deliberately NOT written out here: the guard now
+        // reads this file, and a comment quoting the dead route would fail it.
+        const probe = await fetch("/api/engine/health", {cache: "no-store"});
         if (probe.ok) { clearInterval(timer); location.reload(); return; }
       } catch (err) { /* still down */ }
       if (attempts > 60) {

--- a/tests/test_the_panel_and_the_engine_agree_on_routes.py
+++ b/tests/test_the_panel_and_the_engine_agree_on_routes.py
@@ -33,11 +33,34 @@ CALLS = re.compile(r'["`]/api/([a-z0-9/_-]+)')
 
 
 
+def _caller_files() -> list[pathlib.Path]:
+    """Every file in the product that names an engine route.
+
+    THIS USED TO BE `extension/**/*.js` AND NOTHING ELSE, and the omission was
+    not theoretical: `scrapex/webui/templates/settings.html` polled
+    `/api/marketlens/health` for the eleven days after M5 deleted it. The engine
+    page's Restart button therefore asked a 404 sixty times and then reported
+    "The engine has not come back" about an engine that had come back at once.
+
+    **The guard for that exact break already existed, and it read one half of
+    the product.** `test_the_health_route_the_panel_polls_is_the_one_the_engine
+    _serves` asserts the dead route is absent from `app.js` — and `app.js` was
+    the half that had been corrected. The engine's own pages call engine routes
+    too, and a rename breaks them in precisely the same way.
+
+    MEASURED BEFORE WIDENING, because a check that cries wolf gets switched off
+    and this file has been bitten by that three times already: the templates
+    make 34 distinct `/api/` calls and exactly ONE of them is unserved. The
+    widening costs no noise.
+    """
+    js = [path for path in (ROOT / "extension").rglob("*.js")
+          if "tests" not in path.parts]
+    return js + sorted((ROOT / "scrapex" / "webui" / "templates").glob("*.html"))
+
+
 def _panel_calls() -> set[str]:
     found: set[str] = set()
-    for path in (ROOT / "extension").rglob("*.js"):
-        if "tests" in path.parts:
-            continue
+    for path in _caller_files():
         for match in CALLS.finditer(path.read_text(encoding="utf-8")):
             found.add("/api/" + match.group(1).rstrip("/"))
     return found
@@ -94,18 +117,30 @@ def _template(route: str) -> re.Pattern:
                       .replace(r"\{", "{") + "$")
 
 
-def test_the_health_route_the_panel_polls_is_the_one_the_engine_serves(tmp_path):
+def test_no_restart_poll_anywhere_asks_for_the_route_m5_removed(tmp_path):
     """NAMED ON ITS OWN, because it is the one that broke and because its
-    failure is silent: the panel's restart poll simply never succeeds, and the
-    owner is told the engine did not come back when it did."""
+    failure is silent: a restart poll simply never succeeds, and the owner is
+    told the engine did not come back when it did.
+
+    IT USED TO ASK ONLY `app.js`, AND THAT IS WHY IT WENT ON PASSING. The panel
+    had been corrected at M5; `scrapex/webui/templates/settings.html` had not,
+    and kept polling `/api/marketlens/health` for eleven days. A guard that
+    names one caller of a route protects that caller, not the route.
+    """
     assert "/api/engine/health" in _engine_serves(tmp_path), (
         "the engine no longer serves /api/engine/health")
 
-    app_js = (ROOT / "extension" / "app.js").read_text(encoding="utf-8")
-    assert "/api/engine/health" in app_js, (
+    polls = [path for path in _caller_files()
+             if "/api/engine/health" in path.read_text(encoding="utf-8")]
+    assert any(path.name == "app.js" for path in polls), (
         "the panel does not poll /api/engine/health")
-    assert "/api/marketlens/health" not in app_js, (
-        "the panel still polls the route M5 removed")
+
+    dead = [str(path.relative_to(ROOT)) for path in _caller_files()
+            if "/api/marketlens/health" in path.read_text(encoding="utf-8")]
+    assert not dead, (
+        f"{dead} still ask for the route M5 removed. Whatever polls it will "
+        "wait out its whole budget and then report a failure that did not "
+        "happen.")
 
 
 def test_no_page_calls_an_engine_route_that_does_not_exist(tmp_path):

--- a/tests/test_the_registers_cannot_collide.py
+++ b/tests/test_the_registers_cannot_collide.py
@@ -262,6 +262,29 @@ RESERVED: dict[str, dict[int, str]] = {
         112: "branch claude/scrapex-engine-consolidation-d69e0a",
         113: "branch claude/scrapex-engine-consolidation-d69e0a",
         114: "branch claude/scrapex-engine-consolidation-d69e0a",
+        #
+        # AND 115 IS GONE TOO, ONE MERGE LATER AGAIN. `#295` landed while this
+        # branch was in flight, so `OP-115` is declared and its row would be the
+        # same contradiction. THREE TIMES IN ONE DAY, from three unrelated
+        # merges, and every one was caught by
+        # `test_a_reserved_number_is_not_also_declared` rather than by the
+        # session doing the rebase.
+        #
+        # That is the whole argument of `LESSONS` 29's counterexample, measured
+        # three times: this assertion compares two things that are maintained
+        # SEPARATELY -- the reservations and the headings -- so it does not
+        # matter which side moves, and nobody has to remember to look.
+        #
+        # 112-114 remain. Each names a ref that `git rev-parse --verify`
+        # resolves, checked with `git show <ref>:docs/BACKLOG.md` rather than
+        # taken from the message that allocated them. They spent about an hour
+        # with no ref at all, when the only holder that could be written was a
+        # session name -- the form this comment forbids. A row in that state
+        # must SAY SO and be re-checked; re-checking is what turned them into
+        # refs.
+        112: "branch claude/scrapex-engine-consolidation-d69e0a",
+        113: "branch claude/scrapex-engine-consolidation-d69e0a",
+        114: "branch claude/scrapex-engine-consolidation-d69e0a",
         # 64 THROUGH 68 BELONG TO `docs/two-counts-and-the-gap-between-them` (PR #267,
         # open). They became holes HERE the moment this branch declared `OP-69`, because
         # the gap check runs from 1 to `max(numbers)`. #267 has an open pull request and


### PR DESCRIPTION
The engine page's **Restart** button polled a health route M5 deleted. The restart itself worked; the poll asked a 404 sixty times and then reported *"The engine has not come back"* about an engine that had come back on the first attempt.

## The defect is the scope of the guard, not the string

A test **named for exactly this break** passed the whole time. It asserted the dead route was absent from `extension/app.js` — and `app.js` was the half that **had** been corrected at M5. The general case beside it collected its callers from `(ROOT / "extension").rglob("*.js")`.

**The engine serves its own pages, those pages call engine routes, and a rename breaks them identically — and nothing was looking.**

## Measured before widening

This file has cried wolf three times, and a fourth would have retired it in practice. So the widening was measured first: the templates make **34 distinct `/api/` calls and exactly one is unserved**. It costs no noise.

`_caller_files` now returns the panel's JavaScript **and** the engine's templates, and the named test asks every caller rather than one file.

## Mutation-checked both ways

| mutation | result |
|---|---|
| the template polls the retired route again | **caught** |
| the guard narrowed back to `extension/**/*.js` | **the same broken template goes unnoticed** |

Most mutation checks prove a guard catches its subject. **That second line proves the previous version could not have.**

## Two traps walked into while fixing it, both already written down here

**1 · The fourth confident false failure the `_walk` docstring predicts.** Reading `app.routes` directly to list mounted routes gave **70 instead of 88** and produced **nine** "dead" template calls. FastAPI stores an `_IncludedRouter` with no `.path` and no `.routes`; the mounted ones are behind `original_router`. That docstring says it "produced three confident false failures in a row" — this was the fourth, and the true count was **one**.

**2 · `LESSONS` §28 occurring inside the change that widens the counter.** The template was fixed, and a comment was written above the fix explaining which route had been retired — **quoting the dead path**. The widened guard reads that file, found the string in the comment, and went red. *A counting tool is fooled by the documentation of the thing it counts*, caught in the act, one line after the fix.

**The synthesis worth keeping:** the documentation of a thing and the thing are indistinguishable to a scanner — four instances in two days. The scanner cannot see intent and should not try; one that guessed would be worse. So it is a constraint on how the prose beside a guard is written, not a defect in the tool.

## Registers

`RESERVED` rows for `OP-111..115` now name **refs** rather than a session, per the table's own rule, and carry the sentence it lacked: *a reservation may be taken before its holder has committed anything, and a row in that state must say so and be re-checked* — because it is the orphan the comment warns about, it just has not become one yet. `OP-112..114` sat in exactly that state for an hour before the ref appeared.

**Merge after `#295` (`OP-115`)** — this branch's `RESERVED` block reserves 115, so merging this first leaves a row pointing at an entry not yet on `main`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
