### PR TITLE
The request count speaks while it works (OP-130)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -4424,6 +4424,54 @@ everything that reasons about what the run WILL do, and nothing enumerates those
 
 ---
 
+### OP-130 · The crawl's request count said 0 for hours while its cell count moved
+
+**Found 2026-09-03, watching the crawl he had been waiting for since 2026-08-30 actually
+run.** Read off the live engine, four minutes in:
+
+```
+"progress": {"done": 2, "total": 56}      <- moving
+"fetch": {"requests": 0}                   <- not moving
+```
+
+**Two numbers on one card contradicting each other, on the surface he watches.**
+`record_source_fetch` was called once, in the runner's `finally`, so the request count
+stayed at zero for the whole run. **A progress figure that says nothing while work happens
+is the same defect as a resume that reports nothing** — one card over, and this one had
+hours to be wrong in.
+
+**Fixed at the cell boundary**, which is where the other two figures are written and the
+only point at which every number on that card agrees with the others. Mid-cell,
+`requests_count` is a number in motion. The state vocabulary is the price path's own:
+`waiting` / `fetching` / `done`.
+
+### And a second, structural, found on the way
+
+`cell_closed` reports the fetcher's request count, and `make_fetch` was **forty-nine lines
+below it**. That worked — a closure resolves its names at CALL time, and the first call
+comes from inside `contractors.crawl`, which runs after. **But it worked by ordering.**
+Moving `make_fetch` under the crawl call would be a `NameError` **on the first cell**, hours
+into a run that had already fetched real pages and stored them.
+
+**The fetcher is built above the closures now**, and a guard reads the two line numbers,
+because no behaviour distinguishes the orderings until the day somebody reorders the
+function.
+
+### How it was found, which is the part worth keeping
+
+**By reading the running job rather than the finished one.** Every test in
+`test_the_button_drives_the_collector_the_source_needs.py` asserts on a job that has
+already ended — where the old code was already right. **The new guard reads the counters
+from inside `between_cells`**, which is what a poll from the panel would have seen.
+
+And the first probe of it was **my own error, not the product's**: I read `progress_done`
+at the top level of the reply and the API nests it as `progress: {done, total}`, so the
+crawl looked stalled when it was not. **The measurement that mattered came from the
+database row beside the API's own JSON**, and only the disagreement between the two
+pointed at the real defect.
+
+---
+
 ### OP-128 · A directory crawl bypassed the gate that stops two jobs crawling one site
 
 **Found 2026-09-03, an hour after `#310` merged it. This session wrote the defect and this

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -4445,6 +4445,49 @@ only point at which every number on that card agrees with the others. Mid-cell,
 `requests_count` is a number in motion. The state vocabulary is the price path's own:
 `waiting` / `fetching` / `done`.
 
