### PR TITLE
The engine reports the commit it was built from, and Protocol stops asking for a version (R-77)

### DIFF
--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -3112,6 +3112,16 @@ file. A rule that needs five documents to state it is a rule nobody can follow.
 
 ## The decision: split the three, and let the architecture answer each
 
+> **BUILT 2026-09-02 — clauses 1 and 2. Clause 3's last step needs `mbiX-hub`.** The
+> engine now stamps `git rev-parse HEAD` into its bundle and reports it, and `Protocol` no
+> longer asks whether the engine has a version. **What is not done is the cut**, and the
+> reason is measured rather than chosen: the `Latest version` row feeds
+> `engineReleaseVerdict`, whose `isOlder(installed, latest.version)` produces the download
+> and install surface. With no engine version the check must compare COMMITS, and the
+> published side of it is `mbiX-hub/ScrapeX/json/version.json` — a manual manifest in
+> another repository. Cutting the rows first would leave him unable to install a new engine.
+> `docs/STATE.md` carries the four steps and which two are behind us.
+
 **1 · IDENTITY IS THE COMMIT, NOT A NUMBER.** The engine reports the SHA it was built from.
 It is free, it cannot be wrong, and it needs no rule — which kills the question *"does this
 pull request deserve a bump?"* outright. That question is the source of every conflict in this

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -671,6 +671,61 @@ every source to `capture_source` — the price path. The route to follow is the 
 counters are price-shaped. That chain is two kinds today and a third makes it a registry,
 which is what «خلى الشغل dry» asks for. **Until that lands he still cannot press a button;
 what changed is that the engine no longer refuses the run when something does press it.**
+### The engine reports the commit it was built from — 2026-09-02 · branch `fix/the-engine-reports-the-commit-it-was-built-from`, **open**
+
+**`R-77`'s first two clauses, built. The third leaves this repository, and that is why it
+stops here.**
+
+`R-77` split one number into three questions and answered each with an architecture:
+identity is the **commit**, compatibility is a **protocol number**, and the product version
+is the **extension's alone**. Measured against the code, the first was never built and the
+second was coupled to the thing being retired.
+
+**1 · An installed engine reported no commit at all.**
+[`scrapex/provenance.py`](../scrapex/provenance.py)'s `seal()` returned before `HEAD` was
+read whenever the build was frozen — correctly, because a one-file `.exe` carries no
+repository — and **no stamping mechanism existed anywhere in the repository**, so
+`commit` was `None` on every published build and the panel's `Build` row rendered the bare
+words `installed build`. `engineBuildText` has always known how to draw `installed ·
+<sha7>`; the fact was simply never in the bundle.
+
+`packaging/build_engine.py` now writes `build-stamp.json` from `git rev-parse HEAD` and
+bundles it; `provenance` reads it when frozen. **It still answers `None` for every failure**
+— a bundle from before the stamp, a torn file, anything that is not a 40-character hex
+commit — because under `R-77` that string is the engine's identity and a guess there is
+worse than a blank. Eight such cases are asserted, and the honesty test that predates this
+(`a frozen build answers None and never False`) is untouched: **which code this is** and
+**whether newer code exists** are different questions, and only the second is unknowable
+from inside an `.exe`.
+
+**2 · `Protocol` was gated on the version, so retiring the version would have silenced
+it.** `engineProtocolText` opened `const installed = state.engineVersion; if (!installed)
+return "Not available"`, so an engine that had just stated protocol 1 on `/api/health` and
+carried no version would have reported *Not available* about a fact it supplied. It asks
+`state.engineUp` now — whether an engine answered — which is `R-77`'s second clause
+made structural: a compatibility boundary and a release cadence are independent facts.
+
+**3 · THE CUT IS BLOCKED OUTSIDE THIS REPOSITORY, and this is the measurement to put to
+him.** `Latest version` is not a label. It feeds `engineReleaseVerdict`, whose verdicts —
+`Update available`, `Up to date`, `Available to install` — come from
+`isOlder(installed, latest.version)`, and from those verdicts come the download button and
+the install steps. **Remove the engine's version and the comparison loses its own side**, so
+the update check has to become *is the published build's commit mine?*
+
+That needs the published side to carry a commit, and the published side is
+`mbiX-hub/ScrapeX/json/version.json` — `extension/releases.js`'s `VERSION_MANIFEST`, a
+manual manifest **in a different repository, which he publishes**. Nothing here can add a
+field to it. So:
+
+| | |
+|---|---|
+| stamp the SHA at build time | **done, this branch** |
+| un-gate `Protocol` from the version | **done, this branch** |
+| make the update check compare commits | **needs `version.json` to carry the release's commit — his repository** |
+| cut the two rows | after the above, and not before: cutting first removes his only way to install a new engine |
+
+**The decision stands and the order was the wrong part**, which is what `#293` recorded. Two
+of the four steps are now behind us.
 
 ## Track 1 · The Console migration
 

