### PR TITLE
The panel upgrades through the guarded path (OP-127)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1424,7 +1424,7 @@ installed. That half is `OP-38`.
 **Status: OPEN, filed not fixed, per `R-01`.** Found while looking for the black
 window's trace and finding none.
 
-`_bind_log_streams` (`scrapex/cli.py:992`) says it plainly: *"run it from a terminal
+`_bind_log_streams` (`scrapex/cli.py:988`) says it plainly: *"run it from a terminal
 and this does nothing at all."* It exists for the `pythonw` autostart path, which
 has no streams. A double-click **does** get a console, so the redirect no-ops and
 the failure goes to a window that is closing. `~/.scrapex/engine.log` is dated

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -4540,7 +4540,7 @@ something true and adjacent.
 ### Why the two paths diverged, which is the part that shapes the fix
 
 **The guarded path `print`s, and the native host owns stdout.** `serve()` writes framed
-messages to `sys.stdout.buffer` (`scrapex/native.py:352`), so a `print` reached from a
+messages to `sys.stdout.buffer` (`scrapex/native.py:375`), so a `print` reached from a
 native command injects unframed bytes into the protocol stream and Chrome reads the next
 length prefix wrong. **So the protections could not simply be called from there**, and
 whoever wrote the escape hatch wrote a second, bare path instead.
@@ -4551,10 +4551,37 @@ each caller renders it: the CLI to stdout, the native host into its JSON reply. 
 gives the panel the fourth protection it has never had**: *said out loud*, naming the backup
 by path, on the surface he actually uses.
 
-**FILED, NOT FIXED.** Put to him on 2026-09-02 with this evidence; his standing rule is
-diagnose, confirm, then fix, and a repair landed before the cause is agreed destroys the
-evidence he judges it by. **Until he rules, the safe instruction is: restart the engine —
-the guarded path runs on every launch — and do not press the button.**
+**FILED, NOT FIXED, ON 2026-09-02 — AND FIXED ON 2026-09-03.** It was put to him with this
+evidence and nothing was repaired first, because his standing rule is diagnose, confirm,
+then fix, and a repair landed before the cause is agreed destroys the evidence he judges it
+by. **He then ruled: «نفذ طبقا الأولوية»**, and option (a) is what he had been shown — the
+rule returns its outcome and each caller renders it.
+
+> **BUILT.** `scrapex/dbupgrade.py` holds the guarded upgrade; `cli._upgrade_what_is_only_behind`
+> prints its `Outcome.lines()`, which is the wording that function always had, and
+> `native.upgrade_database` puts it in its reply. **The reply names the backup by path** —
+> the fourth protection arriving on this surface for the first time, because a copy he
+> cannot find is not a copy he can restore. `BEHIND` has one home beside the only rule that
+> reads it, and is not re-exported: nothing outside imported it from `cli`, and a re-export
+> nobody reads is a claim that something does.
+>
+> **Six guards now drive the button** — backs up before it migrates, names the backup by
+> path, migrates nothing when the copy fails, never touches one that is not merely behind,
+> leaves a healthy warehouse alone, and, read as source, neither front door keeps a second
+> copy of the rule and `dbupgrade` never prints. **Every guard that existed drove the
+> command line**, which is how the two doors could differ for so long without anything
+> failing.
+>
+> **AND A FIXTURE BUG THE NEW TESTS FOUND.** `_FakeRegistry.ensure_ready` returned its
+> `after` states unconditionally, so a caller that READS the report first — as the button
+> must, since the rule is decided on it — saw a healthy database and did nothing. The eight
+> tests that predate this pass their report in explicitly and never noticed.
+>
+> **The safe instruction while he was deciding was: restart the engine, do not press the
+> button.** That instruction was also WRONG about his machine, and the correction is worth
+> keeping: his engine runs `0.4.6` from a checkout twelve commits behind `origin/main`, so
+> `0017` is not in that tree and a restart relaunches the same code. **Now the button is
+> the right door**, and it is the only one `R-81` says exists.
 
 ---
 

