### PR TITLE
The table that lost its header, and the five true numbers about the wrong thing

### DIFF
--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -3382,12 +3382,13 @@ at all. A mechanism that is correct, visible, and load-bearing on nothing:
 | design review | `getComputedStyle` read against the `device` palette | **nothing.** It does not resolve a custom property, so `AccentColor` and `color-mix(...)` come back as literal TEXT and there is nothing to score |
 | Drive incident | `if (pointer.bytes && archive.size !== pointer.bytes)` | **nothing, at the only value that matters.** `0 &&` is falsy, so the comparison never ran and a 0-byte backup passed as good |
 | engine page | `test_the_web_page_offers_no_setting_to_change`, which mechanises an owner ruling | **nothing.** Its `_control_ids` regex matches `input\|select\|textarea`, so it cannot see a `<button>` -- and the nine ids it can see are exactly the nine on its own exemption list |
-| rebase, 2026-09-02 | `assert "/api/engine/health" in _engine_serves(tmp_path)`, plus the caller sweep beside it | the route, **in the only configuration that mounts it** -- `create_app(databases=registry)`; `scrapex ui --db <path>` serves no such route and the poll it guards 404s its whole budget (`OP-119`) |
+| design review, 2026-08-30 | **a full suite run to completion, exit 0** | **the tree it STARTED on, not the branch it was reported for** -- a checkout during the run swapped the subject |
+| rebase, 2026-09-02 | `assert "/api/engine/health" in _engine_serves(tmp_path)`, plus the caller sweep beside it | the route, **in the only configuration that mounts it** -- `create_app(databases=registry)`; an engine started against an explicit database path serves no such route and the poll it guards 404s its whole budget (`OP-119`) |
 
-**THREE OF THE EIGHT WERE BORN ROTTEN, NOT ONE, AND THAT IS THE FINDING.** Rows 2, 3 and 4
+**THREE OF THE NINE WERE BORN ROTTEN, NOT ONE, AND THAT IS THE FINDING.** Rows 2, 3 and 4
 rotted -- they held something once and their subject moved. **Rows 1, 5 and 7 never held
