### PR TITLE
No version sits unreleased, and engine-v0.4.8 is the first that carries the baseline (R-87, REQ-57, OP-143)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3476,6 +3476,18 @@ failure, same assertion, same value.** `main`'s CI is green, and
 [the CI workflow](../.github/workflows/ci.yml) runs on ubuntu only — so this is a
 **Windows-only red that CI is structurally unable to report.**
 
+> **CORRECTED 2026-09-04, and the correction narrows it to this machine.** The sentence
+> above is half wrong: `release-engine.yml` builds on **`windows-latest`** and runs this
+> very suite (`SCRAPEX_FULL_MIGRATIONS=1`, `python -m pytest -q`), so a Windows
+> environment DOES report on it — it had simply not been exercised since this entry was
+> written, the last tag predating it by five days. Measured today, twice: the test fails
+> on **his** machine run exactly that way, and the step *"The engine must pass its own
+> tests before it is shipped"* **passed** on GitHub's Windows runner in a `dry_run` of the
+> release. So it is a **machine-specific timing red, not a Windows-generic one**, and it
+> does not gate a release. A prediction that it would refuse `engine-v0.4.8` was made from
+> the old sentence and was wrong — which is why the dry run was spent before the tag was
+> ([REQ-57](REQUESTS.md#req-57--cut-the-tag-at-the-current-baseline-and-make-it-a-rule)).
+
 **Why it matters more than a flaky test.** The test's own failure message states the
 consequence: `_source_is_busy` reads that status, so the source is *"blocked from every
 future crawl and nothing anywhere says why"*. If the sweep really does not run on Windows,
@@ -5304,6 +5316,41 @@ which un-orphaned them without fixing anything, and the guard said so.
 `scrapex/snapshotcrawl.py`, line 169 still holds `if page.url in seen:` while the
 `def store` two lines above it had moved thirteen lines. The block cited both. Only a
 content check can tell a correct number from a coincidence.
+
+### OP-143 · The pre-push hook refuses an engine tag for the right reason and names the wrong one
+
+**Found 2026-09-04** while measuring whether `engine-v0.4.8` could be cut
+([REQ-57](REQUESTS.md#req-57--cut-the-tag-at-the-current-baseline-and-make-it-a-rule)).
+
+`.githooks/pre-push` is `R-64`'s local half: it asks `scrapex database-status` and refuses
+an `engine-v*` push when the answer is not ok. Measured on his warehouse today:
+
+    "ok": false,  "status": "Older than the schema baseline",  "schema_version": 10
+
+So it would refuse — **and its refusal says**:
+
+> *"REFUSED: … would ship an engine this machine's warehouse cannot open. … This is OP-33
+> and OP-84. Land the missing migrations on main first."*
+
+**Both named entries are the opposite state.** `OP-33` and `OP-84` are a warehouse
+**ahead** of the code, with migrations living on an unmerged branch; landing them on
+`main` is the remedy for that. His warehouse is **below the baseline** — a state `R-84`
+created after this hook was written — and no migration on `main` can help it, because the
+migrations that would have are the ones the squash absorbed.
+
+**Why it is worth a number rather than a word change.** `R-64` asked for a refusal that
+can be argued with, and the hook keys on `ok: false`, which now conflates two states with
+opposite remedies. A person who reads it will go looking for an unmerged migration that
+does not exist. The repair is either a status check narrow enough to tell them apart —
+`database-status` already reports `Older than the schema baseline` distinctly — or a
+message that names both possibilities and lets the reader pick.
+
+**It did not block this release**: `git config core.hooksPath` is empty on this machine, so
+the hook is inert here (its own docstring says so: *"a hook is inert until somebody runs
+`git config core.hooksPath .githooks`"*). It will fire on any machine that has run the
+README's setup step.
+
+---
 
 ### OP-142 · Four pointer messages name commands on the panel, and two of them cannot be reworded because the control does not exist
 

--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -156,7 +156,7 @@ git merge-tree --write-tree origin/main origin/claude/a-citation-nothing-reads
   -> f84ebfee            git finds NOTHING to conflict on
 
 FAILED test_a_citation_that_quotes_its_subject_still_points_at_it
-docs/BACKLOG.md:4669 cites scrapex/cli.py:856 and says it holds
+docs/BACKLOG.md:4681 cites scrapex/cli.py:856 and says it holds
 'registry = None if args.db else DatabaseRegistry.defaults()', which is at [852]
 ```
 

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -105,6 +105,7 @@ IDs are stable and never reused, matching the convention BACKLOG.md already uses
 | [REQ-51](#req-51--jobspy-is-the-scheduler-and-should-be-named-for-what-it-does) | `scrapex/jobs.py` is the scheduler and should be named for it | **Ruled** · Captured 2026-08-30 · he approved the rename and the split into its own request | 2026-08-30 |
 | [REQ-52](#req-52--delete-everything-marketlens-a-product-that-was-abandoned) | Delete everything MarketLens, a product that was abandoned | **In flight** — captured and measured 2026-08-30 on `claude/marketlens-is-gone`. **189 references became 17**, and the defect they were hiding is [OP-117](BACKLOG.md): `/data-model` reported **134 tables where 67 exist**, one of them labelled *MarketLens*. What stays names something that still exists — a key in his own `databases.json` whose rename fails **silently**, and two checksummed files naming a column **no database contains**. He reframed the constraint himself («احنا فى مرحلة التطوير … مفيش غيرى») and he is right: there is no installed base. **In flight** — decided and built 2026-09-03 under [R-84](RULINGS.md) — the base may be collapsed before publication and after it no migration is ever deleted. The chain is one baseline at v17, `grep -ci marketlens db/engine/schema.sql` answers **0**, and the reconciliation was checked against his real 2.02 GB warehouse read-only. The waiver on the second machine is recorded as a waiver | 2026-08-30 |
 | [REQ-53](#req-53--everything-about-backup-lives-on-manage-account-and-the-panel-is-what-holds-the-permission) | Everything about backup on one page, and the panel is what may do it | **Captured** — he said it 2026-09-02 and it reached the board a day later. Measured: the local snapshot is built by `/api/storage/backup`, called ONLY from the engine's `_storage.html`; the Drive bundle by `/api/bundle`, called ONLY from the panel; and **restore has no control in the panel at all** — `/api/storage/restore` is engine-page-only and `bundle.unpack()` has no caller outside tests. So he has a backup button in his only interface and no way to restore from it | 2026-09-03 |
+| [REQ-57](#req-57--cut-the-tag-at-the-current-baseline-and-make-it-a-rule) | Cut the tag at the current baseline, and make it a rule | **Done** — `engine-v0.4.8` cut 2026-09-04 on `9b5d920`, the first release since 2026-08-23 and the first that carries the squashed baseline at **schema v17**, so a released engine can reach v17 for the first time. The standing rule he gave with it is [R-87](RULINGS.md#r-87--no-version-sits-unreleased--the-published-engine-follows-the-code-and-the-lag-is-the-defect), whose mechanism is still his to choose. Closed `OP-134`; found `OP-143` and corrected `OP-98` | 2026-09-04 |
 | [REQ-55](#req-55--why-does-the-engine-not-work-and-will-it-happen-again-from-the-current-baseline) | Why the engine does not work, and whether it recurs from the current baseline | **Done** — reviewed 2026-09-04 and answered with measurements. His warehouse reads `user_version = 10` against a baseline of v17 with no migrations, so `R-84`'s refusal is correct and total; the engine's own code is healthy. He ruled the data away and narrowed the question to recurrence, which is [OP-133](BACKLOG.md) (the squash gate cannot see the condition that matters) and [OP-134](BACKLOG.md) (no release ever carried the chain past v10, so a machine on a release is behind by construction). Both wait on him | 2026-09-04 |
 | [REQ-56](#req-56--fix-the-three-that-are-mine-record-the-two-that-are-his-and-take-the-data-loss-on-its-own-branch) | Fix «ج», record «أ» and «ب», then take `OP-141` on its own branch | **Done** — built 2026-09-04 across two branches. `OP-135`, `OP-136`, `OP-137` closed on `claude/engine-failure-review-4287b1` ([#323](https://github.com/muhammadbayoumi/ScrapeX/pull/323)); `OP-141` closed on `claude/a-deletion-ordered-by-the-wrong-clock`, which he asked for separately once he read that it could delete today's copy of a wiped warehouse. `OP-138`, `OP-139`, `OP-140`, `OP-142` recorded with their reasons | 2026-09-04 |
 | [REQ-54](#req-54--a-source-declares-what-it-can-be-asked-to-do-and-the-panel-draws-its-controls-from-that) | A source declares what it can be asked to do | **Captured** — the crawl button starts ONE thing with fixed defaults. `run_mode`'s four values are price vocabulary and none of them means anything for a directory, while muqawil's seven real options are unreachable from the panel. He named the generalisation himself: this repeats with every source added | 2026-09-03 |
@@ -3001,6 +3002,38 @@ to name the snapshot's version and refuse, or warn, when it is older than the ba
 Part of the request, not a follow-up.
 
 ---
+
+## REQ-57 · Cut the tag at the current baseline, and make it a rule
+
+**Captured 2026-09-04, in the session he said it, and Done the same day.** He said it
+twice — once as an instruction, once with the rule that outlives it:
+
+> «اقطع الوسم عند baseline الحالى»
+
+then, after reading what the gap had cost:
+
+> «ادمج #323 ثم #324 ثم اقطع الوسم وضع قاعدة ان الوسم طالما تغير اذا يجب قطعه دائما حتى لا
+> يكون هناك تاخير بين الكود والمنشور»
+
+**`engine-v0.4.8` is cut**, annotated, on `9b5d920` — after `#323` and `#324` merged, in
+the order he gave. It is the first release since **2026-08-23** and the first that carries
+`R-84`'s squashed baseline, so **v17 is a ceiling a released engine can reach for the
+first time** — which is what `OP-134` was about and what closes it.
+
+**THE BLOCKER I PREDICTED DID NOT EXIST, and the way that was settled is the point.** The
+release build runs the whole suite on `windows-latest`, and `OP-98`'s chaos test fails on
+his machine every time it is run there — so I said a tag would be refused. Rather than
+spend a tag to find out, the workflow's own `dry_run` was dispatched: **success, zero
+failed steps**, with *"The engine must pass its own tests before it is shipped"* passing
+on GitHub's Windows runner. `OP-98` is corrected accordingly — it is not a Windows red
+that CI cannot see; it is a red on **his machine**, and the release gate is Windows and
+green.
+
+**The rule he gave with it is [R-87](RULINGS.md#r-87--no-version-sits-unreleased--the-published-engine-follows-the-code-and-the-lag-is-the-defect)**,
+which reverses an expectation `STATE.md` stated in capitals and keeps it marked under
+`C4`. Its mechanism — a guard that cannot forget, or a workflow that cuts the tag itself —
+is recorded as his decision, because it changes who publishes.
+
 
 ## REQ-55 · Why does the engine not work, and will it happen again from the current baseline
 

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -3974,3 +3974,64 @@ fifteen migration files and bumps `VERSION`. **A rebase across that is far worse
 rebase across a positional conflict in `docs/RULINGS.md`**, and this branch adds no migration
 so it cannot invalidate the squash's baseline either way. Both orders were safe; one was
 cheaper. **The primary is expected to say which and why, not merely to say who is next.**
+
+---
+
+### R-87 · No version sits unreleased — the published engine follows the code, and the lag is the defect
+
+**2026-09-04 · release procedure. It reverses an expectation this system had written in
+capitals, and the old text stays marked rather than deleted (`C4`).**
+
+> «وضع قاعدة ان الوسم طالما تغير اذا يجب قطعه دائما حتى لا يكون هناك تاخير بين الكود
+> والمنشور»
+
+He gave it in the same message that asked for `engine-v0.4.8`, having just read what the
+gap had cost.
+
+**WHAT IT REPLACES.** `docs/STATE.md` said, in capitals: *"AND THE NORMAL STATE FROM HERE
+IS SOURCE AHEAD OF PUBLISHED, WHICH IS NOT `OP-32` RETURNING … releases are cut by hand,
+so the two are **expected** to differ between releases."* That sentence is now wrong at
+its centre: the difference is no longer expected, it is the thing to prevent. It stays in
+place, marked, because it is the reasoning a reader will otherwise reconstruct and act on.
+
+**THE MEASUREMENT THAT MADE HIM SAY IT**, taken the same hour:
+
+| | |
+|---|---|
+| the published engine | `engine-v0.3.1`, tagged **2026-08-23** at `467a3ac` |
+| the source | `main` at **2026-09-04** |
+| between them | **60 commits, 38 of which touched `scrapex/` or `packaging/`** |
+| `VERSION` | 0.3.1 → **0.4.8** — five bumps, none of them released |
+
+**AND HIS WORDS HAVE TWO READINGS THAT PRODUCE DIFFERENT WORK, so the one in force is
+stated rather than assumed.** Read literally — a tag per change to shipped code — it is
+38 releases in twelve days, each a ~20-minute Windows build, and it needs a version per
+commit, which `engine-v<VERSION>` cannot express. **The reading in force is the other
+one: no `VERSION` bump may sit unreleased.** It reaches the same end at the granularity
+the repository already has, because `scrapex/version.py` already says `VERSION` *"moves
+whenever a functional, architectural or behavioural change lands"* — so the two rules
+together give one release per real change, and **a bump without a tag becomes a
+checkable defect** rather than a habit. Measured, that habit is the whole problem: only
+**2 of the last 20 merges** moved `VERSION` at all.
+
+**THE MECHANISM IS HIS AND IS NOT YET CHOSEN**, and the difference matters:
+
+- **A guard** — a test that fails when `VERSION` on `main` has no matching `engine-v*`
+  tag. It cannot forget; it also cannot act, so the release stays a thing he does.
+- **An automatic tag** — a workflow on `main` that cuts `engine-v<VERSION>` the moment
+  `VERSION` changes. It removes the human step that produced the twelve days, which is
+  what a rule about lag is for.
+
+Recorded as an open decision rather than picked, because it changes who publishes.
+
+**AND THE GAP BEHIND THIS GAP IS NOT CLOSED BY EITHER.** `PLATFORM-PLAN §5c` says nothing
+reviews an engine release — *"the EXTENSION notices, tells the owner, and installs on
+acceptance"*. `OP-124` measured that updater as **built, mounted and doorless**: nothing
+calls it, and no `api/update` string has ever existed in `extension/`. So this ruling
+closes *code → published* and leaves *published → installed* exactly where it was, which
+is the half he actually double-clicks. A rule about lag has to name both, and this one
+names the second as unbuilt.
+
+**IT BINDS THE ENGINE PATH, NOT THE STORE PATH.** `scrapex-v*` goes through Google's
+review — *"a day or three"* — so a lag there is imposed from outside and no procedure of
+ours removes it.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -23,7 +23,29 @@ Each correction is the argument for the sentence rather than a counter-example t
 > that is only corrected when somebody happens to edit it is not a status document**, and
 > the audit that fixed it is the kind of thing `C2` means by a stale document being a bug.
 
-**THE ENGINE ON GITHUB IS `engine-v0.3.0`, AND IT WAS CUT TODAY.** He asked for it
+**THE ENGINE ON GITHUB IS `engine-v0.4.8`, CUT 2026-09-04 ON `9b5d920`.** The first
+release since 2026-08-23, and **the first that carries `R-84`'s squashed baseline**, so
+**v17 is a ceiling a released engine can reach for the first time** — which is what
+`OP-134` asked for and what closes it. He asked for it directly — *«اقطع الوسم عند
+baseline الحالى»* — and gave the standing rule with it
+([R-87](RULINGS.md#r-87--no-version-sits-unreleased--the-published-engine-follows-the-code-and-the-lag-is-the-defect)):
+**no version sits unreleased.** `REQ-57`.
+
+The gap it closed, measured: **60 commits and five unreleased `VERSION` bumps over twelve
+days**, 38 of those commits in shipped code. And the blocker predicted for it did not
+exist — the release build runs the suite on `windows-latest`, `OP-98` fails there on HIS
+machine, and a `dry_run` of the workflow proved that same step **green on GitHub's Windows
+runner**. `OP-98` is corrected in place rather than left as written.
+
+**What a person installing 0.4.8 gets that 0.3.1 did not**: a below-baseline warehouse
+refused with the reason and no command line (`OP-135`), no full copy of the warehouse per
+launch and the copies bounded by his own policy (`OP-136`), an atomically written backup,
+and a deletion ordered by the stamp rather than the file clock (`OP-141`).
+
+> **The paragraph that follows is the record of the PREVIOUS release** and is kept for its
+> reasoning about `OP-32`, not as the current state.
+
+**THE ENGINE ON GITHUB WAS `engine-v0.3.0`, AND IT WAS CUT ON 2026-08-22.** He asked for it
 directly — *«اقطع الوسم»* — after reading the finding that the panel was offering
 `0.2.1`, the build whose bare invocation printed nothing. The tag sits on `451468d`,
 which is this `main`; `scrapex/version.py:76` and the `pyproject.toml` mirror both
@@ -31,6 +53,13 @@ read `0.3.0` there. **Thirteen days and two `VERSION` bumps of unreleased engine
 closed.** `OP-32` · `REQ-28` · guarded by
 [#253](https://github.com/muhammadbayoumi/ScrapeX/pull/253) — **open, not merged**
 ([R-42](RULINGS.md#r-42--one-primary-session-merges-every-other-session-is-secondary-and-asks)).
+
+> **SUPERSEDED 2026-09-04 BY [R-87](RULINGS.md#r-87--no-version-sits-unreleased--the-published-engine-follows-the-code-and-the-lag-is-the-defect),
+> AND KEPT UNDER `C4`.** He ruled that no version may sit unreleased — *«حتى لا يكون هناك
+> تاخير بين الكود والمنشور»* — so the paragraph below is no longer the standing
+> expectation. What it says about `OP-32` remains true and is why the distinction was
+> drawn; what it says about a gap being *normal* is what he reversed, having measured
+> this one at **60 commits and five unreleased bumps over twelve days**.
 
 **AND THE NORMAL STATE FROM HERE IS SOURCE AHEAD OF PUBLISHED, WHICH IS NOT `OP-32`
 RETURNING.** `VERSION` moved on a contract change under the rule in force then (now replaced by [R-77](RULINGS.md#r-77--one-number-one-question-the-extension-carries-the-version-the-engine-carries-a-protocol-and-a-build), which removes the engine's version entirely))


### PR DESCRIPTION
He asked for the tag and gave the rule in the same message:

> «ادمج #323 ثم #324 ثم اقطع الوسم وضع قاعدة ان الوسم طالما تغير اذا يجب قطعه دائما حتى لا يكون هناك تاخير بين الكود والمنشور»

**Done in that order.** `#323` and `#324` are merged, and **[`engine-v0.4.8`](https://github.com/muhammadbayoumi/ScrapeX/releases/tag/engine-v0.4.8) is cut** — annotated, on `9b5d920`. It is the first release since **2026-08-23** and the **first that carries `R-84`'s squashed baseline**, so **v17 is a ceiling a released engine can reach for the first time**. That closes `OP-134`. This PR is the record.

## `R-87` — the ruling

**It reverses an expectation this system had written in capitals**, and the old text stays marked under `C4`: `STATE.md` said *"the normal state from here is source ahead of published … the two are **expected** to differ between releases."* No longer.

The measurement that produced it:

| | |
|---|---|
| published | `engine-v0.3.1`, **2026-08-23** |
| source | `main`, **2026-09-04** |
| between them | **60 commits, 38 touching `scrapex/` or `packaging/`** |
| `VERSION` | 0.3.1 → 0.4.8 — **five bumps, none released** |

**His words have two readings that produce different work, so the one in force is stated.** Literally — a tag per change to shipped code — is 38 releases in twelve days and needs a version per commit, which `engine-v<VERSION>` cannot express. **In force: no `VERSION` bump may sit unreleased.** It reaches the same end at the granularity the repo already has, because `version.py` already says `VERSION` *"moves whenever a functional, architectural or behavioural change lands"* — and it makes a bump without a tag **checkable** rather than habitual. Measured, the habit is the problem: only **2 of the last 20 merges** moved `VERSION`.

**The mechanism is left as his decision**, because it changes who publishes:
- **a guard** — a test that fails when `VERSION` on `main` has no matching tag; cannot forget, cannot act;
- **an automatic tag** — a workflow that cuts `engine-v<VERSION>` when `VERSION` changes; removes the human step that produced the twelve days.

**And the ruling names the gap behind the gap.** `PLATFORM-PLAN §5c` says the extension notices an engine release and installs on acceptance; `OP-124` measured that updater as **built, mounted and doorless** — nothing calls it, and no `api/update` string has ever existed in `extension/`. So this closes *code → published* and leaves *published → installed* exactly where it was.

## `OP-143` — the hook would have refused for the right reason and named the wrong one

`.githooks/pre-push` asks `database-status` and refuses an `engine-v*` push on `"ok": false`. Measured on his warehouse: `"status": "Older than the schema baseline", "schema_version": 10` → it would refuse, saying *"This is OP-33 and OP-84. Land the missing migrations on main first."* **Both are the opposite state** — a warehouse *ahead* of the code. His is *below the baseline*, a state `R-84` created after the hook was written, and no migration on `main` can help it. `R-64` asked for a refusal that can be argued with.

It did not block this release: `core.hooksPath` is empty on that machine, so the hook is inert there.

## `OP-98` — corrected, and the correction is mine to own

I predicted this tag would fail the release build, because that chaos test fails on Windows here every time and the entry called it *"a Windows-only red that CI is structurally unable to report."* But `release-engine.yml` builds on **`windows-latest`** and runs that very suite — so a Windows environment *does* report on it; it had simply not been exercised since the entry was written.

**Rather than spend a tag to find out, the workflow's own `dry_run` was dispatched: success, zero failed steps**, with *"The engine must pass its own tests before it is shipped"* passing on GitHub's Windows runner. So it is a **machine-specific timing red, not a Windows-generic one**, and it does not gate a release. The entry is corrected in place.

## Verification

`pytest -m docs`: **376 passed, 2 skipped**. One pre-existing citation in `ORCHESTRATION.md` shifted by the new entries and was repointed **by content**, not by arithmetic.

`R-42`: secondary session — merging is his call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