--- a/scrapex/cli.py
+++ b/scrapex/cli.py
@@ -773,7 +773,10 @@ def _cmd_export(args: argparse.Namespace) -> int:
 # The one status that means "behind, and nothing else is wrong". Matched
 # exactly, so "Needs a newer ScrapeX" (a DOWNgrade, never) and "Integrity check
 # failed" (damage, never) both fall through to the refusal below.
-BEHIND = "Needs upgrade"
+# `BEHIND` LIVED HERE AND LIVES IN `scrapex/dbupgrade.py` NOW, beside the only rule that
+# reads it. Not re-exported: measured, nothing outside imported it from this module, and a
+# re-export nobody reads is a claim that something does. One spelling, one home -- two
+# would be a check that silently stops matching (`LESSONS` section 9).
 
 
 def _upgrade_what_is_only_behind(registry, report: dict) -> dict:
@@ -812,28 +815,21 @@ def _upgrade_what_is_only_behind(registry, report: dict) -> dict:
     Returns the report after the attempt — the caller re-reads `ok` and does
     not have to know whether anything happened.
     """
-    from .archive import backup_database
+    # THE RULE MOVED TO `scrapex/dbupgrade.py` AND THIS PRINTS ITS OUTCOME. It used to
+    # live here and print as it went, which is why the panel's own «Upgrade database»
+    # button could not use it: `native.serve` writes framed messages to
+    # `sys.stdout.buffer`, and a `print` reached from a native command corrupts the
+    # protocol stream. So the button called `registry.initialize()` bare, with none of the
+    # four protections, on the one surface the owner actually presses -- `OP-127`.
+    #
+    # NOTHING ABOUT WHAT THIS COMMAND SAYS HAS CHANGED. The same lines, in the same order,
+    # on the same streams: `Outcome.lines()` is the wording this function had.
+    from .dbupgrade import upgrade_what_is_only_behind
 
-    behind = [state for state in report["databases"].values()
-              if not state["ok"] and state["status"] == BEHIND]
-    if not behind or len(behind) != sum(1 for s in report["databases"].values() if not s["ok"]):
-        return report                      # something else is wrong; do not touch it
-
-    for state in behind:
-        path = Path(state["path"])
-        try:
-            made = backup_database(path, tag="pre-upgrade")
-        except Exception as exc:
-            print(f"error: the {state['kind']} database is behind but could not be "
-                  f"backed up, so it was not upgraded ({exc})", file=sys.stderr)
-            return report
-        print(f"backed up the {state['kind']} database to {made} before upgrading")
-
-    applied = registry.initialize()
-    for kind, versions in applied.items():
-        if versions:
-            print(f"upgraded the {kind} database: applied {versions}")
-    return registry.ensure_ready()
+    report, outcome = upgrade_what_is_only_behind(registry, report)
+    for line in outcome.lines():
+        print(line, file=sys.stderr if line.startswith("error: ") else sys.stdout)
+    return report
 
 
 def _cmd_ui(args: argparse.Namespace) -> int:

--- a/scrapex/dbupgrade.py
+++ b/scrapex/dbupgrade.py
@@ -1,0 +1,139 @@
+"""The one guarded way to advance an existing warehouse, for BOTH front doors.
+
+WHY THIS MODULE EXISTS, AND IT IS NOT TIDINESS. `registry.ensure_ready`'s docstring states
+the rule and names its single exception:
+
+    "the protections spec 40 existed for are kept in the caller -- a backup first without
+    exception, forward only, never over damage, and said out loud. Nothing else in the
+    codebase may migrate an existing file."
+
+`cli._upgrade_what_is_only_behind` kept all four. `native.upgrade_database` -- the panel's
+«Upgrade database» button, and under `R-81` the only door the owner uses -- called
+`registry.initialize()` bare: no backup, no BEHIND check, no refusal over damage, and
+nothing said. On a 1.4 GB warehouse. That is `OP-128`'s sibling and it is `OP-127`.
+
+WHY THE TWO PATHS DIVERGED, BECAUSE IT IS WHAT SHAPES THIS MODULE. The guarded version
+PRINTS, and the native host writes framed messages to `sys.stdout.buffer` (`native.serve`).
+A `print` reached from a native command injects unframed bytes into the protocol stream and
+Chrome reads the next length prefix wrong. So the protections could not simply be CALLED
+from there, and whoever wrote the escape hatch wrote a second, bare path instead.
+
+SO THE RULE RETURNS WHAT IT DID INSTEAD OF SAYING IT. Each caller renders the outcome: the
+CLI to stdout in the words it has always used, the native host into its JSON reply. That is
+strictly better than moving code, because it finally gives the panel the FOURTH protection
+it has never had -- *said out loud*, naming the backup by path -- on the surface he
+actually presses.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+#: What `registry.health()` reports for a database whose only fault is its version.
+#: Spelled once here and imported by both callers, because a second spelling is a check
+#: that silently stops matching -- `LESSONS` section 9, a search for one spelling of a
+#: feature is not a measurement of the feature.
+BEHIND = "Needs upgrade"
+
+
+@dataclass(frozen=True)
+class Outcome:
+    """What the guarded upgrade did, in a shape either front door can render.
+
+    `refused` IS A SENTENCE, NOT A FLAG. Every refusal here has a different reason and the
+    owner has to be able to act on it: a database written by a newer build is not the same
+    problem as one that failed its integrity check, and "could not upgrade" is not
+    something a person can do anything with.
+    """
+
+    #: `True` only when migrations were actually applied.
+    upgraded: bool = False
+    #: Empty when nothing stood in the way; otherwise why, in words.
+    refused: str = ""
+    #: `(kind, backup path)` for every database copied before it was touched.
+    backups: tuple[tuple[str, str], ...] = ()
+    #: `kind -> [version numbers applied]`, straight from `registry.initialize()`.
+    applied: dict[str, list[int]] = field(default_factory=dict)
+
+    def lines(self) -> list[str]:
+        """The outcome as the CLI has always printed it, in the same order."""
+        said = [f"backed up the {kind} database to {where} before upgrading"
+                for kind, where in self.backups]
+        if self.refused:
+            said.append(f"error: {self.refused}")
+        said += [f"upgraded the {kind} database: applied {versions}"
+                 for kind, versions in self.applied.items() if versions]
+        return said
+
+    def message(self) -> str:
+        """One sentence for the panel, and it NAMES THE BACKUP.
+
+        The button's old reply said only how many migrations were applied, because there
+        was no backup to name. This is the fourth protection arriving on the surface that
+        never had it.
+        """
+        if self.refused:
+            return self.refused
+        moved = {kind: versions for kind, versions in self.applied.items() if versions}
+        if not moved:
+            return "The database is already up to date."
+        applied = ", ".join(
+            f"{len(versions)} migration{'s' if len(versions) != 1 else ''} to {kind}"
+            for kind, versions in moved.items())
+        if not self.backups:
+            return f"Applied {applied}."
+        kept = "; ".join(f"{kind} backed up to {where}"
+                         for kind, where in self.backups)
+        return f"Applied {applied}. {kept}."
+
+
+def upgrade_what_is_only_behind(registry, report: dict) -> tuple[dict, Outcome]:
+    """Back up and migrate a warehouse whose ONLY fault is that it is behind.
+
+    THE FOUR PROTECTIONS, and every one of them is why this function exists rather than a
+    call to `registry.initialize()`:
+
+      - A BACKUP FIRST, ALWAYS. If the copy cannot be made, nothing is migrated and the
+        outcome says so. There is no path through here that advances a schema without a
+        restorable copy beside it.
+      - ONLY FORWARD, and only from BEHIND. A database written by a NEWER build reports a
+        different status and is never touched -- downgrading is how a warehouse dies.
+      - ONLY WHEN NOTHING ELSE IS WRONG. A damaged file reports "Integrity check failed",
+        and migrating damage is how a small corruption becomes an unrecoverable one.
+      - IT SAYS SO. The outcome names every backup by path, and both callers render it.
+
+    Returns the report after the attempt -- the caller re-reads `ok` and does not have to
+    know whether anything happened -- and the outcome, which is what it renders.
+    """
+    from .archive import backup_database
+
+    states = report.get("databases") or {}
+    faulty = [state for state in states.values() if not state["ok"]]
+    behind = [state for state in faulty if state.get("status") == BEHIND]
+    if not behind:
+        return report, Outcome()
+    if len(behind) != len(faulty):
+        # SOMETHING ELSE IS WRONG AND IT IS NAMED. Refusing silently would leave the owner
+        # pressing a button that does nothing, which is the failure `R-81` is about.
+        other = [f"{state['kind']}: {state['status']}"
+                 for state in faulty if state.get("status") != BEHIND]
+        return report, Outcome(refused=(
+            "the database was not upgraded because something other than its version is "
+            "wrong, and migrating a damaged file is how a small corruption becomes an "
+            "unrecoverable one: " + "; ".join(other)))
+
+    backups: list[tuple[str, str]] = []
+    for state in behind:
+        path = Path(state["path"])
+        try:
+            made = backup_database(path, tag="pre-upgrade")
+        except Exception as exc:
+            return report, Outcome(refused=(
+                f"the {state['kind']} database is behind but could not be backed up, so "
+                f"it was not upgraded ({exc})"), backups=tuple(backups))
+        backups.append((state["kind"], str(made)))
+
+    applied = registry.initialize()
+    return registry.ensure_ready(), Outcome(
+        upgraded=any(versions for versions in applied.values()),
+        backups=tuple(backups), applied=applied)

