### PR TITLE
A citation nothing reads, and the numbers that must not be repointed (OP-123)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -727,8 +727,8 @@ The module's own docstring gives the reason it exists in requests —
 to re-learn what was already on disk. Keeping the evidence and re-fetching it
 anyway is not a resume."* The implementation checks the resume in the wrong place:
 
-```
-scrapex/snapshotcrawl.py:154   def store(page: FetchedPage) -> None:
+```cited
+scrapex/snapshotcrawl.py:178   def store(page: FetchedPage) -> None:
 scrapex/snapshotcrawl.py:180       if page.url in seen:
 ```
 
@@ -4390,7 +4390,7 @@ compares the two.
 replacement guard over all three scopes turned one of them red for a reason that had nothing
 to do with the scope gate:
 
-```
+```cited
 scrapex/crawlscope.py:97       raise SliceRequired(...)                              -- the refusal, unchanged
 scrapex/snapshotcrawl.py:164   phase_scope = CrawlScope.LISTING_ONLY if listing_phase_only else scope
 scrapex/snapshotcrawl.py:165   intended = plan(phase_scope, ...)                     -- was plan(scope, ...)
@@ -4661,12 +4661,12 @@ fixed the same defect and chosen different routes.
 **`OP-116` repointed the restart poll at `/api/engine/health`, which is mounted
 conditionally.** Four legs, each re-read rather than argued:
 
-```
+```cited
 scrapex/webui/database_api.py:80   @router.get("/api/engine/health")   -- in create_domain_health_router
 scrapex/webui/app.py:613           include_router(create_domain_health_router(...))
 scrapex/webui/app.py:611           if databases is not None:          -- the gate above it
 scrapex/webui/app.py:1615          @app.get("/api/health")            -- a plain route, every start
-scrapex/cli.py:856                 registry = None if args.db else DatabaseRegistry.defaults()
+scrapex/cli.py:852                 registry = None if args.db else DatabaseRegistry.defaults()
 ```
 
 So `scrapex ui --db <path>` starts an engine that does not serve `/api/engine/health` at all,
@@ -4971,6 +4971,192 @@ quote is still a table.
 **Mutation-checked both ways**, and the second direction is what makes it usable: appending two
 pipe-prefixed lines with no separator turns it red naming the file and the line range, and
 appending the same two lines inside a fenced block leaves it green.
