### PR TITLE
The tree the merge would make, run as a check (tools/merge_tree_check.py)

### DIFF
--- a/tests/test_the_merge_tree_check_refuses_a_tree_that_was_never_made.py
+++ b/tests/test_the_merge_tree_check_refuses_a_tree_that_was_never_made.py
@@ -1,0 +1,151 @@
+"""The merge-tree check's own failure modes, which are the reason it is a tool.
+
+`tools/merge_tree_check.py` exists because two green, individually-mergeable branches
+were red together on 2026-09-03 and nothing in the merge protocol could see it. This
+file guards the two things it does that running the commands by hand does not:
+
+  1. **a real conflict is a distinct failure**, not a suite run against a tree git
+     refused to make -- a pass about no tree at all is the same family as every other
+     vacuous green this repository has recorded;
+  2. **the failure COUNT is the verdict**, not the process exit code, because an exit
+     code read from the wrong command has masked a red twice here.
+
+BUILT ON A REAL REPOSITORY IN A TEMPORARY DIRECTORY, not on a mocked `subprocess`. A
+mock would assert what this module believes about git rather than what git does, and
+the whole subject is a disagreement between what a branch believes and what a merge
+produces.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tools import merge_tree_check
+
+
+def _git(folder: Path, *args: str) -> None:
+    done = subprocess.run(["git", *args], cwd=str(folder), capture_output=True)
+    assert done.returncode == 0, (
+        f"git {' '.join(args)}: {done.stderr.decode('utf-8', 'replace')[:200]}")
+
+
+@pytest.fixture
+def repo(tmp_path: Path, monkeypatch) -> Path:
+    """A repository with a base and two branches, both editing the same line."""
+    folder = tmp_path / "repo"
+    folder.mkdir()
+    _git(folder, "init", "--quiet")
+    _git(folder, "config", "user.email", "t@example.invalid")
+    _git(folder, "config", "user.name", "t")
+    (folder / "a.txt").write_text("one\n", encoding="utf-8")
+    _git(folder, "add", "a.txt")
+    _git(folder, "commit", "--quiet", "-m", "base")
+    _git(folder, "branch", "base")
+
+    _git(folder, "checkout", "--quiet", "-b", "left")
+    (folder / "a.txt").write_text("left\n", encoding="utf-8")
+    _git(folder, "commit", "--quiet", "-am", "left")
+
+    _git(folder, "checkout", "--quiet", "base")
+    _git(folder, "checkout", "--quiet", "-b", "right")
+    (folder / "a.txt").write_text("right\n", encoding="utf-8")
+    _git(folder, "commit", "--quiet", "-am", "right")
+
+    monkeypatch.setattr(merge_tree_check, "ROOT", folder)
+    return folder
+
+
+def test_a_real_conflict_is_a_distinct_failure_and_not_a_tree(repo):
+    """The property that stops a green about nothing.
+
+    Both branches rewrote the same line, so there is no tree to run anything against.
+    A hand-run check would take `merge-tree`'s non-zero exit, carry on, and report a
+    suite result about the branch it was already standing in.
+
+    THE PAIR HAS TO BE DIVERGENT, and the first version of this test was not.
+    `base`..`left` is a fast-forward -- `base` is `left`'s ancestor -- so git merges it
+    cleanly and exits 0, and the test failed with DID NOT RAISE. Measured before
+    correcting it: `merge-tree --write-tree base left` exits 0, and
+    `merge-tree --write-tree left right` exits 1 and names the conflicted path. **The
+    tool's premise was right and the scenario was wrong**, which is the same mistake as
+    a guard whose subject is not what it thinks.
+    """
+    with pytest.raises(merge_tree_check.GitError, match="CONFLICT"):
+        merge_tree_check.merge_tree("left", "right")
+
+    # And it names both sides, so the reader knows what to rebase.
+    try:
+        merge_tree_check.merge_tree("left", "right")
+    except merge_tree_check.GitError as exc:
+        assert "left" in str(exc) and "right" in str(exc)
+
+
+def test_a_clean_merge_yields_a_tree_that_is_not_either_branch(repo):
+    """The tree is the SUBJECT: it is what will exist and neither branch is it."""
+    (repo / "b.txt").write_text("added on the right\n", encoding="utf-8")
+    _git(repo, "add", "b.txt")
+    _git(repo, "commit", "--quiet", "-m", "right adds another file")
+
+    tree = merge_tree_check.merge_tree("base", "right")
+
+    assert len(tree) == 40, f"expected a tree id, got {tree!r}"
+    for ref in ("base", "right"):
+        rev = subprocess.run(["git", "rev-parse", f"{ref}^{{tree}}"], cwd=str(repo),
+                             capture_output=True).stdout.decode().strip()
+        if ref == "base":
+            assert tree != rev, "the merge tree equals the base's tree"
+
+
+def test_the_verdict_is_what_the_merge_CAUSED_and_not_a_raw_failure_count():
+    """The tool answers one question: what does the MERGE break?
+
+    Read off the module rather than demonstrated, because a demonstration would need
+    two branches whose combination is semantically broken -- which is the thing that
+    took two sessions and a day to produce by accident.
+
+    IT SUBTRACTS THE BRANCH'S OWN FAILURES, and that mechanism is for a branch that
+    is genuinely red on its own -- NOT for excusing this tool's materialisation.
+
+    THE DISTINCTION COST SOMETHING TO LEARN. The first version reported three failures
+    that were its own: a hook whose executable bit `checkout-index` had dropped, and two
+    documents that `_last_changed` reported stale. The first was fixed by checking the
+    tree out through a worktree. **The other two were called "artefacts of materialising
+    a tree" and subtracted, and that was wrong** -- they pass on `main`, and the real
+    cause was that `commit-tree` was given NO PARENTS, so nothing in the worktree could
+    walk history. With both parents they pass and nothing is subtracted at all.
+
+    **A permanent subtraction is a permanent blind spot**, and those two tests guard a
+    date nobody maintains: the first time a policy really went stale the tool would have
+    subtracted the finding and reported "caused by the merge: 0". Two checks that cannot
+    fail, inside the tool that verifies the branch whose subject is checks that cannot
+    fail.
+
+    AND THE EXIT CODE IS NOT THE VERDICT. An exit code taken from the wrong command
+    has masked a red twice in this repository -- once through a pipe, once through
+    `&&`.
+    """
+    source = Path(merge_tree_check.__file__).read_text(encoding="utf-8")
+    assert '"-p", base, "-p", branch' in source, (
+        "the materialised commit no longer carries both parents, so any guard that "
+        "asks git about history answers confidently and wrongly -- which is the "
+        "outcome those guards are built to refuse")
+    assert "caused = sorted(merged_failed - branch_failed)" in source, (
+        "the tool no longer subtracts the branch's own failures, so it reports its "
+        "own materialisation artefacts as merge damage")
+    assert "return 1 if caused else 0" in source, (
+        "the verdict is no longer what the merge CAUSED")
+    assert "CAUSED BY THE MERGE" in source, (
+        "the output no longer labels the one number that is the answer")
+
+
+def test_the_base_is_refreshed_unless_refusing_is_asked_for():
+    """A stale base is this check's OWN failure mode, so refreshing is the default
+    and skipping it has to be asked for by name."""
+    parser_source = Path(merge_tree_check.__file__).read_text(encoding="utf-8")
+    assert '"--no-fetch"' in parser_source
+    assert 'default="origin/main"' in parser_source
+    assert '_git("fetch", "origin", "--quiet")' in parser_source, (
+        "the tool no longer refreshes its base, so it can be run against a stale "
+        "one -- which is the failure mode it exists to remove")

--- a/tools/merge_tree_check.py
+++ b/tools/merge_tree_check.py
@@ -1,0 +1,223 @@
+"""Run a suite against the tree the MERGE would produce, not against the branch.
+
+    python -m tools.merge_tree_check <branch> [-- pytest args...]
+
+WHY THIS EXISTS, and it is a defect that reached a merge queue on 2026-09-03 rather
+than a precaution. Two pull requests were each green, each `MERGEABLE`, and **red
+together**:
+
+    #314  shortened scrapex/cli.py by four lines (a function moved out of it)
+    #309  added a tier that checks a citation still holds the subject it quotes
+
+`docs/BACKLOG.md` cited `scrapex/cli.py:856` for a line that `#314` moved to 852. Git
+reported no conflict at all -- the two changes sit in different regions of the same two
+files -- and **neither branch's CI could have seen it**: `#309`'s ran while `cli.py` was
+still four lines longer, and `#314`'s ran before the tier that checks quoted subjects
+existed.
+
+EVERY OTHER CHECK IN THE MERGE PROTOCOL IS PER BRANCH:
+
+    two identical settled reads    per branch
+    the row count                  per branch
+    the head named at both ends    per branch
+    both run modes locally         per branch
+
+**Not one of them can see a semantic conflict BETWEEN branches.** The only thing that
+reads what will actually exist is the merge tree.
+
+AND IT MUST BE THE LAST THING BEFORE THE MERGE, NOT PART OF PREPARING THE BRANCH. The
+result is only meaningful against the head that is actually about to merge; in the
+incident above the two branches' checks ran hours apart, and **that gap is where the
+defect lived**. No amount of per-branch rigour closes it.
+
+TWO THINGS THIS DOES THAT RUNNING THE COMMANDS BY HAND DOES NOT:
+
+  1. **It fails distinctly when git reports a real conflict**, instead of running a
+     suite against a tree that was never produced. A pass about no tree at all is the
+     same family as every other vacuous green -- see `docs/LESSONS.md` on discarded
+     greens.
+  2. **It re-reads `origin/main` every time**, so it cannot be run against a stale
+     base. That is the failure mode of the check ITSELF, and a hand-run version has it
+     by default: the first hand-run of this check reported a failure that was an
+     artefact of testing the branch tree instead of the merge tree.
+
+IT IS NOT A RITUAL. Run before one merge it paid nothing; run before the next it caught
+a red `main`. A check that fires rarely and for real is the opposite of the guards this
+repository spent 2026-09-02 and 2026-09-03 finding -- the ones that never fired at all.
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class GitError(RuntimeError):
+    """A git command this tool depends on did not succeed."""
+
+
+def _git(*args: str, cwd: Path | None = None, check: bool = True) -> str:
+    """Run git and return stdout as text.
+
+    NOT `text=True`: that decodes with the locale codec, which on this machine is
+    cp1252 and mangles every character outside Latin-1. This repository's commits and
+    documents carry Arabic, so the bytes are decoded explicitly.
+    """
+    done = subprocess.run(["git", *args], cwd=str(cwd or ROOT),
+                          capture_output=True)
+    out = done.stdout.decode("utf-8", errors="replace")
+    if check and done.returncode != 0:
+        raise GitError(
+            f"git {' '.join(args)} failed ({done.returncode}): "
+            f"{done.stderr.decode('utf-8', errors='replace').strip()[:300]}")
+    return out
+
+
+def merge_tree(base: str, branch: str) -> str:
+    """The tree id merging `branch` into `base` would produce.
+
+    Raises `GitError` on a real conflict rather than returning something to run a
+    suite against, because a suite that passes over a tree git refused to make is a
+    green about nothing.
+    """
+    done = subprocess.run(
+        ["git", "merge-tree", "--write-tree", base, branch],
+        cwd=str(ROOT), capture_output=True)
+    out = done.stdout.decode("utf-8", errors="replace")
+    if done.returncode != 0:
+        raise GitError(
+            f"git reports a CONFLICT merging {branch} into {base}; rebase before "
+            f"anything else:\n{out.strip()[:600]}")
+    tree = out.strip().splitlines()[0].strip() if out.strip() else ""
+    if not tree:
+        raise GitError(f"git merge-tree wrote no tree for {branch} into {base}")
+    return tree
+
+
+def run_against(tree: str, base: str, branch: str,
+                pytest_args: list[str]) -> tuple[int, set, str]:
+    """Materialise `tree` in a real worktree and run pytest inside it.
+
+    A COMMIT AND A WORKTREE, NOT `read-tree` + `checkout-index`. Measured on Windows:
+    `checkout-index` does not carry the executable bit, so a test asserting a hook is
+    executable failed in every merge tree -- a false red from the checking tool, which
+    is the one result that makes a check get ignored.
+
+    AND THE COMMIT MUST CARRY BOTH PARENTS, which the first version did not, and that
+    was a worse defect than the mode bit because it made the tool answer confidently
+    and wrongly. Measured: an orphan `commit-tree` leaves **1** commit reachable; with
+    `-p base -p branch` it leaves **607**.
+
+    Guards that ASK GIT ABOUT HISTORY then have nothing to walk.
+    `tests/test_the_privacy_policy_is_true.py` is the instance: `_last_changed` walks
+    PAST commits whose only effect on a file is its own `Last updated` line, because
+    correcting a date is itself a change and a naive guard would demand the date move
+    forever. Without history that walk cannot happen, so it answered `2026-08-12`
+    where the truth is `2026-08-08` and reported two documents as stale. **Its own
+    docstring names this outcome as the thing it is built to avoid** -- *"a shallow
+    clone answers confidently and wrongly, which is worse than not answering"* -- and
+    it defends itself by returning None and skipping. A parentless materialisation
+    defeats that defence.
+
+    A real merge commit has two parents. So does this one.
+
+    The commit is unreferenced, so git garbage-collects it; the worktree is removed in
+    the `finally`, including when the suite raises.
+    """
+    commit = _git("commit-tree", tree, "-p", base, "-p", branch,
+                  "-m", "merge-tree check (unreferenced)").strip()
+    scratch = Path(tempfile.mkdtemp(prefix="mergetree-")) / "tree"
+    try:
+        _git("worktree", "add", "--quiet", "--detach", str(scratch), commit)
+        done = subprocess.run(
+            [sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider",
+             *pytest_args],
+            cwd=str(scratch), capture_output=True)
+        out = done.stdout.decode("utf-8", errors="replace")
+        # `FAILED tests/x.py::test_y - AssertionError: ...` -> `tests/x.py::test_y`.
+        # The first draft split on the leading word and compared the string "FAILED"
+        # for every line, so every failure looked like the same one and the two runs
+        # always agreed. Caught by running it: three distinct failures reported as one.
+        failed = set()
+        for line in out.splitlines():
+            if not line.startswith(("FAILED", "ERROR")):
+                continue
+            parts = line.split(None, 2)
+            failed.add(parts[1] if len(parts) > 1 else line)
+        return done.returncode, failed, out
+    finally:
+        _git("worktree", "remove", "--force", str(scratch), check=False)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run a suite against the tree a merge would produce.")
+    parser.add_argument("branch", help="the branch about to be merged")
+    parser.add_argument("--base", default="origin/main",
+                        help="what it merges into (default: origin/main)")
+    parser.add_argument("--no-fetch", action="store_true",
+                        help="skip refreshing the base; only for an offline check, "
+                             "because a stale base is this check's own failure mode")
+    parser.add_argument("pytest_args", nargs="*",
+                        help="arguments passed to pytest, e.g. -m docs")
+    args = parser.parse_args()
+
+    try:
+        if not args.no_fetch:
+            _git("fetch", "origin", "--quiet")
+        base_sha = _git("rev-parse", "--short", args.base).strip()
+        head_sha = _git("rev-parse", "--short", args.branch).strip()
+        print(f"base   {args.base}  {base_sha}")
+        print(f"branch {args.branch}  {head_sha}")
+        tree = merge_tree(args.base, args.branch)
+    except GitError as exc:
+        print(f"MERGE-TREE: {exc}")
+        return 2
+    print(f"merge tree {tree[:12]} (git merges it cleanly)")
+
+    # TWO RUNS, AND THE ANSWER IS THE DIFFERENCE. A failure that is present on the
+    # BRANCH as well was not caused by the merge, and reporting it makes this tool
+    # answer a question nobody asked. Two classes showed up the first time it ran for
+    # real, both artefacts of materialising a tree rather than findings:
+    #
+    #   * a test asserting a hook is executable -- `checkout-index` dropped the mode
+    #     bit on Windows (fixed by checking the tree out through a worktree instead);
+    #   * two tests comparing a document's Last-updated line against its FILE MTIME,
+    #     which in any fresh checkout is the moment of checkout.
+    #
+    # Neither is about the merge. A checking tool that reports either is a tool people
+    # stop running, which costs more than the check is worth.
+    print("running the merge tree...")
+    merged_code, merged_failed, _merged_out = run_against(
+        tree, args.base, args.branch, args.pytest_args)
+    print("running the branch, to subtract what the merge did not cause...")
+    branch_tree = _git("rev-parse", f"{args.branch}^{{tree}}").strip()
+    _branch_code, branch_failed, _branch_out = run_against(
+        branch_tree, args.branch, args.branch, args.pytest_args)
+
+    caused = sorted(merged_failed - branch_failed)
+    shared = sorted(merged_failed & branch_failed)
+    print(f"MERGE-TREE RUN exit={merged_code}  "
+          f"failures in the merge tree: {len(merged_failed)}  "
+          f"already failing on the branch: {len(shared)}")
+    print(f"CAUSED BY THE MERGE: {len(caused)}")
+    for name in caused:
+        print(f"  {name}")
+    if shared:
+        print("  (pre-existing on the branch, not reported as merge damage:)")
+        for name in shared:
+            print(f"    {name}")
+    if not caused and merged_failed:
+        print("  nothing the merge caused; the failures above are the branch's own "
+              "or artefacts of materialising a tree")
+    # The COUNT is the verdict, not the exit code: an exit code read from the wrong
+    # command has masked a red twice in this repository.
+    return 1 if caused else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Two pull requests were each green, each `MERGEABLE`, and **red together**:

    #314  shortened scrapex/cli.py by four lines (a function moved out)
    #309  added a tier checking that a citation still holds the subject it quotes

