### PR TITLE
The panel tells him to open a terminal, and promises an updater that nothing starts (OP-124, R-81)

### DIFF
--- a/docs/APPROACHES.md
+++ b/docs/APPROACHES.md
@@ -162,7 +162,7 @@ standing next to — do not tidy it, do not restyle it, mention dead code rather
 than deleting it. P1 governs *the thing you are building*.
 
 The live example is B2 step 2: the panel already has Choose-Columns
-(`extension/app.js:1578`, `:1617`), and the instruction is to **extract it into a
+(`extension/app.js:1583`, `:1617`), and the instruction is to **extract it into a
 shared module**, not to write a second one. Writing a duplicate in the name of
 staying surgical is precisely the failure the migration plan warns about — "or
 the two surfaces will disagree about how a column is saved."

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -556,8 +556,8 @@ And only one of the **two** `worker_alive` computations was fixed:
 
 | where | what it calls | verdict |
 |---|---|---|
-| `scrapex/webui/app.py:1726` — `/api/health` | the new two-heartbeat `worker` verdict | correct; the panel reads this one (`extension/engine.js:38`) |
-| `scrapex/webui/app.py:2796` — `_about` | `worker_is_alive(conn)`, single heartbeat | **the function the fix superseded** |
+| `scrapex/webui/app.py:1737` — `/api/health` | the new two-heartbeat `worker` verdict | correct; the panel reads this one (`extension/engine.js:38`) |
+| `scrapex/webui/app.py:2807` — `_about` | `worker_is_alive(conn)`, single heartbeat | **the function the fix superseded** |
 
 `_about` renders the engine's own `/settings` page
 (`scrapex/webui/templates/settings.html:162-167`), so **the engine still shows
@@ -565,7 +565,7 @@ And only one of the **two** `worker_alive` computations was fixed:
 engine is started at all.
 
 **Next action:** three separate things — the second `worker_alive` at
-`app.py:2796`; the heartbeat's behaviour under a held write lock; and the 409 on
+`app.py:2807`; the heartbeat's behaviour under a held write lock; and the 409 on
 `/api/storage/restore` with a mirror of
 `test_start_fresh_is_refused_while_a_crawl_runs`.
 
@@ -1415,7 +1415,7 @@ exactly one place — an unmerged worktree branch that had already been run agai
 warehouse — and `R-24` forbids the obvious shortcut of replacing the database.
 
 **What is NOT closed is the panel's sentence.** An engine that refuses to start never binds a
-port, so `extension/app.js:3400` reports **"Not detected"** for a schema fault, a permissions
+port, so `extension/app.js:3405` reports **"Not detected"** for a schema fault, a permissions
 fault and an absent engine alike — false, and it sends the reader to reinstall what is already
 installed. That half is `OP-38`.
 
@@ -1510,7 +1510,7 @@ is not filed as fixed with it.
 
 An engine that refuses to start never binds a port. So `checkEngine` in
 `extension/engine.js` gets a connection error, and
-`extension/app.js:3400` reports:
+`extension/app.js:3405` reports:
 
     text: "Not detected"      detail: "The panel could not reach the Engine."
 
@@ -1633,7 +1633,7 @@ popup:
 
 | | finance converter | run mode |
 |---|---|---|