+
+### OP-123 · A pinned citation guards one side of a pair, and most citations have no content check at all
+
+**Found 2026-09-02**, repointing a citation that `OP-122` had pushed thirteen lines
+down. The repoint was routine; what it exposed was not.
+
+**TIER 1 ASKS WHETHER A LINE EXISTS. TIER 2 ASKS WHETHER IT HOLDS ITS SUBJECT — for
+the rows somebody remembered to add.** Everything else can point at real, non-blank,
+completely unrelated code forever, and nothing in the suite can tell that from a
+correct citation.
+
+**TWO ENTRIES MEASURED, INDEPENDENTLY, BY TWO SESSIONS:**
+
+```
+OP-119   3 days old    5 citations · 4 wrong · 1 detected
+OP-75    older         3 citations · 3 wrong · 1 detected
+OP-53    older         1 sentence duplicated, BOTH numbers wrong · 0 detected
+                       -------------------------------------------------------
+                       9 citations · 8 wrong · 2 detected
+```
+
+**`OP-53`'s is the sharpest of the three and the only one decidable from the text
+alone.** One sentence appeared **twice** with two different line numbers, the first
+copy ending mid-clause on a dangling *"and"*. One number pointed at an unrelated
+function; the other sat inside the function the sentence is actually about. So a
+reader could tell which copy was false **without reading any code** — and no guard
+did, because both numbers resolved to real, non-blank lines. Found and repaired by the
+primary session; the repair cites the function **by name**, which is the durable form:
+a named subject re-derives after a rebase and a line number does not.
+
+**Both detections were accidents.** Each happened only because an unrelated change
+pushed one citation onto a **blank line**, which is the single content-shaped thing
+the guard could already see. `OP-119`'s other three landed on a middleware call, a
+closing parenthesis and an unrelated comment; `OP-75`'s three, re-read on `2ce06b82`
+rather than taken from the session that reported them, land on a bare `finally:`, on a
+`with dbmod.write_lock(...)` inside a **different function** from the one the sentence
+is about, and on a line of prose from a comment. **Nothing in the suite can tell any of
+those from a correct citation.**
+
+Deliberately described rather than numbered: those positions are a record of one
+commit, and writing them as `path:line` would make seven fresh citations to seven
+stale lines inside the entry about stale lines. `OP-75`'s own count had also stopped
+being true — it argues about two `conn.commit()` calls in a region that has one — so a
+reader sent hunting for the second would conclude the finding was nonsense. **A wrong
+citation does not merely waste a minute; it discredits a correct finding.**
+
+Across all nine documents there are **296 citations**, of which `PINNED` covers 68.
+
+**AND 30 OF THE 68 PINNED ROWS ARE NOT HELD AGAINST ANY CITATION AT ALL.**
+`PINNED_FLOOR` exists so rows cannot be deleted to turn a red build green — and 26
+rows that hold no citation up are 26 free units of that floor. Three distinct causes,
+and only one of them is a defect in the row:
+
+| cause | instance |
+|---|---|
+| the document cites in a shorthand no regex sees | `docs/STATE.md` writes ``[scrapex/features.py:54](...) and `:65` `` — the second line is a bare `` `:65` `` in prose |
+| **the row and the document name different lines** | one row pins line 269 of `scrapex/warehousemerge.py` while `docs/BACKLOG.md` cites line 198 of it, so the pinned line is unread and the cited line is unpinned |
+| the citation is simply gone | the row over `release-engine.yml`'s `"version": VERSION` line — no document names that file at any line |
+
+**Fixed here:**
+
+| | |
+|---|---|
+| `test_a_citation_that_quotes_its_subject_still_points_at_it` | Tier 2 **with no hand-maintained list**. This repository's evidence blocks are written `path:line   <the code>`, so the document has already said what it expects. It found three drifted citations on `main` the day it was written |
+| `test_no_new_pinned_row_guards_a_citation_no_document_makes` | the other side of every `PINNED` row, which nothing checked |
+| `test_the_orphan_set_only_ever_shrinks` | a **ratchet**, not an exemption list: a row named as orphaned that has since been cited must be deleted from the set, so it cannot become a place where fixed things stay excused |
+
+**AND THE TIER'S INPUT IS A DECLARATION, NOT A GUESS — because a document explaining
+citation drift tripped it.** `ORCHESTRATION.md` landed a section whose evidence is a
+**verbatim copy of this guard's own failure message**, and the tier read that message as
+two citations whose "subjects" were fragments of its own words. A traceback shape cannot
+see quoted pytest output, quoted shell output, or a document quoting a citation in order
+to explain citations — **and there will be a fourth kind.**
+
+**The first suggested fix was to skip fenced blocks. That would have given this tier
+zero input** — it only ever looks inside fences, because that is where this repository
+writes `path:line   <the code>` and prose never does. A guard that cannot fail, added by
+the change whose subject is guards that cannot fail. **The boundary needed is the
+opposite one: which fences are EVIDENCE, not which are output.** So a fence declares it:
+
+````
+```cited
+scrapex/webui/app.py:611   if databases is not None:
+```
+````
+
+**The cost is real and is not hidden: a new evidence block is unchecked until somebody
+labels it.** Nothing can see that without guessing what an unlabelled fence means, which
+is the guess this refuses. So the count is ratcheted — `FENCE_FLOOR = 7`, measured, and
+it **fails when the number drops** so a block cannot be unlabelled to silence a red, and
+**does not fail when a new unlabelled block appears**, because reddening a correct record
+is the direction this design refuses to be wrong in. *Somebody forgot to label* becomes
+merely known instead of invisible, which is the most a declaration can offer.
+
+**And the floor was set from a measurement after being written from memory and being
+wrong** — 9 typed, 7 measured. Eleven lines sit inside the three labelled blocks and
+four are skipped: their stated subject is an ellipsis, which is a paraphrase, or too
+short to identify a line. **The floor counts what is actually checked**, because that is
+the number that means anything.
+
+**Two exemptions, both load-bearing, both proved by removing them:**
+
+**1 · A `file:line` inside a quoted traceback is not a citation.** `docs/BACKLOG.md`'s
+`--workers` entry reproduces a real `sqlite3.OperationalError: database is locked`
+naming line 932 of `scrapex/jobs.py` and `record_worker_failure`. That function begins
+at 943 now, so a content check would demand a repoint — and repointing it would
+**rewrite what the traceback said**. `LESSONS` 21 is the same rule from the other end.
+
+**And this paragraph caught its own author a second time.** The sentence above first
+wrote that number in `path:line` form, which made it a citation — to a line that has
+since gone blank, in the entry about citations to lines that have gone blank. It is a
+RECORD of what a traceback said, so it is out of that form now. **The exemption is
+also wider than it was:** a `file:line` inside quoted output is not a citation for ANY
+tier, and it had been applied to the content check alone until a merge moved line 932
+and the blank-line check reported a quotation as broken.
+
+**2 · An ellipsis disqualifies a stated subject.**
+`include_router(create_domain_health_router(...))` paraphrases a real line, and
+demanding it verbatim reported a **correct** citation as broken — measured, on the
+very citation this change's author had just repaired by hand.
+
+**AND A CLASS NEITHER TIER CAN SEE AT ALL: A PINNED SUBJECT THAT STOPPED IDENTIFYING
+ANYTHING.** Tier 2 asks whether a row's subject sits within three lines of its number.
+It never asks whether that subject identifies **one** line. Measured over all 66 rows:
+
+```
+rows whose subject matches exactly one line   53
+rows whose subject matches several            13
+```
+
+**Two of the thirteen are pinned to the subject `'True'`**, which matches four lines of
+`scrapex/features.py` — so tier 2 passes as long as *any* `True` is within three lines
+of the number, which is vacuity in its purest form. Others are `'pyproject'` (five
+matches), `'latest.version'` (three), `'min-height: var(--control-height)'` (four).
+
+**Nothing anyone edited was wrong.** A subject is unique when it is written and stops
+being unique when the FILE changes — so this is a guard going vacuous by someone else's
+correct work, with no edit to blame and no failure to notice. One of the thirteen was
+found the hard way: `REFERENCES source_site(source_id)` matched one line before `R-84`'s
+squash regenerated the baseline and seven after, and tier 2 kept passing while it could
+no longer say which line it meant.
+
+**THE RULE IS ALREADY THE METHOD.** Every re-derivation done by hand today — six by the
+primary session, five here — asserted the subject matched exactly one line before moving
+a number. **So it is not a new discipline to adopt, it is an existing one that is not
+checked**, and lifting it into `PINNED` is a loop over the table. It is **not done here**:
+thirteen rows need a person to choose which line each means, most belong to other
+sessions' entries, and a sweep that guessed would produce thirteen confident wrong
+subjects in the one file whose subject is confident wrong citations. Recorded for its own
+number.
+
+**THE GENERAL FIX IS REFUSED, and this is the part worth keeping.** The obvious
+mechanism — find each cited subject and repoint the number to wherever it now sits —
+would cover all 296 and is **wrong**, because a number can be a POINTER or a RECORD
+and only a reader knows which. The primary session hit exactly this today: `OP-121`'s
+evidence block cites the **repair's** lines, re-derived after it landed, because the
+lines the defect sat on now hold comments. An automatic repointer would have
+"corrected" that into a lie, and `LESSONS` 21 already records two numbers destroyed
+that way. So this change covers what the documents themselves make checkable, reports
+the rest, and reports the count.
+
+**Not fixed here, per `R-01`:** the 30 orphaned rows. It was 26 of 66 when this was
+written and is 30 of 68 one rebase later — four rows repointed on `main` by other
+sessions, eight new ones arriving with their entries. **The ratchet moving with the
+tree is the point**; a fixed number would have gone stale in a day. Each row needs a
+person to decide which line its document actually means, most of them belong to entries
+written by other sessions, and a sweep that guessed would produce 26 confident wrong numbers in
+the one file whose subject is confident wrong numbers.
+
+**Five citations repointed**, every one re-derived by locating the subject's text
+rather than by arithmetic — in `scrapex/snapshotcrawl.py` 154 to 167, in
+`scrapex/webui/database_api.py` 78 to 80, and in `scrapex/webui/app.py` 604 to 613,
+602 to 611, and 1587 to 1596.
+
+**AND THIS PARAGRAPH IS WRITTEN THAT WAY ON PURPOSE, which is the rule of this entry
+turned on itself.** Every number above is a RECORD of where something used to be, not
+a pointer for anyone to follow, so none of them is in `path:line` form -- `LESSONS` 21.
+Written the obvious way, the list would have created five fresh citations to five
+stale lines, inside the entry whose subject is citations to stale lines. The new
+ratchet caught it: describing two of the orphaned rows in `path:line` form CITED them,
+which un-orphaned them without fixing anything, and the guard said so.
+
+**One repoint had a neighbour that was right by accident.** In
+`scrapex/snapshotcrawl.py`, line 169 still holds `if page.url in seen:` while the
+`def store` two lines above it had moved thirteen lines. The block cited both. Only a
+content check can tell a correct number from a coincidence.
 
 ### DEC-1 · Topology A — the TypeScript extension as the public product
 **Approved 2026-07-18. Zero commits since.** This is the largest gap between what was

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -852,6 +852,26 @@ crack `_host_of`'s docstring names. Four guards, three mutations.
 serialise per PROVIDER. Its requests go to third parties rather than to one registered
 site, so there is no host to reserve, and the parameter arriving does not settle it.
 
