### PR TITLE
A deletion ordered by the wrong clock, and a reset-backup carries the warehouse's (OP-141)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -5343,12 +5343,14 @@ whole branch came from.
 
 ---
 
-### OP-141 · The backup prune orders a DELETION by mtime, and a reset-backup's mtime is the warehouse's
+### OP-141 · ~~The backup prune orders a DELETION by mtime, and a reset-backup's mtime is the warehouse's~~ — CLOSED 2026-09-04
 
-**Found 2026-09-04** by an adversarial read of `OP-136`'s new caller — the caller is
-contained rather than shipped over this, so what is recorded here is the defect it would
-have inherited. **It is reachable today from a button he has**, «Back up now» on the
-Storage page, which prunes after every copy it makes.
+**Found 2026-09-04** by an adversarial read of `OP-136`'s new caller, and **closed the
+same day on his instruction**
+([REQ-56](REQUESTS.md#req-56--fix-the-three-that-are-mine-record-the-two-that-are-his-and-take-the-data-loss-on-its-own-branch))
+— *«واصلح OP-141 فى فرع مستقل»* — in its own branch,
+`claude/a-deletion-ordered-by-the-wrong-clock`. It was reachable from a button he has,
+«Back up now» on the Storage page, which prunes after every copy it makes.
 
 **Three measured facts, on this Windows box (Python 3.12, NTFS):**
 
@@ -5357,40 +5359,60 @@ Storage page, which prunes after every copy it makes.
 2. `storage.start_fresh` does not copy the warehouse aside, it **renames** it —
 
 ```cited
-scrapex/storage.py:1042             os.replace(path, displaced)
+scrapex/storage.py:1104             os.replace(path, displaced)
 ```
 
    so `…reset-backup-<stamp>.db` carries **the warehouse's** last-write time, not the
    reset's. Undoing a reset runs `storage.restore`, which `shutil.copy2`s that file back
-   (`scrapex/storage.py:958`), so the same mtime returns to the live file — and a
+   (`scrapex/storage.py:1020`), so the same mtime returns to the live file — and a
    reset / undo / reset cycle produces several reset-backups sharing **one** mtime.
-3. The prune orders by that mtime, at one-second resolution —
-
-```cited
-scrapex/storage.py:735       return sorted(found, key=lambda b: b["modified_at"], reverse=True)
-```
-
-   so among equal mtimes the order is whatever the glob returned, and `prunable_backups`
+3. The prune ordered by that mtime, at one-second resolution. The line was
+   `return sorted(found, key=lambda b: b["modified_at"], reverse=True)` in
+   `list_backups`, and **it is deliberately quoted here without a `file:line`**: the fix
+   below replaced it, so a number would be a record of where something used to be rather
+   than a pointer, and repointing it would rewrite what it records (`LESSONS` 21).
+   Among equal mtimes the order was whatever the glob returned, and `prunable_backups`
    keeps "the first N of each lineage".
 
 **Measured outcome: four reset-backups sharing one mtime, names spanning 2026-01-01 to
 2026-09-04, `keep=3` — the file deleted was TODAY's**, the only copy of everything a
 "Start fresh" had just wiped, and the three kept were the oldest.
 
-**Why this branch does not fix it.** The obvious repair — order by the stamp the name
-already carries, which `backup_tag` already parses — changes what the Restore picker
-shows, and `_STAMP` admits **three spellings that do not sort against each other**
-(`20260904-101112` < `20260904T101112Z`, because `-` is 0x2D and `T` is 0x54), so it needs
-normalising to one form or comparing as parsed datetimes. The cheaper repair — make the
-tie deterministic with the name as a secondary key, descending — is smaller but leaves
-the mtime primary and so leaves a copied-in backup mis-ordered. Both are decisions about a
-shared reader, and neither belongs inside a change about a schema refusal.
+**WHAT LANDED: the name is the record of when the product acted, and the file's clock is
+not.**
 
-**What this branch did instead**: `dbupgrade._bounded` passes `only="pre-upgrade"`, so the
-upgrade path judges the one lineage it writes and never a `reset-backup`. Proved by
-mutation — removing the argument makes
-`test_the_prune_never_reaches_another_tags_copies` delete a `reset-backup` and a
-`rebuild` copy, and it says so by name.
+```cited
+scrapex/storage.py:789   def backup_taken_at(backup_path: Path | str, db_path: Path | str) -> str:
+scrapex/storage.py:746       return sorted(found, key=lambda b: (b["taken_at"], b["name"]), reverse=True)
+```
+
+`backup_taken_at` parses the stamp `backup_database` wrote and re-formats it into
+`_mtime_iso`'s own format, so one comparison orders stamped and unstamped files together;
+`list_backups` sorts on `(taken_at, name)` descending, which also makes the tie
+deterministic in the direction that keeps the newest. Both readers of the naming rule now
+go through one matcher, `_named_backup`, because there are two questions to ask of a name
+and two regexes over one rule is how half the code stops recognising it.
+
+**The three spellings are parsed, never compared raw** — `%Y%m%dT%H%M%SZ`,
+`%Y%m%d-%H%M%S`, `%Y-%m-%dT%H:%M:%SZ` — since `20260601-020000` sorts BELOW
+`20260101T010000Z` as text. **And the third cannot exist as a file on Windows**: NTFS
+refuses `:` in a name (`OSError: [Errno 22]`, measured), so its guard parses a string
+while the other two are ordered as real files, and the test says why rather than quietly
+only ever running on POSIX.
+
+**AND THE PICKER SHOWED THE SAME WRONG CLOCK, which is the half he would have read.**
+`_storage.html`'s Restore list said *"Stored as {modified_at}"* — for a `reset-backup`
+that is the warehouse's own last-write time, a moment that can be months before the reset
+the file is a copy of. It renders `taken_at` now; `modified_at` stays in the payload for
+anything that wants the file's own clock. Guarded, and the guard fails when the template
+is put back.
+
+**Proved by mutation, three times over.** Restoring the mtime ordering fails all three new
+guards, the reset-cycle one included — it is the measured data-loss case, four copies
+sharing one mtime and names spanning nine months, and it asserts that the file removed is
+the OLDEST rather than today's. `OP-136`'s containment (`only="pre-upgrade"`) stays: the
+upgrade path still judges the one lineage it writes, because narrowing what a caller may
+delete is right even when the ordering underneath it is correct.
 
 ---
 
@@ -5642,7 +5664,7 @@ would have been the duplication this repository keeps finding.
 **What landed** is a caller, not a policy:
 
 ```cited
-scrapex/storage.py:813   def prune_backups_at(db_path: Path | str, folder: Path | None = None,
+scrapex/storage.py:875   def prune_backups_at(db_path: Path | str, folder: Path | None = None,
 scrapex/dbupgrade.py:255         pruned += _bounded(path)
 ```
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1031,7 +1031,7 @@ for `^#{2,4} +OP-13[3-9]` and `OP-140`..`OP-142` (nothing declared them anywhere
 | `OP-138` | the five tests that prove `R-84`'s refusal are skipped on `main` and in CI | open, with its reason |
 | `OP-139` | `OP-127` closed the unprotected upgrade on one of the two doors | open, with its reason |
 | `OP-140` | the panel prints the raw key `too_old`; the vocabulary for it exists only on the engine's page | open, with its reason |
-| `OP-141` | the backup prune orders a deletion by mtime, and a reset-backup carries the warehouse's — measured deleting TODAY's copy | **open — data loss, reachable from a button** |
+| `OP-141` | the backup prune orders a deletion by mtime, and a reset-backup carries the warehouse's — measured deleting TODAY's copy | **closed** on `claude/a-deletion-ordered-by-the-wrong-clock`, on his instruction |
 | `OP-142` | four pointer messages name commands on the panel, and two cannot be reworded because the control does not exist | open — needs a control, so his call |
 
 **THE PATTERN IS WORTH MORE THAN ANY ONE OF THEM, and it is now three instances.**
@@ -1056,6 +1056,24 @@ Measured after, on a copy of his warehouse and on his real registry read-only: t
 told `check_storage` with no command in the detail, a refusal makes **no copy at all**, and
 a real in-chain upgrade to v18 applies, backs up once and bounds the copies at three with
 `pre-ledger-repair` and `rebuild` untouched.
+
+### A deletion ordered by the wrong clock — 2026-09-04, `OP-141`
+
+**On `claude/a-deletion-ordered-by-the-wrong-clock`, stacked on the branch above** because
+it edits the same file and closes the entry that branch records. He asked for it separately
+— *«واصلح OP-141 فى فرع مستقل»*.
+
+`storage.start_fresh` does not copy the warehouse aside, it **renames** it, and a rename
+carries the warehouse's own last-write time; `restore` copies that time back with
+`shutil.copy2`. So a reset / undo / reset cycle leaves several `reset-backup` files sharing
+**one** mtime — and the prune, ordered by mtime at one-second resolution, kept whichever
+three the glob returned first. Measured: **the file it deleted was today's**, the only copy
+of everything the reset had just wiped.
+
+Ordering now reads the stamp out of the name (`backup_taken_at`), normalises the three
+spellings `_STAMP` admits, and breaks ties by name descending. Three new guards, all
+proved by mutation; the containment `OP-136` added stays, because narrowing what a caller
+may delete is right even once the ordering under it is right.
 
 ## Track 1 · The Console migration
 

--- a/scrapex/storage.py
+++ b/scrapex/storage.py
@@ -726,13 +726,24 @@ def list_backups(db_path: Path | str, folder: Path | None = None) -> list[dict]:
     if not where.is_dir():
         return []
     found = [{"path": str(p), "name": p.name, "bytes": _size(p),
-              "modified_at": _mtime_iso(p), "tag": backup_tag(p, path)}
+              "modified_at": _mtime_iso(p),
+              # WHEN THE PRODUCT ACTED, falling back to the file's clock only for a
+              # name that carries no stamp — the hand-named copies, which are never
+              # grouped and never pruned anyway. `backup_taken_at` returns
+              # `_mtime_iso`'s own format, so one comparison orders both kinds.
+              "taken_at": backup_taken_at(p, path) or _mtime_iso(p),
+              "tag": backup_tag(p, path)}
              # SQLite leaves `-shm` and `-wal` beside a database it has opened,
              # and the glob was matching them: the Restore list offered a
              # write-ahead log as something you could make live again.
              for p in where.glob(f"{base_stem(path)}.*backup*")
              if p.suffix == Path(path).suffix or p.suffix == ".db"]
-    return sorted(found, key=lambda b: b["modified_at"], reverse=True)
+    # ORDERED BY WHEN IT WAS TAKEN, AND TIES BROKEN BY NAME (`OP-141`). This decides a
+    # DELETION: `prunable_backups` keeps the first N of each lineage, so an order that
+    # is merely stable — which is what `sorted` gives equal keys — kept whichever file
+    # the glob happened to return first. With the name descending as the second key, a
+    # tie keeps the newest, which is the answer that is right when both keys are.
+    return sorted(found, key=lambda b: (b["taken_at"], b["name"]), reverse=True)
 
 
 # What backup_database writes: <stem>.<tag>-<stamp>.backup<suffix>. Reset writes
@@ -744,14 +755,65 @@ def list_backups(db_path: Path | str, folder: Path | None = None) -> list[dict]:
 _STAMP = r"(?:\d{8}T\d{6}Z|\d{8}-\d{6}|[\d-]{10}T[\d:]{8}Z)"
 
 
+def _named_backup(backup_path: Path | str, db_path: Path | str) -> re.Match | None:
+    """The match this product's own naming makes on a file, or None.
+
+    ONE MATCHER, because there are now two questions to ask of a name — which lineage
+    it belongs to, and WHEN it was taken — and the answer to both is in the same
+    string. Two regexes over one naming rule is the shape where a name the product
+    writes stops being recognised by half the code that reads it.
+    """
+    stem = re.escape(base_stem(db_path))
+    return re.match(
+        rf"^{stem}\.(?:(?P<tag>.+?)-(?P<stamp>{_STAMP})\.backup"
+        rf"|reset-backup-(?P<reset>{_STAMP}))$",
+        Path(backup_path).stem)
+
+
 def backup_tag(backup_path: Path | str, db_path: Path | str) -> str:
     """Which lineage this backup belongs to, or "" if this product did not name it."""
-    stem = re.escape(base_stem(db_path))
-    match = re.match(rf"^{stem}\.(?:(?P<tag>.+?)-{_STAMP}\.backup|reset-backup-{_STAMP})$",
-                     Path(backup_path).stem)
+    match = _named_backup(backup_path, db_path)
     if match is None:
         return ""
     return match.group("tag") or "reset"
+
+
+#: The three spellings `_STAMP` admits, in the order they are tried. They do NOT sort
+#: against each other as text — `20260904-101112` < `20260904T101112Z` because `-` is
+#: 0x2D and `T` is 0x54 — so a stamp is parsed and re-formatted rather than compared
+#: raw. The output format is `_mtime_iso`'s exactly, which is what lets one comparison
+#: order stamped and unstamped files together.
+_STAMP_FORMATS = ("%Y%m%dT%H%M%SZ", "%Y%m%d-%H%M%S", "%Y-%m-%dT%H:%M:%SZ")
+
+
+def backup_taken_at(backup_path: Path | str, db_path: Path | str) -> str:
+    """When the product MADE this copy, read out of the name it wrote, or "".
+
+    WHY NOT THE FILE'S OWN CLOCK, which is what this used to be ordered by. A backup's
+    mtime is not the backup's: `start_fresh` does not copy the warehouse aside, it
+    RENAMES it (`os.replace` preserves the last-write time), so a `reset-backup`
+    carries the warehouse's own last-write time — and `restore` copies that same time
+    back onto the live file with `shutil.copy2`. A reset / undo / reset cycle therefore
+    produces several reset-backups sharing ONE mtime, at one-second resolution.
+
+    MEASURED, and it is why this function exists: four reset-backups sharing an mtime,
+    names spanning 2026-01-01 to 2026-09-04, `keep=3` — the file the policy deleted was
+    **today's**, the only copy of everything the reset had just wiped, and the three it
+    kept were the oldest. The name is the only record of when the product acted.
+    """
+    from datetime import datetime
+
+    match = _named_backup(backup_path, db_path)
+    if match is None:
+        return ""
+    raw = match.group("stamp") or match.group("reset")
+    for form in _STAMP_FORMATS:
+        try:
+            parsed = datetime.strptime(raw, form)
+        except ValueError:
+            continue
+        return parsed.replace(tzinfo=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return ""
 
 
 BACKUPS_KEPT_PER_TAG = 3

--- a/scrapex/webui/templates/_storage.html
+++ b/scrapex/webui/templates/_storage.html
@@ -91,11 +91,19 @@
         {% for b in storage.backups %}
           {# An <option> cannot hold a child element, so the label rides in
              data-utc-prefix and timezone.js writes the whole text. Same one
-             formatter as everywhere else — see _time.html. #}
-          <option value="{{ b.path }}" data-utc="{{ b.modified_at }}"
+             formatter as everywhere else — see _time.html.
+
+             `taken_at`, NOT `modified_at`, and for the reason `OP-141` records: a
+             backup's mtime is not the backup's. `start_fresh` RENAMES the warehouse
+             aside, so a `reset-backup` carries the warehouse's own last-write time —
+             the label said "Stored as" and named a moment that could be months before
+             the reset the file is a copy of. `taken_at` is read from the stamp the
+             product wrote into the name, and falls back to the file's clock only for a
+             hand-named copy that carries no stamp. #}
+          <option value="{{ b.path }}" data-utc="{{ b.taken_at }}"
                   data-utc-prefix="{{ b.name }} — {{ '{:,}'.format(b.bytes) }} bytes, "
-                  title="Stored as {{ b.modified_at }} (UTC)">{{ b.name }} — {{ "{:,}".format(b.bytes) }} bytes,
-            {{ b.modified_at }}</option>
+                  title="Stored as {{ b.taken_at }} (UTC)">{{ b.name }} — {{ "{:,}".format(b.bytes) }} bytes,
+            {{ b.taken_at }}</option>
         {% endfor %}
       </select>
     </div>

--- a/tests/test_backups_stop_growing_without_end.py
+++ b/tests/test_backups_stop_growing_without_end.py
@@ -152,17 +152,20 @@ def test_the_warehouse_says_what_the_policy_would_free(warehouse):
 # ---- the entry point for a caller with no database open ----------------------
 
 def test_the_policy_runs_with_no_database_open(warehouse):
-    """WHY A SECOND ENTRY POINT EXISTS AT ALL. The path that reliably makes copies
-    is the guarded upgrade, and it runs while the database is at a schema this build
-    does not read — below the baseline (`R-84`) it cannot be opened at all, which is
-    the state that was making one full copy per engine launch. `prune_backups(conn,
-    ...)` cannot be called from there, and that is the whole reason 963,768,320 bytes
-    of pre-upgrade copies accumulated beside a 316 MB warehouse while a policy that
+    """WHY A SECOND ENTRY POINT EXISTS AT ALL. The path that reliably makes copies is
+    the guarded upgrade, and it runs while the database is at a schema this build does
+    not read — below the baseline (`R-84`) it cannot be opened at all, which is the
+    state that was making one full copy per engine launch. `prune_backups(conn, ...)`
+    cannot be called from there, and that is the whole reason 963,768,320 bytes of
+    pre-upgrade copies accumulated beside a 316 MB warehouse while a policy that
     already recognised them sat one caller away.
     """
     _conn, db = warehouse
-    for i in range(5):
-        _make(db, f"scrapex-engine.pre-upgrade-2026010{i}T000000Z.backup.db", i + 1)
+    # REAL DATES. `20260100` is not one, and now that the order is read from the NAME
+    # (`OP-141`) an unparseable stamp falls back to the file clock and sorts as the
+    # NEWEST -- the fallback working correctly, and the old fixture being wrong.
+    for i in range(1, 6):
+        _make(db, f"scrapex-engine.pre-upgrade-2026010{i}T000000Z.backup.db", i)
     assert storage.backup_tag(
         db.with_name("scrapex-engine.pre-upgrade-20260101T000000Z.backup.db"),
         db) == "pre-upgrade", "the policy does not recognise its own file name"
@@ -172,28 +175,28 @@ def test_the_policy_runs_with_no_database_open(warehouse):
     assert len(removed) == 3, removed
     assert freed > 0
     left = sorted(p.name for p in db.parent.glob("*pre-upgrade*"))
-    assert left == ["scrapex-engine.pre-upgrade-20260103T000000Z.backup.db",
-                    "scrapex-engine.pre-upgrade-20260104T000000Z.backup.db"], left
+    assert left == ["scrapex-engine.pre-upgrade-20260104T000000Z.backup.db",
+                    "scrapex-engine.pre-upgrade-20260105T000000Z.backup.db"], left
     assert db.is_file(), "the live database was removed"
 
 
 def test_a_pruned_copy_takes_its_journal_files_with_it(warehouse):
     """A `-wal` without the file it journalled is meaningless, and `list_backups`
     already refuses to offer one as restorable. Three orphan pairs sit beside the
-    owner's warehouse today, left where a copy's `.db` went and its sidecars did
-    not."""
+    owner's warehouse today, left where a copy's `.db` went and its sidecars did not."""
     _conn, db = warehouse
-    for i in range(2):
-        copy = _make(db, f"scrapex-engine.pre-upgrade-2026010{i}T000000Z.backup.db", i + 1)
+    for i in range(1, 3):
+        copy = _make(db, f"scrapex-engine.pre-upgrade-2026010{i}T000000Z.backup.db", i)
         for suffix in ("-wal", "-shm"):
             pathlib.Path(f"{copy}{suffix}").write_bytes(b"journal")
 
     storage.prune_backups_at(db, keep=1)
 
-    assert not list(db.parent.glob("*20260100*")), \
+    assert not list(db.parent.glob("*20260101*")), \
         "the pruned copy left its journal files behind"
-    assert pathlib.Path(f"{db.with_name('scrapex-engine.pre-upgrade-20260101T000000Z.backup.db')}-wal") \
-        .is_file(), "the surviving copy lost its journal"
+    survivor = db.with_name("scrapex-engine.pre-upgrade-20260102T000000Z.backup.db")
+    assert pathlib.Path(f"{survivor}-wal").is_file(), \
+        "the surviving copy lost its journal"
 
 
 def test_a_partial_copy_is_not_a_backup_the_policy_can_see(warehouse):
@@ -216,3 +219,119 @@ def test_a_partial_copy_is_not_a_backup_the_policy_can_see(warehouse):
     left = sorted(p.name for p in db.parent.glob("*.backup.db"))
     assert left == ["scrapex-engine.pre-upgrade-20260102T000000Z.backup.db",
                     "scrapex-engine.pre-upgrade-20260103T000000Z.backup.db"], left
+
+
+# ---- OP-141: the deletion is ordered by the clock that wrote the name --------
+
+def _at(db, name: str, mtime: int) -> pathlib.Path:
+    """A backup with a chosen modification time, which is the whole subject here."""
+    import os
+
+    path = db.with_name(name)
+    path.write_bytes(b"x" * 1024)
+    os.utime(path, (mtime, mtime))
+    return path
+
+
+def test_a_reset_undo_reset_cycle_does_not_lose_todays_copy(warehouse):
+    """THE MEASURED FAILURE. `start_fresh` does not copy the warehouse aside, it
+    RENAMES it — and `os.replace` preserves the last-write time, so a `reset-backup`
+    carries the WAREHOUSE's clock, not the reset's. `restore` then copies that same
+    time back onto the live file with `shutil.copy2`. So every reset in a
+    reset / undo / reset cycle produces a file with ONE shared mtime.
+
+    Ordered by mtime, `sorted` is merely stable, so "the newest three" was whichever
+    three the glob returned first: measured on four such files with names spanning
+    2026-01-01 to 2026-09-04 and `keep=3`, the file deleted was **today's** — the only
+    copy of everything the reset had just wiped — and the three kept were the oldest.
+    """
+    _conn, db = warehouse
+    shared = 1_740_000_000                      # one warehouse last-write time
+    for stamp in ("20260101T090000Z", "20260401T090000Z",
+                  "20260701T090000Z", "20260904T090000Z"):
+        _at(db, f"scrapex-engine.reset-backup-{stamp}.db", shared)
+
+    freed, removed = storage.prune_backups_at(db, keep=3)
+
+    assert removed == ["scrapex-engine.reset-backup-20260101T090000Z.db"], removed
+    assert (db.parent / "scrapex-engine.reset-backup-20260904T090000Z.db").is_file(), \
+        "the newest reset copy was deleted and older ones were kept"
+    assert freed > 0
+
+
+def test_a_copy_carried_in_with_an_older_clock_is_not_treated_as_older(warehouse):
+    """`shutil.copy2` preserves the last-write time, so a backup restored from
+    another disk arrives with a clock older than the day the product wrote its name.
+    The name is the record of when the product acted; the file's clock is not."""
+    _conn, db = warehouse
+    old_clock = 1_600_000_000
+    new_clock = 1_780_000_000
+    _at(db, "scrapex-engine.rebuild-20260901T090000Z.backup.db", old_clock)
+    _at(db, "scrapex-engine.rebuild-20260101T090000Z.backup.db", new_clock)
+
+    _freed, removed = storage.prune_backups_at(db, keep=1)
+
+    assert removed == ["scrapex-engine.rebuild-20260101T090000Z.backup.db"], removed
+
+
+def test_the_three_stamp_spellings_order_against_each_other(warehouse):
+    """`_STAMP` admits three forms and they do NOT sort as text: `-` is 0x2D and `T` is
+    0x54, so `20260601-020000` sorts BELOW `20260101T010000Z`. Parsed and re-formatted,
+    they order by the moment they name.
+
+    THE THIRD SPELLING CANNOT BE A FILE ON THIS PLATFORM — NTFS refuses `:` in a name
+    (`OSError: [Errno 22] Invalid argument`, measured while writing this) — so it is
+    parsed as a string and the two writable ones are ordered as files. That is all the
+    platform allows either half of this to be, and saying so is better than a test that
+    silently only ever ran on POSIX.
+    """
+    _conn, db = warehouse
+    assert storage.backup_taken_at(
+        "scrapex-engine.reset-backup-2026-09-04T03:00:00Z.db", db) == "2026-09-04T03:00:00Z"
+
+    shared = 1_740_000_000
+    names = ["scrapex-engine.reset-backup-20260101T010000Z.db",
+             "scrapex-engine.reset-backup-20260601-020000.db"]
+    for name in names:
+        _at(db, name, shared)
+
+    order = [b["name"] for b in storage.list_backups(db)]
+
+    assert order == list(reversed(names)), order
+    assert [storage.backup_taken_at(n, db) for n in names] == [
+        "2026-01-01T01:00:00Z", "2026-06-01T02:00:00Z"]
+
+
+def test_a_hand_named_copy_still_falls_back_to_the_file_clock(warehouse):
+    """No stamp, no lineage, never pruned — and it still has to take a place in the
+    order, because `list_backups` is what the Restore picker renders."""
+    _conn, db = warehouse
+    _at(db, "scrapex-engine.pre0056.backup.db", 1_600_000_000)
+    _at(db, "scrapex-engine.rebuild-20260101T090000Z.backup.db", 1_780_000_000)
+
+    listed = storage.list_backups(db)
+
+    assert [b["name"] for b in listed] == [
+        "scrapex-engine.rebuild-20260101T090000Z.backup.db",
+        "scrapex-engine.pre0056.backup.db"], [b["name"] for b in listed]
+    assert storage.backup_taken_at("scrapex-engine.pre0056.backup.db", db) == ""
+    assert storage.prunable_backups(db) == []
+
+
+def test_the_restore_picker_names_when_the_copy_was_taken(warehouse):
+    """The label says "Stored as", and for a `reset-backup` the file's clock is the
+    WAREHOUSE's last-write time — a moment that can be months before the reset the file
+    is a copy of. It shows `taken_at`, read from the stamp the product wrote."""
+    from fastapi.testclient import TestClient
+
+    from scrapex.webui.app import create_app
+
+    conn, db = warehouse
+    _at(db, "scrapex-engine.reset-backup-20260904T090000Z.db", 1_600_000_000)
+
+    body = TestClient(create_app(db)).get("/settings").text
+
+    assert "2026-09-04T09:00:00Z" in body, \
+        "the picker does not name the moment the copy was taken"
+    assert "2020-09-13" not in body, \
+        "the picker still shows the file's own clock, which is the warehouse's"

--- a/tests/test_the_documents_cite_what_they_claim.py
+++ b/tests/test_the_documents_cite_what_they_claim.py
@@ -736,7 +736,7 @@ FENCE_LABEL = "cited"
 #: floor counts what is actually checked, because that is the number that means
 #: something. Set from the measurement after writing 9 from memory and being wrong.
 #:
-#: The floor may only be RAISED. Raised from 7 to 23 on 2026-09-04 by the entries
+#: The floor may only be RAISED. Raised from 7 to 24 on 2026-09-04 by the entries
 #: `OP-133`..`OP-142`, measured with `_quoted_subjects()` rather than counted by
 #: hand -- the same way the 7 was arrived at, and for the same reason: a floor
 #: written from memory is a floor that means nothing.
@@ -746,7 +746,7 @@ FENCE_LABEL = "cited"
 #: reddening a correct record is the direction this design refuses to be wrong in.
 #: That turns "somebody forgot to label" from invisible into merely known, which is the
 #: most a declaration can offer.
-FENCE_FLOOR = 23
+FENCE_FLOOR = 24
 
 
 def _quoted_subjects():


### PR DESCRIPTION
He asked for this one separately — *«واصلح OP-141 فى فرع مستقل»* ([REQ-56](https://github.com/muhammadbayoumi/ScrapeX/blob/claude/a-deletion-ordered-by-the-wrong-clock/docs/REQUESTS.md)) — once he read what it could delete.

> **Stacked on [#323](https://github.com/muhammadbayoumi/ScrapeX/pull/323)**, whose base is `main`. It edits the same file and closes the entry #323 records, so its base is that branch; GitHub retargets it to `main` when #323 merges.

## The defect

`storage.start_fresh` does not copy the warehouse aside — it **renames** it, and a rename carries the last-write time. `storage.restore` copies that time back with `shutil.copy2`. So a reset / undo / reset cycle leaves several `reset-backup` files sharing **one** mtime.

The prune ordered by that mtime at one-second resolution, and `sorted` on equal keys is merely *stable* — so "the newest three" was whichever three the glob happened to return first.

**Measured**: four such files sharing an mtime, names spanning 2026-01-01 to 2026-09-04, `keep=3` → **the file it deleted was today's**, the only copy of everything a "Start fresh" had just wiped, and the three it kept were the oldest. Reachable from a button he has: «Back up now» prunes after every copy it makes.

## The fix

The name is the record of when the product acted; the file's clock is not.

- `backup_taken_at` parses the stamp `backup_database` wrote and re-formats it into `_mtime_iso`'s own format, so **one comparison orders stamped and unstamped files together**.
- `list_backups` sorts on `(taken_at, name)` descending — which also makes a tie keep the newest, the direction that is right when both keys are.
- Both readers of the naming rule now go through one matcher, `_named_backup`: there are two questions to ask of a name, and two regexes over one rule is how half the code stops recognising a name the product writes.
- **The three spellings are parsed, never compared raw** — `20260601-020000` sorts *below* `20260101T010000Z` as text, because `-` is 0x2D and `T` is 0x54.
- **And the Restore picker showed the same wrong clock**: it said *"Stored as {modified_at}"*, which for a `reset-backup` is a moment that can be months before the reset the file is a copy of. It renders `taken_at`; `modified_at` stays in the payload.

## Verification

- **Four new guards, every one proved by mutation.** Restoring the mtime ordering fails three of them — the reset-cycle case included, which asserts the file removed is the *oldest* rather than today's. Putting the template back fails the fourth.
- **Two fixtures of mine were corrected by the change rather than by argument**: `20260100` is not a date, and an unparseable stamp correctly falls back to the file clock and sorts as the newest; and **NTFS refuses `:` in a filename** (`OSError: [Errno 22]`, measured), so `_STAMP`'s third spelling cannot exist as a file here — it is parsed as a string, and the test says why rather than silently only ever running on POSIX.
- `ruff check scrapex/` clean; every touched test file green.
- `OP-136`'s containment stays (`only="pre-upgrade"`): narrowing what a caller may delete is right even once the ordering under it is right.

`R-42`: secondary session — **merging is his call**, and this one merges after #323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