-anything.** Row 8 is neither, and it is the reason this section's closing claim had to be
-rewritten rather than extended -- see below.
+anything.** Rows 6, 8 and 9 are none of those three things, and row 9 is the reason this
+section's closing claim had to be rewritten rather than extended -- see below.
 
 > *(Row 6 arrived after this section was written, from the engine-page work. It is added
 > here rather than in a section of its own, and the counts above and below are moved with
@@ -3458,21 +3459,48 @@ were read off the captured output -- but the number was a true statement about t
 process. The fix is to record the status of the thing you meant to measure, in the artefact you
 will read: `echo "pytest exit=$?"` into the file itself.
 
-    row 8   a green   for the tree the run STARTED on
-    row 9   a route   in the configuration the guard always builds
-    tooling an exit 0 from the last process in the pipe
+**AND BY THE END OF THAT DAY THE TOOLING HAD SUPPLIED TWO MORE, WHICH IS WHAT MAKES THIS THE
+SECTION'S MOST GENERAL FINDING RATHER THAN A NOTE ABOUT GUARDS.** Every one is a true number
+about a subject nobody asked about:
 
-**All three are honest reports of the wrong subject, and no count anywhere would differ.** So
+    row 8    a green      for the tree the run STARTED on, not the branch reported
+    row 9    a route      in the configuration the guard always builds
+    `tail`   an exit 0    from the last process in the pipe, not from pytest
+    `grep -c` an exit 1   because it matched nothing -- which was the good news
+    `git diff --stat origin/main`   614 deletions   because `main` had MOVED, not
+                                                    because the branch deletes anything
+
+**The last two arrived while writing this paragraph.** `grep -cE "^FAILED" out/gate.txt` was the
+final command in a gate script, so a fully green run was announced as *failed with exit code 1*:
+zero matches is success to the person and failure to `grep`. And `git diff --stat origin/main`
+reported **614 deletions** on a branch whose real diff was 224 insertions and 56 deletions --
+truthful about a comparison against a `main` that had moved two merges ahead, and read as *"my
+change deletes 614 lines"*. **Neither was carelessness. Both are the same question unasked:
+which subject is this number about?**
+
+The fix is the same in all five: **record the status of the thing you meant to measure, in the
+artefact you will read** -- `echo "pytest exit=$?"` into the output file, `git diff --stat
+<your own base>` rather than a moving ref -- and never read a verdict off a wrapper that has
+its own opinion about success.
+
+**All of them are honest reports of the wrong subject, and no count anywhere would differ.** So
 the question the section closes on is not only *could this ever have failed* but **what exactly
 did this measure, and is it the thing the sentence beside it claims?**
- `LESSONS` §7 is the older half of
-this and §21 is the citation half; what 2026-08-30 added is that **it is not rare**. The test
-that finds them is the one §18 already states: *if the thing it protects were broken right
-now, would this fail?* -- asked of the guard's SUBJECT and not of its assertion.
 
-| Drive incident | `if (pointer.bytes && archive.size !== pointer.bytes)` | **nothing, at the only value that matters.** `0 &&` is falsy, so the comparison never ran and a 0-byte backup passed as good |
-| design review | **a full suite run to completion, exit 0** | **the tree it STARTED on, not the branch it was reported for** -- a checkout during the run swapped the subject |
-| rebase, 2026-09-02 | `assert "/api/engine/health" in _engine_serves(tmp_path)`, plus the caller sweep beside it | the route, **in the only configuration that mounts it** -- `create_app(databases=registry)`; an engine started against an explicit database path serves no such route and the poll it guards 404s its whole budget (`OP-119`) |
+**§7 IS THE OLDER HALF OF ALL OF THIS and §21 is the citation half**; what 2026-08-30 added is
+that **it is not rare**. The test that finds them is the one §18 already states: *if the thing
+it protects were broken right now, would this fail?* -- asked of the guard's SUBJECT and not of
+its assertion.
+
+> *(That sentence began mid-thought until 2026-09-02, and a three-row table stub with no header
+> sat immediately below it. Both were one keep-both merge resolution on 2026-08-30, in this
+> section, by the session that wrote the row it stranded: a paragraph was inserted INTO the
+> sentence, so its opening clause left with the other side, and the table's tail was kept twice
+> -- once in place and once as an orphan. **The stub's third row existed nowhere else**, so the
+> real table was one row short while the prose above it counted nine, and the numbers were the
+> only symptom. **A dangling half-sentence and an unheaded table are what a keep-both looks
+> like a day later**, which is the argument for resolving by numeric order AND re-reading the
+> prose across the seam. Resolving by order alone is what produced this.)*
 
 **The sixth was found the same day, in the Drive incident, and it is the sharpest of them because it names the VALUE at which a guard switches off.** A size, a count, a duration and a checksum all share one property: **zero is the least interesting number and the most alarming one**, and a truthiness test discards exactly it. Ask for PRESENCE — `typeof x === "number"` — which forgives an absent field and refuses a zero one.
 


### PR DESCRIPTION
A keep-both merge resolution in `LESSONS` §29 on 2026-08-30 left three defects
that no gate could see, and they reached `main` through #293. Mine, and by the
session that wrote the row it stranded.

| what was wrong | how it happened |
|---|---|
| a sentence beginning mid-thought — *"`LESSONS` §7 is the older half of this…"* | a paragraph was inserted INTO it, so its opening clause left with the other side of the conflict |
| a three-row table stub with **no header**, loose in the prose | the table's tail was kept twice — once in place, once as an orphan |
| the real table held **eight** rows while the prose above it counted **nine** | two stub rows duplicated the table; the third existed nowhere else |

**The arithmetic was the only symptom**, and it is the symptom this very section
was written to name.

## What changes

The stub is gone. Its unique row — *a full suite run to completion, exit 0,
against the tree it **started** on* — rejoins the table after row 7, which makes
it row 8 and `OP-119` row 9. **That is exactly what the prose already said**, so
the paragraphs are not rewritten; the table is corrected to the shape they were
written for. One count moves, eight to nine.

The sentence gets its subject back, and the incident is recorded in the section
it happened to, because it is the one thing that section did not say:

> a dangling half-sentence and an unheaded table are what a keep-both looks like
> a day later — which is the argument for resolving by numeric order **and
> re-reading the prose across the seam**. Order alone is what produced this.

## And the third-family paragraph gains two more members

Both found while writing it. `grep -cE "^FAILED" out/gate.txt` was the last
command in a gate script, so a fully green run was announced as *failed with
exit code 1* — zero matches is success to the person and failure to `grep`. And
`git diff --stat origin/main` reported **614 deletions** for a branch whose real
diff was 224 insertions and 56 deletions, truthful about a comparison against a
`main` that had moved two merges ahead.

```
row 8     a green     for the tree the run STARTED on, not the branch reported
row 9     a route     in the configuration the guard always builds
tail      an exit 0   from the last process in the pipe, not from pytest
grep -c   an exit 1   because it matched nothing — which was the good news
git diff  614 dels    because main moved, not because the branch deletes anything
a rebase
+ checkout 17 fails   from a tree that changed under a run already in flight
```

**None is carelessness and none is a wrong number.** All are the same question
unasked: *which subject is this number about?*

The last one is **row 8 arriving while the paragraph about row 8 was being
written** — gates launched in the background, `git checkout -b` twenty-six
minutes later to split this work out, and gate 2 then reporting 17 failures,
every one in the two tests that read repository files at run time. No defect; a
measurement of a tree that no longer existed. It is recorded because that is the
point: **knowing a trap is written down is not the same as remembering it at the
moment you step into it.** The operational rule now has two instances and two
sessions behind it — *never move the tree while a gate is in flight.*

## Scope and gates

`docs/LESSONS.md` only — 44 insertions, 16 deletions, one file. No code, no
register, no citation table.

| gate | result |
|---|---|
| `pytest -q` | `exit=0`, 0 failed |
| `SCRAPEX_FULL_MIGRATIONS=1 pytest -q` | `exit=0`, 0 failed |
| `node --test` | `exit=0`, 421/421 |
| `ruff check scrapex/` | `exit=0` |

Measured with the tree held still for the whole run, for the reason above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
