### PR TITLE
The drift check that was off, and the migration it found (OP-120)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -4512,6 +4512,75 @@ instance in this branch, the first found by a guard written in the same commit. 
 now name that route by description and never by path, and say why in one line so the next
 writer does not spend the minute.
 
+### OP-120 · The two-way drift check `ENGINEERING.md` T5 mandates had been off for a month, and its first run found a shipped defect
+
+**Found 2026-09-02**, while pricing the baseline squash (`REQ-52`) — the drift check is what
+would PROVE that squash, so it was run before anything was deleted, and it turned out not to
+be running at all.
+
+**A constant left behind by a deletion, and a skip that was the only thing watching.**
+`tests/test_migration_drift.py` held `PREVIOUS_RELEASE = 30` — the **deleted** price stream's
+number — and gated both tests on `len(db._migrations) <= PREVIOUS_RELEASE`:
+
+```
+PREVIOUS_RELEASE = 30                                          -- the deleted stream's number
+if len(db._migrations) <= PREVIOUS_RELEASE: pytest.skip(...)   -- the only thing watching
+```
+
+**Deliberately quoted without line numbers.** This commit replaces both lines, so a citation
+to them would be repointed by the next rebase at whatever now sits there — which is how two
+`LESSONS` entries lost the numbers they existed to record.
+
+The engine stream is **16**, so `16 <= 30` skipped both tests. Measured:
+`ss  SKIPPED [2] the engine stream is 16 migration(s)`. And the file's own docstring promised
+*"The moment engine migration 0002 exists, this runs again"* — 0002 through 0016 all exist and
+it never did. **The promise was in prose and the mechanism was a number nobody re-derived.**
+
+**ITS FIRST REAL RUN FOUND A DEFECT IN A MIGRATION THAT HAS ALREADY SHIPPED.**
+`0014_one_source_registry.sql:88` rebuilds `source_site` with `base_url TEXT NOT NULL
+DEFAULT ''`, and line 108 copies the old column through by name in an `INSERT ... SELECT`.
+**A DEFAULT applies only to a column the INSERT omits**, so the NULL is carried into a NOT NULL
+column. `source_site.base_url` was nullable through v13 — measured, `notnull=0` — so the row
+that triggers it is legal, not corrupt. Reproduced at every stop point from v2 to v13:
+
+```
+stop v2 .. v13  ->  IntegrityError: NOT NULL constraint failed: source_site_rebuilt.base_url
+stop v14, v15   ->  OK, and 0 drift: no table, column, index, trigger or view differs
+```
+
+**The migration's own comment shows it was reasoned about and the mechanism mistaken**
+(`0014:80`): *"on his warehouse zero rows of either table hold a NULL -- 0 of 12 and 0 of 2 --
+so the stronger constraint costs nothing."* True of that data. The constraint is free **only**
+on that data, and the `DEFAULT` that was supposed to be the second half of the protection is
+not protection at all here.
+
+**IT CANNOT BE FIXED IN PLACE.** `0014` is applied and its digest is in the ledger of every
+existing warehouse, so editing one character makes those databases refuse to open
+(`scrapex/databases/domain.py` `_verify_checksums`). The pending squash absorbs the file and
+removes the wall with it — at a cost priced separately in `REQ-52`.
+
+**AND THE TEST'S OWN SEED PRODUCED A SECOND DEFECT THAT WAS NOT REAL.** Every crude row said
+`"x"`, so the moment `0014` MERGED two source registries the two rows collided:
+`UNIQUE constraint failed: source_site.source_key`. **Turning this file on reported two
+defects and only one of them existed.** Values are now distinct per `(table, column)`
+(`tests/test_migration_drift.py:122`).
+
+**Fixed here:**
+
+| | |
+|---|---|
+| `PREVIOUS_RELEASE` 30 → **14** (`tests/test_migration_drift.py:59`) | and the reason for 14 rather than the midpoint is written into the constant: v2..v13 are walled off by `0014`, so the span exercised over real rows is v15 and v16 — two migrations, not eight. Weaker than the file wants, said out loud rather than hidden behind a number chosen to make the suite green |
+| `test_the_stop_point_is_a_version_this_stream_actually_has` (`tests/test_migration_drift.py:152`) | asserts `2 <= PREVIOUS_RELEASE < len(stream)` and **fails rather than skips**. A skip is what hid this for a month |
+| `test_a_null_base_url_still_stops_the_registry_merge` (`tests/test_migration_drift.py:250`) | records the wall with the **exact** error text, so it fails if the wall moves to another column or another migration instead of quietly continuing to pass |
+
+**WHY THIS IS A NUMBER AND NOT A ONE-LINE CONSTANT CHANGE.** The gate compared
+`PREVIOUS_RELEASE` against the stream and nothing compared `PREVIOUS_RELEASE` against
+**reality** — every other test in the file READS that constant and therefore agrees with
+whatever it says. The new assertion is the only one that holds two independently-maintained
+things against each other, which is the shape that has caught every silent guard found this
+week. **A skip must never be the only reporter**: it costs one character of output in a run
+nobody reads, and here it bought a month.
+
 ### OP-122 · Two builders resolved the migration plan, and the baseline's version was a literal in both
 
 **Found 2026-09-02**, pricing `REQ-52`'s baseline squash. The squash is not what

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -727,6 +727,32 @@ field to it. So:
 **The decision stands and the order was the wrong part**, which is what `#293` recorded. Two
 of the four steps are now behind us.
 
