### PR TITLE
The listing phase refused a scope it could not have dishonoured (OP-118, OP-121)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -708,7 +708,7 @@ anyway is not a resume."* The implementation checks the resume in the wrong plac
 
 ```
 scrapex/snapshotcrawl.py:154   def store(page: FetchedPage) -> None:
-scrapex/snapshotcrawl.py:169       if page.url in seen:
+scrapex/snapshotcrawl.py:180       if page.url in seen:
 ```
 
 `store` is the walker's `on_page`, and `PageWalker.walk` calls it **after**
@@ -4298,6 +4298,31 @@ its own first line) and a row whose reason was too thin to be a reason.
 
 ### OP-118 · A registry source's `crawl_scope` has no door — not in the panel, not in the API
 
+> **CORRECTED 2026-09-02, AND THE BLOCKAGE IS GONE.** The paragraph below calls the refusal
+> *correct* and repeats the module's own reason for it. **That reason was measurably false.**
+> `crawl_partition` passes `listing_phase_only=True` to the walker unconditionally and the
+> walker short-circuits on that flag *before* it consults the scope, so a detail page could
+> never be fetched from there under any registration. Bypassing only the gate, with the row
+> still reading `full_then_listing`, a real cell crawl fetched **9 listing pages, 0 detail
+> pages** and closed provably complete — and the fixture raises on a URL with no `?page=`,
+> so one detail attempt would have crashed rather than been miscounted.
+>
+> So the refusal never prevented the ~40,000 requests; it prevented
+> `full_then_listing`'s own second phase — *"then the listing catches the changes"*, the
+> half its name is about — from running at all. **It is gone**, replaced by
+> `test_the_listing_phase_fetches_no_detail_page_under_any_scope`, which asserts the
+> behaviour over all three scopes and reddens on the mutation the refusal could not see:
+> `listing_phase_only=False`.
+>
+> **Ask 3 below survives and gets sharper.** The scope moved from `listing_plus_slice` to
+> `full_then_listing` as data, against `R-39`, with nothing comparing the two — that is
+> still true and still unguarded. **Asks 1 and 2 lose their urgency, not their point**: the
+> reason he needed a write was the refusal, and there is nothing to change now to start a
+> listing crawl.
+>
+> The original text is kept below rather than edited, per `C4`: a register that quietly
+> replaces a wrong reason with a right one teaches nobody why the check was there.
+
 **Found 2026-08-30 while running his listing crawl on his behalf, and it stopped the crawl.**
 
 `crawl_partition` refuses any scope that is not `listing_only`, and refuses rather than
@@ -4335,6 +4360,46 @@ compares the two.
    his own crawl this afternoon instead of asking a session to.
 3. **A guard that a ruling's registered value still holds**, which is the general form and
    the one that would have caught this in August rather than today.
+
+---
+
+### OP-121 · A whole-crawl check standing over one phase of it, in three places
+
+**Found 2026-09-02 while removing the scope refusal `OP-118` recorded.** Writing the
+replacement guard over all three scopes turned one of them red for a reason that had nothing
+to do with the scope gate:
+
+```
+scrapex/crawlscope.py:97       raise SliceRequired(...)                              -- the refusal, unchanged
+scrapex/snapshotcrawl.py:164   phase_scope = CrawlScope.LISTING_ONLY if listing_phase_only else scope
+scrapex/snapshotcrawl.py:165   intended = plan(phase_scope, ...)                     -- was plan(scope, ...)
+scrapex/pagewalk.py:114        plan_scope(CrawlScope.LISTING_ONLY if listing_phase_only else scope, ...)
+```
+
+Those three numbers are **the repair's**, re-derived by content after it landed: the two
+plan calls moved by eleven and seven lines, so the lines the defect sat on now hold comments.
+
+**A partitioned listing crawl of a site registered `listing_plus_slice` with no slice died
+before its first request**, on a demand it could not act on: under `listing_phase_only` the
+walker never reaches `_details_wanted`, so a slice is never consulted. `SliceRequired`'s own
+reasoning is right — *"the only honest reading is 'every detail page'"* — and it is
+reasoning about a WHOLE crawl, asked of one phase that has no detail pages in it.
+
+**And the same mistake was costing a second thing quietly.** `plan(...)` feeds
+`declare_frontier(fetcher, intended.requests)`, the progress denominator. Under
+`listing_phase_only` it was declaring the registered scope's detail pages too, so progress
+on a `full_then_listing` source could only ever stall at a fraction it can never close.
+`crawl_partition` passes `fetcher=None`, which is why nobody had seen it.
+
+**Fixed** by asking about the phase rather than the registration —
+`CrawlScope.LISTING_ONLY if listing_phase_only else scope` — in both places. The scope still
+comes from the database and only from there; what changed is which question is put to it.
+
+**THE GENERAL FORM, and it is the third instance in one afternoon.** `listing_phase_only`
+was added on 2026-08-21 to stop a live `crawl_scope` change from breaking a running crawl,
+and it fixed the walker. **Three checks above the walker were never revisited** — the scope
+refusal, and these two plan calls. A flag that narrows what a run DOES has to be carried to
+everything that reasons about what the run WILL do, and nothing enumerates those callers.
 
 ---
 

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -971,7 +971,7 @@ resume is explained in its module docstring in terms of **requests**:
 > anyway is not a resume.
 
 Every word of that is the right intent. The check sits in `store`
