### PR TITLE
One migration plan, not two, and the baseline declares its own version (OP-122, R-84)

### DIFF
--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -142,9 +142,22 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # THE BASELINE COUNTS, AND IT USED NOT TO. This read migration FILENAMES
+          # only, so a commit whose schema lives in db/engine/schema.sql and whose
+          # migrations folder is empty measured as carrying no schema at all -- and
+          # the `${here:?...}` line below then aborted the release saying that
+          # "cannot be right". It can be right: it is exactly what a squashed
+          # baseline looks like, and this gate would have refused to cut any release
+          # after one. The version a file DECLARES is the number SQLite obeys, so
+          # both sources are read into one sort and the higher wins. Verified against
+          # HEAD, origin/main and 42ef0680: all three answer 16, as before.
           ceiling() {
-            git ls-tree --name-only "$1" db/engine/migrations/ 2>/dev/null \
-              | sed -n 's|.*/0*\([0-9][0-9]*\)_.*|\1|p' | sort -n | tail -1
+            {
+              git show "$1:db/engine/schema.sql" 2>/dev/null \
+                | sed -n 's|^[[:space:]]*PRAGMA[[:space:]]\{1,\}user_version[[:space:]]*=[[:space:]]*\([0-9]\{1,\}\).*|\1|p'
+              git ls-tree --name-only "$1" db/engine/migrations/ 2>/dev/null \
+                | sed -n 's|.*/0*\([0-9][0-9]*\)_.*|\1|p'
+            } | sort -n | tail -1
           }
           # fetch-depth: 0 above gives full history for THIS ref only; the other
           # branches still have to be asked for. Blob-less keeps it to seconds.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -4447,6 +4447,95 @@ instance in this branch, the first found by a guard written in the same commit. 
 now name that route by description and never by path, and say why in one line so the next
 writer does not spend the minute.
 