+### And a third face, found by watching the card during a long cell
+
+**The heartbeat was written at cell boundaries too.** Cell four of his run fetched for
+**over forty minutes**, so `crawl_job.last_heartbeat_at` sat forty minutes stale while 740
+pages were being stored — and `busy` in the engine's health report went empty, losing the
+one detail worth having: *what* the worker is busy with. The report still said
+`worker_alive: True`, because the worker LOOP beats separately, so the damage was confined
+to the job's own card.
+
+**`jobs.py` names this defect above its own constant, at a narrower window:**
+
+> *"A JOB may go quiet for far longer than a loop pass and still be healthy … Judging a
+> job by the loop's 30s window is what made a working crawl look dead."*
+
+**A boundary-only beat reintroduced it at fifteen minutes.** The beat now fires after every
+request — `fetch` is wrapped — **on its own connection**, for `record_worker_failure`'s
+stated reason: a heartbeat inside the crawl's transaction can be rolled away with whatever
+the crawl was doing, and it would commit the crawl's pending work on a schedule the crawl
+did not choose. **After the fetch, not before**, because the claim is that a request
+COMPLETED; a beat written first keeps a hung request looking healthy.
+
+### And my own guard for it was vacuous, which the mutation said and I did not
+
+**Three times, each one narrower than the last:**
+
+1. It compared the heartbeat **before the run** against the value **after** — and the
+   runner's opening `_update` writes that column unconditionally, so it passed with the
+   per-request beat removed entirely.
+2. Measuring inside the cell, it collected six identical timestamps: `utc_now_iso()` has
+   one-second resolution and six fake fetches take microseconds. **It could not tell a
+   beat from no beat.** So the column is sabotaged before each fetch and the beat has to
+   overwrite it.
+3. `BEAT_EVERY_S` was a **local**, so setting it to zero from the test did nothing and
+   five of six fetches were silently throttled. **A tuning number inside a function is one
+   no test can vary and no reader can see** — it is a module constant now, beside
+   `DEFAULT_PACE_S`.
+
+**And the mechanism was guarded while the shipped NUMBER was not.** Because the beat test
+sets the interval to zero, it also overrode any change to the default: measured,
+`BEAT_EVERY_S = 10 ** 9` passed the entire suite. There is a ceiling on it now, tied to
+`JOB_HEARTBEAT_MAX_AGE_S` with a margin — **the number that matters is how long the card
+can be wrong for, not how rarely the write happens.**
+
 ### And a second, structural, found on the way
 
 `cell_closed` reports the fetcher's request count, and `make_fetch` was **forty-nine lines

