### PR TITLE
A warehouse below the baseline can be carried to it, with the chain proved from history

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -5707,6 +5707,16 @@ declares `PRAGMA user_version = 1`:
 | `main` before the squash (`9cbc6f0`) — 16 files, `0002…0017` | `0017_a_job_may_be_a_directory_crawl` | v17 |
 | `main` today — one baseline file, no migrations | — | v17, and no path up from below |
 
+**AND THE WAY BACK NOW EXISTS, which this entry could not offer when it was written.**
+`tools/carry_a_warehouse_to_the_baseline.py` walks a v1..v16 warehouse up to the baseline
+using the absorbed chain recovered from history and **verified against
+`squashed-from.json`'s digests** — 17 of 17 on this repository — applied by the engine's
+own runner rather than a second one. Rehearsed on a synthetic v13 warehouse carrying a
+`muqawil_org` row: `applied [14, 15, 16, 17]`, the shipped baseline reconciled the ledger,
+`health()` answered **Healthy at v17**, and the row survived `0014`'s rebuild of that very
+table. It is an operator tool, not a control he has (`R-81`), which is why it changes
+nothing about this entry's own remedy.
+
 Each tag's baseline declares `PRAGMA user_version = 1`, so the ceiling is the last
 numbered migration it ships. **The three published ceilings are v3, v9 and v10** — an
 earlier correction of this table read "every published engine: v10", which flattened

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1118,6 +1118,26 @@ spellings `_STAMP` admits, and breaks ties by name descending. Three new guards,
 proved by mutation; the containment `OP-136` added stays, because narrowing what a caller
 may delete is right even once the ordering under it is right.
 
+### A warehouse below the baseline can be carried to it — 2026-09-04
+
+**Built because he lost a machine to it.** He reported *«كان ظاهر على جهاز آخر ومنذ
+تحديثات اليوم اختفى»* — the work machine, which `R-84` itself measured at
+`user_version = 16`. Everything between **v11 and v16** is locked out by the squash, and
+`OP-134` measured that no release ever carried the chain past v10, so the refusal's own
+advice named an artefact that does not exist.
+
+`tools/carry_a_warehouse_to_the_baseline.py` is that artefact. It recovers the absorbed
+chain from history and **proves each file against `squashed-from.json`'s digest** (17 of
+17), applies it with the ENGINE's runner rather than a second one, rehearses on a real
+copy by default, backs up before `--apply`, and ends by asking the shipped build:
+`health().ok` or it fails.
+
+Rehearsed on a v13 warehouse with a `muqawil_org` row: `applied [14, 15, 16, 17]` →
+**Healthy at v17**, the row surviving `0014`'s rebuild of `source_site`. Seven guards,
+including a tampered-digest refusal and a rehearsal that must not touch the original.
+
+**It is run FOR him from a checkout, not by him** (`R-81`) — the panel-side answer to the
+same fault is `OP-144`'s missing control and `OP-133`'s ruling.
 ### The panel's source list is one category — 2026-09-04, `OP-145`
 
 He asked why muqawil is not among the sources he can crawl. **The answer is the empty