+### OP-122 · Two builders resolved the migration plan, and the baseline's version was a literal in both
+
+**Found 2026-09-02**, pricing `REQ-52`'s baseline squash. The squash is not what
+makes these defects; it is what makes them visible, and each one is wrong today.
+
+**ONE FACT, THREE COPIES, AND ONLY ONE OF THEM IS OBEYED.** The engine's baseline
+version was written as the literal `1` in
+[`scrapex/db.py`](../scrapex/db.py) `_migration_files`, again in
+[`scrapex/databases/domain.py`](../scrapex/databases/domain.py) `_engine_plan`, and a
+third time in `db/engine/schema.sql` as `PRAGMA user_version = 1`. **Only the SQL one
+is the number SQLite obeys.** The other two were assertions about it that nothing
+checked.
+
+**That is not a tidiness argument.** `latest_schema_version()` derives from those
+literals and flows into [`scrapex/storage.py:409`](../scrapex/storage.py#L409) →
+`health()`, which decides whether a database is too new for this engine to open. A
+stale copy does not merely disagree — it tells the owner his warehouse *"was written
+by a later version; update ScrapeX and do not downgrade the database"* about a
+warehouse this build wrote.
+
+**AND TWO SEPARATE BUILDERS WALKED THE SAME FOLDER**, agreeing only by coincidence
+and not even equivalent: `db`'s raises on a file in `db/engine/migrations/` that does
+not match `NNNN_name.sql`; `domain`'s globbed silently past it. **The coincidence was
+already load-bearing** — `tests/conftest.py` `_stream_fingerprint` decides whether a
+cached migrated database may be reused by resolving `db`'s builder, while the
+migration that filled that cache ran through `domain`'s. Two lists, one cache key.
+
+**`.githooks/pre-push` had already reached this conclusion** and says so in a comment:
+it asks `scrapex database-status` rather than reading `PRAGMA user_version` itself,
+because that *"keeps one owner for the comparison"*. This entry is that rule applied
+to the two places that had not got it.
+
+**Fixed here:**
+
+| | |
+|---|---|
+| `db._migration_files` is the only builder | `domain._engine_plan` wraps it; `_folder_migrations` is deleted. The direction is forced, not chosen — `domain` already imports `db`, so the shared code has to live there |
+| `declared_schema_version()` reads the version from the file that declares it | and requires **exactly one** `PRAGMA user_version`, because seven of the fifteen shipped migrations declare none at all and are silently corrected by the runner, so "take the last match" would read a number out of a file that never set one |
+| the plan must be **contiguous from the baseline's own version**, not gapless from 1 | "starts at 1" was true of the stream that existed when the rule was written. The half that matters — no MISSING migration between two present ones — is kept, and the floor stays 1 because `PRAGMA user_version` is 0 on a database nobody has migrated |
+| `release-engine.yml` `ceiling()` reads the baseline too | it measured schema level from migration FILENAMES, so a commit whose schema lives in the baseline with an empty folder measured as carrying **no schema at all** — and the `${here:?...}` line then aborted the release saying that "cannot be right". **No release could have been cut after a squash**, by the gate whose purpose is preventing migration loss |
+
+**Two assertions were only coincidentally true and now hold against the baseline**:
+`tests/test_db.py`'s `first == list(range(1, latest + 1))` and
+`latest_schema_version() == len(_migration_files())`. Both were right *because* the
+baseline declares 1, and both would have gone FALSE on a correct chain the moment it
+declared anything else — a guard moving in the worst direction.
+
+**PROVED BY MUTATION, five defects injected one at a time**, each caught by the one
+guard written for it and by no other:
+
+```
+CAUGHT  domain builds its own plan again          -> test_the_engine_plan_follows_the_one_builder
+CAUGHT  the baseline's number is the literal 1    -> test_a_migration_numbered_at_or_below_the_baseline_is_refused
+CAUGHT  gapless-from-1 is restored                -> test_a_plan_that_starts_above_one_is_accepted
+CAUGHT  the contiguity check is dropped           -> test_a_hole_in_the_plan_is_still_refused
+CAUGHT  the version reader takes the last match   -> test_the_declared_version_must_be_stated_exactly_once
+```
+
+`tests/test_one_migration_plan_not_two.py` holds all five. Its version reader is
+written a **second** way — walking lines and splitting on `=`, sharing no code with
+the subject — because the failure here is a fact asserted twice where only one copy is
+obeyed, and a guard that calls the implementation it checks reproduces that failure
+instead of catching it.
+
+**DELIBERATELY NOT IN THIS CHANGE.** `scrapex/contractstamp.py:43` builds the schema
+half of the contract fingerprint from the migrations folder **only** — it never reads
+`db/engine/schema.sql` — so a change to the file that defines the whole shape for
+every fresh install is invisible to the version gate. The fix is written and held
+back, because putting the baseline into the fingerprint MOVES the fingerprint
+(measured: `added: ["schema.sql v1"]`, nothing removed), and the gate's only sanctioned
+answer is a `VERSION` bump. `REQ-52`'s squash needs that bump anyway. **One bump, in
+the change that genuinely warrants it, rather than two.** The hole's reach is narrow
+meanwhile: editing the baseline's content cannot ship quietly, because every existing
+warehouse holds its digest in the ledger and refuses to open when it moves.
+
+**AND ONE THING THIS CHANGE TRIPPED OVER, WORTH ITS OWN NUMBER IF THE PRIMARY AGREES.**
+Inserting thirteen lines into `ceiling()` moved a Tier-2 pinned citation from
+`release-engine.yml:540` to `:553`, which is a legitimate repoint — the symbol still
+exists and the row's job is to sit beside it. But the row's OTHER side is gone:
+`grep -n "release-engine.yml[#:]"` over every document in the map returns **nothing**,
+so no document cites that file at any line. The row therefore asserts that the workflow
+still holds `"version": VERSION` — true, and worth asserting — while claiming to be a
+citation guard, and **nothing can tell the difference, because no test checks that a
+pinned row's DOCUMENT still cites it.** It also counts toward `PINNED_FLOOR`, so a row
+that has stopped being a citation still holds the floor up. Left in place and repointed
+rather than deleted, because deleting rows is precisely what that floor refuses. **Same
+shape as everything else found this week: a guard comparing one side of a pair whose
+other side had quietly left.**
+
 ### DEC-1 · Topology A — the TypeScript extension as the public product
 **Approved 2026-07-18. Zero commits since.** This is the largest gap between what was
 decided and what exists.

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -3557,3 +3557,100 @@ The repair changes code before it changes the warehouse. The running Organizatio
 Enrichment job has an immutable input snapshot and cannot see a later re-approval. Apply the
 eight recovered profiles after that job finishes, then run the update enrichment so only the
 newly available profile facts enter the next snapshot.
+
+### R-84 · The base changes now — and at publication no migration is ever deleted again
+
+**2026-09-02 · architecture. It governs the migration CHAIN, and it does not touch
+`R-24`, which governs the DATA.**
+
+> «قواعد البيانات يتم ترقيتها ولكن base يتغير الان بحيث اننى لا اريد الاحتفاظ
+> بترحيلات كثيرة لا يستخدمها احد اكيد عند نشر الاداة ساريد الحفاظ على كافة الترحيلات
+> لانها ستكون مهمة للمستخدمين حيث غير محدد اى مستخدم توقف عنده هذه النسخة ولكن قبل
+> الاصدار لا اريد اراكم الكود باختبارات وترحيلات لن تستخدم سوى مرة واحدة وهى لى»
+
+and, earlier the same day, the sentence this refines:
+
+> «قاعدة تحت v16 لا تُرقّى — تُحمَل أو تُبنى من جديد»
+
+**PROVENANCE, because `C3` asks for HIS words and these two sentences reached two
+different sessions.** Neither is second-hand: each was given by him directly, to
+whichever session was in front of him at the time.
+
+| the sentence | received directly by |
+|---|---|
+| «قاعدة تحت v16 لا تُرقّى — تُحمَل أو تُبنى من جديد» | the session that built `OP-120`-`OP-123`, in its own conversation |
+| «قواعد البيانات يتم ترقيتها ولكن base يتغير الان …» | the **primary** session, in its own conversation, then passed on character-for-character |
+
+**The distinction is not pedantry.** *"A session was told he said this"* and *"the
+session he said it to wrote it down"* are different claims, and only the second
+supports a ruling. Both here are the second. Recorded in the repository rather than
+left in either conversation, which is the whole of `C7` — and the reason two sessions
+had to compare notes to assemble one ruling is `ORCHESTRATION.md`'s subject, not a
+defect in either.
+
+**IT SUPERSEDES NOTHING, AND THE LINE WAS ALREADY IN `R-24`.** Read `R-24`'s own
+quotation again — *«طبعا الافضل تطويرها لان **عند نشر الاداة** المفروض نحافظ على بيانات
+المستخدمين»*. **The publication boundary was in that ruling from the day it was made.**
+What nobody had done was apply it to the migration CHAIN rather than to the DATA. He
+reaffirms the data half in this ruling's first clause: *«قواعد البيانات يتم ترقيتها»*.
+
+| | |
+|---|---|
+| [`R-24`](#r-24--a-database-is-upgraded-never-replaced--the-users-data-survives-the-schema) protects **the data** | a database is upgraded, never replaced. **Untouched, and restated by him here** |
+| **`R-84`** governs **the baseline** | before publication the chain is not a user-facing asset and may be collapsed. After it, **no migration is ever deleted** |
+
+**AND A CORRECTION IS RECORDED HERE UNDER `C5`, because a session reported a conflict
+that does not exist.** It read `R-24` as forbidding this and said so — *"a carry-over or
+migration that refuses on real data is a release blocker"* and *"`init-db` is for an
+installation with nothing to lose"*. **Those sentences are the ruling's ELABORATION,
+written by a session, and they are stated unconditionally where his words were
+publication-scoped.** The collision was between his ruling and its own commentary, not
+between two of his rulings. Left standing in `R-24` rather than edited, because the
+elaboration is right about the world it describes — the published one — and rewriting
+it would hide that the distinction had to be found. `C4`'s reasoning applies to a gloss
+as much as to a ruling: a corrected text inherited by the next session teaches nobody
+that the mistake was available.
+
+**AND THE GENERAL SHAPE, because it is not about these two rulings.** **An elaboration
+under a ruling is not the ruling — and one written without the ruling's scope reads as
+a stronger rule than the owner gave.** Every ruling here is his words plus a session's
+working-out of them, and the working-out is the part that gets quoted later, because it
+is in English and in bullet points. `R-24`'s gloss dropped «عند نشر الاداة» and became
+an unconditional release blocker; two sessions then read it as his. **So a sentence in
+an elaboration that constrains future work must carry the scope its quotation carried**,
+or it will be obeyed further than it was meant. Three of the failures found on
+2026-09-02 were prose disagreeing with a mechanism; this one is prose disagreeing with
+the prose above it, which nothing guards at all.
+
+**«تُحمَل» DOES NOT NEED IMPLEMENTING, and that was the blocker.** His warehouse was
+measured read-only at `PRAGMA user_version = 16` — the head of the chain. **A baseline
+squashed at the head replays nothing over it**: there is no upgrade for it to take, so
+there is no carry-over to write and no rebuild to perform. The path that does not exist
+for an engine database — `carry_over` reads the two pre-M5 files and never an engine
+one, `warehousemerge` is evidence-only by its own docstring — is a path this ruling
+never asks for.
+
+**THE PRICE, RECORDED AS A WAIVER AND NOT AS A MEASUREMENT.** The squash removes the
+upgrade path for any database below the new baseline. His primary machine is at the
+head and unaffected. **The second machine's version is unknown and was never
+measured** — he said *«لا اكترث لجهازى الثانى الان»*, and that is a waiver. **If that
+warehouse is below the baseline, this change strands it**, and he accepted that on
+2026-09-02 without its version being known. Written down because `C5` is satisfied by
+recording missing evidence, not by treating a waiver as a finding.
+
+**WHAT MUST BE BUILT BECAUSE OF THIS RULING, and it is not the squash.** He says the
+rule INVERTS at publication: every migration kept forever, *«حيث غير محدد اى مستخدم
+توقف عنده هذه النسخة»*. **A rule that lives only in prose is the failure this
+repository keeps recording** — `R-07` ordered something removed on 2026-08-16 and
+thirteen days of sessions read past it. So the squash lands with a check that refuses
+to delete a migration once a release marker exists. That is the difference between
+this ruling holding and this ruling being remembered.
+
+**AND IT COVERS TESTS, WHICH IS EASY TO MISS IN HIS SENTENCE:** *«لا اريد اراكم الكود
+باختبارات وترحيلات لن تستخدم سوى مرة واحدة»* — **tests too**. A test that exists only
+to exercise a one-off migration is the same debt. **Two of them are not**, and the
+distinction has to be made per file rather than by name: a test named for a migration
+often asserts a PROPERTY of the resulting schema and is then the only thing checking
+it; and `tests/test_migration_drift.py` must survive regardless, because proving that
+an upgraded database equals a fresh build is the entire claim a new baseline makes.
+

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -595,6 +595,35 @@ advice: `test_the_reservation_table_has_no_shadowed_rows` reads the source with 
 monkeypatches `_pairs` and its stub predated the `ids` keyword, so `approve` raised
 `TypeError` — the first thing to exercise the keyword at all. The stub records what it was
 handed rather than swallowing it, and the test now asserts the forward.
+### One migration plan, not two — 2026-09-02 · branch `claude/one-migration-plan-not-two`, no PR yet
+
+**`OP-122` and [`R-84`](RULINGS.md#r-84--the-base-changes-now--and-at-publication-no-migration-is-ever-deleted-again).**
+Rebased onto `main` at `43f6ae50`. Secondary session;
+`recursing-shannon-068e63` merges
+([R-42](RULINGS.md#r-42--one-primary-session-merges-every-other-session-is-secondary-and-asks)).
+Fifth in the primary's fixed queue, behind `OP-120`.
+
+**Stage 1 of `REQ-52`'s squash, and correct with or without it.** Two builders resolved
+the engine migration plan and the baseline's version was a literal in both, while the
+only copy SQLite obeys is the `PRAGMA user_version` inside `db/engine/schema.sql`.
+`latest_schema_version()` derives from those literals and reaches `health()`, which is
+what tells the owner a warehouse is too new to open. Read `OP-122` in
+[BACKLOG.md](BACKLOG.md) before touching the migration framework.
+
+**HE HAS RULED AND THE SQUASH IS UNBLOCKED — `R-84`, carried by this branch.** The
+base may be collapsed before publication; after it, no migration is ever deleted. It
+supersedes nothing: `R-24`'s own words already scoped the data guarantee to *«عند نشر
+الاداة»*, and he restates that guarantee in this ruling's first clause. **And it
+dissolves the blocker rather than answering it** — his warehouse is at the head of the
+chain, so a baseline squashed there replays nothing over it and no carry-over path
+needs writing.
+
+**Stage 2, the squash itself, is priced and NOT built.** See `OP-122`'s closing
+paragraph for the one piece deliberately held back, `OP-120` for the shipped migration
+defect the squash absorbs, and `R-84` for the two things it must carry: a check that
+refuses to delete a migration once a release marker exists, and the separation of
+tests that exercise a one-off migration from tests that assert a property of the
+resulting schema.
 
 ## Track 1 · The Console migration
 

--- a/scrapex/databases/domain.py
+++ b/scrapex/databases/domain.py
@@ -149,16 +149,15 @@ def _sqlite_connect(path: Path, *, create: bool) -> sqlite3.Connection:
     return conn
 
 
-def _folder_migrations(folder: Path, start: int = 2) -> list[Migration]:
-    if not folder.is_dir():
-        return []
-    result: list[Migration] = []
-    for path in sorted(folder.glob("[0-9][0-9][0-9][0-9]_*.sql")):
-        number = int(path.name[:4])
-        if number < start:
-            continue
-        result.append(Migration(number, path))
-    return result
+# `_folder_migrations` STOOD HERE AND IS GONE (2026-09-02). It walked
+# `db/engine/migrations/` and built a plan, and `db._migration_files` walked the
+# same folder and built the same plan -- separately written, agreeing only by
+# coincidence, and not even equivalent: `db`'s raises on a file that does not
+# match `NNNN_name.sql` and this one globbed silently past it.
+#
+# `_engine_plan` now wraps `db._migration_files`, so there is one builder. The
+# direction is forced rather than chosen: this module already imports `db`, so the
+# shared code has to live there.
 
 
 # `_MARKETLENS_LEGACY_NUMBERS` AND `_IDENTITY_POSITION` STOOD HERE AND ARE GONE
@@ -188,9 +187,22 @@ class DomainDatabase(Generic[T]):
         self.path = Path(path)
         self._migrations = migrations
         numbers = [item.number for item in migrations]
-        if numbers != list(range(1, len(numbers) + 1)):
+        # CONTIGUOUS FROM THE BASELINE'S OWN VERSION, not from 1. What this rule
+        # protects is that no migration is MISSING between two that are present --
+        # a hole means a database can reach a version this build cannot explain.
+        # "Starts at 1" was never part of that; it was true of the stream that
+        # happened to exist when the rule was written, and it is the half that a
+        # squashed baseline gives up while keeping the half that matters.
+        #
+        # The floor is still 1, because `PRAGMA user_version` is 0 on a database
+        # that has never been migrated and a plan numbered from 0 could not tell
+        # "never touched" from "already at the baseline".
+        first = numbers[0] if numbers else 0
+        if not numbers or first < 1 or \
+                numbers != list(range(first, first + len(numbers))):
             raise DatabaseMigrationError(
-                f"{self.kind} migrations must be gapless from 1, got {numbers}"
+                f"{self.kind} migrations must be contiguous from the baseline's own "
+                f"version and start at 1 or above, got {numbers}"
             )
 
     @property
@@ -617,8 +629,18 @@ class DomainDatabase(Generic[T]):
 
 
 def _engine_plan() -> tuple[Migration, ...]:
-    """One stream: the derived schema at v1, then the folder beside it."""
-    return (Migration(1, ENGINE_SCHEMA), *_folder_migrations(ENGINE_MIGRATIONS))
+    """One stream, and one builder for it: `db._migration_files` resolves the plan,
+    this wraps it in the typed objects this module works with.
+
+    THE BASELINE'S NUMBER IS NO LONGER THE LITERAL 1. It is whatever
+    `db/engine/schema.sql` declares in its own `PRAGMA user_version`, which is the
+    only copy of that number SQLite obeys. Today it declares 1 and this returns
+    1..16 exactly as before -- verified rather than assumed, because a refactor that
+    changes what the product DOES while claiming not to is worse than the
+    duplication it removes.
+    """
+    return tuple(Migration(number, path)
+                 for number, path in legacy_db._migration_files())
 
 
 class EngineDatabase(DomainDatabase[T]):

--- a/scrapex/db.py
+++ b/scrapex/db.py
@@ -120,9 +120,66 @@ def has_column(conn: sqlite3.Connection, table: str, column: str) -> bool:
                for row in conn.execute(f"PRAGMA table_info({table})"))
 
 
+_USER_VERSION = re.compile(
+    r"^[ \t]*PRAGMA[ \t]+user_version[ \t]*=[ \t]*(\d+)[ \t]*;",
+    re.MULTILINE | re.IGNORECASE)
+
+#: `declared_schema_version` reads a 55 KB file, and `EngineDatabase()` builds its
+#: plan on every construction -- the suite does that hundreds of times. Keyed on
+#: mtime and size so an EDIT is still seen; a stat is three orders of magnitude
+#: cheaper than the read it replaces.
+_DECLARED: dict[tuple[str, int, int], int] = {}
+
+
+def declared_schema_version(path: Path) -> int:
+    """The version a migration file stamps, read from the file that stamps it.
+
+    THE BASELINE'S NUMBER USED TO BE THE LITERAL `1` IN THREE PLACES: here, in
+    `databases/domain.py` `_engine_plan`, and in `db/engine/schema.sql` itself as
+    `PRAGMA user_version = 1`. Only the third is the one SQLite obeys, and the
+    other two were assertions about it that nothing checked.
+
+    THAT IS NOT A TIDINESS ARGUMENT. `latest_schema_version()` is derived from this
+    number and flows into `storage.py` `health()`, which decides whether a database
+    is too new for this engine to open. Two hardcoded copies of a fact the file
+    declares is the shape where a change to the file leaves the code reporting the
+    old answer confidently -- and the answer it reports is "your warehouse was
+    written by a newer ScrapeX; do not downgrade it".
+
+    EXACTLY ONE is required, and the count is checked rather than the first match
+    taken: seven of the fifteen shipped migrations declare NO version at all and are
+    silently corrected by the runner, so "take the last one you find" would read a
+    number out of a file that never set one.
+    """
+    stat = path.stat()
+    key = (str(path), stat.st_mtime_ns, stat.st_size)
+    if key not in _DECLARED:
+        found = _USER_VERSION.findall(path.read_text(encoding="utf-8"))
+        if len(found) != 1:
+            raise ValueError(
+                f"{path.name} declares {len(found)} `PRAGMA user_version = N` "
+                "statements and exactly one is required: every other part of the "
+                "product derives its schema version from it")
+        _DECLARED[key] = int(found[0])
+    return _DECLARED[key]
+
+
 def _migration_files() -> list[tuple[int, Path]]:
-    """Ordered migrations: schema.sql is 0001; db/migrations/NNNN_*.sql follow."""
-    migrations: list[tuple[int, Path]] = [(1, SCHEMA_FILE)]
+    """THE migration plan, and the only builder of it.
+
+    `databases/domain.py` `_engine_plan` wraps this list rather than walking the
+    folder itself, which it used to do. The two builders agreed only by
+    coincidence -- same folder, same pattern, separately written -- and they were
+    not even equivalent: this one RAISES on a file in the migrations folder that
+    does not match `NNNN_name.sql`, and the other silently globbed past it.
+
+    The coincidence was already load-bearing. `tests/conftest.py`
+    `_stream_fingerprint` decides whether a cached migrated database may be reused
+    by resolving THIS function, while the migration that filled that cache ran
+    through the other builder. Two lists, one cache key.
+    """
+    baseline = declared_schema_version(SCHEMA_FILE)
+    migrations: list[tuple[int, Path]] = [(baseline, SCHEMA_FILE)]
     if MIGRATIONS_DIR.is_dir():
         for file in sorted(MIGRATIONS_DIR.iterdir()):
             match = _MIGRATION_NAME.match(file.name)
@@ -131,14 +188,19 @@ def _migration_files() -> list[tuple[int, Path]]:
                     f"migration file {file.name!r} does not match NNNN_name.sql (S6)"
                 )
             number = int(match.group(1))
-            if number == 1:
-                raise ValueError("0001 is reserved for db/schema.sql")
+            if number <= baseline:
+                raise ValueError(
+                    f"migration {file.name!r} is numbered {number}, at or below the "
+                    f"baseline's own declared version {baseline}; "
+                    f"{SCHEMA_FILE.name} already carries everything up to there")
             migrations.append((number, file))
     numbers = [n for n, _ in migrations]
     if numbers != sorted(set(numbers)):
         raise ValueError(f"migration numbers must be unique and ordered, got {numbers}")
-    if numbers != list(range(1, len(numbers) + 1)):
-        raise ValueError(f"migration numbers must be gapless from 1, got {numbers}")
+    if numbers != list(range(baseline, baseline + len(numbers))):
+        raise ValueError(
+            f"migration numbers must be contiguous from the baseline's own declared "
+            f"version {baseline}, got {numbers}")
     return migrations
 
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -30,7 +30,13 @@ def test_migrate_is_idempotent(tmp_path: Path):
     # THE WHOLE CHAIN, ASKED RATHER THAN TYPED. It used to be a literal list ending
     # at 61; that number belonged to a stream retired on 2026-08-29, and a literal
     # here would have to be edited by hand every time a migration is added.
-    assert first == list(range(1, dbmod.latest_schema_version() + 1))
+    #
+    # AND IT STARTS WHERE THE BASELINE SAYS, not at 1. `range(1, ...)` was right by
+    # coincidence -- `db/engine/schema.sql` happens to declare version 1 -- so the
+    # assertion agreed with the code for a reason that had nothing to do with the
+    # property it is about, which is that migrate() reports EVERY number it applied.
+    baseline = dbmod.declared_schema_version(dbmod.SCHEMA_FILE)
+    assert first == list(range(baseline, dbmod.latest_schema_version() + 1))
     assert second == []  # T4: running again applies nothing
 
 
@@ -38,7 +44,14 @@ def test_latest_schema_version_matches_the_migration_chain():
     # NOT a tautology: the left side reads the last NUMBER and the right counts the
     # FILES, so a gap or a duplicate in the chain shows up here rather than in a
     # migration that silently never runs.
-    assert dbmod.latest_schema_version() == len(dbmod._migration_files())
+    #
+    # THE COUNT IS OFFSET BY THE BASELINE'S OWN VERSION. `latest == len(files)` held
+    # only because the baseline declares 1; stated that way the assertion breaks the
+    # moment the baseline declares anything else, and it breaks by going FALSE on a
+    # correct chain -- which is the worst direction for a guard to move.
+    files = dbmod._migration_files()
+    baseline = dbmod.declared_schema_version(dbmod.SCHEMA_FILE)
+    assert dbmod.latest_schema_version() == baseline + len(files) - 1
 
 
 def test_foreign_keys_actually_enforced(tmp_path: Path):

--- a/tests/test_no_tag_is_cut_while_the_warehouse_is_ahead.py
+++ b/tests/test_no_tag_is_cut_while_the_warehouse_is_ahead.py
@@ -202,6 +202,12 @@ def test_the_ci_half_compares_ceilings_across_every_branch():
         "the step does not compare migration numbers, so a branch merely BEHIND would "
         "trip it and a branch ahead might not")
     assert "exit 1" in step, "the step reports and does not refuse"
+    assert "db/engine/schema.sql" in step, (
+        "`ceiling()` does not read the BASELINE's declared version, only migration "
+        "filenames -- so a commit whose schema lives in db/engine/schema.sql with an "
+        "empty migrations folder measures as carrying no schema at all, and the "
+        "`${here:?...}` line below aborts every release saying that cannot be right. "
+        "It can be: it is what a squashed baseline looks like.")
 
 
 def test_the_install_line_is_in_the_readme():

--- a/tests/test_one_migration_plan_not_two.py
+++ b/tests/test_one_migration_plan_not_two.py
@@ -1,0 +1,174 @@
+"""There is one migration plan, and the baseline's number is read where it is declared.
+
+TWO BUILDERS WALKED THE SAME FOLDER. `scrapex/db.py` `_migration_files` and
+`scrapex/databases/domain.py` `_folder_migrations` each resolved
+`db/engine/migrations/` into an ordered plan, separately written, and they were not
+equivalent: `db`'s RAISES on a file that does not match `NNNN_name.sql`, the other
+globbed silently past it.
+
+The coincidence was already load-bearing. `tests/conftest.py` `_stream_fingerprint`
+decides whether a cached migrated database may be reused by resolving `db`'s
+builder, while the migration that filled that cache ran through the other one.
+
+AND THE BASELINE'S NUMBER WAS THE LITERAL 1 IN THREE PLACES: both builders, and
+`db/engine/schema.sql` itself as `PRAGMA user_version = 1`. Only the third is the
+one SQLite obeys. `latest_schema_version()` derives from it and flows into
+`storage.py` `health()`, which decides whether a warehouse is too new for this
+engine to open -- so a stale copy does not merely disagree, it tells the owner his
+database was written by a newer ScrapeX and must not be downgraded.
+
+`.githooks/pre-push` had already reached this conclusion and says so: it asks
+`scrapex database-status` rather than reading `PRAGMA user_version` itself, because
+that *"keeps one owner for the comparison"*. This file is that rule applied to the
+two places that had not got it.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scrapex import db as dbmod
+from scrapex.databases.domain import (
+    DatabaseMigrationError,
+    DomainDatabase,
+    EngineDatabase,
+    Migration,
+    _engine_plan,
+)
+
+
+class _Probe(DomainDatabase):
+    """A domain type with no file behind it: only `__init__`'s rule is under test."""
+
+    kind = "probe"
+    application_id = 1
+
+
+def _version_the_file_declares() -> int:
+    """An INDEPENDENT reader of the baseline's version.
+
+    Deliberately not `dbmod.declared_schema_version`, and not its regex either. The
+    whole failure this file is about is a fact asserted in two places where only one
+    of them is obeyed, so a guard that calls the implementation it is checking would
+    reproduce the failure instead of catching it. This walks lines and splits on
+    `=`, which shares no code with the subject.
+    """
+    found = []
+    for line in dbmod.SCHEMA_FILE.read_text(encoding="utf-8").splitlines():
+        head, _, tail = line.partition("=")
+        if head.strip().lower().replace("  ", " ") == "pragma user_version":
+            found.append(int(tail.strip().rstrip(";").strip()))
+    assert len(found) == 1, f"the baseline declares {len(found)} versions, expected 1"
+    return found[0]
+
+
+def test_the_engine_plan_follows_the_one_builder(monkeypatch):
+    """`domain` must READ the plan, not rebuild it.
+
+    NOT A TAUTOLOGY, and this is the assertion that makes the change stick: the
+    builder is replaced with one that returns a different stream, and the engine's
+    plan has to change with it. A `domain` that walks the folder itself again passes
+    every other test in the suite and fails this one.
+    """
+    whole = dbmod._migration_files()
+    monkeypatch.setattr(dbmod, "_migration_files", lambda: whole[:3])
+
+    assert [item.number for item in _engine_plan()] == [n for n, _ in whole[:3]]
+    assert EngineDatabase("unused.db").latest_schema_version == whole[2][0]
+
+
+def test_the_baseline_number_comes_from_the_file_that_declares_it():
+    """The plan's first number is the one the SQL sets, read two different ways."""
+    declared = _version_the_file_declares()
+
+    assert dbmod.declared_schema_version(dbmod.SCHEMA_FILE) == declared
+    assert dbmod._migration_files()[0][0] == declared
+    assert _engine_plan()[0].number == declared
+
+
+def test_the_declared_version_must_be_stated_exactly_once(tmp_path: Path):
+    """Zero and two are both refused, and the count is why.
+
+    Seven of the fifteen shipped migrations set no `PRAGMA user_version` at all and
+    are silently corrected by the runner, so "take the last match" would happily
+    read a number out of a file that never stated one.
+    """
+    none = tmp_path / "none.sql"
+    none.write_text("CREATE TABLE x(a);\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="declares 0 "):
+        dbmod.declared_schema_version(none)
+
+    twice = tmp_path / "twice.sql"
+    twice.write_text("PRAGMA user_version = 3;\nPRAGMA user_version = 4;\n",
+                     encoding="utf-8")
+    with pytest.raises(ValueError, match="declares 2 "):
+        dbmod.declared_schema_version(twice)
+
+
+def test_a_plan_that_starts_above_one_is_accepted():
+    """What the old rule forbade and nothing needed it to.
+
+    `gapless from 1` was true of the stream that existed when it was written, and a
+    squashed baseline gives up exactly that half. The half that matters -- no
+    MISSING migration between two present ones -- is kept below.
+    """
+    _Probe("unused.db", (Migration(16, dbmod.SCHEMA_FILE),))
+    _Probe("unused.db", (Migration(16, dbmod.SCHEMA_FILE),
+                         Migration(17, dbmod.SCHEMA_FILE)))
+
+
+def test_a_hole_in_the_plan_is_still_refused():
+    """The half of the old rule that was doing real work.
+
+    A hole means a database can reach a version this build cannot explain, which is
+    what `R-24` and `OP-30` both turn on.
+    """
+    with pytest.raises(DatabaseMigrationError, match="contiguous"):
+        _Probe("unused.db", (Migration(16, dbmod.SCHEMA_FILE),
+                             Migration(18, dbmod.SCHEMA_FILE)))
+    with pytest.raises(DatabaseMigrationError, match="contiguous"):
+        _Probe("unused.db", (Migration(1, dbmod.SCHEMA_FILE),
+                             Migration(3, dbmod.SCHEMA_FILE)))
+
+
+def test_a_plan_numbered_from_zero_is_refused():
+    """0 is what `PRAGMA user_version` reads on a database nobody has migrated, so a
+    plan starting there could not tell "never touched" from "already at the
+    baseline"."""
+    with pytest.raises(DatabaseMigrationError, match="1 or above"):
+        _Probe("unused.db", (Migration(0, dbmod.SCHEMA_FILE),))
+
+
+def test_a_migration_numbered_at_or_below_the_baseline_is_refused(
+        tmp_path: Path, monkeypatch):
+    """The rule that replaces "0001 is reserved for schema.sql".
+
+    A file numbered below the baseline can never run -- `_migrate` skips anything at
+    or under the current version -- so it is a migration the author believes is
+    shipping and which is dead on arrival. It used to be checked against the literal
+    1; now it is checked against whatever the baseline says.
+    """
+    baseline = tmp_path / "schema.sql"
+    baseline.write_text("PRAGMA user_version = 9;\n", encoding="utf-8")
+    folder = tmp_path / "migrations"
+    folder.mkdir()
+    (folder / "0005_too_early.sql").write_text("PRAGMA user_version = 5;\n",
+                                               encoding="utf-8")
+    monkeypatch.setattr(dbmod, "SCHEMA_FILE", baseline)
+    monkeypatch.setattr(dbmod, "MIGRATIONS_DIR", folder)
+
+    with pytest.raises(ValueError, match="at or below the baseline"):
+        dbmod._migration_files()
+
+
+def test_the_plan_is_contiguous_from_the_baseline_as_shipped():
+    """The shipped stream, held against the rule rather than against a literal."""
+    plan = dbmod._migration_files()
+    numbers = [n for n, _ in plan]
+    first = _version_the_file_declares()
+
+    assert numbers == list(range(first, first + len(numbers))), (
+        f"the shipped plan is not contiguous from the baseline's declared version "
+        f"{first}: {numbers}")
+    assert dbmod.latest_schema_version() == numbers[-1]

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -323,7 +323,21 @@ PINNED = (
     # written down — the guard catching its author, in the exact shape LESSONS §7
     # describes. The third move was the 0.3.0 packaging fix, which explained the
     # new `ScrapeX UI` demand in twenty-seven lines of comment directly above.
-    ("docs/BACKLOG.md", ".github/workflows/release-engine.yml", 540, '"version": VERSION'),
+    # REPOINTED 540 -> 553 on 2026-09-02: `OP-122` inserted thirteen lines into
+    # `ceiling()` above it, so the subject moved and the citation had to follow. A
+    # legitimate repoint -- the symbol still exists and this row's whole job is to
+    # sit beside it -- unlike the two `LESSONS` entries whose numbers were the
+    # RECORD and were destroyed by being repointed.
+    #
+    # AND THE DOCUMENT SIDE OF THIS ROW IS GONE. `docs/BACKLOG.md` contains no
+    # citation to this file at any line: measured, `grep -n "release-engine.yml[#:]"`
+    # over every document returns nothing. So this row asserts that the workflow
+    # still holds `"version": VERSION`, which is true and worth asserting, but it is
+    # not what tier 2 is for -- and nothing here can tell the difference, because no
+    # test checks that a pinned row's DOCUMENT still cites it. It also counts toward
+    # `PINNED_FLOOR`. Left in place rather than deleted, because removing rows is
+    # exactly what that floor exists to refuse; recorded in `OP-122`.
+    ("docs/BACKLOG.md", ".github/workflows/release-engine.yml", 553, '"version": VERSION'),
     ("docs/BACKLOG.md", "tests/test_the_two_release_paths.py", 276,
      'got["version"] == manifest["version"]'),
     # And the line whose VALUE went stale under a citation that stayed correct --

--- a/tests/test_the_registers_cannot_collide.py
+++ b/tests/test_the_registers_cannot_collide.py
@@ -316,6 +316,25 @@ RESERVED: dict[str, dict[int, str]] = {
         # `main` was already carrying the paragraph below saying they were gone WHILE
         # the rows were still here -- a comment and the rows it contradicts, which is
         # the same one-side-of-a-pair shape this table keeps catching in other files.
+        # 120 and 121 became holes when this branch declared OP-122. Both are inside
+        # the EXISTING "OP" entry rather than in a second one: this table carried a
+        # duplicated register key twice this week and Python keeps the last, so a new
+        # entry for a register that already has one silently discards whichever half
+        # is written first.
+        #
+        # Holders VERIFIED against the refs, never taken from the messages that
+        # allocated the numbers:
+        #   git show origin/claude/the-drift-check-that-was-off:docs/BACKLOG.md \
+        #     | grep "### OP-120"
+        #   git show fix/the-listing-phase-has-a-door:docs/BACKLOG.md | grep "### OP-121"
+        # A sweep of every local and remote ref found OP-122 declared on none of them.
+        #
+        # Delete each row the day its branch merges.
+        120: "branch claude/the-drift-check-that-was-off (pushed, no PR yet)",
+        # 121's ref is LOCAL ONLY -- checked out in a sibling worktree, not on origin
+        # -- so `git ls-remote` would report the number free. `git branch -a` is the
+        # check that works here, because worktrees share one ref namespace.
+        121: "branch fix/the-listing-phase-has-a-door (local ref only, not pushed)",
         # 101 THROUGH 110 WERE RESERVED HERE AND THE ROWS ARE GONE, which is this
         # table's own rule applied to itself: `claude/design-system-review-d6787a`
         # merged, so the numbers are declared on `main` and a reservation for a


### PR DESCRIPTION
Stage 1 of `REQ-52`'s baseline squash. **Every part of it is a defect today**, not a preparation for one — and it carries **`R-84`**, his ruling on the squash.

## One fact, three copies, one of them obeyed

The engine baseline's version was the literal `1` in `db._migration_files`, again in `domain._engine_plan`, and a third time inside `db/engine/schema.sql` as `PRAGMA user_version = 1`. **Only the SQL is what SQLite obeys.**

That is not tidiness. `latest_schema_version()` derives from those literals and reaches `storage.py` `health()`, which decides whether a database is too new for this engine to open — so a stale copy tells the owner his warehouse was written by a later ScrapeX and must not be downgraded, about a warehouse this build wrote.

## And two builders walked the same folder

Agreeing by coincidence and not even equivalent: `db`'s **raises** on a file that does not match `NNNN_name.sql`, the other globbed silently past it. The coincidence was already load-bearing — `tests/conftest.py` `_stream_fingerprint` decides whether a cached migrated database may be reused by resolving `db`'s builder, while the migration that filled that cache ran through the other. Two lists, one cache key.

`.githooks/pre-push` had already reached this conclusion and says so: it asks `scrapex database-status` rather than reading `PRAGMA user_version` itself, because that *"keeps one owner for the comparison"*.

## What changed

| | |
|---|---|
| `db._migration_files` is the only builder | `domain._engine_plan` wraps it; `_folder_migrations` deleted. Direction forced, not chosen — `domain` already imports `db` |
| `declared_schema_version()` reads the version from the file that declares it | and requires **exactly one** `PRAGMA user_version`: seven of the fifteen shipped migrations declare none and are silently corrected by the runner, so "take the last match" would read a number out of a file that never set one |
| plan must be **contiguous from the baseline's own version**, not gapless from 1 | the half that mattered — no missing migration between two present ones — is kept. Floor stays 1, because `PRAGMA user_version` is 0 on a database nobody has migrated |
| `release-engine.yml` `ceiling()` reads the baseline too | it measured schema level from **filenames**, so a commit whose schema lives in the baseline with an empty folder measured as carrying no schema at all and `${here:?...}` aborted the release. **No release could have been cut after a squash**, by the gate whose purpose is preventing migration loss |

Two assertions in `tests/test_db.py` now hold against the baseline instead of the literal 1. Both were true only *because* the baseline declares 1, and both would have gone **false on a correct chain** — a guard moving in the worst direction.

## Proved by mutation

Five defects injected one at a time, each caught by the one guard written for it:

```
CAUGHT  domain builds its own plan again
CAUGHT  the baseline's number is the literal 1 again
CAUGHT  gapless-from-1 is restored
CAUGHT  the contiguity check is dropped entirely
CAUGHT  the version reader takes the last match instead of requiring one
```

`tests/test_one_migration_plan_not_two.py` holds them. Its version reader is written a **second** way — walking lines, splitting on `=`, sharing no code with the subject — because the failure here is a fact asserted twice where one copy is obeyed, and a guard that calls the implementation it checks reproduces that failure instead of catching it.

## R-84

> «قواعد البيانات يتم ترقيتها ولكن base يتغير الان … اكيد عند نشر الاداة ساريد الحفاظ على كافة الترحيلات … ولكن قبل الاصدار لا اريد اراكم الكود باختبارات وترحيلات لن تستخدم سوى مرة واحدة وهى لى»

The base may be collapsed before publication; after it, **no migration is ever deleted**. Recorded here rather than on the squash branch, because a ruling recorded only on the branch it authorises is unrecorded until that branch merges.

**It supersedes nothing, and a correction is recorded with it under `C5`.** This session reported the ruling as colliding with `R-24`. `R-24`'s own quotation already scopes the data guarantee to «عند نشر الاداة», and he restates that guarantee in this ruling's first clause. The collision was between his ruling and **`R-24`'s elaboration** — a session's commentary written unconditionally where his words were publication-scoped. The elaboration is left standing, because it is right about the published world it describes.

**And it dissolves the blocker rather than answering it.** Measured read-only, his warehouse is at `PRAGMA user_version = 16` — the head of the chain — so a baseline squashed there replays nothing over it. No carry-over needs writing. The price is recorded as a **waiver, not a measurement**: the second machine's version is unknown, and if it is below the baseline this change strands it.

## Not in this change, deliberately

`contractstamp.py` builds the schema half of the contract fingerprint from the migrations folder only and never reads `db/engine/schema.sql`, so a change to the file that defines the whole shape is invisible to the version gate. The fix is written and held back: it moves the fingerprint (measured — `added: ["schema.sql v1"]`, nothing removed) and the gate's only sanctioned answer is a `VERSION` bump, which the squash needs anyway. **One bump, in the change that warrants it.**

## Verification

```
MODE A (full)              exit=0
MODE B (extension or docs) exit=0
ruff check scrapex/        All checks passed
contractstamp.differences() against the recorded baseline: empty — no version bump
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)