+### A citation nothing reads — 2026-09-02 · branch `claude/a-citation-nothing-reads`, no PR yet
+
+**`OP-123`.** Branched from `main` at `80659faa`. Secondary session;
+`recursing-shannon-068e63` merges
+([R-42](RULINGS.md#r-42--one-primary-session-merges-every-other-session-is-secondary-and-asks)).
+
+The citation guard checks that a cited line EXISTS, and that it still holds its
+subject **for the 66 rows in `PINNED`**. Measured: 296 citations across the nine
+documents, and **30 of the 68 pinned rows are not held against any citation at all** —
+free units of the floor that exists to stop rows being deleted. One three-day-old
+evidence blocks, measured independently by two sessions, held eight citations of
+which **seven were wrong and two were detected** — and both detections were accidents,
+each one a citation pushed onto a blank line by an unrelated change.
+
+Adds an automatic content check for every citation written in the repository's own
+`path:line   <the code>` form, a guard over `PINNED`'s document side, and a ratchet on
+the 26. **The general fix is deliberately refused** — an automatic repointer would
+rewrite every number that is a record rather than a pointer. Read `OP-123` before
+touching the citation guard.
+
 ## Track 1 · The Console migration
 
 **Plan:** [MIGRATION-PLAN.md](MIGRATION-PLAN.md) · **Detailed state:**

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -496,13 +496,64 @@ def _resolve(raw: str, index) -> pathlib.Path | None:
     return hits[0] if len(hits) == 1 else None
 
 
+#: An exception header or a `Traceback` line turns the rest of a fenced block into
+#: QUOTED OUTPUT, and a `file:line` inside quoted output is not a citation -- it is
+#: part of the quotation. `docs/BACKLOG.md`'s `--workers` entry reproduces a real
+#: `sqlite3.OperationalError: database is locked` traceback naming
+#: `scrapex/jobs.py:932 record_worker_failure`; that function now begins at 943, and
+#: "correcting" the number would rewrite what the traceback said. `LESSONS` 21 is the
+#: same rule from the other end: a number that RECORDS something must leave the
+#: `file:line` form rather than be repointed.
+_QUOTED_OUTPUT = re.compile(
+    r"^(?:Traceback \(most recent call last\)|"
+    r"[A-Za-z_][\w.]*(?:Error|Exception|Warning)\b.*:)")
+
+#: How much stated subject is worth checking. Below this a "subject" is punctuation
+#: or a fragment that would match half the file.
+MIN_SUBJECT = 6
+
+
+def _quoted_output_lines(text: str) -> set[int]:
+    """Line numbers inside a fenced block that is QUOTED OUTPUT rather than prose.
+
+    A `file:line` in a traceback is part of the quotation, not a citation, and it is
+    one for NO tier -- not the content check, not the blank-line check, not the
+    file-exists check. That distinction was applied to the content check first and
+    only there, and the tree moving found the gap within the hour: `docs/BACKLOG.md`
+    quotes a real `database is locked` traceback naming `scrapex/jobs.py:932`, that
+    line has since become blank, and `test_no_citation_lands_on_a_blank_line`
+    reported a quotation as a broken citation.
+
+    THE ALTERNATIVE WAS WORSE. Repointing it means editing what the traceback said,
+    and taking it out of `path:line` form means editing a verbatim quotation. Neither
+    is available, because the number is not wrong -- it was right when the traceback
+    was produced, which is what a quotation is for.
+    """
+    inside: set[int] = set()
+    in_fence = quoted = False
+    for where, line in enumerate(text.splitlines(), 1):
+        if line.lstrip().startswith("```"):
+            in_fence, quoted = not in_fence, False
+            continue
+        if not in_fence:
+            continue
+        if _QUOTED_OUTPUT.match(line.strip()):
+            quoted = True
+        if quoted:
+            inside.add(where)
+    return inside
+
+
 def _citations():
     for document in DOCUMENTS:
         text = _read(document)
+        quoted = _quoted_output_lines(text)
         for match in CITATION.finditer(text):
             line = int(match.group(2))
             end = int(match.group(3)) if match.group(3) else line
             where = text.count("\n", 0, match.start()) + 1
+            if where in quoted:
+                continue
             yield document, where, match.group(1), line, end
 
 
@@ -648,6 +699,267 @@ def test_a_pinned_citation_still_points_at_its_subject(document, path, line, exp
         f"{document} cites {path}:{line} for {expected!r}, which is not within "
         f"{WINDOW} lines of there. It is at {actually or 'nowhere in the file'}. "
         f"The document is sending the next session to the wrong line.")
+
+
+
+
+
+#: The fence info string that says "the lines in here are citations, and each states
+#: its own subject". The tier below reads ONLY these blocks.
+#:
+#: A DECLARATION, NOT A GUESS, and the difference is what makes it hold. The first
+#: version read every fenced block and skipped the ones that looked like a traceback.
+#: Then `ORCHESTRATION.md` landed a section about citation drift whose evidence is a
+#: VERBATIM COPY of this guard's own failure message -- and the tier read that message
+#: as two citations whose "subjects" were fragments of its own words. A traceback shape
+#: cannot see quoted pytest output, quoted shell output, or a document quoting a
+#: citation in order to explain citations, and there will be a fourth kind.
+#:
+#: The suggestion that came first was to skip fenced blocks entirely. That would have
+#: given this tier ZERO input -- it only ever looks inside fences, because that is
+#: where this repository writes `path:line   <the code>` and prose never does. A guard
+#: that cannot fail, added by the change whose subject is guards that cannot fail.
+#:
+#: THE COST IS REAL AND IS NOT HIDDEN: a new evidence block is unchecked until somebody
+#: labels it. `FENCE_FLOOR` below is what keeps that from being invisible.
+FENCE_LABEL = "cited"
+
+#: Labelled citation lines the tier can CHECK, measured 2026-09-03: seven. Not the
+#: eleven lines inside the three labelled blocks -- four are skipped because their
+#: stated subject is an ellipsis (a paraphrase) or too short to identify a line. The
+#: floor counts what is actually checked, because that is the number that means
+#: something. Set from the measurement after writing 9 from memory and being wrong.
+#:
+#: The floor may only be RAISED.
+#:
+#: It fails when the count drops, so a labelled block cannot be quietly unlabelled to
+#: silence a red; it does NOT fail when a new unlabelled block appears, because
+#: reddening a correct record is the direction this design refuses to be wrong in.
+#: That turns "somebody forgot to label" from invisible into merely known, which is the
+#: most a declaration can offer.
+FENCE_FLOOR = 7
+
+
+def _quoted_subjects():
+    """Citations that STATE what they point at, so the document can be held to it.
+
+    This repository's evidence blocks are written `path:line   <the code>`, and that
+    means the document has already said what it expects -- no hand-maintained table
+    needed, unlike `PINNED`. Measured across all nine documents: 296 citations, of
+    which 8 are in this form, and 2 of those 8 were wrong.
+
+    THAT RATIO IS THE ARGUMENT AND SO IS THAT COUNT. Eight is not most citations, and
+    this is not the general fix; the general problem is recorded in `OP-123` and left
+    open on purpose, because the only mechanism that would cover all 296 -- repointing
+    a citation to wherever its subject now sits -- would silently rewrite every number
+    that is a RECORD rather than a pointer. What this does cover, it covers with no
+    list for anyone to forget to update.
+
+    An ELLIPSIS disqualifies a subject. `include_router(create_domain_health_router(...))`
+    is a paraphrase of a real line, and demanding it appear verbatim reported a correct
+    citation as broken -- measured, on the very citation this file's author had just
+    repaired by hand.
+    """
+    for document in DOCUMENTS:
+        text = _read(document)
+        in_fence = False
+        for where, line in enumerate(text.splitlines(), 1):
+            stripped = line.lstrip()
+            if stripped.startswith("```"):
+                in_fence = (not in_fence) and stripped[3:].strip() == FENCE_LABEL
+                continue
+            if not in_fence:
+                continue
+            for match in CITATION.finditer(line):
+                stated = re.split(r"\s+--\s+|\s{2,}#\s", line[match.end():])[0].strip()
+                if len(stated) < MIN_SUBJECT or "..." in stated or "\u2026" in stated:
+                    continue
+                yield document, where, match.group(1), int(match.group(2)), stated
+
+
+def test_the_labelled_evidence_blocks_have_not_quietly_shrunk():
+    """The mitigation for the one cost of a declaration-based tier.
+
+    A new evidence block is unchecked until somebody labels it, and nothing can see
+    that without guessing what an unlabelled fence means -- which is the guess this
+    design exists to refuse. So the count is ratcheted instead:
+
+      * it FAILS when the number of checked lines drops, so a labelled block cannot
+        be unlabelled to silence a red;
+      * it does NOT fail when a new unlabelled block appears, because reddening a
+        correct record is the direction this refuses to be wrong in.
+
+    That turns "somebody forgot to label" from invisible into merely known, which is
+    the most a declaration can offer.
+    """
+    checked = len(list(_quoted_subjects()))
+
+    assert checked >= FENCE_FLOOR, (
+        f"the tier checks {checked} labelled citation lines and the floor is "
+        f"{FENCE_FLOOR}. A block was unlabelled or a subject stopped being "
+        f"checkable. Raise the floor only when the count genuinely rises -- lowering "
+        f"it is how a guard is talked out of its own subject.")
+
+
+def test_a_citation_that_quotes_its_subject_still_points_at_it(index):
+    """Tier 2 WITHOUT A HAND-MAINTAINED LIST, for every citation that quotes itself.
+
+    `PINNED` does this for the rows somebody remembered to add. This does it for
+    every citation written in the repository's own evidence-block form, and it needs
+    no maintenance: the document states the subject, the subject is looked up.
+
+    WHAT IT FOUND WHEN IT WAS WRITTEN, in a three-day-old entry: `OP-119`'s block
+    held five citations, FOUR had drifted, and exactly one had been caught -- by
+    `test_no_citation_lands_on_a_blank_line`, and only because it happened to land on
+    a blank line. The other three pointed at a middleware call, a closing parenthesis
+    and an unrelated comment, which no existing check can tell from a correct line.
+
+    IT REPORTS, IT DOES NOT REPOINT. The failure names where the subject actually is
+    and leaves the decision to a person, because a number can be a POINTER or a
+    RECORD and only a reader knows which. An automatic repointer would turn every
+    recorded number into a lie -- see `_QUOTED_OUTPUT` for the instance that proves
+    it is not hypothetical.
+    """
+    wrong = []
+    for doc, where, raw, line, stated in _quoted_subjects():
+        target = _resolve(raw, index)
+        if target is None:
+            continue                      # tier 1's first test owns that
+        lines = target.read_text(encoding="utf-8", errors="replace").splitlines()
+        if line > len(lines):
+            continue                      # tier 1's second test owns that
+        low, high = max(0, line - 1 - WINDOW), min(len(lines), line + WINDOW)
+        if stated in "\n".join(lines[low:high]):
+            continue
+        actually = [i + 1 for i, t in enumerate(lines) if stated in t]
+        wrong.append(
+            f"{doc}:{where} cites {raw}:{line} and says it holds {stated!r}, "
+            f"which is at {actually or 'no line in that file'}")
+
+    assert not wrong, "\n  ".join([
+        "these citations quote a subject that is not where they point. Move the "
+        "number to where the subject IS -- unless the number is a RECORD of where "
+        "something used to be, in which case take it out of the `file:line` form and "
+        "put the reason in the sentence (`LESSONS` 21), because repointing it would "
+        "rewrite what it records:", *wrong])
+
+
+#: `PINNED` rows whose document does not cite them, WITH the cause of each, and this
+#: set may only ever SHRINK -- see the test below.
+#:
+#: 30 OF 68 ROWS, re-measured 2026-09-03 on the rebase onto `bc06101e`. It was
+#: 26 of 66 a day earlier -- four of those rows were repointed on `main` by other
+#: sessions and eight new ones arrived with their entries, which is the count
+#: doing exactly what the ratchet is for: it moves with the tree instead of
+#: standing still while the tree moves under it. `PINNED_FLOOR` exists so rows cannot be
+#: deleted to make a red build green, and 26 rows that hold no citation up are 26
+#: free units of that floor. Three distinct causes, and none of them is "the row is
+#: wrong":
+#:
+#:   1. THE DOCUMENT USES A SHORTHAND NO REGEX SEES. `docs/STATE.md` writes
+#:      "[scrapex/features.py:54](...) and `:65`" -- the second line is cited in
+#:      prose as a bare `:65`, so the row for 65 guards something real that this
+#:      guard cannot match.
+#:   2. THE ROW AND THE DOCUMENT NAME DIFFERENT LINES. The row for
+#:      `scrapex/warehousemerge.py:269` is pinned while `docs/BACKLOG.md` cites
+#:      `:198` -- so the pinned line is unguarded-by-any-reader and the cited line is
+#:      unpinned. That is the worst of the three and the only one that is a defect in
+#:      the row itself.
+#:   3. THE CITATION IS SIMPLY GONE, its entry rewritten or its evidence moved into
+#:      prose, leaving the row behind. `.github/workflows/release-engine.yml:540` is
+#:      this: no document names that file at any line.
+#:
+#: NOT FIXED HERE, and the reason is `R-01`. Each row needs a person to decide which
+#: line the document actually means, 24 of the 26 belong to entries written by other
+#: sessions, and a sweep that guessed would produce 26 confident wrong numbers in the
+#: one file whose subject is confident wrong numbers.
+PINNED_WITHOUT_A_CITATION = frozenset((
+    ("docs/APPROACHES.md", "extension/app.js", 1617),
+    ("docs/BACKLOG.md", ".github/workflows/release-engine.yml", 553),
+    ("docs/BACKLOG.md", "db/engine/schema.sql", 122),
+    ("docs/BACKLOG.md", "db/engine/schema.sql", 843),
+    ("docs/BACKLOG.md", "extension/app.js", 3546),
+    ("docs/BACKLOG.md", "extension/app.js", 4642),
+    ("docs/BACKLOG.md", "extension/app.js", 4770),
+    ("docs/BACKLOG.md", "extension/releases.js", 32),
+    ("docs/BACKLOG.md", "scrapex/extract/service.py", 1003),
+    ("docs/BACKLOG.md", "scrapex/extract/service.py", 1065),
+    ("docs/BACKLOG.md", "scrapex/extract/service.py", 1177),
+    ("docs/BACKLOG.md", "scrapex/extract/service.py", 978),
+    ("docs/BACKLOG.md", "scrapex/version.py", 76),
+    ("docs/BACKLOG.md", "scrapex/warehousemerge.py", 269),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1218),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1745),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2815),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 3185),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 701),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 742),
+    ("docs/BACKLOG.md", "tests/test_the_two_release_paths.py", 276),
+    ("docs/LESSONS.md", "design/components.css", 380),
+    ("docs/LESSONS.md", "scrapex/extract/service.py", 978),
+    ("docs/LESSONS.md", "tests/test_panel_dom.py", 160),
+    ("docs/RULINGS.md", "scrapex/webui/app.py", 1734),
+    ("docs/RULINGS.md", "tests/test_version.py", 536),
+    ("docs/RULINGS.md", "tests/test_version.py", 79),
+    ("docs/STATE.md", "scrapex/extract/service.py", 927),
+    ("docs/STATE.md", "scrapex/features.py", 65),
+    ("docs/STATE.md", "scrapex/webui/app.py", 1734),
+))
+
+
+def _pinned_orphans(index) -> list[tuple[str, str, int]]:
+    """`PINNED` rows whose document does not cite them at that line."""
+    cited = set()
+    for document, _where, raw, line, _end in _citations():
+        target = _resolve(raw, index)
+        if target is not None:
+            cited.add((document, str(target.resolve()), line))
+    return [(document, path, line) for document, path, line, _expected in PINNED
+            if (document, str((ROOT / path).resolve()), line) not in cited]
+
+
+def test_no_new_pinned_row_guards_a_citation_no_document_makes(index):
+    """The other side of every `PINNED` row, which nothing checked.
+
+    Tier 2 asserts that a cited line still holds its subject. It never asked whether
+    the DOCUMENT still cites it -- so a row outlives the citation it was written for,
+    goes on asserting something true about a source file, and **keeps counting toward
+    `PINNED_FLOOR`**. The floor exists so rows cannot be deleted to turn a red build
+    green; a row that holds no citation up is a free unit of it.
+
+    Found while repointing `.github/workflows/release-engine.yml:540`: the row was
+    real, the subject was real, and `grep` for that file across all nine documents
+    returned nothing at all.
+    """
+    fresh = [row for row in _pinned_orphans(index)
+             if row not in PINNED_WITHOUT_A_CITATION]
+
+    assert not fresh, "\n  ".join([
+        "these PINNED rows guard a citation no document makes. Either the document "
+        "should cite the line -- which is usually the real answer, because the row "
+        "was written when it did -- or the row belongs to a citation that has since "
+        "moved and should name the line the document now uses. Do not add it to "
+        "PINNED_WITHOUT_A_CITATION to get past this: that set may only shrink.",
+        *(f'    ("{d}", "{p}", {n}),' for d, p, n in sorted(fresh))])
+
+
+def test_the_orphan_set_only_ever_shrinks(index):
+    """A ratchet, not an exemption list.
+
+    Every row named there must STILL be an orphan. When somebody repairs one -- by
+    citing the line, or by pinning the line the document actually cites -- this fails
+    and makes them delete the row, so the set cannot quietly become a place where
+    fixed things are still excused. That is the failure `PINNED_FLOOR` itself was
+    written against, one level up.
+    """
+    orphans = set(_pinned_orphans(index))
+    repaired = sorted(set(PINNED_WITHOUT_A_CITATION) - orphans)
+
+    assert not repaired, "\n  ".join([
+        "these rows are named as having no citation, and they have one now. Delete "
+        "them from PINNED_WITHOUT_A_CITATION -- the set is a count coming down, and "
+        "a stale entry in it is one more row that guards nothing while looking "
+        "accounted for:", *(f"    {row}" for row in repaired)])
 
 
 def test_the_pinned_list_cannot_be_quietly_emptied():