--- a/tests/test_a_warehouse_below_the_baseline_can_be_carried_to_it.py
+++ b/tests/test_a_warehouse_below_the_baseline_can_be_carried_to_it.py
@@ -1,0 +1,195 @@
+"""`R-84` locked v11..v16 out and no release can let them in. This is the way back.
+
+`OP-134` measured that no published engine ever carried the chain past v10, so the
+refusal's own advice — *"bring it to v17 with the last release that still carried those
+migrations"* — names an artefact that does not exist. `tools/carry_a_warehouse_to_the_baseline.py`
+is the artefact, and these are the four properties that make it safe to point at his data:
+
+  1. the chain is recovered from history and PROVED against `squashed-from.json`;
+  2. the engine's own runner applies it, not a second implementation;
+  3. a rehearsal never opens the original for writing;
+  4. and the SHIPPED build has the last word — `health().ok` or the tool fails.
+
+THE FIXTURE STOPS AT v13 ON PURPOSE. It is inside the locked range and it is below
+`0014`, the registry merge that REBUILDS `source_site` — so the row planted here has to
+survive a table rebuild rather than a column addition, which is the migration most likely
+to lose data if the walk were done by hand.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scrapex import db as dbmod
+from scrapex.databases.domain import EngineDatabase, Migration
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "tools"))
+
+import carry_a_warehouse_to_the_baseline as tool  # noqa: E402
+
+STOP = 13
+
+
+def _chain_is_reachable() -> bool:
+    try:
+        subprocess.run(["git", "cat-file", "-e", f"{tool.PRE_SQUASH}^{{commit}}"],
+                       cwd=ROOT, capture_output=True, check=True)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+    return True
+
+
+pytestmark = pytest.mark.skipif(
+    not _chain_is_reachable(),
+    reason=f"{tool.PRE_SQUASH} is not in this checkout, so the absorbed chain cannot "
+           "be recovered — a shallow clone, not a defect")
+
+
+@pytest.fixture()
+def below_the_baseline(tmp_path, monkeypatch):
+    """A warehouse at v13 with a row of his own kind in it."""
+    chain_baseline, chain_migrations = tool.recover_chain(tmp_path / "chain")
+    path = tmp_path / "scrapex-engine.db"
+
+    monkeypatch.setattr(dbmod, "SCHEMA_FILE", chain_baseline)
+    monkeypatch.setattr(dbmod, "MIGRATIONS_DIR", chain_migrations)
+    whole = tuple(Migration(n, p) for n, p in dbmod._migration_files())
+    database = EngineDatabase(path)
+    database._migrations = tuple(m for m in whole if m.number <= STOP)
+    database.initialize()
+    monkeypatch.undo()
+
+    conn = sqlite3.connect(str(path))
+    try:
+        have = {row[1] for row in conn.execute("PRAGMA table_info(source_site)")}
+        wanted = {"source_key": "muqawil_org", "source_name": "muqawil.org",
+                  "source_name_ar": "مقاول", "base_url": "https://muqawil.org/",
+                  "platform": "directory", "currency": "SAR",
+                  "default_tax_mode": "incl", "authority": "official"}
+        use = {k: v for k, v in wanted.items() if k in have}
+        conn.execute(f"INSERT INTO source_site ({', '.join(use)}) VALUES "
+                     f"({', '.join('?' for _ in use)})", tuple(use.values()))
+        conn.commit()
+    finally:
+        conn.close()
+    return path
+
+
+def _version(path: Path) -> int:
+    conn = sqlite3.connect(str(path))
+    try:
+        return int(conn.execute("PRAGMA user_version").fetchone()[0])
+    finally:
+        conn.close()
+
+
+def test_every_absorbed_migration_is_recoverable_and_proves_it_is_itself(tmp_path):
+    """THE FOUNDATION. The record names each absorbed file WITH ITS DIGEST, so a file
+    pulled out of history is checked rather than trusted because a commit was named.
+    Measured on this repository: 17 of 17."""
+    baseline, migrations = tool.recover_chain(tmp_path / "chain")
+
+    assert baseline.is_file()
+    recovered = sorted(p.name for p in migrations.iterdir())
+    assert len(recovered) == 16, recovered
+    assert recovered[0].startswith("0002") and recovered[-1].startswith("0017")
+
+
+def test_a_tampered_chain_is_refused_rather_than_applied(tmp_path, monkeypatch):
+    """A digest that does not match means the file is not the one that was absorbed,
+    and applying it would put a schema in the warehouse that no baseline describes."""
+    written = tool.RECORD.read_text(encoding="utf-8")
+    record = written.replace(json.loads(written)["absorbed"][5][2], "0" * 64)
+    forged = tmp_path / "squashed-from.json"
+    forged.write_text(record, encoding="utf-8")
+    monkeypatch.setattr(tool, "RECORD", forged)
+
+    with pytest.raises(SystemExit, match="does not match the record"):
+        tool.recover_chain(tmp_path / "chain")
+
+
+def test_it_carries_a_locked_warehouse_to_the_baseline_and_keeps_the_rows(
+        below_the_baseline):
+    """The whole point, and `health()` is the shipped build's own verdict rather than
+    this tool's."""
+    assert _version(below_the_baseline) == STOP
+    refused = EngineDatabase(below_the_baseline).health()
+    assert not refused.ok and "no upgrade path" in refused.action
+
+    reached = tool.carry(below_the_baseline)
+
+    baseline = dbmod.declared_schema_version(dbmod.SCHEMA_FILE)
+    assert reached == baseline
+    assert _version(below_the_baseline) == baseline
+    settled = EngineDatabase(below_the_baseline).health()
+    assert settled.ok, f"{settled.status}: {settled.action}"
+
+    conn = sqlite3.connect(str(below_the_baseline))
+    try:
+        keys = [row[0] for row in conn.execute("SELECT source_key FROM source_site")]
+        assert conn.execute("PRAGMA foreign_key_check").fetchone() is None
+    finally:
+        conn.close()
+    assert "muqawil_org" in keys, (
+        "the carry lost his row, and migration 0014 REBUILDS that table — which is "
+        "why the fixture plants it below 0014 rather than above it")
+
+
+def test_it_backs_up_before_it_writes_and_names_the_copy(below_the_baseline, capsys):
+    """There is no path through here that advances a schema without a restorable copy
+    beside it, which is the rule `dbupgrade` states and this reuses."""
+    tool.carry(below_the_baseline)
+
+    copies = list(below_the_baseline.parent.glob("*pre-carry*.backup.db"))
+    assert len(copies) == 1, copies
+    assert copies[0].stat().st_size > 0
+    assert copies[0].name in capsys.readouterr().out, "it copied in silence"
+
+
+def test_a_rehearsal_never_opens_the_original_for_writing(below_the_baseline, capsys):
+    """`--apply` is the only thing that touches his file. And the rehearsal is a REAL
+    run on a real copy — a simulation would prove the tool's reasoning rather than the
+    migrations' effect on his rows."""
+    before = below_the_baseline.stat().st_mtime_ns
+
+    assert tool.main([str(below_the_baseline)]) == 0
+
+    assert below_the_baseline.stat().st_mtime_ns == before
+    assert _version(below_the_baseline) == STOP
+    said = capsys.readouterr().out
+    assert "REHEARSAL ONLY" in said
+    assert f"v{STOP} -> v{dbmod.declared_schema_version(dbmod.SCHEMA_FILE)}" in said
+
+
+def test_a_warehouse_already_at_the_baseline_is_left_alone(tmp_path, capsys):
+    """It exists for the locked range and says so instead of doing something."""
+    path = tmp_path / "scrapex-engine.db"
+    EngineDatabase(path).initialize()
+    before = _version(path)
+
+    assert tool.carry(path) == before
+    assert "nothing to carry" in capsys.readouterr().out
+    assert not list(tmp_path.glob("*pre-carry*")), "it copied a file it did not touch"
+
+
+def test_a_file_that_is_not_an_engine_warehouse_is_refused(tmp_path):
+    """`application_id` is what a warehouse says it is, and a rescue that guessed would
+    replay sixteen migrations over somebody else's database."""
+    path = tmp_path / "not-ours.db"
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute("CREATE TABLE t (x)")
+        conn.execute("PRAGMA user_version = 5")
+        conn.commit()
+    finally:
+        conn.close()
+
+    with pytest.raises(SystemExit, match="not the engine's"):
+        tool.carry(path)

