### PR TITLE
A command he cannot run, on four surfaces, and the copies nothing removed (OP-135, OP-136, OP-137)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -5423,10 +5423,12 @@ vocabulary is how the last three of these began.
 
 ### OP-133 · The squash gate asks whether the tool is published; what decides the outcome is whether HIS warehouses are at the head
 
-**Found 2026-09-04**, answering his own question about recurrence — *«اريد معرفة هل
-المشاكل التى ذكرتها ستحدث مرة اخرى فى حالت اردت تحديث القاعدة من الوضع الحالى»* — and
-then narrowed by him to *«انا بتكلم من اول baseline الحالى»*: from the current baseline
-onwards, will this happen again. **It can, and this entry is the mechanism.**
+**Found 2026-09-04**, answering his own question about recurrence
+([REQ-55](REQUESTS.md#req-55--why-does-the-engine-not-work-and-will-it-happen-again-from-the-current-baseline)) —
+*«اريد معرفة هل المشاكل التى ذكرتها ستحدث مرة اخرى فى حالت اردت تحديث القاعدة من الوضع
+الحالى»* — and then narrowed by him to *«انا بتكلم من اول baseline الحالى»*: from the
+current baseline onwards, will this happen again. **It can, and this entry is the
+mechanism.**
 
 **THE CONDITION IS EXACT AND BOTH SIDES OF IT ARE ALREADY TESTED.** A squash strands a
 database if and only if that database is BEHIND THE HEAD at the moment of the squash:

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -250,7 +250,7 @@ on what the code does, and a GET can write while a crawl holds the lock.
 **This is also what makes read-only connections more than a one-line change.** Neither
 `read_conn` nor `general_read_conn` opens read-only: both reach plain
 `sqlite3.connect(str(path))`
-([databases/domain.py:144](../scrapex/databases/domain.py#L144)), and the only `?mode=ro` in
+([databases/domain.py:149](../scrapex/databases/domain.py#L149)), and the only `?mode=ro` in
 the package is in `bundle.py` and `carry_over.py`. Making the read paths read-only breaks
 this GET **immediately**, so every endpoint must first be classified "reads" against "reads
 and seeds". **His direction: put the lock where the write already is, and move the seeding
@@ -2235,7 +2235,7 @@ diagnosis:** every step the engine announced succeeded, and then it could not re
 
 | the runtime opens | at | bundled before |
 |---|---|---|
-| `db/` | [scrapex/db.py:22](../scrapex/db.py#L22), [scrapex/databases/domain.py:21](../scrapex/databases/domain.py#L21) | **yes** |
+| `db/` | [scrapex/db.py:22](../scrapex/db.py#L22), [scrapex/databases/domain.py:26](../scrapex/databases/domain.py#L26) | **yes** |
 | `sources.yaml` | [scrapex/config.py:55](../scrapex/config.py#L55) | **yes** |
 | `scrapex/webui/templates` | [scrapex/webui/app.py:316](../scrapex/webui/app.py#L316), [scrapex/extract/api.py:33](../scrapex/extract/api.py#L33) | **no** |
 | `scrapex/webui/static` | [scrapex/webui/app.py:386](../scrapex/webui/app.py#L386) | **no** |
@@ -3574,7 +3574,7 @@ two files of one backup cannot be split; and an age-guarded sweep
 
 **Residual, named rather than closed.** The lock is in-process, which is correct here —
 `start_engine` refuses to spawn a second engine on a held port
-([scrapex/native.py:297](../scrapex/native.py#L297)), and a crashed build leaves no
+([scrapex/native.py:304](../scrapex/native.py#L304)), and a crashed build leaves no
 survivor to race. An engine started by hand on another port would share the folder and
 defeat it; that is why the sweep keeps a 6-hour age guard
 ([scrapex/webui/app.py:2935](../scrapex/webui/app.py#L2935)) rather than deleting any
@@ -4180,7 +4180,7 @@ any amount of hiding. It stayed green for as long as the defect existed. Its doc
 stated the dead premise as present fact: *"The migrations directory holds BOTH streams."*
 
 **Fixed here.** The tuple and the filter are gone
-([scrapex/databases/domain.py:164](../scrapex/databases/domain.py#L164) records what stood
+([scrapex/databases/domain.py:169](../scrapex/databases/domain.py#L169) records what stood
 there and why); the ledger is now the whole answer
 ([scrapex/db.py:198](../scrapex/db.py#L198)), which is safe because `schema.sql` is recorded
 in the ledger like any other migration and so still excludes itself without being named. The
@@ -4684,7 +4684,7 @@ something true and adjacent.
 ### Why the two paths diverged, which is the part that shapes the fix
 
 **The guarded path `print`s, and the native host owns stdout.** `serve()` writes framed
-messages to `sys.stdout.buffer` (`scrapex/native.py:375`), so a `print` reached from a
+messages to `sys.stdout.buffer` (`scrapex/native.py:382`), so a `print` reached from a
 native command injects unframed bytes into the protocol stream and Chrome reads the next
 length prefix wrong. **So the protections could not simply be called from there**, and
 whoever wrote the escape hatch wrote a second, bare path instead.
@@ -5304,6 +5304,471 @@ which un-orphaned them without fixing anything, and the guard said so.
 `scrapex/snapshotcrawl.py`, line 169 still holds `if page.url in seen:` while the
 `def store` two lines above it had moved thirteen lines. The block cited both. Only a
 content check can tell a correct number from a coincidence.
+
+### OP-142 · Four pointer messages name commands on the panel, and two of them cannot be reworded because the control does not exist
+
+**Found 2026-09-04** by sweeping every string in the product that names a runnable
+command and tracing each to a surface, rather than by re-reading the one that was wrong.
+`OP-135` closed the `health()` path; **this is the pointer path, and it is untouched.**
+
+`DatabaseRegistry.read()` raises `DatabasePointerError` with instructions, and every one
+of them reaches his panel: `defaults()` → `native._database_report`, whose
+`except Exception as exc: return None, str(exc)` (`scrapex/native.py:201-202`) feeds
+`startup_check`'s `startup_check_failed`, which `extension/app.js` `issueCopy` renders as
+the issue body. The same text reaches the first-run console through
+`packaging/engine_entry.py`.
+
+| the message | what it names |
+|---|---|
+| `scrapex/databases/registry.py:69` — the pointer could not be read | `scrapex init-db` |
+| `scrapex/databases/registry.py:83-86` — the pointer is from before the collapse | **three**: `scrapex carry-over`, `scrapex database-status`, and `init-db` named to warn against it |
+| `scrapex/databases/registry.py:93` — the pointer does not say which database is live | `scrapex init-db` |
+| `scrapex/databases/registry.py:98` — the pointer names no database | `scrapex init-db` |
+
+**AND THE REASON THIS IS RECORDED RATHER THAN REWRITTEN IS THE INTERESTING HALF.** Two of
+those commands have **no control anywhere in the panel** — measured: `carry-over` appears
+in no `extension/**/*.js`, in no `/api/databases` route (the router has `GET /health` and
+`POST /upgrade`, nothing else), and in no native command (`STANDALONE_COMMANDS` is `PING`,
+`START_ENGINE`, `AUTOSTART_STATUS`, `SET_AUTOSTART`, `CHECK_STARTUP`, `UPGRADE_DATABASE`).
+So pointing that sentence at a button, the way `OP-135` pointed the upgrade action, would
+be **a false promise rather than a fix** — the exact defect `OP-124` found in the installer
+note, one step earlier.
+
+`R-81` says a capability with no control in the panel has no control, and **saying so is
+the honest report**. The repair is therefore a control first and a sentence second, which
+is his call and not a session's. `init-db`'s equivalent button does exist, so those three
+messages can be reworded today; the pre-collapse one cannot, and it is the one that fires
+on a machine whose pointer predates the collapse — which is the two-machine case this
+whole branch came from.
+
+---
+
+### OP-141 · The backup prune orders a DELETION by mtime, and a reset-backup's mtime is the warehouse's
+
+**Found 2026-09-04** by an adversarial read of `OP-136`'s new caller — the caller is
+contained rather than shipped over this, so what is recorded here is the defect it would
+have inherited. **It is reachable today from a button he has**, «Back up now» on the
+Storage page, which prunes after every copy it makes.
+
+**Three measured facts, on this Windows box (Python 3.12, NTFS):**
+
+1. `os.replace` and `shutil.copy2` both PRESERVE the last-write time. A rename never
+   touches it; a copy2 carries it across.
+2. `storage.start_fresh` does not copy the warehouse aside, it **renames** it —
+
+```cited
+scrapex/storage.py:1042             os.replace(path, displaced)
+```
+
+   so `…reset-backup-<stamp>.db` carries **the warehouse's** last-write time, not the
+   reset's. Undoing a reset runs `storage.restore`, which `shutil.copy2`s that file back
+   (`scrapex/storage.py:958`), so the same mtime returns to the live file — and a
+   reset / undo / reset cycle produces several reset-backups sharing **one** mtime.
+3. The prune orders by that mtime, at one-second resolution —
+
+```cited
+scrapex/storage.py:735       return sorted(found, key=lambda b: b["modified_at"], reverse=True)
+```
+
+   so among equal mtimes the order is whatever the glob returned, and `prunable_backups`
+   keeps "the first N of each lineage".
+
+**Measured outcome: four reset-backups sharing one mtime, names spanning 2026-01-01 to
+2026-09-04, `keep=3` — the file deleted was TODAY's**, the only copy of everything a
+"Start fresh" had just wiped, and the three kept were the oldest.
+
+**Why this branch does not fix it.** The obvious repair — order by the stamp the name
+already carries, which `backup_tag` already parses — changes what the Restore picker
+shows, and `_STAMP` admits **three spellings that do not sort against each other**
+(`20260904-101112` < `20260904T101112Z`, because `-` is 0x2D and `T` is 0x54), so it needs
+normalising to one form or comparing as parsed datetimes. The cheaper repair — make the
+tie deterministic with the name as a secondary key, descending — is smaller but leaves
+the mtime primary and so leaves a copied-in backup mis-ordered. Both are decisions about a
+shared reader, and neither belongs inside a change about a schema refusal.
+
+**What this branch did instead**: `dbupgrade._bounded` passes `only="pre-upgrade"`, so the
+upgrade path judges the one lineage it writes and never a `reset-backup`. Proved by
+mutation — removing the argument makes
+`test_the_prune_never_reaches_another_tags_copies` delete a `reset-backup` and a
+`rebuild` copy, and it says so by name.
+
+---
+
+### OP-140 · The panel prints `too_old`: the engine's page has a vocabulary for the storage statuses and the panel has none
+
+**Found 2026-09-04** by an adversarial read of `OP-135`'s change rather than by the change
+itself — it is older than this branch, and it is the form `OP-131`'s new status arrives in
+front of him.
+
+`storage.health()` reports MACHINE keys: `healthy`, `damaged`, `not_scrapex`,
+`incompatible`, `too_old`, `missing`. The engine's own page maps every one of them to a
+sentence (`scrapex/webui/templates/_storage.html:34-38`). **The panel renders the key.**
+
+```cited
+extension/app.js:5206       <div class="kv"><span>Health</span><span>${esc(s.health.status)}</span></div>
+```
+
+So the Storage row on his only interface reads `healthy` where the engine's page reads
+"Healthy", and now `too_old` where that page reads "Older than this engine's schema".
+Measured: **no `too_old`, `incompatible` or `not_scrapex` string appears anywhere in
+`extension/app.js`** — the vocabulary exists exactly once, in a template he does not open,
+which is `R-80`'s one-place rule pointing at the wrong place.
+
+**Not fixed here.** The panel needs that table, and the two copies then need something
+holding them together — the same pin `OP-135` added for the pair it created, one step
+further out. Recorded rather than patched because a second hand-written copy of a six-word
+vocabulary is how the last three of these began.
+
+---
+
+### OP-133 · The squash gate asks whether the tool is published; what decides the outcome is whether HIS warehouses are at the head
+
+**Found 2026-09-04**, answering his own question about recurrence — *«اريد معرفة هل
+المشاكل التى ذكرتها ستحدث مرة اخرى فى حالت اردت تحديث القاعدة من الوضع الحالى»* — and
+then narrowed by him to *«انا بتكلم من اول baseline الحالى»*: from the current baseline
+onwards, will this happen again. **It can, and this entry is the mechanism.**
+
+**THE CONDITION IS EXACT AND BOTH SIDES OF IT ARE ALREADY TESTED.** A squash strands a
+database if and only if that database is BEHIND THE HEAD at the moment of the squash:
+
+| the database at squash time | what happens | the test that fixes it |
+|---|---|---|
+| at the head | accepted, `initialize() == []`, ledger re-stamped once | `test_a_database_that_went_through_the_chain_opens` — whose own docstring calls it *"THE ONE THAT MATTERS: his warehouse"* |
+| behind the head | refused, nothing replayed | `test_a_database_below_the_baseline_is_refused_and_not_replayed` |
+
+So the reconciliation works and a squash at the head is genuinely harmless. What is
+missing is anything that establishes the condition before the collapse. The only gate is
+one manually-set flag:
+
+```cited
+scrapex/version.py:99                    PUBLISHED_TO_OTHERS = False
+tools/squash_engine_baseline.py:372      if version.PUBLISHED_TO_OTHERS:
+```
+
+**AND THE FLAG EXCLUDES HIS OWN MACHINES ON PURPOSE**, which is not an oversight to be
+corrected quietly — it is written into its own docstring:
+
+> *"A GIT TAG IS NOT THIS MARKER … `engine-v0.2.1`, `engine-v0.3.0` and `engine-v0.3.1`
+> already exist and are **the owner's own installs on his own two machines**. A guard
+> keyed on tags would have refused the squash he authorised."*
+
+That reasoning is sound about tags and it leaves the owner unprotected, on the
+two-machine setup [../CLAUDE.md](../CLAUDE.md) opens by describing. `R-84`'s own
+measurement — *"His warehouse was measured read-only at `PRAGMA user_version = 16` — the
+head of the chain"* — was true of ONE of the two. **The other was measured on 2026-09-04
+at `user_version = 10`** and is the warehouse that stopped opening: 16,411
+`generic_record`, 20,379 snapshots, 3,739 price observations, 15,559 taxonomy
+memberships.
+
+**What would remove the recurrence rather than repeat the promise**: the gate refuses
+unless a committed record says every warehouse he has is at the head, and that record is
+in the repository, because a note on one machine does not exist on the other (`C1`). It
+cannot be inferred from tags — the docstring is right about that — and it cannot be
+inferred from the machine running the squash either, which is the half nobody had.
+
+**HIS CALL, NOT A SESSION'S.** `R-84` is his ruling and the exclusion was deliberate.
+Two shapes to choose between, both cheap: declare his own installs a publication
+(`PUBLISHED_TO_OTHERS = True`, one line, and the squash is refused for ever), or gate on
+the recorded per-warehouse version so a squash is possible again the moment both are at
+the head. Related: `OP-134`, which is why one of them is reliably behind.
+
+---
+
+### OP-134 · No release has ever carried the chain past v10, so a machine on a release is permanently behind the head
+
+**Found 2026-09-04**, measuring `OP-133`'s condition rather than assuming it. It is the
+reason "behind at squash time" is not bad luck but the normal state of one of his two
+machines.
+
+Measured at the tag rather than from prose — `git ls-tree engine-v0.3.1` lists
+`0002…0010` in `db/engine/migrations/`, and `git show engine-v0.3.1:db/engine/schema.sql`
+declares `PRAGMA user_version = 1`:
+
+| build | last migration it carries | schema ceiling |
+|---|---|---|
+| `engine-v0.2.1` | `0003_a_source_says_how_deep_its_crawl_goes` | **v3** |
+| `engine-v0.3.0` | `0009_a_contractor_points_at_a_taxonomy_instead_of_repeating_it` | **v9** |
+| `engine-v0.3.1` — **the newest installable engine** | `0010_a_membership_carries_what_the_site_said_about_it` | **v10** |
+| `main` before the squash (`9cbc6f0`) — 16 files, `0002…0017` | `0017_a_job_may_be_a_directory_crawl` | v17 |
+| `main` today — one baseline file, no migrations | — | v17, and no path up from below |
+
+Each tag's baseline declares `PRAGMA user_version = 1`, so the ceiling is the last
+numbered migration it ships. **The three published ceilings are v3, v9 and v10** — an
+earlier correction of this table read "every published engine: v10", which flattened
+three numbers into the newest one.
+
+**So his v10 warehouse is not a warehouse that fell behind: v10 is exactly the ceiling of
+the newest engine he can install.** Migrations `0011…0017` existed only on unreleased
+`main`, and the squash deleted them.
+
+**AND IT MAKES BOTH REMEDIES THE REFUSAL PRINTS IMPOSSIBLE**, which is worth stating
+plainly because the sentence is honest and the world it describes does not exist:
+
+| what the refusal offers | measured |
+|---|---|
+| *"Bring it to v17 with the last release that still carried those migrations"* | **no release ever carried them** — every published engine tops out at v10 |
+| *"or start a new one and carry this one's rows into it"* | `databases/carry_over.py` reads the two pre-M5 files and never an engine one; `warehousemerge` is evidence-only by its own docstring. **The path does not exist** |
+
+The only artifact that can take a v10 warehouse to v17 is a checkout of `9cbc6f0`, which
+is a terminal, which is not a door he has (`R-81`).
+
+**HIS CALL: cut a release at the current baseline.** It is the half of `OP-133` that a
+gate cannot fix — while the newest installable engine is older than the source head,
+every machine that uses a release is behind it by construction, so the next squash finds
+exactly the state that broke this one. `OP-32`'s three conditions are the right thing to
+check against, and the second of them is true again today.
+
+---
+
+### OP-135 · `health()` answered "Needs upgrade. Run 'python -m scrapex.cli init-db'" about a database no command can upgrade — CLOSED 2026-09-04
+
+**Found 2026-09-04** while reviewing why his engine would not start, and closed on the
+branch that found it. **`OP-131`'s sibling, one surface further in**: that entry fixed
+`storage.py`'s `health()`, which reports `too_old` correctly. This is the OTHER health
+surface — `EngineDatabase.health()` — and it is the one the side panel actually reads.
+
+**One line reached four surfaces.** `DatabaseHealth.action` is rendered verbatim by the
+panel (`native.startup_check` → `startup_blocked` → `extension/app.js` `issueCopy`), by
+the engine's own attention banner on **every** page (`webui/templates/base.html`), by
+`database_unavailable.html`, and by the first-run console (`cli.py` prints
+`state['action']`). For a below-baseline database all four said *"Run 'python -m
+scrapex.cli init-db' to upgrade it, then retry"* — a terminal he does not use (`R-81`)
+naming a command that raises the very error being reported (`R-84`).
+
+**AND THE STATUS DECIDED A BUTTON, so the wrong status cost 302 MB a press.**
+`native.startup_check` sets `action: "upgrade_database"` by matching that status string,
+the panel renders «Upgrade database», and the guarded upgrade then took a full copy
+before `initialize()` refused. Measured on a copy of his warehouse: **316,760,064 bytes
+per press, and nothing changed.** `domain.py`'s own `_migrate` comment had already
+recorded this loop — *"every engine launch left another copy of the warehouse and then
+failed, while `health()` went on advising the one command that could not work"* — and the
+report it describes was still doing it.
+
+**MEASURED, AND IT WAS NOT AN EDGE CASE: the "Needs upgrade" branch was UNREACHABLE for a
+real engine database.** With the chain collapsed the plan is one file, so
+`baseline == latest == 17` and every version between 1 and the head is below the
+baseline. Every behind engine database took the branch that named the command.
+
+**What landed.** A status of its own for below-baseline, so the panel stops offering a
+repair that cannot exist, and one sentence shared by the three places that tell the same
+fact:
+
+```cited
+scrapex/dbupgrade.py:55                  TOO_OLD = "Older than the schema baseline"
+scrapex/databases/domain.py:371              baseline = self._migrations[0].number
+scrapex/native.py:233        state["status"] == BEHIND for _, state in blocked
+```
+
+`native.py` compared against a **literal** while `dbupgrade.BEHIND` documented itself as
+*"spelled once here and imported by both callers"* — it is imported now. `no_upgrade_path`
+is the one sentence, read by `EngineDatabase.health()`, by `_migrate`'s exception and by
+`storage.py`'s `too_old` detail; the behind action names the button and the screen, the
+way `OP-124` pointed its banner. Measured after: the panel is told
+`action: "check_storage"` with no command, and a refusal makes **no copy at all**.
+
+**AND "THE BUTTON DISAPPEARS" IS TRUE OF ONE OF THE TWO BUTTONS, which is worth stating
+exactly rather than claiming the tidier thing.** There are two, and only one is decided by
+`action`:
+
+| where | what it does below the baseline, after this change |
+|---|---|
+| the issue card's «Upgrade database» (`extension/app.js` `issueCopy` → `data-runtime-upgrade`) | **not offered** — `action` is now `check_storage` |
+| the standing «Upgrade database» on Settings (`extension/app.html:1795`, static markup, never gated on health) | still there. With the engine down it takes the native door and now REFUSES without copying anything (`OP-137`); with the engine up it takes `POST /api/databases/upgrade`, which calls `initialize()` bare and answers HTTP 500 — unchanged, and that is `OP-139` |
+
+**The launch path is the one that mattered most and it is fully closed**: `cli._cmd_ui`
+runs the guarded upgrade on every start, so a below-baseline warehouse cost a full copy
+*per engine launch*, not per press. It now refuses, names `R-84`, and copies nothing.
+
+**AND TWO TESTS DEMANDED THE COMMAND**, which is why a green suite shipped it:
+`test_a_database_that_is_behind_is_called_upgradeable_not_broken` and
+`test_a_genuinely_behind_database_still_says_upgrade` both asserted `"init-db" in action`
+— and both were reading the below-baseline branch while believing they were reading the
+upgrade one, because `latest - 1` stopped meaning "behind" the day the chain was
+collapsed. A third, `test_a_database_that_degrades_while_running_is_announced_with_its_fix`,
+asserted `"init-db" in body` of the engine's own page. All three are corrected, a
+`one_migration_above_the_baseline` fixture makes "behind, above the baseline" reachable
+at all, and `test_no_database_status_ever_answers_with_a_command_line` sweeps every state
+that carries an action rather than the one that happened to be wrong — the guard whose
+absence let one sentence ship on four surfaces while
+`test_the_refusal_says_what_to_do_and_names_no_terminal_command` guarded the exception
+beside it.
+
+**AND THERE WAS A SECOND WAY INTO THE SAME FIELD, which the first fix did not touch.**
+`health()` interpolates a caught exception verbatim into its "Integrity check failed"
+branch, and `EngineDatabase._verify`'s contract-marker refusal read *"run 'scrapex
+init-db' or restore a compatible backup and retry"*. So after the version branch had
+stopped naming a command, `DatabaseHealth.action` could still print one — on the same four
+surfaces. **Found by asking which OTHER exceptions land in that branch**, not by
+re-reading the one that was wrong, and the sweep now reaches it: six states, not five.
+
+**Two remainders, recorded rather than folded in.**
+
+- **`health()` can raise instead of reporting.** A contract marker that is not a number
+  reaches `int()` in `contract.stored_contract_version` and raises `ValueError`, which
+  `health()` catches nowhere — so a corrupt marker takes down the surface whose whole job
+  is to report corruption. Measured while writing the sweep above, with `'wrong'` as the
+  stored value. Not fixed here: the choice is whether the parse or the caller absorbs it,
+  and that is a decision about every reader of that marker.
+- **The R-81 surface sweep cannot see a module.** `tests/test_panel_dom.py`'s sweep selects
+  `extension/` and `scrapex/webui/` only, so it watches the files a string is RENDERED in
+  and not the ones a string is WRITTEN in — which is exactly how one sentence in
+  `databases/domain.py` reached four surfaces with the sweep green. Its subcommand
+  alternation also omits `carry-over` and `database-status`, both of which
+  `databases/registry.py` instructs the reader to run. Widening it would light up the
+  legitimate CLI strings too, so it needs a rule about which modules feed a surface —
+  which is `OP-140`'s question in a more general form.
+
+---
+
+### OP-136 · Nothing removed a pre-upgrade copy, because the policy that would have had no caller on the path that makes them — CLOSED 2026-09-04
+
+**Found 2026-09-04**, measured on his machine: **five copies totalling 963,768,320 bytes**
+beside a 316 MB warehouse, and while `OP-135`'s refusal was live, one more full copy on
+every engine launch and every press of the button, each changing nothing.
+
+**THE FIRST DIAGNOSIS WAS WRONG AND THE CORRECTION IS THE ENTRY.** It read as "there is no
+retention policy for these files" — `retention.py` never mentions a backup and
+`settings.backup_keep_versions` governs Drive. **There is one, and it already recognised
+them**: `storage.backup_tag` classifies `scrapex-engine.pre-upgrade-<stamp>.backup.db` as
+the `pre-upgrade` lineage, `BACKUPS_KEPT_PER_TAG` is 3, and the owner can change it —
+`Setting("backups_kept_per_tag", "3", label="Backups kept of each kind")`. It had **one
+caller**, `storage.backup_now`, reached only from the Storage page's button, which the
+upgrade path never touches. **A policy with no caller on the path that makes the files is
+not a thing a search for "prune" can show you**, and a second prune written beside it
+would have been the duplication this repository keeps finding.
+
+**What landed** is a caller, not a policy:
+
+```cited
+scrapex/storage.py:813   def prune_backups_at(db_path: Path | str, folder: Path | None = None,
+scrapex/dbupgrade.py:255         pruned += _bounded(path)
+```
+
+`prune_backups(conn, …)` now reads the owner's number and his folder and calls the same
+removal; `prune_backups_at` is that removal for a caller with **no database open**, which
+is what the upgrade path is — the file is still at its old schema there, and below the
+baseline it cannot be opened at all, which is the state that was making a copy per launch.
+`_bounded` asks for his `backups_kept_per_tag` on a bare connection and falls back to the
+shipped 3 on any failure: housekeeping must not be able to fail an upgrade.
+
+Kept properties, all inherited rather than re-argued: only files this product named are
+ever removed, the newest of **every** lineage survives (so a run of pre-upgrade copies can
+never evict the only `pre-wipe` copy of a source erased months ago), a copy held open is
+skipped rather than fatal, and the outcome NAMES what it deleted on both doors — a
+deletion is the half of "it says so" he cannot discover any other way. A pruned copy's
+`-wal`/`-shm` now go with it; three orphan pairs sit beside his warehouse today.
+
+Verified end to end on a real upgrade: five copies plus the new one, bounded to **3**,
+with `pre-ledger-repair` and `rebuild` untouched.
+
+**AND ADDING THE CALLER CREATED A DATA-LOSS PATH THAT HAD TO BE CLOSED WITH IT.** Found by
+an adversarial read of this very change: `archive.backup_database` wrote through
+`source.backup(target)` straight into the FINAL name, and that call fills its destination
+page by page. A process killed mid-copy — or a disk that fills, which is the state five
+copies of a 316 MB warehouse produce — left a **partial database carrying the newest stamp
+of its lineage**. While nothing pruned this lineage that was clutter; the moment a keep-N
+policy ran over it, the fragment could be kept while a complete older copy was deleted.
+**The one moment a backup is needed is the one where it had been replaced by a piece of
+itself.**
+
+Closed the way `bundle.py` already closed it (`PARTIAL_SUFFIX`, after the 0-byte archive
+that reached Drive): the copy is written to `<name>.part`, opened to prove its header and
+schema arrived, and only then `os.replace`d onto the real name; any failure — including
+`KeyboardInterrupt`, which is not an `Exception` and is exactly the interruption in
+question — removes the partial. **A leftover `.part` is invisible to the policy by
+construction**, because `storage.list_backups` accepts only a `.db` suffix, so an
+interrupted copy leaves litter that cannot be mistaken for a backup or counted as one of
+the kept. Both halves are guarded, from the writer's side and from the policy's.
+
+
+---
+
+### OP-137 · "The database is already up to date" about a database the engine refuses to open — CLOSED 2026-09-04
+
+**Found 2026-09-04** while fixing `OP-135`, and it is `OP-131`'s defect on a third
+surface: not the wrong remedy but **no fault at all**.
+
+`upgrade_what_is_only_behind` filters the faulty databases down to the ones whose status
+is `BEHIND`, and an empty result meant two completely different things — nothing is
+wrong, or something is wrong that an upgrade cannot fix (below the baseline, written by a
+newer build, damaged). Both returned a bare `Outcome()`. With no refusal to render,
+`native.upgrade_database` answered `ok: True` with *"The database is already up to
+date."*, and `cli`'s door printed nothing.
+
+**It was latent before this branch and would have been reached by it**: the below-baseline
+status `OP-135` introduces lands exactly there, so the fix had to come with it rather than
+after it.
+
+```cited
+scrapex/dbupgrade.py:222         if faulty:
+```
+
+The faults are now named in the refusal both doors already render.
+`test_a_fault_an_upgrade_cannot_fix_is_never_reported_as_up_to_date` holds it, and asserts
+the other half too: **no copy of the warehouse is made** by a refusal.
+
+---
+
+### OP-138 · The five tests that prove `R-84`'s refusal are skipped on `main`, and on CI
+
+**Found 2026-09-04**, and it is the reason `OP-135` could ship: the file that guards the
+below-baseline behaviour builds its database from the pre-squash chain, and reads that
+chain from `origin/main`.
+
+```cited
+tests/test_a_squashed_baseline_opens_what_it_should_and_refuses_the_rest.py:64                     "origin/main:db/engine/migrations").decode().split()
+```
+
+The squash deleted that directory, so `git ls-tree origin/main:db/engine/migrations` is
+`fatal: Not a valid object name` and the fixture returns `None`. Measured with `-rs`:
+**five of the six tests in the file skip**, including
+`test_a_database_below_the_baseline_is_refused_and_not_replayed` and
+`test_the_refusal_says_what_to_do_and_names_no_terminal_command`. The sixth, which builds
+its own file in `tmp_path`, is the only one that runs.
+
+**The skip is honest and its reason has expired.** *"A shallow clone or a detached CI
+checkout may not have the ref"* was the case it was written for; what happened instead is
+that the ref exists and no longer carries the chain, permanently, everywhere — including
+CI, which fetches the same `origin/main`. **So the change that made the refusal necessary
+also turned off every test that proves the refusal is right**, and nothing said so.
+
+Not fixed here: the repair is either a pinned pre-squash commit (nothing records one —
+`db/engine/squashed-from.json` carries `absorbed`, `fingerprint`, `head` and `seed`, and no
+commit) or a fixture that builds the chain from that record instead of from git. Both are
+design choices about what the record should contain, which is `OP-133`'s neighbourhood.
+The new guards added with `OP-135` deliberately do not depend on that ref.
+
+---
+
+### OP-139 · `OP-127` closed the unprotected upgrade on one of the two doors, and the panel prefers the other one
+
+**Found 2026-09-04**, tracing the button for `OP-135`. `OP-127` records that the panel's
+«Upgrade database» pressed `registry.initialize()` bare — no backup, no BEHIND check, no
+refusal over damage, nothing said — and moved it onto the guarded path. That fix landed on
+the **native** door only.
+
+```cited
+scrapex/webui/database_api.py:50          applied = current().initialize()
+```
+
+`POST /api/databases/upgrade` still calls it bare, and `extension/app.js`
+`upgradeDatabaseFromPanel` tries **HTTP first**, falling back to the native host only when
+nothing answers. So the four protections apply exactly when the engine is DOWN, and the
+ordinary case — engine up, database one migration behind — takes the door with none of
+them, including the one whose absence `OP-127` measured: `initialize()` migrates before it
+verifies, so a damaged file is migrated first.
+
+Its docstring states the old sentence as the reason it exists — *"an instruction the owner
+cannot follow, because he does not use a terminal"* — which is true and is not the same as
+being safe.
+
+Not fixed here: routing it through `upgrade_what_is_only_behind` changes what the route
+returns (a refusal is not an exception) and `OP-135`'s status change alters which faults
+reach it, so it is a change with its own tests rather than a line moved in passing. It is
+the same shape as `OP-131` and `OP-135`: **a repair applied to one of two surfaces that
+tell the same thing**, three instances now, which is the pattern rather than the incident.
+
+---
 
 ### OP-131 · `health()` said "No problems found" about a database the engine refuses to open
 

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -105,6 +105,8 @@ IDs are stable and never reused, matching the convention BACKLOG.md already uses
 | [REQ-51](#req-51--jobspy-is-the-scheduler-and-should-be-named-for-what-it-does) | `scrapex/jobs.py` is the scheduler and should be named for it | **Ruled** · Captured 2026-08-30 · he approved the rename and the split into its own request | 2026-08-30 |
 | [REQ-52](#req-52--delete-everything-marketlens-a-product-that-was-abandoned) | Delete everything MarketLens, a product that was abandoned | **In flight** — captured and measured 2026-08-30 on `claude/marketlens-is-gone`. **189 references became 17**, and the defect they were hiding is [OP-117](BACKLOG.md): `/data-model` reported **134 tables where 67 exist**, one of them labelled *MarketLens*. What stays names something that still exists — a key in his own `databases.json` whose rename fails **silently**, and two checksummed files naming a column **no database contains**. He reframed the constraint himself («احنا فى مرحلة التطوير … مفيش غيرى») and he is right: there is no installed base. **In flight** — decided and built 2026-09-03 under [R-84](RULINGS.md) — the base may be collapsed before publication and after it no migration is ever deleted. The chain is one baseline at v17, `grep -ci marketlens db/engine/schema.sql` answers **0**, and the reconciliation was checked against his real 2.02 GB warehouse read-only. The waiver on the second machine is recorded as a waiver | 2026-08-30 |
 | [REQ-53](#req-53--everything-about-backup-lives-on-manage-account-and-the-panel-is-what-holds-the-permission) | Everything about backup on one page, and the panel is what may do it | **Captured** — he said it 2026-09-02 and it reached the board a day later. Measured: the local snapshot is built by `/api/storage/backup`, called ONLY from the engine's `_storage.html`; the Drive bundle by `/api/bundle`, called ONLY from the panel; and **restore has no control in the panel at all** — `/api/storage/restore` is engine-page-only and `bundle.unpack()` has no caller outside tests. So he has a backup button in his only interface and no way to restore from it | 2026-09-03 |
+| [REQ-55](#req-55--why-does-the-engine-not-work-and-will-it-happen-again-from-the-current-baseline) | Why the engine does not work, and whether it recurs from the current baseline | **Done** — reviewed 2026-09-04 and answered with measurements. His warehouse reads `user_version = 10` against a baseline of v17 with no migrations, so `R-84`'s refusal is correct and total; the engine's own code is healthy. He ruled the data away and narrowed the question to recurrence, which is [OP-133](BACKLOG.md) (the squash gate cannot see the condition that matters) and [OP-134](BACKLOG.md) (no release ever carried the chain past v10, so a machine on a release is behind by construction). Both wait on him | 2026-09-04 |
+| [REQ-56](#req-56--fix-the-three-that-are-mine-record-the-two-that-are-his-and-take-the-data-loss-on-its-own-branch) | Fix «ج», record «أ» and «ب», then take `OP-141` on its own branch | **Done** — built 2026-09-04 across two branches. `OP-135`, `OP-136`, `OP-137` closed on `claude/engine-failure-review-4287b1` ([#323](https://github.com/muhammadbayoumi/ScrapeX/pull/323)); `OP-141` closed on `claude/a-deletion-ordered-by-the-wrong-clock`, which he asked for separately once he read that it could delete today's copy of a wiped warehouse. `OP-138`, `OP-139`, `OP-140`, `OP-142` recorded with their reasons | 2026-09-04 |
 | [REQ-54](#req-54--a-source-declares-what-it-can-be-asked-to-do-and-the-panel-draws-its-controls-from-that) | A source declares what it can be asked to do | **Captured** — the crawl button starts ONE thing with fixed defaults. `run_mode`'s four values are price vocabulary and none of them means anything for a directory, while muqawil's seven real options are unreachable from the panel. He named the generalisation himself: this repeats with every source added | 2026-09-03 |
 ---
 
@@ -2999,6 +3001,71 @@ to name the snapshot's version and refuse, or warn, when it is older than the ba
 Part of the request, not a follow-up.
 
 ---
+
+## REQ-55 · Why does the engine not work, and will it happen again from the current baseline
+
+**Captured 2026-09-04, in the session he said it.** It arrived as a review and became a
+question about recurrence, which is the part that outlives the day:
+
+> «اريد مراجعة لماذا لا يعمل المحرك ؟»
+
+then, after the answer:
+
+> «لا ترقى القاعدة لا مشكلة فانا لا احتاج الداتا عليها ولكن اريد معرفة هل المشاكل التى
+> ذكرتها ستحدث مرة اخرى فى حالت اردت تحديث القاعدة من الوضع الحالى»
+
+and, narrowing it himself:
+
+> «انا بتكلم من اول baseline الحالى»
+
+**THE ANSWER WAS NOT THE ENGINE.** Measured read-only on his warehouse: `PRAGMA
+user_version = 10` against a baseline of **v17 with no migrations at all**, so `R-84`'s
+refusal is correct and total. The engine's own code is healthy — booted from source on a
+fresh v17 database it answers `ok: true` and serves `GET /` **200**. What was broken was
+everything the product then SAID about it, which is `OP-135`.
+
+**And the recurrence question has an exact answer**, both halves of it already tested: a
+squash strands a warehouse **if and only if that warehouse is behind the head when it
+happens**. What nothing establishes is the condition — the gate reads a manual publication
+flag whose own docstring excludes his two machines on purpose ([OP-133](BACKLOG.md)) — and
+what makes the condition reliably true is that no release ever carried the chain past
+**v10**, so a machine on a release can never be at the head ([OP-134](BACKLOG.md)).
+
+**He ruled the data away** rather than have it upgraded, which is why the work carries no
+migration and touches no row. Both open items are his: one amends a guard he set, the
+other is a tag.
+
+
+## REQ-56 · Fix the three that are mine, record the two that are his, and take the data loss on its own branch
+
+**Captured 2026-09-04, in the session he said it**, after reading the three options the
+recurrence answer produced:
+
+> «نفذ ج وسجل أ و ب فى BACKLOG»
+
+then, once the work was reported:
+
+> «نعم اعمل commit وافتح PR، واصلح OP-141 فى فرع مستقل»
+
+**«ج» was the small, independent half**: the status that stops the panel offering a repair
+that cannot exist, the sentence with no command in it, and the retention policy finally
+called on the path that makes the copies — `OP-135`, `OP-136`, `OP-137`, closed on
+`claude/engine-failure-review-4287b1`.
+
+**«أ» and «ب» are the two he kept for himself** and they are recorded rather than built:
+`OP-133` (the squash gate) and `OP-134` (a release at the current baseline).
+
+**AND HE SPLIT THE DATA LOSS OFF HIMSELF.** `OP-141` was found by an adversarial read of
+this very change — a prune ordered by mtime, where a `reset-backup` carries the
+warehouse's last-write time, measured deleting **today's** copy of a warehouse a "Start
+fresh" had just wiped. It is closed on `claude/a-deletion-ordered-by-the-wrong-clock`,
+stacked on the first branch because it edits the same file.
+
+**What is recorded and not built, each with its reason in the entry**: `OP-138` (five
+tests that prove `R-84`'s refusal skip on `main` and in CI), `OP-139` (`OP-127` closed on
+one of two doors), `OP-140` (the panel prints a raw status key), `OP-142` (four pointer
+messages name commands, and two cannot be reworded because the control does not exist).
+
 
 ## REQ-54 · A source declares what it can be asked to do, and the panel draws its controls from that
 

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -3004,8 +3004,8 @@ Part of the request, not a follow-up.
 
 ## REQ-55 · Why does the engine not work, and will it happen again from the current baseline
 
-**Captured 2026-09-04, in the session he said it.** It arrived as a review and became a
-question about recurrence, which is the part that outlives the day:
+**Captured 2026-09-04, in the session he said it, and Done the same day.** It arrived as
+a review and became a question about recurrence, which is the part that outlives the day:
 
 > «اريد مراجعة لماذا لا يعمل المحرك ؟»
 
@@ -3038,8 +3038,8 @@ other is a tag.
 
 ## REQ-56 · Fix the three that are mine, record the two that are his, and take the data loss on its own branch
 
-**Captured 2026-09-04, in the session he said it**, after reading the three options the
-recurrence answer produced:
+**Captured 2026-09-04, in the session he said it, and Done the same day** — after reading
+the three options the recurrence answer produced:
 
 > «نفذ ج وسجل أ و ب فى BACKLOG»
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -71,6 +71,23 @@ published `0.3.0`, so `engine-v0.3.1` ships the fix and no bump is needed
 [R-77](RULINGS.md#r-77--one-number-one-question-the-extension-carries-the-version-the-engine-carries-a-protocol-and-a-build)). **Cutting the tag is his call**, and until he does
 there is nothing installable that serves a page.
 
+**AND ON 2026-09-04 HE ASKED WHY THE ENGINE DOES NOT WORK, AND THE ANSWER WAS NOT THE
+ENGINE.** *«اريد مراجعة لماذا لا يعمل المحرك ؟»* — measured read-only on his warehouse on
+this machine: **`PRAGMA user_version = 10` against a baseline of v17 with no migrations at
+all**, so `R-84`'s refusal is correct and total, and every start printed one line and made
+a **316,760,064-byte** copy first. The engine's own code is healthy — booted from source on
+a fresh v17 database, `/api/health` answers `ok: true` and `GET /` returns **200**.
+
+**He ruled the data away rather than have it upgraded**: *«لا ترقى القاعدة لا مشكلة فانا لا
+احتاج الداتا عليها»*. What he asked for instead was whether the failures recur *«من اول
+baseline الحالى»* — from the current baseline onwards — and the answer is measured in
+`OP-133` and `OP-134`: **a squash strands a warehouse if and only if that warehouse is
+behind the head when it happens**, both sides of which are already tested, and **the gate
+cannot see the condition** because it reads a manual publication flag whose own docstring
+excludes his two machines. `OP-134` is why one of them is reliably behind: **every
+published engine tops out at schema v10**, so a machine on a release can never be at the
+head. Both are his calls — a guard he set, and a tag.
+
 This is the document that is **wrong the moment it is out of date**. Update it
 when a phase lands, a PR merges, or the owner rules — in the same pull request as
 the work it describes (**C2**, [../CLAUDE.md](../CLAUDE.md)).
@@ -836,7 +853,7 @@ before the squash: this check is what proves that squash, and it was not running
 
 **`REQ-52`'s squash is priced and NOT built.** Measured cost, in one line each so the next
 session does not re-derive it: two independent migration-plan builders carry the same
-gapless-from-1 rule ([`scrapex/databases/domain.py:191`](../scrapex/databases/domain.py#L191)
+gapless-from-1 rule ([`scrapex/databases/domain.py:196`](../scrapex/databases/domain.py#L196)
 and [`scrapex/db.py:140`](../scrapex/db.py#L140)); `latest_schema_version()` hardcodes the
 baseline as 1 ([`scrapex/db.py:125`](../scrapex/db.py#L125)) and that 1 reaches the Storage
 page through `storage.py` `health()`; the baseline has 51 `CREATE TABLE` and no
@@ -992,6 +1009,53 @@ differ.
 `CREATE TABLE` and no `IF NOT EXISTS`; before this, `_migrate` would have run the whole
 schema over a populated database. The refusal names `R-84`, says nothing has been
 changed, and offers the two actions `R-84` allows.
+
+### Why the engine would not start, and the four fixes it earned — 2026-09-04
+
+**On the branch `claude/engine-failure-review-4287b1`, base `3c45086`, not yet proposed.**
+It began as a review — *«اريد مراجعة لماذا لا يعمل المحرك ؟»* — and what it found is at the
+top of this file. He then narrowed the question to recurrence and ruled that the v10
+warehouse is not to be upgraded, so the branch carries no migration and touches no data.
+
+**Register numbers `OP-133`..`OP-142` claimed** after sweeping every local and remote ref
+for `^#{2,4} +OP-13[3-9]` and `OP-140`..`OP-142` (nothing declared them anywhere) — §3 of
+[ORCHESTRATION.md](ORCHESTRATION.md). Contiguous, so no `RESERVED` row was needed.
+
+| number | what it is | state |
+|---|---|---|
+| `OP-133` | the squash gate asks whether the tool is published, not whether his warehouses are at the head | **open — his ruling** |
+| `OP-134` | no release ever carried the chain past v10, so a machine on a release is behind by construction | **open — his call to cut a tag** |
+| `OP-135` | `health()` answered "Needs upgrade. Run 'python -m …init-db'" about a database no command can upgrade | closed here |
+| `OP-136` | nothing removed a pre-upgrade copy: 963,768,320 bytes, and the policy that would have had no caller on this path | closed here |
+| `OP-137` | "The database is already up to date" about a database the engine refuses to open | closed here |
+| `OP-138` | the five tests that prove `R-84`'s refusal are skipped on `main` and in CI | open, with its reason |
+| `OP-139` | `OP-127` closed the unprotected upgrade on one of the two doors | open, with its reason |
+| `OP-140` | the panel prints the raw key `too_old`; the vocabulary for it exists only on the engine's page | open, with its reason |
+| `OP-141` | the backup prune orders a deletion by mtime, and a reset-backup carries the warehouse's — measured deleting TODAY's copy | **open — data loss, reachable from a button** |
+| `OP-142` | four pointer messages name commands on the panel, and two cannot be reworded because the control does not exist | open — needs a control, so his call |
+
+**THE PATTERN IS WORTH MORE THAN ANY ONE OF THEM, and it is now three instances.**
+`OP-131`, `OP-135` and `OP-139` are each **a repair applied to one of two surfaces that
+tell the same thing** — two `health()` implementations, two upgrade doors — where the fixed
+one was the one being read at the time and the other went on being wrong. `OP-138` is the
+same shape one level up: the change that made the refusal necessary also turned off the
+tests that prove the refusal is right.
+
+**What landed, all of it behind guards that do not depend on `origin/main`'s deleted
+chain:** a status of its own for a below-baseline database, so the panel stops offering
+«Upgrade database» for a repair that cannot exist; `no_upgrade_path`, one sentence read by
+the three places that tell that fact, none of them naming a command (`R-81`); the owner's
+own `backups_kept_per_tag` policy called on the path that makes the copies, rather than a
+second prune written beside it; a refusal that names the fault instead of reporting
+success; and `test_no_database_status_ever_answers_with_a_command_line`, which sweeps every
+state that carries an action — the guard whose absence let one sentence reach the panel, the
+engine's every page, `database_unavailable.html` and the first-run console at once, with
+**three tests demanding it**.
+
+Measured after, on a copy of his warehouse and on his real registry read-only: the panel is
+told `check_storage` with no command in the detail, a refusal makes **no copy at all**, and
+a real in-chain upgrade to v18 applies, backs up once and bounds the copies at three with
+`pre-ledger-repair` and `rebuild` untouched.
 
 ## Track 1 · The Console migration
 

--- a/scrapex/archive.py
+++ b/scrapex/archive.py
@@ -8,6 +8,7 @@ visibly gone. Nothing is destroyed, and the file backup is the rollback path.
 """
 from __future__ import annotations
 
+import os
 import sqlite3
 from pathlib import Path
 
@@ -28,14 +29,44 @@ def backup_database(db_path: Path | str, tag: str = "rebuild") -> Path:
         raise FileNotFoundError(f"there is no database at {src} to back up")
     stamp = utc_now_iso().replace(":", "").replace("-", "")
     dst = src.with_name(f"{src.stem}.{tag}-{stamp}.backup{src.suffix or '.db'}")
+    # A TORN COPY MUST NEVER CARRY THE FINAL NAME, and this became load-bearing the
+    # day the retention policy gained a caller on the upgrade path (`OP-136`).
+    # `source.backup(target)` fills the destination page by page, so a process killed
+    # mid-copy — or a disk that fills — left a PARTIAL database named exactly like a
+    # good one, with the newest stamp of its lineage. `storage.prunable_backups` keeps
+    # the newest N per lineage, so that file could be kept while a complete older copy
+    # was deleted: the one state where a backup is needed is the one where it had been
+    # replaced by a fragment of itself.
+    #
+    # The partial name is invisible to the policy on purpose: `storage.list_backups`
+    # accepts only `.db`, and `.part` is neither offered for restore nor pruned. So an
+    # interrupted copy leaves litter that cannot be mistaken for a backup, which is the
+    # right way round. `bundle.py` writes through a partial name for the same reason.
+    partial = dst.with_name(dst.name + ".part")
+    partial.unlink(missing_ok=True)
     source = sqlite3.connect(str(src))
     try:
-        target = sqlite3.connect(str(dst))
+        target = sqlite3.connect(str(partial))
         try:
             with target:
                 source.backup(target)
         finally:
             target.close()
+        # OPENABLE BEFORE IT IS ALLOWED TO HAVE THE REAL NAME. Cheap on purpose --
+        # reading `sqlite_master` proves the header and the schema arrived, and
+        # `quick_check` is O(file size) on a warehouse that measured 0.879 s at
+        # 1,067 MB. The expensive check belongs to Storage, which offers it.
+        check = sqlite3.connect(str(partial))
+        try:
+            check.execute("SELECT COUNT(*) FROM sqlite_master").fetchone()
+        finally:
+            check.close()
+        os.replace(partial, dst)
+    except BaseException:
+        # Including KeyboardInterrupt: a Ctrl-C during a backup is exactly the
+        # interruption this exists for, and it is not an `Exception`.
+        partial.unlink(missing_ok=True)
+        raise
     finally:
         source.close()
     return dst

--- a/scrapex/databases/domain.py
+++ b/scrapex/databases/domain.py
@@ -18,6 +18,11 @@ from typing import Any, Generic, TypeVar
 from .. import db as legacy_db
 from ..database_ids import ENGINE_APPLICATION_ID, ENGINE_DATABASE_KIND
 
+# The status vocabulary and the one sentence for a below-baseline database. Both
+# live in `dbupgrade` because the guarded upgrade and the panel's button decide on
+# them, and a second spelling is a check that silently stops matching.
+from ..dbupgrade import BEHIND, TOO_OLD, no_upgrade_path
+
 ROOT_DB_DIR = Path(__file__).resolve().parents[2] / "db"
 
 # ONE FILE, AND ITS STREAM STARTS AGAIN AT 1. The whole warehouse — priced
@@ -348,11 +353,33 @@ class DomainDatabase(Generic[T]):
                     f"upgrade: {exc}",
                     version, None,
                 )
+            # BELOW THE BASELINE IS NOT "BEHIND", AND THE DIFFERENCE IS THE ENTIRE
+            # REMEDY. `R-84` collapsed the chain into the baseline, so a database
+            # under it has no upgrade path at all -- and this branch used to answer
+            # it with "Needs upgrade. Run 'python -m scrapex.cli init-db'": a command
+            # the owner has no terminal for (`R-81`) and one that raises the very
+            # error being reported. It is also read by `native.startup_check` to
+            # decide whether to offer "Upgrade database", so the wrong status here is
+            # a button that copies the whole warehouse and then changes nothing --
+            # measured at 316,760,064 bytes per press.
+            #
+            # AND IT IS NOT AN EDGE CASE TODAY. With the chain squashed the plan is
+            # one file, so `baseline == latest` and EVERY version below the head is
+            # below the baseline: until a migration lands above it, the branch below
+            # this one cannot be reached by a real engine database at all. Three
+            # tests that believed they were exercising it were exercising this.
+            baseline = self._migrations[0].number
+            if version is not None and baseline > 1 and 0 < version < baseline:
+                return DatabaseHealth(
+                    self.kind, str(self.path), False, TOO_OLD,
+                    no_upgrade_path(version, baseline, f"This {self.kind} database"),
+                    version, None,
+                )
             return DatabaseHealth(
-                self.kind, str(self.path), False, "Needs upgrade",
+                self.kind, str(self.path), False, BEHIND,
                 f"This database is at schema v{version} and this build expects "
-                f"v{self.latest_schema_version}. Run 'python -m scrapex.cli init-db' "
-                "to upgrade it, then retry.",
+                f"v{self.latest_schema_version}. Use the Upgrade database button on "
+                "the Settings screen, then retry.",
                 version, None,
             )
         except (sqlite3.DatabaseError, DatabaseUnavailableError,
@@ -451,14 +478,13 @@ class DomainDatabase(Generic[T]):
         # difference between a refusal and a loop.
         baseline = self._migrations[0]
         if baseline.number > 1 and 0 < current < baseline.number:
+            # ONE SENTENCE, READ FROM ONE PLACE. This message, `health()`'s action
+            # above and `storage.py`'s `too_old` detail are the same fact told to
+            # three different readers, and they were three separately written
+            # paragraphs -- which is how one of them came to name a command.
             raise DatabaseMigrationError(
-                f"this {self.kind} database is at schema v{current} and this build's "
-                f"baseline starts at v{baseline.number}, so there is no upgrade path "
-                f"between them -- the migrations that led to v{baseline.number} were "
-                "collapsed into the baseline (R-84). Nothing has been changed. Use "
-                "the last release that still carried the chain to bring this database "
-                f"to v{baseline.number} first, or start a new database and carry this "
-                "one's rows into it.")
+                no_upgrade_path(current, baseline.number,
+                                f"This {self.kind} database"))
         applied: list[int] = []
         for migration in self._migrations:
             if migration.number <= current:
@@ -786,10 +812,17 @@ class EngineDatabase(DomainDatabase[T]):
 
         stored = stored_contract_version(conn)
         if stored != CONTRACT_VERSION:
+            # THE SECOND WAY A COMMAND REACHED `DatabaseHealth.action`, and the first
+            # one's fix did not touch it. `health()` interpolates this exception
+            # verbatim into the "Integrity check failed" branch, so `run 'scrapex
+            # init-db'` went on reaching the panel, every engine page and the
+            # first-run console from here after the version branch had stopped
+            # saying it (`R-81`). Found by asking which OTHER exceptions land in
+            # that branch rather than by re-reading the one that was wrong.
             raise DatabaseMigrationError(
                 f"the engine database's contract marker is {stored!r}, expected "
-                f"{CONTRACT_VERSION}; run 'scrapex init-db' or restore a "
-                "compatible backup and retry"
+                f"{CONTRACT_VERSION}. Use the Upgrade database button on the "
+                "Settings screen, or restore a compatible backup, then retry"
             )
 
 

--- a/scrapex/dbupgrade.py
+++ b/scrapex/dbupgrade.py
@@ -35,6 +35,48 @@ from pathlib import Path
 #: feature is not a measurement of the feature.
 BEHIND = "Needs upgrade"
 
+#: What it reports for a database BELOW this build's squashed baseline (`R-84`).
+#: A different fault with a different remedy: there is no upgrade path to offer, so
+#: the panel must not offer one. It is spelled here beside `BEHIND` for exactly the
+#: same reason -- `native.startup_check` decides whether to show the "Upgrade
+#: database" button by comparing against these strings.
+#:
+#: IT MIRRORS `_storage.html`'s WORDS for `storage.py`'s `too_old` -- "Older than
+#: this engine's schema" -- because two surfaces already describe this state and the
+#: owner should not have to work out that they are the same one. It drops the
+#: possessive, and both reasons are mechanical rather than aesthetic:
+#:
+#:   - `/api/health` composes it as `f"{kind} {status.lower()}"` (`webui/app.py`),
+#:     where "this engine's" would reach the panel as "engine older than this
+#:     engine's schema".
+#:   - `base.html` renders it through Jinja with autoescaping on, so an apostrophe
+#:     arrives in the page as `&#39;` -- and a test that looked for the plain form
+#:     would pass or fail for a reason that has nothing to do with the status.
+TOO_OLD = "Older than the schema baseline"
+
+def no_upgrade_path(version: int, baseline: int,
+                    subject: str = "This warehouse") -> str:
+    """The one sentence for a database below this build's baseline (`R-84`).
+
+    IT HAD THREE SPELLINGS AND ONE OF THEM WAS A LIE. `EngineDatabase._migrate`
+    raises it, `storage.py` `health()` reports it as `too_old` -- and
+    `EngineDatabase.health()`, the one the side panel actually reads, said "Needs
+    upgrade. Run 'python -m scrapex.cli init-db'" about a database that no command
+    can upgrade. A sentence that must never name a command (`R-81`), must name
+    `R-84`, and must say that nothing was touched is exactly the sentence to write
+    once and read from everywhere.
+
+    `subject` because the same fact is told about different things: a file being
+    restored, and the engine's own warehouse refusing to open.
+    """
+    return (
+        f"{subject} is at schema v{version} and this build's baseline starts at "
+        f"v{baseline}, so there is no upgrade path between them: the migrations "
+        f"that led to v{baseline} were collapsed into the baseline before release "
+        f"(R-84). Nothing has been changed. Bring it to v{baseline} with the last "
+        "release that still carried those migrations, or start a new one and carry "
+        "this one's rows into it.")
+
 
 @dataclass(frozen=True)
 class Outcome:
@@ -54,11 +96,20 @@ class Outcome:
     backups: tuple[tuple[str, str], ...] = ()
     #: `kind -> [version numbers applied]`, straight from `registry.initialize()`.
     applied: dict[str, list[int]] = field(default_factory=dict)
+    #: Superseded backups removed AFTER the new copy was safely made, by name.
+    pruned: tuple[str, ...] = ()
 
     def lines(self) -> list[str]:
         """The outcome as the CLI has always printed it, in the same order."""
         said = [f"backed up the {kind} database to {where} before upgrading"
                 for kind, where in self.backups]
+        if self.pruned:
+            # A DELETION HAS TO SAY SO LOUDER THAN A COPY DOES. "It says out loud
+            # what it did" is the fourth protection, and removing one of the
+            # owner's backups is the half of it he cannot discover any other way.
+            said.append(
+                f"removed {len(self.pruned)} superseded backup(s): "
+                + ", ".join(self.pruned))
         if self.refused:
             said.append(f"error: {self.refused}")
         said += [f"upgraded the {kind} database: applied {versions}"
@@ -84,7 +135,51 @@ class Outcome:
             return f"Applied {applied}."
         kept = "; ".join(f"{kind} backed up to {where}"
                          for kind, where in self.backups)
-        return f"Applied {applied}. {kept}."
+        swept = (f" {len(self.pruned)} superseded backup(s) removed."
+                 if self.pruned else "")
+        return f"Applied {applied}. {kept}.{swept}"
+
+
+def _bounded(path: Path) -> list[str]:
+    """Apply the owner's backup retention policy to the copy just made.
+
+    THE POLICY IS NOT WRITTEN HERE AND MUST NOT BE. `storage`'s keep-N-per-LINEAGE
+    rule already recognises these files (`storage.backup_tag` classifies a
+    `pre-upgrade-<stamp>` copy) and already protects the ones that matter: it keeps
+    the newest of every lineage, so a run of pre-upgrade copies can never evict the
+    only `pre-wipe` copy of a source erased months ago, and it never touches a file a
+    person named by hand. What it lacked was a caller on this path -- its only one is
+    `storage.backup_now`, reached from the Storage page's button.
+
+    HIS NUMBER WHEN IT CAN BE READ, the shipped default when it cannot.
+    `storage.backups_kept` reads `backups_kept_per_tag` from the database, and this
+    runs while that database is at a schema this build does not read -- so it is
+    asked on a bare connection and every failure falls back. Housekeeping must not
+    be able to fail an upgrade, and a setting read is not worth one.
+
+    The folder is the database's own, deliberately: `archive.backup_database` writes
+    beside the file it copies, wherever `backup_folder` may point.
+
+    AND IT JUDGES ONE LINEAGE, ITS OWN. `pre-upgrade` is the lineage this function
+    creates; `reset-backup` is the only copy of everything a "Start fresh" wiped, and
+    its ordering cannot be trusted because `start_fresh` RENAMES the warehouse aside
+    and a rename carries the warehouse's own last-write time (`OP-141`). An upgrade
+    that quietly deleted today's reset copy would be the worst thing in this file.
+    """
+    import sqlite3
+
+    from . import storage
+
+    keep = storage.BACKUPS_KEPT_PER_TAG
+    try:
+        conn = sqlite3.connect(str(path))
+        try:
+            keep = storage.backups_kept(conn)
+        finally:
+            conn.close()
+    except Exception:                       # every failure falls back, see above
+        pass
+    return storage.prune_backups_at(path, keep=keep, only="pre-upgrade")[1]
 
 
 def upgrade_what_is_only_behind(registry, report: dict) -> tuple[dict, Outcome]:
@@ -101,6 +196,11 @@ def upgrade_what_is_only_behind(registry, report: dict) -> tuple[dict, Outcome]:
       - ONLY WHEN NOTHING ELSE IS WRONG. A damaged file reports "Integrity check failed",
         and migrating damage is how a small corruption becomes an unrecoverable one.
       - IT SAYS SO. The outcome names every backup by path, and both callers render it.
+      - AND THE COPIES ARE BOUNDED, by the owner's own retention policy rather than
+        by a number invented here (`_bounded` below). Unbounded was not untidiness:
+        a refusal that copies 302 MB and then changes nothing repeats on every
+        launch, and the policy that would have removed them had no caller on this
+        path -- measured at 963,768,368 bytes across five copies.
 
     Returns the report after the attempt -- the caller re-reads `ok` and does not have to
     know whether anything happened -- and the outcome, which is what it renders.
@@ -111,6 +211,20 @@ def upgrade_what_is_only_behind(registry, report: dict) -> tuple[dict, Outcome]:
     faulty = [state for state in states.values() if not state["ok"]]
     behind = [state for state in faulty if state.get("status") == BEHIND]
     if not behind:
+        # AN EMPTY `behind` MEANS TWO COMPLETELY DIFFERENT THINGS, and answering both
+        # with a bare `Outcome()` made the second one lie. "Nothing is wrong" is one;
+        # the other is a fault an upgrade cannot fix -- a database below the squashed
+        # baseline (`R-84`), one written by a newer build, a damaged file. `Outcome()`
+        # carries no refusal, so `native.upgrade_database` answered `ok: True` with
+        # "The database is already up to date." about a database the engine refuses to
+        # open. That is `OP-131`'s defect on a third surface, and its worst property:
+        # a reader told nothing is wrong is sent nowhere at all.
+        if faulty:
+            return report, Outcome(refused=(
+                "the database was not upgraded because its fault is not a pending "
+                "migration: " + "; ".join(
+                    f"{state['kind']}: {state['status']}. {state['action']}".strip()
+                    for state in faulty)))
         return report, Outcome()
     if len(behind) != len(faulty):
         # SOMETHING ELSE IS WRONG AND IT IS NAMED. Refusing silently would leave the owner
@@ -123,6 +237,7 @@ def upgrade_what_is_only_behind(registry, report: dict) -> tuple[dict, Outcome]:
             "unrecoverable one: " + "; ".join(other)))
 
     backups: list[tuple[str, str]] = []
+    pruned: list[str] = []
     for state in behind:
         path = Path(state["path"])
         try:
@@ -132,8 +247,14 @@ def upgrade_what_is_only_behind(registry, report: dict) -> tuple[dict, Outcome]:
                 f"the {state['kind']} database is behind but could not be backed up, so "
                 f"it was not upgraded ({exc})"), backups=tuple(backups))
         backups.append((state["kind"], str(made)))
+        # PRUNED HERE, NOT AFTER THE MIGRATION, and the order is the whole point. The
+        # copy just made is a verified point-in-time copy of the file as it stands, so
+        # the newest copy is never the one at risk -- and the path that REPEATS is the
+        # failing one, where `initialize()` raises below the baseline and a line placed
+        # after it would never run at all.
+        pruned += _bounded(path)
 
     applied = registry.initialize()
     return registry.ensure_ready(), Outcome(
         upgraded=any(versions for versions in applied.values()),
-        backups=tuple(backups), applied=applied)
+        backups=tuple(backups), applied=applied, pruned=tuple(pruned))

--- a/scrapex/native.py
+++ b/scrapex/native.py
@@ -222,8 +222,15 @@ def startup_check() -> dict:
         f"{name}: {state['status']}. {state['action']}"
         for name, state in blocked
     )
+    # THE CONSTANT, NOT A FOURTH COPY OF THE WORDS. `dbupgrade.BEHIND` documents
+    # itself as "spelled once here and imported by both callers" and this was the
+    # second spelling the whole time: the button offered here is the one
+    # `upgrade_what_is_only_behind` decides to act on, and the two decided it by
+    # comparing against strings that nothing held together.
+    from .dbupgrade import BEHIND
+
     action = "upgrade_database" if any(
-        state["status"] == "Needs upgrade" for _, state in blocked
+        state["status"] == BEHIND for _, state in blocked
     ) else "check_storage"
     return _error(
         "startup_blocked",

--- a/scrapex/storage.py
+++ b/scrapex/storage.py
@@ -430,16 +430,17 @@ def _warehouse_identity(conn: sqlite3.Connection) -> tuple[str, str] | None:
     # by a newer ScrapeX", and this file was made by an OLDER one.
     baseline = dbmod.declared_schema_version(dbmod.SCHEMA_FILE)
     if version < baseline:
+        # THE SENTENCE IS SHARED WITH THE TWO SURFACES THAT TELL THE SAME FACT --
+        # `EngineDatabase.health()` and the exception `_migrate` raises. It was
+        # written here first and copied by hand into one of them; the copy that was
+        # never written is the one that answered with a terminal command instead.
+        from .dbupgrade import no_upgrade_path
+
         return (
             "too_old",
-            f"The file uses ScrapeX schema v{version}, and this engine's schema "
-            f"starts at v{baseline}: the migrations that led there were collapsed "
-            "into the baseline before release (R-84), so this build has no upgrade "
-            f"path from v{version}. Nothing has been changed. Bring it to v{baseline} "
-            "with the last release that still carried those migrations, or start a "
-            "new warehouse and carry this one's rows into it. From publication "
-            "onwards every migration is kept, so this cannot happen to a released "
-            "build.",
+            no_upgrade_path(version, baseline, "The file")
+            + " From publication onwards every migration is kept, so this cannot "
+              "happen to a released build.",
         )
 
     objects = {
@@ -772,7 +773,8 @@ def backups_kept(conn: sqlite3.Connection) -> int:
 
 
 def prunable_backups(db_path: Path | str, folder: Path | None = None,
-                     keep: int = BACKUPS_KEPT_PER_TAG) -> list[dict]:
+                     keep: int = BACKUPS_KEPT_PER_TAG,
+                     only: str | None = None) -> list[dict]:
     """The backups a keep-N-per-lineage policy would remove, newest kept.
 
     Untagged files are absent by construction — see backup_tag. Grouping by
@@ -780,10 +782,16 @@ def prunable_backups(db_path: Path | str, folder: Path | None = None,
     the one pre-wipe copy of a source that was erased months ago: measured on
     the owner's warehouse, `rebuild` alone held 10 files and 491 MB while
     `pre-wipe-SIKAEGSHOP` held the only copy of 13.7 MB nothing else has.
+
+    `only` NARROWS IT TO ONE LINEAGE, for a caller that made one copy and has no
+    business judging the others. The upgrade path is that caller: it writes a
+    `pre-upgrade` copy and must not decide the fate of a `reset-backup`, whose
+    ordering is not even reliable (`OP-141`). The Storage button passes nothing and
+    keeps governing everything, as it always has.
     """
     by_tag: dict[str, list[dict]] = {}
     for backup in list_backups(db_path, folder):
-        if backup.get("tag"):
+        if backup.get("tag") and (only is None or backup["tag"] == only):
             by_tag.setdefault(backup["tag"], []).append(backup)
     drop: list[dict] = []
     for entries in by_tag.values():
@@ -802,6 +810,57 @@ def _mtime_iso(path: Path) -> str:
     return stamp.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+def prune_backups_at(db_path: Path | str, folder: Path | None = None,
+                     keep: int = BACKUPS_KEPT_PER_TAG,
+                     only: str | None = None) -> tuple[int, list[str]]:
+    """The removal itself, WITH NO DATABASE OPEN. Returns (bytes freed, names).
+
+    THE ENTRY POINT WITHOUT A CONNECTION, and it exists because the one path that
+    reliably produces copies could not use the entry point with one. Every guarded
+    upgrade takes a full copy of the warehouse before migrating it
+    (`dbupgrade.upgrade_what_is_only_behind`) and nothing removed those: measured on
+    the owner's machine 2026-09-04, five copies totalling **963,768,320 bytes**
+    beside a 316 MB warehouse.
+
+    AND THE POLICY WAS ALREADY HERE. `backup_tag` already classifies a
+    `pre-upgrade-<stamp>` file, so this rule already governed them — it simply had
+    ONE caller, `backup_now`, which the upgrade path never reaches. The gap was
+    never a missing policy; it was a policy with no caller on the path that makes
+    the copies, which is not a thing a search for the word "prune" can show you.
+
+    A CONNECTION IS EXACTLY WHAT THAT PATH CANNOT OFFER. The database is still at
+    its old schema while the copy is being taken, and below the baseline (`R-84`) it
+    cannot be opened at all — which is the state that was making a copy per launch.
+
+    `only` is passed by that caller and is not optional politeness: see
+    `prunable_backups` and `OP-141`.
+    """
+    doomed = prunable_backups(db_path, folder, keep, only=only)
+    freed, removed = 0, []
+    for backup in doomed:
+        target = Path(backup["path"])
+        try:
+            size = _size(target)
+            target.unlink()
+        except OSError:
+            # A backup held open by another process is not an error worth
+            # failing a crawl — or an upgrade — over: it is simply still there
+            # next time. Housekeeping never fails the work it is tidying after.
+            continue
+        # AND ITS SIDECARS. `list_backups` deliberately never offers a `-wal` as
+        # something restorable, and a journal without the file it journalled is
+        # meaningless: three orphan pairs sit beside the owner's warehouse now,
+        # left by copies whose `.db` was removed by hand.
+        for sidecar in (Path(f"{target}-wal"), Path(f"{target}-shm")):
+            try:
+                sidecar.unlink(missing_ok=True)
+            except OSError:
+                pass
+        freed += size
+        removed.append(target.name)
+    return freed, removed
+
+
 def prune_backups(conn: sqlite3.Connection, db_path: Path | str,
                   keep: int | None = None) -> RunResult:
     """Remove the backups the policy no longer keeps. Returns what it freed.
@@ -814,22 +873,14 @@ def prune_backups(conn: sqlite3.Connection, db_path: Path | str,
     Deliberately NOT a sweep of everything old. It only ever removes files this
     product named (backup_tag), it keeps the newest of every lineage, and it
     never touches the live database or its sidecars.
+
+    This is the entry point that reads the owner's number and his backup folder;
+    `prune_backups_at` above is the same removal for a caller that has no database
+    open to read them from.
     """
     keep = backups_kept(conn) if keep is None else keep
     folder = backup_folder(conn, db_path)
-    doomed = prunable_backups(db_path, folder, keep)
-    freed, removed = 0, []
-    for backup in doomed:
-        target = Path(backup["path"])
-        try:
-            size = _size(target)
-            target.unlink()
-        except OSError:
-            # A backup held open by another process is not an error worth
-            # failing a crawl over — it is simply still there next time.
-            continue
-        freed += size
-        removed.append(target.name)
+    freed, removed = prune_backups_at(db_path, folder, keep)
     return RunResult(
         ok=True, rows=len(removed), location=str(folder),
         detail=(f"Removed {len(removed)} superseded backup(s), freeing "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -292,3 +292,31 @@ def pytest_unconfigure(config: pytest.Config) -> None:
         import shutil
 
         shutil.rmtree(_TEMPLATE_DIR, ignore_errors=True)
+
+
+@pytest.fixture()
+def one_migration_above_the_baseline(tmp_path_factory, monkeypatch):
+    """Make "behind, but ABOVE the baseline" reachable at all.
+
+    `R-84`'s squash collapsed the chain into `db/engine/schema.sql`, so the plan is a
+    single file and `baseline == latest`. Every version below the head is therefore
+    also below the BASELINE, and `EngineDatabase.health()`'s "Needs upgrade" branch
+    cannot be reached by rewinding a version: three tests that rewound by one
+    believed they were exercising it and were exercising the refusal instead. One
+    real migration above the baseline makes both branches exist.
+
+    `conftest`'s schema template steps aside on its own here -- `_may_restore`
+    refuses when `_stream_fingerprint()` no longer matches the stock stream, which
+    is exactly what monkeypatching the migrations folder changes.
+
+    Yields the version the extra migration takes a database to.
+    """
+    from scrapex import db as dbmod
+
+    folder = tmp_path_factory.mktemp("above-the-baseline")
+    head = dbmod.declared_schema_version(dbmod.SCHEMA_FILE) + 1
+    (folder / f"{head:04d}_a_column_lands_above_the_baseline.sql").write_text(
+        "ALTER TABLE crawl_job ADD COLUMN a_column_above_the_baseline INTEGER;\n"
+        f"PRAGMA user_version = {head};\n", encoding="utf-8")
+    monkeypatch.setattr(dbmod, "MIGRATIONS_DIR", folder)
+    yield head

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -65,3 +65,56 @@ def test_backup_database_makes_a_readable_copy(tmp_path: Path):
         assert restored.execute("SELECT COUNT(*) FROM price_observation").fetchone()[0] == 1
     finally:
         restored.close()
+
+
+# ---- the copy is atomic, because the policy now deletes ----------------------
+
+def test_a_failure_after_the_copy_leaves_nothing_at_the_final_name(tmp_path, monkeypatch):
+    """THE HAZARD THE RETENTION POLICY CREATED FOR ITSELF.
+
+    `source.backup(target)` fills its destination page by page. While nothing pruned
+    the pre-upgrade lineage, a copy interrupted halfway was clutter; once the upgrade
+    path started applying the keep-N policy (`OP-136`), a partial file carrying the
+    NEWEST stamp of its lineage could be kept while a complete older copy was
+    deleted — the one moment a backup is needed being the one where it had been
+    replaced by a fragment.
+    """
+    import os as _os
+
+    live = tmp_path / "scrapex-engine.db"
+    conn = sqlite3.connect(str(live))
+    conn.execute("CREATE TABLE t (x)")
+    conn.execute("INSERT INTO t VALUES (1)")
+    conn.commit()
+    conn.close()
+
+    def refuse(src, dst):
+        raise OSError("the disk filled while the copy was being renamed")
+
+    monkeypatch.setattr(_os, "replace", refuse)
+
+    with pytest.raises(OSError):
+        backup_database(live, tag="pre-upgrade")
+
+    assert not list(tmp_path.glob("*.backup.db")), \
+        "a copy that never completed took the name of a finished one"
+    assert not list(tmp_path.glob("*.part")), "the partial file was left behind"
+    assert live.is_file(), "the live database was disturbed by a failed backup"
+
+
+def test_a_completed_copy_leaves_no_partial_beside_it(tmp_path):
+    live = tmp_path / "scrapex-engine.db"
+    conn = sqlite3.connect(str(live))
+    conn.execute("CREATE TABLE t (x)")
+    conn.commit()
+    conn.close()
+
+    made = backup_database(live, tag="pre-upgrade")
+
+    assert made.is_file() and made.name.endswith(".backup.db")
+    assert not list(tmp_path.glob("*.part"))
+    restored = sqlite3.connect(str(made))
+    try:
+        assert restored.execute("SELECT COUNT(*) FROM sqlite_master").fetchone()[0] >= 1
+    finally:
+        restored.close()

--- a/tests/test_backups_stop_growing_without_end.py
+++ b/tests/test_backups_stop_growing_without_end.py
@@ -147,3 +147,72 @@ def test_the_warehouse_says_what_the_policy_would_free(warehouse):
     verdict = storage.health(db)
 
     assert verdict["prunable_backup_bytes"] > 0
+
+
+# ---- the entry point for a caller with no database open ----------------------
+
+def test_the_policy_runs_with_no_database_open(warehouse):
+    """WHY A SECOND ENTRY POINT EXISTS AT ALL. The path that reliably makes copies
+    is the guarded upgrade, and it runs while the database is at a schema this build
+    does not read — below the baseline (`R-84`) it cannot be opened at all, which is
+    the state that was making one full copy per engine launch. `prune_backups(conn,
+    ...)` cannot be called from there, and that is the whole reason 963,768,320 bytes
+    of pre-upgrade copies accumulated beside a 316 MB warehouse while a policy that
+    already recognised them sat one caller away.
+    """
+    _conn, db = warehouse
+    for i in range(5):
+        _make(db, f"scrapex-engine.pre-upgrade-2026010{i}T000000Z.backup.db", i + 1)
+    assert storage.backup_tag(
+        db.with_name("scrapex-engine.pre-upgrade-20260101T000000Z.backup.db"),
+        db) == "pre-upgrade", "the policy does not recognise its own file name"
+
+    freed, removed = storage.prune_backups_at(db, keep=2)
+
+    assert len(removed) == 3, removed
+    assert freed > 0
+    left = sorted(p.name for p in db.parent.glob("*pre-upgrade*"))
+    assert left == ["scrapex-engine.pre-upgrade-20260103T000000Z.backup.db",
+                    "scrapex-engine.pre-upgrade-20260104T000000Z.backup.db"], left
+    assert db.is_file(), "the live database was removed"
+
+
+def test_a_pruned_copy_takes_its_journal_files_with_it(warehouse):
+    """A `-wal` without the file it journalled is meaningless, and `list_backups`
+    already refuses to offer one as restorable. Three orphan pairs sit beside the
+    owner's warehouse today, left where a copy's `.db` went and its sidecars did
+    not."""
+    _conn, db = warehouse
+    for i in range(2):
+        copy = _make(db, f"scrapex-engine.pre-upgrade-2026010{i}T000000Z.backup.db", i + 1)
+        for suffix in ("-wal", "-shm"):
+            pathlib.Path(f"{copy}{suffix}").write_bytes(b"journal")
+
+    storage.prune_backups_at(db, keep=1)
+
+    assert not list(db.parent.glob("*20260100*")), \
+        "the pruned copy left its journal files behind"
+    assert pathlib.Path(f"{db.with_name('scrapex-engine.pre-upgrade-20260101T000000Z.backup.db')}-wal") \
+        .is_file(), "the surviving copy lost its journal"
+
+
+def test_a_partial_copy_is_not_a_backup_the_policy_can_see(warehouse):
+    """The other half of the atomicity fix, stated from the policy's side: a `.part`
+    file is not a lineage member, is never offered for restore, is never pruned, and
+    — the part that matters — does not occupy one of the kept slots."""
+    _conn, db = warehouse
+    for i in range(1, 4):
+        _make(db, f"scrapex-engine.pre-upgrade-2026010{i}T000000Z.backup.db", i)
+    torn = _make(db, "scrapex-engine.pre-upgrade-20260109T000000Z.backup.db.part", 9)
+
+    assert storage.backup_tag(torn, db) == "", \
+        "a partial file was classified as a member of a lineage"
+    assert torn.name not in {b["name"] for b in storage.list_backups(db)}
+
+    freed, removed = storage.prune_backups_at(db, keep=2)
+
+    assert torn.is_file(), "the policy deleted a file it does not understand"
+    assert len(removed) == 1 and "20260101" in removed[0], removed
+    left = sorted(p.name for p in db.parent.glob("*.backup.db"))
+    assert left == ["scrapex-engine.pre-upgrade-20260102T000000Z.backup.db",
+                    "scrapex-engine.pre-upgrade-20260103T000000Z.backup.db"], left

--- a/tests/test_database_integrity_report.py
+++ b/tests/test_database_integrity_report.py
@@ -49,14 +49,25 @@ def test_an_edited_applied_migration_is_reported_as_what_it_is(tmp_path, monkeyp
         "the report still names a command that raises this very error"
 
 
-def test_a_genuinely_behind_database_still_says_upgrade(tmp_path):
-    """The guard must narrow to the equal-version case, not swallow the real one."""
-    db = _db_at_head(tmp_path)
+def test_a_genuinely_behind_database_still_says_upgrade(
+        tmp_path, one_migration_above_the_baseline):
+    """The guard must narrow to the equal-version case, not swallow the real one.
+
+    AND "GENUINELY BEHIND" NEEDED A REAL MIGRATION TO STILL EXIST. `R-84`'s squash
+    made `latest - 1` a version BELOW the baseline, so this test was reaching the
+    no-upgrade-path branch while asserting the upgrade one — and asserting that its
+    action named `init-db`, a command the owner has no terminal for (`R-81`).
+    """
+    db = EngineDatabase(tmp_path / "scrapex-engine.db")
+    db.initialize()
     with db.connect() as conn:
-        conn.execute(f"PRAGMA user_version = {db.latest_schema_version - 1}")
+        conn.execute(f"PRAGMA user_version = {one_migration_above_the_baseline - 1}")
         conn.commit()
 
     report = db.health()
     assert report.ok is False
     assert report.status == "Needs upgrade", report.status
-    assert "init-db" in report.action
+    assert "Upgrade database" in report.action, \
+        "the fix must be named as the button it is"
+    assert "init-db" not in report.action, \
+        "the report names a command the owner cannot run — R-81"

--- a/tests/test_database_notification.py
+++ b/tests/test_database_notification.py
@@ -63,8 +63,15 @@ def test_a_database_that_degrades_while_running_is_announced_with_its_fix(tmp_pa
     body = client.get("/").text
     assert "Databases need attention" in body, "the status went stale"
     assert "Database attention needed" in body, "the banner must name the problem"
-    assert "Needs upgrade" in body
-    assert "init-db" in body, "a warning without the fix leaves the owner stuck"
+    assert "Older than the schema baseline" in body
+
+    # THE ENGINE'S OWN PAGE IS THE THIRD SURFACE THAT PRINTED A COMMAND, and this
+    # test DEMANDED it: "a warning without the fix leaves the owner stuck". That was
+    # true of the sentence and false of the fix — he has no terminal (`R-81`), so
+    # what was stuck was a person told to type something he cannot type. One line in
+    # `EngineDatabase.health()` fed the panel, this page and `/api/health` alike.
+    assert "init-db" not in body, \
+        "the page names a command line — R-81, and this page is not a terminal"
 
 
 def test_the_status_is_words_not_only_a_colour(tmp_path):
@@ -118,7 +125,9 @@ def test_a_reachable_engine_on_an_unusable_database_does_not_report_ok(tmp_path)
 
     assert body["databases"]["ok"] is False
     assert "engine" in body["databases"]["detail"]
-    assert "needs upgrade" in body["databases"]["detail"]
+    # Composed as `f"{kind} {status.lower()}"`, which is why the status carries no
+    # possessive: "engine older than the schema baseline" is a sentence.
+    assert "older than the schema baseline" in body["databases"]["detail"]
 
 
 # ---- before the engine can start ---------------------------------------------

--- a/tests/test_database_startup.py
+++ b/tests/test_database_startup.py
@@ -99,18 +99,116 @@ def test_an_existing_database_that_is_behind_is_reported_not_upgraded(registry):
     assert still == behind, "ensure_ready migrated a database it was not asked to"
 
 
-def test_a_database_that_is_behind_is_called_upgradeable_not_broken(registry):
+def test_a_database_that_is_behind_is_called_upgradeable_not_broken(
+        tmp_path, one_migration_above_the_baseline):
     """"Failed — restore a verified backup" sends the owner to destroy good data
-    over a one-command upgrade."""
+    over an upgrade he can press a button for.
+
+    IT REWOUND BY ONE, AND THAT STOPPED MEANING "BEHIND". After `R-84`'s squash
+    `latest - 1` is BELOW the baseline, so this test was reading the refusal branch
+    while asserting the upgrade one — and what it asserted about the action was that
+    it named `init-db`, which is the defect rather than the fix (`R-81`: the owner
+    has no terminal, so a command is a dead end printed inside a live failure).
+    """
+    database = EngineDatabase(tmp_path / "engine" / "scrapex-engine.db")
+    database.initialize()
+    _rewind_schema(database, one_migration_above_the_baseline - 1)
+
+    state = database.health()
+
+    assert state.status == "Needs upgrade", state.status
+    assert "Upgrade database" in state.action and "Settings" in state.action, \
+        "the fix must be named as the button it is, and the screen it is on"
+    for command in ("scrapex ", "python -m", "init-db"):
+        assert command not in state.action, \
+            f"the action names {command!r}, a command line — R-81"
+    assert "backup" not in state.action.lower(), \
+        "restoring a backup is the wrong instruction for a database that is behind"
+
+
+def test_a_database_below_the_baseline_is_not_called_upgradeable(registry):
+    """`R-84`: below the baseline there is no upgrade path, so calling it "Needs
+    upgrade" offers a repair that cannot exist.
+
+    THIS IS THE BRANCH A REAL ENGINE DATABASE REACHES TODAY, measured: the plan is
+    one file, so every version between 1 and the head is below the baseline. What it
+    cost while it answered "Needs upgrade" is two things at once — `startup_check`
+    offered the panel's "Upgrade database" button, and pressing it copied the whole
+    warehouse (316,760,064 bytes, measured on his) before failing and changing
+    nothing.
+    """
     registry.ensure_ready()
     _rewind_schema(registry.engine, registry.engine.latest_schema_version - 1)
 
     state = registry.engine.health()
 
-    assert state.status == "Needs upgrade"
-    assert "init-db" in state.action, "the fix must be named, not implied"
-    assert "backup" not in state.action.lower(), \
-        "restoring a backup is the wrong instruction for a database that is behind"
+    assert state.status == "Older than the schema baseline", state.status
+    assert "R-84" in state.action, "the refusal does not name the ruling behind it"
+    assert "Nothing has been changed" in state.action, (
+        "the action does not say the database is untouched, which is the first "
+        "thing its reader needs to know")
+    for command in ("scrapex ", "python -m", "init-db"):
+        assert command not in state.action, \
+            f"the action names {command!r}, a command line — R-81"
+
+
+def test_no_database_status_ever_answers_with_a_command_line(
+        tmp_path, one_migration_above_the_baseline):
+    """THE GUARD THAT WAS MISSING, and its absence is why one command shipped on
+    three surfaces at once.
+
+    `test_the_refusal_says_what_to_do_and_names_no_terminal_command` asserts this of
+    the EXCEPTION `_migrate` raises. Nothing asserted it of `DatabaseHealth.action`
+    — which the side panel renders (`native.startup_check`), the engine's own pages
+    print (`base.html`), and `/api/health` carries — so "Run 'python -m scrapex.cli
+    init-db'" reached all three from one line, with a green suite and two tests
+    DEMANDING it.
+
+    Every state that carries an action is swept, not the one that happened to be
+    wrong. A new status is a new row here.
+    """
+    head = one_migration_above_the_baseline
+    database = EngineDatabase(tmp_path / "engine" / "scrapex-engine.db")
+
+    states = {"Missing": database.health()}
+    database.initialize()
+    states["Healthy"] = database.health()
+    for version, case in ((head - 1, "behind"),
+                          (head - 2, "below the baseline"),
+                          (head + 5, "from a newer build")):
+        _rewind_schema(database, version)
+        state = database.health()
+        assert state.status not in states, f"{case} reported {state.status!r} twice"
+        states[state.status] = state
+
+    # AND THE BRANCH REACHED BY SOMETHING OTHER THAN A VERSION, which is where the
+    # SECOND command was hiding: `health()` interpolates the exception verbatim, and
+    # `_verify`'s contract-marker refusal named `scrapex init-db` long after the
+    # version branch had stopped naming anything. A sweep that only rewinds versions
+    # cannot see it — five statuses looked like all of them.
+    _rewind_schema(database, head)
+    conn = sqlite3.connect(str(database.path))
+    try:
+        # A NUMBER, and a wrong one. `'wrong'` reaches `int()` in
+        # `contract.stored_contract_version` and raises `ValueError`, which
+        # `health()` does not catch at all -- so a corrupt marker takes down the
+        # surface that exists to report corruption. Recorded in `OP-135`; this test
+        # is about the ACTION's words, so it takes the path that reports.
+        conn.execute("UPDATE scrapex_meta SET value = '999' "
+                     "WHERE key = 'contract_version'")
+        conn.commit()
+    finally:
+        conn.close()
+    broken = database.health()
+    assert broken.status == "Integrity check failed", broken.status
+    states[broken.status] = broken
+
+    assert len(states) == 6, f"a state was not reached: {sorted(states)}"
+    for status, state in states.items():
+        for command in ("scrapex ", "python -m", "init-db", "pip install"):
+            assert command not in state.action, (
+                f"{status!r} answers with {command!r}, a command line — R-81. "
+                f"Its action reads: {state.action}")
 
 
 def test_a_database_from_a_future_build_says_update_scrapex(registry):

--- a/tests/test_native.py
+++ b/tests/test_native.py
@@ -654,6 +654,75 @@ def test_startup_check_names_the_database_action(monkeypatch):
     assert "marketlens: Needs upgrade. Run init-db" == answer["detail"]
 
 
+def test_a_database_below_the_baseline_is_not_offered_a_button_that_cannot_work(
+        monkeypatch):
+    """THE ONLY ASSERTION THAT PROVES THE DEAD BUTTON IS GONE.
+
+    `action` is what the panel keys «Upgrade database» off (`extension/app.js`
+    `issueCopy`), and below the baseline there is no upgrade path to offer (`R-84`).
+    While this answered `upgrade_database`, every press copied the whole warehouse
+    and then refused: 316,760,064 bytes, measured on his.
+    """
+    from scrapex import native
+    from scrapex.dbupgrade import TOO_OLD
+
+    monkeypatch.setattr(native, "_database_report", lambda: ({
+        "engine": {"ok": False, "status": TOO_OLD,
+                   "action": "There is no upgrade path from v10 (R-84)."},
+    }, None))
+
+    answer = native.startup_check()
+
+    assert answer["ok"] is False
+    assert answer["error"] == "startup_blocked"
+    assert answer["action"] == "check_storage", (
+        "the panel is still offered the upgrade button for a database no upgrade "
+        "can repair")
+
+
+def test_a_database_that_is_only_behind_still_gets_the_button(monkeypatch):
+    """The other direction, because a fix that suppressed both would take away the
+    working repair. `BEHIND` is the status an upgrade genuinely fixes."""
+    from scrapex import native
+    from scrapex.dbupgrade import BEHIND, TOO_OLD
+
+    monkeypatch.setattr(native, "_database_report", lambda: ({
+        "engine": {"ok": False, "status": BEHIND, "action": "Use the button."},
+    }, None))
+    assert native.startup_check()["action"] == "upgrade_database"
+
+    # AND A MIXED REPORT KEEPS IT, deliberately: the guarded upgrade refuses and
+    # NAMES the other fault (`OP-137`), which is more useful than a button that
+    # vanishes without saying why. Unreachable with one database in the registry,
+    # asserted because `any()` is a choice and not an accident.
+    monkeypatch.setattr(native, "_database_report", lambda: ({
+        "engine": {"ok": False, "status": BEHIND, "action": "Use the button."},
+        "other": {"ok": False, "status": TOO_OLD, "action": "No path (R-84)."},
+    }, None))
+    assert native.startup_check()["action"] == "upgrade_database"
+
+
+def test_the_two_surfaces_describe_the_below_baseline_state_with_one_vocabulary():
+    """`storage.py` reports the machine key `too_old` and the engine's own page has a
+    word for it; `EngineDatabase.health()` reports a human status. They are the same
+    fact, and the pair is pinned so a later edit to one is a decision rather than a
+    drift.
+
+    THE ONE WORD OF DIFFERENCE IS DELIBERATE and its reason is mechanical, not
+    aesthetic — `/api/health` composes `f"{kind} {status.lower()}"`, so a possessive
+    would read as "engine older than this engine's schema". See the constant.
+    """
+    from scrapex.dbupgrade import TOO_OLD
+
+    page = (ROOT / "scrapex" / "webui" / "templates" / "_storage.html").read_text(
+        encoding="utf-8")
+
+    assert TOO_OLD == "Older than the schema baseline"
+    assert '"too_old": "Older than this engine\'s schema"' in page, (
+        "the engine's page no longer carries the word this status mirrors; if that "
+        "was intended, move both together")
+
+
 def test_the_two_protocol_constants_cannot_drift(conn):
     """PROTOCOL_VERSION is written twice — once in Python, once in JavaScript —
     because the extension cannot import Python. Two constants that must agree

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -736,14 +736,17 @@ FENCE_LABEL = "cited"
 #: floor counts what is actually checked, because that is the number that means
 #: something. Set from the measurement after writing 9 from memory and being wrong.
 #:
-#: The floor may only be RAISED.
+#: The floor may only be RAISED. Raised from 7 to 23 on 2026-09-04 by the entries
+#: `OP-133`..`OP-142`, measured with `_quoted_subjects()` rather than counted by
+#: hand -- the same way the 7 was arrived at, and for the same reason: a floor
+#: written from memory is a floor that means nothing.
 #:
 #: It fails when the count drops, so a labelled block cannot be quietly unlabelled to
 #: silence a red; it does NOT fail when a new unlabelled block appears, because
 #: reddening a correct record is the direction this design refuses to be wrong in.
 #: That turns "somebody forgot to label" from invisible into merely known, which is the
 #: most a declaration can offer.
-FENCE_FLOOR = 7
+FENCE_FLOOR = 23
 
 
 def _quoted_subjects():

--- a/tests/test_the_engine_upgrades_its_own_warehouse.py
+++ b/tests/test_the_engine_upgrades_its_own_warehouse.py
@@ -19,6 +19,7 @@ said out loud.
 
 from __future__ import annotations
 
+import os
 import pathlib
 
 import pytest
@@ -323,3 +324,134 @@ def test_both_front_doors_hold_ONE_copy_of_the_rule():
     assert "print(" not in rule, (
         "`dbupgrade` prints, so the native host cannot call it without corrupting its "
         "own stdout -- which is the divergence this module exists to end")
+
+
+# ---- and the copies are bounded ---------------------------------------------
+
+_OLD_STAMPS = ("20250101T000000Z", "20250102T000000Z",
+               "20250103T000000Z", "20250104T000000Z")
+
+
+def _older_copies(warehouse) -> list[pathlib.Path]:
+    """Older copies, oldest first — and their MODIFICATION TIMES are set, not left
+    to the clock.
+
+    `storage.prunable_backups` orders by `modified_at`, which `list_backups` reads
+    from the filesystem at one-second resolution. Four files written in a loop share
+    a second, and a tie decides by glob order — so a test that asserted WHICH copies
+    survived while leaving the mtimes to chance would be asserting something the
+    policy does not promise. The stamps in the names and the mtimes agree here, the
+    way they agree on a real machine.
+    """
+    made = []
+    for order, stamp in enumerate(_OLD_STAMPS, 1):
+        path = warehouse.parent / f"marketlens.pre-upgrade-{stamp}.backup.db"
+        path.write_bytes(b"an older copy")
+        os.utime(path, (1_740_000_000 + order * 3600, 1_740_000_000 + order * 3600))
+        made.append(path)
+    return made
+
+
+def _behind(warehouse):
+    states = {"marketlens": _state("marketlens", warehouse, False, "Needs upgrade")}
+    healthy = {k: dict(v, ok=True, status="Healthy") for k, v in states.items()}
+    return states, _FakeRegistry(states, after=healthy)
+
+
+def test_older_pre_upgrade_copies_are_removed_once_the_new_one_exists(
+        warehouse, capsys):
+    """MEASURED ON HIS MACHINE: five copies, 963,768,320 bytes, beside a 316 MB
+    warehouse — and nothing had ever removed one. While the below-baseline refusal
+    was live it made one MORE on every launch and every press, each changing nothing.
+
+    THE POLICY WAS ALREADY THERE. `storage`'s keep-N-per-lineage rule already
+    classified these files; it had one caller, the Storage page's button, which this
+    path never reaches. What is new here is the CALLER, which is why the assertion
+    below is about this path and the policy's own behaviour is guarded in
+    `tests/test_backups_stop_growing_without_end.py`.
+    """
+    _older_copies(warehouse)
+    states, registry = _behind(warehouse)
+
+    cli._upgrade_what_is_only_behind(registry, _report(states))
+
+    left = sorted(p.name for p in
+                  warehouse.parent.glob("marketlens.pre-upgrade-*.backup.db"))
+    assert len(left) == 3, left
+    assert not [name for name in left if "20250101" in name or "20250102" in name], \
+        f"the two oldest copies survived: {left}"
+    assert "removed 2 superseded backup(s)" in capsys.readouterr().out, \
+        "copies were deleted in silence, and a deletion is the half he cannot see"
+
+
+def test_the_prune_never_reaches_another_tags_copies(warehouse):
+    """The other tags are not hypothetical: `pre-ledger-repair` and `pre-reapprove`
+    copies sit in this exact folder on the owner's machine, and one of them is the
+    rollback for a repair that moved 17,000 rows."""
+    others = [warehouse.parent / "marketlens.pre-ledger-repair.backup.db",
+              warehouse.parent / "marketlens.pre-reapprove.backup.db",
+              warehouse.parent / "marketlens.bundle-20250101T000000Z.backup.db"]
+    # AND A LINEAGE OVER ITS OWN LIMIT, which is the case that separates "the newest
+    # of each lineage survives" from "this caller judges only its own lineage". Four
+    # `rebuild` copies against a keep of three: the Storage button would remove one,
+    # and an upgrade must remove none. `reset-backup` is the real stake -- it is the
+    # only copy of everything a "Start fresh" wiped, and its ordering is not even
+    # reliable (`OP-141`).
+    others += [warehouse.parent / f"marketlens.rebuild-2025010{n}T000000Z.backup.db"
+               for n in (1, 2, 3, 4)]
+    others += [warehouse.parent / f"marketlens.reset-backup-2025010{n}T000000Z.db"
+               for n in (1, 2, 3, 4)]
+    for order, path in enumerate(others, 1):
+        path.write_bytes(b"not mine to delete")
+        os.utime(path, (1_730_000_000 + order * 3600,) * 2)
+    _older_copies(warehouse)
+    states, registry = _behind(warehouse)
+
+    cli._upgrade_what_is_only_behind(registry, _report(states))
+
+    for path in others:
+        assert path.is_file(), f"the pre-upgrade prune deleted {path.name}"
+    assert warehouse.is_file(), "the prune deleted the live database"
+
+
+def test_a_copy_that_cannot_be_removed_does_not_fail_the_upgrade(warehouse):
+    """HOUSEKEEPING NEVER FAILS THE WORK. On Windows an open handle refuses the
+    unlink outright; the upgrade is the thing being done and it must not be lost to
+    a backup viewer left open on last week's copy."""
+    victims = _older_copies(warehouse)
+    states, registry = _behind(warehouse)
+
+    held = open(victims[0], "rb")
+    try:
+        result = cli._upgrade_what_is_only_behind(registry, _report(states))
+    finally:
+        held.close()
+
+    assert registry.initialized, "a copy it could not delete stopped the upgrade"
+    assert result["ok"]
+
+
+def test_a_fault_an_upgrade_cannot_fix_is_never_reported_as_up_to_date(warehouse):
+    """`OP-131`'s defect on a third surface, and the worst one to read.
+
+    `behind` is empty for two completely different reasons — nothing is wrong, or
+    something is wrong that an upgrade cannot fix — and both returned a bare
+    `Outcome()`. With no refusal to render, `native.upgrade_database` answered
+    `ok: True` with "The database is already up to date." about a database the
+    engine refuses to open. A surface that reports the wrong remedy sends a person
+    somewhere; one that reports nothing wrong sends them nowhere.
+    """
+    from scrapex.dbupgrade import TOO_OLD, upgrade_what_is_only_behind
+
+    states = {"marketlens": _state("marketlens", warehouse, False, TOO_OLD)}
+    registry = _FakeRegistry(states)
+
+    _, outcome = upgrade_what_is_only_behind(registry, _report(states))
+
+    assert not registry.initialized, "it migrated below the baseline"
+    assert outcome.refused, "the refusal said nothing at all"
+    assert outcome.message() != "The database is already up to date."
+    assert TOO_OLD in outcome.message(), \
+        "the reason the panel renders does not name the actual fault"
+    assert not list(warehouse.parent.glob("*pre-upgrade*")), \
+        "a refusal copied the whole warehouse — the loop R-84 exists to stop"


### PR DESCRIPTION
He asked why the engine does not work — *«اريد مراجعة لماذا لا يعمل المحرك ؟»* — and the answer was not the engine.

**Measured read-only on his warehouse:** `PRAGMA user_version = 10` against a baseline of **v17 with no migrations at all**, so `R-84`'s refusal is correct and total. The engine's own code is healthy: booted from source on a fresh v17 database, `/api/health` answers `ok: true`, `GET /` returns **200**, the worker runs.

He then **ruled the data away** — *«لا ترقى القاعدة لا مشكلة فانا لا احتاج الداتا عليها»* — and asked whether the failures recur *«من اول baseline الحالى»*. This branch carries no migration and touches no data.

## What it fixes

| | |
|---|---|
| **`OP-135`** | `EngineDatabase.health()` answered a below-baseline database *"Needs upgrade. Run `python -m scrapex.cli init-db`"* — one line reaching **four** surfaces (the panel, the engine's attention banner on every page, `database_unavailable.html`, the first-run console). `OP-131` fixed the *other* `health()`; this is the one the panel reads. The status also decided a button, so a press copied **316,760,064 bytes** and changed nothing — and **every engine launch** did the same through `cli._cmd_ui`. A second path into the same field is closed with it: `_verify`'s contract-marker refusal named `scrapex init-db`, and `health()` interpolates it verbatim. |
| **`OP-136`** | Nothing had ever removed a pre-upgrade copy — **963,768,320 bytes** beside a 316 MB warehouse. **The first diagnosis was wrong and the correction is the fix:** the policy already exists and already classifies these files; it had one caller, the Storage page's button. This adds a **caller, not a policy**, scoped to the `pre-upgrade` lineage. `backup_database` is atomic now, because a killed copy used to leave a fragment carrying the newest stamp of its lineage — harmless until something pruned, which is what this adds. |
| **`OP-137`** | An empty `behind` meant both *"nothing is wrong"* and *"an upgrade cannot fix this"*, so the panel was told **"The database is already up to date."** about a database the engine refuses to open. |

## Measured after

- `health()` → `Older than the schema baseline`, no command; `startup_check` → `action: "check_storage"`, so the issue card stops offering a repair that cannot exist.
- A refusal makes **no copy at all**; a real in-chain upgrade to v18 applies, backs up once, and bounds the copies at three with `pre-ledger-repair` and `rebuild` untouched.
- **"The button disappears" is true of one of the two buttons** and the entry says so: the standing Settings button is static markup and still reaches the unguarded HTTP route — that is `OP-139`.

## Awaiting his ruling

- **`OP-133`** — the squash gate asks whether the tool is *published*; what decides the outcome is whether **every warehouse he has is at the head**. Both sides of that condition are already tested; nothing establishes it before a collapse, and the flag's own docstring excludes his two machines on purpose.
- **`OP-134`** — no release ever carried the chain past **v10** (`engine-v0.2.1` → v3, `engine-v0.3.0` → v9, `engine-v0.3.1` → v10, measured per tag), so a machine on a release is behind the head by construction.

Also recorded with their reasons: **`OP-138`** (five tests that prove `R-84`'s refusal skip on `main` and in CI), **`OP-140`** (the panel prints the raw key `too_old`), **`OP-141`** (**data loss, reachable from a button today** — the prune orders a deletion by mtime and a `reset-backup` carries the *warehouse's*; measured deleting today's copy. Contained here, fixed in its own branch), **`OP-142`** (four pointer messages name commands, and two cannot be reworded because the control does not exist).

## Verification

- `ruff check scrapex/` clean.
- Every touched area green across 19 test files, including **15 new guards**. The ones that matter are sweeps: every state `DatabaseHealth` can report is checked for a command line, `startup_check` is asserted to stop offering the button, and the lineage containment is **proved by mutation** — removing it makes the test delete a `reset-backup` and say its name.
- `one_migration_above_the_baseline` exists because with the chain collapsed `latest - 1` stopped meaning "behind": three tests believed they were exercising the upgrade branch and were exercising the refusal, and **two of them demanded the command**.
- **No `VERSION` bump**, measured rather than assumed: 2 of the last 20 merges moved it, and `OP-127`/`OP-124` — the same family of fix — did not. The contract fingerprint has not moved.
- A local full-suite run was still in flight when this was pushed; CI is the gate, and this repository's own history is why (#251/#252 both passed against a base that stopped existing).

`R-42`: this is a secondary session — **merging is his call.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
