### PR TITLE
A source registered in the code is listed before it has data (#330, re-based on main)

### DIFF
--- a/docs/archive/BACKLOG.md
+++ b/docs/archive/BACKLOG.md
@@ -185,7 +185,7 @@ Related and separate: `fields.delete_view` is `DELETE FROM saved_view WHERE save
 ### OP-73 · `POST /api/fields` has no catalogue branch, so hiding a contractor column returns 404
 
 **Found 2026-08-26.** Step 0 of the plan gave `GET /api/fields` a dataset branch
-([scrapex/webui/app.py:2310](../scrapex/webui/app.py#L2310)) and **the POST at
+([scrapex/webui/app.py:2399](../scrapex/webui/app.py#L2399)) and **the POST at
 [:2349](../scrapex/webui/app.py#L2396) never got one.** It runs the price machinery
 unconditionally, and its seeding is keyed on `BROWSE_COLUMNS`: `wanted = [key for key, _ in
 BROWSE_COLUMNS if key in present or key == body.get("field_key")]`.
@@ -201,7 +201,7 @@ The comprehension iterates `BROWSE_COLUMNS`, so a contractor key never enters `w
 the Choose-Columns panel builder at
 [grid.js:1205](../scrapex/webui/static/grid.js#L1205). Open the contractors table, hide a
 column from the column menu without opening Choose-Columns → 404. **And the comment at
-[app.py:1143](../scrapex/webui/app.py#L1143) describes this exact failure and says it was
+[app.py:1227](../scrapex/webui/app.py#L1227) describes this exact failure and says it was
 fixed** — the fix is `BROWSE_COLUMNS`-shaped, so it is products-only.
 
 **Nothing tests it:** every `POST /api/fields` test uses a products key, and all four
@@ -212,7 +212,7 @@ fixed** — the fix is `BROWSE_COLUMNS`-shaped, so it is products-only.
 
 ### OP-74 · `list(body["order"])` is unguarded: a 500 one way, a forged «this is your arrangement» the other
 
-**Found 2026-08-26.** [scrapex/webui/app.py:2460](../scrapex/webui/app.py#L2460) is
+**Found 2026-08-26.** [scrapex/webui/app.py:2549](../scrapex/webui/app.py#L2549) is
 `reorder(conn, source_key, list(body["order"]))` with no type check. Two failure modes,
 traced through [scrapex/fields.py:153](../scrapex/fields.py#L153):
 
@@ -235,8 +235,8 @@ and an unknown key.**
 ### OP-75 · `GET /api/fields` writes and commits on both branches, outside the write lock every `POST` pays for
 
 **Found 2026-08-26.** The GET commits inside `api_fields`
-([app.py:2354](../scrapex/webui/app.py#L2354)) while every `POST` goes through
-`_write` ([app.py:2238](../scrapex/webui/app.py#L2238)), which takes the lock for
+([app.py:2443](../scrapex/webui/app.py#L2443)) while every `POST` goes through
+`_write` ([app.py:2327](../scrapex/webui/app.py#L2327)), which takes the lock for
 the reason it states: *"A crawl in progress holds that lock."*
 
 > **THREE CITATIONS RE-DERIVED 2026-09-02, AND ALL THREE WERE ALREADY WRONG.** This entry
@@ -317,7 +317,7 @@ test.
 `list_fields`, which is `SELECT ... FROM dataset_field WHERE source_key = ?` with no
 intersection against the dataset's real schema. The intersection that makes `OP-53`'s eleven
 price-path rows inert lives **only on the read path**, in `_dataset_fields`
-([app.py:2301](../scrapex/webui/app.py#L2301)). So the eleven are invisible in the
+([app.py:2390](../scrapex/webui/app.py#L2390)). So the eleven are invisible in the
 chooser and still occupy `display_order` slots whenever anything is reordered.
 
 > **This paragraph carried that sentence TWICE, with two different line numbers, until
@@ -351,7 +351,7 @@ second surface.
 **Found 2026-08-26.** Zero hits for `cache-control|etag|last-modified|max-age` across
 `webui/app.py`, `reports.py`, `extract/service.py` and `fields.py`, and zero for
 `lru_cache|functools.cache|@cache` across **all** of `scrapex/`. None of the three registered
-middlewares ([app.py:573](../scrapex/webui/app.py#L573)) adds a header. Every open of a data
+middlewares ([app.py:574](../scrapex/webui/app.py#L574)) adds a header. Every open of a data
 tab recomputes the whole payload, measured at 24.26 MB over 17,304 rows for `contractors`.
 
 **Recorded as a characteristic rather than a defect to fix, and he ruled against caching
@@ -496,7 +496,7 @@ rhetoric in a measurement file is how a number stops being checked.
 *"The router-factory pattern is already applied inside the same file to four
 fragments"* — it is not inside the file. `grep -nE 'def [a-z_]*(router|_api)\w*\(' scrapex/webui/app.py`
 returns nothing. All four factories live in **sibling modules** and are imported
-(`app.py:56`, `:161`, `:162`):
+(`app.py:57`, `:161`, `:162`):
 
 | module | lines | routes |
 |---|---|---|
@@ -565,8 +565,8 @@ And only one of the **two** `worker_alive` computations was fixed:
 
 | where | what it calls | verdict |
 |---|---|---|
-| `scrapex/webui/app.py:1751` — `/api/health` | the new two-heartbeat `worker` verdict | correct; the panel reads this one (`extension/engine.js:38`) |
-| `scrapex/webui/app.py:2821` — `_about` | `worker_is_alive(conn)`, single heartbeat | **the function the fix superseded** |
+| `scrapex/webui/app.py:1835` — `/api/health` | the new two-heartbeat `worker` verdict | correct; the panel reads this one (`extension/engine.js:38`) |
+| `scrapex/webui/app.py:2910` — `_about` | `worker_is_alive(conn)`, single heartbeat | **the function the fix superseded** |
 
 `_about` renders the engine's own `/settings` page
 (`scrapex/webui/templates/settings.html:151-160`), so **the engine still shows
@@ -574,7 +574,7 @@ And only one of the **two** `worker_alive` computations was fixed:
 engine is started at all.
 
 **Next action:** three separate things — the second `worker_alive` at
-`app.py:2821`; the heartbeat's behaviour under a held write lock; and the 409 on
+`app.py:2910`; the heartbeat's behaviour under a held write lock; and the 409 on
 `/api/storage/restore` with a mirror of
 `test_start_fresh_is_refused_while_a_crawl_runs`.
 
@@ -2163,7 +2163,7 @@ Two do not, and neither failure has anything to do with datasets:
 is a real route (`scrapex/webui/app.py` line 1294 **at `31c369e`**, which is what it
 was re-derived against and is not a pointer into HEAD; #257 moved
 
-is a real route (`scrapex/webui/app.py:1316`, re-derived at `31c369e`; #257 moved
+is a real route (`scrapex/webui/app.py:1400`, re-derived at `31c369e`; #257 moved
 it from 1223) and answers 200. So this is a wrong
 URL rather than a missing feature — one line, but it changes what a card does on
 his screen, which is why it was recorded instead of fixed inside a PR about the
@@ -2249,8 +2249,8 @@ diagnosis:** every step the engine announced succeeded, and then it could not re
 |---|---|---|
 | `db/` | [scrapex/db.py:22](../scrapex/db.py#L22), [scrapex/databases/domain.py:26](../scrapex/databases/domain.py#L26) | **yes** |
 | `sources.yaml` | [scrapex/config.py:55](../scrapex/config.py#L55) | **yes** |
-| `scrapex/webui/templates` | [scrapex/webui/app.py:316](../scrapex/webui/app.py#L316), [scrapex/extract/api.py:33](../scrapex/extract/api.py#L33) | **no** |
-| `scrapex/webui/static` | [scrapex/webui/app.py:386](../scrapex/webui/app.py#L386) | **no** |
+| `scrapex/webui/templates` | [scrapex/webui/app.py:317](../scrapex/webui/app.py#L317), [scrapex/extract/api.py:33](../scrapex/extract/api.py#L33) | **no** |
+| `scrapex/webui/static` | [scrapex/webui/app.py:387](../scrapex/webui/app.py#L387) | **no** |
 | `apps_script/StagingAppScript.txt` | [scrapex/outputs.py:214](../scrapex/outputs.py#L214) | **no** |
 
 **Only one of the three missing ones crashes, and that is the luck in it.**
@@ -3576,13 +3576,13 @@ deadline, and nothing was watching the two numbers together. Its baseline is als
 **Three consequences outlived the deadline itself**, all now fixed:
 
 * **The double click.** The panel re-enables its button the moment a request fails
-  (`extension/app.js:6122`), so a failure at ten seconds invited a second click while the
+  (`extension/app.js:6135`), so a failure at ten seconds invited a second click while the
   first build was still packing — two warehouse copies, two staging trees, and `_newest`
   free to hand the panel an archive from one build beside the manifest of the other.
 * **Nothing pruned local bundles, ever.** 372.6 MB per successful backup, kept for good.
   Only Drive was pruned (`extension/drive.js:65`, `KEEP = 3`).
 * **A killed engine leaks its staging tree.** The `rmtree` is in a `finally`
-  ([scrapex/webui/app.py:3135](../scrapex/webui/app.py#L3135)), so a process that dies
+  ([scrapex/webui/app.py:3224](../scrapex/webui/app.py#L3224)), so a process that dies
   skips it and leaves the bundle expanded — 1.5 GB. This, not a second build, is what
   actually survives a crash: the build is a thread inside the engine and cannot outlive it.
 
@@ -3590,20 +3590,20 @@ deadline, and nothing was watching the two numbers together. Its baseline is als
 `bundleBuild: 600000` ([extension/startup.js:33](../extension/startup.js#L33)) with a rule
 that deliberately excludes the two streaming sub-paths
 ([extension/startup.js:52](../extension/startup.js#L52)); a non-blocking
-`threading.Lock` ([scrapex/webui/app.py:2951](../scrapex/webui/app.py#L2951)) refusing a
+`threading.Lock` ([scrapex/webui/app.py:3040](../scrapex/webui/app.py#L3040)) refusing a
 concurrent build with the house 409; `BUNDLE_KEEP = 2`
-([scrapex/webui/app.py:2932](../scrapex/webui/app.py#L2932)) pruning **by stamp** so the
+([scrapex/webui/app.py:3021](../scrapex/webui/app.py#L3021)) pruning **by stamp** so the
 two files of one backup cannot be split; and an age-guarded sweep
-([scrapex/webui/app.py:2969](../scrapex/webui/app.py#L2969)) for orphaned staging.
+([scrapex/webui/app.py:3058](../scrapex/webui/app.py#L3058)) for orphaned staging.
 
 **Residual, named rather than closed.** The lock is in-process, which is correct here —
 `start_engine` refuses to spawn a second engine on a held port
 ([scrapex/native.py:304](../scrapex/native.py#L304)), and a crashed build leaves no
 survivor to race. An engine started by hand on another port would share the folder and
 defeat it; that is why the sweep keeps a 6-hour age guard
-([scrapex/webui/app.py:2935](../scrapex/webui/app.py#L2935)) rather than deleting any
+([scrapex/webui/app.py:3024](../scrapex/webui/app.py#L3024)) rather than deleting any
 
-([scrapex/webui/app.py:2925](../scrapex/webui/app.py#L2925)) rather than deleting any
+([scrapex/webui/app.py:3014](../scrapex/webui/app.py#L3014)) rather than deleting any
 staging tree it finds.
 
 **Two things this measurement exposed that belong to other tracks.**
@@ -4022,9 +4022,9 @@ local disk, so nothing was lost — but nothing on either side said so.
 2. **`zipfile.ZipFile(archive, "w")` created the file under its FINAL name immediately**,
    at zero bytes, and filled it over the ~33 s of the deflate.
 3. **`GET /api/bundle/archive` answers with the newest `.zip` by mtime**
-   ([scrapex/webui/app.py:2964](../scrapex/webui/app.py#L2964)), so it handed the panel the
+   ([scrapex/webui/app.py:3053](../scrapex/webui/app.py#L3053)), so it handed the panel the
 
-   ([scrapex/webui/app.py:2946](../scrapex/webui/app.py#L2946)), so it handed the panel the
+   ([scrapex/webui/app.py:3035](../scrapex/webui/app.py#L3035)), so it handed the panel the
    second build's empty, in-progress file.
 4. **Nothing compared what arrived with what the engine had described.** The pointer took
    `bytes` from the uploaded blob (0) and `sha256` from the manifest of the *complete*
@@ -4178,7 +4178,7 @@ after:   reports pending = [13, 14, 16]
 
 **`0014` is `one_source_registry`** — the merge of `site_profile` into `source_site`. A
 warehouse that never received it cannot resolve a dataset source at all, and the banner
-([scrapex/webui/app.py:1632](../scrapex/webui/app.py#L1632)) told its owner nothing was
+([scrapex/webui/app.py:1716](../scrapex/webui/app.py#L1716)) told its owner nothing was
 pending. That is the exact silence `pending_migrations`' own docstring says it exists to
 break: *"nothing said 'the database is one migration behind'; the product simply broke and
 the raw SQLite text was the only clue."*
@@ -4831,9 +4831,9 @@ conditionally.** Four legs, each re-read rather than argued:
 
 ```cited
 scrapex/webui/database_api.py:80   @router.get("/api/engine/health")   -- in create_domain_health_router
-scrapex/webui/app.py:627           include_router(create_domain_health_router(...))
-scrapex/webui/app.py:625           if databases is not None:          -- the gate above it
-scrapex/webui/app.py:1629          @app.get("/api/health")            -- a plain route, every start
+scrapex/webui/app.py:628           include_router(create_domain_health_router(...))
+scrapex/webui/app.py:626           if databases is not None:          -- the gate above it
+scrapex/webui/app.py:1713          @app.get("/api/health")            -- a plain route, every start
 scrapex/cli.py:852                 registry = None if args.db else DatabaseRegistry.defaults()
 ```
 
@@ -5224,7 +5224,7 @@ opposite one: which fences are EVIDENCE, not which are output.** So a fence decl
 
 ````
 ```cited
-scrapex/webui/app.py:625   if databases is not None:
+scrapex/webui/app.py:626   if databases is not None:
 ```
 ````
 
@@ -5341,7 +5341,7 @@ an hour after a fresh warehouse was created on his machine.
 > says so:
 >
 > ```cited
-> scrapex/webui/app.py:1890           out.extend(_dataset_listing())
+> scrapex/webui/app.py:1974           out.extend(_dataset_listing())
 > ```
 >
 > The route appends dataset-backed sites AFTER the manifest loop, and the comment beside
@@ -5630,7 +5630,7 @@ front of him.
 sentence (`scrapex/webui/templates/_storage.html:34-38`). **The panel renders the key.**
 
 ```cited
-extension/app.js:5206       <div class="kv"><span>Health</span><span>${esc(s.health.status)}</span></div>
+extension/app.js:5219       <div class="kv"><span>Health</span><span>${esc(s.health.status)}</span></div>
 ```
 
 So the Storage row on his only interface reads `healthy` where the engine's page reads
@@ -5793,7 +5793,7 @@ fact:
 ```cited
 scrapex/dbupgrade.py:55                  TOO_OLD = "Older than the schema baseline"
 scrapex/databases/domain.py:371              baseline = self._migrations[0].number
-scrapex/native.py:233        state["status"] == BEHIND for _, state in blocked
+scrapex/native.py:283        state["status"] == BEHIND for _, state in blocked
 ```
 
 `native.py` compared against a **literal** while `dbupgrade.BEHIND` documented itself as

--- a/docs/archive/LESSONS.md
+++ b/docs/archive/LESSONS.md
@@ -697,7 +697,7 @@ data entries and the runtime opens five.
     --add-data db;db
     --add-data sources.yaml;.
 
-Nothing else rode along. `scrapex/webui/app.py:386` computes
+Nothing else rode along. `scrapex/webui/app.py:387` computes
 `Path(__file__).parent / "static"`, which in a one-file build is
 `_MEIPASS/scrapex/webui/static` — exactly the path in the owner's error —
 `StaticFiles(check_dir=True)` refuses to mount a directory that is not there, and

--- a/docs/archive/REQUESTS.md
+++ b/docs/archive/REQUESTS.md
@@ -2174,7 +2174,7 @@ the decision.
 
 Measured above the transport, so the step is **parameterising what works, not inventing it**:
 a live backend address field (`extension/app.html:1772`), a switch that re-activates and
-re-adopts appearance, timezone and the UI contract (`extension/app.js:6367-6339`),
+re-adopts appearance, timezone and the UI contract (`extension/app.js:6380-6339`),
 abort-and-generation-bump on change (`extension/backend.js:68-77`), and a repaint guard
 whose own comment already names the multi-app hazard (`extension/data.js:74-76`):
 
@@ -2482,7 +2482,7 @@ reason is four links long, every one measured on the live engine rather than arg
 | link | evidence |
 |---|---|
 | 1 | the panel's crawl action sends `POST /api/jobs` with `source_keys` — `extension/app.js:4044` |
-| 2 | **CLOSED.** That route validated the key against `app.state.manifest` — a FILE — and now resolves it through `SourceResolver`, which asks the manifest first and `source_site` second: `scrapex/webui/app.py:3618`, beside the comment that has outlived four line numbers, *"fail before queueing, not mid-crawl"*. **That comment is why this row survived at all**: the number moved 43 lines in `#274`, again for the bundle-build lock, was 27 lines stale in between, moved a fourth time when `#302` landed 7,242 insertions, a FIFTH when `#301` landed on top of it -- 4064 to 4044 -- and a SIXTH here, found every time by the quoted call and not by any delta. Tier 1 only asks that a cited line EXIST, and a stale line that is not blank still exists — so the quoted text, not the number, is what kept finding it |
+| 2 | **CLOSED.** That route validated the key against `app.state.manifest` — a FILE — and now resolves it through `SourceResolver`, which asks the manifest first and `source_site` second: `scrapex/webui/app.py:3707`, beside the comment that has outlived four line numbers, *"fail before queueing, not mid-crawl"*. **That comment is why this row survived at all**: the number moved 43 lines in `#274`, again for the bundle-build lock, was 27 lines stale in between, moved a fourth time when `#302` landed 7,242 insertions, a FIFTH when `#301` landed on top of it -- 4064 to 4044 -- and a SIXTH here, found every time by the quoted call and not by any delta. Tier 1 only asks that a cited line EXIST, and a stale line that is not blank still exists — so the quoted text, not the number, is what kept finding it |
 | 3 | the manifest is `sources.yaml` — **12 price sources, and neither `muqawil` nor `contractors` is in it.** **This row was true when written and half of it is not now**: `0014` merged `site_profile` into `source_site` on 2026-08-29, which is what made a resolver possible rather than a third registry |
 | 4 | `scrapex/jobs.py`, which is what the button drives, contains **zero** references to `muqawil`, `generic_record`, `partitioncrawl`, `snapshotcrawl`, `contractors` or `dataset` — **and this turned out to be the DESIGN rather than the defect.** It asks a source for three things and none is price-specific, so the fix was a resolver and `jobs.py` is unchanged. **What remains is the collector**: the route now queues `muqawil_org`, and the worker still hands it to `capture_source` |
 

--- a/docs/archive/RULINGS.md
+++ b/docs/archive/RULINGS.md
@@ -1448,7 +1448,7 @@ Against the base plan's own decision table (`MIGRATION-PLAN.md:60`):
 > *"Export stays in the engine — it is SQL over SQLite, not a file move."*
 
 **Export is a user-facing capability that exists only in the engine today**
-(`scrapex/webui/app.py:1343`, `@app.get("/export/{source_key}.xlsx")`). Both statements
+(`scrapex/webui/app.py:1427`, `@app.get("/export/{source_key}.xlsx")`). Both statements
 are his, the newer one contradicts the older, and **the rule says a newer conflict is
 his to settle.** So it goes to him rather than being resolved here. `Jobs stay in the
 engine` (`:61`) is the same shape and rides with it.
@@ -3161,7 +3161,7 @@ SHA, both facts rather than judgements.
 2026-08-30, thirteen days later, still live in three places:
 
     scrapex/version.py:517      "latest_extension_version": VERSION
-    scrapex/webui/app.py:1761   "latest_extension_version": VERSION
+    scrapex/webui/app.py:1845   "latest_extension_version": VERSION
     extension/app.js:612, :646  drawn to the user as "Latest available extension"
 
 The engine answers *"what is the newest extension available"* with **its own number**, which

--- a/docs/archive/STATE.md
+++ b/docs/archive/STATE.md
@@ -658,7 +658,7 @@ whole time, so it had always passed.
 
 **`#297` LANDED WITH A DEFECT AND IT IS ON `main` NOW -- read `OP-119` before touching that
 guard.** Its fix repointed `settings.html` at `/api/engine/health`, which
-[`scrapex/webui/app.py:616`](../scrapex/webui/app.py#L616) mounts only `if databases is not
+[`scrapex/webui/app.py:617`](../scrapex/webui/app.py#L617) mounts only `if databases is not
 None`, and [`scrapex/cli.py:856`](../scrapex/cli.py#L856) sets `registry = None` for
 `scrapex ui --db <path>`. On that start the restart poll 404s its whole sixty-attempt budget
 and reports a failure that did not happen -- **the defect `OP-116` set out to fix, reproduced
@@ -1760,7 +1760,7 @@ written and 58 two days ago. It grows every time this is deferred.
 **The blocker, verified 2026-08-17 and still present:**
 `"latest_extension_version": VERSION` at
 [scrapex/version.py:517](../scrapex/version.py) and
-[scrapex/webui/app.py:1761](../scrapex/webui/app.py), drawn by
+[scrapex/webui/app.py:1845](../scrapex/webui/app.py), drawn by
 [extension/app.js:612](../extension/app.js) and `:646`.
 
 > **Re-verified 2026-08-19, and three of these citations had already drifted.**

--- a/extension/app.js
+++ b/extension/app.js
@@ -4771,9 +4771,17 @@ const SOURCE_ACTIONS = [
  * has a menu and pass.
  */
 function sourceActions(source) {
-  const base = source.kind === "dataset"
-    ? SOURCE_ACTIONS.filter((item) => item.proof === RESOLVES_A_DATASET)
-    : SOURCE_ACTIONS;
+  // A REGISTERED DIRECTORY HAS NEITHER SET. `kind: "directory"` is a source this
+  // build can crawl and has not crawled yet (`app.py` `_registered_directories`,
+  // his «المفروض المصادر تظهر بدون بيانات فهى مسجلة ومحفوظة فى الكود»): the
+  // manifest-only actions would 400 on it and the dataset-resolving ones would 404,
+  // because `/api/table/{key}` has no dataset to resolve. So it starts with none and
+  // gains exactly one below -- the crawl, which is the only thing it can do.
+  const base = source.kind === "directory"
+    ? []
+    : source.kind === "dataset"
+      ? SOURCE_ACTIONS.filter((item) => item.proof === RESOLVES_A_DATASET)
+      : SOURCE_ACTIONS;
   // ONE ROW PER TABLE THE CARD STANDS FOR, and the fold is why this exists.
   //
   // `R-47` collapsed muqawil's two datasets into one card. The menu kept ONE
@@ -4819,7 +4827,12 @@ function sourceActions(source) {
   // right collector, a runner exists and the migration lets the row be written, and he
   // presses nothing. `R-81` -- if it has no control in the panel it does not exist for the
   // one person the tool is for.
-  const crawlable = source.kind === "dataset" && source.site_key ? [{
+  // ON `site_key`, WHICH IS WHAT THE COMMENT ABOVE ALREADY SAID. It read "GUARDED ON
+  // `site_key` RATHER THAN ON THE KIND" while the code also demanded one exact kind --
+  // so a registered directory, which carries a `site_key` and can be crawled today,
+  // was refused the control by the half of the condition the comment disowned.
+  const crawlable = source.site_key
+      && (source.kind === "dataset" || source.kind === "directory") ? [{
     action: "update",
     label: "Update now",
     why: "Crawl this source once, immediately.",

--- a/scrapex/sourceboard.py
+++ b/scrapex/sourceboard.py
@@ -142,6 +142,48 @@ def from_warehouse(conn: sqlite3.Connection) -> tuple[Source, ...]:
     return tuple(found)
 
 
+def from_code() -> tuple[Source, ...]:
+    """The directories this BUILD can crawl, whether or not the warehouse knows them.
+
+    THE HALF `_LIFECYCLE` ABOVE SAYS IS MISSING, from the other side. That note records
+    that the generic side cannot say a site is *listed with no collector*; the gap that
+    actually bit him is its mirror — a site **with** a collector and no `source_site`
+    row at all, because that row is written by `catalog.register_site` from inside the
+    collector's own first run. On a warehouse created an hour earlier `muqawil_org` was
+    therefore in no list on any surface, while `directories.BUILDERS` had known how to
+    crawl it the whole time. He said what the rule should be:
+
+        «المفروض المصادر تظهر بدون بيانات فهى مسجلة ومحفوظة فى الكود»
+
+    `built`, NOT `registered`, and the vocabulary at the top of this module is why: a
+    collector exists for it in this build and nothing is scheduled, which is exactly
+    what `built` means here. `registered` is reserved for a source on the list with no
+    collector yet, which is a different thing and still only the manifest can say it.
+
+    THIS FUNCTION IS THE SINGLE ANSWER TO "WHICH DIRECTORIES DOES THE CODE REGISTER"
+    (`ENGINEERING` P1/Q1). `webui/app.py` had its own copy of that knowledge for a few
+    hours — the panel then listed muqawil and `scrapex sources` did not, which is the
+    split this module was written to end.
+    """
+    from . import directories
+
+    found = []
+    for key in sorted(directories.BUILDERS):
+        directory = directories.BUILDERS[key]()
+        found.append(Source(
+            key=key,
+            category=SourceCategory.CONTRACTORS,
+            name=directory.display_name,
+            base_url=directory.base_url,
+            # What collects it, which is the question `collector` answers. The
+            # warehouse side prints scope and dataset counts; before the first crawl
+            # there are neither, and naming the registry is the honest answer.
+            collector="directory · registered in the code",
+            state="built",
+            registry="code"))
+    return tuple(found)
+
+
 def board(conn: sqlite3.Connection | None = None,
           manifest_file: Path | str = MANIFEST_FILE,
           category: SourceCategory | None = None) -> tuple[Source, ...]:
@@ -153,6 +195,12 @@ def board(conn: sqlite3.Connection | None = None,
     found = list(from_manifest(manifest_file))
     if conn is not None:
         found.extend(from_warehouse(conn))
+    # THE CODE REGISTRY LAST, AND ONLY FOR WHAT THE WAREHOUSE HAS NOT SEEN. Once a
+    # directory has been crawled it has a `source_site` row, and that row carries its
+    # real lifecycle and dataset count — a second entry beside it would be the
+    # twice-drawn card `REQ-37` and `R-47` are about, in this list instead of on screen.
+    known = {one.key for one in found}
+    found.extend(one for one in from_code() if one.key not in known)
     if category is not None:
         found = [one for one in found if one.category == category]
     return tuple(sorted(found, key=lambda one: (one.category.value, one.key)))

--- a/scrapex/webui/app.py
+++ b/scrapex/webui/app.py
@@ -40,6 +40,7 @@ from .. import (
     provenance,
     rates,
     retention,
+    sourceboard,
 )
 from .. import db as dbmod
 from .. import version as engine_version
@@ -796,6 +797,89 @@ def create_app(
             } for row in catalogue]
         finally:
             general.close()
+
+    def _registered_directories(shown: list[dict]) -> list[dict]:
+        """Directories this BUILD can crawl, listed before they hold a single row.
+
+        HIS REQUIREMENT, in his words, after muqawil was missing from `Choose sites`
+        on a warehouse created an hour earlier: *«المفروض المصادر تظهر بدون بيانات فهى
+        مسجلة ومحفوظة فى الكود»* — a source registered in the code should appear
+        without data. It is the state `sourceboard` already names, from his own
+        earlier sentence: `registered`, *"on the list and waiting its turn"*.
+
+        WHY IT WAS MISSING, measured. `/api/sources` was the manifest plus
+        `_dataset_listing()`, and `_dataset_listing` groups `dataset_definition` rows —
+        so a directory appeared only AFTER its first crawl had stored something. On a
+        fresh warehouse (`dataset_definition` 0, `generic_record` 0) muqawil was in no
+        list at all, on either screen, while `directories.BUILDERS` had known how to
+        crawl it the whole time.
+
+        AND THE ENGINE WAS ALREADY READY FOR IT, which is what makes this a listing
+        gap and not a feature: `POST /api/jobs` resolves keys through
+        `SourceResolver` — *"asked of the registry, not the file"*, `R-78` — so
+        `muqawil_org` is accepted there today, and `directory_keys` already routes it
+        to the directory collector rather than the price one. The button had a target
+        and the panel drew no row for it.
+
+        `source_key` IS THE SITE KEY, deliberately, and this is the half that makes
+        the row pressable. A dataset card carries `dataset_key` (`contractors`), which
+        `POST /api/jobs` refuses; `BUILDERS` is keyed by `site_key`, which it accepts.
+        So a registered row names the thing that can actually be run.
+
+        IT IS SUPPRESSED ONCE THE SITE HAS A CARD. `REQ-37` and `R-47` are about
+        muqawil being drawn TWICE on one screen; a registered row beside its own
+        dataset card would be that defect again, so anything already listed — by
+        `source_key` or by `site_key` — wins.
+        """
+        listed = {row.get("source_key") for row in shown}
+        listed |= {row.get("site_key") for row in shown if row.get("site_key")}
+        rows = []
+        # ASKED OF `sourceboard`, NOT OF `directories` DIRECTLY (`ENGINEERING` P1/Q1).
+        # This function knew `BUILDERS` for a few hours and the cost was immediate: the
+        # panel listed muqawil and `scrapex sources` did not, so the product had two
+        # answers to "which sources exist". `sourceboard.from_code()` is the one answer;
+        # this route decorates it with the per-row facts the cards draw.
+        for source in sourceboard.from_code():
+            key = source.key
+            if key in listed:
+                continue
+            rows.append({
+                # `directory`, NOT `dataset`, and the difference is a dead button.
+                # The panel gates "Open the data table" on `kind == "dataset"`
+                # (`app.js` `sourceActions`), and that action reaches
+                # `/api/table/{key}` -- which 404s for a site holding no dataset yet.
+                # Borrowing the dataset marker to get the crawl control would have
+                # brought a dead one with it, which is the rule this codebase states
+                # as "a button that cannot work is worse than no button". The panel
+                # admits this kind to the crawl and to nothing else.
+                "kind": "directory",
+                "site_key": key,
+                "source_key": key,
+                "source_name": source.name,
+                "source_name_ar": "",
+                "base_url": source.base_url,
+                # `generic` is the marker the panel reads to hide the price-path row
+                # actions (Update, Wipe, Rename) that answer 400 for anything but a
+                # price source. Same value a dataset card carries, for the same
+                # reason, rather than a second word meaning the same thing.
+                "family": "generic",
+                # NOT active: nothing is scheduled for it. `implemented` is True and
+                # that is the point of the row — a collector exists in this build, so
+                # the source is runnable by hand today.
+                "active": False,
+                "implemented": True,
+                "supports_history": False,
+                # Zero, and zero is the honest number. `_dataset_rows` carries the row
+                # count into both of these; there are no rows yet.
+                "observations": 0,
+                "products": 0,
+                # Never crawled, which the panel renders in words rather than as a
+                # blank or a nought (`freshnessLine`).
+                "last_success": None,
+                "kept_pages": 0,
+                "kept_at": None,
+            })
+        return rows
 
     def _dataset_listing():
         """The same datasets, as ONE CARD PER SITE. `R-47`, and `REQ-37` before it.
@@ -1888,6 +1972,11 @@ def create_app(
         # where the two stored datasets stay two. The same function serving both is
         # what drew `muqawil.org` twice on his Data screen (`REQ-37`).
         out.extend(_dataset_listing())
+        # REGISTERED IN THE CODE, LISTED WITHOUT DATA. His requirement, and the reason
+        # `Choose sites` had no muqawil row on a warehouse an hour old. Appended after
+        # the dataset listing so a site that already has a card keeps it and is not
+        # drawn twice (`REQ-37`).
+        out.extend(_registered_directories(out))
         return {"sources": out}
 
     @app.get("/api/resolve")
@@ -3616,6 +3705,25 @@ def create_app(
         sources = SourceResolver(app.state.manifest,
                                  lambda: dbmod.connect(app.state.db_path))
         for key in source_keys:  # fail before queueing, not mid-crawl
+            # A DIRECTORY THIS BUILD CAN CRAWL IS KNOWN BEFORE ITS ROW EXISTS, and
+            # that is not a hole in the check -- it is where the row comes from.
+            # `SourceResolver` asks the manifest and `source_site`; a directory's
+            # `source_site` row is written by `catalog.register_site` from inside the
+            # collector's own first run (`contractors._run_for`, "registering the site
+            # first if it is not there"), because approval happens after pages are
+            # stored and the first crawl of a new source necessarily precedes it.
+            #
+            # SO ON A FRESH WAREHOUSE THIS ROUTE ANSWERED 404 FOR THE ONE KEY IT WAS
+            # TAUGHT TO ACCEPT. Measured 2026-09-04 on a warehouse an hour old:
+            # `{"detail": "unknown source_key 'muqawil_org'"}` -- while
+            # `directories.BUILDERS` held a collector for it and `directory_keys`
+            # below was ready to route it. His requirement is that a source
+            # registered in the code is listed («المفروض المصادر تظهر بدون بيانات فهى
+            # مسجلة ومحفوظة فى الكود»), and a listed source that 404s on the one
+            # action it offers is the "button that cannot work" this file rejects
+            # everywhere else.
+            if key in directories.BUILDERS:
+                continue
             try:
                 sources.get(key)
             except LookupError:

--- a/tests/test_a_dataset_is_a_table_like_any_other.py
+++ b/tests/test_a_dataset_is_a_table_like_any_other.py
@@ -498,10 +498,30 @@ def test_a_price_source_still_carries_no_kind(tmp_path):
     client = TestClient(create_app(databases=registry))
 
     rows = client.get("/api/sources").json()["sources"]
-    priced = [row for row in rows if row.get("kind") != "dataset"]
+
+    # PRICE SOURCES ARE IDENTIFIED BY THE MANIFEST, not by the absence of the key
+    # this test is about. Filtering on `kind != "dataset"` was true while there were
+    # exactly two shapes; `kind: "directory"` is a third, so that filter swept a
+    # directory row into the price list and the assertion below failed for the one
+    # reason it must never fail — the marker doing its job.
+    from scrapex.config import MANIFEST_FILE, load_manifest
+    declared = {entry.source_key for entry in load_manifest(MANIFEST_FILE).sources}
+    priced = [row for row in rows if row["source_key"] in declared]
 
     assert priced, "the manifest's own sources vanished from the list"
-    assert all("kind" not in row for row in priced)
+    assert all("kind" not in row for row in priced), (
+        "a manifest source carries the marker: "
+        f"{[row['source_key'] for row in priced if 'kind' in row]}")
+
+    # AND THE OTHER HALF, which the old filter could not state: every row that is NOT
+    # a price source declares which shape it is, out of a vocabulary that is closed.
+    # Without this, a new shape could arrive carrying no marker at all and the panel
+    # would draw it a price menu.
+    others = [row for row in rows if row["source_key"] not in declared]
+    assert others, "the code-registered sources vanished from the list"
+    assert all(row.get("kind") in {"dataset", "directory"} for row in others), (
+        "a non-price row carries no known kind: "
+        f"{[(row['source_key'], row.get('kind')) for row in others]}")
 
 
 # ---- what the owner reported on 2026-08-20 -----------------------------------

--- a/tests/test_a_registered_source_is_listed_before_it_has_data.py
+++ b/tests/test_a_registered_source_is_listed_before_it_has_data.py
@@ -1,0 +1,174 @@
+"""His requirement, in his words, and the reason it was not already true.
+
+    «المفروض المصادر تظهر بدون بيانات فهى مسجلة ومحفوظة فى الكود»
+
+He said it after `muqawil` was missing from **Choose sites** in the Run tab on a
+warehouse created an hour earlier. `/api/sources` was the price manifest plus
+`_dataset_listing()`, and that second half groups `dataset_definition` rows — so a
+directory appeared only AFTER its first crawl had stored something, while
+`directories.BUILDERS` had known how to crawl it the whole time.
+
+THE ENGINE WAS ALREADY READY, which is what makes this a listing gap rather than a
+feature: `POST /api/jobs` resolves keys through `SourceResolver` (`R-78`, *"asked of the
+registry, not the file"*) and routes a `BUILDERS` key to the directory collector. The
+button had a target and the panel drew no row for it — `R-81`.
+
+The last test here is the one that matters: the key the row carries is a key the job
+route accepts. A row he can see and cannot run would not have answered him.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+from fastapi.testclient import TestClient
+
+from scrapex import directories
+from scrapex.databases.domain import EngineDatabase
+from scrapex.webui.app import create_app
+
+
+@pytest.fixture()
+def empty_warehouse(tmp_path):
+    """A warehouse with nothing in it — `R-23` calls that the normal first run."""
+    path = tmp_path / "scrapex-engine.db"
+    EngineDatabase(path).initialize()
+    return path
+
+
+def _sources(path) -> list[dict]:
+    with TestClient(create_app(path)) as client:
+        answer = client.get("/api/sources")
+    assert answer.status_code == 200, answer.text
+    return answer.json()["sources"]
+
+
+def test_a_directory_registered_in_the_code_is_listed_with_no_data_at_all(empty_warehouse):
+    """The requirement itself. Measured before this change: 12 rows, none of them a
+    directory, on a warehouse holding `dataset_definition` 0 and `generic_record` 0."""
+    rows = {row["source_key"]: row for row in _sources(empty_warehouse)}
+
+    for key in directories.BUILDERS:
+        assert key in rows, (
+            f"{key} is registered in `directories.BUILDERS` and this build can crawl "
+            "it, and the panel is not told it exists")
+
+    muqawil = rows["muqawil_org"]
+    assert muqawil["implemented"] is True, (
+        "a collector exists for it in this build; `implemented` false would draw it "
+        "as 'Not supported yet'")
+    assert muqawil["active"] is False, "nothing is scheduled for it"
+    assert muqawil["observations"] == 0 and muqawil["products"] == 0
+    assert muqawil["last_success"] is None
+    assert muqawil["base_url"] and muqawil["source_name"]
+
+
+def test_it_declares_itself_a_directory_and_not_a_dataset(empty_warehouse):
+    """`kind` DECIDES WHICH CONTROLS THE PANEL DRAWS, so borrowing the dataset marker
+    to get the crawl button would have brought "Open the data table" with it — and that
+    reaches `/api/table/{key}`, which 404s for a site holding no dataset. The rule this
+    codebase states is that a button which cannot work is worse than no button."""
+    rows = {row["source_key"]: row for row in _sources(empty_warehouse)}
+
+    assert rows["muqawil_org"]["kind"] == "directory"
+    assert rows["muqawil_org"]["site_key"] == "muqawil_org", (
+        "the panel gates the crawl control on `site_key`")
+
+
+def test_the_key_it_carries_is_a_key_the_job_route_accepts(empty_warehouse):
+    """THE ASSERTION THAT MAKES THE ROW MORE THAN A LABEL.
+
+    A dataset card carries `dataset_key` (`contractors`), which `POST /api/jobs`
+    refuses — measured as `OP-52`. `BUILDERS` is keyed by `site_key`, which it accepts
+    since `R-78`. So this row names the thing that can actually be run, and pressing
+    Update now reaches a collector rather than a 404.
+    """
+    rows = {row["source_key"]: row for row in _sources(empty_warehouse)}
+    key = rows["muqawil_org"]["source_key"]
+
+    with TestClient(create_app(empty_warehouse)) as client:
+        answer = client.post("/api/jobs", json={"source_keys": [key]})
+
+    assert answer.status_code != 404, (
+        f"the panel would offer a crawl for {key!r} and the route refuses it: "
+        f"{answer.text}")
+    assert answer.status_code < 500, answer.text
+
+
+def test_a_site_that_already_has_a_card_is_not_drawn_twice(empty_warehouse):
+    """`REQ-37` and `R-47`: he complained twice, with screenshots, that `muqawil.org`
+    appeared TWICE on one screen. A registered row beside its own dataset card would be
+    that defect again, so anything already listed wins."""
+    conn = sqlite3.connect(str(empty_warehouse))
+    try:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(source_site)")}
+        wanted = {"source_key": "muqawil_org", "source_name": "muqawil.org",
+                  "source_name_ar": "مقاول", "base_url": "https://muqawil.org/",
+                  "platform": "directory", "currency": "SAR",
+                  "default_tax_mode": "incl", "authority": "official",
+                  "lifecycle": "active"}
+        use = {k: v for k, v in wanted.items() if k in columns}
+        conn.execute(f"INSERT INTO source_site ({', '.join(use)}) VALUES "
+                     f"({', '.join('?' for _ in use)})", tuple(use.values()))
+        source_id = conn.execute(
+            "SELECT source_id FROM source_site WHERE source_key = 'muqawil_org'"
+        ).fetchone()[0]
+
+        # EVERY NOT-NULL COLUMN WITHOUT A DEFAULT, discovered rather than listed: the
+        # fixture must survive a migration adding one (`discovery_method` is how it
+        # first failed) instead of pinning today's shape.
+        # A CHECK-CONSTRAINED COLUMN NEEDS A REAL VALUE, not a placeholder: the
+        # discovery below fills what it can and `known` carries the ones the schema
+        # constrains to a set.
+        known = {"source_id": source_id, "dataset_key": "contractors",
+                 "display_name": "Contractors", "original_name": "Contractors",
+                 "dataset_name": "Contractors", "discovery_method": "manual"}
+        use = {}
+        for row in conn.execute("PRAGMA table_info(dataset_definition)"):
+            name, kind, notnull, default, pk = row[1], row[2], row[3], row[4], row[5]
+            if name in known:
+                use[name] = known[name]
+            elif notnull and default is None and not pk:
+                use[name] = 0 if "INT" in (kind or "").upper() else "test"
+        conn.execute(f"INSERT INTO dataset_definition ({', '.join(use)}) VALUES "
+                     f"({', '.join('?' for _ in use)})", tuple(use.values()))
+        conn.commit()
+    finally:
+        conn.close()
+
+    rows = _sources(empty_warehouse)
+    for_site = [row for row in rows
+                if row.get("site_key") == "muqawil_org"
+                or row["source_key"] == "muqawil_org"]
+
+    assert len(for_site) == 1, (
+        "muqawil is drawn twice — the dataset card and the registered row — which is "
+        f"REQ-37 again: {[row['source_key'] for row in for_site]}")
+    assert for_site[0]["kind"] == "dataset", (
+        "the card with the data lost to the placeholder")
+
+
+def test_the_panel_and_the_command_line_answer_from_one_place(empty_warehouse):
+    """`ENGINEERING` P1/Q1, as a property rather than as a promise.
+
+    THE SPLIT THIS GUARDS AGAINST EXISTED FOR A FEW HOURS AND WAS MINE. The first
+    version of `_registered_directories` knew `directories.BUILDERS` itself, so
+    `/api/sources` listed muqawil and `sourceboard.board()` — which the `scrapex
+    sources` report reads — did not. Two answers to "which sources exist", from two
+    places, in one product.
+
+    On an empty warehouse both surfaces reduce to the same two registries, the manifest
+    and the code, so their KEY SETS must be identical. If a later change teaches one
+    surface about a registry the other cannot see, this fails and names the difference.
+    """
+    from scrapex import sourceboard
+
+    panel = {row["source_key"] for row in _sources(empty_warehouse)}
+    board = {one.key for one in sourceboard.board(None)}
+
+    assert panel == board, (
+        "the panel and the board disagree about which sources exist.\n"
+        f"  only the panel: {sorted(panel - board)}\n"
+        f"  only the board: {sorted(board - panel)}")
+    assert "muqawil_org" in panel, "neither surface knows the one registered directory"

--- a/tests/test_every_source_appears_on_one_board.py
+++ b/tests/test_every_source_appears_on_one_board.py
@@ -56,22 +56,53 @@ def site(conn, key: str, *, lifecycle: str = "active",
 # ---- it works before there is anything to report ----------------------------
 
 def test_the_board_reads_without_a_database(conn):
-    """`conn=None` is the new user's first run, and the products half is a file."""
+    """`conn=None` is the new user's first run, and NEITHER half needs a database.
+
+    THE CODE REGISTRY IS THE HALF HE ASKED FOR — *«المفروض المصادر تظهر بدون بيانات فهى
+    مسجلة ومحفوظة فى الكود»*. A directory this build can crawl is a fact about the
+    build, so it is listed before any warehouse exists, exactly as the manifest is.
+    """
     found = sourceboard.board(None, manifest_file=MANIFEST)
 
     assert found, "the manifest's own sources should be listed with no warehouse"
-    assert {one.registry for one in found} == {"manifest"}
+    assert {one.registry for one in found} == {"manifest", "code"}
+    assert [one.key for one in found if one.registry == "code"] == ["muqawil_org"]
 
 
 def test_a_warehouse_adds_to_the_list_rather_than_replacing_it(conn):
-    """Both registries, one list — which is the whole point of the module."""
+    """Every registry, one list — which is the whole point of the module.
+
+    IT USED TO ADD `muqawil_org` AND THAT STOPPED BEING AN ADDITION. The code registry
+    lists that key before any crawl, so inserting it now REPLACES rather than adds —
+    which is the next test. A key the code does not register is what still measures
+    addition.
+    """
     before = sourceboard.board(None, manifest_file=MANIFEST)
-    site(conn, "muqawil_org")
+    site(conn, "some_other_directory")
 
     after = sourceboard.board(conn, manifest_file=MANIFEST)
 
     assert len(after) == len(before) + 1
-    assert {one.registry for one in after} == {"manifest", "warehouse"}
+    assert {one.registry for one in after} == {"manifest", "warehouse", "code"}
+
+
+def test_a_crawled_directory_is_listed_once_by_the_warehouse_and_not_twice(conn):
+    """`REQ-37` and `R-47` in the list instead of on the screen.
+
+    Once a directory has been crawled it has a `source_site` row carrying its real
+    lifecycle and dataset count. The code registry's entry for the same key must step
+    aside: two rows for one source is the twice-drawn card he complained about, and a
+    board that reported it would send the panel the same defect.
+    """
+    site(conn, "muqawil_org", lifecycle="paused")
+
+    found = [one for one in sourceboard.board(conn, manifest_file=MANIFEST)
+             if one.key == "muqawil_org"]
+
+    assert len(found) == 1, [(one.registry, one.state) for one in found]
+    assert found[0].registry == "warehouse", "the placeholder beat the real row"
+    assert found[0].state == "paused", (
+        "the code registry's `built` overwrote a decision someone took")
 
 
 # ---- the state vocabulary ---------------------------------------------------
@@ -110,7 +141,16 @@ def test_a_source_with_no_collector_reads_as_registered(tmp_path):
 
     found = sourceboard.board(None, manifest_file=manifest)
 
-    assert [(one.key, one.state) for one in found] == [("NEWTHING", "registered")]
+    # THE MANIFEST HALF, NAMED. This asserted on the whole board, which measured the
+    # manifest only while the manifest was the only registry that needs no database.
+    # `registered` still comes from exactly one place and this still proves it.
+    from_manifest = [(one.key, one.state) for one in found
+                     if one.registry == "manifest"]
+    assert from_manifest == [("NEWTHING", "registered")]
+    assert not [one for one in found
+                if one.state == "registered" and one.registry != "manifest"], (
+        "a second registry started claiming `registered`, which only the manifest can "
+        "say: a source on the list with no collector at all")
 
 
 def test_a_paused_site_is_not_reported_as_built(conn):
@@ -154,9 +194,13 @@ def test_the_summary_counts_by_category_and_state(conn):
     counted = sourceboard.summary(
         sourceboard.board(conn, manifest_file=MANIFEST))
 
-    assert counted["contractors"] == {"active": 1}
+    assert counted["contractors"] == {"active": 1}, (
+        "the crawled row and the code registry's placeholder were both counted")
+    # THE PRODUCTS CELL IS THE MANIFEST, and it used to be compared against the whole
+    # database-less board — which was the same number only while the manifest was the
+    # only registry that needs no database. `from_manifest` names what it means.
     assert sum(counted["products"].values()) == len(
-        sourceboard.board(None, manifest_file=MANIFEST))
+        sourceboard.from_manifest(MANIFEST))
 
 
 # ---- the split stays visible ------------------------------------------------


### PR DESCRIPTION
**#330's work, on a branch that actually targets `main`.** This is a mistake of mine, not
new work.

## What went wrong

[#330](https://github.com/muhammadbayoumi/ScrapeX/pull/330) was opened with
`claude/a-socket-is-not-an-engine` as its **base**, not `main`. When I merged
[#329](https://github.com/muhammadbayoumi/ScrapeX/pull/329) first and #330 second, #330
squashed onto a branch that had already been absorbed — so GitHub reports it MERGED, and
its commit `48ee301` is **not an ancestor of `main`**.

Measured rather than assumed: on `main`, `grep -c from_code scrapex/sourceboard.py` = 0 and
`grep -c 'kind === "directory"' extension/app.js` = 0. The work was not there.

This branch is `48ee301` cherry-picked onto `main`. Same content, 11 files, +459/−52.

## What it restores — the thing he actually reported

> المفروض المصادر تظهر بدون بيانات فهى مسجلة ومحفوظة فى الكود

`/api/sources` was the price manifest plus `_dataset_listing()`, and that second half
groups `dataset_definition` rows — so a directory appeared only **after** its first crawl
had stored something, while `directories.BUILDERS` had known how to crawl it all along. On
a warehouse an hour old, muqawil was missing from *Choose sites*.

One place decides now: `sourceboard.from_code()` yields the code-registered directories,
the panel and the board read the same set, and a guard asserts their key sets are
identical — the DRY defect he caught when the registry knowledge was written into
`webui/app.py` while `sourceboard` already owned it.

## Verified before pushing

`test_a_registered_source_is_listed_before_it_has_data.py` ·
`test_a_dataset_is_a_table_like_any_other.py` (including the rewritten
`test_a_price_source_still_carries_no_kind`, which now identifies a price source by the
manifest instead of by the absence of the marker) · `test_settings_page.py` ·
`test_the_documents_cite_what_they_claim.py` — all green on this branch.

#330 stays closed-as-merged; this is where its content reaches `main`.
