### PR TITLE
The tag follows the version, and the first thing the release taught (R-87's mechanism, OP-144)

### DIFF
--- a/.github/workflows/tag-the-release.yml
+++ b/.github/workflows/tag-the-release.yml
@@ -1,0 +1,155 @@
+# R-87's MECHANISM, and he chose it over a guard: «واعمل workflow يقطع الوسم تلقائيا».
+#
+# The rule is that no `VERSION` sits unreleased. A guard could only have said so after
+# the fact; this removes the step that produced the gap it was ruled over — measured at
+# 60 commits and five unreleased bumps across twelve days, `engine-v0.3.1` (2026-08-23)
+# against a source at 0.4.8.
+#
+# IT TAGS WHAT PASSED, NOT WHAT IS NEWEST, and that is the whole reason it hangs off
+# `workflow_run` rather than `push`. A push trigger would tag the commit that had just
+# landed, before anything had run against it; this waits for CI to conclude on `main`
+# and tags the exact SHA that CI ran on. A tag on a red commit is a lie a release then
+# repeats.
+#
+# WHY IT DISPATCHES INSTEAD OF RELYING ON THE TAG PUSH. A tag pushed with the automatic
+# `GITHUB_TOKEN` does not start another workflow — GitHub suppresses event-triggered runs
+# from that token so a workflow cannot recurse into itself. `release-engine.yml` listens
+# on `push: tags`, so it would never wake. `workflow_dispatch` is the documented way
+# through, and the step after it CHECKS that a run actually appeared: a mechanism whose
+# failure mode is silence would be exactly `OP-124`'s defect — built, mounted, doorless.
+name: Tag the release
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+  # For a version already sitting unreleased when this landed, and for re-running after
+  # a release build was fixed. It takes no input: what to tag is never a choice, it is
+  # whatever `scrapex/version.py` says.
+  workflow_dispatch:
+
+permissions:
+  contents: write        # the tag
+  actions: write         # the dispatch
+
+concurrency:
+  # Two green CI runs on `main` minutes apart must not both try to create the same tag.
+  # The loser would fail on a tag that already exists, which reads as a broken mechanism
+  # rather than as the no-op it is.
+  group: tag-the-release
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    # A red `main` publishes nothing. `workflow_dispatch` carries no conclusion, so it is
+    # admitted explicitly rather than by the absence of a failure.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: The commit CI actually passed, with every tag fetched
+        uses: actions/checkout@v4
+        with:
+          # `head_sha` on a `workflow_run`, `main` on a manual dispatch. Tagging
+          # `github.sha` would tag whatever `main` is NOW, which on a busy afternoon is
+          # not the commit that was tested.
+          ref: ${{ github.event.workflow_run.head_sha || 'main' }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: What version is this, and is it already released
+        id: read
+        run: |
+          set -euo pipefail
+          version=$(python -c "import re,pathlib;print(re.search(r'^VERSION = \"([^\"]+)\"', pathlib.Path('scrapex/version.py').read_text(encoding='utf-8'), re.M).group(1))")
+          tag="engine-v${version}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          # Asked of the REMOTE, not of the local tag list: the checkout above fetched
+          # tags, but a tag created by a run that started seconds earlier would not be
+          # in it, and `concurrency` serialises those runs rather than preventing them.
+          if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+            echo "released=yes" >> "$GITHUB_OUTPUT"
+            echo "${tag} already exists — nothing to do. R-87 is satisfied."
+          else
+            echo "released=no" >> "$GITHUB_OUTPUT"
+            echo "${version} has no tag yet; cutting ${tag} on $(git rev-parse --short HEAD)."
+          fi
+
+      - name: Cut the tag on the commit that passed
+        if: steps.read.outputs.released == 'no'
+        env:
+          TAG: ${{ steps.read.outputs.tag }}
+          VERSION: ${{ steps.read.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # ANNOTATED, because a release marker that cannot say why it exists is the
+          # thing `R-87` was ruled against. The message names the rule and the commit.
+          git tag -a "$TAG" -m "$TAG
+
+          Cut automatically by .github/workflows/tag-the-release.yml under R-87: no
+          version sits unreleased, so the tag follows VERSION rather than waiting for
+          somebody to remember.
+
+          VERSION  $VERSION
+          commit   $(git rev-parse HEAD)
+          CI       ${{ github.event.workflow_run.html_url || 'manual dispatch' }}"
+          # THE ONE FAILURE THIS CANNOT FIX FOR ITSELF, stated rather than shown as a
+          # raw 403. Measured on 2026-09-04: this repository's
+          # `default_workflow_permissions` is **read**, so the `permissions:` block above
+          # is what grants the write — and if an organisation policy ever caps it below
+          # that, the block is silently insufficient and this is where it shows.
+          if ! git push origin "$TAG"; then
+            echo "::error::could not push $TAG."
+            echo "The token could not write to this repository. Either:" >&2
+            echo "  - Settings > Actions > General > Workflow permissions:" >&2
+            echo "    allow read and write, which is what the permissions block needs;" >&2
+            echo "  - or store a fine-grained PAT with Contents: write as a secret and" >&2
+            echo "    use it here, the way release-engine.yml uses PUBLIC_SITE_TOKEN." >&2
+            echo "Nothing was published and VERSION $VERSION is still unreleased." >&2
+            exit 1
+          fi
+
+      - name: Start the release, because a tag this token pushed will not
+        id: dispatch
+        if: steps.read.outputs.released == 'no'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.read.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # `dry_run=false`, said out loud: the default on that workflow's input is
+          # `true`, so omitting it would build a release and publish nothing — a
+          # mechanism that appears to work and ships nothing.
+          gh workflow run release-engine.yml --ref "$TAG" -f dry_run=false
+          echo "dispatched release-engine.yml on ${TAG}"
+
+      - name: And it must actually have started
+        if: steps.read.outputs.released == 'no'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.read.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # THE STEP THAT STOPS THIS BEING A PROMISE. If `workflow_dispatch` from
+          # GITHUB_TOKEN is ever restricted the way `push` is, the dispatch above
+          # succeeds and nothing runs — and `R-87` would be satisfied on paper by a tag
+          # nobody built. Twelve attempts over a minute, then red.
+          for _ in $(seq 1 12); do
+            if [ "$(gh run list --workflow=release-engine.yml --branch "$TAG" \
+                      --limit 1 --json databaseId --jq 'length')" = "1" ]; then
+              gh run list --workflow=release-engine.yml --branch "$TAG" --limit 1
+              echo "the release is building on ${TAG}."
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::${TAG} was pushed and release-engine.yml never started." >&2
+          echo "The tag exists and nothing is published, which is OP-32's shape." >&2
+          echo "Dispatch it by hand on ${TAG} with dry_run=false, and treat the" >&2
+          echo "dispatch-from-GITHUB_TOKEN assumption in this file as disproved." >&2
+          exit 1

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -5317,6 +5317,55 @@ which un-orphaned them without fixing anything, and the guard said so.
 `def store` two lines above it had moved thirteen lines. The block cited both. Only a
 content check can tell a correct number from a coincidence.
 
+### OP-144 · The refusal is correct and there is nothing he can press: the remedy is behind a page the engine cannot serve
+
+**Found 2026-09-04 by him, within the hour of installing `engine-v0.4.8`**, which is the
+first build that carries the refusal `OP-135` shipped. What he saw:
+
+```
+  [2/3] Preparing your database...
+        already there: C:\Users\Muhammad\.scrapex\engine\scrapex-engine.db
+  [3/3] Starting the engine...
+
+error: the database was not upgraded because its fault is not a pending migration:
+       engine: Older than the schema baseline. … (R-84) … Nothing has been changed.
+error: the engine database is older than the schema baseline — …
+
+  Open ScrapeX in Chrome; the Engine page says what is missing.
+  Press Enter to close this window.
+```
+
+**EVERY WORD OF THAT IS THE FIX WORKING.** It refuses instead of copying 302 MB and
+crashing, it names `R-84`, it says nothing was changed, and it contains no command line
+(`R-81`). `OP-135`, `OP-136` and `OP-137` are all visible in those two lines.
+
+**AND THEN IT DEAD-ENDS**, which is the entry. Traced:
+
+| the door | why it is shut |
+|---|---|
+| the engine's own Engine/Storage page — *"Open ScrapeX in Chrome; the Engine page says what is missing"* | `cli._cmd_ui` returns before `create_app`, so **no page is served at all**. The sentence points at a page that cannot exist in this state |
+| the panel's «Upgrade database» | correctly refuses — there is no upgrade path (`R-84`) |
+| anything else over the native pipe | `native.STANDALONE_COMMANDS` is `PING`, `START_ENGINE`, `AUTOSTART_STATUS`, `SET_AUTOSTART`, `CHECK_STARTUP`, `UPGRADE_DATABASE`. **No start-fresh, no carry-over, no restore** |
+| `storage.start_fresh`, which does EXACTLY what is needed — renames the warehouse aside as `…reset-backup-<stamp>.db` and creates a fresh one | reachable only from `_storage.html` (`data-storage="start-fresh"`), i.e. from the page above |
+
+**So the capability exists and its only door is inside the thing that will not start.**
+That is `OP-124`'s shape — *"the remedy is itself absent on a `--db` start"* — and
+`R-81`'s subject exactly: a capability with no control in the panel has no control. The
+remaining action is a rename in File Explorer, which is not a terminal and is therefore
+not forbidden, but it is not the product either.
+
+**The console sentence is also now wrong**, and it is one line: it sends him to a page
+that is not being served. It should say what the panel can actually do about it — which
+today is nothing, so saying nothing true is possible until the control exists.
+
+**Not fixed here.** The repair is a native command (`START_FRESH`, guarded like
+`UPGRADE_DATABASE` and going through `storage.start_fresh`, which already backs the
+warehouse up by renaming rather than deleting it) plus a control on the panel's engine
+screen — and it is destructive-adjacent enough that it is his call how it asks. Recorded
+the hour it was found, with his own transcript above.
+
+---
+
 ### OP-143 · The pre-push hook refuses an engine tag for the right reason and names the wrong one
 
 **Found 2026-09-04** while measuring whether `engine-v0.4.8` could be cut

--- a/docs/REQUESTS.md
+++ b/docs/REQUESTS.md
@@ -3031,8 +3031,19 @@ green.
 
 **The rule he gave with it is [R-87](RULINGS.md#r-87--no-version-sits-unreleased--the-published-engine-follows-the-code-and-the-lag-is-the-defect)**,
 which reverses an expectation `STATE.md` stated in capitals and keeps it marked under
-`C4`. Its mechanism — a guard that cannot forget, or a workflow that cuts the tag itself —
-is recorded as his decision, because it changes who publishes.
+`C4`.
+
+**AND HE CHOSE ITS MECHANISM THE SAME DAY** — *«ادمج #325 واعمل workflow يقطع الوسم
+تلقائيا»* — the workflow rather than the guard, because a guard reports a lag it cannot
+close. `.github/workflows/tag-the-release.yml` tags the SHA CI passed and starts the
+release itself.
+
+**AND THE FIRST THING THE RELEASE TAUGHT, within the hour, is `OP-144`.** He downloaded
+0.4.8, ran it, and got the refusal this branch shipped — correct, naming `R-84`, saying
+nothing was changed, **and with no command line in it**, which is `OP-135` working. What
+he then had was a black window and no door: the remedy exists (`storage.start_fresh`) and
+is reachable only through a page the engine cannot serve while the warehouse is below the
+baseline.
 
 
 ## REQ-55 · Why does the engine not work, and will it happen again from the current baseline

--- a/docs/RULINGS.md
+++ b/docs/RULINGS.md
@@ -4014,15 +4014,30 @@ together give one release per real change, and **a bump without a tag becomes a
 checkable defect** rather than a habit. Measured, that habit is the whole problem: only
 **2 of the last 20 merges** moved `VERSION` at all.
 
-**THE MECHANISM IS HIS AND IS NOT YET CHOSEN**, and the difference matters:
+**THE MECHANISM WAS HIS TO CHOOSE AND HE CHOSE THE SECOND, the same day:**
 
-- **A guard** — a test that fails when `VERSION` on `main` has no matching `engine-v*`
-  tag. It cannot forget; it also cannot act, so the release stays a thing he does.
-- **An automatic tag** — a workflow on `main` that cuts `engine-v<VERSION>` the moment
-  `VERSION` changes. It removes the human step that produced the twelve days, which is
-  what a rule about lag is for.
+> «واعمل workflow يقطع الوسم تلقائيا»
 
-Recorded as an open decision rather than picked, because it changes who publishes.
+- ~~**A guard** — a test that fails when `VERSION` on `main` has no matching `engine-v*`
+  tag. It cannot forget; it also cannot act, so the release stays a thing he does.~~
+  **Not taken**, and the reason is the ruling's own subject: a guard reports a lag it
+  cannot close.
+- **An automatic tag** — **BUILT** as `.github/workflows/tag-the-release.yml`. It hangs
+  off `workflow_run` after CI concludes on `main` and tags **the SHA CI passed**, not
+  whatever `main` is by then; it asks the remote whether the version is already released,
+  so it is a cheap no-op on every other merge; and it dispatches `release-engine.yml`
+  explicitly with `dry_run=false`, **then checks that a run actually started**. A tag
+  pushed by `GITHUB_TOKEN` starts nothing — GitHub suppresses event-triggered runs from
+  that token — so without the dispatch the mechanism would be `OP-124`'s defect again:
+  built, mounted, doorless. Guarded by
+  `tests/test_the_tag_follows_the_version.py`, whose last test RUNS the workflow's own
+  version-extraction expression against `scrapex/version.py` rather than looking for a
+  string in a YAML file.
+
+**One thing it cannot grant itself, measured 2026-09-04**: this repository's
+`default_workflow_permissions` is **read**. The workflow's `permissions:` block is what
+grants the write, and if a policy ever caps it lower the tag push fails — so that failure
+names the setting and the alternative instead of showing a raw 403.
 
 **AND THE GAP BEHIND THIS GAP IS NOT CLOSED BY EITHER.** `PLATFORM-PLAN §5c` says nothing
 reviews an engine release — *"the EXTENSION notices, tells the owner, and installs on

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -37,6 +37,20 @@ exist — the release build runs the suite on `windows-latest`, `OP-98` fails th
 machine, and a `dry_run` of the workflow proved that same step **green on GitHub's Windows
 runner**. `OP-98` is corrected in place rather than left as written.
 
+**AND THE MECHANISM FOR `R-87` IS BUILT, not promised**:
+`.github/workflows/tag-the-release.yml` tags the SHA CI passed and starts the release
+itself, so the next `VERSION` bump publishes without anybody remembering. He chose it over
+a guard — *«واعمل workflow يقطع الوسم تلقائيا»*. One precondition is his:
+`default_workflow_permissions` on this repository is **read**, so if the workflow's own
+`permissions:` block is ever capped by policy the tag push fails and says which setting.
+
+**AND WITHIN THE HOUR HE INSTALLED IT AND FOUND `OP-144`.** The refusal works exactly as
+shipped — it names `R-84`, changes nothing, and prints no command — **and there is nothing
+he can press**: the console sends him to the engine's page, which is not served because
+the engine did not start, and the panel's only database command is the upgrade that
+correctly refuses. `storage.start_fresh` is the remedy and its only door is inside the
+thing that will not start.
+
 **What a person installing 0.4.8 gets that 0.3.1 did not**: a below-baseline warehouse
 refused with the reason and no command line (`OP-135`), no full copy of the warehouse per
 launch and the copies bounded by his own policy (`OP-136`), an atomically written backup,

--- a/tests/test_the_tag_follows_the_version.py
+++ b/tests/test_the_tag_follows_the_version.py
@@ -1,0 +1,126 @@
+"""R-87's mechanism, held to the four things that make it a mechanism.
+
+He chose a workflow over a guard — «واعمل workflow يقطع الوسم تلقائيا» — so the thing
+that can now go wrong is not forgetting to release. It is releasing the wrong commit,
+releasing nothing while appearing to work, or a version this file cannot read.
+
+Every assertion below is one of those, and the last is the only one that reads the
+workflow's own extraction expression against the real `scrapex/version.py` rather than
+looking for a string in a YAML file.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scrapex.version import VERSION
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "tag-the-release.yml"
+RELEASE = ROOT / ".github" / "workflows" / "release-engine.yml"
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict:
+    assert WORKFLOW.is_file(), f"{WORKFLOW} is missing, so R-87 has no mechanism"
+    # `on` is parsed by PyYAML as the boolean True — YAML 1.1's reserved words, which
+    # is why every reader of a GitHub workflow trips on it once.
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def steps(workflow) -> list[dict]:
+    return workflow["jobs"]["tag"]["steps"]
+
+
+def test_it_waits_for_ci_and_never_fires_on_a_bare_push(workflow):
+    """IT TAGS WHAT PASSED. A `push` trigger would tag the commit that had just landed,
+    before anything ran against it — and a release then repeats that lie to whoever
+    installs it."""
+    triggers = workflow[True]
+
+    assert "push" not in triggers, (
+        "it fires on push, so it can tag a commit nothing has tested yet")
+    assert triggers["workflow_run"]["workflows"] == ["CI"], triggers["workflow_run"]
+    assert triggers["workflow_run"]["branches"] == ["main"]
+    assert "workflow_dispatch" in triggers, (
+        "there is no way to release a version that was already sitting unreleased")
+
+    guard = workflow["jobs"]["tag"]["if"]
+    assert "workflow_run.conclusion == 'success'" in guard, guard
+    assert "workflow_dispatch" in guard, (
+        "a manual dispatch carries no conclusion, so it must be admitted explicitly")
+
+
+def test_it_checks_out_the_commit_ci_ran_on(steps):
+    """`github.sha` is whatever `main` is NOW, which on a busy afternoon is not the
+    commit that was tested. Five sessions produced seven pull requests in one afternoon
+    once (`ORCHESTRATION.md`), so this is not hypothetical."""
+    checkout = next(s for s in steps if str(s.get("uses", "")).startswith("actions/checkout"))
+
+    ref = checkout["with"]["ref"]
+    assert "workflow_run.head_sha" in ref, ref
+    assert checkout["with"]["fetch-tags"] is True, "it cannot see whether a tag exists"
+
+
+def test_it_asks_the_remote_whether_the_version_is_already_released(steps):
+    """The checkout fetches tags, but a tag created by a run that started seconds
+    earlier is not in that fetch — `concurrency` serialises those runs, it does not
+    prevent them."""
+    body = "\n".join(str(s.get("run", "")) for s in steps)
+
+    assert "git ls-remote" in body and "refs/tags/" in body, (
+        "it decides whether to cut a tag from a local list, which can be stale")
+
+
+def test_it_says_dry_run_false_out_loud(steps):
+    """THE DEFAULT ON THE OTHER WORKFLOW IS `true`, so omitting the input would build a
+    release and publish nothing — a mechanism that appears to work and ships nothing."""
+    release = yaml.safe_load(RELEASE.read_text(encoding="utf-8"))
+    default = release[True]["workflow_dispatch"]["inputs"]["dry_run"]["default"]
+
+    assert default is True, (
+        "release-engine.yml's dry_run no longer defaults to true; this test and the "
+        "comment in tag-the-release.yml both describe a world that changed")
+
+    dispatch = next(s for s in steps if "gh workflow run" in str(s.get("run", "")))
+    assert "-f dry_run=false" in dispatch["run"], dispatch["run"]
+    assert "release-engine.yml" in dispatch["run"]
+
+
+def test_it_proves_the_release_started_rather_than_assuming_it(steps):
+    """A tag pushed with GITHUB_TOKEN does not start another workflow, which is why the
+    dispatch exists at all. If dispatching is ever restricted the same way, the dispatch
+    still succeeds and nothing runs — `R-87` satisfied on paper by a tag nobody built.
+    That is `OP-124`'s defect exactly: built, mounted, doorless."""
+    checker = [s for s in steps if "gh run list" in str(s.get("run", ""))]
+
+    assert checker, "nothing checks that the release actually started"
+    body = checker[-1]["run"]
+    assert "::error::" in body, "it fails quietly, which is the one thing it must not do"
+    assert "exit 1" in body
+
+
+def test_the_expression_it_reads_the_version_with_actually_reads_it():
+    """THE ONLY ASSERTION HERE THAT IS NOT ABOUT A STRING IN A YAML FILE. The workflow
+    extracts `VERSION` with a regex in a `python -c`; if that expression is wrong the
+    workflow fails at the moment of releasing, which is the worst moment to find out.
+    It is run here, against the real file, and compared with the imported value."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    match = re.search(r'version=\$\(python -c "(?P<code>.+?)"\)', text)
+    assert match, "the version-reading step is no longer a `python -c` this can extract"
+
+    code = match.group("code").replace('\\"', '"')
+    proc = subprocess.run([sys.executable, "-c", code], cwd=ROOT,
+                          capture_output=True, text=True)
+
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == VERSION, (
+        f"the workflow would tag engine-v{proc.stdout.strip()} while "
+        f"scrapex/version.py says {VERSION}")


### PR DESCRIPTION
He chose the mechanism over the guard, in one line:

> «واعمل workflow يقطع الوسم تلقائيا»

`R-87` says no `VERSION` sits unreleased. A guard could only have reported a lag it cannot close — which is the thing the ruling was made over, measured at **60 commits and five unreleased bumps across twelve days**.

## `.github/workflows/tag-the-release.yml`

Every choice in it is a failure it refuses to have:

| | |
|---|---|
| **It tags what passed** | It hangs off `workflow_run` after CI concludes on `main` and checks out `workflow_run.head_sha` — not `github.sha`, which is whatever `main` is by then. A `push` trigger would tag a commit nothing had run against yet, and a release repeats that lie to whoever installs it |
| **It asks the remote** | not the local tag list: `concurrency` serialises two green runs, it does not prevent them. On every merge that does not move `VERSION` it is a ~20-second no-op |
| **It dispatches explicitly** | with `dry_run=false` said out loud, because that input **defaults to `true`**. A tag pushed by `GITHUB_TOKEN` starts nothing — GitHub suppresses event-triggered runs from that token — so relying on the tag push would have been `OP-124` again: built, mounted, doorless |
| **And it proves the release started** | twelve checks over a minute, then red with the reason. A mechanism whose failure mode is silence satisfies `R-87` on paper with a tag nobody built |
| **The one thing it cannot grant itself is stated** | measured today: this repository's `default_workflow_permissions` is **read**. The `permissions:` block is what grants the write; if policy ever caps it, the push fails naming the setting and the PAT alternative, not a raw 403 |

## Six guards, and the last is the only one that is not about a string in a YAML file

`tests/test_the_tag_follows_the_version.py` **runs the workflow's own version-reading expression** against `scrapex/version.py` and compares the result with the imported `VERSION` — because a wrong expression fails at the moment of releasing, which is the worst moment to find out. The others hold the four properties above, and one asserts that `release-engine.yml`'s `dry_run` still defaults to `true`, so if that ever changes this file's reasoning is corrected rather than silently stale.

## `OP-144` — and he found it within the hour, by installing 0.4.8

He ran the release and got the refusal this work shipped. **Every word of it is the fix working**: it names `R-84`, says nothing was changed, makes no 302 MB copy, and contains no command line.

**And then it dead-ends**, which is the entry:

- the console says *"Open ScrapeX in Chrome; the Engine page says what is missing"* — but `cli._cmd_ui` returns before `create_app`, so **no page is served at all**;
- the panel's «Upgrade database» correctly refuses;
- `native.STANDALONE_COMMANDS` holds six commands and **none of them is start-fresh, carry-over or restore**;
- and `storage.start_fresh` — which does exactly what is needed and **keeps** the old file by renaming it — is reachable only from that unserved page.

**The capability exists and its only door is inside the thing that will not start.** That is `R-81`'s subject and `OP-124`'s shape. Recorded with his own transcript, and not fixed here: it needs a native command plus a control, and how a destructive-adjacent button asks is his call.

His warehouse was renamed aside on his instruction — `scrapex-engine.v10-kept-2026-09-04.old.db`, 316,760,064 bytes, **kept** — and `database-status` now answers `Missing`, which the launch path creates rather than refuses.

`R-42`: secondary session — merging is his call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