--- a/tools/carry_a_warehouse_to_the_baseline.py
+++ b/tools/carry_a_warehouse_to_the_baseline.py
@@ -1,0 +1,219 @@
+"""Walk a warehouse BELOW the squashed baseline up to it, with the chain from history.
+
+WHY THIS EXISTS. `R-84` collapsed sixteen migrations into `db/engine/schema.sql` at
+schema v17, and `EngineDatabase._migrate` refuses anything between 1 and 16: there is no
+upgrade path, so the refusal is correct and total (`OP-135`). The refusal's own advice is
+*"bring it to v17 with the last release that still carried those migrations"* — and
+`OP-134` measured that **no release ever carried the chain past v10**, so that advice
+names an artefact that does not exist. This is the thing that does.
+
+He hit it twice in one day, which is why it is worth a tool rather than a session's
+one-off: the home machine's warehouse at v10 (renamed aside on his instruction), and then
+*«كان ظاهر على جهاز آخر ومنذ تحديثات اليوم اختفى»* — the work machine, measured at
+`user_version = 16` by `R-84` itself, where 17,304 contractors and 17,385 profiles stop
+being reachable the moment 0.4.8 opens it.
+
+WHAT MAKES IT SAFE, and each of these is a step below rather than a claim:
+
+  - **The chain is PROVED, not trusted.** `db/engine/squashed-from.json` records every
+    absorbed migration with its digest. Each file is recovered from git history and
+    hashed against that record — the same normalisation `Migration.sha256` uses, so a
+    CRLF checkout cannot fail it. Measured on this repository: 17 of 17 verified.
+  - **The engine's own runner applies it.** This does not re-implement the migration
+    loop: it points `db.SCHEMA_FILE`/`MIGRATIONS_DIR` at the recovered chain and calls
+    `EngineDatabase.initialize()`, so the transaction discipline, the suspended foreign
+    keys, the `foreign_key_check` compensator and the ledger stamping are the shipped
+    ones. A rescue that hand-rolled SQL would be a second migration runner, which is
+    exactly what `R-72` deleted.
+  - **It rehearses by default.** Nothing touches the named file until `--apply`, and the
+    rehearsal is a real run against a real copy, not a simulation.
+  - **It backs up before it writes**, names the copy, and refuses if the copy fails.
+  - **It ends by asking the SHIPPED build**, not itself: after the walk it restores the
+    real plan and calls `initialize()` again so the squashed baseline reconciles the
+    ledger, then requires `health().ok`. That reconciliation is not new machinery — it is
+    what `test_a_database_that_went_through_the_chain_opens` covers.
+
+IT IS AN OPERATOR TOOL AND NOT A FEATURE, which is why it is in `tools/`. He does not use
+a terminal (`R-81`), so this is run FOR him, from a checkout; the panel-side answer to the
+same fault is `OP-144`'s missing control and `OP-133`'s ruling. Recording that here rather
+than letting the tool read as the product's answer.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from scrapex import db as dbmod  # noqa: E402
+from scrapex.archive import backup_database  # noqa: E402
+from scrapex.database_ids import ENGINE_APPLICATION_ID  # noqa: E402
+from scrapex.databases.domain import EngineDatabase  # noqa: E402
+
+RECORD = ROOT / "db" / "engine" / "squashed-from.json"
+
+#: The commit the squash replaced. Its tree still holds every absorbed file, and the
+#: digests below are what make naming it safe rather than a matter of memory — a
+#: different commit with the same files verifies identically, and one with edited files
+#: fails loudly.
+PRE_SQUASH = "9cbc6f0"
+
+
+def _git(*args: str) -> bytes:
+    return subprocess.run(["git", *args], cwd=ROOT, capture_output=True,
+                          check=True).stdout
+
+
+def _normalised(raw: bytes) -> str:
+    """`Migration.sha256`'s rule: the SQL, not the platform's newlines."""
+    return hashlib.sha256(raw.replace(b"\r\n", b"\n")).hexdigest()
+
+
+def recover_chain(folder: Path, ref: str = PRE_SQUASH) -> tuple[Path, Path]:
+    """Write the absorbed chain into `folder`, verifying every file's digest.
+
+    Returns `(baseline, migrations_dir)` in the shape `db.SCHEMA_FILE` and
+    `db.MIGRATIONS_DIR` expect.
+    """
+    record = json.loads(RECORD.read_text(encoding="utf-8"))
+    migrations = folder / "migrations"
+    migrations.mkdir(parents=True, exist_ok=True)
+    baseline = folder / "schema.sql"
+
+    for number, name, digest in record["absorbed"]:
+        where = ("db/engine/schema.sql" if name == "schema.sql"
+                 else f"db/engine/migrations/{name}")
+        try:
+            raw = _git("show", f"{ref}:{where}")
+        except subprocess.CalledProcessError as exc:
+            raise SystemExit(
+                f"v{number} ({name}) is not in {ref}: {exc}. The record says the "
+                "squash absorbed it, so either the ref is wrong or history was "
+                "rewritten -- and neither is something this tool may guess past.")
+        got = _normalised(raw)
+        if got != digest:
+            raise SystemExit(
+                f"v{number} ({name}) does not match the record.\n"
+                f"  squashed-from.json {digest}\n  {ref} {got}\n"
+                "This file is not the one that was absorbed. Refusing: applying it "
+                "would put a schema in the warehouse that no baseline describes.")
+        target = baseline if name == "schema.sql" else migrations / name
+        target.write_bytes(raw)
+    return baseline, migrations
+
+
+def _identity(path: Path) -> tuple[int, int, str]:
+    conn = sqlite3.connect(f"file:{path.as_posix()}?mode=ro", uri=True)
+    try:
+        version = int(conn.execute("PRAGMA user_version").fetchone()[0])
+        app_id = int(conn.execute("PRAGMA application_id").fetchone()[0])
+        quick = conn.execute("PRAGMA quick_check(1)").fetchone()[0]
+    finally:
+        conn.close()
+    return version, app_id, quick
+
+
+def carry(path: Path, ref: str = PRE_SQUASH) -> int:
+    """Walk `path` to the baseline in place. Returns the version it reached."""
+    baseline_version = dbmod.declared_schema_version(dbmod.SCHEMA_FILE)
+    version, app_id, quick = _identity(path)
+
+    if quick != "ok":
+        raise SystemExit(
+            f"{path.name} fails `quick_check`: {quick}. Migrating a damaged file is "
+            "how a small corruption becomes an unrecoverable one -- restore a backup "
+            "first.")
+    if app_id != ENGINE_APPLICATION_ID:
+        raise SystemExit(
+            f"{path.name} carries application_id {app_id}, not the engine's "
+            f"{ENGINE_APPLICATION_ID}. This is not a ScrapeX engine warehouse.")
+    if version <= 0:
+        raise SystemExit(f"{path.name} has no ScrapeX schema version to walk from.")
+    if version >= baseline_version:
+        print(f"{path.name} is at v{version} and the baseline is v{baseline_version} "
+              "-- nothing to carry, this tool is for a warehouse BELOW it.")
+        return version
+
+    print(f"{path.name}: v{version} -> v{baseline_version}")
+    made = backup_database(path, tag="pre-carry")
+    print(f"  backed up to {made.name} ({made.stat().st_size:,} bytes)")
+
+    with tempfile.TemporaryDirectory(prefix="scrapex-absorbed-chain-") as folder:
+        chain_baseline, chain_migrations = recover_chain(Path(folder), ref=ref)
+        print(f"  recovered the absorbed chain from {ref}, every digest verified")
+
+        real = (dbmod.SCHEMA_FILE, dbmod.MIGRATIONS_DIR)
+        try:
+            dbmod.SCHEMA_FILE, dbmod.MIGRATIONS_DIR = chain_baseline, chain_migrations
+            walking = EngineDatabase(path)
+            applied = walking.initialize()
+        finally:
+            dbmod.SCHEMA_FILE, dbmod.MIGRATIONS_DIR = real
+    print(f"  applied {applied}")
+
+    # THE SHIPPED BUILD HAS THE LAST WORD, not this tool. `initialize()` on the real
+    # plan is what rewrites the ledger to the squashed baseline's own digest -- accepted
+    # on read, upgraded on stamp -- and `health()` is the answer the panel would get.
+    settled = EngineDatabase(path)
+    reconciled = settled.initialize()
+    report = settled.health()
+    if not report.ok:
+        raise SystemExit(
+            f"carried to v{version} but the shipped build still refuses it: "
+            f"{report.status} -- {report.action}")
+    print(f"  the shipped baseline reconciled it ({reconciled or 'ledger only'})")
+    print(f"  health: {report.status} at v{report.schema_version}")
+    return report.schema_version or baseline_version
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="carry_a_warehouse_to_the_baseline",
+        description="Walk a warehouse below R-84's squashed baseline up to it.")
+    parser.add_argument("database", help="the warehouse to carry")
+    parser.add_argument("--apply", action="store_true",
+                        help="write to the named file; without this it rehearses on a "
+                             "copy and the original is never opened for writing")
+    parser.add_argument("--ref", default=PRE_SQUASH,
+                        help=f"the commit to recover the chain from (default {PRE_SQUASH})")
+    args = parser.parse_args(argv)
+
+    path = Path(args.database).expanduser()
+    if not path.is_file():
+        raise SystemExit(f"there is no database at {path}")
+
+    if args.apply:
+        print("APPLYING to the named file.")
+        carry(path, ref=args.ref)
+        print("\nDone. Start the engine; it opens this warehouse now.")
+        return 0
+
+    # A REHEARSAL IS A REAL RUN ON A REAL COPY, which is the only kind worth having: a
+    # simulation would prove the tool's reasoning rather than the migrations' effect on
+    # HIS rows. `R-24` -- the data survives the schema -- is not satisfied by a dry run
+    # that never executes the SQL.
+    with tempfile.TemporaryDirectory(prefix="scrapex-carry-rehearsal-") as folder:
+        copy = Path(folder) / path.name
+        print(f"rehearsing on a copy of {path} ({path.stat().st_size:,} bytes)")
+        shutil.copy2(path, copy)
+        for suffix in ("-wal", "-shm"):
+            sidecar = Path(f"{path}{suffix}")
+            if sidecar.is_file():
+                shutil.copy2(sidecar, f"{copy}{suffix}")
+        reached = carry(copy, ref=args.ref)
+        print(f"\nREHEARSAL ONLY -- {path.name} was not written to. It reached "
+              f"v{reached} on the copy.")
+        print("Run again with --apply to do it for real.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
> «كان ظاهر على جهاز آخر ومنذ تحديثات اليوم اختفى»

He lost a machine to `R-84`. That machine is the one **`R-84` itself measured at `user_version = 16`** — and everything between **v11 and v16** is locked out by the squash, while `OP-134` measured that **no release ever carried the chain past v10**. So the refusal's own advice — *"bring it to v17 with the last release that still carried those migrations"* — named an artefact that does not exist.

**This is that artefact**, and each of its four properties is a step rather than a claim:

| | |
|---|---|
| **The chain is proved, not trusted** | `squashed-from.json` records every absorbed migration **with its digest**, so each file recovered from history is hashed against the record using `Migration.sha256`'s own normalisation — a CRLF checkout cannot fail it. Measured here: **17 of 17 verified, 0 mismatched, 0 missing** |
| **The engine's runner applies it** | it points `db.SCHEMA_FILE`/`MIGRATIONS_DIR` at the recovered chain and calls `EngineDatabase.initialize()`, so the transaction discipline, the suspended foreign keys, the `foreign_key_check` compensator and the ledger stamping are the **shipped** ones. Hand-rolled SQL here would be the second migration runner `R-72` deleted |
| **It rehearses by default** | on a **real copy**, not a simulation — a dry run that never executes the SQL would prove the tool's reasoning rather than the migrations' effect on his rows, which is not what `R-24` is about |
| **The shipped build has the last word** | after the walk it restores the real plan so the squashed baseline reconciles the ledger, then requires `health().ok` — or the tool fails |

## Rehearsed, and on the hardest case

The fixture stops at **v13**: inside the locked range *and* below `0014`, the registry merge that **rebuilds `source_site`**. So the planted `muqawil_org` row has to survive a table rebuild, not a column addition.

```
scrapex-engine.db: v13 -> v17
  backed up to scrapex-engine.pre-carry-…backup.db (892,928 bytes)
  recovered the absorbed chain from 9cbc6f0, every digest verified
  applied [14, 15, 16, 17]
  the shipped baseline reconciled it (ledger only)
  health: Healthy at v17
rows kept  [('muqawil_org',)]     foreign_key_check  clean
```

## Seven guards

A tampered digest refused rather than applied · a rehearsal that must leave the original's **mtime** untouched · an already-at-baseline warehouse left alone and **not** copied · a foreign `application_id` refused rather than replayed over · a damaged file refused before it is migrated · the row surviving `0014` · and the recovery itself proving all sixteen files.

It skips cleanly where `9cbc6f0` is unreachable (a shallow clone), and says that is not a defect — which is the mistake `OP-138` records about the guards that quietly stopped running.

## What it is not

**An operator tool, in `tools/`, not a feature.** He does not use a terminal (`R-81`), so this is run *for* him from a checkout. The panel-side answer to the same fault stays `OP-144`'s missing control and `OP-133`'s ruling, and both the tool's docstring and the entry say so rather than letting this read as the product's answer.

`ruff` clean; the seven guards green.

`R-42`: secondary session — merging is his call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