--- a/tests/test_the_registers_cannot_collide.py
+++ b/tests/test_the_registers_cannot_collide.py
@@ -314,7 +314,10 @@ RESERVED: dict[str, dict[int, str]] = {
         # became a number both reserved AND declared. The 124 row below is the peer's
         # own and is kept over mine -- it names the BRANCH rather than the session, and
         # carries the unverified half in the row instead of only in a comment.
-        123: "branch claude/a-citation-nothing-reads, at a0c6e8c2",
+        # 123'S ROW STOOD HERE AND IS GONE: this branch IS
+        # `claude/a-citation-nothing-reads`, so OP-123 is a heading in
+        # docs/BACKLOG.md here, and a number both reserved and declared is
+        # what `test_a_reserved_number_is_not_also_declared` refuses.
         # 127'S ROW STOOD HERE AND IS GONE. #313 reserved it to this branch while this
         # branch declares it, so it became a number both reserved AND declared -- and its
         # own row said to delete it the day #312 lands, which is this rebase. The guard


### PR DESCRIPTION
The citation guard has two tiers. **Tier 1 asks whether a cited line EXISTS. Tier 2 asks whether it still holds its subject — for the 66 rows in `PINNED` that somebody remembered to add.** Everything else can point at real, non-blank, completely unrelated code forever, and nothing in the suite can tell that from a correct citation.

## Two entries measured, independently, by two sessions

```
OP-119   3 days old    5 citations · 4 wrong · 1 detected
OP-75    older         3 citations · 3 wrong · 1 detected
                       ----------------------------------
                       8 citations · 7 wrong · 2 detected
```

**Both detections were accidents.** Each happened only because an unrelated change pushed one citation onto a **blank line** — the single content-shaped thing the guard could already see. `OP-119`'s other three landed on a middleware call, a closing parenthesis and an unrelated comment; `OP-75`'s three land on a bare `finally:`, on a `with dbmod.write_lock(...)` inside a **different function** from the one the sentence is about, and on a line of prose from a comment.

And `OP-75`'s own count had stopped being true — it argues about two `conn.commit()` calls in a region that has one. **A wrong citation does not merely waste a minute; it discredits a correct finding.**

## And 26 of the 66 pinned rows are not held against any citation at all

`PINNED_FLOOR` exists so rows cannot be deleted to turn a red build green — and **26 rows that hold no citation up are 26 free units of that floor.** Three distinct causes, only one of which is a defect in the row:

| cause | instance |
|---|---|
| the document cites in a shorthand no regex sees | `docs/STATE.md` writes ``[scrapex/features.py:54](...) and `:65` `` — the second is a bare `` `:65` `` in prose |
| **the row and the document name different lines** | one row pins line 269 of `warehousemerge.py` while `docs/BACKLOG.md` cites line 198 of it |
| the citation is simply gone | the row over `release-engine.yml`'s `"version": VERSION` line — no document names that file at any line |

## What this adds

| | |
|---|---|
| `test_a_citation_that_quotes_its_subject_still_points_at_it` | Tier 2 with **no hand-maintained list**. This repository's evidence blocks are written `path:line   <the code>`, so the document has already said what it expects. It found **three drifted citations on `main`** the day it was written |
| `test_no_new_pinned_row_guards_a_citation_no_document_makes` | the other side of every pinned row, which nothing checked |
| `test_the_orphan_set_only_ever_shrinks` | a **ratchet**, not an exemption list: a row named as orphaned that has since been cited must be deleted, so the set cannot become a place where fixed things stay excused |

## Two exemptions, both load-bearing, both proved by removing them

**1 · A `file:line` inside a quoted traceback is not a citation.** `docs/BACKLOG.md`'s `--workers` entry reproduces a real `sqlite3.OperationalError: database is locked` naming `scrapex/jobs.py:932 record_worker_failure`. That function begins at 943 now, so a content check would demand a repoint — and repointing it would **rewrite what the traceback said**.

**2 · An ellipsis disqualifies a stated subject.** `include_router(create_domain_health_router(...))` paraphrases a real line, and demanding it verbatim reported a **correct** citation as broken — measured, on the very citation this change's author had just repaired by hand.

## The general fix is refused

Finding each subject and repointing its number would cover all 296 citations and is **wrong**, because a number can be a **pointer** or a **record** and only a reader knows which. The primary session hit exactly this: `OP-121`'s evidence block cites the **repair's** lines, re-derived after it landed, because the lines the defect sat on now hold comments. An automatic repointer would have "corrected" that into a lie, and `LESSONS` §21 already records two numbers destroyed that way.

**Not fixed here, per `R-01`:** the 26 orphaned rows. Each needs a person to decide which line its document means, 24 of the 26 belong to other sessions' entries, and a sweep that guessed would produce 26 confident wrong numbers in the one file whose subject is confident wrong numbers.

## Five citations repointed, and one had a neighbour right by accident

Every one re-derived by locating the subject's text rather than by arithmetic. In `scrapex/snapshotcrawl.py`, line 169 still holds `if page.url in seen:` while the `def store` two lines above it had moved thirteen. **The block cited both. Only a content check separates a correct number from a coincidence.**

## And the new ratchet caught this change's own author

The entry first described two orphaned rows in `path:line` form — which **cited** them, un-orphaning them without fixing anything. Every number in that entry is a record of where something used to be, so none is in citation form now (`LESSONS` §21). **The rule was going into the guard in the same commit that broke it.**

## Verification

```
MODE A (full)              exit=0
MODE B (extension or docs) exit=0
6 mutations, 6 caught, each by the guard written for it
```

Note for the merge: `#304` inserts eleven lines above `snapshotcrawl.py:169` and other branches move `app.py`, so a rebase here will re-derive those numbers **by content**. That is the case this PR is about, not drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)