--- a/scrapex/native.py
+++ b/scrapex/native.py
@@ -234,25 +234,48 @@ def startup_check() -> dict:
 
 
 def upgrade_database() -> dict:
-    """Apply forward migrations from the native host when HTTP is unavailable."""
+    """Apply forward migrations from the native host when HTTP is unavailable.
+
+    THROUGH THE GUARDED PATH SINCE `OP-127`. This called
+    `DatabaseRegistry.defaults().initialize()` directly, which migrates an existing file
+    with **none** of the four protections `registry.ensure_ready`'s docstring says are
+    kept in the caller: no backup, no BEHIND check, no refusal over damage, and nothing
+    said out loud. `EngineDatabase.initialize()` also migrates BEFORE it verifies, so a
+    damaged file was migrated first -- the third protection's exact stated hazard.
+
+    AND THIS IS THE DOOR THE OWNER USES. `R-81`: the panel is the only interface, so the
+    surface with no safety was the only one he could reach. The engine's own launch has
+    always gone through the guarded path -- `_spawn_engine` runs `engine_argv("ui", ...)`
+    -- which is why the two doors differed for so long without anything failing.
+
+    THE REPLY NOW NAMES THE BACKUP, which is the fourth protection arriving here for the
+    first time: *said out loud*. The old message could only say how many migrations were
+    applied, because there was no backup to name.
+    """
     try:
         from .databases import DatabaseRegistry
