### PR TITLE
The tool is a store of apps, and ours is one of them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,8 +41,16 @@ the Google Sheet the mbiX Excel add-in reads. Setup and data flow: [README.md](R
 ## Rules
 
 - **He works only from the extension panel — never a terminal.** A `scrapex ...` command
-  is not an answer to him. A capability with no control in the panel has no control; say
-  that instead of offering a command line.
+  is not an answer to him, and a capability with no control in the panel has no control.
+- **A capability is a contract; apps implement it.** Our engines — the crawler,
+  `scrapex/enrichment/` — are apps under the contract, not the contract itself. An
+  open-source project that does the same job its own way is installed **beside** ours,
+  never instead of it, and installing one never pauses ours: ours grows where the
+  external ones do not serve. Choose per run by measured performance, not by who wrote
+  it. Dropping an app must cost no more than adding one. The registries to extend are
+  `scrapex/connectors/factory.py` and `scrapex/enrichment/providers/__init__.py`.
+- **A recorded plan is not an approved plan.** Nothing in a milestone is built until he
+  reviews it and says what he wants.
 - **A button that cannot work is worse than no button.** If the route 404s, do not draw
   the control.
 - **Diagnose, confirm, then fix.** Prove the cause with evidence, ask before editing.


### PR DESCRIPTION
His ruling of 2026-09-04, in the words he confirmed before it was recorded.

## I wrote it backwards first

My first attempt said a capability with an open-source project behind it is *"integrated
and used, not reimplemented"*, with building our own as *"the exception"*. He corrected it:

> بدل ما ابنى من الصفر استخدم ايضا المتاح وكأنه تطبيق يمكن اضافته للاداة — ولكن دا لا يمنع
> اطلاقا من استكمال وتحديث org enrichment الخاص بى، لانى سوف اطوره فى الاتجاه الذى لا تلبى
> المصادر الخارجية احتياجاتى فيه.
>
> الفكرة كالموبيل: يوجد تطبيقات اصلية مع الشركة، ولكن يوجد ايضا store يمكن من خلاله تحميل
> تطبيقات تعمل نفس الشغل ولكن باسلوبها.

It is not integrate-**instead-of**-build. It is **both, side by side, as interchangeable
apps behind one contract.** Adding `Scrapy` does not pause our crawler; adding an
enrichment project does not pause `scrapex/enrichment/` — it frees ours to grow where the
external ones do not serve. Choice is by measured performance, not authorship. Whether an
external app is ever dropped is an outcome to measure later, not a decision now.

The retraction is on the record where the wrong version was published:
[#495](https://github.com/muhammadbayoumi/ScrapeX/issues/495#issuecomment-5545880161).

## The shape already exists twice, which is why the rule names those two files

- `scrapex/connectors/factory.py` — `_BUILDERS`, an explicit family→connector registry
  where an unimplemented family **fails loud**, never silently. `HISTORY_CAPABLE` beside it
  declares which apps hold an extra capability.
- `scrapex/enrichment/providers/__init__.py` — `ProviderSpec` already carries `key`,
  `label`, `available()`, `reason()`, `version` and `estimated_requests_per_entity`: an id,
  a display name, whether it can run, why not, its version and its cost. **An app-store
  entry in all but name.**

What is missing from it is performance **measured** rather than estimated, and something
that chooses on it.

## What the rule deliberately does not settle

[#565](https://github.com/muhammadbayoumi/ScrapeX/issues/565), to be answered at the first
app we add, on his instruction: who chooses per run · what "strongest" means when a faster
app returns worse rows · how to compare without paying the politeness budget twice ·
whether the store is a surface he sees.

## Paid for, as the file's own rule requires

The panel rule loses its third line — *"say that instead of offering a command line"* said
the same thing as the clause before it. **137 → 145 lines**, still under the 150 the file
sets itself.

The second rule added is the other half of what he said: **a recorded plan is not an
approved plan.** Nothing in a milestone is built until he reviews it and says what he
wants — which is now a rule rather than an inference from the research's closing
paragraphs.
