### PR TITLE
The panel is the operating system, the engine is the host, and the host is not an app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,13 +42,18 @@ the Google Sheet the mbiX Excel add-in reads. Setup and data flow: [README.md](R
 
 - **He works only from the extension panel — never a terminal.** A `scrapex ...` command
   is not an answer to him, and a capability with no control in the panel has no control.
-- **A capability is a contract; apps implement it.** Our engines — the crawler,
-  `scrapex/enrichment/` — are apps under the contract, not the contract itself. An
+- **A capability is a contract; apps implement it.** The panel is the operating system —
+  the only surface, and the one that chooses. The engine is the **host** where apps
+  execute, and ours — the crawler, `scrapex/enrichment/` — is the first app in it. An
   open-source project that does the same job its own way is installed **beside** ours,
-  never instead of it, and installing one never pauses ours: ours grows where the
-  external ones do not serve. Choose per run by measured performance, not by who wrote
-  it. Dropping an app must cost no more than adding one. The registries to extend are
-  `scrapex/connectors/factory.py` and `scrapex/enrichment/providers/__init__.py`.
+  never instead of it, and installing one never pauses ours: ours grows where the external
+  ones do not serve. Choose per run by measured performance, not by who wrote it. Dropping
+  an app must cost no more than adding one. The registries live in the engine and the panel
+  reads them: `scrapex/connectors/factory.py`, `scrapex/enrichment/providers/__init__.py`.
+- **The host is never one of the apps.** The engine cannot be dropped the way an app can:
+  nothing executes without it and nothing writes the warehouse but it. Measured in
+  `spikes/opfs-sqlite/FINDINGS.md` — an MV3 service worker can read the warehouse and never
+  write it, and wa-sqlite ran 70-208x slower than Python on the Data page's own query.
 - **A recorded plan is not an approved plan.** Nothing in a milestone is built until he
   reviews it and says what he wants.
 - **A button that cannot work is worse than no button.** If the route 404s, do not draw

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,8 +52,9 @@ the Google Sheet the mbiX Excel add-in reads. Setup and data flow: [README.md](R
   reads them: `scrapex/connectors/factory.py`, `scrapex/enrichment/providers/__init__.py`.
 - **The host is never one of the apps.** The engine cannot be dropped the way an app can:
   nothing executes without it and nothing writes the warehouse but it. Measured in
-  `spikes/opfs-sqlite/FINDINGS.md` — an MV3 service worker can read the warehouse and never
-  write it, and wa-sqlite ran 70-208x slower than Python on the Data page's own query.
+  `spikes/opfs-sqlite/FINDINGS.md` — an MV3 service worker cannot write the warehouse, OPFS
+  loses WAL, and its access handle is exclusive with no queue, so nothing else may hold the
+  file while the engine has it. **Reading is a different question and it passes.**
 - **A recorded plan is not an approved plan.** Nothing in a milestone is built until he
   reviews it and says what he wants.
 - **A button that cannot work is worse than no button.** If the route 404s, do not draw


### PR DESCRIPTION
His model, checked before the separation plan is executed:

> هذه الخطة هى فكرة التطبيق الاصلى الى بيجى مع الشركة وextension نظام التشغيل هنا — مضبوط؟

It is, and the rule now says it: **the panel is the operating system** — the only surface
and the one that chooses — **the engine is the host** where apps execute, and ours is the
first app in it. Both registries live in the engine and the panel reads them, which the
rule now states instead of leaving it to be inferred from two file paths.

## The line that stops the analogy being taken literally

On a phone the system can drop its built-in app. Here it cannot: nothing executes without
the engine, and nothing writes the warehouse but it. *"Ours is one of the apps"* is true
when choosing **which app does a job** and false of the engine **as host** — two different
things wearing one word, and confusing them is the failure the migration plan exists to
remove.

## And a correction inside the same PR

The first version of that line cited *"wa-sqlite ran 70–208× slower than Python"*. That is
true of `wa-sqlite` — which `spikes/opfs-sqlite/FINDINGS.md:17-19` calls **"the one part
that is simply the wrong choice"** — and misleading as a statement about SQLite in the
browser:

| what was actually measured | |
|---|---|
| the spike's own headline | **"Topology A is viable with four constraints"**, not dead |
| `@sqlite.org/sqlite-wasm` 3.53 over the OPFS SAH pool | **1.4–1.6×** of Python on the same Data-page query |
| reading the real 74.8 MiB file | 40 tables · 59 indexes · 2 triggers · 2 views · `user_version` 54 · 73,278 price observations — **identical to Python** under both engines |

`docs/archive/REQUESTS.md:2167-2172` had already recorded that reproducing the wa-sqlite row
alone is *"the number that would change the decision"*. I reproduced it anyway, out loud
first and then in this file.

So the rule now names what actually makes the host a host, which is not speed: an MV3
service worker **cannot write** the warehouse, OPFS loses WAL, and its access handle is
exclusive with no queue — nothing else may hold the file while the engine has it. And it
ends with the sentence the next reader needs: **reading is a different question and it
passes.**

145 → 151 lines. Folded into the existing rule rather than added beside it, because the
operating-system model is part of *"a capability is a contract"* and not a separate rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