+        from .dbupgrade import upgrade_what_is_only_behind
 
-        applied = DatabaseRegistry.defaults().initialize()
+        registry = DatabaseRegistry.defaults()
+        # THE REPORT FIRST, BECAUSE THE RULE IS DECIDED ON IT. `ensure_ready` creates a
+        # database that does not exist -- which holds nothing to lose -- and REPORTS one
+        # that does, without touching it. That report is what says whether the only fault
+        # is the version.
+        report = registry.ensure_ready()
+        report, outcome = upgrade_what_is_only_behind(registry, report)
         states, failure = _database_report()
         if failure:
             return _error("database_upgrade_failed", failure, action="check_storage")
-        moved = {name: numbers for name, numbers in applied.items() if numbers}
-        message = (
-            "Both databases are already up to date."
-            if not moved else
-            "Applied " + ", ".join(
-                f"{len(numbers)} migration{'s' if len(numbers) != 1 else ''} to {name}"
-                for name, numbers in moved.items()
-            ) + "."
-        )
-        return {"ok": True, "applied": applied, "databases": states or {},
-                "message": message}
+        if outcome.refused:
+            # REFUSED IS NOT A CRASH AND IT IS NOT A SUCCESS. The panel gets the reason in
+            # words and the action it can take, because a button that reports nothing is
+            # the failure `R-81` names.
+            return _error("database_upgrade_failed", outcome.refused,
+                          action="check_storage")
+        return {"ok": True, "applied": outcome.applied, "databases": states or {},
+                "backups": [{"kind": kind, "path": where}
+                            for kind, where in outcome.backups],
+                "message": outcome.message()}
     except Exception as exc:
         return _error("database_upgrade_failed", str(exc), action="check_storage")
 

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -232,7 +232,7 @@ PINNED = (
     # OP-34 · why a black window leaves no trace. The whole finding is that this
     # function DELIBERATELY does nothing when it has real streams, which is the
     # double-click case -- so the log is not evidence about a failed launch.
-    ("docs/BACKLOG.md", "scrapex/cli.py", 992, "def _bind_log_streams("),
+    ("docs/BACKLOG.md", "scrapex/cli.py", 988, "def _bind_log_streams("),
     # OP-49's evidence is a SENTENCE of prose, and it drifted twice inside one
     # branch: 611 -> 691 -> 755, each time landing on a real, non-blank line
     # that tier 1 and tier 2 both accepted. A citation of prose needs pinning more

--- a/tests/test_the_engine_upgrades_its_own_warehouse.py
+++ b/tests/test_the_engine_upgrades_its_own_warehouse.py
@@ -39,7 +39,14 @@ class _FakeRegistry:
         return {"marketlens": [59], "general": []}
 
     def ensure_ready(self):
-        states = self._after if self._after is not None else self._states
+        # BEFORE THE UPGRADE IT REPORTS THE CURRENT STATE, AFTER IT REPORTS THE NEW ONE,
+        # which is what a real registry does and what this fake did not. It returned
+        # `after` unconditionally, so a caller that READS the report first -- as
+        # `native.upgrade_database` must, since the rule is decided on it -- saw a healthy
+        # database and did nothing. The tests above pass their report in explicitly and
+        # never noticed.
+        states = (self._after if self._after is not None and self.initialized
+                  else self._states)
         return {"ok": all(s["ok"] for s in states.values()),
                 "created": [], "databases": states}
 
@@ -175,3 +182,144 @@ def test_the_reversal_is_recorded_where_the_rule_was_written():
     assert "_upgrade_what_is_only_behind" in source, (
         "ensure_ready still reads as though nothing may ever upgrade an "
         "existing database, and one caller now does")
+
+
+# ---- the same four, for the door he actually presses (OP-127) ---------------
+#
+# `native.upgrade_database` is the panel's «Upgrade database» button. Until 2026-09-03 it
+# called `DatabaseRegistry.defaults().initialize()` bare -- no backup, no BEHIND check, no
+# refusal over damage, nothing said -- while every test above proved the protections for
+# the command line. `R-81`: the panel is the only interface, so the surface with no safety
+# was the only one he could reach.
+
+
+def _panel(monkeypatch, states, after=None):
+    """Drive the button with a registry that reports `states`, and return its reply."""
+    from scrapex import databases, native
+
+    registry = _FakeRegistry(states, after=after)
+    monkeypatch.setattr(databases.DatabaseRegistry, "defaults",
+                        classmethod(lambda cls: registry))
+    monkeypatch.setattr(native, "_database_report", lambda: (states, None))
+    return registry, native.upgrade_database()
+
+
+def test_the_panel_button_backs_up_before_it_migrates(warehouse, monkeypatch):
+    """A BACKUP FIRST, WITHOUT EXCEPTION — on the surface that had none.
+
+    His warehouse is 1.4 GB and `job_capacity` is not the only setting that differs from
+    the shipped default. There is no path through this button that advances a schema
+    without a restorable copy beside it.
+    """
+    states = {"marketlens": _state("marketlens", warehouse, False, "Needs upgrade")}
+    healthy = {k: dict(v, ok=True, status="Healthy") for k, v in states.items()}
+
+    registry, reply = _panel(monkeypatch, states, after=healthy)
+
+    assert reply["ok"] is True, reply
+    assert registry.initialized, "the button did not migrate at all"
+    copies = list(warehouse.parent.glob("marketlens.pre-upgrade-*.backup.db"))
+    assert len(copies) == 1, (
+        "the panel migrated an existing warehouse with no backup beside it, which is what "
+        f"`registry.ensure_ready`'s docstring forbids in terms: {copies}")
+    assert copies[0].stat().st_size > 0
+
+
+def test_the_panel_reply_names_the_backup_by_path(warehouse, monkeypatch):
+    """SAID OUT LOUD — the fourth protection, arriving here for the first time.
+
+    The old reply could only say how many migrations were applied, because there was no
+    backup to name. A copy the owner cannot find is not a copy he can restore, and this is
+    the only surface he sees.
+    """
+    states = {"marketlens": _state("marketlens", warehouse, False, "Needs upgrade")}
+    healthy = {k: dict(v, ok=True, status="Healthy") for k, v in states.items()}
+
+    _registry, reply = _panel(monkeypatch, states, after=healthy)
+
+    assert reply["backups"], f"the reply names no backup: {reply}"
+    named = reply["backups"][0]["path"]
+    assert pathlib.Path(named).is_file(), f"the reply names a path that is not there: {named}"
+    assert "backed up" in reply["message"], (
+        f"the sentence the panel shows does not mention the backup: {reply['message']!r}")
+    assert named in reply["message"], (
+        "the message says a backup was made and does not say where, so he cannot find it")
+
+
+def test_the_panel_button_migrates_nothing_when_the_backup_cannot_be_made(tmp_path,
+                                                                          monkeypatch):
+    """IF THE COPY CANNOT BE MADE, NOTHING IS MIGRATED. The button reports the reason
+    rather than proceeding, and rather than crashing — a button that reports nothing is
+    the failure `R-81` is about."""
+    missing = tmp_path / "not-there.db"
+    states = {"marketlens": _state("marketlens", missing, False, "Needs upgrade")}
+
+    registry, reply = _panel(monkeypatch, states)
+
+    assert not registry.initialized, (
+        "the backup failed and the button migrated anyway")
+    assert reply["ok"] is False
+    assert "could not be backed up" in reply["detail"], reply
+
+
+def test_the_panel_button_never_touches_a_database_that_is_not_merely_behind(warehouse,
+                                                                            monkeypatch):
+    """ONLY WHEN NOTHING ELSE IS WRONG. Migrating damage is how a small corruption becomes
+    an unrecoverable one — and `EngineDatabase.initialize()` migrates BEFORE it verifies,
+    so the bare call the button used to make did exactly that."""
+    states = {"marketlens": _state("marketlens", warehouse, False, "Needs upgrade"),
+              "general": _state("general", warehouse, False, "Integrity check failed")}
+
+    registry, reply = _panel(monkeypatch, states)
+
+    assert not registry.initialized, (
+        "one database was behind and another was damaged, and the button migrated")
+    assert reply["ok"] is False
+    assert "Integrity check failed" in reply["detail"], (
+        f"the refusal does not name what was actually wrong: {reply}")
+    assert not list(warehouse.parent.glob("*.pre-upgrade-*.backup.db")), (
+        "it took a backup for an upgrade it then refused, which is copies piling up for "
+        "nothing")
+
+
+def test_a_healthy_warehouse_is_left_alone_by_the_button(warehouse, monkeypatch):
+    """Nothing to do is not a failure, and it must not read as one."""
+    states = {"marketlens": _state("marketlens", warehouse, True, "Healthy")}
+
+    registry, reply = _panel(monkeypatch, states)
+
+    assert reply["ok"] is True, reply
+    assert not registry.initialized
+    assert not list(warehouse.parent.glob("*.pre-upgrade-*.backup.db"))
+
+
+def test_both_front_doors_hold_ONE_copy_of_the_rule():
+    """THE DIVERGENCE ITSELF, and the reason it lasted.
+
+    The protections lived inside a function that PRINTS, and `native.serve` writes framed
+    messages to `sys.stdout.buffer` — so a `print` reached from a native command corrupts
+    the protocol stream and the rule could not be called from there. Whoever wrote the
+    escape hatch wrote a second, bare path instead.
+
+    So the rule returns its outcome now and each caller renders it. This asserts there is
+    no second copy: neither front door takes a backup of its own, and neither spells
+    `BEHIND` again. Read as source, because two copies that happen to agree today would
+    pass every behavioural assertion above.
+    """
+    from scrapex import cli, dbupgrade, native
+
+    for module in (cli, native):
+        source = pathlib.Path(module.__file__).read_text(encoding="utf-8")
+        assert "backup_database(" not in source or module is cli, (
+            f"{module.__name__} takes its own backup instead of going through "
+            "`dbupgrade.upgrade_what_is_only_behind`")
+        assert 'BEHIND = ' not in source, (
+            f"{module.__name__} spells BEHIND again; two spellings is a check that "
+            "silently stops matching")
+
+    # AND THE PRINTS STAY OUT OF THE NATIVE PATH, which is why the rule returns rather
+    # than says. A `print` here is unframed bytes in the protocol stream.
+    rule = pathlib.Path(dbupgrade.__file__).read_text(encoding="utf-8")
+    assert "print(" not in rule, (
+        "`dbupgrade` prints, so the native host cannot call it without corrupting its "
+        "own stdout -- which is the divergence this module exists to end")


### PR DESCRIPTION
`registry.ensure_ready`'s docstring states the rule and names its one exception:

> *"the protections spec 40 existed for are kept in the caller — **a backup first without exception, forward only, never over damage, and said out loud**. Nothing else in the codebase may migrate an existing file."*

`cli._upgrade_what_is_only_behind` kept all four. **`native.upgrade_database` — the panel's «Upgrade database» button, and under `R-81` the only door the owner can reach — called `DatabaseRegistry.defaults().initialize()` bare.** No backup, no `BEHIND` check, no refusal over damage, nothing said. On a 1.4 GB warehouse.

And `EngineDatabase.initialize()` migrates **before** it verifies, so a damaged file was migrated first — the third protection's exact stated hazard.

## Why the two paths diverged, because it is what shapes the fix

The guarded version **prints**, and `native.serve` writes framed messages to `sys.stdout.buffer`. A `print` reached from a native command injects unframed bytes into the protocol stream and Chrome reads the next length prefix wrong. **So the protections could not simply be called from there**, and whoever wrote the escape hatch wrote a second, bare path instead.

**So the rule returns what it did instead of saying it.** `scrapex/dbupgrade.py` holds it and each caller renders the outcome — the CLI to stdout in the words it has always used (`Outcome.lines()` *is* that wording), the native host into its JSON reply.

**That is better than moving code**, because it finally gives the panel the fourth protection it has never had: *said out loud*, **naming the backup by path**, on the surface he presses. A copy he cannot find is not a copy he can restore.

`BEHIND` has one home now, beside the only rule that reads it. **Not re-exported** from `cli`: measured, nothing outside imported it from there, and a re-export nobody reads is a claim that something does.

## The protections were already tested — for one door

This file's own docstring says *"every one of those is a test below"*, and **every one of those tests drives the command line.** Six now drive the button:

```
backs up before it migrates                      a backup first, without exception
names the backup by path in its reply            said out loud  <- new to this surface
migrates nothing when the copy fails             and reports why, rather than crashing
never touches one that is not merely behind      never over damage
leaves a healthy warehouse alone                 nothing to do is not a failure
both front doors hold ONE copy of the rule       read as source, incl. dbupgrade never prints
```

## A fixture bug the new tests found

`_FakeRegistry.ensure_ready` returned its `after` states **unconditionally**, so a caller that *reads* the report first — as the button must, since the rule is decided on it — saw a healthy database and did nothing. **The eight tests above pass their report in explicitly and never noticed.** It now reports the current state before the upgrade and the new one after, which is what a real registry does.

## Verification

- **Three mutations:** the button back to the bare `initialize()` (five guards red), the message no longer naming the backup, and a `print` inside the rule. Each reddens exactly the guard written for it.
- `ruff check scrapex/` clean · 14 of 14 in that suite · both run modes to follow with the head named.
- **Queued behind `#313` (`OP-128`) and `#312`**, and it will rebase to amend `#312`'s `OP-127` entry from *filed, not fixed* to fixed — the entry was true when written.