-([scrapex/snapshotcrawl.py:169](../scrapex/snapshotcrawl.py)), which is the
+([scrapex/snapshotcrawl.py:180](../scrapex/snapshotcrawl.py)), which is the
 walker's `on_page` — called **after** the fetch. So the resume saves the INSERT and
 saves no request at all, and the docstring's own justification is the one thing it
 does not deliver. Recorded as [OP-21](BACKLOG.md).

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -624,6 +624,53 @@ defect the squash absorbs, and `R-84` for the two things it must carry: a check 
 refuses to delete a migration once a release marker exists, and the separation of
 tests that exercise a one-off migration from tests that assert a property of the
 resulting schema.
+### The listing phase has a door — 2026-09-02 · branch `fix/the-listing-phase-has-a-door`, **open**
+
+**`OP-118` corrected, `OP-121` filed.** His muqawil listing crawl has been blocked since
+2026-08-30 on one refusal, and the refusal's stated reason was **false when it was written
+down**. It is gone.
+
+**What was measured, because the entry it corrects repeats the wrong reason.**
+`crawl_partition` refused any scope but `listing_only`, saying a `full_then_listing` run
+"would fetch a detail page for every row it read" and turn ~2,000 requests into ~40,000. But
+`crawl_partition` passes `listing_phase_only=True` to the walker **unconditionally**, and the
+walker short-circuits on that flag *before* it reads the scope. Bypassing only the gate, with
+the row still reading `full_then_listing`, a real cell crawl fetched **9 listing pages, 0
+detail pages** and closed provably complete.
+
+So the refusal never prevented the 40,000 requests. It prevented `full_then_listing`'s own
+second phase — *"then the listing catches the changes"*, the half its name is about —
+from running at all, and the only route offered him was editing `source_site.crawl_scope` and
+editing it back afterwards, because the detail crawl reads the same column. He does not use a
+terminal ([R-81](RULINGS.md#r-81--a-command-line-answer-is-not-an-answer-the-panel-is-the-only-door)).
+
+**What replaces it is stronger than what it removed.**
+`test_the_listing_phase_fetches_no_detail_page_under_any_scope` asserts the behaviour over
+all three scopes. The refusal could never have caught a change that dropped
+`listing_phase_only`; this reddens on exactly that, with the count in the message.
+
+**And the guard was vacuous until a mutation said so.** `Partition.detail_urls` in the
+fixture returned `()`, so no scope could ever produce a detail fetch and the new assertion
+passed under the very defect it was written for. The fake publishes and serves its detail
+pages now.
+
+**`OP-121`, found while writing that guard:** the same mistake in two more places.
+`SliceRequired` was asked of the registration rather than the phase, in
+`snapshotcrawl.crawl_to_snapshots` and `pagewalk.walk`, so a partitioned listing crawl of a
+site registered `listing_plus_slice` with no slice **died before its first request** on a
+demand it could not act on. The same call feeds `declare_frontier`, so progress on a
+`full_then_listing` source could only ever stall at a fraction it can never close. Three
+checks above the walker were never revisited when `listing_phase_only` was added on
+2026-08-21.
+
+**THE OTHER HALF OF THE BUTTON IS STILL NOT BUILT, and this branch does not pretend
+otherwise.** `POST /api/jobs` queues `muqawil_org` since `REQ-45`, and the worker still hands
+every source to `capture_source` — the price path. The route to follow is the one
+`organization_enrichment` already took: a job KIND with its own runner
+([scrapex/jobs.py](../scrapex/jobs.py), `_start_job`), not a widened `CaptureResult`, whose
+counters are price-shaped. That chain is two kinds today and a third makes it a registry,
+which is what «خلى الشغل dry» asks for. **Until that lands he still cannot press a button;
+what changed is that the engine no longer refuses the run when something does press it.**
 
 ## Track 1 · The Console migration
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -672,6 +672,54 @@ counters are price-shaped. That chain is two kinds today and a third makes it a 
 which is what «خلى الشغل dry» asks for. **Until that lands he still cannot press a button;
 what changed is that the engine no longer refuses the run when something does press it.**
 
+### His ruling of 2026-09-02 on the migration baseline — captured here, being written as `R-84` elsewhere
+
+**Recorded under `C3` in the session he gave it, because the ruling itself is being written
+on `claude/one-migration-plan-not-two` (`OP-122`) and a decision that exists only in an
+unmerged branch is a decision that did not happen.** This is a pointer, not a second
+ruling — no `R-` heading, nothing the register guard can collide on. It goes when `R-84`
+lands.
+
+> «قواعد البيانات يتم ترقيتها ولكن base يتغير الان بحيث اننى لا اريد الاحتفاظ بترحيلات
+> كثيرة لا يستخدمها احد اكيد عند نشر الاداة ساريد الحفاظ على كافة الترحيلات لانها ستكون
+> مهمة للمستخدمين حيث غير محدد اى مستخدم توقف عنده هذه النسخة ولكن قبل الاصدار لا اريد
+> اراكم الكود باختبارات وترحيلات لن تستخدم سوى مرة واحدة وهى لى»
+
+**It reaffirms [R-24](RULINGS.md#r-24--a-database-is-upgraded-never-replaced--the-users-data-survives-the-schema)
+rather than superseding any part of it**, and two sessions — this one included — had it
+the other way round for most of the day. His first clause is `R-24`'s own rule: *databases
+are upgraded*. What moves is the **baseline**. And `R-24`'s own quotation already drew the
+line he is drawing now: «طبعا الافضل تطويرها لان **عند نشر الاداة** المفروض نحافظ على بيانات
+المستخدمين». The publication boundary was in the ruling from the day it was made; what
+nobody had done was apply it to the migration CHAIN instead of to the DATA.
+
+| | |
+|---|---|
+| `R-24` governs **the data** | upgraded, never replaced. Untouched by this |
+| `R-84` governs **the baseline** | before publication the chain is not a user-facing asset; after it, no migration is ever deleted |
+
+**And one measurement makes it safe rather than merely authorised.** Read read-only from
+his live warehouse on 2026-09-02: `PRAGMA user_version = 16`, the head of the chain. **A
+baseline squashed at 16 replays nothing over his database** — there is no upgrade for it
+to take, so «تُحمَل» needs no implementation and no carry-over path is to be built.
+
+**The price, recorded as a waiver and not as a measurement.** The squash removes the
+upgrade path for any database below the new baseline. His primary machine is at 16 and
+unaffected; **the second machine's version is unknown and was never measured.** He said
+«لا اكترث لجهازى الثانى الان», which is a waiver. If that warehouse is below the baseline,
+this change strands it, and he accepted that without its version being known.
+
+**Two things his sentence carries that the plan did not.**
+1. **Tests, not only migrations** — «لا اريد اراكم الكود باختبارات وترحيلات». A test that
+   exists solely to exercise a one-off migration is the same debt. But a test *named* for a
+   migration is not always *about* it: some assert a property of the resulting schema and
+   survive as the only thing checking it. And `OP-120`'s drift check must not go — it is
+   what proves an upgraded database equals a fresh build, which is the whole claim a new
+   baseline makes.
+2. **The rule inverts at publication, and a rule in prose alone is the `R-07` failure** —
+   ordered on 2026-08-16, still live thirteen days later, read past by every session. So
+   the squash owes a check that refuses to delete a migration once a release marker exists.
+
 ## Track 1 · The Console migration
 
 **Plan:** [MIGRATION-PLAN.md](MIGRATION-PLAN.md) · **Detailed state:**

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -672,54 +672,6 @@ counters are price-shaped. That chain is two kinds today and a third makes it a 
 which is what «خلى الشغل dry» asks for. **Until that lands he still cannot press a button;
 what changed is that the engine no longer refuses the run when something does press it.**
 
-### His ruling of 2026-09-02 on the migration baseline — captured here, being written as `R-84` elsewhere
-
-**Recorded under `C3` in the session he gave it, because the ruling itself is being written
-on `claude/one-migration-plan-not-two` (`OP-122`) and a decision that exists only in an
-unmerged branch is a decision that did not happen.** This is a pointer, not a second
-ruling — no `R-` heading, nothing the register guard can collide on. It goes when `R-84`
-lands.
-
-> «قواعد البيانات يتم ترقيتها ولكن base يتغير الان بحيث اننى لا اريد الاحتفاظ بترحيلات
-> كثيرة لا يستخدمها احد اكيد عند نشر الاداة ساريد الحفاظ على كافة الترحيلات لانها ستكون
-> مهمة للمستخدمين حيث غير محدد اى مستخدم توقف عنده هذه النسخة ولكن قبل الاصدار لا اريد
-> اراكم الكود باختبارات وترحيلات لن تستخدم سوى مرة واحدة وهى لى»
-
-**It reaffirms [R-24](RULINGS.md#r-24--a-database-is-upgraded-never-replaced--the-users-data-survives-the-schema)
-rather than superseding any part of it**, and two sessions — this one included — had it
-the other way round for most of the day. His first clause is `R-24`'s own rule: *databases
-are upgraded*. What moves is the **baseline**. And `R-24`'s own quotation already drew the
-line he is drawing now: «طبعا الافضل تطويرها لان **عند نشر الاداة** المفروض نحافظ على بيانات
-المستخدمين». The publication boundary was in the ruling from the day it was made; what
-nobody had done was apply it to the migration CHAIN instead of to the DATA.
-
-| | |
-|---|---|
-| `R-24` governs **the data** | upgraded, never replaced. Untouched by this |
-| `R-84` governs **the baseline** | before publication the chain is not a user-facing asset; after it, no migration is ever deleted |
-
-**And one measurement makes it safe rather than merely authorised.** Read read-only from
-his live warehouse on 2026-09-02: `PRAGMA user_version = 16`, the head of the chain. **A
-baseline squashed at 16 replays nothing over his database** — there is no upgrade for it
-to take, so «تُحمَل» needs no implementation and no carry-over path is to be built.
-
-**The price, recorded as a waiver and not as a measurement.** The squash removes the
-upgrade path for any database below the new baseline. His primary machine is at 16 and
-unaffected; **the second machine's version is unknown and was never measured.** He said
-«لا اكترث لجهازى الثانى الان», which is a waiver. If that warehouse is below the baseline,
-this change strands it, and he accepted that without its version being known.
-
-**Two things his sentence carries that the plan did not.**
-1. **Tests, not only migrations** — «لا اريد اراكم الكود باختبارات وترحيلات». A test that
-   exists solely to exercise a one-off migration is the same debt. But a test *named* for a
-   migration is not always *about* it: some assert a property of the resulting schema and
-   survive as the only thing checking it. And `OP-120`'s drift check must not go — it is
-   what proves an upgraded database equals a fresh build, which is the whole claim a new
-   baseline makes.
-2. **The rule inverts at publication, and a rule in prose alone is the `R-07` failure** —
-   ordered on 2026-08-16, still live thirteen days later, read past by every session. So
-   the squash owes a check that refuses to delete a migration once a release marker exists.
-
 ## Track 1 · The Console migration
 
 **Plan:** [MIGRATION-PLAN.md](MIGRATION-PLAN.md) · **Detailed state:**

--- a/scrapex/contractors.py
+++ b/scrapex/contractors.py
@@ -284,16 +284,6 @@ def crawl(conn, directory: Directory, fetch, fetcher, run_ref: str,
         say(f"replaying {len(kept):,} conditional validator(s) — an unchanged page "
             "answers 304 with no body")
 
-    # SAID BEFORE THE FIRST REQUEST, because this command is one PHASE of the
-    # registered scope and a person watching it must not read "crawl finished" as
-    # "everything the site publishes is on disk". Under `full_then_listing` the
-    # profile half is a separate deliberate command and this names it; the refusal
-    # this replaces said the same thing by declining to run at all.
-    registered, _slice_of = read_scope(conn, directory.key)
-    say(f"registered scope: {registered.value} — this is its listing phase")
-    if registered is not CrawlScope.LISTING_ONLY:
-        say("  the profile half is not part of this run: `scrapex contractors "
-            "--details` fetches it, and it reads the same registration")
     say(f"crawl {run_ref} starting")
     # `R-54`: A RUN WITH AN IDENTITY, opened before the first fetch so every page this
     # crawl stores names it. `run_ref` above is the operator's label and is derived per
@@ -301,6 +291,18 @@ def crawl(conn, directory: Directory, fetch, fetcher, run_ref: str,
     # column compares against instead of `MAX(last_seen_at)` — a timestamp to the second
     # that only the crawl's final second could ever equal.
     run_id = _run_for(conn, directory, "listing")
+    # SAID BEFORE THE FIRST REQUEST, AND AFTER `_run_for`, WHICH IS THE ORDER THAT
+    # WORKS. This command is one PHASE of the registered scope, and a person watching
+    # it must not read "crawl finished" as "everything the site publishes is on disk" --
+    # the refusal this replaces said that by declining to run at all. Read here rather
+    # than twenty lines up because `_run_for` is what REGISTERS a site that has no
+    # `source_site` row yet, and reading the scope before it turned two driver tests red
+    # with `SiteNotRegistered` on a fixture that had every right not to pre-register.
+    registered, _slice_of = read_scope(conn, directory.key)
+    say(f"registered scope: {registered.value} — this is its listing phase")
+    if registered is not CrawlScope.LISTING_ONLY:
+        say("  the profile half is not part of this run: `scrapex contractors "
+            "--details` fetches it, and it reads the same registration")
     conn.commit()          # the workers open their own connections and must see it
     outcome = crawl_partition(conn, partition, directory.base_url, fetch=fetch,
                               run_ref=run_ref, run_id=run_id,

--- a/scrapex/contractors.py
+++ b/scrapex/contractors.py
@@ -284,6 +284,16 @@ def crawl(conn, directory: Directory, fetch, fetcher, run_ref: str,
         say(f"replaying {len(kept):,} conditional validator(s) — an unchanged page "
             "answers 304 with no body")
 
+    # SAID BEFORE THE FIRST REQUEST, because this command is one PHASE of the
+    # registered scope and a person watching it must not read "crawl finished" as
+    # "everything the site publishes is on disk". Under `full_then_listing` the
+    # profile half is a separate deliberate command and this names it; the refusal
+    # this replaces said the same thing by declining to run at all.
+    registered, _slice_of = read_scope(conn, directory.key)
+    say(f"registered scope: {registered.value} — this is its listing phase")
+    if registered is not CrawlScope.LISTING_ONLY:
+        say("  the profile half is not part of this run: `scrapex contractors "
+            "--details` fetches it, and it reads the same registration")
     say(f"crawl {run_ref} starting")
     # `R-54`: A RUN WITH AN IDENTITY, opened before the first fetch so every page this
     # crawl stores names it. `run_ref` above is the operator's label and is derived per

--- a/scrapex/pagewalk.py
+++ b/scrapex/pagewalk.py
@@ -104,7 +104,15 @@ class PageWalker:
         # for a slice scope with no slice named, and asking it here means the
         # refusal costs nothing instead of arriving after fourteen minutes of
         # listing pages.
-        plan_scope(scope, listing_pages=0, detail_pages=0, slice_of=slice_of)
+        #
+        # AND IT IS ASKED ABOUT THE PHASE, NOT THE REGISTRATION. Under
+        # `listing_phase_only` the loop below never reaches `_details_wanted`, so a
+        # slice is not consulted and "name the slice" is a demand this run cannot
+        # act on and does not need. Measured 2026-09-02: a partitioned listing crawl
+        # of a site registered `listing_plus_slice` with no slice died on it, having
+        # fetched nothing, in a run that was never going to look at a slice.
+        plan_scope(CrawlScope.LISTING_ONLY if listing_phase_only else scope,
+                   listing_pages=0, detail_pages=0, slice_of=slice_of)
 
         report = WalkReport(scope=scope)
         for url in self._source.listing_urls(base_url):

--- a/scrapex/partitioncrawl.py
+++ b/scrapex/partitioncrawl.py
@@ -98,7 +98,6 @@ from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
 from .connectors.base import declare_frontier
-from .crawlscope import CrawlScope
 from .pagesource import WHOLE, Cell, PageSource
 from .sightings import record_sightings
 from .snapshotbody import decode
@@ -151,25 +150,14 @@ DRY_ATTEMPTS = 2
 class NotASubdivision(ValueError):
     """The cells handed in are not all inside the parent they claim to subdivide.
 
-    REFUSED RATHER THAN AUDITED, for the same reason `ScopeNotPartitionable`
-    refuses rather than narrowing. The nested audit's whole claim is
+    REFUSED RATHER THAN AUDITED, and this is the one refusal in this module that
+    survives: it is about the ARITHMETIC, not about configuration. The nested audit's
+    whole claim is
     `Sum N_child == N_parent`, and a child that dropped one of the parent's
     filters is measured over a different, larger set. Such a run could report a
     zero deficit while covering none of the parent — a completeness claim that is
     false rather than merely weak, and the one failure this module is built to
     make impossible.
-    """
-
-
-class ScopeNotPartitionable(ValueError):
-    """This site is registered for a scope a listing partition cannot honour.
-
-    REFUSED RATHER THAN NARROWED. The scope comes from `source_site` and from
-    nowhere else — that is `snapshotcrawl`'s rule and the reason it has no scope
-    parameter. A partition crawl under `full_then_listing` would fetch twenty
-    profile pages for every listing page it read, so a run priced at ~2,000
-    requests would silently become ~40,000 and take a day. Quietly downgrading
-    the scope instead would be this module deciding what the owner registered.
     """
 
 
@@ -982,8 +970,20 @@ def crawl_partition(conn: sqlite3.Connection, partition: PartitionedListing,
     residual crawl fetched 7,898 pages — four times the first crawl's 1,982 — to
     find nothing in its last 43 minutes. An allowance is not a stopping rule.
 
-    IT REFUSES A SCOPE IT CANNOT HONOUR rather than narrowing one. See
-    `ScopeNotPartitionable`.
+    THIS IS THE LISTING PHASE AND IT CANNOT BE ANYTHING ELSE, which is why it no
+    longer asks `source_site.crawl_scope` for permission. `listing_phase_only=True`
+    goes to the walker unconditionally below, and the walker short-circuits on that
+    flag before it reads the scope -- so a detail page cannot be fetched from here
+    under any registration. `test_the_listing_phase_fetches_no_detail_page_under_any_scope`
+    asserts that over all three scopes, which is the property the old
+    `ScopeNotPartitionable` refusal was standing in for.
+
+    IT REFUSED `full_then_listing` UNTIL 2026-09-02, and the reason it gave --
+    "would fetch twenty profile pages for every listing page it read" -- was already
+    impossible when it was written down. What the refusal actually did was leave that
+    scope's own second phase, the "then the listing catches the changes" half of its
+    name, with no way to run: the only route offered was editing the row and editing
+    it back, because the detail crawl reads the same column.
 
     `parent` IS THE NESTED AUDIT, AND IT IS ONE SIZING REQUEST. Every number this
     returns is measured against `parent`: pass `WHOLE` (the default) and the
@@ -996,14 +996,12 @@ def crawl_partition(conn: sqlite3.Connection, partition: PartitionedListing,
     one. The cells must actually lie inside `parent` or this raises
     `NotASubdivision`.
     """
-    scope, _slice = read_scope(conn, partition.site_key)
-    if scope is not CrawlScope.LISTING_ONLY:
-        raise ScopeNotPartitionable(
-            f"{partition.site_key} is registered as {scope.value!r}. A partition "
-            "crawl is the LISTING half and would fetch a detail page for every "
-            "row it read under that scope — thousands of requests nobody asked "
-            f"for. Register it as {CrawlScope.LISTING_ONLY.value!r} for this "
-            "crawl, or run the detail crawl deliberately.")
+    # READ FOR THE REGISTRATION, NOT FOR PERMISSION. `read_scope` raises
+    # `SiteNotRegistered` for a site nobody has decided about, and that check is worth
+    # keeping: a crawl that picked the default would be answering for the owner. The
+    # scope VALUE is not this function's business -- see `_the_listing_phase_only` in
+    # the docstring above.
+    read_scope(conn, partition.site_key)
 
     plan = tuple(cells) if cells is not None else partition.cells()
 

--- a/scrapex/snapshotcrawl.py
+++ b/scrapex/snapshotcrawl.py
@@ -151,7 +151,18 @@ def crawl_to_snapshots(conn: sqlite3.Connection, source: PageSource,
     # it now means the refusal costs nothing instead of arriving after fourteen
     # minutes of listing pages. The walker asks it again for itself; that is
     # deliberate duplication of a CHECK, never of the rule.
-    intended = plan(scope, listing_pages=listing_pages,
+    #
+    # AND THE PHASE DECIDES WHICH PLAN IS BEING MADE. `listing_phase_only` means no
+    # detail page will be fetched, so planning the registered scope's detail pages
+    # would declare a frontier this run cannot reach -- progress stalling at a
+    # fraction it can never close. It also asked `SliceRequired` a question the phase
+    # does not have: measured 2026-09-02, a partitioned listing crawl of a site
+    # registered `listing_plus_slice` with no slice raised "listing_plus_slice needs
+    # the slice named" out of a run that was never going to look at a slice. Same
+    # shape as the scope refusal `partitioncrawl` dropped the same day -- a
+    # whole-crawl check standing over one phase of it.
+    phase_scope = CrawlScope.LISTING_ONLY if listing_phase_only else scope
+    intended = plan(phase_scope, listing_pages=listing_pages,
                     detail_pages=detail_pages, slice_pages=slice_pages,
                     slice_of=slice_of)
     declare_frontier(fetcher, intended.requests)

--- a/tests/test_a_crawl_that_can_prove_it_read_everything.py
+++ b/tests/test_a_crawl_that_can_prove_it_read_everything.py
@@ -35,7 +35,6 @@ from scrapex.pagesource import WHOLE, Cell
 from scrapex.partitioncrawl import (
     DRY_ATTEMPTS,
     NotASubdivision,
-    ScopeNotPartitionable,
     crawl_partition,
     size_cell,
     witness,
@@ -78,6 +77,13 @@ class Directory:
 
     def fetch(self, url: str) -> str:
         self.fetched.append(url)
+        if "?" not in url:
+            # A DETAIL PAGE, SERVED RATHER THAN REFUSED. The fixture used to parse
+            # `?page=` unconditionally and died on a profile URL with an IndexError,
+            # which reddens a test without telling its reader what happened. Serving
+            # it means the assertion that counts detail fetches is what speaks.
+            self._noise += 1
+            return f"<html><!-- profile {self._noise} -->{url}</html>"
         query = url.split("?", 1)[1]
         parts = dict(pair.split("=", 1) for pair in query.split("&"))
         number = int(parts.pop("page"))
@@ -137,7 +143,16 @@ class _CellSource:
                     base_url, locale=locale, page=page, cell=self._cell)
 
     def detail_urls(self, page):
-        return ()
+        """The row links this page published, which the listing HTML already carries.
+
+        IT RETURNED `()` UNTIL 2026-09-02 AND THAT MADE A GUARD VACUOUS. With no
+        detail URL to yield, `_details_wanted` can produce nothing, so
+        `test_the_listing_phase_fetches_no_detail_page_under_any_scope` passed under
+        the very mutation it exists to catch -- `listing_phase_only=False` in
+        `partitioncrawl`. Every other test here reaches the walker through
+        `crawl_partition`, which is the listing phase, so nothing else reads this.
+        """
+        return tuple(re.findall(r'href="(/en/row/[^"]+)"', page.html))
 
     def belongs_to_slice(self, page, row_index, slice_of):
         return True
@@ -560,18 +575,51 @@ def test_a_cell_above_the_witness_ceiling_is_read_once_and_says_so(conn):
 
 # ---- the scope, which is the owner's and comes from the database -------------
 
-def test_a_scope_a_listing_partition_cannot_honour_is_refused(conn):
-    """REFUSED BEFORE THE FIRST REQUEST, and never narrowed. Under
-    `full_then_listing` this crawl would fetch a detail page for every row it
-    read: a run priced at ~2,000 requests becomes ~40,000 and takes a day."""
-    register(conn, scope="full_then_listing")
-    directory = Directory({"whole": ["1"], "region_id_1": ["1"]})
+@pytest.mark.parametrize("scope", ["listing_only", "listing_plus_slice",
+                                   "full_then_listing"])
+def test_the_listing_phase_fetches_no_detail_page_under_any_scope(conn, scope):
+    """THIS REPLACES A REFUSAL, AND IT IS THE PROPERTY THAT REFUSAL STOOD IN FOR.
+
+    Until 2026-09-02 `crawl_partition` refused anything but `listing_only`, and the
+    reason it gave was that under `full_then_listing` it "would fetch a detail page for
+    every row it read: a run priced at ~2,000 requests becomes ~40,000 and takes a day."
+
+    **That was measurably false when it was written.** `crawl_partition` passes
+    `listing_phase_only=True` to the walker unconditionally, and `pagewalk` short-circuits
+    on that flag BEFORE it consults the scope. Bypassing only the gate, with the row still
+    reading `full_then_listing`, a real cell crawl fetched 9 listing pages, 0 detail pages,
+    and closed provably complete.
+
+    What the refusal actually cost was a door: `full_then_listing` means "one founding
+    crawl of everything, then the listing catches the changes", and the listing half --
+    the half its name is about -- could not be run at all. The owner's muqawil
+    registration is `full_then_listing`, and the only route offered was editing
+    `source_site.crawl_scope` and editing it back, because the detail crawl reads the same
+    column.
+
+    SO THE ASSERTION MOVED FROM THE CONFIGURATION TO THE BEHAVIOUR, over all three
+    scopes. The refusal could not have caught a change that dropped `listing_phase_only`;
+    this does, and that flag is the only thing keeping this module inside its phase.
+    """
+    register(conn, scope=scope)
+    ids = [str(n) for n in range(1, 9)]
+    directory = Directory({"whole": list(ids), "region_id_1": list(ids)})
     partition = Partition(directory, cells=(cell(region_id=1),))
 
-    with pytest.raises(ScopeNotPartitionable) as raised:
-        run(conn, partition, directory)
-    assert "full_then_listing" in str(raised.value)
-    assert not directory.fetched, "and it cost nothing to refuse"
+    outcome = run(conn, partition, directory)
+
+    # THE FAKE SITE IS THE WITNESS, not the arithmetic. `Directory.fetch` parses
+    # `?page=` out of the query, and a detail URL -- `/en/row/3/143` -- has no query at
+    # all, so a single detail attempt raises rather than being quietly counted as a page.
+    detail = [url for url in directory.fetched if "page=" not in url]
+    assert not detail, (
+        f"registered {scope!r} and this crawl fetched {len(detail)} detail page(s): "
+        f"{detail[:3]} -- `listing_phase_only` is no longer holding, and the listing "
+        "phase has silently become a full crawl")
+    assert directory.fetched, "it fetched nothing at all, so it proves nothing"
+    assert outcome.cells[0].provably_complete, (
+        f"the cell did not close under {scope!r}, so this asserts nothing about a "
+        "crawl that works")
 
 
 # ---- arrivals, and a parse that must not look like a dead page ---------------

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -205,8 +205,8 @@ PINNED = (
     # a reader sent one line off reads `store`'s docstring, agrees with it, and
     # concludes the entry is wrong. If someone moves this check into the walk, the
     # entry is answered and this row should go with it.
-    ("docs/BACKLOG.md", "scrapex/snapshotcrawl.py", 169, "if page.url in seen:"),
-    ("docs/LESSONS.md", "scrapex/snapshotcrawl.py", 169, "if page.url in seen:"),
+    ("docs/BACKLOG.md", "scrapex/snapshotcrawl.py", 180, "if page.url in seen:"),
+    ("docs/LESSONS.md", "scrapex/snapshotcrawl.py", 180, "if page.url in seen:"),
     # OP-22 / LESSONS §2 · one database, and where it is. That section described
     # the pre-collapse split layout in the present tense until 2026-08-20, so the
     # line naming the single file is worth holding still.

--- a/tests/test_the_registers_cannot_collide.py
+++ b/tests/test_the_registers_cannot_collide.py
@@ -294,6 +294,25 @@ RESERVED: dict[str, dict[int, str]] = {
         # LAST duplicate key, so the guard stayed green and the file grew a copy
         # nobody read -- `LESSONS` section 3, a third time, inside the register
         # guard itself. De-duplicated 2026-09-02.
+        # 120, 122 AND 123 ARE HOLES THIS BRANCH CREATES by declaring OP-121 over them,
+        # and all three are VERIFIED AGAINST REFS rather than taken from the messages
+        # that announced them. Re-check before trusting; the commands are the check:
+        #   git show refs/remotes/origin/claude/the-drift-check-that-was-off:docs/BACKLOG.md | grep "^### OP-120"
+        #   git show refs/remotes/origin/claude/one-migration-plan-not-two:docs/BACKLOG.md | grep "^### OP-122"
+        #   git show refs/remotes/origin/claude/a-citation-nothing-reads:docs/BACKLOG.md | grep "^### OP-123"
+        # 121 IS THIS BRANCH'S OWN and is a heading in docs/BACKLOG.md, not a row here.
+        # DELETE EACH ROW THE DAY ITS PULL REQUEST LANDS -- a reservation left behind is a
+        # permanent hole nobody owns, which is the rule this table states about itself.
+        # 120 SURVIVES AS ONE ROW CARRYING BOTH SIDES' EVIDENCE. Two sessions
+        # reserved it and keep-both left two rows; the guard below reported
+        # `OP[120]` and the copy Python keeps is the lower one. Verified with
+        #   git show refs/remotes/origin/claude/the-drift-check-that-was-off:docs/BACKLOG.md | grep "### OP-120"
+        # at c6bdf813, and it now has PR #307 open, which the earlier row could
+        # not know. 121 and 122 are GONE: 121 is declared by this branch and 122
+        # landed with #306 (`3c2aaa0d`), so each was a number reserved AND
+        # declared -- the contradiction the neighbouring test refuses.
+        120: "branch claude/the-drift-check-that-was-off, PR #307, at c6bdf813",
+        123: "branch claude/a-citation-nothing-reads, at a0c6e8c2",
         45: "branch claude/drive-without-a-server",
         # 112 THROUGH 114 became holes when this branch declared OP-117.
         # 116's row was here and is GONE: #297 merged, so it is declared on
@@ -330,11 +349,6 @@ RESERVED: dict[str, dict[int, str]] = {
         # A sweep of every local and remote ref found OP-122 declared on none of them.
         #
         # Delete each row the day its branch merges.
-        120: "branch claude/the-drift-check-that-was-off (pushed, no PR yet)",
-        # 121's ref is LOCAL ONLY -- checked out in a sibling worktree, not on origin
-        # -- so `git ls-remote` would report the number free. `git branch -a` is the
-        # check that works here, because worktrees share one ref namespace.
-        121: "branch fix/the-listing-phase-has-a-door (local ref only, not pushed)",
         # 101 THROUGH 110 WERE RESERVED HERE AND THE ROWS ARE GONE, which is this
         # table's own rule applied to itself: `claude/design-system-review-d6787a`
         # merged, so the numbers are declared on `main` and a reservation for a


### PR DESCRIPTION
His muqawil listing crawl has been blocked since 2026-08-30 on one refusal, and **the
refusal's stated reason was false when it was written down.**

## What was measured

`crawl_partition` refused any scope but `listing_only`, and said why: under
`full_then_listing` it *"would fetch a detail page for every row it read"*, turning a run
priced at ~2,000 requests into ~40,000.

But `crawl_partition` passes `listing_phase_only=True` to the walker **unconditionally**,
and `pagewalk` short-circuits on that flag **before** it consults the scope. Bypassing only
the gate, with the row still reading `full_then_listing`:

| | |
|---|---|
| listing pages fetched | **9** |
| detail pages fetched | **0** |
| the cell | closed provably complete |

And the fixture's `fetch` parses `?page=` out of the query, so a detail URL — which has no
query at all — would have crashed rather than been miscounted.

**So the refusal never prevented the 40,000 requests.** What it prevented was
`full_then_listing`'s own second phase — *"then the listing catches the changes"*, the half
its name is about — from running at all. The only route offered him was editing
`source_site.crawl_scope` and editing it back afterwards, because the detail crawl reads the
same column, and he does not use a terminal (`R-81`).

## What replaces it is stronger than what it removed

`test_the_listing_phase_fetches_no_detail_page_under_any_scope` asserts the **behaviour**
over all three scopes instead of the configuration over one. The refusal could never have
caught a change that dropped `listing_phase_only`, which is the only thing keeping this
module inside its phase; this reddens on exactly that, with the count in the message.

`read_scope` is still called, for the registration check — `SiteNotRegistered` for a site
nobody has decided about is worth keeping, since a crawl that picked the default would be
answering for the owner. What is gone is asking the scope for permission. And the listing
crawl now **says** which phase it is and names the command that fetches the other half, so
"crawl finished" cannot be read as "everything the site publishes is on disk".

## And the new guard was vacuous until a mutation said so

`Partition.detail_urls` in the fixture returned `()`. With no detail URL to yield,
`_details_wanted` can produce nothing and **no scope can ever produce a detail fetch** — so
the new assertion passed under the very defect it was written for. The fake publishes and
serves its detail pages now; the mutation reddens with `registered 'full_then_listing' and
this crawl fetched 8 detail page(s)`. Every other test in the file reaches the walker
through `crawl_partition`, which is the listing phase, so nothing else reads the new value.

## OP-121 — the same mistake in two more places, found while writing that guard

Parametrising the guard over all three scopes turned one red for a reason unrelated to the
scope gate: `SliceRequired` was asked of the **registration** rather than the **phase**, in
`snapshotcrawl.crawl_to_snapshots` and `pagewalk.walk`. A partitioned listing crawl of a
site registered `listing_plus_slice` with no slice **died before its first request**, on a
demand it could not act on — under `listing_phase_only` the walker never reaches
`_details_wanted`, so a slice is never consulted.

The same call feeds `declare_frontier(fetcher, intended.requests)`, so progress on a
`full_then_listing` source could only ever stall at a fraction it can never close.
`crawl_partition` passes `fetcher=None`, which is why nobody had seen it.

**Three checks above the walker were never revisited** when `listing_phase_only` was added
on 2026-08-21 to stop a live `crawl_scope` change from breaking a running crawl. It fixed
the walker. A flag that narrows what a run DOES has to be carried to everything that reasons
about what the run WILL do, and nothing enumerates those callers.

## One ordering repair the full suite caught and two targeted suites did not

`_run_for` is what writes a `source_site` row for a directory that has none, so reading the
scope twenty lines above it raised `SiteNotRegistered` in two driver tests — on fixtures
that had every right not to pre-register, since nothing had asked them to before. Found by
the full run in both modes, not by the suites the change was written against.

## OP-118 is corrected, not marked fixed

That entry calls the refusal *correct* and repeats the module's reason for it. The original
text stays and the correction sits above it, per `C4`: a register that quietly replaces a
wrong reason with a right one teaches nobody why the check was there. Its **ask 3 survives
and gets sharper** — the scope moved from `listing_plus_slice` to `full_then_listing` as
data, against `R-39`, with nothing comparing the two. Asks 1 and 2 lose their urgency, not
their point: the reason he needed a write was the refusal.

## What this does NOT do

**He still cannot press a button.** `POST /api/jobs` queues `muqawil_org` since `REQ-45`,
and the worker still hands every source to `capture_source` — the price path. The route to
follow is the one `organization_enrichment` already took: a job **kind** with its own runner
in `jobs.py`'s `_start_job`, not a widened `CaptureResult`, whose counters are price-shaped.
That chain is two kinds today and a third makes it a registry, which is what «خلى الشغل
dry» asks for. **What changed is that the engine no longer refuses the run when something
does press it.**

## Verification

- Both run modes green, before the rebase at `2e7117a7` and again after it, per
  [LESSONS §24](docs/LESSONS.md). Head recorded before and after each run and unmoved.
- `ruff check scrapex/` clean; the docs suite green after the rebase onto `80659faa`.
- **Two mutations, both restored:** `listing_phase_only=False`, which now reddens the new
  guard with a count instead of passing; and the first version of that guard against the
  `()` fixture, which is how the vacuity was found.
- `OP-121`'s three citations are **the repair's** line numbers, re-derived by content after
  it landed — the two plan calls moved by eleven and seven lines, so the lines the defect
  sat on now hold comments.
