### PR TITLE
Two of his requests captured, and the reason the second is one line late (REQ-53, REQ-54, OP-132)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -4424,6 +4424,51 @@ everything that reasons about what the run WILL do, and nothing enumerates those
 
 ---
 
+### OP-132 · The button's crawl runs one worker where the terminal's runs six
+
+**Measured on his live crawl, 2026-09-03, while he asked when it would finish.** Seven of
+fifty-six cells closed in 198 minutes:
+
+```
+closed 7/56       3,216 contractors · 1,299 listing requests · 198 min
+per contractor    0.404 requests
+projected total   7,035 requests for 17,417 contractors   ->  5,736 remaining
+measured rate     6.6 requests/min          SINGLE WORKER
+                  14.6 h left
+at six workers    2.4 h left
+```
+
+**`contractors.crawl` takes `workers: int = 1` and `scrapex/directoryjob.py` never passes
+it**, so the crawl the panel starts is one worker and the crawl `scrapex contractors
+--crawl` starts can be six. **`R-39`'s 52.5 pages a minute was measured at six workers**,
+which is 8.75 per worker and consistent with the 6.6 measured here including re-sizing and
+retries.
+
+**AND THE POLITENESS IS NOT THE OBSTACLE**, which is the reason this is a gap rather than a
+trade-off. `HttpFetcher._throttle` holds its lock across its own sleep, so *measured
+2026-08-21* four workers made 20 requests in 1.02 s where 3.80 s was owed
+(`partitioncrawl.py`'s own note). **The concurrency buys overlap on latency and never a
+higher request rate**, which is why `R-21` and `SR-8` survive it and why
+`crawl_partition` already carries `workers` and a `connect` factory.
+
+**What it needs is the factory, not the flag.** `sqlite3` refuses a connection across
+threads, so above one worker each needs its own — `jobs.run_job_once` already offers
+exactly that to the price path (*"only the worker knows a real path to reopen, so only the
+worker can offer concurrency"*), and the directory runner can derive it the same way it
+derives its heartbeat connection.
+
+**And it matters far more for the half that is not built.** The profile crawl is 34,834
+pages: **87 hours single-threaded against about 14 with six**, which is `R-39`'s own
+amended arithmetic. The same one-line omission would make that the difference between four
+days and half a day.
+
+**Not fixed while his crawl runs.** Pausing is safe at a cell boundary and a resume under
+the same run ref skips the pages already stored, so the repair costs no fetch — but it is
+his call whether to stop a run at 7/56 to make it six times faster, and the numbers above
+are what that call needs. Put to him 2026-09-03.
+
+---
+
 ### OP-130 · The crawl's request count said 0 for hours while its cell count moved
 
 **Found 2026-09-03, watching the crawl he had been waiting for since 2026-08-30 actually

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -104,6 +104,8 @@ IDs are stable and never reused, matching the convention BACKLOG.md already uses
 | [REQ-50](#req-50--the-engine-lives-on-the-engine-page-enough-warning-a-restart-to-press-and-one-home-for-every-engine-control) | The engine lives on the Engine page: enough warning, a restart to press, and one home for every engine control | **In flight** — ruled the same day as [R-80](RULINGS.md#r-80--one-feature-one-place-and-a-read-only-second-copy-is-still-a-second-copy), branch `claude/scrapex-engine-consolidation-d69e0a`. The Build row said *Restart needed* and the page had nothing to press, while **four callers** of `POST /api/engine/restart` sat elsewhere — two in Settings, two on the engine's own web pages; measured across the product, **11 routes on both surfaces, 31 only on the engine's pages, 18 only in the panel, 8 settings changeable nowhere but the web UI**. Landed: the duplicate restart deleted and the survivor moved onto the Engine screen, its budget raised from 30 s to the engine's real 121.5 s, `schema_lag` carried so its banner can appear at all, and the spec-row grid repaired. **The power switch waits on `POST /api/engine/stop`**, which cannot land until `R-77`'s gate work or his word. Files [OP-112](BACKLOG.md)–[OP-114](BACKLOG.md) | 2026-08-30 |
 | [REQ-51](#req-51--jobspy-is-the-scheduler-and-should-be-named-for-what-it-does) | `scrapex/jobs.py` is the scheduler and should be named for it | **Ruled** · Captured 2026-08-30 · he approved the rename and the split into its own request | 2026-08-30 |
 | [REQ-52](#req-52--delete-everything-marketlens-a-product-that-was-abandoned) | Delete everything MarketLens, a product that was abandoned | **In flight** — captured and measured 2026-08-30 on `claude/marketlens-is-gone`. **189 references became 17**, and the defect they were hiding is [OP-117](BACKLOG.md): `/data-model` reported **134 tables where 67 exist**, one of them labelled *MarketLens*. What stays names something that still exists — a key in his own `databases.json` whose rename fails **silently**, and two checksummed files naming a column **no database contains**. He reframed the constraint himself («احنا فى مرحلة التطوير … مفيش غيرى») and he is right: there is no installed base. **In flight** — decided and built 2026-09-03 under [R-84](RULINGS.md) — the base may be collapsed before publication and after it no migration is ever deleted. The chain is one baseline at v17, `grep -ci marketlens db/engine/schema.sql` answers **0**, and the reconciliation was checked against his real 2.02 GB warehouse read-only. The waiver on the second machine is recorded as a waiver | 2026-08-30 |
+| [REQ-53](#req-53--everything-about-backup-lives-on-manage-account-and-the-panel-is-what-holds-the-permission) | Everything about backup on one page, and the panel is what may do it | **Captured** — he said it 2026-09-02 and it reached the board a day later. Measured: the local snapshot is built by `/api/storage/backup`, called ONLY from the engine's `_storage.html`; the Drive bundle by `/api/bundle`, called ONLY from the panel; and **restore has no control in the panel at all** — `/api/storage/restore` is engine-page-only and `bundle.unpack()` has no caller outside tests. So he has a backup button in his only interface and no way to restore from it | 2026-09-03 |
+| [REQ-54](#req-54--a-source-declares-what-it-can-be-asked-to-do-and-the-panel-draws-its-controls-from-that) | A source declares what it can be asked to do | **Captured** — the crawl button starts ONE thing with fixed defaults. `run_mode`'s four values are price vocabulary and none of them means anything for a directory, while muqawil's seven real options are unreachable from the panel. He named the generalisation himself: this repeats with every source added | 2026-09-03 |
 ---
 
 ## REQ-01 · One documentation system, in the repository
@@ -2938,4 +2940,110 @@ the person it cost.
 **Also missing and worth naming here:** `tools/derive_engine_schema.py`, which generated the
 current baseline, **is not in the tree**. Collapsing the chain without the tool that generates
 baselines is exactly the file that looked unnecessary until it was needed.
+---
 
+## REQ-53 · Everything about backup lives on Manage account, and the panel is what holds the permission
+
+**Captured 2026-09-03 · he said it on 2026-09-02**, to another session, twice — the
+second time to correct its reading of the scope:
+
+> «اى حاجة ليها علاقة ب backup احصرها فى الكود وانقلها الى صفحة Manage account فى extension
+> · مع العلم تحديد من لديه القدرة على عمل backup هل هى الextension ام المحرك · لان
+> extension هى الاساس والمحرك فرعى داخل extension وايضا extension هى ما لديها الصلاحيات»
+
+> «اقصد بصفحة Manage account الصفحة بالصورة حيث لا اريد اجد ما يقدم نفس الميزة بطرق مختلفة
+> فى الاداة مثل ما هو موجود فى setting extension او صفحة الويب الخاصة بالمحرك · هذا لمزيد
+> من الفهم لا اقصد بالطبع ملف فى الكود · بحيث الكود يكون نظيف ومرتب»
+
+**A DAY LATE, AND THAT IS THE DEFECT `C7` NAMES.** It was measured in detail the day he
+said it, reported to him, and then carried in a conversation — which is worse than an
+unresearched request nobody looked at, because the work was done and still invisible on the
+board that tracks what he asked for. `REQ-04` is why the rule says *in the session he said
+it* rather than *soon*.
+
+### What is measured, and it is the part that decides the shape
+
+| | local snapshot | Drive bundle |
+|---|---|---|
+| built by | `/api/storage/backup` | `/api/bundle` |
+| called from | `_storage.html` — **the engine's page only** | `extension/app.js` — **the panel only** |
+| restored by | `/api/storage/restore` — engine page only | **nothing.** `bundle.unpack()` has no caller outside tests |
+
+**So he has a backup button in his only interface and not one restore control anywhere in
+it**, and the only door to restore is a page he does not use
+([R-81](RULINGS.md#r-81--a-command-line-answer-is-not-an-answer-the-panel-is-the-only-door)).
+That is also why *"no feature offered two ways"* cannot be satisfied by deleting the engine
+page: it is currently the only place one of the two halves exists at all.
+
+**And his second question — who may take a backup — is answered by measurement rather than
+by preference:** both routes are the ENGINE's, because only the engine has the file. What
+moves to the panel is the decision and the control; what stays in the engine is the hand on
+the disk. That is [R-50](RULINGS.md#r-50--the-engine-is-a-helper-to-the-extension-and-any-task-the-extension-can-do-moves-to-it)
+applied to this feature, not a new rule.
+
+### One hazard that arrives WITH the restore control and did not exist before
+
+**A restore can put the warehouse BELOW the baseline**, and since
+[R-84](RULINGS.md#r-84--the-base-changes-now--and-at-publication-no-migration-is-ever-deleted-again)
+a database below the baseline has no upgrade path. So a control that simply replaces the
+file can leave him with a warehouse the engine refuses to open — the state `OP-131` is
+about, arriving as a consequence of a new button rather than of a squash. **The control has
+to name the snapshot's version and refuse, or warn, when it is older than the baseline.**
+Part of the request, not a follow-up.
+
+---
+
+## REQ-54 · A source declares what it can be asked to do, and the panel draws its controls from that
+
+**Captured 2026-09-03, in the session he said it**, while he was watching the first crawl
+the button ever started:
+
+> «هل الزحف اصبح متصلا بالواجهة حيث يمكن للمستخدم تحديد زحف مقاول ويحدد بالتحديد ماذا يفعل
+> · يعنى فى طرق زحف مخصصة لمقاول اعتقد غير مرطبة باى مصدر اخر وفى المستقببل مع اضافة مصادر
+> اخرى ربما تنشى طرق زحف مخصصة اخرى ولكن زر run به اختيارات محدودة حتى اصلا مع تحديد عدد من
+> المصادر المختلفة يصعب تحديد للاداة ماذا يزحف او يفعل فى كل مصدر»
+
+**The answer to his question is no**, and `REQ-45` closing does not change it: the button
+is *connected* and it is not *controllable*. It starts the listing phase with fixed
+defaults and there is no second thing it can be asked to do.
+
+### Measured against the code rather than argued
+
+**`run_mode` is price vocabulary.** Its four values — `initial_crawl`, `update`,
+`full_rebuild`, `history_backfill` — describe how a job treats existing PRICE data. Not one
+of them means anything for a contractor directory, and the panel offers nothing else.
+
+**What muqawil can actually be asked to do, and none of it is reachable from the panel:**
+
+| | |
+|---|---|
+| `--details` | the profile pages — a **separate collector**, 34,834 pages |
+| `--only <cells>` | the unproven cells alone, without re-reading the proven ones (`R-26`) |
+| `--workers N` | **the difference between 14.6 hours and 2.4** — measured on his running crawl, `OP-132` |
+| `--ceiling N` | a bounded trial instead of the whole frontier |
+| `--ids <numbers>` | one named contractor, which is `OP-64`'s documented remediation |
+| `--approve` | interpret stored evidence with no network at all |
+| `--coverage` | who arrived and who left, against a sightings window |
+
+### His generalisation is the request, and it is right
+
+> *"with other sources added, perhaps other custom crawl methods get created — but the Run
+> button has limited choices, and even selecting several different sources it is hard to
+> tell the tool what to crawl or do for each one."*
+
+**A wider Run dialog is the wrong answer**, and it is the answer this repository would reach
+for. Every option above is a fact about ONE SOURCE, and a dialog that enumerates them is a
+second place those facts live — the drift `SourceResolver` and `directories.BUILDERS` were
+built to stop, one surface further out.
+
+**So: a source declares its capabilities and the panel renders that declaration.** The
+precedent is in the tree and already load-bearing — `directories.BUILDERS` says which
+collector reads a source and the route asks it rather than carrying a condition (`REQ-45`),
+and `SOURCE_ACTIONS`'s `proof` field says which actions a card may offer and is **measured
+against real routes** rather than asserted. **This request is that pattern applied to what
+a crawl can be asked to do**, and the declaration is what makes a second directory cost a
+registry entry instead of a dialog.
+
+**Not designed here.** It needs his ruling on how much a declaration may say — a list of
+flags is not the same thing as a set of named operations — and the answer decides whether
+the panel renders controls or offers a menu of prepared runs.


### PR DESCRIPTION
**Two of his requests were captured on a branch with no pull request, and `main` has never
had them.** Found by auditing every branch against `main`. **C7** exists because `REQ-04`
was ruled, never built, and dropped out of sight — this is the same failure caught one
step earlier: recorded, but not where anyone reads.

Docs only. `REQ-53`, `REQ-54`, `OP-132`. No code changes.

---

## The commit's own admission, kept

> *"I TOLD HIM REQ-54 WAS RECORDED BEFORE IT WAS.* He asked whether the crawl is
> controllable from the panel, I answered no with the measurement, and wrote *"I have
> recorded it as REQ-54"* in the same message. It was not recorded. This commit is that
> sentence being made true, and the gap between saying and doing is exactly what C7 is
> about."

`REQ-53` reached the board **a day late** — he said it 2026-09-02, twice, the second time
to correct a session's reading of the scope. The work was measured that same day and
reported to him, then carried in conversation, invisible on the board that tracks what he
asked for.

## What lands

**`REQ-53` — everything about backup on one page, and the panel is what holds the
permission.** Its measurement decides its shape:

| half | route | reachable from |
|---|---|---|
| local snapshot | `/api/storage/backup` | **engine page only** |
| Drive bundle | `/api/bundle` | **panel only** |
| **restore** | `/api/storage/restore` | **nowhere in the panel**; `bundle.unpack()` has no caller outside tests |

So he has a backup button in his only interface and **no way to restore from it** — and
*"no feature offered two ways"* cannot be satisfied by deleting the engine page, because
that page is the only place one of the halves exists.

**And a hazard that arrives with the restore control:** a restore can put the warehouse
**below the baseline**, which since `R-84` (merged today as #318) has no upgrade path. The
control must name the snapshot's version and refuse or warn when it is older. Part of the
request, not a follow-up.

**`REQ-54` — a source declares what it can be asked to do, and the panel draws its
controls from that.** His question; the answer is no. `REQ-45` made the button
**connected**, not **controllable**: `run_mode`'s four values are price vocabulary and
none means anything for a directory, while **seven real muqawil options are unreachable**.
His generalisation is the request — it repeats with every source added — and a wider Run
dialog is the wrong answer, because every one of those options is a fact about **one
source** and a dialog enumerating them is a second place those facts live.

**`OP-132` — the button's crawl runs one worker where the terminal's runs six.** Measured
on his live crawl: **6.6 requests/min, 14.6 h remaining, against 2.4 h at six workers.**
`contractors.crawl` takes `workers: int = 1` and `directoryjob.py` never passes it. The
politeness is not the obstacle — `_throttle` holds its lock across its sleep, so
concurrency buys overlap on latency and never a higher request rate. It matters more for
the half not built: the profile crawl is **87 hours single-threaded against about 14 with
six**.

## Rebase

Two commits behind; one conflict, in the `REQUESTS.md` board. `main`'s `REQ-52` row was
rewritten by #318 today (decided and built under `R-84`, chain collapsed to one baseline
at v17) while this branch still carried the older *"Open, and his: collapse the migration
chain"* text. **Resolved to `main`'s row**, with only the two new rows added beneath it —
the branch's contribution here is `REQ-53` and `REQ-54`, not a `REQ-52` verdict.

## Checks

- Register numbers verified free on `main` before rebasing: `main` tops at **`REQ-52`** and
  **`OP-131`**, and no `RESERVED` row holds 53, 54 or 132.
- `test_the_registers_cannot_collide.py` + `test_the_documents_cite_what_they_claim.py` —
  **101 pass** locally.
- Merge tree against `main` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