--- a/scrapex/directoryjob.py
+++ b/scrapex/directoryjob.py
@@ -127,6 +127,12 @@ def run_directory_crawl_job_once(conn: sqlite3.Connection, job_ref: str,
 
     done = {"cells": 0}
     stopped: list[str] = []
+    # BUILT BEFORE THE CLOSURES THAT READ IT. `cell_closed` reports this fetcher's request
+    # count, and a closure resolves its names at CALL time -- so building the fetcher
+    # further down worked, and worked BY ORDERING. Moving `make_fetch` below the crawl
+    # would then be a `NameError` on the first cell, hours into a run that had already
+    # fetched real pages. Structural beats incidental.
+    fetcher, fetch = contractors.make_fetch(DEFAULT_PACE_S)
 
     def note(line: str) -> None:
         """One line of the crawl's own report, into the job log.
@@ -152,6 +158,18 @@ def run_directory_crawl_job_once(conn: sqlite3.Connection, job_ref: str,
         jobs._update(conn, job["job_id"], status=JobStatus.RUNNING.value,
                      stage=JobStage.FETCHING.value, progress_done=done["cells"],
                      last_heartbeat_at=utc_now_iso())
+        # AND THE REQUEST COUNT, HERE RATHER THAN ONLY AT THE END. It was written once in
+        # `finally`, so the panel showed `requests: 0` beside `cells 2/56` for hours --
+        # two numbers on one card contradicting each other, on the surface he watches.
+        # `OP-130`. The price path updates as it goes and its vocabulary is already
+        # `waiting` / `fetching` / `done`.
+        #
+        # AT THE BOUNDARY, because mid-cell `requests_count` is a number in motion and
+        # this is the one point where every figure on that card agrees with the others.
+        jobs.record_source_fetch(
+            conn, job["job_id"], source_key,
+            requests=int(getattr(fetcher, "requests_count", 0) or 0),
+            state="fetching")
         conn.commit()
         current = jobs.get_job(conn, job_ref)
         control = jobs._control_of(conn, job["job_id"])
@@ -176,7 +194,6 @@ def run_directory_crawl_job_once(conn: sqlite3.Connection, job_ref: str,
         return bool(current is None)
 
     started = time.monotonic()
-    fetcher, fetch = contractors.make_fetch(DEFAULT_PACE_S)
     # ONE DEFINITION OF A HOST, taken from `jobs` rather than written again here.
     # `_host_of`'s docstring names the crack a second derivation would open: a source
     # filed under one host name for grouping and another for reservation is two jobs

--- a/scrapex/directoryjob.py
+++ b/scrapex/directoryjob.py
@@ -45,6 +45,17 @@ JOB_KIND = "directory_crawl"
 #: to different degrees.
 DEFAULT_PACE_S = contractors.DEFAULT_PACE_S
 
+#: Seconds between heartbeats while a cell is being fetched. A request takes about a
+#: second at `DEFAULT_PACE_S`, so this is roughly one small write every twenty pages --
+#: often enough that the job card is never more than twenty seconds behind, rare enough
+#: that it is not a write per request.
+#:
+#: AT MODULE SCOPE BECAUSE IT WAS A LOCAL AND THAT HID IT. A tuning number inside the
+#: function cannot be varied by a test or seen by anyone reading the module, and the guard
+#: for the beat found exactly that: it set the interval to zero, nothing changed, and five
+#: of six fetches were silently throttled.
+BEAT_EVERY_S = 20.0
+
 
 class NotADirectory(LookupError):
     """This job names a source that is not a directory this build can crawl.
@@ -134,6 +145,55 @@ def run_directory_crawl_job_once(conn: sqlite3.Connection, job_ref: str,
     # fetched real pages. Structural beats incidental.
     fetcher, fetch = contractors.make_fetch(DEFAULT_PACE_S)
 
+    def beating(url: str) -> str:
+        """One page, and a heartbeat if one is due.
+
+        THE JOB'S HEARTBEAT WAS WRITTEN AT CELL BOUNDARIES ONLY, and a cell can be long:
+        the fourth cell of his 2026-09-03 run fetched for over forty minutes, so the job
+        card read "reported 40 min ago" while it was storing hundreds of pages.
+        `jobs.py`'s own comment above `JOB_HEARTBEAT_MAX_AGE_S` names this defect at a
+        narrower window -- *"judging a job by the loop's 30s window is what made a working
+        crawl look dead"* -- and a boundary-only beat reintroduced it at fifteen minutes.
+        `OP-130`.
+
+        AFTER THE FETCH, NOT BEFORE, because the claim is that a request COMPLETED. A beat
+        written before would keep a hung request looking healthy, which is the one state
+        worth seeing.
+
+        ON ITS OWN CONNECTION, for `record_worker_failure`'s stated reason one file over:
+        a heartbeat written inside the crawl's transaction is a heartbeat that can be
+        rolled away with whatever the crawl was doing -- and it would commit the crawl's
+        pending work on a schedule the crawl did not choose.
+        """
+        text = fetch(url)
+        now = time.monotonic()
+        if now - beat_at[0] < globals()["BEAT_EVERY_S"]:
+            return text
+        beat_at[0] = now
+        try:
+            own = sqlite3.connect(db_file, timeout=5.0)
+            try:
+                own.execute("PRAGMA busy_timeout = 5000")
+                own.execute(
+                    "UPDATE crawl_job SET last_heartbeat_at = ? WHERE job_id = ?",
+                    (utc_now_iso(), job["job_id"]))
+                own.commit()
+            finally:
+                own.close()
+        except sqlite3.Error:
+            # A HEARTBEAT MAY NOT END A CRAWL. It is a record OF the work, not the work,
+            # and the same rule `contractors.say` states about a log line: lose the beat,
+            # never the run.
+            pass
+        return text
+
+    beat_at = [0.0]
+    #: The warehouse this job's connection is open on, asked of the connection itself
+    #: rather than threaded in as a parameter -- the runner contract is
+    #: `(conn, job_ref, admission)` and a fourth argument for a path the connection
+    #: already knows would be a second place for it to be wrong.
+    db_file = conn.execute("PRAGMA database_list").fetchone()[2]
+
     def note(line: str) -> None:
         """One line of the crawl's own report, into the job log.
 
@@ -203,7 +263,7 @@ def run_directory_crawl_job_once(conn: sqlite3.Connection, job_ref: str,
     admit = admission.lane(host) if admission is not None else nullcontext()
     try:
         with admit, contractors.lines_go_to(note):
-            contractors.crawl(conn, directory, fetch, fetcher, run_ref,
+            contractors.crawl(conn, directory, beating, fetcher, run_ref,
                               contractors.DEFAULT_MAX_ATTEMPTS,
                               between_cells=cell_closed)
     except contractors.CrawlStopped:

--- a/tests/test_the_button_drives_the_collector_the_source_needs.py
+++ b/tests/test_the_button_drives_the_collector_the_source_needs.py
@@ -818,3 +818,129 @@ def test_the_fetcher_exists_before_the_closure_that_reads_it():
     assert built < closure, (
         f"`make_fetch` is at line {built} and `cell_closed` at {closure}: the closure "
         "reads a name assigned after it, which holds only until someone moves either one")
+
+
+def test_the_heartbeat_beats_while_one_long_cell_fetches(conn, tmp_path, monkeypatch):
+    """`OP-130`, THIRD FACE: A CELL CAN BE LONG AND THE CARD SAID NOTHING.
+
+    The heartbeat was written at cell boundaries only. On his 2026-09-03 run the fourth
+    cell fetched for over FORTY MINUTES, so the job card read *"reported 40 min ago"* while
+    the crawl stored hundreds of pages -- and `busy` in the engine's health report went
+    empty, losing the one detail worth having: what the worker is busy WITH.
+
+    `jobs.py` names this defect above its own constant, at a narrower window: *"judging a
+    job by the loop's 30s window is what made a working crawl look dead."* A boundary-only
+    beat reintroduced it at fifteen minutes.
+
+    ASSERTED WITHOUT CLOSING A CELL, which is the whole point: the fetches happen and no
+    boundary is reached, exactly as they did inside cell four.
+    """
+    monkeypatch.setattr(contractors, "coverage", lambda *a, **k: "coverage")
+    monkeypatch.setattr(contractors, "make_fetch",
+                        lambda pace: (_QuietFetcher(), lambda url: ""))
+    monkeypatch.setattr(directoryjob, "BEAT_EVERY_S", 0.0, raising=False)
+
+    job_ref = jobs.create_job(conn, ["muqawil_org"], RunMode.UPDATE,
+                              job_kind=directoryjob.JOB_KIND)
+    seen: list[str | None] = []
+
+    def sabotage(value: str) -> None:
+        """Put an impossible heartbeat in the column, on its own connection."""
+        own = sqlite3.connect(str(tmp_path / "scrapex-engine.db"), timeout=5.0)
+        try:
+            own.execute("UPDATE crawl_job SET last_heartbeat_at = ? WHERE job_ref = ?",
+                        (value, job_ref))
+            own.commit()
+        finally:
+            own.close()
+
+    def read_beat() -> str | None:
+        """The stored heartbeat, on a connection of its own — the runner writes its
+        beat that way, so a read through `conn` could miss an uncommitted value."""
+        own = sqlite3.connect(str(tmp_path / "scrapex-engine.db"), timeout=5.0)
+        try:
+            row = own.execute("SELECT last_heartbeat_at FROM crawl_job WHERE job_ref = ?",
+                              (job_ref,)).fetchone()
+            return row[0] if row else None
+        finally:
+            own.close()
+
+    class _LongCell:
+        """Many fetches, NO cell boundary -- cell four, in miniature.
+
+        MEASURED FROM INSIDE THE CELL, and the first version of this test was vacuous for
+        measuring outside it: the runner's OPENING `_update` writes `last_heartbeat_at`
+        unconditionally, so comparing before-the-run against after-the-run passed with the
+        per-request beat removed entirely. The mutation said so. Between the first fetch
+        and the last, nothing but the wrapper can move that column.
+        """
+
+        def __call__(self, *args, **kwargs):
+            from scrapex.partitioncrawl import WHOLE, CellSize, PartitionOutcome
+            for page in range(6):
+                # SABOTAGED, THEN FETCHED. `utc_now_iso()` has one-second resolution and
+                # six fake fetches take microseconds, so comparing timestamps cannot see
+                # a beat inside one second -- the first version of this loop collected six
+                # identical strings and could not tell a beat from no beat. An impossible
+                # value the beat must overwrite says it fired.
+                sabotage("2026-01-01T00:00:00Z")
+                kwargs["fetch"](f"https://muqawil.org/en/contractors?page={page}")
+                seen.append(read_beat())
+            size = CellSize(cell=WHOLE, last_page=1, cards_per_page=1, tail_cards=1,
+                            requests=1)
+            return PartitionOutcome(whole=size, cells=(), whole_at_end=None, parent=WHOLE)
+
+    monkeypatch.setattr(contractors, "crawl_partition", _LongCell())
+    directoryjob.run_directory_crawl_job_once(conn, job_ref)
+
+    assert len(seen) == 6, f"the fake did not fetch six times: {seen}"
+    assert set(seen) == {seen[0]} or True                      # shape, not the claim
+    assert "2026-01-01T00:00:00Z" not in seen, (
+        "a request went out, no boundary was reached, and the heartbeat this test had "
+        f"sabotaged was still there afterwards -- so a long cell reads as a dead job: "
+        f"{seen}")
+
+
+def test_a_heartbeat_that_cannot_be_written_does_not_end_the_crawl():
+    """`say`'S RULE, ONE LAYER OUT: a record OF the work may not end the work.
+
+    The beat opens its own connection -- `record_worker_failure`'s stated reason, because
+    a heartbeat inside the crawl's transaction is one that can be rolled away with it --
+    and its own connection can fail. A locked warehouse must lose the beat, never the run,
+    which is exactly what `contractors.say` says about a log line that cannot be encoded.
+
+    Read as source: the write is wrapped and the handler swallows, and no fixture can make
+    sqlite fail on demand without also breaking the crawl it is meant to protect.
+    """
+    import pathlib as _pathlib
+
+    source = _pathlib.Path(directoryjob.__file__).read_text(encoding="utf-8")
+    beating = source[source.index("def beating("):source.index("beat_at = [0.0]")]
+
+    assert "except sqlite3.Error" in beating, (
+        "the heartbeat write is not guarded, so a locked warehouse ends a crawl that had "
+        "already fetched hundreds of pages")
+    assert beating.strip().endswith("return text"), (
+        "`beating` must return the page it fetched whatever happened to the beat")
+
+
+def test_the_shipped_heartbeat_interval_keeps_the_card_fresh():
+    """THE MECHANISM WAS GUARDED AND THE NUMBER WAS NOT.
+
+    `test_the_heartbeat_beats_while_one_long_cell_fetches` sets `BEAT_EVERY_S` to zero,
+    which is right for testing the mechanism and means it also overrides any change to
+    the SHIPPED value. Measured: `BEAT_EVERY_S = 10 ** 9` passed the entire suite -- the
+    beat would fire once per run and a long cell would read as a dead job again, which is
+    the whole of `OP-130`.
+
+    The ceiling is `JOB_HEARTBEAT_MAX_AGE_S` (fifteen minutes) with a wide margin, because
+    the number that matters is how long the card can be wrong for, not how rarely the
+    write happens.
+    """
+    assert 0 < directoryjob.BEAT_EVERY_S <= 60.0, (
+        f"the shipped heartbeat interval is {directoryjob.BEAT_EVERY_S}s. Above a minute "
+        "the job card goes quiet for long enough to read as dead, and at zero it is a "
+        "database write per request")
+    assert directoryjob.BEAT_EVERY_S * 4 < jobs.JOB_HEARTBEAT_MAX_AGE_S, (
+        "the interval is within a factor of four of the window that decides whether a "
+        "job counts as alive, which leaves no margin for a slow page")

--- a/tests/test_the_button_drives_the_collector_the_source_needs.py
+++ b/tests/test_the_button_drives_the_collector_the_source_needs.py
@@ -743,3 +743,78 @@ def test_the_host_rule_has_one_definition():
     assert "netloc" not in runner_source, (
         "scrapex/directoryjob.py derives a host itself instead of calling "
         "`jobs.host_of_url`, which is the second definition `_host_of` warns about")
+
+
+def test_the_request_count_is_visible_before_the_job_ends(conn, monkeypatch):
+    """`OP-130`: TWO NUMBERS ON ONE CARD THAT CONTRADICTED EACH OTHER.
+
+    `record_source_fetch` was called once, in `finally`, so the panel showed
+    `requests: 0` beside `cells 2/56` for as long as the crawl ran -- and the crawl he
+    started ran for hours. A progress figure that says nothing while work happens is the
+    same defect as a silent resume, one card over.
+
+    ASSERTED AT A CELL BOUNDARY, not at the end, because at the end the old code was
+    already right. The count is read from inside `between_cells`, which is the only point
+    where every figure on that card agrees with the others.
+    """
+    seen: list[int | None] = []
+    partition = _CellByCell(cells=3)
+
+    def watch() -> bool:
+        counters = jobs.get_job(conn, job_ref)["counters"]
+        slot = (counters.get("sources") or {}).get("muqawil_org") or {}
+        seen.append(slot.get("requests"))
+        return False
+
+    monkeypatch.setattr(contractors, "crawl_partition", partition)
+    monkeypatch.setattr(contractors, "coverage", lambda *a, **k: "coverage")
+    monkeypatch.setattr(contractors, "make_fetch",
+                        lambda pace: (_QuietFetcher(), lambda url: ""))
+    job_ref = jobs.create_job(conn, ["muqawil_org"], RunMode.UPDATE,
+                              job_kind=directoryjob.JOB_KIND)
+
+    real = contractors.crawl
+
+    def crawl_and_watch(*args, **kwargs):
+        # THE RUNNER'S OWN `between_cells` RUNS FIRST, then this reads what it wrote --
+        # so the assertion is about what a poll from the panel would have seen mid-run.
+        inner = kwargs.pop("between_cells", None)
+
+        def both() -> bool:
+            stop = bool(inner()) if inner is not None else False
+            watch()
+            return stop
+
+        return real(*args, between_cells=both, **kwargs)
+
+    monkeypatch.setattr(contractors, "crawl", crawl_and_watch)
+    directoryjob.run_directory_crawl_job_once(conn, job_ref)
+
+    assert seen, "no cell boundary was reached, so this proves nothing"
+    assert seen[0] == _QuietFetcher.requests_count, (
+        "the panel would have shown `requests: 0` while cells were closing -- two figures "
+        f"on one card contradicting each other: {seen}")
+
+    counters = jobs.get_job(conn, job_ref)["counters"]
+    slot = (counters.get("sources") or {}).get("muqawil_org") or {}
+    assert slot.get("state") == "done", (
+        f"the final state is not `done`, so the card never settles: {slot}")
+
+
+def test_the_fetcher_exists_before_the_closure_that_reads_it():
+    """STRUCTURAL, NOT INCIDENTAL. `cell_closed` reports the fetcher's request count, and
+    a closure resolves its names at CALL time -- so building the fetcher below the closure
+    worked, and worked by ordering. Moving `make_fetch` under the crawl call would then be
+    a `NameError` on the FIRST CELL, hours into a run that had already fetched real pages.
+
+    Read as source, because the ordering is the property and no behaviour distinguishes it
+    until the day someone reorders the function."""
+    import pathlib as _pathlib
+
+    lines = _pathlib.Path(directoryjob.__file__).read_text(encoding="utf-8").split(chr(10))
+    built = next(n for n, line in enumerate(lines, 1) if "make_fetch(" in line)
+    closure = next(n for n, line in enumerate(lines, 1) if "def cell_closed(" in line)
+
+    assert built < closure, (
+        f"`make_fetch` is at line {built} and `cell_closed` at {closure}: the closure "
+        "reads a name assigned after it, which holds only until someone moves either one")

--- a/tests/test_the_registers_cannot_collide.py
+++ b/tests/test_the_registers_cannot_collide.py
@@ -318,6 +318,22 @@ RESERVED: dict[str, dict[int, str]] = {
         # `claude/a-citation-nothing-reads`, so OP-123 is a heading in
         # docs/BACKLOG.md here, and a number both reserved and declared is
         # what `test_a_reserved_number_is_not_also_declared` refuses.
+        # 129 AND 131 ARE HOLES, and both are claims by ALLOCATION rather than by a
+        # heading. This session allocated them to `eager-robinson-1d8a3a`:
+        #   129  the pinned-subject uniqueness guard, after that session measured 13 of 66
+        #        pinned subjects matching more than one line -- two of them pinned to the
+        #        literal `True`, which matches four lines of `features.py`, so tier 2
+        #        passed whenever ANY `True` sat within three lines of the number
+        #   131  `storage.health()`'s missing floor: it reported "healthy, no problems
+        #        found" about a database `initialize()` refuses to open
+        # WHAT IS AND IS NOT VERIFIED:
+        #   verified     -- the allocations, which are this session's own acts
+        #   NOT verified -- neither is a heading on any ref. Swept every local and remote
+        #                   ref on 2026-09-03: 127 and 128 on `main`, 130 declared by THIS
+        #                   branch, nothing at 129 or 131
+        # Delete each row the day its pull request lands.
+        129: "allocated to eager-robinson-1d8a3a for the pinned-subject guard",
+        131: "allocated to eager-robinson-1d8a3a for storage.health()'s floor",
         # 127'S ROW STOOD HERE AND IS GONE. #313 reserved it to this branch while this
         # branch declares it, so it became a number both reserved AND declared -- and its
         # own row said to delete it the day #312 lands, which is this rebase. The guard


### PR DESCRIPTION
**Found by watching the crawl he had been waiting for since 2026-08-30 actually run.** Four minutes in, read off the live engine:

```
"progress": {"done": 2, "total": 56}      <- moving
"fetch": {"requests": 0}                   <- not moving
```

**Two numbers on one card contradicting each other, on the surface he watches.** `record_source_fetch` was called once, in the runner's `finally`, so the request count stayed at zero for the whole run. **A progress figure that says nothing while work happens is the same defect as a resume that reports nothing** — one card over, and this one had hours to be wrong in.

Written **at the cell boundary** now: where the other two figures are written, and the only point at which every number on that card agrees with the others. Mid-cell, `requests_count` is a number in motion. The state vocabulary is the price path's own — `waiting` / `fetching` / `done`.

## A second one, structural, found on the way

`cell_closed` reports the fetcher's request count and `make_fetch` was **forty-nine lines below it.** That worked — a closure resolves its names at *call* time and the first call comes from inside `contractors.crawl`, which runs after.

**But it worked by ordering.** Moving `make_fetch` under the crawl call would be a `NameError` **on the first cell**, hours into a run that had already fetched and stored real pages. The fetcher is built above the closures now, and a guard reads the two line numbers — because no behaviour distinguishes the orderings until somebody reorders the function.

## How it was found, which is the part worth keeping

**Every test in that file asserts on a job that has already ended** — where the old code was already right. The new guard reads the counters from **inside `between_cells`**, which is what a poll from the panel would have seen.

And my first probe was **my own error, not the product's**: I read `progress_done` at the top level and the API nests it as `progress: {done, total}`, so the crawl looked stalled when it was not. **The measurement that mattered came from the database row beside the API's own JSON**, and only the disagreement between the two pointed at the real defect.

## Verification

```
the request count is visible before the job ends      read from inside between_cells
the fetcher exists before the closure that reads it   read as source; ordering is the property
```

- **Two mutations:** the count back to once at the end; `make_fetch` back below the closures. Each reddens exactly the guard written for it.
- `ruff check scrapex/` clean · 29 of 29 in that suite · `pytest -m docs` green · both run modes to follow with the commit named at both ends.
- `OP-129` reserved to `eager-robinson` for the pinned-subject guard, with the unverified half named: the allocation is this session's own act, and the number is a heading on no ref.