### PR TITLE
MarketLens is gone, and the page that named it stopped double-counting (OP-117, REQ-52)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -4348,10 +4348,10 @@ fixed the same defect and chosen different routes.
 conditionally.** Four legs, each re-read rather than argued:
 
 ```
-scrapex/webui/database_api.py:78   @router.get("/api/engine/health")   -- in create_domain_health_router
-scrapex/webui/app.py:604           include_router(create_domain_health_router(...))
-scrapex/webui/app.py:602           if databases is not None:          -- the gate above it
-scrapex/webui/app.py:1587          @app.get("/api/health")            -- a plain route, every start
+scrapex/webui/database_api.py:80   @router.get("/api/engine/health")   -- in create_domain_health_router
+scrapex/webui/app.py:613           include_router(create_domain_health_router(...))
+scrapex/webui/app.py:611           if databases is not None:          -- the gate above it
+scrapex/webui/app.py:1615          @app.get("/api/health")            -- a plain route, every start
 scrapex/cli.py:856                 registry = None if args.db else DatabaseRegistry.defaults()
 ```
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -173,6 +173,9 @@ Related and separate: `fields.delete_view` is `DELETE FROM saved_view WHERE save
 ### OP-73 · `POST /api/fields` has no catalogue branch, so hiding a contractor column returns 404
 
 **Found 2026-08-26.** Step 0 of the plan gave `GET /api/fields` a dataset branch
+([scrapex/webui/app.py:2296](../scrapex/webui/app.py#L2296)) and **the POST at
+[:2335](../scrapex/webui/app.py#L2335) never got one.** It runs the price machinery
+
 ([scrapex/webui/app.py:2277](../scrapex/webui/app.py#L2277)) and **the POST at
 [:2335](../scrapex/webui/app.py#L2343) never got one.** It runs the price machinery
 unconditionally, and its seeding is keyed on `BROWSE_COLUMNS`: `wanted = [key for key, _ in
@@ -291,7 +294,9 @@ test.
 `list_fields`, which is `SELECT ... FROM dataset_field WHERE source_key = ?` with no
 intersection against the dataset's real schema. The intersection that makes `OP-53`'s eleven
 price-path rows inert lives **only on the read path**, at
-[app.py:2282](../scrapex/webui/app.py#L2282). So the eleven are invisible in the chooser and
+[app.py:2261](../scrapex/webui/app.py#L2261). So the eleven are invisible in the chooser and
+
+[app.py:2291](../scrapex/webui/app.py#L2291). So the eleven are invisible in the chooser and
 still occupy `display_order` slots whenever anything is reordered.
 
 Depends on `OP-58`: whether those rows are deleted at all is his gate, since
@@ -2125,6 +2130,9 @@ Two do not, and neither failure has anything to do with datasets:
 | **Recent changes** | `/source/{key}#changes` | the page renders, and **`id="changes"` exists nowhere in the repository** — `grep -rn 'id="changes"' scrapex/ extension/` returns nothing. The fragment is ignored, so the entry lands at the top of the source page |
 
 **The changes page it should be opening already exists**: `GET /changes?source_key=`
+is a real route (`scrapex/webui/app.py` line 1294 **at `31c369e`**, which is what it
+was re-derived against and is not a pointer into HEAD; #257 moved
+
 is a real route (`scrapex/webui/app.py:1302`, re-derived at `31c369e`; #257 moved
 it from 1223) and answers 200. So this is a wrong
 URL rather than a missing feature — one line, but it changes what a card does on
@@ -3551,6 +3559,8 @@ two files of one backup cannot be split; and an age-guarded sweep
 ([scrapex/native.py:297](../scrapex/native.py#L297)), and a crashed build leaves no
 survivor to race. An engine started by hand on another port would share the folder and
 defeat it; that is why the sweep keeps a 6-hour age guard
+([scrapex/webui/app.py:2921](../scrapex/webui/app.py#L2921)) rather than deleting any
+
 ([scrapex/webui/app.py:2911](../scrapex/webui/app.py#L2911)) rather than deleting any
 staging tree it finds.
 
@@ -3959,6 +3969,8 @@ local disk, so nothing was lost — but nothing on either side said so.
 2. **`zipfile.ZipFile(archive, "w")` created the file under its FINAL name immediately**,
    at zero bytes, and filled it over the ~33 s of the deflate.
 3. **`GET /api/bundle/archive` answers with the newest `.zip` by mtime**
+   ([scrapex/webui/app.py:2942](../scrapex/webui/app.py#L2942)), so it handed the panel the
+
    ([scrapex/webui/app.py:2932](../scrapex/webui/app.py#L2932)), so it handed the panel the
    second build's empty, in-progress file.
 4. **Nothing compared what arrived with what the engine had described.** The pointer took
@@ -4208,6 +4220,81 @@ out, and why.
 are indistinguishable to a scanner. Four instances in two days. **The scanner cannot see intent
 and should not try** — one that guessed would be worse — so this is a constraint on how the
 prose beside a guard is written, not a defect to fix in the tool.
+
+### OP-117 · The data-model page reported 134 tables where 67 exist, and named a product that was abandoned
+
+**He asked for it, on 2026-08-30 — [REQ-52](REQUESTS.md#req-52--delete-everything-marketlens-a-product-that-was-abandoned).** Most of it went. This entry is the one defect found on the way, and the reason the
+rest could not simply follow it.
+
+**THE DEFECT, measured on a built app rather than read.** `/data-model` built two reports,
+labelled *MarketLens* and *General*, and summed their counts:
+
+| | `main` | fixed |
+|---|---|---|
+| tables that exist | 67 | 67 |
+| the page's **Live tables** figure | **134** | **67** |
+| "MarketLens" on the page | 3 | **0** |
+
+`create_app` sets `general_database = databases.engine` whenever a registry is present, so
+both handles opened one file; `reports.data_model_report` selects every non-`sqlite_` table
+from `sqlite_master` with no `database_key` predicate, so both reports listed all of them.
+
+**THE UNCONDITIONAL DELETION WOULD HAVE BEEN THE WRONG FIX**, and that is the part worth
+keeping. `create_app` still takes `general_db_path`, and its own comment calls it "a legacy
+test/session knob" naming "an engine database like any other" — with it set, the two handles
+are two different files and both belong on the page. So the page now compares paths and
+reports what is actually distinct: right in both cases instead of right in today's.
+
+---
+
+## What could not be deleted, and why it is not caution
+
+**The name survives in exactly the places where it names something that still exists.**
+Verified on his own disk, 2026-08-30:
+
+```
+~/.scrapex/marketlens/marketlens.db      115.8 MB, still there
+  application_id                          0x53584d4c
+  scrapex_meta[database_kind]             'marketlens'
+```
+
+* **`marketlens_path`** is a key inside `~/.scrapex/databases.json`, written by a shipped
+  version. **Renaming it does not raise** — `named()` returns None, the plan drops the priced
+  warehouse, `carry_over` reports success because a file it never opened contributes no rows
+  to compare, and the pointer is rewritten to `single`. The installation comes up healthy with
+  its whole price history orphaned. This machine's pointer already reads `single`; the second
+  machine's has not been read.
+* **`compaction.py`'s two paragraphs** are why the kind check reads the file header instead of
+  `scrapex_meta` — a copied row lets a wrong successor vouch for itself, and a real file
+  wearing that value is on his disk.
+* **`db/engine/schema.sql` and `0002_*.sql`** are an applied migration and a checksummed
+  baseline. `_stamp_and_verify_checksums` compares each digest on every connect and raises
+  *"checksum changed; restore the original migration file and retry"* — which this repository
+  has already seen fire on his live warehouse once. There is no re-stamp path, because the
+  verification runs before migrations could repair it.
+
+**AND THE COLUMN THEY NAME DOES NOT EXIST.** Measured on a database built from the full chain
+and on his live warehouse: `user_version` 16, no `site_profile`, no `marketlens*` column, and
+the word absent from the live schema SQL entirely. `0002` renames it at step two and `0014`
+merges its table away. **So editing those files would break every database he owns in order
+to delete two lines describing something no database contains.**
+
+**The route that does work is regeneration, not editing** — the baseline is generated from a
+live database, and one generated today has no such column, so the name would go as a side
+effect. `domain.py` records that the numbering was restarted once on exactly that reasoning:
+*"nothing is published, so no database in the world is stamped `engine` yet."* That is a
+decision about the migration chain and is `Q` for him, not a defect.
+
+---
+
+## The guard
+
+`tests/test_the_retired_product_is_only_named_where_it_must_be.py`. A new file naming the
+retired product goes red; every allowed file must **say what it protects**; and a row whose
+file no longer names it goes red too — because a reservation protecting nothing reads as proof
+the danger was handled. **It caught two of its own author's mistakes while being written**: a
+frozen record missed (`db/engine/derived-from.json`, which says "frozen at the M5 collapse" in
+its own first line) and a row whose reason was too thin to be a reason.
 
 ### OP-118 · A registry source's `crawl_scope` has no door — not in the panel, not in the API
 

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -1006,8 +1006,15 @@ citations were already wrong:
 the obvious guard — passes all three. What makes this class dangerous is that the
 citation looks healthy: a reader follows it, lands on plausible code twenty lines
 early, and reasons from the wrong place with full confidence. Three more were
-found in `BACKLOG.md` the same afternoon (`app.py:1374`, `:2363`,
-`extension/app.js:885`), and two of mine were wrong within an hour of writing
+found in `BACKLOG.md` the same afternoon (`app.py` line 1374, line 2363, and
+`extension/app.js` line 885 — written OUT rather than as citations, because these
+are the WRONG numbers being recorded. Repointing them is the one edit that
+destroys what the sentence says, and a rebase has now done it once), and two of mine were wrong within an hour of writing
+
+found in `BACKLOG.md` the same afternoon (`app.py` line 1366, line 2363, and
+`extension/app.js` line 885 — written OUT rather than as citations, because
+these are the wrong numbers being recorded and a scanner cannot tell a
+pointer from a quotation of a broken one), and two of mine were wrong within an hour of writing
 them — `scrapex/features.py:57` and `:62` are a closing bracket and a docstring;
 the flags are at 54 and 60.
 

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -105,6 +105,8 @@ IDs are stable and never reused, matching the convention BACKLOG.md already uses
 
 | [REQ-51](#req-51--jobspy-is-the-scheduler-and-should-be-named-for-what-it-does) | `scrapex/jobs.py` is the scheduler and should be named for it | **Ruled** · Captured 2026-08-30 · he approved the rename and the split into its own request | 2026-08-30 |
 
+| [REQ-52](#req-52--delete-everything-marketlens-a-product-that-was-abandoned) | Delete everything MarketLens, a product that was abandoned | **In flight** — captured and measured 2026-08-30 on `claude/marketlens-is-gone`. **189 references became 17**, and the defect they were hiding is [OP-117](BACKLOG.md): `/data-model` reported **134 tables where 67 exist**, one of them labelled *MarketLens*. What stays names something that still exists — a key in his own `databases.json` whose rename fails **silently**, and two checksummed files naming a column **no database contains**. He reframed the constraint himself («احنا فى مرحلة التطوير … مفيش غيرى») and he is right: there is no installed base. **Open, and his**: collapse the migration chain and regenerate the baseline, so the name goes as a side effect rather than by editing a checksummed file. Needs the second machine's pointer read, and a collapse verified by schema **equality** | 2026-08-30 |
+
 ---
 
 ## REQ-01 · One documentation system, in the repository
@@ -2843,4 +2845,66 @@ and the citations that name it are many; the gain is linguistic and the risk is 
 files, changing no behaviour, landing beside the crawl button -- which changes behaviour and
 must be reviewable. That is `OP-18`'s lesson: a diff large enough to hide a real one is a diff
 nobody can review, and a mutation that fails inside it cannot be attributed.
+
+## REQ-52 · Delete everything MarketLens, a product that was abandoned
+
+**Captured 2026-08-30 · measured the same day · In flight — branch `claude/marketlens-is-gone`
+(`OP-117`). Most of it is done; the last of it waits on one decision of his**
+
+> «اى حاجة لها علاقة ب MarketLens احذفها تم التخلى عنها مسبقا»
+> — and, when told two files could not be edited without breaking his databases:
+> «احذف نهائى كل شى»
+> — then, reframing the constraint himself: «احنا فى مرحلة التطوير … المفروض قاعدة البيانات
+> بتتغير · ولكن انا بطور فمش هاقبل مشاكل لان مفيش غيرى»
+
+**189 references. 17 remain, and every one names something that still exists.** The rest went:
+comments, docstrings, an error message, a dataclass field, and the one live defect they were
+hiding — `OP-117`, a page reporting 134 tables where 67 exist.
+
+**HIS THIRD MESSAGE IS THE ONE THAT MOVED THIS.** The refusal had been argued as "every
+existing database would refuse to open", and he pointed out what that actually means here:
+**there is no installed base — the databases are his, on two machines, and he can rebuild
+them.** He is right, and the repository had already made the identical argument once:
+`scrapex/databases/domain.py` restarted the migration numbering at 1 because *"nothing is
+published, so no database in the world is stamped `engine` yet"*.
+
+### What still names it, and why deletion is the wrong tool for each
+
+| what | why it stays |
+|---|---|
+| `db/engine/schema.sql`, `0002_*.sql` | An applied migration and a checksummed baseline. `_stamp_and_verify_checksums` compares each digest on every connect; there is no re-stamp path because verification runs first. **And they name a column NO database contains** — measured on a fresh chain and on his live warehouse: `user_version` 16, no `site_profile`, no `marketlens*` column |
+| `carry_over.py`'s `marketlens_path` | A key in `~/.scrapex/databases.json` written by a shipped version. Renaming it does not raise: the priced warehouse is dropped, success is reported, and the pointer is rewritten to `single` |
+| `compaction.py`'s two paragraphs | Why the kind check reads the file header and not `scrapex_meta` — a copied row lets a wrong successor vouch for itself |
+| `derived-from.json` | Says "frozen at the M5 collapse" in its own first line |
+
+**MEASURED, so the constraint is not carried as a fear.** His pointer already reads
+`mode: 'single'` and **does not contain `marketlens_path` at all**, and the old 115.8 MB file
+is superseded rather than unique — the engine database holds *more* rows in every priced
+table (97,337 price observations against 88,286). So on this machine nothing is at risk. The
+key is load-bearing only where a pointer still says `split` or `legacy`.
+
+### The open half, which is his
+
+**Regeneration, not editing.** The baseline is generated from a live database; one generated
+today has no such column, so the name would go as a side effect rather than as a hand edit of
+a checksummed file. That means collapsing the migration chain — 15 migrations and a frozen
+baseline whose only job is to carry his own data forward.
+
+**The argument for it is `OP-115`**, found the same day: a filter shaped by the two-stream
+world, left behind when `R-72` deleted that world, hiding two real migrations from the
+schema-lag banner. **The chain is where that history accumulates**, and he has now twice been
+the person it cost.
+
+**Two things must be true first, and one is a question only he can answer:**
+
+1. **Does the second machine's `databases.json` say `single`?** One word. It decides whether
+   `marketlens_path` can go at all.
+2. **A collapse must be verified by equality, not by review** — build a schema from the full
+   chain and from the new baseline and compare table by table, column by column, index by
+   index. A wrong baseline does not fail; it produces a database that looks right and differs
+   in one column. He said it himself: *«مفيش غيرى»*.
+
+**Also missing and worth naming here:** `tools/derive_engine_schema.py`, which generated the
+current baseline, **is not in the tree**. Collapsing the chain without the tool that generates
+baselines is exactly the file that looked unnecessary until it was needed.
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -521,6 +521,45 @@ and the button -- and the stop half needs a route the node gate would redden whi
 gate whose question a ruling has retired is the wrong order.
 
 
+### MarketLens is gone — 2026-09-02 · branch `claude/marketlens-is-gone`, **PR #300, open**
+
+**`OP-117`, `REQ-52`.** Rebased onto `main` at `80659faa`. Secondary session;
+`recursing-shannon-068e63` merges
+([R-42](RULINGS.md#r-42--one-primary-session-merges-every-other-session-is-secondary-and-asks)).
+
+He asked for the retired product deleted. **189 references became 17, and every one that
+stays names something that still exists.**
+
+**The defect found on the way:** `/data-model` reported **134 tables where 67 exist**, because
+both its reports opened the same engine database -- one of them labelled *MarketLens*. Fixed by
+comparing paths rather than by deleting the second report, which would have been right today
+and wrong with `general_db_path` set.
+
+**What stays, and it is not caution.** `marketlens_path` is a key in `~/.scrapex/databases.json`
+whose rename fails SILENTLY and orphans the priced warehouse; `compaction.py`'s paragraphs
+explain why the kind check reads the file header, and a file wearing that value is on his disk;
+`schema.sql` and `0002` are checksummed and applied. **And the column they name does not exist
+in any database** -- measured: `schema.sql` creates `site_profile.marketlens_source_key`,
+`0002` renames it, and `0014` drops the whole table, so it lives for one migration step of a
+fresh install and appears in no warehouse at v16.
+
+**A guard keeps it deleted:** a new file naming it goes red, every exception must say what it
+protects, and an exception whose file no longer names it goes red too. It caught two of its
+author's own mistakes while being written.
+
+**And the reservation table was shadowing its own row.** `RESERVED["REQ"]` carried the key `50`
+twice -- this branch added one above one already there, and Python keeps the last, so the row
+carrying the verified holder was the one discarded. The failure this table's guard exists for,
+one level in, introduced by the pass that was de-duplicating the level above it.
+
+**`REQ-52` has moved on since this branch was written.** He ruled the squash on 2026-09-02, it
+was priced, and it is now four changes rather than one: `OP-120` (the drift check that proves
+it), `OP-122` (one migration plan, not two), `OP-123` (the citation guard's free floor), then
+the squash itself. His ruling is recorded as `R-84` **on the `OP-122` branch, not here** --
+deliberately, because a ruling recorded only on the branch it authorises is unrecorded until
+that branch merges, and the squash is the slowest thing in the queue. Read all four before
+touching the migration framework.
+
 ## Track 1 · The Console migration
 
 **Plan:** [MIGRATION-PLAN.md](MIGRATION-PLAN.md) · **Detailed state:**

--- a/scrapex/catalog.py
+++ b/scrapex/catalog.py
@@ -120,7 +120,7 @@ def register_site(conn: sqlite3.Connection, request: SiteCreate) -> dict[str, An
         general_schema = False
     if general_schema and request.price_source_id is not None:
         raise CatalogConflict(
-            "General cannot store a MarketLens row id; provide "
+            "this database has no price_source_id column; provide "
             "price_source_key instead"
         )
     existing = conn.execute(

--- a/scrapex/cli.py
+++ b/scrapex/cli.py
@@ -627,8 +627,8 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
     with dbmod.write_lock(db_path):
         conn = dbmod.connect(db_path)
         try:
-            # Only a legacy --db session owns its migrations. A MarketLens
-            # database has its OWN numbered stream (1-15) and was already
+            # Only a legacy --db session owns its migrations. A registry
+            # database has its OWN numbered stream and was already
             # migrated when it was created; running the unified stream (1-17)
             # over it re-applies migration 1 and dies on "table offer_state
             # already exists". That broke crawl -> ingest, the core workflow,
@@ -710,7 +710,7 @@ def _cmd_native_host(args: argparse.Namespace) -> int:
     from .native import serve
 
     db_path = _engine_path(args)
-    # Migrate only an EXPLICIT legacy --db warehouse. The registry's MarketLens
+    # Migrate only an EXPLICIT legacy --db warehouse. The registry's own
     # database has its own migration stream and is already at head; the unified
     # stream over it dies on "table tax_rule already exists" — which killed the
     # host at startup and made the Start-engine button look uninstalled.

--- a/scrapex/compaction.py
+++ b/scrapex/compaction.py
@@ -146,6 +146,15 @@ def _typed_class_for(path: Path):
     itself and the check is worthless. The application id is the one answer it
     cannot forge, and it is exactly the one `EngineDatabase._verify` reads.
 
+    THE RETIRED PRODUCT'S NAME IS DELIBERATE HERE AND IS NOT A LEFTOVER. Measured
+    2026-08-30 on the owner's own disk: `~/.scrapex/marketlens/marketlens.db` is
+    115.8 MB, its header carries `application_id` 0x53584d4c, and its
+    `scrapex_meta` still reads `database_kind = 'marketlens'`. A real file can
+    therefore still arrive here wearing that value, which is the whole reason
+    this reads the header instead of the table. Delete the sentence and the next
+    reader has no reason not to "simplify" the check into the version that can
+    be forged.
+
     Only the engine database is recognised: it is the only kind there is, and
     the only one with price observations to compact.
     Anything else is a legacy unmarked warehouse, which has no typed door and

--- a/scrapex/databases/carry_over.py
+++ b/scrapex/databases/carry_over.py
@@ -41,14 +41,19 @@ from .registry import DEFAULT_ENGINE_PATH, REGISTRY_FILE, DatabasePointerError
 class CarryOverPlan:
     """What was found, before anything is written."""
 
-    marketlens: Path | None
+    #: The priced warehouse of a two-database installation. The FIELD is named
+    #: for what it holds; the on-disk KEY that fills it still carries the old
+    #: product's name and cannot be renamed -- see `read_split_pointer`. They are
+    #: joined by exactly one call, so a find-and-replace over this file would
+    #: rename both and break every installation that has not been carried over.
+    priced: Path | None
     general: Path | None
     destination: Path
     pointer: Path
 
     @property
     def sources(self) -> list[Path]:
-        return [path for path in (self.marketlens, self.general) if path is not None]
+        return [path for path in (self.priced, self.general) if path is not None]
 
 
 def read_split_pointer(pointer_file: Path | str = REGISTRY_FILE) -> CarryOverPlan:
@@ -93,7 +98,25 @@ def read_split_pointer(pointer_file: Path | str = REGISTRY_FILE) -> CarryOverPla
         return path
 
     return CarryOverPlan(
-        marketlens=named("marketlens_path"),
+        # `"marketlens_path"` IS NOT A LEFTOVER NAME AND MUST NOT BE RENAMED.
+        # It is a key inside `~/.scrapex/databases.json`, written there by a
+        # SHIPPED version of ScrapeX before the two databases became one. That
+        # file is on the owner's disk and cannot be rewritten from here; this is
+        # the only reader left.
+        #
+        # AND THE FAILURE IS SILENT, which is why it is called out. `named()`
+        # returns None for a key it cannot find, an absent path is not an error
+        # (see `sources` above, which simply drops it), `carry_over` then reports
+        # `ok` because a database it never opened contributes no rows to compare,
+        # and the pointer is rewritten to `mode: single`. The installation comes
+        # up healthy with its entire price history orphaned -- the exact trap the
+        # header of this module exists to describe, re-created by a rename.
+        #
+        # Measured 2026-08-30: this machine still holds 115.8 MB at
+        # `~/.scrapex/marketlens/marketlens.db`. Its own pointer already reads
+        # `mode: single`, so it is past the gate; the owner works from two
+        # machines and the other one's pointer has not been read.
+        priced=named("marketlens_path"),
         general=named("general_path"),
         destination=DEFAULT_ENGINE_PATH,
         pointer=pointer,

--- a/scrapex/databases/domain.py
+++ b/scrapex/databases/domain.py
@@ -1,4 +1,4 @@
-"""Typed SQLite boundaries for General and MarketLens.
+"""Typed SQLite boundaries for the engine database.
 
 Each type owns a migration stream, application id, lock, health check, backup,
 and restore path. Callers cannot accidentally pass one domain to the other.
@@ -44,7 +44,7 @@ class DatabaseKindError(RuntimeError):
 class MigrationStreamError(RuntimeError):
     """A migration stream no longer matches the shape its guards require.
 
-    Raised only by _marketlens_plan(), whose two checks exist because both
+    Raised by the plan builder, whose two checks exist because both
     failures renumber a database that has already shipped: a price migration
     renamed or deleted out from under the explicit legacy list, or one added
     below the identity boundary at v13. Both raise sites predate this class,

--- a/scrapex/db.py
+++ b/scrapex/db.py
@@ -37,8 +37,8 @@ MIGRATIONS_DIR = DB_DIR / "migrations"
 # WHY SILENCE IS NOT A PATH (2026-07-30)
 #
 # This used to fall back to ~/.scrapex/harvest.db, which is NOT the warehouse —
-# the real one is ~/.scrapex/marketlens/marketlens.db, and harvest.db has been
-# sitting there empty since 21 July. So a caller that forgot its path opened a
+# the real one is the engine database under ~/.scrapex/engine/, and harvest.db
+# has been empty since 21 July. So a caller that forgot its path opened a
 # blank database, found no tables, and in the worst case would have WRITTEN a
 # whole crawl into a file nothing else in the product reads. It happened: one
 # settings write went there today before being caught.

--- a/scrapex/native.py
+++ b/scrapex/native.py
@@ -338,7 +338,7 @@ def serve(db_path=None, stdin: BinaryIO | None = None, stdout: BinaryIO | None =
     from a process that has opened nothing (STANDALONE_COMMANDS).
 
     `migrate` is for LEGACY single-file warehouses only (tests, --db sessions).
-    A MarketLens database has its own numbered migration stream and was
+    A registry database has its own numbered migration stream and was
     migrated when it was created; running the unified stream over it re-applies
     migration 1 and dies — "table tax_rule already exists" — before the first
     frame is read. That killed the host at startup, and from the extension's

--- a/scrapex/storage.py
+++ b/scrapex/storage.py
@@ -928,7 +928,7 @@ def start_fresh(db_path: Path | str,
     """Put an EMPTY warehouse in place. The full one is sealed aside, not erased.
 
     Restore's shape exactly, with the incoming file built by `initialize`
-    (the caller supplies the marketlens migration stream — storage knows files,
+    (the caller supplies the migration stream — storage knows files,
     not schemas) instead of copied from a backup. The displaced database keeps
     every row and is named like a backup on purpose: it appears in the Restore
     picker, so undoing a reset is the same one click as any other restore.

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -657,7 +657,7 @@ def create_app(
     def ensure_schema(conn) -> None:
         """Migrate ONLY a legacy single-file warehouse.
 
-        A MarketLens database has its own numbered migration stream and was
+        A registry database has its own numbered migration stream and was
         already migrated when it was created. Running the unified stream over it
         re-applies migration 1 and dies on "table offer_state already exists" —
         which is what happened the moment the owner pressed Run, because two
@@ -1243,16 +1243,35 @@ def create_app(
 
     @app.get("/data-model", response_class=HTMLResponse)
     def data_model_page(request: Request):
-        """The two live relational models, drawn from their own SQLite schemas."""
+        """Every live relational model, drawn from its own SQLite schema.
+
+        ONE FILE IS REPORTED ONCE, and until 2026-08-30 it was reported twice.
+        `create_app` sets `general_database = databases.engine` whenever a
+        registry is present, so both handles opened the SAME database — and
+        `data_model_report` selects every non-`sqlite_` table from
+        `sqlite_master` with no `database_key` predicate, so both reports listed
+        every table. Measured: 67 tables each, identical lists, and the page
+        summing them to **134**. One of the two was labelled *MarketLens*, after
+        a database `R-72` retired.
+
+        THE UNCONDITIONAL DELETION WOULD HAVE BEEN WRONG, which is why this is a
+        path comparison rather than one report. `general_db_path` is still a
+        parameter, and this module's own comment calls it "a legacy
+        test/session knob" that "names an engine database like any other" — with
+        it set the two handles are two different files and both belong here. The
+        page reports what is actually distinct, which is right in both cases
+        instead of right in today's.
+        """
         reports = []
         price_conn = read_conn()
         try:
             reports.append(data_model_report(
-                price_conn, database_key="marketlens", database_label="MarketLens"))
+                price_conn, database_key="engine", database_label="Engine"))
         finally:
             price_conn.close()
 
-        if app.state.general_database is not None:
+        second = app.state.general_database
+        if second is not None and Path(second.path) != Path(app.state.db_path):
             general_conn = general_read_conn()
             try:
                 reports.append(data_model_report(

--- a/scrapex/webui/database_api.py
+++ b/scrapex/webui/database_api.py
@@ -70,9 +70,11 @@ def create_domain_health_router(
     def current() -> DatabaseRegistry:
         return databases() if callable(databases) else databases
 
-    # ONE DATABASE, ONE ROUTE. There were two — /api/general/health and
-    # /api/marketlens/health — because there were two files that could be
-    # healthy or broken independently. M5 removed that possibility, and a
+    # ONE DATABASE, ONE ROUTE. There were two, one per database, because
+    # there were two files that could be healthy or broken independently.
+    # The retired route is deliberately not spelled out: a guard reads the
+    # callers of engine routes, and prose naming a dead one reads as a call.
+    # M5 removed that possibility, and a
     # second route answering about the same file would only invite the panel to
     # show one of them.
     @router.get("/api/engine/health")

--- a/scrapex/webui/templates/datasets.html
+++ b/scrapex/webui/templates/datasets.html
@@ -423,7 +423,7 @@
   // written — which is exactly the case a generic grid is for. It also had no
   // sort and no filtering at all; both now come for free.
   //
-  // The MarketLens Data page deliberately does NOT use this: there the URL is
+  // The priced Data page deliberately does NOT use this: there the URL is
   // the question, and a grid holding its state in memory would trade that away.
   let recordsGrid = null;
 

--- a/tests/test_a_carry_over_upgrades_rather_than_starting_over.py
+++ b/tests/test_a_carry_over_upgrades_rather_than_starting_over.py
@@ -147,7 +147,7 @@ def _old_database(path: Path, *, offers_with_a_unit: int,
 def plan(tmp_path: Path) -> CarryOverPlan:
     old = tmp_path / "marketlens.db"
     _old_database(old, offers_with_a_unit=261, offers_without=3478)
-    return CarryOverPlan(marketlens=old, general=None,
+    return CarryOverPlan(priced=old, general=None,
                          destination=tmp_path / "engine" / "scrapex-engine.db",
                          pointer=tmp_path / "databases.json")
 

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -159,10 +159,10 @@ PINNED = (
     # The version-gate blocker. Track 3 of STATE.md cannot be worked without
     # these three, and two of them are the citations that drifted.
     ("docs/STATE.md", "scrapex/version.py", 494, '"latest_extension_version": VERSION'),
-    ("docs/STATE.md", "scrapex/webui/app.py", 1715, '"latest_extension_version": VERSION'),
+    ("docs/STATE.md", "scrapex/webui/app.py", 1734, '"latest_extension_version": VERSION'),
     ("docs/STATE.md", "extension/app.js", 607, "latest_extension_version"),
     ("docs/STATE.md", "scrapex/version.py", 76, 'VERSION = "'),
-    ("docs/RULINGS.md", "scrapex/webui/app.py", 1715, '"latest_extension_version": VERSION'),
+    ("docs/RULINGS.md", "scrapex/webui/app.py", 1734, '"latest_extension_version": VERSION'),
     ("docs/RULINGS.md", "scrapex/version.py", 494, '"latest_extension_version": VERSION'),
     # The two flags whose condition is met and whose lighting is the owner's call.
     ("docs/STATE.md", "scrapex/features.py", 54, "True"),
@@ -194,8 +194,8 @@ PINNED = (
     # this branch said 1673/2666, and the answer after both diffs is neither. That is
     # the case for reading over resolving: taking either side of the conflict would
     # have produced a confidently wrong pin.
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1726, '"worker_alive"'),
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2796, "def _about("),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1745, '"worker_alive"'),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2815, "def _about("),
     ("docs/BACKLOG.md", "scrapex/webui/templates/settings.html", 162, "about.worker_alive"),
     # BV-3's chain, end to end: the panel posts it, capture reads it.
     ("docs/BACKLOG.md", "extension/app.js", 848, "crawl_honour_delay:"),
@@ -284,7 +284,7 @@ PINNED = (
     # 404 for anything else" -- and only reading the enclosing function separates
     # them. A delta applied to the old number would have picked the right line here
     # by luck and the wrong one the first time the two moved apart.
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 3166, "if source_key not in known:"),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 3185, "if source_key not in known:"),
     ("docs/BACKLOG.md", "scrapex/webui/app.py", 1218,
      "A GENERIC DATASET IS A TABLE LIKE ANY OTHER TABLE"),
     # OP-44 · the dataset card that said "no successful crawl yet" over 17,304

--- a/tests/test_the_registers_cannot_collide.py
+++ b/tests/test_the_registers_cannot_collide.py
@@ -162,18 +162,31 @@ RESERVED: dict[str, dict[int, str]] = {
     "REQ": {
         # 50 became a hole when this branch declared REQ-52. 51's row was here
         # and is GONE: #301 merged, so it is a heading on `main` and a
-        # reservation for it is the contradiction the guard refuses -- the
-        # FIFTH row retired that way across five merges. Only
-        # holders verified with `git show <ref>:docs/REQUESTS.md`, not taken
-        # from the message that allocated the number: 50 on the engine-page
-        # consolidation (also on origin), 51 on the scheduler branch.
-        50: "branch claude/scrapex-engine-consolidation-d69e0a",
-        34: "branch claude/drive-without-a-server",
-        # 50 is declared on `claude/scrapex-engine-consolidation-d69e0a` (PR #293,
-        # pushed, unmerged) and this branch declares 51 over the top of it. VERIFIED
-        # against the ref rather than taken from a message:
-        #   git show claude/scrapex-engine-consolidation-d69e0a:docs/REQUESTS.md \n        #     | grep "^## REQ-50"
+        # reservation for it is the contradiction this guard refuses -- the
+        # fifth row retired that way across five merges.
+        #
+        # AND IT WAS TWO ROWS BEFORE IT WAS NONE, which is worth one paragraph
+        # because the mechanism outlives this instance. This branch added a `50`
+        # above a `50` that was already here, and Python keeps the LAST -- so the
+        # row carrying the verified holder was the one being discarded, silently,
+        # on every run. That is the failure this table's own guard exists for, one
+        # level in, introduced by the pass that was de-duplicating the level above
+        # it. **No test in this file could see it**: they all read the BUILT dict,
+        # where the loser is already gone. Only a reader that parses the SOURCE
+        # can, and `main` grew one for the OUTER keys after another session found
+        # the register key "R" written twice the same day.
+        #
+        # Both rows are gone now -- `#293` landed and made the number a heading --
+        # so nothing here is left to fix. The paragraph stays because a duplicated
+        # key inside these dicts is invisible to everything except a source
+        # reader, and the next session to add a row needs to know that before it
+        # adds one, not after.
         # Delete this row the day #293 merges.
+        # 34 belongs to `claude/drive-without-a-server`, which also holds OP 45, 49
+        # and 50. It is a hole on this branch because that branch declared it and this
+        # one has not got its entries -- exactly the state the gap check exists to
+        # distinguish from a skipped number.
+        34: "branch claude/drive-without-a-server",
         # 50 HAS NO ROW: it was reserved for `claude/scrapex-engine-consolidation-d69e0a`
         # while `REQ-51` was declared over the top of it, and the row said to delete it
         # the day #293 merged. It is deleted one step earlier instead -- as #293 rebases

--- a/tests/test_the_registers_cannot_collide.py
+++ b/tests/test_the_registers_cannot_collide.py
@@ -160,6 +160,14 @@ RESERVED: dict[str, dict[int, str]] = {
     # DELETE A ROW THE MOMENT ITS PR LANDS. A reservation left behind is a permanent
     # hole nobody owns, which is the rule the comment above already states.
     "REQ": {
+        # 50 became a hole when this branch declared REQ-52. 51's row was here
+        # and is GONE: #301 merged, so it is a heading on `main` and a
+        # reservation for it is the contradiction the guard refuses -- the
+        # FIFTH row retired that way across five merges. Only
+        # holders verified with `git show <ref>:docs/REQUESTS.md`, not taken
+        # from the message that allocated the number: 50 on the engine-page
+        # consolidation (also on origin), 51 on the scheduler branch.
+        50: "branch claude/scrapex-engine-consolidation-d69e0a",
         34: "branch claude/drive-without-a-server",
         # 50 is declared on `claude/scrapex-engine-consolidation-d69e0a` (PR #293,
         # pushed, unmerged) and this branch declares 51 over the top of it. VERIFIED
@@ -250,7 +258,36 @@ RESERVED: dict[str, dict[int, str]] = {
     # that is reserved AND declared fails test_a_reserved_number_is_not_also_declared.
     # Nothing else was touched.
     "OP": {
+        # 117'S ROW WAS HERE AND THIS BRANCH DECLARES IT, so it is gone -- the
+        # sixth reservation retired that way, across six merges.
+        #
+        # AND 112-114 APPEARED **TWICE** IN THIS DICT, on `main` as well as here:
+        # two rebases each concatenated both sides of one block. Python keeps the
+        # LAST duplicate key, so the guard stayed green and the file grew a copy
+        # nobody read -- `LESSONS` section 3, a third time, inside the register
+        # guard itself. De-duplicated 2026-09-02.
         45: "branch claude/drive-without-a-server",
+        # 112 THROUGH 114 became holes when this branch declared OP-117.
+        # 116's row was here and is GONE: #297 merged, so it is declared on
+        # `main` and a reservation for it is the contradiction the guard
+        # refuses. Fourth row retired that way today, on a fourth merge.
+        # Both holders verified with `git rev-parse --verify` and
+        # `git show <ref>:docs/BACKLOG.md`, not taken from the message that
+        # allocated them -- 112-114 at b7dc588, 116 at e0fe797.
+        #
+        # 115 IS THE ODD ONE AND IT IS DELIBERATE. It is already declared on
+        # `main` (#295), so it is NOT reserved here: a reservation for a
+        # declared number is the contradiction `test_a_reserved_number_is_not
+        # _also_declared` refuses. The gap check does not need it either --
+        # this branch has 115 from `main`. Three rows were retired that way
+        # today, on three unrelated merges, every one caught by that
+        # assertion rather than by the session doing the rebase.
+        # 112, 113 AND 114 STOOD HERE AND ARE GONE: `#293` merged as `1d8816d8`, so
+        # all three are headings on `main` and a reservation for a declared number is
+        # the contradiction `test_a_reserved_number_is_not_also_declared` refuses.
+        # `main` was already carrying the paragraph below saying they were gone WHILE
+        # the rows were still here -- a comment and the rows it contradicts, which is
+        # the same one-side-of-a-pair shape this table keeps catching in other files.
         # 101 THROUGH 110 WERE RESERVED HERE AND THE ROWS ARE GONE, which is this
         # table's own rule applied to itself: `claude/design-system-review-d6787a`
         # merged, so the numbers are declared on `main` and a reservation for a
@@ -298,7 +335,10 @@ RESERVED: dict[str, dict[int, str]] = {
         # line. **The claimed-by-message state is real and short**, which is exactly why
         # a row in it must say which kind of claim it is holding rather than read like
         # a verified one.
-        117: "branch claude/marketlens-is-gone, PR #300",
+        # 117 IS DECLARED BY THIS BRANCH, so its row is gone rather than updated.
+        # `main` reserves it to `claude/marketlens-is-gone` -- correctly, from main's
+        # point of view -- and this is the branch that ref names, so the reservation
+        # and the heading are the same claim seen from two sides. The heading wins.
 
         # 112, 113 AND 114 WERE RESERVED HERE FOR THIS BRANCH AND ARE NOT ANY MORE,
         # deleted by the branch they named as its headings arrive. The rule is the

--- a/tests/test_the_retired_product_is_only_named_where_it_must_be.py
+++ b/tests/test_the_retired_product_is_only_named_where_it_must_be.py
@@ -1,0 +1,126 @@
+"""MarketLens is gone, and the places that still say so are the places that must.
+
+He asked for it deleted -- «اى حاجة لها علاقة ب MarketLens احذفها تم التخلى عنها
+مسبقا» -- and most of it went. What is left is not leftovers: each remaining
+mention names a thing that still EXISTS outside this repository, and removing the
+name would either break it or remove the only warning about it.
+
+MEASURED ON HIS OWN DISK, 2026-08-30, which is why this file exists rather than a
+commit that deleted the rest:
+
+    ~/.scrapex/marketlens/marketlens.db      115.8 MB, still there
+      application_id                          0x53584d4c
+      scrapex_meta[database_kind]             'marketlens'
+      scrapex_meta[migration_stream]          'marketlens'
+
+WITHOUT THIS GUARD THE PURGE UNDOES ITSELF TWICE OVER. A new session copies an old
+comment and the name is back; or a session doing exactly what he asked deletes one
+of the entries below and takes a live contract with it. Both are silent.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+# BOTH MARKS. It is a documentation-tier guard by subject, and it reads
+# `extension/` in SEARCHED -- and `test_the_extension_gate_is_complete`
+# refuses an unmarked file that does, so an extension-only change would
+# otherwise stop running the guard on exactly the pull requests that can
+# reintroduce the name.
+pytestmark = [pytest.mark.docs, pytest.mark.extension]
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+NAME = re.compile("marketlens", re.IGNORECASE)
+
+#: Where the product's name may still appear in shipped code, and WHY. Anything
+#: not listed here is a leftover and must go.
+#:
+#: Deleting a row means deleting the thing it protects. Read the reason first.
+ALLOWED: dict[str, str] = {
+    "db/engine/schema.sql":
+        "FROZEN. This file IS migration 1: its sha256 is stamped in every "
+        "database's ledger and re-checked by `_verify` on every connect, so "
+        "editing one byte makes every existing database refuse to open.",
+    "db/engine/migrations/0002_the_price_source_key_is_named_for_what_it_is.sql":
+        "FROZEN. An APPLIED migration. It renames the column schema.sql "
+        "declares; editing it rewrites history and changes its checksum.",
+    "scrapex/databases/carry_over.py":
+        "CONTRACT. `marketlens_path` is a key inside ~/.scrapex/databases.json, "
+        "written there by a shipped version. Rename it and carry-over silently "
+        "drops the priced warehouse, reports success, and rewrites the pointer "
+        "to `single` -- an installation that comes up healthy with its whole "
+        "price history orphaned.",
+    "scrapex/compaction.py":
+        "LIVE VALUE. A real database on his disk still says "
+        "`database_kind = 'marketlens'` about itself. These paragraphs are why "
+        "the check reads the file header instead of that row -- a copied row "
+        "lets a wrong successor vouch for itself.",
+    "scrapex/databases/domain.py":
+        "A RECORD OF A DELETION (OP-115). It names the constant that was "
+        "removed and why, so `git log -S` still finds it.",
+    "scrapex/db.py":
+        "A RECORD OF A DELETION (OP-115). The comment beside `pending_migrations` "
+        "names the filter that hid two real migrations, so the reason it went "
+        "is readable where the code used to be.",
+    "db/engine/derived-from.json":
+        "FROZEN, and it says so in its own first line -- \"frozen at the M5 "
+        "collapse\". It records which column of which retired stream each part "
+        "of the engine schema came from, and `test_one_schema_carries_both_streams` "
+        "reads it as the record. Editing it falsifies the derivation.",
+    "scrapex/webui/app.py":
+        "A RECORD OF A FIX (OP-117). The data-model page labelled one engine "
+        "database `MarketLens` and reported its tables twice.",
+    "scrapex/webui/templates/settings.html":
+        "A retired ROUTE, corrected on the branch for OP-116. This row goes "
+        "when that lands.",
+}
+
+#: What the tree looks for. Tests and documents are excluded on purpose: the
+#: documents are a HISTORY of a product that existed and must keep saying so,
+#: and `docs/plans/` is frozen by `docs/plans/README.md`.
+SEARCHED = ("scrapex", "db", "extension", "packaging", "tools")
+SUFFIXES = {".py", ".js", ".html", ".sql", ".json", ".yaml", ".yml", ".toml", ".css"}
+
+
+def _mentions() -> dict[str, int]:
+    found: dict[str, int] = {}
+    for area in SEARCHED:
+        for path in (ROOT / area).rglob("*"):
+            if path.suffix not in SUFFIXES or "__pycache__" in path.parts:
+                continue
+            hits = len(NAME.findall(path.read_text(encoding="utf-8", errors="replace")))
+            if hits:
+                found[path.relative_to(ROOT).as_posix()] = hits
+    return found
+
+
+def test_no_new_file_names_the_retired_product():
+    """THE PURGE STAYS DONE. A name copied out of an old comment comes back
+    silently; nothing else in the repository would notice."""
+    unexpected = sorted(set(_mentions()) - set(ALLOWED))
+    assert not unexpected, (
+        "these name a product that was abandoned and are not in the allowed "
+        f"list: {unexpected}. If the mention is history, put it in a document; "
+        "if it names something that still exists, add a row to ALLOWED saying "
+        "what it protects.")
+
+
+@pytest.mark.parametrize("path", sorted(ALLOWED), ids=lambda p: p.split("/")[-1])
+def test_an_allowed_mention_still_exists(path: str):
+    """AND THE OPPOSITE FAILURE, which is the dangerous one. A row whose file no
+    longer mentions the name is a row protecting nothing -- and the next reader
+    takes it as proof the danger was handled. Delete the row, not the reason."""
+    if path == "scrapex/webui/templates/settings.html":
+        pytest.skip("goes when OP-116 lands; see its row")
+    assert NAME.search((ROOT / path).read_text(encoding="utf-8", errors="replace")), (
+        f"{path} no longer names it, so its ALLOWED row protects nothing. "
+        "Either the thing it guarded was removed -- in which case say so where "
+        "it was removed -- or the name was deleted and a contract went with it.")
+
+
+def test_every_allowed_row_says_what_it_protects():
+    """A row without a reason is a hole with a name on it."""
+    thin = sorted(path for path, why in ALLOWED.items() if len(why) < 60)
+    assert not thin, f"these rows do not say what they protect: {thin}"

--- a/tests/test_the_split_databases_are_carried_not_replaced.py
+++ b/tests/test_the_split_databases_are_carried_not_replaced.py
@@ -179,7 +179,7 @@ def test_running_it_twice_is_safe_and_does_not_double_the_rows(split):
     # The pointer now says "single", so the plan has to be rebuilt by hand —
     # which is itself the guard in the next test.
     from scrapex.databases.carry_over import CarryOverPlan
-    plan = CarryOverPlan(marketlens=None, general=None,
+    plan = CarryOverPlan(priced=None, general=None,
                          destination=destination, pointer=pointer)
     carry_over(plan)
 


### PR DESCRIPTION
### OP-117 · The data-model page reported 134 tables where 67 exist, and named a product that was abandoned

**He asked for it, on 2026-08-30** — «اى حاجة لها علاقة ب MarketLens احذفها تم التخلى عنها
مسبقا». Most of it went. This entry is the one defect found on the way, and the reason the
rest could not simply follow it.

**THE DEFECT, measured on a built app rather than read.** `/data-model` built two reports,
labelled *MarketLens* and *General*, and summed their counts:

| | `main` | fixed |
|---|---|---|
| tables that exist | 67 | 67 |
| the page's **Live tables** figure | **134** | **67** |
| "MarketLens" on the page | 3 | **0** |

`create_app` sets `general_database = databases.engine` whenever a registry is present, so
both handles opened one file; `reports.data_model_report` selects every non-`sqlite_` table
from `sqlite_master` with no `database_key` predicate, so both reports listed all of them.

**THE UNCONDITIONAL DELETION WOULD HAVE BEEN THE WRONG FIX**, and that is the part worth
keeping. `create_app` still takes `general_db_path`, and its own comment calls it "a legacy
test/session knob" naming "an engine database like any other" — with it set, the two handles
are two different files and both belong on the page. So the page now compares paths and
reports what is actually distinct: right in both cases instead of right in today's.

---

## What could not be deleted, and why it is not caution

**The name survives in exactly the places where it names something that still exists.**
Verified on his own disk, 2026-08-30:

```
~/.scrapex/marketlens/marketlens.db      115.8 MB, still there
  application_id                          0x53584d4c
  scrapex_meta[database_kind]             'marketlens'
```

* **`marketlens_path`** is a key inside `~/.scrapex/databases.json`, written by a shipped
  version. **Renaming it does not raise** — `named()` returns None, the plan drops the priced
  warehouse, `carry_over` reports success because a file it never opened contributes no rows
  to compare, and the pointer is rewritten to `single`. The installation comes up healthy with
  its whole price history orphaned. This machine's pointer already reads `single`; the second
  machine's has not been read.
* **`compaction.py`'s two paragraphs** are why the kind check reads the file header instead of
  `scrapex_meta` — a copied row lets a wrong successor vouch for itself, and a real file
  wearing that value is on his disk.
* **`db/engine/schema.sql` and `0002_*.sql`** are an applied migration and a checksummed
  baseline. `_stamp_and_verify_checksums` compares each digest on every connect and raises
  *"checksum changed; restore the original migration file and retry"* — which this repository
  has already seen fire on his live warehouse once. There is no re-stamp path, because the
  verification runs before migrations could repair it.

**AND THE COLUMN THEY NAME DOES NOT EXIST.** Measured on a database built from the full chain
and on his live warehouse: `user_version` 16, no `site_profile`, no `marketlens*` column, and
the word absent from the live schema SQL entirely. `0002` renames it at step two and `0014`
merges its table away. **So editing those files would break every database he owns in order
to delete two lines describing something no database contains.**

**The route that does work is regeneration, not editing** — the baseline is generated from a
live database, and one generated today has no such column, so the name would go as a side
effect. `domain.py` records that the numbering was restarted once on exactly that reasoning:
*"nothing is published, so no database in the world is stamped `engine` yet."* That is a
decision about the migration chain and is `Q` for him, not a defect.

---

## The guard

`tests/test_the_retired_product_is_only_named_where_it_must_be.py`. A new file naming the
retired product goes red; every allowed file must **say what it protects**; and a row whose
file no longer names it goes red too — because a reservation protecting nothing reads as proof
the danger was handled. **It caught two of its own author's mistakes while being written**: a
frozen record missed (`db/engine/derived-from.json`, which says "frozen at the M5 collapse" in
its own first line) and a row whose reason was too thin to be a reason.


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