+### The drift check that was off — 2026-09-02 · branch `claude/the-drift-check-that-was-off`, no PR yet
+
+**`OP-120`.** Branched from `main` at `1d8816d8`. Secondary session;
+`recursing-shannon-068e63` merges
+([R-42](RULINGS.md#r-42--one-primary-session-merges-every-other-session-is-secondary-and-asks)).
+Fourth in a queue the primary fixed: `#299`, `#300`, its own branch, this, then the squash.
+
+The two-way drift check `ENGINEERING.md` T5 mandates had been skipping since the M5 collapse,
+because its stop point was the deleted price stream's version number. Turned on, its first run
+found `0014_one_source_registry.sql` cannot upgrade a row whose `base_url` is NULL. **Read
+`OP-120` in [BACKLOG.md](BACKLOG.md) before touching the migration framework**, and read it
+before the squash: this check is what proves that squash, and it was not running.
+
+**`REQ-52`'s squash is priced and NOT built.** Measured cost, in one line each so the next
+session does not re-derive it: two independent migration-plan builders carry the same
+gapless-from-1 rule ([`scrapex/databases/domain.py:191`](../scrapex/databases/domain.py#L191)
+and [`scrapex/db.py:140`](../scrapex/db.py#L140)); `latest_schema_version()` hardcodes the
+baseline as 1 ([`scrapex/db.py:125`](../scrapex/db.py#L125)) and that 1 reaches the Storage
+page through `storage.py` `health()`; the baseline has 51 `CREATE TABLE` and no
+`IF NOT EXISTS`, so replaying it over a populated database fails on the first table; and
+[`.github/workflows/release-engine.yml:154`](../.github/workflows/release-engine.yml#L154)
+aborts the release when the migrations folder is empty. **Stage 1 unifies those four and is
+correct with or without the squash. Stage 2 is the squash, and it needs his word on the
+sentence "a database below v16 is not upgraded — it is carried over or rebuilt" before it
+merges.**
+
 ## Track 1 · The Console migration
 
 **Plan:** [MIGRATION-PLAN.md](MIGRATION-PLAN.md) · **Detailed state:**

--- a/tests/test_migration_drift.py
+++ b/tests/test_migration_drift.py
@@ -12,12 +12,27 @@ from the stream itself: stop at version N, put rows in, then apply the rest. Tha
 is exactly the shape an existing owner upgrades through, and the shape a fresh
 install never takes.
 
-NOTE (M5): this deliberately stays on the PRICE stream, which still has
-fifty-nine migrations. It tests a property of the MIGRATION FRAMEWORK — that a
-database upgraded step by step ends up identical to one built fresh — and that
-needs a long stream to stop partway through. The engine stream is one migration
-today, so pointing this at it would assert nothing. It moves across the day
-engine migrations 0002+ exist.
+IT WAS OFF FOR A MONTH AND NOTHING SAID SO. The note that stood here promised
+"it moves across the day engine migrations 0002+ exist" — and the gate below it
+compared the stream's length against PREVIOUS_RELEASE = 30, the number the
+DELETED price stream had. Engine migrations 0002 through 0016 arrived, the engine
+stream reached 16, and 16 <= 30 kept skipping. The promise was in prose and the
+mechanism was a constant nobody re-derived; measured on 2026-09-02, both tests in
+this file had been reporting `ss` since the M5 collapse.
+
+THE FIRST REAL RUN FOUND A SHIPPED DEFECT, which is the argument for this file
+rather than a story about it: 0014_one_source_registry.sql rebuilds source_site
+with `base_url TEXT NOT NULL DEFAULT ''` and then copies the old column through
+by name, and a DEFAULT never applies to a column an INSERT names. base_url was
+nullable through v13, so a legal row fails the upgrade. Reproduced at every stop
+point from v2 to v13. The migration's own comment shows it was reasoned about and
+the mechanism mistaken: zero NULLs were measured in one warehouse and the
+constraint was called free on that evidence.
+
+SO THE SKIP NOW HAS AN ASSERTION BEHIND IT. PREVIOUS_RELEASE is checked against
+the shipped stream by a test of its own, because that is the one comparison that
+would have failed the day 30 stopped being a version this stream has. A skip
+cannot be the only thing standing between a mandate and nothing.
 """
 from __future__ import annotations
 
@@ -27,9 +42,25 @@ import pytest
 
 from scrapex.databases.domain import EngineDatabase
 
-# Far enough in that the price chain exists, far enough back that a real span of
-# migrations runs over the seeded rows.
-PREVIOUS_RELEASE = 30
+#: The version an existing owner is upgrading FROM. It must be a real version of
+#: the shipped stream with something after it, and
+#: `test_the_stop_point_is_a_version_this_stream_actually_has` enforces that --
+#: see this file's header for what one unenforced constant cost.
+#:
+#: WHY 14 AND NOT THE MIDPOINT, which is the honest answer rather than the
+#: flattering one: every stop point from v2 to v13 currently fails, because
+#: migration 0014 cannot upgrade a row whose base_url is NULL. So the span
+#: actually exercised over real rows is v15 and v16 -- two migrations, not eight.
+#: That is weaker than this file wants to be, and it is written down rather than
+#: hidden, because the alternative is a number chosen to make the suite green and
+#: a reader who cannot tell that from a number chosen on evidence. It rises the
+#: moment 0014 stops being a wall, which the pending baseline squash does by
+#: absorbing it.
+PREVIOUS_RELEASE = 14
+
+#: The deepest stop point migration 0014 refuses, kept as a test rather than as a
+#: sentence -- see `test_a_null_base_url_still_stops_the_registry_merge`.
+BLOCKED_BY_0014 = 13
 
 
 def _fingerprint(conn: sqlite3.Connection) -> dict:
@@ -80,7 +111,15 @@ def _seed_every_table(conn: sqlite3.Connection, tables: list[str]) -> int:
                 continue
             cols.append(name)
             kind = (decl or "TEXT").upper()
-            values.append(1 if ("INT" in kind or "REAL" in kind or "NUM" in kind) else "x")
+            # DISTINCT PER COLUMN, and it has to be. Every crude row used to say
+            # "x", so the moment a migration MERGED two tables the two rows
+            # collided on a UNIQUE key and 0014 reported
+            #     UNIQUE constraint failed: source_site.source_key
+            # -- a failure belonging to the seed and not to the migration. Turning
+            # this file back on reported two defects before this line was fixed,
+            # and only one of them was real.
+            values.append(1 if ("INT" in kind or "REAL" in kind or "NUM" in kind)
+                          else f"{table}.{name}")
         marks = ", ".join("?" for _ in cols)
         names = ", ".join(f'"{c}"' for c in cols)
         # A SAVEPOINT per table, not a rollback: a crude row that a foreign key
@@ -101,23 +140,52 @@ def _seed_every_table(conn: sqlite3.Connection, tables: list[str]) -> int:
     return seeded
 
 
-def _requires_a_stream_it_can_stop_inside(db) -> None:
-    """M5 restarted the engine stream at 1, and this test needs to stop PARTWAY
-    through one.
+def _stop_point_is_valid(count: int) -> bool:
+    """Whether PREVIOUS_RELEASE names a version this stream can stop inside.
 
-    NOT A SKIP THAT ROTS — it turns itself back on. And it is a skip rather than
-    a synthetic stream on purpose: the property here is about the SHIPPED
-    migrations, that upgrading through them lands identical to a fresh build of
-    the same schema. With one migration, fresh and upgraded are the same object
-    and the comparison asserts nothing. A rig with two invented migrations would
-    test the framework instead, which is a different and separately useful thing
-    — not this. The moment engine migration 0002 exists, this runs again.
+    Two migrations are the minimum: with one, a fresh build and an upgraded one
+    are the same object and the comparison asserts nothing.
     """
-    if len(db._migrations) <= PREVIOUS_RELEASE:
+    return 2 <= PREVIOUS_RELEASE < count
+
+
+def test_the_stop_point_is_a_version_this_stream_actually_has():
+    """The one assertion that would have caught a month of silence.
+
+    It compares two things maintained by different hands -- a constant in this
+    file and the length of the shipped stream -- which is the only shape that
+    catches a constant left behind by a deletion. Every other test here READS
+    PREVIOUS_RELEASE and therefore agrees with whatever it says.
+
+    IT FAILS RATHER THAN SKIPS, deliberately. A skip is what hid the problem for
+    a month; when the stream stops being long enough to measure drift inside,
+    that is a decision someone has to take and write down, not a line of `ss` in
+    a run nobody reads.
+    """
+    count = len(EngineDatabase("unused.db")._migrations)
+    assert _stop_point_is_valid(count), (
+        f"PREVIOUS_RELEASE = {PREVIOUS_RELEASE} is not a version the shipped "
+        f"engine stream has: it holds {count} migration(s), so a stop point must "
+        f"be at least 2 and at most {count - 1}. This exact mismatch turned the "
+        f"two-way drift check ENGINEERING.md T5 mandates off for a month -- 30 "
+        f"was the deleted price stream's number. If the stream is now too short "
+        f"to measure drift inside, say what replaces this check before lowering "
+        f"the bar: a frozen fingerprint of the shape the chain produced is the "
+        f"pattern this repository already uses (db/engine/derived-from.json).")
+
+
+def _requires_a_stream_it_can_stop_inside(db) -> None:
+    """Skips only when the assertion above is ALREADY FAILING, so a skip here
+    is never the whole report.
+
+    That is the difference from the version of this that rotted: the skip used to
+    be the only thing that noticed, and it noticed quietly.
+    """
+    if not _stop_point_is_valid(len(db._migrations)):
         pytest.skip(
-            f"the engine stream is {len(db._migrations)} migration(s); drift "
-            f"cannot be measured until there is a version {PREVIOUS_RELEASE} "
-            "to stop at and something after it")
+            f"PREVIOUS_RELEASE = {PREVIOUS_RELEASE} is not a stop point in a "
+            f"stream of {len(db._migrations)}; see the failure in "
+            "test_the_stop_point_is_a_version_this_stream_actually_has")
 
 
 def _upgraded_from_previous_release(path, monkeypatch) -> EngineDatabase:
@@ -177,3 +245,58 @@ def test_the_whole_stream_survives_migrating_over_real_rows(tmp_path, monkeypatc
         assert not broken, f"the upgrade left rows pointing at nothing: {broken[:3]}"
         assert conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
     assert db.health().ok, db.health().action
+
+
+def test_a_null_base_url_still_stops_the_registry_merge(tmp_path):
+    """The wall that holds PREVIOUS_RELEASE at 14, as a test rather than a note.
+
+    `0014_one_source_registry.sql` rebuilds `source_site` with
+    `base_url TEXT NOT NULL DEFAULT ''` and then copies the old column through by
+    name:
+
+        INSERT INTO source_site_rebuilt (... base_url ...)
+        SELECT                            ... base_url ...
+
+    A DEFAULT applies only to a column an INSERT OMITS, so the NULL is carried
+    into a NOT NULL column and the migration fails. `source_site.base_url` was
+    nullable through v13 -- measured, `notnull=0` -- so the row that triggers it
+    is legal, not corrupt.
+
+    THE MIGRATION'S OWN COMMENT SHOWS IT WAS REASONED ABOUT AND THE MECHANISM
+    MISTAKEN: "on his warehouse zero rows of either table hold a NULL -- 0 of 12
+    and 0 of 2 -- so the stronger constraint costs nothing". True of that data,
+    and the constraint is free only on that data.
+
+    IT ASSERTS THE EXACT MESSAGE, NOT MERELY THAT SOMETHING RAISED. A bare
+    `pytest.raises` here would keep passing if the wall moved to a different
+    column or a different migration, and would then be recording a defect that no
+    longer exists while hiding the one that does.
+
+    WHY THIS IS NOT FIXED IN PLACE: `0014` is applied and its digest is in the
+    ledger of every existing warehouse, so editing one character of it makes those
+    databases refuse to open (`domain.py` `_verify_checksums`). The pending
+    baseline squash absorbs it, which removes the file and the wall together --
+    and this test must be DELETED in that change, because the stop point it
+    explains stops existing with it.
+    """
+    db = EngineDatabase(tmp_path / "at_the_wall.db")
+    whole = db._migrations
+    assert len(whole) > BLOCKED_BY_0014, (
+        "the stream no longer reaches past the wall this test describes; if "
+        "0014 has been absorbed, delete this test with it")
+    db._migrations = whole[:BLOCKED_BY_0014]
+    db.initialize()
+    with db.connect() as conn:
+        columns = {r[1]: r[3] for r in conn.execute("PRAGMA table_info(source_site)")}
+        assert columns["base_url"] == 0, (
+            "base_url is no longer nullable at this version, so the row below "
+            "is not the legal row this test is about")
+        conn.execute(
+            "INSERT INTO source_site (source_key, source_name_ar, base_url) "
+            "VALUES ('a-shop-with-no-known-url', 'متجر', NULL)")
+        conn.commit()
+
+    db._migrations = whole
+    with pytest.raises(sqlite3.IntegrityError, match=
+            r"NOT NULL constraint failed: source_site_rebuilt\.base_url"):
+        db.initialize()

--- a/tests/test_the_registers_cannot_collide.py
+++ b/tests/test_the_registers_cannot_collide.py
@@ -303,15 +303,12 @@ RESERVED: dict[str, dict[int, str]] = {
         # 121 IS THIS BRANCH'S OWN and is a heading in docs/BACKLOG.md, not a row here.
         # DELETE EACH ROW THE DAY ITS PULL REQUEST LANDS -- a reservation left behind is a
         # permanent hole nobody owns, which is the rule this table states about itself.
-        # 120 SURVIVES AS ONE ROW CARRYING BOTH SIDES' EVIDENCE. Two sessions
-        # reserved it and keep-both left two rows; the guard below reported
-        # `OP[120]` and the copy Python keeps is the lower one. Verified with
-        #   git show refs/remotes/origin/claude/the-drift-check-that-was-off:docs/BACKLOG.md | grep "### OP-120"
-        # at c6bdf813, and it now has PR #307 open, which the earlier row could
-        # not know. 121 and 122 are GONE: 121 is declared by this branch and 122
-        # landed with #306 (`3c2aaa0d`), so each was a number reserved AND
-        # declared -- the contradiction the neighbouring test refuses.
-        120: "branch claude/the-drift-check-that-was-off, PR #307, at c6bdf813",
+        # 120'S ROW STOOD HERE AND IS GONE, on the rule this table states about
+        # itself: THIS branch is `claude/the-drift-check-that-was-off`, so OP-120
+        # is a heading in `docs/BACKLOG.md` here and a reservation for a declared
+        # number is the contradiction `test_a_reserved_number_is_not_also_declared`
+        # refuses. It caught the row on this rebase rather than a person doing so.
+        # 121 and 122 went the same way earlier, for the same reason.
         123: "branch claude/a-citation-nothing-reads, at a0c6e8c2",
         45: "branch claude/drive-without-a-server",
         # 112 THROUGH 114 became holes when this branch declared OP-117.


### PR DESCRIPTION
`tests/test_migration_drift.py` is the two-way drift check **`ENGINEERING.md` T5 mandates** — apply every migration to a previous release's database, then diff it against a fresh build. **It had been skipping since the M5 collapse.**

## A constant left behind by a deletion

The stop point was `PREVIOUS_RELEASE = 30`, the number the **deleted** price stream had, and the gate was `len(migrations) <= PREVIOUS_RELEASE`. The engine stream reached 16 and `16 <= 30` kept skipping:

```
ss  SKIPPED [2] the engine stream is 16 migration(s); drift cannot be
                measured until there is a version 30 to stop at
```

The file's own docstring promised *"the moment engine migration 0002 exists, this runs again"*. **0002 through 0016 all exist. It never ran.** The promise was in prose and the mechanism was a number nobody re-derived.

## Its first real run found a defect in a shipped migration

`0014_one_source_registry.sql` rebuilds `source_site` with `base_url TEXT NOT NULL DEFAULT ''` and then copies the old column through **by name** in an `INSERT ... SELECT`. **A DEFAULT applies only to a column the INSERT omits**, so the NULL is carried into a NOT NULL column. `source_site.base_url` was nullable through v13 — measured, `notnull=0` — so the row that triggers it is legal, not corrupt:

```
stop v2 .. v13  ->  IntegrityError: NOT NULL constraint failed: source_site_rebuilt.base_url
stop v14, v15   ->  OK, and zero drift in tables, columns, indexes, triggers or views
```

**The migration's own comment shows it was reasoned about and the mechanism mistaken:** *"on his warehouse zero rows of either table hold a NULL — 0 of 12 and 0 of 2 — so the stronger constraint costs nothing."* True of that data, and of no other.

**It is not fixed here.** The file is applied and its digest is in every existing ledger, so editing it makes those warehouses refuse to open. `REQ-52`'s baseline squash absorbs it.

## And the test's own seed produced a second defect that was not real

Every crude row said `"x"`, so when `0014` **merged** two source registries the rows collided: `UNIQUE constraint failed: source_site.source_key`. **Turning this file on reported two defects and only one existed.** Values are now distinct per `(table, column)`.

## What changed

| | |
|---|---|
| `PREVIOUS_RELEASE` 30 → **14** | with the reason for 14 rather than the midpoint written into the constant: v2..v13 are walled off by `0014`, so the span exercised over real rows is two migrations, not eight. Said out loud rather than hidden behind a number picked to make the suite green |
| `test_the_stop_point_is_a_version_this_stream_actually_has` | asserts `2 <= PREVIOUS_RELEASE < len(stream)` and **fails rather than skips**. A skip is what hid this for a month |
| `test_a_null_base_url_still_stops_the_registry_merge` | records the wall with the **exact** error text, so it fails if the wall moves to another column or another migration instead of quietly continuing to pass |

## Why this is a number and not a one-line constant change

The gate compared `PREVIOUS_RELEASE` against the stream and **nothing compared `PREVIOUS_RELEASE` against reality** — every other test in the file reads that constant and therefore agrees with whatever it says. The new assertion is the only one holding two independently-maintained things against each other.

**A skip must never be the only reporter.** It costs one character of output in a run nobody reads, and here it bought a month.

Worth reading alongside: `tests/conftest.py:31`, written 2026-07-31, lists the squash among measured-and-rejected options because it *"deletes the upgrade path T5 exists to check"* — **and T5 is this check, which was not running.** The stated reason for not squashing was protecting a guard that had been off the whole time.

## Verification

```
MODE A (full)              exit=0
MODE B (extension or docs) exit=0
tests/test_migration_drift.py   4 passed   (was: ss)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)