-| entry point | `setupFinanceConverterSelect` ([extension/app.js:940](../extension/app.js#L940)) | `setupRunModeSelect` ([extension/app.js:1992](../extension/app.js#L1992)) |
+| entry point | `setupFinanceConverterSelect` ([extension/app.js:945](../extension/app.js#L945)) | `setupRunModeSelect` ([extension/app.js:1997](../extension/app.js#L1997)) |
 | `close({restoreFocus})` | adds `hidden`, `aria-expanded=false`, removes `is-open`, restores focus | same four steps, same order |
 | `open()` | removes `hidden`, `aria-expanded=true`, adds `is-open`, `requestAnimationFrame` then focuses selected-or-first with `preventScroll` | same five steps, same order |
 | `choose(value)` | validates against `select.options`, assigns, dispatches bubbling `change`, closes with `restoreFocus: true` | same four steps, same order |
@@ -2302,7 +2302,7 @@ reader is the whole of this change and the writer is the next one.
 **Status: OPEN. Measured 2026-08-23, re-measured at `f1844af`. A latent structural gap, not a live
 defect — that distinction is the whole entry.**
 
-A citation written as `` (`extension/app.js:1578`, `:1641`) `` carries two references
+A citation written as `` (`extension/app.js:1583`, `:1641`) `` carries two references
 and the guard sees one. `CITATION` in
 `tests/test_the_documents_cite_what_they_claim.py` requires a path before the colon, so
 it matches `app.js:1641` and does not match a bare `:1641`. Measured directly: the
@@ -3571,9 +3571,9 @@ that deliberately excludes the two streaming sub-paths
 ([extension/startup.js:52](../extension/startup.js#L52)); a non-blocking
 `threading.Lock` ([scrapex/webui/app.py:2937](../scrapex/webui/app.py#L2937)) refusing a
 concurrent build with the house 409; `BUNDLE_KEEP = 2`
-([scrapex/webui/app.py:2907](../scrapex/webui/app.py#L2907)) pruning **by stamp** so the
+([scrapex/webui/app.py:2918](../scrapex/webui/app.py#L2918)) pruning **by stamp** so the
 two files of one backup cannot be split; and an age-guarded sweep
-([scrapex/webui/app.py:2982](../scrapex/webui/app.py#L2982)) for orphaned staging.
+([scrapex/webui/app.py:2955](../scrapex/webui/app.py#L2955)) for orphaned staging.
 
 **Residual, named rather than closed.** The lock is in-process, which is correct here —
 `start_engine` refuses to spawn a second engine on a held port
@@ -3990,7 +3990,7 @@ local disk, so nothing was lost — but nothing on either side said so.
 2. **`zipfile.ZipFile(archive, "w")` created the file under its FINAL name immediately**,
    at zero bytes, and filled it over the ~33 s of the deflate.
 3. **`GET /api/bundle/archive` answers with the newest `.zip` by mtime**
-   ([scrapex/webui/app.py:2942](../scrapex/webui/app.py#L2942)), so it handed the panel the
+   ([scrapex/webui/app.py:2950](../scrapex/webui/app.py#L2950)), so it handed the panel the
 
    ([scrapex/webui/app.py:2932](../scrapex/webui/app.py#L2932)), so it handed the panel the
    second build's empty, in-progress file.
@@ -5292,6 +5292,75 @@ retirement, but a third thing** — so the failure that led here was not even ab
 subject. Renamed, with a `HISTORICAL` row naming the commit that still holds the
 original.
 
+### OP-124 · The panel tells him to open a terminal, and promises an updater that nothing starts
+
+**Found 2026-09-02**, in the banner this branch had just made visible for the first time.
+Two sentences on his only interface, both against `R-81`, and the second is worse than the
+first because it describes a capability rather than a chore.
+
+**1 · THE BANNER NAMES A TERMINAL COMMAND, AND IT IS WRITTEN TWICE.**
+
+```
+scrapex/webui/app.py   "fix": "python -m scrapex.cli init-db"      the engine sends it
+extension/app.js       "Fix: " + (lag.fix || "python -m ...")      the panel hardcodes it
+                                                                     AGAIN, as a fallback
+extension/app.js       POST /api/databases/upgrade                   the button that works
+```
+
+**He does not use a terminal** ([R-81](RULINGS.md)), so this is not an instruction, it is a
+dead end printed inside a live failure. **And a button that performs it already exists on the
+Settings screen.** The duplication is the part worth a number rather than a one-line fix: one
+string in two files with nothing comparing them, so correcting the engine alone would have
+left the panel printing it from its own copy.
+
+**This banner had never appeared before this branch.** `OP-113` is why -- `schema_lag` was
+published and rendered and never carried -- so the first thing the repair did was put a
+terminal command in front of him. **A fix that makes a surface visible inherits everything
+wrong with it**, and nothing in the change that carried the field would have said so.
+
+**Checked before pointing the banner anywhere:** `POST /api/databases/upgrade` is mounted only
+`if databases is not None`, so the remedy is itself absent on a `--db` start. The banner names
+the screen and the button rather than a route, which is true on every start. **That check is
+`OP-119` applied inside the fix for something else**, which is the only reason it was made.
+
+**2 · AND THE INSTALLER NOTE PROMISES AN UPDATER THAT NOTHING HAS EVER STARTED.**
+
+The note beside the download's SHA-256 read, in `#246`'s words and still on `main`:
+
+> *"From here on the Engine downloads and checks its own updates against this number before
+> installing."*
+
+**It is false, and it was false the day it was written.** Measured across `origin/main`:
+
+| what exists | what calls it |
+|---|---|
+| `create_update_router()` -- mounted unconditionally, `GET` and `POST` handlers | **nothing** |
+| `update.fetch_and_verify()`, `plan_swap()`, `staging_dir()`, `swap_is_possible()` | only `update_api` |
+| any `api/update` string in `extension/**/*.js`, `extension/**/*.html`, or the engine's own templates | **none, in the whole history** -- `git log -S` over those paths returns no commit |
+| a timer or startup task in the engine that checks by itself | **none** -- nothing imports `update` except the router |
+
+**So the updater is built, mounted, and doorless**, and the only sentence describing it to him
+claims it is running. `R-81` says a capability with no control in the panel has no control;
+this is the same defect one step further on, because a screen asserts the control exists.
+**That is a bigger finding than either sentence and it needs its own number** -- recorded here
+rather than folded in, because the repair is either a caller or a deletion and that is not a
+session's call.
+
+**AND THE GUARD OVER THAT SENTENCE COULD NOT TELL A PROMISE FROM ITS DENIAL.**
+`test_the_checksum_on_screen_says_who_checks_it` asserted `"Engine" in text`. Its docstring
+states the rule exactly right -- *"a number nothing verifies is worse than none, it reads as a
+promise"* -- and then checked for a **word**. *"The Engine checks its own updates"* and *"the
+Engine does not fetch or install its own updates"* both contain it. **It stayed green across
+the entire period its subject was false, and it would have gone red on the honest sentence had
+the honest sentence omitted the word.**
+
+**Fixed here.** The claim is tied to the code instead of to a word: the note may say the engine
+verifies updates **only while something actually calls `/api/update`**, and the assertion fails
+in **both** directions -- restoring the promise reddens it, and building the caller reddens it
+too, demanding the sentence be updated. Mutation-checked both ways. `LESSONS` §29 rows 10 and 11
+are this and the terminal blocklist, and the rule they produced is that **a guard which can only
+fail in one direction is half a guard.**
+
 ### DEC-1 · Topology A — the TypeScript extension as the public product
 **Approved 2026-07-18. Zero commits since.** This is the largest gap between what was
 decided and what exists.
@@ -5946,7 +6015,7 @@ at the run, don't assume it.
 ### BV-3 · Settings moved into the extension panel — CONFIRMED, and its warning has come true
 **Re-measured 2026-08-12. The "not yet confirmed" half is CLOSED by the live
 warehouse**, which shows the whole chain working on the owner's machine in a real
-crawl: `extension/app.js:848` posts `crawl_honour_delay` → `scrapex/capture.py:95`
+crawl: `extension/app.js:853` posts `crawl_honour_delay` → `scrapex/capture.py:95`
 reads it → `scrapex/connectors/base.py:560` emits the sentence → `job_log_entry`
 for job 120 carries it. Two settings hold non-default values, so something wrote
 them: `crawl_honour_delay = '0'`, `crawl_min_interval_s = '1'`.

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -2526,7 +2526,7 @@ crawl", and the honest report would have had to say so.
 Not part of the incident, and it is recorded here because **this branch is what
 demonstrated it.** A continuation citation — a bare `` `:NNN` `` inheriting its path
 from a full citation a few words earlier, as in
-`` (`extension/app.js:1578`, `:1641`) `` — **is invisible to
+`` (`extension/app.js:1583`, `:1641`) `` — **is invisible to
 `tests/test_the_documents_cite_what_they_claim.py`.** `CITATION` requires a path before
 the colon, so it matches `app.js:1641` and does not match `:1641`. Measured, not
 reasoned: the regex returns a match for the first string and `None` for the second.
@@ -3377,7 +3377,7 @@ Related: section 21's rule about re-deriving citations after an insertion is the
 discipline applied to line numbers rather than to counts, and `OP-97` is the same failure
 applied to a file LIST — a census scoped to 9 stylesheets when there were 19.
 
-## 29 · Deleting a ruling rewrites the sentences that talk ABOUT it, and one blind spot was found seven times in a day and twice more since
+## 29 · Deleting a ruling rewrites the sentences that talk ABOUT it, and one blind spot was found seven times in a day and six times more since
 
 `R-77` deleted five rulings and every live citation of them was repointed mechanically.
 That is the right operation for a link. **It is the wrong operation for a sentence that
@@ -3402,7 +3402,7 @@ drift that produced them. The fix was to make each docstring say *"this enforces
 has been replaced, here is what it becomes, and this is the first thing its builder changes"*.
 
 **THE SAME SHAPE, FOUND SEVEN TIMES ON 2026-08-30 BY FOUR SESSIONS THAT WERE NOT LOOKING
-FOR IT, AND AN EIGHTH ON 2026-09-02** -- and three of the eight could never have failed
+FOR IT, AND SIX MORE ON 2026-09-02** -- and three of the thirteen could never have failed
 at all. A mechanism that is correct, visible, and load-bearing on nothing:
 
 | found | the mechanism | what it actually held |
@@ -3416,21 +3416,29 @@ at all. A mechanism that is correct, visible, and load-bearing on nothing:
 | engine page | `test_the_web_page_offers_no_setting_to_change`, which mechanises an owner ruling | **nothing.** Its `_control_ids` regex matches `input\|select\|textarea`, so it cannot see a `<button>` -- and the nine ids it can see are exactly the nine on its own exemption list |
 | design review, 2026-08-30 | **a full suite run to completion, exit 0** | **the tree it STARTED on, not the branch it was reported for** -- a checkout during the run swapped the subject |
 | rebase, 2026-09-02 | `assert "/api/engine/health" in _engine_serves(tmp_path)`, plus the caller sweep beside it | the route, **in the only configuration that mounts it** -- `create_app(databases=registry)`; an engine started against an explicit database path serves no such route and the poll it guards 404s its whole budget (`OP-119`) |
+| `R-81` repair, 2026-09-02 | `assert "scrapex ui" not in surface`, plus one more literal | **two strings.** The docstring stated the rule -- *"anything that needs a terminal is a missing button"* -- and the assertion was a blocklist; the terminal command in a live banner contains neither (`OP-124`) |
+| `R-81` repair, 2026-09-02 | `assert "Engine" in text` on the installer checksum note | **the word, not the claim.** *"The Engine checks its own updates"* and *"the Engine does not fetch or install its own updates"* both contain it, so it could not tell a promise from its denial -- and stayed green for the whole period the promise was false |
+| `OP-126`, 2026-09-02 | `assert 400 <= status < 500` on a refused panel action | **that a refusal happened, never which one.** The recipe carried the same invalid `run_mode` copied out of `app.js`, so the reason it RECORDED was not the reason it measured -- and «Update now» was broken on every card since the handler was written |
+| `OP-126`, 2026-09-02 | `test_a_dataset_card_offers_only_the_actions_that_work`, asserting the action is ABSENT | **the defect, as a requirement.** A guard that asserts a capability is missing goes red only when someone fixes it |
 
-**THREE OF THE NINE WERE BORN ROTTEN, NOT ONE, AND THAT IS THE FINDING.** Rows 2, 3 and 4
+**THREE OF THE THIRTEEN WERE BORN ROTTEN, NOT ONE, AND THAT IS THE FINDING.** Rows 2, 3 and 4
 rotted -- they held something once and their subject moved. **Rows 1, 5 and 7 never held
-anything.** Rows 6, 8 and 9 are none of those three things, and row 9 is the reason this
-section's closing claim had to be rewritten rather than extended -- see below.
+anything.** Rows 6 and 8 through 13 are none of those three things -- seven of the thirteen are
+neither stale nor born wrong -- and row 9 is the reason this section's closing claim had to be
+rewritten rather than extended. **The section began as "guards that rotted" and its own table
+now says that is the minority case.** See below.
 
 > *(Row 6 arrived after this section was written, from the engine-page work. It is added
 > here rather than in a section of its own, and the counts above and below are moved with
 > it -- a table that grows while its own arithmetic stays put is the defect this section
-> describes, committed by the person describing it Row 8 arrived three days later the same
-> way, and its arrival cost more than a row: it made the section's closing generalisation
-> false, so that sentence is rewritten above rather than qualified. **A counterexample
-> found after the conclusion is the cheapest evidence there is and the easiest to file as
-> an exception** -- filing it as an exception is how a document keeps a claim its own
-> table refutes.)*
+> describes, committed by the person describing it. **Rows 8 to 11 arrived the same way three
+> days later**, and row 9's arrival cost more than a row: it made the section's closing
+> generalisation false, so that sentence is rewritten above rather than qualified. **A
+> counterexample found after the conclusion is the cheapest evidence there is and the easiest
+> to file as an exception** -- filing it as an exception is how a document keeps a claim its
+> own table refutes. (The missing full stop after *"describing it"* is where a keep-both
+> merge joined two sentences into one on 2026-09-02, and it survived a further rebase before
+> anyone read the line rather than the numbers around it.)*
 
 The `forEach` assertion was written on **2026-08-29** (`208d829`) against a file that had
 carried **two** occurrences since **2026-07-27** (`6779573`) -- checked with `git log -S`, and
@@ -3454,7 +3462,7 @@ was never expanded and it asserted against an empty set. When the include walk w
 nine controls it could finally see were exempted in the same change. **Two independent
 mistakes, each of which alone would have left it working.**
 
-**AND THERE IS A NINTH SHAPE THAT NO GUARD COULD HAVE CAUGHT, which is why it is recorded
+**AND THERE IS A SHAPE NO GUARD COULD HAVE CAUGHT, which is why it is recorded
 here rather than as a defect in one.** Twice on 2026-08-30 a mechanism was found still
 running against a boundary that had been DELETED:
 
@@ -3491,9 +3499,36 @@ were read off the captured output -- but the number was a true statement about t
 process. The fix is to record the status of the thing you meant to measure, in the artefact you
 will read: `echo "pytest exit=$?"` into the file itself.
 
-**AND BY THE END OF THAT DAY THE TOOLING HAD SUPPLIED TWO MORE, WHICH IS WHAT MAKES THIS THE
-SECTION'S MOST GENERAL FINDING RATHER THAN A NOTE ABOUT GUARDS.** Every one is a true number
-about a subject nobody asked about:
+**AND ROWS 10 AND 11 ARE A FOURTH KIND: THE ASSERTION CANNOT TELL A CLAIM FROM ITS DENIAL.**
+`assert "scrapex ui" not in surface` asks about two strings while its own docstring asks about
+terminals. `assert "Engine" in text` is satisfied by *"the Engine checks its own updates"* and
+equally by *"the Engine does not fetch or install its own updates"* -- so it held for the entire
+period the sentence it guarded was FALSE. **Both were repaired by tying the assertion to the code
+rather than to a word**: the terminal guard reads string VALUES via `ast` and asks about command
+SHAPE, and the checksum guard permits the claim only while `/api/update` has a caller -- failing
+in BOTH directions, since restoring the promise reddens it and building the updater reddens it
+too, demanding the sentence be updated. **A guard that can only fail in one direction is half a
+guard**, and this pair is what made that concrete.
+
+**ROW 12 IS THE FOURTH KIND AT ITS PUREST, BECAUSE THE IMPRECISION IS THE ABSTRACTION'S POINT.**
+`assert 400 <= status < 500` cannot separate *"wrong source key"* from *"not a RunMode"* -- and
+a status-code RANGE is not a sloppy assertion, it is a deliberately general one. So the guard
+recorded a reason it had never measured, and «Update now» was refused on every card, since the
+handler was written, with every check over it green. **When an assertion is imprecise BY DESIGN,
+the design is the defect.**
+
+**AND ROW 13 IS A FIFTH KIND: A GUARD THAT ASSERTS A CAPABILITY IS MISSING.**
+`test_a_dataset_card_offers_only_the_actions_that_work` required the action to be ABSENT, so it
+held the missing-ness in place: it converts a defect into a requirement, and **the only change
+that can ever turn it red is the fix.** Three instances now --
+`test_the_web_page_offers_no_setting_to_change`, `#297`'s `assert any(path.name == "app.js"
+...)`, and this -- which makes it a shape rather than three accidents. The tell is grammatical:
+**an assertion whose subject is an absence has nothing to protect**, and the repair is to assert
+what should be there instead, then delete the row that said it should not be.
+
+**AND BY THE END OF THAT DAY THE TOOLING HAD SUPPLIED TWO MORE BESIDES THE PIPE, WHICH IS WHAT
+MAKES THIS THE SECTION'S MOST GENERAL FINDING RATHER THAN A NOTE ABOUT GUARDS.** Every one is a
+true number about a subject nobody asked about:
 
     row 8    a green      for the tree the run STARTED on, not the branch reported
     row 9    a route      in the configuration the guard always builds
@@ -3501,6 +3536,13 @@ about a subject nobody asked about:
     `grep -c` an exit 1   because it matched nothing -- which was the good news
     `git diff --stat origin/main`   614 deletions   because `main` had MOVED, not
                                                     because the branch deletes anything
+    a rebase then a checkout   17 failures   from a tree that changed under a run
+                                             already in flight -- row 8, again, to the
+                                             session writing this paragraph
+    a row count                11 rows       counting the header and the separator AS
+                                             rows -- a LINE count reported as a ROW
+                                             count, and used as evidence that a repair
+                                             to a count had landed
 
 **The last two arrived while writing this paragraph.** `grep -cE "^FAILED" out/gate.txt` was the
 final command in a gate script, so a fully green run was announced as *failed with exit code 1*:
@@ -3510,9 +3552,29 @@ truthful about a comparison against a `main` that had moved two merges ahead, an
 change deletes 614 lines"*. **Neither was carelessness. Both are the same question unasked:
 which subject is this number about?**
 
-The fix is the same in all five: **record the status of the thing you meant to measure, in the
-artefact you will read** -- `echo "pytest exit=$?"` into the output file, `git diff --stat
-<your own base>` rather than a moving ref -- and never read a verdict off a wrapper that has
+**AND THE LAST ONE IS ROW 8 ITSELF, ARRIVING WHILE THIS PARAGRAPH WAS BEING WRITTEN ABOUT IT.**
+Four gates were launched in the background; twenty-six minutes later the same session ran
+`git checkout -b` to split the work into two branches. The second gate then reported **17
+failures**, every one of them in the two tests that read repository files at run time -- so they
+had seen a tree that changed under them. There was no defect. **Row 8 was already in the table,
+written by another session, describing precisely this**, and it was walked into anyway by the
+session documenting it. It is recorded because that is the whole point: *knowing the trap is
+written down is not the same as remembering it at the moment you are about to step in it.* The
+operational rule is one line -- **never move the tree while a gate is in flight** -- and it now
+has a second instance and two sessions behind it.
+
+**AND THE LAST ONE HAPPENED INSIDE THE VERIFICATION OF THIS SECTION'S OWN REPAIR**, which is
+why it is here rather than in a footnote. Checking that the table had been fixed, a session
+counted the pipe-prefixed lines -- eleven -- and reported eleven ROWS. Two of the eleven were
+the header and the separator; the table held nine. **The claim was true and the figure was
+not**, and the figure was the evidence. It was caught by re-measuring rather than by anything
+in the tree, and the session that made it corrected itself unprompted. *(Its own finding, and
+its own words for it.)*
+
+The fix is the same in all seven: **record the status of the thing you meant to measure, in the
+artefact you will read**, and make sure nothing changes the subject while you measure it --
+`echo "pytest exit=$?"` into the output file, `git diff --stat <your own base>` rather than a
+moving ref, no checkout while a run is open -- and never read a verdict off a wrapper that has
 its own opinion about success.
 
 **All of them are honest reports of the wrong subject, and no count anywhere would differ.** So
@@ -3550,6 +3612,19 @@ its assertion.
 > documents has no separator above it** -- which is mechanical, and which is `OP-125`: written
 > to measure whether it would be noisy, it found two more on `main` in a document nobody
 > suspected.)*
+>
+> *(**AND IT HAPPENED AGAIN TWICE MORE, TO THE SESSION THAT WROTE THE RULE, IN THE TWO REBASES
+> THAT CARRIED THIS PARAGRAPH FORWARD.** Both were caught, and only because the rule was
+> followed literally rather than remembered: both sides read, resolved in numeric order, **and
+> then the prose re-read across the seam.** That third step -- the one that feels redundant --
+> is what found a wholly duplicated paragraph, a summary block citing row numbers the merged
+> table no longer had, *"Row 11 is a full suite"* where it was row 8, *"three of the nine"*
+> against an eleven-row table, an ordinal left from an older count, one case told twice, and a
+> **missing full stop** where an earlier keep-both had welded two sentences into one and
+> survived a whole rebase because everyone was reading the numbers and not the line. Seven
+> things, none of which any guard could see. **The rule works and it is not automatic**, and
+> the difference between those two statements is the whole reason it is written here rather
+> than assumed.)*
 
 **The sixth was found the same day, in the Drive incident, and it is the sharpest of them because it names the VALUE at which a guard switches off.** A size, a count, a duration and a checksum all share one property: **zero is the least interesting number and the most alarming one**, and a truthiness test discards exactly it. Ask for PRESENCE — `typeof x === "number"` — which forgives an absent field and refuses a zero one.
 

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -2085,7 +2085,7 @@ them on this exact point. The corrected finding is better news than the error wa
 changes the request from *build this* to **finish and re-document this**.
 
 **THE DATA PAGE ALREADY READS HIS DATA WITH NO ENGINE. It has since 2026-08-12.**
-`extension/app.js:4394-4429` is the `catch` around `loadDatasets`, and its own comment says
+`extension/app.js:4434-4497` is the `catch` around `loadDatasets`, and its own comment says
 what it is for:
 
 > *"NOT A DEAD END ANY MORE. This is the machine with no engine on it — the case the whole
@@ -2157,7 +2157,7 @@ the decision.
 
 Measured above the transport, so the step is **parameterising what works, not inventing it**:
 a live backend address field (`extension/app.html:1772`), a switch that re-activates and
-re-adopts appearance, timezone and the UI contract (`extension/app.js:6362-6334`),
+re-adopts appearance, timezone and the UI contract (`extension/app.js:6367-6339`),
 abort-and-generation-bump on change (`extension/backend.js:68-77`), and a repaint guard
 whose own comment already names the multi-app hazard (`extension/data.js:74-76`):
 
@@ -2465,7 +2465,7 @@ reason is four links long, every one measured on the live engine rather than arg
 | link | evidence |
 |---|---|
 | 1 | the panel's crawl action sends `POST /api/jobs` with `source_keys` — `extension/app.js:4044` |
-| 2 | **CLOSED.** That route validated the key against `app.state.manifest` — a FILE — and now resolves it through `SourceResolver`, which asks the manifest first and `source_site` second: `scrapex/webui/app.py:3570`, beside the comment that has outlived four line numbers, *"fail before queueing, not mid-crawl"*. **That comment is why this row survived at all**: the number moved 43 lines in `#274`, again for the bundle-build lock, was 27 lines stale in between, and moved a fourth time when `#302` landed 7,242 insertions and a FIFTH when `#301` landed on top of it -- 4064 to 4044, found by the quoted call and not by any delta. Tier 1 only asks that a cited line EXIST, and a stale line that is not blank still exists — so the quoted text, not the number, is what kept finding it |
+| 2 | **CLOSED.** That route validated the key against `app.state.manifest` — a FILE — and now resolves it through `SourceResolver`, which asks the manifest first and `source_site` second: `scrapex/webui/app.py:3604`, beside the comment that has outlived four line numbers, *"fail before queueing, not mid-crawl"*. **That comment is why this row survived at all**: the number moved 43 lines in `#274`, again for the bundle-build lock, was 27 lines stale in between, and moved a fourth time when `#302` landed 7,242 insertions and a FIFTH when `#301` landed on top of it -- 4064 to 4044, found by the quoted call and not by any delta. Tier 1 only asks that a cited line EXIST, and a stale line that is not blank still exists — so the quoted text, not the number, is what kept finding it |
 | 3 | the manifest is `sources.yaml` — **12 price sources, and neither `muqawil` nor `contractors` is in it.** **This row was true when written and half of it is not now**: `0014` merged `site_profile` into `source_site` on 2026-08-29, which is what made a resolver possible rather than a third registry |
 | 4 | `scrapex/jobs.py`, which is what the button drives, contains **zero** references to `muqawil`, `generic_record`, `partitioncrawl`, `snapshotcrawl`, `contractors` or `dataset` — **and this turned out to be the DESIGN rather than the defect.** It asks a source for three things and none is price-specific, so the fix was a resolver and `jobs.py` is unchanged. **What remains is the collector**: the route now queues `muqawil_org`, and the worker still hands it to `capture_source` |
 

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -3149,8 +3149,8 @@ SHA, both facts rather than judgements.
 2026-08-30, thirteen days later, still live in three places:
 
     scrapex/version.py:517      "latest_extension_version": VERSION
-    scrapex/webui/app.py:1715   "latest_extension_version": VERSION
-    extension/app.js:607, :641  drawn to the user as "Latest available extension"
+    scrapex/webui/app.py:1747   "latest_extension_version": VERSION
+    extension/app.js:612, :646  drawn to the user as "Latest available extension"
 
 The engine answers *"what is the newest extension available"* with **its own number**, which
 is not an answer it has. `R-07` correctly said this is Chrome's fact, not the engine's. The
@@ -3460,6 +3460,36 @@ them.
 listing crawl, priced at 58 minutes — and has sat since under "awaiting the owner". **He was
 never the blocker.** It waits on a control he does not have, and this session filed it against
 him again on 2026-08-30 before he corrected it.
+
+**5 · AND IT WAS BEING BROKEN IN A LIVE FAILURE BANNER, WHICH THE GUARD FOR IT COULD NOT SEE.**
+Measured 2026-09-02, when he asked whether his own architectural decisions had been wrong.
+`scrapex/webui/app.py` published `"fix": "python -m scrapex.cli init-db"` inside the
+*database is behind the engine* banner, `extension/app.js` carried the same string a second
+time as a hardcoded fallback, and `POST /api/databases/upgrade` -- the button that does
+exactly that -- had already existed for weeks. `webui/database_api.py`'s `upgrade` docstring
+records that the identical instruction was taken OFF the database-attention page and replaced
+by that button, for this ruling's reason. **The command was removed from one page and went on
+living in two more.**
+
+**THE GUARD WAS NAMED FOR THIS RULE AND IMPLEMENTED A BLOCKLIST OF TWO STRINGS**
+(`"scrapex ui"`, `"in a terminal"`), while its own docstring stated the rule correctly:
+*"anything that needs a terminal is a missing button."* `python -m scrapex.cli init-db`
+contains neither literal. **A rule in prose and a blocklist in code are not the same thing**,
+and the gap was the whole defect -- `LESSONS` §29's ninth instance, and the only one where the
+guard's docstring already described what it should have been doing.
+
+**AND THE BANNER COULD NOT APPEAR AT ALL UNTIL `OP-113` WAS FIXED**, four commits earlier on
+the same branch. So repairing a warning that had never rendered is what put a terminal command
+in front of him for the first time. **A defect can be created by fixing the thing that was
+hiding it**, and no count anywhere would have moved.
+
+**Fixed 2026-09-02**: both copies name the button; the guard now asks about SHAPE, reading
+string VALUES via `ast` so that prose explaining a past defect does not trip it (§28), scoped
+to the two things with a screen -- `extension/` and `scrapex/webui/`. `scrapex/cli.py` is
+deliberately not a surface: its stdout IS a terminal, so a command there is the answer rather
+than the defect. Mutation-checked three ways, and the third is what makes it usable: the old
+command turns it red, a DIFFERENT command shape the blocklist never knew turns it red, and a
+comment describing the old command does not.
 
 **WHY THIS WAS NOT ALREADY WRITTEN DOWN, since it is the obvious question.** The repository
 says the *shape* of it in three places and the *fact* in none.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -923,7 +923,7 @@ test (#200) · sign-out (#201, ruling [R-13](RULINGS.md#r-13--sign-out-of-all-ac
    source's answers 404 **without confirming the id exists at all**.
 2. **Choose-Columns — `GET`/`POST /api/fields/{key}`. Do not write a second one.**
    The panel already has the whole thing: `loadSourceColumns`
-   (`extension/app.js:1578`) and `saveSourceColumns` (`:1641`), speaking the same
+   (`extension/app.js:1583`) and `saveSourceColumns` (`:1641`), speaking the same
    bodies. **Extract** it into a shared module the way `backend.js` was, or the
    two surfaces will disagree about how a column is saved.
 3. **Saved views — `POST /api/views/{key}`, `DELETE /api/views/{id}`.**
@@ -1488,8 +1488,8 @@ written and 58 two days ago. It grows every time this is deferred.
 **The blocker, verified 2026-08-17 and still present:**
 `"latest_extension_version": VERSION` at
 [scrapex/version.py:517](../scrapex/version.py) and
-[scrapex/webui/app.py:1715](../scrapex/webui/app.py), drawn by
-[extension/app.js:607](../extension/app.js) and `:641`.
+[scrapex/webui/app.py:1747](../scrapex/webui/app.py), drawn by
+[extension/app.js:612](../extension/app.js) and `:646`.
 
 > **Re-verified 2026-08-19, and three of these citations had already drifted.**
 > `webui/app.py` was **1355**, now 1375 — #211 and #212 inserted twenty lines

--- a/extension/app.html
+++ b/extension/app.html
@@ -1641,9 +1641,21 @@
                  yours to compare if you want to. Every update after this one
                  is fetched and verified by the engine itself before anything
                  is replaced (R-36). -->
+            <!-- WHAT THIS SAID WAS FALSE, and measurably: `GET /api/update`
+                 has ZERO callers in `extension/`, and `scrapex/update.py`'s own
+                 module docstring says it "deliberately does not" replace the
+                 running executable -- `plan_swap` names the steps as data
+                 rather than performing them. So the engine does not download,
+                 verify or install anything today. `R-36` permits the updater;
+                 nothing has built it. Promising it here is the same defect as
+                 a terminal instruction, one layer up: a sentence the product
+                 cannot honour. -->
             <p class="text-sm" id="engine-checksum-note">
-              Compare this if you wish. From here on the Engine downloads and
-              checks its own updates against this number before installing.
+              This is the SHA-256 of the file you just downloaded. Nothing
+              checks it for you yet, so if you want it checked, compare it
+              against the number on the release page before you run the
+              installer. Updates are not fetched or installed for you: an
+              update means downloading the new engine here, the same way.
             </p>
           </div>
         </details>

--- a/extension/app.js
+++ b/extension/app.js
@@ -489,8 +489,13 @@ function renderSchemaLag(lag) {
   const title = el("div", "setup-title", "Database is behind the engine");
   const what = el("div", "muted steps mb-2", lag.message || "");
   const how = el("div", "muted text-xs");
-  how.textContent = "Fix: " + (lag.fix || "python -m scrapex.cli init-db")
-    + " — back up first, and apply it before restarting the engine.";
+  // THE FALLBACK IS A SECOND COPY AND IT WAS THE WORSE ONE: it survived a
+  // terminal command being taken off the engine's own page, and this banner
+  // could not appear at all until `OP-113` was fixed -- so repairing the
+  // warning is what put the command on screen for the first time. Both halves
+  // now name the button that already exists (`R-81`).
+  how.textContent = "Fix: " + (lag.fix || "press Upgrade database on the Settings screen")
+    + " — back up first, and do it before restarting the engine.";
   const which = el("div", "muted text-xs tech", lag.pending.join(", "));
   box.append(title, what, which, how);
   box.classList.remove("hidden");

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -1651,9 +1651,20 @@ def create_app(
             if waiting:
                 schema_lag = {
                     "pending": [name for _n, name in waiting],
-                    # Named so the message can be acted on without a manual:
-                    # the fix is one command, and it is the ONLY sanctioned one.
-                    "fix": "python -m scrapex.cli init-db",
+                    # NAMED SO IT CAN BE ACTED ON, AND THAT MEANS A BUTTON.
+                    # This field held a terminal command until 2026-09-02, and
+                    # `POST /api/databases/upgrade` had been built for exactly
+                    # this remedy -- its own docstring in `database_api.py` says
+                    # the database-attention page's identical instruction was
+                    # replaced by that button because the owner does not use a
+                    # terminal (`R-81`). The command was removed from one page
+                    # and went on living in this field, which the panel renders.
+                    # The button works on either start: the panel tries the
+                    # route and falls back to the native host on a 404
+                    # (`app.js`, `upgradeDatabaseFromPanel`), so naming it here
+                    # is safe in both configurations -- checked, because a
+                    # remedy that is itself conditional is `OP-119` again.
+                    "fix": ("press Upgrade database on the Settings screen"),
                     "message": (
                         f"{len(waiting)} migration(s) on disk are not applied to "
                         f"this database — {waiting[0][1]} onward. Pages that read "

--- a/tests/test_panel_dom.py
+++ b/tests/test_panel_dom.py
@@ -2722,13 +2722,84 @@ def test_no_surface_tells_the_owner_to_open_a_terminal():
     button. The panel told him to run `scrapex ui` in one - on a machine where
     the launcher WAS installed and the helper answered - because a cold start
     took longer than the five-second budget and every failure printed the same
-    sentence."""
-    panel = (ROOT / "extension" / "app.js").read_text(encoding="utf-8")
-    settings = (ROOT / "scrapex" / "webui" / "templates" / "settings.html").read_text(encoding="utf-8")
+    sentence.
 
-    for surface, name in ((panel, "the panel"), (settings, "Settings")):
-        assert "scrapex ui" not in surface, f"{name} still names a terminal command"
-        assert "in a terminal" not in surface, f"{name} still sends the owner to a terminal"
+    THE ASSERTION USED TO BE TWO LITERALS -- `"scrapex ui"` and `"in a
+    terminal"` -- and the docstring above already stated the rule correctly.
+    A rule in prose and a blocklist in code are not the same thing, and the gap
+    between them was measurable: `"python -m scrapex.cli init-db"` sat in the
+    schema-lag banner's `fix` field, contains neither literal, and was rendered
+    in the panel. It had even been REMOVED from the database-attention page and
+    replaced by a button, and went on living in a second copy -- see
+    `webui/database_api.py`'s `upgrade` docstring, which records that removal.
+
+    SO THIS ASKS ABOUT SHAPE, and it reads STRING VALUES rather than files.
+    Scanning raw text would flag every comment that explains a past defect,
+    which is `LESSONS` 28 and would make the check noisy enough to switch off.
+    Python surfaces are parsed with `ast` so a docstring is distinguishable
+    from a value; JavaScript and HTML have their comments stripped first.
+
+    `scrapex/cli.py` IS DELIBERATELY NOT A SURFACE. Its stdout is a terminal, so
+    a command there is the answer rather than the defect. The surfaces are the
+    two things with a screen: `extension/` and `scrapex/webui/`.
+    """
+    import ast
+    import re
+
+    command = re.compile(
+        r"(python\s+-m\s+\S|py\s+-m\s+\S|pip\s+install"
+        r"|(?<![A-Za-z])scrapex\s+(?:ui|init-db|contractors|crawl|export|ingest|migrate)"
+        r"|in a terminal|on the command line|command prompt"
+        r"|open (?:a|the) terminal|PowerShell)")
+
+    def literals(path):
+        """Every string a surface can DISPLAY, without its prose."""
+        text = path.read_text(encoding="utf-8")
+        if path.suffix == ".py":
+            out = []
+            tree = ast.parse(text)
+            docstrings = {
+                id(node.body[0].value)
+                for node in ast.walk(tree)
+                if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef,
+                                     ast.AsyncFunctionDef))
+                and node.body and isinstance(node.body[0], ast.Expr)
+                and isinstance(node.body[0].value, ast.Constant)
+                and isinstance(node.body[0].value.value, str)
+            }
+            for node in ast.walk(tree):
+                if (isinstance(node, ast.Constant) and isinstance(node.value, str)
+                        and id(node) not in docstrings):
+                    out.append((node.lineno, node.value))
+            return out
+        stripped = re.sub(r"/\*.*?\*/|<!--.*?-->", " ", text, flags=re.S)
+        stripped = re.sub(r"^\s*//.*$", "", stripped, flags=re.M)
+        return [(n, line) for n, line in enumerate(stripped.splitlines(), 1)
+                if '"' in line or "'" in line or "`" in line]
+
+    surfaces = (
+        [p for p in (ROOT / "extension").rglob("*.js") if "tests" not in p.parts]
+        + list((ROOT / "extension").rglob("*.html"))
+        + [p for p in (ROOT / "scrapex" / "webui").rglob("*.py")]
+        + list((ROOT / "scrapex" / "webui" / "templates").rglob("*.html"))
+    )
+    assert len(surfaces) > 20, f"the surface list collapsed to {len(surfaces)}"
+
+    offenders = []
+    for path in surfaces:
+        if "tests" in path.parts:
+            continue
+        for line, value in literals(path):
+            found = command.search(value)
+            if found:
+                offenders.append(
+                    f"{path.relative_to(ROOT).as_posix()}:{line} -> {found.group(1)!r}")
+
+    assert not offenders, (
+        "these surfaces tell the owner to type something: "
+        + "; ".join(sorted(offenders))
+        + ". He does not use a terminal (R-81), so each of these is a button "
+        "that was never built or one that exists and is not named.")
 
 
 def test_each_native_failure_is_named_rather_than_blamed_on_the_install():

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -159,19 +159,19 @@ PINNED = (
     # The version-gate blocker. Track 3 of STATE.md cannot be worked without
     # these three, and two of them are the citations that drifted.
     ("docs/STATE.md", "scrapex/version.py", 517, '"latest_extension_version": VERSION'),
-    ("docs/STATE.md", "scrapex/webui/app.py", 1734, '"latest_extension_version": VERSION'),
-    ("docs/STATE.md", "extension/app.js", 607, "latest_extension_version"),
+    ("docs/STATE.md", "scrapex/webui/app.py", 1747, '"latest_extension_version": VERSION'),
+    ("docs/STATE.md", "extension/app.js", 612, "latest_extension_version"),
     ("docs/STATE.md", "scrapex/version.py", 76, 'VERSION = "'),
-    ("docs/RULINGS.md", "scrapex/webui/app.py", 1734, '"latest_extension_version": VERSION'),
+    ("docs/RULINGS.md", "scrapex/webui/app.py", 1747, '"latest_extension_version": VERSION'),
     ("docs/RULINGS.md", "scrapex/version.py", 517, '"latest_extension_version": VERSION'),
     # The two flags whose condition is met and whose lighting is the owner's call.
     ("docs/STATE.md", "scrapex/features.py", 54, "True"),
     ("docs/STATE.md", "scrapex/features.py", 65, "True"),
     # B2 step 2 -- "do not write a second one". The instruction is to EXTRACT
     # these two, so a reader sent to the wrong line writes the duplicate instead.
-    ("docs/STATE.md", "extension/app.js", 1578, "async function loadSourceColumns("),
-    ("docs/APPROACHES.md", "extension/app.js", 1578, "async function loadSourceColumns("),
-    ("docs/APPROACHES.md", "extension/app.js", 1617, "async function saveSourceColumns("),
+    ("docs/STATE.md", "extension/app.js", 1583, "async function loadSourceColumns("),
+    ("docs/APPROACHES.md", "extension/app.js", 1583, "async function loadSourceColumns("),
+    ("docs/APPROACHES.md", "extension/app.js", 1622, "async function saveSourceColumns("),
     # The guards the documents claim exist. A rule that cites a dead guard is a
     # rule with nothing behind it -- which is how W4 came to be believed.
     ("docs/RULINGS.md", "tests/test_version.py", 536,
@@ -194,11 +194,11 @@ PINNED = (
     # this branch said 1673/2666, and the answer after both diffs is neither. That is
     # the case for reading over resolving: taking either side of the conflict would
     # have produced a confidently wrong pin.
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1745, '"worker_alive"'),
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2815, "def _about("),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1758, '"worker_alive"'),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2828, "def _about("),
     ("docs/BACKLOG.md", "scrapex/webui/templates/settings.html", 162, "about.worker_alive"),
     # BV-3's chain, end to end: the panel posts it, capture reads it.
-    ("docs/BACKLOG.md", "extension/app.js", 848, "crawl_honour_delay:"),
+    ("docs/BACKLOG.md", "extension/app.js", 853, "crawl_honour_delay:"),
     ("docs/BACKLOG.md", "scrapex/capture.py", 95, "crawl_honour_delay"),
     # OP-21 · the resume that saves the write and none of the requests. This is a
     # citation of a DEFECT at an exact line, so it is the kind that must not drift:
@@ -228,7 +228,7 @@ PINNED = (
     # is refusing to start for a nameable reason. The entry's argument is that this
     # exact branch is the one a schema-ahead warehouse lands in, so a reader sent
     # to the wrong line reads the timeout branch and concludes the entry is wrong.
-    ("docs/BACKLOG.md", "extension/app.js", 3400, 'text: "Not detected"'),
+    ("docs/BACKLOG.md", "extension/app.js", 3405, 'text: "Not detected"'),
     # OP-34 · why a black window leaves no trace. The whole finding is that this
     # function DELIBERATELY does nothing when it has real streams, which is the
     # double-click case -- so the log is not evidence about a failed launch.
@@ -265,7 +265,7 @@ PINNED = (
     # than being loosened to keep passing — the same call `OP-36` records above.
     # `return ""` for a dataset is what OP-42 was about; the pin follows the
     # argument to the filter that replaced it.
-    ("docs/BACKLOG.md", "extension/app.js", 4770,
+    ("docs/BACKLOG.md", "extension/app.js", 4775,
      "SOURCE_ACTIONS.filter((item) => item.proof === RESOLVES_A_DATASET)"),
     ("docs/BACKLOG.md", "scrapex/webui/app.py", 742, '"kind": "dataset",'),
     # 2710 -> 2725 -> 2787 -> 2911, and the fourth move is the same story as the
@@ -284,7 +284,7 @@ PINNED = (
     # 404 for anything else" -- and only reading the enclosing function separates
     # them. A delta applied to the old number would have picked the right line here
     # by luck and the wrong one the first time the two moved apart.
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 3185, "if source_key not in known:"),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 3198, "if source_key not in known:"),
     ("docs/BACKLOG.md", "scrapex/webui/app.py", 1218,
      "A GENERIC DATASET IS A TABLE LIKE ANY OTHER TABLE"),
     # OP-44 · the dataset card that said "no successful crawl yet" over 17,304
@@ -294,7 +294,7 @@ PINNED = (
     # The sentence itself, so it is clear the card reads a MISSING key and not a
     # missing crawl -- which is why writing a `crawl_run` row would not have moved
     # this line at all.
-    ("docs/BACKLOG.md", "extension/app.js", 4642, "const last = s.last_success;"),
+    ("docs/BACKLOG.md", "extension/app.js", 4647, "const last = s.last_success;"),
     # Why the row could not honestly be written: the column is NOT NULL into
     # source_site, and muqawil is in source_site.
     # 122 -> 91 WITH THE SUBJECT MADE UNIQUE. `REFERENCES source_site(source_id)`
@@ -322,7 +322,7 @@ PINNED = (
     # agree and the release simply was not cut, so a reader sent to the wrong line
     # on any one of them would go hunting for a defect that is not there.
     ("docs/BACKLOG.md", "extension/releases.js", 32, "ScrapeX/json/version.json"),
-    ("docs/BACKLOG.md", "extension/app.js", 3546, "latest.version"),
+    ("docs/BACKLOG.md", "extension/app.js", 3551, "latest.version"),
     # 488, and it was 379, 352, and 344 before that. THREE times now the same
     # pull request
     # has added comment lines above it and had to correct the number it had just
@@ -391,9 +391,9 @@ PINNED = (
     # all four of `OP-46`'s citations into it still name their symbols after #258 moved
     # that file. The remaining five citations in that entry stay unpinned on purpose --
     # they are the measured numbers, not the two symbols the argument rests on.
-    ("docs/BACKLOG.md", "extension/app.js", 940,
+    ("docs/BACKLOG.md", "extension/app.js", 945,
      "function setupFinanceConverterSelect("),
-    ("docs/BACKLOG.md", "extension/app.js", 1992, "function setupRunModeSelect("),
+    ("docs/BACKLOG.md", "extension/app.js", 1997, "function setupRunModeSelect("),
     # AND THE ONE CITATION THE ANCHOR SWEEP FOUND ACTUALLY FALSE. `docs/BACKLOG.md`
     # quotes this docstring as the reason the panel hides Update/Wipe/Rename on a
     # dataset row, and it read `app.py:706` under `#L697` -- two different wrong
@@ -880,13 +880,13 @@ def test_a_citation_that_quotes_its_subject_still_points_at_it(index):
 #: sessions, and a sweep that guessed would produce 26 confident wrong numbers in the
 #: one file whose subject is confident wrong numbers.
 PINNED_WITHOUT_A_CITATION = frozenset((
-    ("docs/APPROACHES.md", "extension/app.js", 1617),
+    ("docs/APPROACHES.md", "extension/app.js", 1622),
     ("docs/BACKLOG.md", ".github/workflows/release-engine.yml", 553),
     ("docs/BACKLOG.md", "db/engine/schema.sql", 1191),
     ("docs/BACKLOG.md", "db/engine/schema.sql", 91),
-    ("docs/BACKLOG.md", "extension/app.js", 3546),
-    ("docs/BACKLOG.md", "extension/app.js", 4642),
-    ("docs/BACKLOG.md", "extension/app.js", 4770),
+    ("docs/BACKLOG.md", "extension/app.js", 3551),
+    ("docs/BACKLOG.md", "extension/app.js", 4647),
+    ("docs/BACKLOG.md", "extension/app.js", 4775),
     ("docs/BACKLOG.md", "extension/releases.js", 32),
     ("docs/BACKLOG.md", "scrapex/extract/service.py", 1003),
     ("docs/BACKLOG.md", "scrapex/extract/service.py", 1065),
@@ -895,21 +895,19 @@ PINNED_WITHOUT_A_CITATION = frozenset((
     ("docs/BACKLOG.md", "scrapex/version.py", 76),
     ("docs/BACKLOG.md", "scrapex/warehousemerge.py", 269),
     ("docs/BACKLOG.md", "scrapex/webui/app.py", 1218),
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1745),
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2815),
-    ("docs/BACKLOG.md", "scrapex/webui/app.py", 3185),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 1758),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 2828),
+    ("docs/BACKLOG.md", "scrapex/webui/app.py", 3198),
     ("docs/BACKLOG.md", "scrapex/webui/app.py", 701),
     ("docs/BACKLOG.md", "scrapex/webui/app.py", 742),
     ("docs/BACKLOG.md", "tests/test_the_two_release_paths.py", 276),
     ("docs/LESSONS.md", "design/components.css", 380),
     ("docs/LESSONS.md", "scrapex/extract/service.py", 978),
     ("docs/LESSONS.md", "tests/test_panel_dom.py", 160),
-    ("docs/RULINGS.md", "scrapex/webui/app.py", 1734),
     ("docs/RULINGS.md", "tests/test_version.py", 536),
     ("docs/RULINGS.md", "tests/test_version.py", 79),
     ("docs/STATE.md", "scrapex/extract/service.py", 927),
     ("docs/STATE.md", "scrapex/features.py", 65),
-    ("docs/STATE.md", "scrapex/webui/app.py", 1734),
 ))
 
 

--- a/tests/test_the_panel_hands_the_installer_to_chrome.py
+++ b/tests/test_the_panel_hands_the_installer_to_chrome.py
@@ -133,8 +133,32 @@ def test_the_checksum_on_screen_says_who_checks_it():
     note = re.search(r'id="engine-checksum-note">(.*?)</p>', APP_HTML, re.S)
     assert note, "the note element has no text"
     text = " ".join(note.group(1).split())
-    assert "Engine" in text, f"the note does not say who verifies it: {text!r}"
-    assert "check" in text.lower()
+    assert "check" in text.lower(), (
+        f"the note does not say whether anything verifies the number: {text!r}")
+
+    # `assert "Engine" in text` STOOD HERE AND COULD NOT FAIL USEFULLY. The
+    # sentence it was written for -- "the Engine checks its own updates" -- and
+    # the sentence that replaced it -- "the Engine does not fetch or install its
+    # own updates" -- both contain the word, so the assertion could not tell a
+    # promise from its denial. It was satisfied throughout the whole period the
+    # promise was FALSE.
+    #
+    # SO THE CLAIM IS TIED TO THE CODE INSTEAD. The note may say the engine
+    # verifies updates only while something actually asks it to: measured
+    # 2026-09-02, `GET /api/update` has zero callers in `extension/`, and
+    # `scrapex/update.py`'s module docstring says it "deliberately does not"
+    # replace the running executable. See `R-81` clause 5 and `R-36`.
+    panel_js = (ROOT / "extension" / "app.js").read_text(encoding="utf-8")
+    asks_the_engine = "/api/update" in panel_js
+    claims_the_engine_checks = any(
+        phrase in text.lower()
+        for phrase in ("engine downloads and", "engine checks its own",
+                       "checked by the engine", "verified by the engine"))
+    assert claims_the_engine_checks == asks_the_engine, (
+        "the note claims engine-side update verification while nothing calls "
+        "/api/update" if claims_the_engine_checks else
+        "the panel now calls /api/update, so the note may say the engine "
+        "verifies updates — and should")
 
 
 def test_the_saveas_dialogue_is_suppressed_deliberately():

--- a/tests/test_the_registers_cannot_collide.py
+++ b/tests/test_the_registers_cannot_collide.py
@@ -366,18 +366,16 @@ RESERVED: dict[str, dict[int, str]] = {
         # branch declares it, so it became a number both reserved AND declared -- and its
         # own row said to delete it the day #312 lands, which is this rebase. The guard
         # named it before the session did, which is the fifth time today.
-        # 124 IS CLAIMED BY MESSAGE ONLY, and this row says so because the rule above
-        # requires it to: the primary session allocated it for the terminal command in
-        # the schema-lag banner, and a search of every local and remote ref finds NO
-        # `### OP-124` heading -- checked with
-        #   git show <ref>:docs/BACKLOG.md | grep "^### OP-124 "
-        # over refs/heads and refs/remotes. The work exists on
-        # `claude/the-command-that-outlived-its-removal`; the ENTRY does not yet, and
-        # that branch cites `OP-124` from a `LESSONS` 29 row, so it must declare the
-        # heading before it merges or the row points at nothing. RE-CHECK THIS ROW
-        # rather than trusting it -- a holder with no ref is the orphan this table warns
-        # about, one step before becoming one.
-        124: "branch claude/the-command-that-outlived-its-removal (no heading on any ref yet)",
+        # 124 HAS NO ROW ANY MORE, and the way it went is the point. It was reserved
+        # here as CLAIMED BY MESSAGE ONLY -- allocated for the terminal command in the
+        # schema-lag banner, with no `### OP-124` heading on any ref, checked across
+        # refs/heads and refs/remotes rather than taken from the message. The row said
+        # to re-check it rather than trust it, and said the holding branch must declare
+        # the heading before merging or its `LESSONS` 29 row would point at nothing.
+        # THIS IS THAT REBASE: the heading is declared, so the row is the contradiction
+        # `test_a_reserved_number_is_not_also_declared` exists to catch -- and it caught
+        # it, again, before the session did. SEVENTH ROW THIS SESSION HAS RETIRED, and
+        # every one was named by the guard first.
         45: "branch claude/drive-without-a-server",
         # 112 THROUGH 114 became holes when this branch declared OP-117.
         # 116's row was here and is GONE: #297 merged, so it is declared on


### PR DESCRIPTION
Two sentences on his only interface that are not true, the guard that let one of
them stand, and the thing that guard could never have caught.

He does not use a terminal ([R-81](docs/RULINGS.md)). The panel is his only
interface. So a screen that prints a shell command is not an instruction, and a
screen that describes a capability nothing provides is worse than silence.

## 1 · The banner names a terminal command, and it is written twice

```
scrapex/webui/app.py   "fix": "python -m scrapex.cli init-db"     the engine sends it
extension/app.js       "Fix: " + (lag.fix || "python -m ...")     the panel hardcodes
                                                                  it AGAIN, as a fallback
extension/app.js       POST /api/databases/upgrade                the button that works
```

**A button that performs it already exists on the Settings screen.** The
duplication is why this is `OP-124` and not a one-line fix: one string in two
files with nothing comparing them, so correcting the engine alone would have
left the panel printing it from its own copy.

**This banner had never appeared before `#293`.** `OP-113` is why — `schema_lag`
was published, rendered, and never carried — so the first thing that repair did
was put a terminal command in front of him. **A fix that makes a surface visible
inherits everything wrong with it**, and nothing in the change that carried the
field would have said so.

**Checked before pointing the banner anywhere:** `POST /api/databases/upgrade`
is mounted only `if databases is not None`, so the remedy is itself absent on a
`--db` start. The banner names the screen and the button rather than a route,
which is true on every start. That check is `OP-119` applied inside the fix for
something else.

## 2 · And the installer note promises an updater that nothing has ever started

The note beside the download's SHA-256 says, in `#246`'s words and still on
`main`:

> *"From here on the Engine downloads and checks its own updates against this
> number before installing."*

**It is false, and it was false the day it was written.** Measured across
`origin/main`:

| what exists | what calls it |
|---|---|
| `create_update_router()` — mounted unconditionally, `GET` and `POST` | **nothing** |
| `update.fetch_and_verify()`, `plan_swap()`, `swap_is_possible()` | only `update_api` |
| any `api/update` string in `extension/**/*.js`, `extension/**/*.html`, or the engine's templates | **none, in the whole history** — `git log -S` over those paths returns no commit |
| a timer or startup task that checks by itself | **none** — nothing imports `update` except the router |

**So the updater is built, mounted, and doorless**, and the only sentence
describing it claims it is running. `R-81` says a capability with no control in
the panel has no control; this is that one step further on, because a screen
asserts the control exists.

**The doorless updater is recorded, not repaired** — `OP-124` names it and says
why: the fix is either a caller or a deletion, and that is the owner's call.
This PR only stops the screen claiming otherwise.

## 3 · And the guard over that sentence could not tell a promise from its denial

`test_the_checksum_on_screen_says_who_checks_it` asserted `"Engine" in text`.
Its docstring states the rule exactly right — *"a number nothing verifies is
worse than none, it reads as a promise"* — and then checked for a **word**.

> *"The Engine checks its own updates"* and *"the Engine does not fetch or
> install its own updates"* both contain it.

**It stayed green across the entire period its subject was false**, and it would
have gone red on the honest sentence had the honest sentence omitted the word.

**Now the claim is tied to the code**: the note may say the engine verifies
updates **only while something actually calls `/api/update`**, and it fails in
**both** directions.

| mutation | result |
|---|---|
| restore the promise | **red** — *claims engine-side verification while nothing calls /api/update* |
| build the caller | **red** — *the panel now calls it, so the note may say so, and should* |

A guard that can only fail in one direction is half a guard.

## `LESSONS` §29 goes from eleven rows to thirteen

Rows 12 and 13 are two kinds the taxonomy did not have, both from the primary
session's `OP-126`:

- **`assert 400 <= status < 500`** cannot separate *"wrong source key"* from
  *"not a RunMode"*, and a status-code range is not a sloppy assertion — it is a
  deliberately general one. **When an assertion is imprecise by design, the
  design is the defect.**
- **A guard that asserts a capability is MISSING** holds the missing-ness in
  place: it converts a defect into a requirement, and the only change that can
  turn it red is the fix. Three instances now, so it is a shape.

Plus a seventh true-number-about-the-wrong-subject: **a line count reported as a
row count**, which happened inside the verification of this section's own
repair. Its author caught and corrected it unprompted; the words are theirs.

## Register

`OP-124` is declared, and its reservation on `main` retired — the **seventh**
this session has retired, and every one was named by
`test_a_reserved_number_is_not_also_declared` before the session noticed.

## Gates

Rebased onto `main` across sixteen merges. Every citation the rebase moved was
re-derived **by content**, not by a delta — fourteen of them, by running the
guard until it went silent — and one was corrected a second time because the
loop had taken the **first** of two matches when the entry described the second.

**Local gates were still running when this was opened, at the owner's
instruction. CI is the verdict here; I will post the settled local reads as a
comment rather than claim a green I have not seen.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