--- a/extension/app.js
+++ b/extension/app.js
@@ -3451,9 +3451,20 @@ function updateEngineStatus() {
   $("engine-state-detail").textContent = summary.detail;
 }
 
+// GATED ON WHETHER AN ENGINE ANSWERED, NOT ON WHETHER IT HAS A VERSION NUMBER.
+// It read `state.engineVersion` until 2026-09-02, which coupled this row to a number
+// `R-77` retires: "the engine gets no marketing version at all -- a protocol number
+// and a build SHA, both facts rather than judgements." Under that ruling the version
+// row goes, and with the old gate the Protocol row would have gone silent with it --
+// reporting `Not available` about a protocol the engine had just stated. The two are
+// independent facts: whether a wire is compatible has nothing to do with a release
+// cadence, which is the whole argument of `R-77`'s second clause.
+//
+// `engineUp` IS THE RIGHT QUESTION because `/api/health` is what carries the protocol,
+// and it answers only from a running engine. Reachable-but-stopped has no protocol to
+// report and correctly falls into the same branch it always did.
 function engineProtocolText() {
-  const installed = state.engineVersion;
-  if (!installed) return "Not available";
+  if (!state.engineUp) return "Not available";
   if (state.engineProtocol === null) return `Not reported · Extension expects ${PROTOCOL_VERSION}`;
   if (state.protocolMismatch) return `Engine ${state.engineProtocol} · Extension ${PROTOCOL_VERSION}`;
   return String(state.engineProtocol);

--- a/packaging/build_engine.py
+++ b/packaging/build_engine.py
@@ -22,8 +22,10 @@ NOT IMPLEMENTED HERE — stated plainly rather than stubbed:
 """
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
+from datetime import UTC, datetime
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -73,12 +75,61 @@ RUNTIME_DATA: tuple[tuple[str, str], ...] = (
 )
 
 
-def add_data_arguments() -> list[str]:
-    """`RUNTIME_DATA` as PyInstaller arguments, with the platform's separator."""
+#: Where the commit lands inside the bundle. `scrapex/provenance.py` reads this name
+#: and nothing else does -- one string, in one place, so the two cannot drift.
+STAMP_NAME = "build-stamp.json"
+
+
+def head_commit() -> str | None:
+    """The commit this build is being cut from, or `None` outside a repository.
+
+    `None` RATHER THAN A PLACEHOLDER. `R-77` chose the commit as the engine's identity
+    precisely because "it cannot be wrong"; a build that could not read one and stamped
+    `unknown` anyway would put a value that is wrong into the field whose whole claim is
+    that it never is. A bundle with no stamp reports no commit, which is what
+    `provenance` already does honestly.
+    """
+    try:
+        found = subprocess.run(["git", "-C", str(ROOT), "rev-parse", "HEAD"],
+                               capture_output=True, text=True, timeout=30, check=False)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    commit = found.stdout.strip()
+    return commit if found.returncode == 0 and len(commit) == 40 else None
+
+
+def write_build_stamp(into: Path) -> Path | None:
+    """Write the stamp beside the build, and return it, or `None` if there is nothing.
+
+    NOT IN `RUNTIME_DATA`: every entry there is a tracked path checked for existence
+    before the build, and this one is generated and belongs to a single build.
+    """
+    commit = head_commit()
+    if commit is None:
+        return None
+    into.mkdir(parents=True, exist_ok=True)
+    stamp = into / STAMP_NAME
+    stamp.write_text(json.dumps({
+        "commit": commit,
+        # THE MOMENT, RECORDED BECAUSE A CLAIM WITHOUT ITS BASE IS THE FAILURE FAMILY
+        # `provenance` was written for (`docs/LESSONS.md` section 14). Nothing reads it
+        # today; it costs one line and answers "when was this cut" without a release feed.
+        "built_at": datetime.now(UTC).isoformat(timespec="seconds"),
+    }, indent=2) + "\n", encoding="utf-8")
+    return stamp
+
+
+def add_data_arguments(stamp: Path | None = None) -> list[str]:
+    """`RUNTIME_DATA` as PyInstaller arguments, with the platform's separator.
+
+    `stamp`, when given, is added at the bundle root -- the one generated resource.
+    """
     separator = ";" if sys.platform == "win32" else ":"
     arguments: list[str] = []
     for source, destination in RUNTIME_DATA:
         arguments += ["--add-data", f"{ROOT / source}{separator}{destination}"]
+    if stamp is not None:
+        arguments += ["--add-data", f"{stamp}{separator}."]
     return arguments
 
 
@@ -96,6 +147,19 @@ def build() -> int:
         print(f"the engine reads these at runtime and they are not here: {missing}",
               file=sys.stderr)
         return 1
+    # STAMPED BEFORE THE BUILD, from the tree being built. `R-77`: the engine's
+    # identity is the commit, and an installed build had no way to report one -- so
+    # `Build` read the bare words `installed build` on the surface that exists to say
+    # which code is running. Said out loud when it cannot be read, because a build
+    # nobody can identify is worth knowing about at build time rather than in the panel.
+    stamp = write_build_stamp(ROOT / "build")
+    if stamp is None:
+        print("WARNING: no commit could be read, so this build will report none. "
+              "The engine's identity is the commit under R-77; a build cut outside a "
+              "repository cannot have one, and will not invent one.", file=sys.stderr)
+    else:
+        print(f"stamped {stamp.name} with {json.loads(stamp.read_text())['commit'][:7]}")
+
     command = [
         sys.executable, "-m", "PyInstaller",
         "--onefile", "--name", NAME,
@@ -118,7 +182,7 @@ def build() -> int:
         "--distpath", str(ROOT / "dist"),
         "--workpath", str(ROOT / "build"),
         "--specpath", str(ROOT / "build"),
-        *add_data_arguments(),
+        *add_data_arguments(stamp),
         str(ENTRY),
     ]
     print(" ".join(command))

--- a/scrapex/provenance.py
+++ b/scrapex/provenance.py
@@ -64,6 +64,8 @@ when a file has ALREADY been seen to change.
 from __future__ import annotations
 
 import hashlib
+import json
+import re
 import sys
 import time
 from datetime import UTC, datetime
@@ -209,6 +211,35 @@ def _read_head(git_dir: Path) -> str | None:
     return None
 
 
+#: What `packaging/build_engine.py` writes into the bundle. The name is declared there
+#: and repeated here rather than imported: `packaging/` is not on the path of an
+#: installed engine, and a build-time module is the wrong thing for a runtime read to
+#: depend on. `test_the_frozen_stamp_name_matches_the_builder` compares the two.
+BUNDLE_STAMP = "build-stamp.json"
+
+
+def _bundled_commit() -> str | None:
+    """The commit a frozen build was cut from, read from its own bundle.
+
+    EVERY FAILURE ANSWERS `None`. A bundle from before the stamp existed, a truncated
+    file, a value that is not a 40-character hex commit -- all of them mean "this build
+    cannot say", and that is what the field already meant. Under `R-77` this string is
+    the engine's identity, so a guess here is worse than a blank.
+    """
+    root = getattr(sys, "_MEIPASS", None)
+    if root is None:
+        return None
+    try:
+        found = json.loads((Path(root) / BUNDLE_STAMP).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    commit = found.get("commit") if isinstance(found, dict) else None
+    if not isinstance(commit, str):
+        return None
+    commit = commit.strip()
+    return commit if re.fullmatch(r"[0-9a-f]{40}", commit) else None
+
+
 class _Snapshot:
     """What the process had loaded at the moment it sealed, and when that was.
 
@@ -236,9 +267,19 @@ class _Snapshot:
         self.head = None
         self.git_dir = None
         if self.frozen:
-            # A frozen build has no source tree and no repository. Sealing it
-            # records the MODE and nothing else, so `report()` has a truthful
-            # basis for answering `None` rather than inventing a comparison.
+            # A frozen build has no source tree and no repository, so `report()`
+            # answers `None` to every comparison rather than inventing one.
+            #
+            # IT DOES CARRY ITS OWN IDENTITY, THOUGH, AND USED NOT TO. `R-77` made the
+            # commit the engine's identity -- "it is free, it cannot be wrong, and it
+            # needs no rule" -- and this branch returned before `head` was ever set, so
+            # an installed engine reported no commit at all and the panel's `Build` row
+            # read the bare words `installed build`. `packaging/build_engine.py` puts the
+            # commit in the bundle; this reads it. Still `None` when the bundle has none,
+            # which is the honesty `test_a_frozen_build_answers_unknown_and_never_false`
+            # protects: the comparison is unknowable, the identity is a fact, and the two
+            # are different questions.
+            self.head = _bundled_commit()
             return
         self.git_dir = _git_dir(_package_root())
         if self.git_dir is not None:

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -4522,6 +4522,34 @@ def test_the_engine_page_says_not_detected_when_unreachable(open_panel):
     assert text_of(page, "#engine-protocol-row") == "Not available"
 
 
+def test_the_protocol_row_does_not_depend_on_the_engine_having_a_version(open_panel):
+    """`R-77` RETIRES THE ENGINE'S VERSION AND KEEPS ITS PROTOCOL, so one row must not
+    be able to silence the other.
+
+    `engineProtocolText` opened with `const installed = state.engineVersion; if
+    (!installed) return "Not available"` -- so an engine that stated protocol 1 on
+    `/api/health` and carried no version number would have had its Protocol row read
+    *Not available* about a fact it had just supplied. That is not hypothetical: the
+    ruling's third clause is that the engine gets no marketing version at all, and the
+    two version rows on this page are going, so this row's gate had to stop being one of
+    them first.
+
+    The engine here is UP and reports an empty version, which is exactly the state the
+    ruling creates. The row must show the protocol.
+    """
+    page = open_panel(engine_version="")
+    page.click("#tab-engines")
+    page.wait_for_function(
+        "() => document.getElementById('engine-status-region').getAttribute('aria-busy') === 'false'",
+        timeout=10_000)
+
+    open_engine(page)
+    assert text_of(page, "#engine-protocol-row") == str(PROTOCOL), (
+        "an engine with no version number reported no protocol either, so the two "
+        "facts are still coupled: "
+        + text_of(page, "#engine-protocol-row"))
+
+
 def test_the_engine_status_uses_a_single_live_region(open_panel):
     """Status changes are announced once through a polite live region, and the
     region exposes busy while the engine and release feed are being checked."""

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -265,7 +265,7 @@ PINNED = (
     # than being loosened to keep passing — the same call `OP-36` records above.
     # `return ""` for a dataset is what OP-42 was about; the pin follows the
     # argument to the filter that replaced it.
-    ("docs/BACKLOG.md", "extension/app.js", 4742,
+    ("docs/BACKLOG.md", "extension/app.js", 4753,
      "SOURCE_ACTIONS.filter((item) => item.proof === RESOLVES_A_DATASET)"),
     ("docs/BACKLOG.md", "scrapex/webui/app.py", 742, '"kind": "dataset",'),
     # 2710 -> 2725 -> 2787 -> 2911, and the fourth move is the same story as the
@@ -294,7 +294,7 @@ PINNED = (
     # The sentence itself, so it is clear the card reads a MISSING key and not a
     # missing crawl -- which is why writing a `crawl_run` row would not have moved
     # this line at all.
-    ("docs/BACKLOG.md", "extension/app.js", 4629, "const last = s.last_success;"),
+    ("docs/BACKLOG.md", "extension/app.js", 4642, "const last = s.last_success;"),
     # Why the row could not honestly be written: the column is NOT NULL into
     # source_site, and muqawil is in source_site.
     ("docs/BACKLOG.md", "db/engine/schema.sql", 122,

--- a/tests/test_the_engine_knows_which_code_it_is_running.py
+++ b/tests/test_the_engine_knows_which_code_it_is_running.py
@@ -51,6 +51,7 @@ compare itself to a source tree it does not carry.
 from __future__ import annotations
 
 import hashlib
+import json
 import subprocess
 import sys
 import types
@@ -279,6 +280,193 @@ def test_a_frozen_build_answers_unknown_and_never_false(monkeypatch):
     assert report["moved"] is None
     assert report["commit_now"] is None
     assert "cannot be answered" in report["detail"]
+
+
+def _recipe():
+    """`packaging/build_engine.py`, which is not importable as a package.
+
+    THE SAME LOADER `test_the_frozen_engine_carries_its_own_files.py` USES, and for the
+    same reason: the build recipe is a script, and a guard that re-implemented what it
+    says would be asserting against its own copy.
+    """
+    import importlib.util
+
+    recipe = ROOT / "packaging" / "build_engine.py"
+    assert recipe.is_file(), f"{recipe} is gone; this guard must follow it"
+    spec = importlib.util.spec_from_file_location("scrapex_build_recipe", recipe)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _frozen_bundle(monkeypatch, tmp_path: Path, stamp: str | None) -> dict:
+    """Seal as an installed build whose bundle holds `stamp`, and report."""
+    monkeypatch.setattr(provenance.enginelaunch, "frozen", lambda: True)
+    monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path), raising=False)
+    if stamp is not None:
+        (tmp_path / provenance.BUNDLE_STAMP).write_text(stamp, encoding="utf-8")
+    provenance._SNAPSHOT = provenance._Snapshot()
+    provenance.seal()
+    return provenance.report()
+
+
+def test_a_frozen_build_reports_the_commit_its_bundle_carries(monkeypatch, tmp_path):
+    """`R-77` MADE THE COMMIT THE ENGINE'S IDENTITY, AND AN INSTALLED ONE HAD NONE.
+
+    The ruling's first clause is that identity is the commit rather than a number --
+    "it is free, it cannot be wrong, and it needs no rule". But `seal()` returned before
+    `head` was read whenever the build was frozen, and nothing in the repository stamped
+    a commit anywhere, so every installed engine answered `commit: None` and the panel's
+    Build row rendered the bare words `installed build`. `engineBuildText` has always
+    known how to draw `installed - <sha7>`; the fact was simply never in the bundle.
+
+    AND THE IDENTITY IS A DIFFERENT QUESTION FROM THE COMPARISON, which is why the
+    honesty assertions below still hold here: this build now says WHICH code it is and
+    still refuses to say whether newer code exists, because it carries no source tree
+    to compare against and never will.
+    """
+    commit = "b" * 40
+    report = _frozen_bundle(monkeypatch, tmp_path,
+                            json.dumps({"commit": commit, "built_at": "2026-09-02"}))
+
+    assert report["mode"] == "frozen"
+    assert report["commit"] == commit, "the bundle carried its commit and it was not read"
+    assert report["stale"] is None, "reading a commit taught it something it cannot know"
+    assert report["moved"] is None
+    assert report["commit_now"] is None
+
+
+@pytest.mark.parametrize("stamp", [
+    None,                                   # a bundle from before the stamp existed
+    "",                                     # a truncated write
+    "{",                                    # a torn one
+    '{"commit": null}',
+    '{"commit": ""}',
+    '{"commit": "abc123"}',                 # short
+    '{"commit": "' + "z" * 40 + '"}',       # 40 characters, not hex
+    '{"commit": ' + '["' + "a" * 40 + '"]}',  # the right value, wrong shape
+    '["' + "a" * 40 + '"]',                 # not an object at all
+])
+def test_a_frozen_build_invents_no_commit_it_cannot_read(monkeypatch, tmp_path, stamp):
+    """EVERY FAILURE IS A BLANK, NEVER A PLACEHOLDER, and there are eight of them.
+
+    Under `R-77` this string is the engine's identity, so `unknown` or a truncated hash
+    in that field is worse than an empty one: the field's whole claim is that it cannot
+    be wrong. An engine installed before the stamp existed is the common case and is not
+    an error -- it is a build that cannot say, which is what the field already meant.
+    """
+    report = _frozen_bundle(monkeypatch, tmp_path, stamp)
+
+    assert report["mode"] == "frozen"
+    assert report["commit"] is None, (
+        f"a stamp reading {stamp!r} produced {report['commit']!r} as this engine's "
+        "identity")
+    assert "cannot be answered" in report["detail"]
+
+
+def test_a_source_build_reads_head_and_not_a_bundle(monkeypatch, tmp_path):
+    """THE STAMP MUST NOT REACH THE PATH THAT ALREADY HAD AN ANSWER.
+
+    A source checkout reads `HEAD` from the repository, which is exact and live. If a
+    stray `_MEIPASS` or a stamp file could influence it, the honest path would start
+    answering from a stale artefact -- and `moved` compares `head` at seal against `HEAD`
+    now, so a wrong `head` reports a checkout that moved when it did not.
+    """
+    (tmp_path / provenance.BUNDLE_STAMP).write_text(
+        json.dumps({"commit": "c" * 40}), encoding="utf-8")
+    monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path), raising=False)
+    provenance._SNAPSHOT = provenance._Snapshot()
+    provenance.seal()
+
+    report = provenance.report()
+
+    assert report["mode"] == "source"
+    assert report["commit"] != "c" * 40, (
+        "a source build took its identity from a bundle stamp instead of HEAD")
+
+
+def test_the_stamp_name_is_one_string_and_not_two():
+    """WRITTEN BY THE BUILD, READ BY THE RUNTIME, AND THE TWO CANNOT BE IMPORTED
+    TOGETHER: `packaging/` is not on the path of an installed engine, so `provenance`
+    repeats the name rather than importing it. This is what stops the repetition from
+    becoming a drift -- the same failure `RUNTIME_DATA`'s own comment records about
+    `pyproject.toml` carrying the same fact twice with nothing comparing them."""
+    assert _recipe().STAMP_NAME == provenance.BUNDLE_STAMP
+
+
+def test_the_builder_stamps_the_commit_it_is_building(tmp_path):
+    """A STAMP IS ONLY WORTH ANYTHING IF IT IS THIS TREE'S COMMIT.
+
+    Asserted against `git rev-parse HEAD` run separately, so a builder that wrote a
+    constant, an abbreviated hash, or the wrong repository's head fails here rather
+    than shipping an engine that misidentifies itself.
+    """
+    recipe = _recipe()
+    stamp = recipe.write_build_stamp(tmp_path / "build")
+
+    head = subprocess.run(["git", "-C", str(ROOT), "rev-parse", "HEAD"],
+                          capture_output=True, text=True, check=True).stdout.strip()
+    assert stamp is not None, "the recipe read no commit inside a repository"
+    assert stamp.name == provenance.BUNDLE_STAMP
+    written = json.loads(stamp.read_text(encoding="utf-8"))
+    assert written["commit"] == head, (
+        f"stamped {written['commit']!r} for a tree whose HEAD is {head!r}")
+    assert written["built_at"], "the stamp carries no moment, so its claim has no base"
+
+
+def test_the_stamp_rides_along_in_the_bundle(tmp_path):
+    """A RESOURCE ABSENT FROM THE BUNDLE IS DISCOVERED BY A PERSON, ON THEIR MACHINE.
+
+    That sentence is `RUNTIME_DATA`'s own, earned by a published build that started,
+    prepared a database and could not serve one page. The stamp cannot join that list --
+    every entry there is a tracked path checked for existence before the build, and this
+    one is generated per build -- so it is added separately, and this is what says the
+    separate path is wired.
+    """
+    recipe = _recipe()
+    stamp = recipe.write_build_stamp(tmp_path / "build")
+    arguments = recipe.add_data_arguments(stamp)
+
+    separator = ";" if sys.platform == "win32" else ":"
+    assert f"{stamp}{separator}." in arguments, (
+        "the stamp was written and not handed to PyInstaller, so the .exe carries "
+        f"no commit: {arguments[-4:]}")
+    # AND IT IS ABSENT WHEN THERE IS NOTHING TO ADD, rather than passed as an empty
+    # argument PyInstaller would reject.
+    assert recipe.add_data_arguments(None) == recipe.add_data_arguments()
+
+
+def test_the_build_ITSELF_passes_the_stamp_and_not_only_the_helper(monkeypatch):
+    """ASSERTING THE HELPER WAS NOT ENOUGH, AND A MUTATION PROVED IT.
+
+    `test_the_stamp_rides_along_in_the_bundle` calls `add_data_arguments(stamp)` itself,
+    so it says the function can carry a stamp and nothing about whether `build()` hands
+    it one. Changing `build()` back to `add_data_arguments()` -- the exact defect, an
+    engine stamped on disk and shipped without it -- left that test GREEN.
+
+    So this reads the command `build()` actually assembles. `subprocess.call` is replaced
+    rather than the build run: PyInstaller takes ten minutes and is not installed in
+    every environment, and what is under test is the argument list, which is complete
+    before the call.
+    """
+    recipe = _recipe()
+    seen: list[list[str]] = []
+    monkeypatch.setattr(recipe.subprocess, "call",
+                        lambda command, *a, **k: seen.append(command) or 0)
+
+    assert recipe.build() == 0
+    assert seen, "build() assembled no command at all"
+    command = seen[0]
+
+    stamped = [argument for argument in command if recipe.STAMP_NAME in argument]
+    assert stamped, (
+        "build() never handed the stamp to PyInstaller, so the .exe it produces "
+        "reports no commit and its Build row reads `installed build` -- which is the "
+        f"whole defect this branch exists for. Command tail: {command[-6:]}")
+    separator = ";" if sys.platform == "win32" else ":"
+    assert all(one.endswith(f"{separator}.") for one in stamped), (
+        f"the stamp is bundled somewhere other than the root, where `provenance` "
+        f"reads it: {stamped}")
 
 
 def test_an_engine_that_never_sealed_says_it_does_not_know(monkeypatch):


### PR DESCRIPTION
`R-77` split one number into three questions and answered each with an architecture:
identity is the **commit**, compatibility is a **protocol number**, and the product version
is the **extension's alone**. Measured against the code, the first was never built and the
second was coupled to the thing being retired. Both are built here.

**The third — cutting the two version rows — leaves this repository, and that is why this
branch stops.** It is not a decision left open; it is a step that cannot be taken from
here, and the measurement is below.

## 1 · An installed engine reported no commit at all

`R-77`'s first clause is that identity is the commit rather than a number — *"it is free,
it cannot be wrong, and it needs no rule"*, and it is what kills the question *"does this
pull request deserve a bump?"* outright.

`provenance._Snapshot.seal()` returned before `HEAD` was read whenever the build was
frozen. That is correct on its own terms — a one-file `.exe` carries no repository — but
**no stamping mechanism existed anywhere in the repository**, so `commit` was `None` on
every published build and the panel's `Build` row rendered the bare words `installed
build`. `engineBuildText` has always known how to draw `installed · <sha7>`; the fact was
simply never in the bundle.

`packaging/build_engine.py` now writes `build-stamp.json` from `git rev-parse HEAD` and
bundles it at the root; `provenance` reads it when frozen. **Not in `RUNTIME_DATA`** —
every entry there is a tracked path checked for existence before the build, and this one is
generated per build, so it is added separately and a test asserts the separate path is
wired.

### It invents nothing, and that is asserted eight ways

No stamp · a truncated write · a torn file · `null` · empty · short · forty non-hex
characters · the right value in the wrong shape. **Every one answers `None`.** Under
`R-77` that string *is* the engine's identity, so a placeholder there is worse than a
blank, and an engine installed before the stamp existed is the common case rather than an
error — it is a build that cannot say, which is what the field already meant.

The honesty test that predates this — *a frozen build answers `None` and never `False`* —
is untouched. **Which code this is** and **whether newer code exists** are different
questions, and only the second is unknowable from inside an `.exe`.

### And asserting the helper was not enough

The first guard called `add_data_arguments(stamp)` itself, so it said the function *can*
carry a stamp and nothing about whether `build()` hands it one. Changing `build()` back to
`add_data_arguments()` — an engine stamped on disk and shipped without it, the whole defect
— left that test **green**. The replacement reads the command `build()` actually assembles,
with `subprocess.call` replaced rather than PyInstaller run: the argument list is complete
before the call, and PyInstaller takes ten minutes and is not installed everywhere.

## 2 · Protocol was gated on the version, so retiring the version would have silenced it

    function engineProtocolText() {
      const installed = state.engineVersion;
      if (!installed) return "Not available";

An engine that had just stated protocol 1 on `/api/health` and carried no version number
would have had this row read *Not available* about a fact it supplied. It asks
`state.engineUp` now — whether an engine answered — which is `R-77`'s second clause made
structural: a compatibility boundary and a release cadence are independent facts, and
`/api/health` is what carries the protocol, so reachable-but-stopped correctly falls into
the same branch it always did.

Guarded by an engine that is **up** and reports an empty version — exactly the state the
ruling creates — and mutation-checked by restoring the old gate.

## 3 · Why the cut is not here

`Latest version` is not a label. It feeds `engineReleaseVerdict`, whose verdicts — `Update
available`, `Up to date`, `Available to install` — come from `isOlder(installed,
latest.version)`, and from those verdicts come the download button and the install steps.
**Remove the engine's version and the comparison loses its own side**, so the update check
has to become *is the published build's commit mine?*

That needs the published side to carry a commit, and the published side is
`mbiX-hub/ScrapeX/json/version.json` — `extension/releases.js`'s `VERSION_MANIFEST`, a
manual manifest **in a different repository, which the owner publishes**. Nothing here can
add a field to it.

| step | state |
|---|---|
| stamp the SHA at build time | **done, this branch** |
| un-gate `Protocol` from the version | **done, this branch** |
| make the update check compare commits | needs `version.json` to carry the release's commit — his repository |
| cut the two rows | after the above, and not before: cutting first removes his only way to install a new engine |

**The decision stands and the order was the wrong part**, which is what `#293` recorded.
Two of the four steps are now behind us. `R-77` and `docs/STATE.md` carry the table.

## Verification

- Both run modes green, per [LESSONS §24](docs/LESSONS.md) — head recorded before and after
  and unmoved. Re-verified after the rebase onto `80659faa`: docs suite, `ruff check
  scrapex/`, and the provenance suite.
- `eslint` over the extension, exactly as CI invokes it — clean.
- **Three mutations, each restored:** a placeholder instead of a blank (reddens three of
  the eight honesty cases); `build()` dropping the stamp (which is how the vacuous first
  guard was found); and the old `engineVersion` gate on Protocol.
- Two `PINNED` citations into `extension/app.js` moved by the comment block this branch
  adds, re-derived by content — each subject confirmed unique in the file before its number
  was changed.