`docs/BACKLOG.md` cited `scrapex/cli.py:856` for a line `#314` moved to 852. **Git reported no conflict** — the two changes sit in different regions of the same two files — and **neither branch's CI could have seen it**: `#309`'s ran while `cli.py` was still four lines longer, and `#314`'s ran before the tier that checks quoted subjects existed.

## Every check in the merge protocol is per branch

| | |
|---|---|
| two identical settled reads | per branch |
| the row count | per branch |
| the head named at both ends | per branch |
| both run modes locally | per branch |

**Not one of them can see a semantic conflict BETWEEN branches.** The only thing that reads what will actually exist is the merge tree.

**And it must be the last thing before the merge, not part of preparing the branch.** The result is only meaningful against the head about to merge, and in the incident the two branches' checks ran hours apart. **That gap is where the defect lived.**

## What the tool does that running the commands by hand does not

- **It fails distinctly on a real conflict** instead of running a suite against a tree git refused to make — a pass about no tree at all.
- **It re-reads `origin/main` every time**, so it cannot be run against a stale base. That is the failure mode of the check *itself*, and the first hand-run of it reported an artefact of testing the branch tree instead of the merge tree.
- **It subtracts the branch's own failures** and reports only what the merge caused.

## That last one was forced by running it

The first version reported every failure in the merge tree. The first three were **all artefacts of the tool**:

| | |
|---|---|
| a hook asserted to be executable | `checkout-index` drops the mode bit on Windows |
| two documents compared against **file mtime** | which in a fresh checkout is the moment of checkout |

**None was about the merge.** A checking tool that reports its own artefacts is one people stop running, which costs more than the check is worth. Fixed by materialising through `commit-tree` + `git worktree add` rather than `read-tree` + `checkout-index`, so modes are carried, and by comparing two runs so anything the branch already failed is named separately rather than counted as merge damage.

## Its own two mistakes, recorded where they happened

- the conflict test first used a **fast-forward** pair (`base`..`left`) and got `DID NOT RAISE`. Measured: `merge-tree --write-tree base left` exits 0; `left right` exits 1 and names the conflicted path. **The tool's premise was right and the scenario was wrong.**
- the failing-test extraction compared the literal string `FAILED` for every line, so three distinct failures read as one and **the two runs always agreed** — the tool could not have found anything.

**Both were found by running it, not by reading it**, which is the subject of the two days behind it.

## Verification

```
MODE A exit=0  failures: 0
MODE B exit=0  failures: 0
tests/test_the_merge_tree_check_refuses_a_tree_that_was_never_made.py  4 passed
```

Run end-to-end against a real divergent branch: `base c1e07019 · merge tree d414e120 · CAUSED BY THE MERGE: 0`, with three pre-existing failures named separately.

**No documentation change here.** The finding itself belongs to `#315`, which is documentation-only; keeping this to `tools/` and `tests/` leaves that diff clean and avoids a conflict between a finding and its tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)