### PR TITLE
Three cells of one directory at once, from the panel (#420)

### DIFF
--- a/extension/app.html
+++ b/extension/app.html
@@ -1985,6 +1985,10 @@
               <input id="crawl_parallel_sources" type="number" step="1" min="1" max="8" dir="ltr">
               <p class="muted text-xs" id="crawl-parallel-effect">&nbsp;</p>
 
+              <label for="directory_crawl_workers">Cells of one directory at the same time</label>
+              <input id="directory_crawl_workers" type="number" step="1" min="1" max="8" dir="ltr">
+              <p class="muted text-xs" id="directory-workers-effect">&nbsp;</p>
+
               <label for="crawl_timeout_s">Request timeout in seconds</label>
               <input id="crawl_timeout_s" type="number" min="1" dir="ltr">
 

--- a/extension/app.js
+++ b/extension/app.js
@@ -791,6 +791,16 @@ const CRAWL_KEYS = ["crawl_honour_delay", "crawl_min_interval_s",
 // rather than accepting a number and silently ignoring it.
 const MAX_PARALLEL_SOURCES = 8;
 
+// A SEPARATE CEILING FOR A SEPARATE AXIS, and equal to it only by coincidence today.
+// That one bounds how many SITES a wave crawls; this one bounds how many CELLS of one
+// directory a single crawl reads at once (directoryjob.MAX_WORKERS). They would move
+// for different reasons -- one is politeness across sites, the other is writer
+// contention inside one warehouse (issue 367) -- so sharing a constant would make a
+// change to either silently move the other. The issue number is written without its
+// hash on purpose: 367 is three valid hex digits and the colour-literal guard reads
+// it as one.
+const MAX_DIRECTORY_WORKERS = 8;
+
 function crawlPaceEffect() {
   // What the choice MEANS, in the units the owner thinks in. A checkbox that
   // silently decides whether a crawl takes one hour or eleven should say so.
@@ -858,7 +868,7 @@ async function saveCrawlSettings() {
       crawl_min_interval_s: String(interval),
       directory_crawl_workers: String(Math.min(
         Math.max(parseInt($("directory_crawl_workers").value, 10) || 1, 1),
-        MAX_PARALLEL_SOURCES)),
+        MAX_DIRECTORY_WORKERS)),
       crawl_parallel_sources: String(Math.min(
         Math.max(parseInt($("crawl_parallel_sources").value, 10) || 1, 1),
         MAX_PARALLEL_SOURCES)),

--- a/extension/app.js
+++ b/extension/app.js
@@ -824,6 +824,10 @@ async function loadCrawlSettings() {
   $("crawl_honour_delay").checked = !["0", "false", false].includes(value("crawl_honour_delay"));
   $("crawl_min_interval_s").value = value("crawl_min_interval_s") || "1.0";
   $("crawl_parallel_sources").value = value("crawl_parallel_sources") || "1";
+  // A rendering fallback, not a second definition of the default: the engine answers
+  // with its own catalogue value, and this only shows when that answer has no such key
+  // -- an engine older than this panel.
+  $("directory_crawl_workers").value = value("directory_crawl_workers") || "3";
   $("crawl_timeout_s").value = value("crawl_timeout_s") || "30";
   $("crawl_user_agent").value = value("crawl_user_agent") || "";
   $("log_retention_days").value = value("log_retention_days") || "30";
@@ -852,6 +856,9 @@ async function saveCrawlSettings() {
     await post("/api/settings", {
       crawl_honour_delay: $("crawl_honour_delay").checked ? "1" : "0",
       crawl_min_interval_s: String(interval),
+      directory_crawl_workers: String(Math.min(
+        Math.max(parseInt($("directory_crawl_workers").value, 10) || 1, 1),
+        MAX_PARALLEL_SOURCES)),
       crawl_parallel_sources: String(Math.min(
         Math.max(parseInt($("crawl_parallel_sources").value, 10) || 1, 1),
         MAX_PARALLEL_SOURCES)),

--- a/scrapex/directoryjob.py
+++ b/scrapex/directoryjob.py
@@ -87,10 +87,16 @@ def workers_for(conn: sqlite3.Connection) -> int:
     from . import settings
 
     spec = settings.SETTINGS.get(WORKERS_SETTING)
-    # ONE IF THE KEY IS GONE, which is a build that deleted the setting rather than a
-    # database that never had it -- so the safe reading is the old behaviour, not a
-    # concurrency nothing declared.
-    shipped = int(spec.default) if spec is not None else 1
+    try:
+        # ONE IF THE KEY IS GONE, which is a build that deleted the setting rather than
+        # a database that never had it -- so the safe reading is the old behaviour, not
+        # a concurrency nothing declared. And one if the catalogue holds a value that is
+        # not a number, because the sentence above is about ANY bad value: parsing the
+        # shipped default outside this guard would let a typo in our own literal kill
+        # every directory crawl at start-up.
+        shipped = int(spec.default) if spec is not None else 1
+    except (TypeError, ValueError):
+        shipped = 1
     try:
         asked = settings.get(conn, WORKERS_SETTING)
     except (sqlite3.DatabaseError, settings.UnknownSettingError):

--- a/scrapex/directoryjob.py
+++ b/scrapex/directoryjob.py
@@ -27,10 +27,12 @@ are already on disk, so a resume under the same `--run-ref` skips them.
 from __future__ import annotations
 
 import sqlite3
+import threading
 import time
-from contextlib import nullcontext
+from contextlib import closing, nullcontext
 
 from . import contractors, directories
+from . import db as dbmod
 from .payload import utc_now_iso
 from .vocab import JobControl, JobStage, JobStatus, LogLevel
 
@@ -55,6 +57,48 @@ DEFAULT_PACE_S = contractors.DEFAULT_PACE_S
 #: for the beat found exactly that: it set the interval to zero, nothing changed, and five
 #: of six fetches were silently throttled.
 BEAT_EVERY_S = 20.0
+
+#: The setting that says how many cells one directory crawl reads at once.
+#:
+#: THE KEY IS NAMED HERE AND THE NUMBER IS NOT. `settings.SETTINGS` carries the shipped
+#: number and the reason for it, so changing the default is one edit in one file; a
+#: constant here beside a duplicate of itself in the catalogue is two places for one
+#: fact, and the panel field would have been a third.
+WORKERS_SETTING = "directory_crawl_workers"
+
+#: Refused above this however the setting is written. A pool wider than the partition is
+#: threads queued on a pace lock, and a mistyped 600 should not open 600 connections to a
+#: 2 GB warehouse. The panel input carries the same ceiling; this is the one that binds.
+MAX_WORKERS = 8
+
+
+def workers_for(conn: sqlite3.Connection) -> int:
+    """How many cells this crawl reads at once, from the setting, clamped.
+
+    READ FROM THE SETTINGS TABLE AND CLAMPED HERE, for the reason `jobs.job_capacity`
+    gives about `crawl_parallel_sources`: one definition, read by the thing that
+    enforces it, so nothing can promise a concurrency the crawl will not deliver.
+
+    A BAD VALUE IS THE SHIPPED DEFAULT, NOT A FAILURE. A crawl that refused to start
+    because the setting held the word "six" would be a mistyped number taking the
+    collection offline, and the number is typed into a panel field that will happily
+    submit an empty string.
+    """
+    from . import settings
+
+    spec = settings.SETTINGS.get(WORKERS_SETTING)
+    # ONE IF THE KEY IS GONE, which is a build that deleted the setting rather than a
+    # database that never had it -- so the safe reading is the old behaviour, not a
+    # concurrency nothing declared.
+    shipped = int(spec.default) if spec is not None else 1
+    try:
+        asked = settings.get(conn, WORKERS_SETTING)
+    except (sqlite3.DatabaseError, settings.UnknownSettingError):
+        return shipped
+    try:
+        return max(1, min(int(asked), MAX_WORKERS))
+    except (TypeError, ValueError):
+        return shipped
 
 
 class NotADirectory(LookupError):
@@ -125,6 +169,17 @@ def run_directory_crawl_job_once(conn: sqlite3.Connection, job_ref: str,
     # label that is stable across a pause and a re-pick.
     run_ref = f"job-{job_ref}"
     cells = len(directory.partition().cells())
+    #: The warehouse this job connection is open on, asked of the connection itself
+    #: rather than threaded in as a parameter -- the runner contract is
+    #: `(conn, job_ref, admission)` and a fourth argument for a path the connection
+    #: already knows would be a second place for it to be wrong.
+    db_file = conn.execute("PRAGMA database_list").fetchone()[2]
+    # A POOL NEEDS A FILE ON DISK. `PRAGMA database_list` reports an empty name for an
+    # in-memory database, and `dbmod.connect(":memory:")` called from a worker would be
+    # a DIFFERENT, empty database -- so the crawl would store its pages where nothing
+    # can read them and report a success over it. An in-memory run therefore stays
+    # sequential, which is also what every existing test of this runner gets.
+    workers = workers_for(conn) if db_file else 1
 
     jobs._update(conn, job["job_id"], status=JobStatus.PREPARING.value,
                  stage=JobStage.PREPARING.value, progress_total=cells,
@@ -134,6 +189,17 @@ def run_directory_crawl_job_once(conn: sqlite3.Connection, job_ref: str,
     jobs.append_log(conn, job["job_id"],
                     f"{directory.display_name}: listing crawl of {cells:,} cell(s) "
                     f"as {run_ref}", source_key=source_key)
+    if workers > 1:
+        # SAID, BECAUSE HE CANNOT SEE IT ANY OTHER WAY. A pool is invisible from the job
+        # card -- the cells still close one at a time -- and a crawl that suddenly runs
+        # six times faster with nothing saying why is a crawl he cannot audit. The
+        # sentence names the RATE as well as the width, because the rate is the part
+        # `R-21` is about and the part that has not changed.
+        jobs.append_log(
+            conn, job["job_id"],
+            f"  {workers} cell(s) at once. The request RATE is unchanged at one per "
+            f"{DEFAULT_PACE_S:g}s -- what overlaps is the waiting, not the asking",
+            source_key=source_key)
     conn.commit()
 
     done = {"cells": 0}
@@ -188,11 +254,41 @@ def run_directory_crawl_job_once(conn: sqlite3.Connection, job_ref: str,
         return text
 
     beat_at = [0.0]
-    #: The warehouse this job's connection is open on, asked of the connection itself
-    #: rather than threaded in as a parameter -- the runner contract is
-    #: `(conn, job_ref, admission)` and a fourth argument for a path the connection
-    #: already knows would be a second place for it to be wrong.
-    db_file = conn.execute("PRAGMA database_list").fetchone()[2]
+
+    #: The thread the job was handed to. `for_writing` compares against it, so the
+    #: comparison is with THIS run rather than with whatever the main thread happens to
+    #: be -- the job loop runs every job in a thread of its own.
+    job_thread = threading.get_ident()
+
+    def for_writing():
+        """The connection this callback writes on: the job connection, or a fresh one.
+
+        THE ONE CHANGE THAT MADE A POOL POSSIBLE HERE. `crawl_partition` calls `on_cell`
+        -- and so `contractors.say`s sink and `between_cells` -- in the thread that
+        closed the cell, and `sqlite3` refuses a connection from a thread it was not
+        created on. Every write below went through the job connection, so the first cell
+        to close inside a worker would have raised `ProgrammingError` from inside the job
+        log writer, hours into a real crawl.
+
+        BY THREAD, AND NOT BY `workers > 1`, WHICH IS WHAT MEASUREMENT CHANGED. The
+        first version took a fresh connection whenever the pool was wide, and two
+        directory jobs then spent 11.75 s doing 0.7 s of work. A thread dump two seconds
+        in showed the crawl blocked inside its own `jobs.append_log`: `contractors.crawl`
+        writes `validator_store.save(conn, ...)` on the job connection and commits only
+        after its closing report, so a log line written on a SECOND connection to the
+        same file waited out the whole `busy_timeout` against an uncommitted write of its
+        own making. A connection deadlocked against its sibling, and the only symptom is
+        a five-second stall and then `database is locked`.
+
+        SO THE JOB THREAD KEEPS THE JOB CONNECTION -- sharing that transaction rather
+        than fighting it -- and only a worker takes its own. That also makes the
+        sequential path identical by construction rather than by argument: with one
+        worker nothing runs off this thread, so every write goes exactly where it went
+        before.
+        """
+        if threading.get_ident() == job_thread:
+            return nullcontext(conn)
+        return closing(dbmod.connect(db_file))
 
     def note(line: str) -> None:
         """One line of the crawl's own report, into the job log.
@@ -203,7 +299,12 @@ def run_directory_crawl_job_once(conn: sqlite3.Connection, job_ref: str,
         job that logged its own summary instead would be a second account of the same
         run, free to disagree with the console's.
         """
-        jobs.append_log(conn, job["job_id"], line, source_key=source_key)
+        with for_writing() as own:
+            jobs.append_log(own, job["job_id"], line, source_key=source_key)
+            # COMMITTED HERE, WHERE IT USED TO RIDE ON THE NEXT `cell_closed`. A line
+            # written on a connection that is then closed is a line that was rolled
+            # back, and the report the crawl writes IS the job log.
+            own.commit()
 
     def cell_closed() -> bool:
         """Called between cells. `True` asks the crawl to stop here.
@@ -214,44 +315,65 @@ def run_directory_crawl_job_once(conn: sqlite3.Connection, job_ref: str,
         The heartbeat and the progress write happen here too, because between cells is
         also the only moment at which `progress_done` is a fact rather than a guess.
         """
+        if stopped:
+            # ALREADY STOPPED BY AN EARLIER CELL, AND THIS IS A POOL DEFECT WITH A
+            # SEQUENTIAL PATH THAT NEVER HAD IT. When a pause is honoured, the cells that
+            # were already in flight still close -- `stopping` in `crawl_partition` keeps
+            # the UNSTARTED ones from running, and nothing can un-start the others -- so
+            # their progress write would put `running` back over `paused`. A job that says
+            # it is running with nothing running is exactly the state
+            # `test_a_killed_engine_does_not_leave_a_job_claiming_to_run` exists for, and
+            # from the panel it is a crawl he cannot resume because it never stopped.
+            #
+            # `True` RATHER THAN `False`: the answer to "may this run continue?" is still
+            # no, so the cell that asked raises too and its worker stops as well.
+            return True
         done["cells"] += 1
-        jobs._update(conn, job["job_id"], status=JobStatus.RUNNING.value,
-                     stage=JobStage.FETCHING.value, progress_done=done["cells"],
-                     last_heartbeat_at=utc_now_iso())
-        # AND THE REQUEST COUNT, HERE RATHER THAN ONLY AT THE END. It was written once in
-        # `finally`, so the panel showed `requests: 0` beside `cells 2/56` for hours --
-        # two numbers on one card contradicting each other, on the surface he watches.
-        # `OP-130`. The price path updates as it goes and its vocabulary is already
-        # `waiting` / `fetching` / `done`.
-        #
-        # AT THE BOUNDARY, because mid-cell `requests_count` is a number in motion and
-        # this is the one point where every figure on that card agrees with the others.
-        jobs.record_source_fetch(
-            conn, job["job_id"], source_key,
-            requests=int(getattr(fetcher, "requests_count", 0) or 0),
-            state="fetching")
-        conn.commit()
-        current = jobs.get_job(conn, job_ref)
-        control = jobs._control_of(conn, job["job_id"])
-        if control == JobControl.PAUSE.value:
-            jobs._update(conn, job["job_id"], status=JobStatus.PAUSED.value,
-                         control=JobControl.NONE.value, stage=None,
+        # NOT LOCKED, AND IT DOES NOT NEED TO BE. `crawl_partition` calls `on_cell`
+        # inside one lock, and `contractors.crawl` asks `between_cells` from inside
+        # `on_cell` -- so however wide the pool, exactly one thread is in this function
+        # at a time. That is also what makes `done["cells"]` a count rather than a race.
+        with for_writing() as own:
+            jobs._update(own, job["job_id"], status=JobStatus.RUNNING.value,
+                         stage=JobStage.FETCHING.value, progress_done=done["cells"],
                          last_heartbeat_at=utc_now_iso())
-            jobs.append_log(
-                conn, job["job_id"],
-                f"paused at a cell boundary, {done['cells']:,} of {cells:,} closed. "
-                f"Resuming under {run_ref} skips the pages already stored",
-                source_key=source_key)
-            conn.commit()
-            stopped.append(JobStatus.PAUSED.value)
-            return True
-        if control == JobControl.CANCEL.value:
-            jobs._finish(conn, job["job_id"], JobStatus.CANCELLED, None)
-            stopped.append(JobStatus.CANCELLED.value)
-            return True
-        # `current` IS READ AND USED, not read and discarded: a job the worker has
-        # been told to drop its database for is a job whose next cell must not open.
-        return bool(current is None)
+            # AND THE REQUEST COUNT, HERE RATHER THAN ONLY AT THE END. It was written
+            # once in `finally`, so the panel showed `requests: 0` beside `cells 2/56`
+            # for hours -- two numbers on one card contradicting each other, on the
+            # surface he watches. `OP-130`. The price path updates as it goes and its
+            # vocabulary is already `waiting` / `fetching` / `done`.
+            #
+            # AT THE BOUNDARY, because mid-cell `requests_count` is a number in motion
+            # and this is the one point where every figure on that card agrees with the
+            # others. With a pool it is also the only point at which it is READ from one
+            # thread rather than incremented by several, which is why it is taken here
+            # and not inside the fetch.
+            jobs.record_source_fetch(
+                own, job["job_id"], source_key,
+                requests=int(getattr(fetcher, "requests_count", 0) or 0),
+                state="fetching")
+            own.commit()
+            current = jobs.get_job(own, job_ref)
+            control = jobs._control_of(own, job["job_id"])
+            if control == JobControl.PAUSE.value:
+                jobs._update(own, job["job_id"], status=JobStatus.PAUSED.value,
+                             control=JobControl.NONE.value, stage=None,
+                             last_heartbeat_at=utc_now_iso())
+                jobs.append_log(
+                    own, job["job_id"],
+                    f"paused at a cell boundary, {done['cells']:,} of {cells:,} closed. "
+                    f"Resuming under {run_ref} skips the pages already stored",
+                    source_key=source_key)
+                own.commit()
+                stopped.append(JobStatus.PAUSED.value)
+                return True
+            if control == JobControl.CANCEL.value:
+                jobs._finish(own, job["job_id"], JobStatus.CANCELLED, None)
+                stopped.append(JobStatus.CANCELLED.value)
+                return True
+            # `current` IS READ AND USED, not read and discarded: a job the worker has
+            # been told to drop its database for is a job whose next cell must not open.
+            return bool(current is None)
 
     started = time.monotonic()
     # ONE DEFINITION OF A HOST, taken from `jobs` rather than written again here.
@@ -261,11 +383,28 @@ def run_directory_crawl_job_once(conn: sqlite3.Connection, job_ref: str,
     # source, so two unresolvable sources can never share a reservation.
     host = jobs.host_of_url(directory.base_url, source_key)
     admit = admission.lane(host) if admission is not None else nullcontext()
+
+    def a_connection() -> sqlite3.Connection:
+        """One connection for one worker, opened IN that worker.
+
+        THE FACTORY IS PASSED, NOT A CONNECTION, for the reason
+        `partitioncrawl._run_and_close` states in terms: calling it on the submitting
+        thread and handing the result over raises on the `close()`, after the cell has
+        already been crawled.
+
+        THE JOB DATABASE, NOT THE DEFAULT ONE. `contractors.py` builds its factory from
+        `DatabaseRegistry.defaults()`, which is right for a command line and wrong here
+        -- a job running against a test or a second warehouse would have its cells
+        crawled into the default one. This asks the job connection where it is.
+        """
+        return dbmod.connect(db_file)
+
     try:
         with admit, contractors.lines_go_to(note):
             contractors.crawl(conn, directory, beating, fetcher, run_ref,
                               contractors.DEFAULT_MAX_ATTEMPTS,
-                              between_cells=cell_closed)
+                              between_cells=cell_closed, workers=workers,
+                              connect=a_connection if workers > 1 else None)
     except contractors.CrawlStopped:
         # NOT AN ERROR, AND NOT SILENT EITHER. The crawl was asked to stop by
         # `cell_closed`, which has already written the status and said why.

--- a/scrapex/partitioncrawl.py
+++ b/scrapex/partitioncrawl.py
@@ -1051,15 +1051,36 @@ def crawl_partition(conn: sqlite3.Connection, partition: PartitionedListing,
     # thread-safe. A caller's progress reporter writes to a log and a dict; making
     # every caller learn that is how a convenience becomes a defect.
     guard = threading.Lock()
+    # SET BY THE FIRST CELL TO RAISE, AND READ BY EVERY CELL THAT HAS NOT STARTED.
+    # `ThreadPoolExecutor.__exit__` calls `shutdown(wait=True)` without
+    # `cancel_futures`, so every cell already submitted RUNS even after a worker has
+    # raised -- and `on_cell` is where a caller asks whether the run may continue.
+    # Measured on the shape of the 2026-09-03 job: a pause requested at cell 3 of 56
+    # would have fetched the remaining 53 before the `CrawlStopped` raised by cell 3
+    # was re-raised below. That is a pause that crawls the whole site.
+    #
+    # THE SEQUENTIAL PATH NEVER HAD THIS, which is why it went unnoticed: `raise` from
+    # `on_cell` leaves the `for` loop and no further cell is read.
+    #
+    # ANY EXCEPTION, NOT ONLY A STOP. `future.result()` re-raises the first one and the
+    # `PartitionOutcome` is discarded either way, so the queued cells were going to be
+    # fetched and thrown away.
+    stopping = threading.Event()
 
     def one(index: int, size: CellSize, worker_conn: sqlite3.Connection) -> None:
         nonlocal newly_sighted
-        outcome, sighted = _crawl_one_cell(size, conn=worker_conn, **per_cell)
-        with guard:
-            found[index] = outcome
-            newly_sighted += sighted
-            if on_cell is not None:
-                on_cell(outcome)
+        if stopping.is_set():
+            return
+        try:
+            outcome, sighted = _crawl_one_cell(size, conn=worker_conn, **per_cell)
+            with guard:
+                found[index] = outcome
+                newly_sighted += sighted
+                if on_cell is not None:
+                    on_cell(outcome)
+        except BaseException:
+            stopping.set()
+            raise
 
     if workers > 1 and connect is not None:
         # A CONNECTION PER WORKER, NOT A SHARED ONE. `sqlite3` refuses a connection

--- a/scrapex/settings.py
+++ b/scrapex/settings.py
@@ -87,6 +87,17 @@ SETTINGS: dict[str, Setting] = {s.key: s for s in [
     # in the order the job listed them. Raising it crawls that many SITES at
     # once — never two sources of one site, whatever the number says.
     Setting("crawl_parallel_sources", "1", label="Sources crawled at the same time"),
+    # Cells of ONE directory read at once -- a different axis from the line above, which
+    # is how many SITES. Three, not one, because the panel cannot type `--workers` and a
+    # default of 1 leaves that capability reachable only from a terminal he does not use.
+    # Three, not six, because issue #367 measured six concurrent writers holding the
+    # warehouse past `busy_timeout = 5000`, so starting the engine during a six-worker
+    # crawl failed with `database is locked` -- and he uses the panel while a crawl runs.
+    #
+    # The request RATE does not change with this number: `HttpFetcher._throttle` holds its
+    # lock across its own sleep, so a pool overlaps the waiting and never asks faster.
+    Setting("directory_crawl_workers", "3",
+            label="Cells of one directory read at the same time"),
     # --- Google Finance exchange rates ---
     # Six hours remains the shipped default, but is no longer hidden policy.
     # Manual refresh remains available even when automatic refresh is off.

--- a/tests/test_a_crawl_that_can_prove_it_read_everything.py
+++ b/tests/test_a_crawl_that_can_prove_it_read_everything.py
@@ -1375,3 +1375,53 @@ def test_a_replayed_attempt_does_not_count_as_a_dry_read(conn):
     assert not only.went_dry(), (
         "a replayed attempt fetched nothing and cannot be evidence that the site "
         "has nothing left")
+
+
+def test_a_stop_does_not_crawl_the_cells_that_have_not_started(registry):
+    """`shutdown(wait=True)` RUNS WHAT IS ALREADY QUEUED, and that is a pause that
+    crawls the whole site.
+
+    `ThreadPoolExecutor.__exit__` calls `shutdown(wait=True)` without `cancel_futures`,
+    so every cell already submitted still runs after a worker raises -- and `on_cell` is
+    where `contractors.crawl` asks `between_cells` whether the run may continue. Measured
+    on the shape of the 2026-09-03 job: a pause requested at cell 3 of 56 would have
+    fetched the remaining 53 before the `CrawlStopped` from cell 3 was re-raised.
+
+    The sequential path never had this, which is why it went unnoticed: `raise` from
+    `on_cell` leaves the `for` loop and no further cell is read.
+
+    ASSERTED ON WORK NOT DONE, not on a count of callbacks: the sightings of the cells
+    that never started must not be in the ledger. Four workers may already be in flight
+    when the first one raises, so the bound is the pool's width and not one.
+    """
+    conn = registry.engine.connect()
+    try:
+        conn.execute(
+            "INSERT INTO source_site (source_key, source_name, base_url, crawl_scope) "
+            "VALUES ('site_test','A site',?, 'listing_only')", (BASE,))
+        conn.commit()
+        ids = {n: [str(n * 100 + k) for k in range(8)] for n in range(1, 9)}
+        cells = tuple(cell(region_id=n) for n in range(1, 9))
+        directory = Directory({"whole": [x for v in ids.values() for x in v],
+                               **{c.label: list(ids[n]) for n, c in
+                                  zip(range(1, 9), cells, strict=True)}})
+
+        from scrapex.contractors import CrawlStopped
+
+        def stop(_outcome):
+            raise CrawlStopped
+
+        with pytest.raises(CrawlStopped):
+            _pool_run(conn, registry, Partition(directory, cells=cells), directory,
+                      cells, workers=4, on_cell=stop)
+
+        stored = {row[0] for row in conn.execute(
+            "SELECT external_id FROM dataset_sighting")}
+        started = {n for n in range(1, 9) if set(ids[n]) & stored}
+        assert len(started) <= 4, (
+            f"the stop was asked for at the first closed cell and {len(started)} of 8 "
+            "cells were crawled anyway, so a pause pays for the whole partition: "
+            f"{sorted(started)}")
+        assert len(started) < 8, "no cell was spared, so the stop stopped nothing"
+    finally:
+        conn.close()

--- a/tests/test_the_button_drives_the_collector_the_source_needs.py
+++ b/tests/test_the_button_drives_the_collector_the_source_needs.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import json
 import pathlib
 import sqlite3
+import threading
 import time
 
 import pytest
@@ -944,3 +945,203 @@ def test_the_shipped_heartbeat_interval_keeps_the_card_fresh():
     assert directoryjob.BEAT_EVERY_S * 4 < jobs.JOB_HEARTBEAT_MAX_AGE_S, (
         "the interval is within a factor of four of the window that decides whether a "
         "job counts as alive, which leaves no margin for a slow page")
+
+
+# ---- the pool the panel gets, and the three things it broke (OP-132) --------
+#
+# `--workers` has been on `scrapex contractors --crawl` since 2026-08-22 and `R-81` says
+# the panel is his only interface, so the crawl he can actually start was the
+# single-threaded one -- measured on his own run, 7 cells of 56 in 198 minutes, 14.6
+# hours for the listing alone. Wiring the pool into the runner broke three things that no
+# reading of the diff would have suggested, and each is a test below.
+
+
+class _CellsInAWorkerThread:
+    """`crawl_partition`, faked with the ONE property that matters: `on_cell` is called
+    in a WORKER thread, under a single lock, exactly as the real pool calls it.
+
+    THE REAL POOL IS NOT USED HERE ON PURPOSE. `crawl_partition` needs a partition, a
+    base url, sized cells and a fetch that answers -- and this file has no network and no
+    site. What the runner has to survive is narrower than a crawl and it is entirely
+    about which thread the callback arrives on, so that is what this reproduces.
+    """
+
+    def __init__(self, cells: int = 4, workers: int = 2) -> None:
+        self.cells = cells
+        self.workers = workers
+        self.reported = 0
+        self.threads: set[int] = set()
+
+    def __call__(self, *args, **kwargs):
+        from concurrent.futures import ThreadPoolExecutor
+
+        from scrapex.partitioncrawl import (
+            WHOLE,
+            Attempt,
+            CellOutcome,
+            CellSize,
+            PartitionOutcome,
+        )
+
+        report = kwargs["on_cell"]
+        size = CellSize(cell=WHOLE, last_page=1, cards_per_page=1, tail_cards=1,
+                        requests=1)
+        # ONE LOCK ROUND THE CALLBACK, which is `crawl_partition`'s own arrangement and
+        # the reason `cell_closed` needs no lock of its own.
+        guard = threading.Lock()
+
+        def one(_index: int) -> None:
+            with guard:
+                self.reported += 1
+                self.threads.add(threading.get_ident())
+                report(CellOutcome(size=size, attempts=(
+                    Attempt(ids=(), pages_read=1, witnessed=True, note="fake",
+                            run_ref="fake-a1"),)))
+
+        with ThreadPoolExecutor(max_workers=self.workers,
+                                thread_name_prefix="cell") as pool:
+            for future in [pool.submit(one, n) for n in range(self.cells)]:
+                future.result()
+        return PartitionOutcome(whole=size, cells=(), whole_at_end=None, parent=WHOLE)
+
+
+def _run_it_threaded(conn, monkeypatch, *, cells: int = 4, control: str | None = None):
+    """The same job as `_run_the_job`, with the cells closing off the job's thread."""
+    partition = _CellsInAWorkerThread(cells=cells)
+    monkeypatch.setattr(contractors, "crawl_partition", partition)
+    monkeypatch.setattr(contractors, "coverage", lambda *a, **k: "coverage")
+    monkeypatch.setattr(contractors, "make_fetch",
+                        lambda pace: (_QuietFetcher(), lambda url: ""))
+    job_ref = jobs.create_job(conn, ["muqawil_org"], RunMode.UPDATE,
+                              job_kind=directoryjob.JOB_KIND)
+    if control is not None:
+        conn.execute("UPDATE crawl_job SET control = ? WHERE job_ref = ?",
+                     (control, job_ref))
+        conn.commit()
+    found = directoryjob.run_directory_crawl_job_once(conn, job_ref)
+    return job_ref, found, partition
+
+
+def test_the_crawls_report_survives_arriving_on_a_worker_thread(conn, monkeypatch):
+    """THE DEFECT THAT MADE A POOL IMPOSSIBLE HERE, and it is not a slow path.
+
+    Every write in this runner went through the job's own connection -- the log line, the
+    progress figure, the request count, the control read -- and `crawl_partition` calls
+    `on_cell` in the thread that closed the cell. `sqlite3` refuses a connection from a
+    thread it was not created on, so the FIRST cell to close inside a worker would have
+    raised `ProgrammingError` from inside the job's log writer: not a degraded crawl, a
+    dead one, hours into a real run.
+    """
+    job_ref, found, partition = _run_it_threaded(conn, monkeypatch, cells=4)
+
+    assert found["status"] == JobStatus.COMPLETED.value, found
+    assert partition.reported == 4
+    assert partition.threads and threading.get_ident() not in partition.threads, (
+        "the fake reported every cell on the job's own thread, so this test would pass "
+        "with the defect in place -- it is asserting nothing")
+    logged = " ".join(row["message"] for row in jobs.job_logs(conn, job_ref))
+    assert "listing crawl" in logged, (
+        "the crawl's own report never reached the job log from the worker")
+    assert "LISTING phase" in logged
+
+
+def test_a_pause_asked_for_while_a_worker_holds_the_cell_still_pauses(conn, monkeypatch):
+    """The owner's pause is READ and WRITTEN from the worker too.
+
+    `cell_closed` reads `control`, writes `paused`, and says where it stopped -- all on
+    the connection the callback was handed. A pause that could only be honoured on the
+    job's thread would be a pause the panel offers and the pool ignores.
+    """
+    job_ref, found, _partition = _run_it_threaded(
+        conn, monkeypatch, cells=4, control=JobControl.PAUSE.value)
+
+    assert found["status"] == JobStatus.PAUSED.value, found
+    logged = " ".join(row["message"] for row in jobs.job_logs(conn, job_ref))
+    assert "paused at a cell boundary" in logged
+    assert "skips the pages already stored" in logged, (
+        "the pause did not tell him a resume is cheap, which is the one thing that "
+        "decides whether he presses it")
+
+
+def test_the_job_thread_writes_on_the_jobs_own_connection(conn, monkeypatch):
+    """WHY THE CHOICE IS BY THREAD AND NOT BY WORKER COUNT, measured rather than argued.
+
+    The first version took a fresh connection whenever the pool was wide. Two directory
+    jobs then spent 11.75 s doing 0.7 s of work, and a thread dump two seconds in showed
+    the crawl blocked inside its own `jobs.append_log`: `contractors.crawl` writes
+    `validator_store.save(conn, ...)` on the job connection and commits only after its
+    closing report, so a log line on a SECOND connection to the same file waited out the
+    whole `busy_timeout` against an uncommitted write of its own making. A connection
+    deadlocked against its sibling; the only symptom is a five-second stall and then
+    `database is locked`.
+
+    ASSERTED BY REFUSING TO OPEN ONE. A crawl whose cells all close on the job's thread
+    must complete with `dbmod.connect` unusable -- which is a property of the code and
+    not of a timing, so it cannot pass by luck on a fast machine.
+    """
+    def refuse(*a, **k):
+        raise AssertionError(
+            "the job thread opened a second connection to its own database, which is "
+            "the deadlock this arrangement exists to avoid")
+
+    monkeypatch.setattr(directoryjob.dbmod, "connect", refuse)
+
+    _job_ref, found, partition = _run_the_job(conn, monkeypatch, cells=3)
+
+    assert found["status"] == JobStatus.COMPLETED.value, found
+    assert partition.reported == 3
+
+
+def test_the_pool_width_is_read_from_the_setting_and_clamped(conn):
+    """The number is the owner's, within a ceiling the crawl will actually honour."""
+    from scrapex import settings
+
+    shipped = int(settings.SETTINGS[directoryjob.WORKERS_SETTING].default)
+    assert directoryjob.workers_for(conn) == shipped, (
+        "an untouched warehouse did not get the shipped width")
+
+    settings.save(conn, {directoryjob.WORKERS_SETTING: "2"})
+    conn.commit()
+    assert directoryjob.workers_for(conn) == 2
+
+    settings.save(conn, {directoryjob.WORKERS_SETTING: "600"})
+    conn.commit()
+    assert directoryjob.workers_for(conn) == directoryjob.MAX_WORKERS, (
+        "a mistyped width was accepted, so the crawl promised a concurrency it would "
+        "not deliver -- `job_capacity` clamps for the same reason")
+
+    settings.save(conn, {directoryjob.WORKERS_SETTING: "six"})
+    conn.commit()
+    assert directoryjob.workers_for(conn) == shipped, (
+        "a word where a number belongs took the collection offline instead of falling "
+        "back to the shipped width")
+
+    settings.save(conn, {directoryjob.WORKERS_SETTING: ""})
+    conn.commit()
+    assert directoryjob.workers_for(conn) == shipped, (
+        "clearing the field is how a setting returns to its default, and it did not")
+
+
+def test_the_shipped_width_has_one_home_and_is_more_than_one():
+    """TWO PROPERTIES, AND BOTH WOULD BE LOST BY A TIDY-UP.
+
+    ONE HOME: the number lives in `settings.SETTINGS` and `directoryjob` names only the
+    key. A constant here beside a duplicate in the catalogue is `R-80`'s drift at the
+    smallest possible scale -- and the panel's field would then be a third copy.
+
+    MORE THAN ONE: the whole point is that `R-81` leaves him no way to type `--workers`.
+    A default of 1 restores the capability-with-no-door this change removed, and it would
+    look like a conservative choice rather than a regression.
+    """
+    from scrapex import settings
+
+    source = pathlib.Path(directoryjob.__file__).read_text(encoding="utf-8")
+    assert "DEFAULT_WORKERS" not in source, (
+        "the shipped width is spelled in `directoryjob` as well as in the settings "
+        "catalogue, so the two can disagree and nothing would say which is real")
+
+    shipped = int(settings.SETTINGS[directoryjob.WORKERS_SETTING].default)
+    assert 1 < shipped <= directoryjob.MAX_WORKERS, (
+        f"the shipped width is {shipped}. At 1 the panel's crawl is single-threaded "
+        "again and `--workers` is reachable only from a terminal he does not use "
+        "(`R-81`); above the ceiling the crawl clamps it and the setting lies")

--- a/tests/test_the_button_drives_the_collector_the_source_needs.py
+++ b/tests/test_the_button_drives_the_collector_the_source_needs.py
@@ -1145,3 +1145,28 @@ def test_the_shipped_width_has_one_home_and_is_more_than_one():
         f"the shipped width is {shipped}. At 1 the panel's crawl is single-threaded "
         "again and `--workers` is reachable only from a terminal he does not use "
         "(`R-81`); above the ceiling the crawl clamps it and the setting lies")
+
+
+def test_the_pool_opens_the_jobs_own_warehouse(conn, monkeypatch):
+    """THE CLAIM `a_connection` MAKES, HELD UP.
+
+    `contractors.py` builds its worker factory from `DatabaseRegistry.defaults()`, which
+    is right for a command line and wrong here: a job running against a second warehouse
+    -- a test's, or a restored one -- would have its cells crawled into the default file
+    instead. The runner asks the job's own connection where it is, and this is the only
+    thing that says so. Without it the docstring is the only evidence, and a docstring is
+    not evidence.
+    """
+    opened: list[str] = []
+    real = directoryjob.dbmod.connect
+    monkeypatch.setattr(directoryjob.dbmod, "connect",
+                        lambda path, *a, **k: (opened.append(str(path)), real(path))[1])
+
+    _job_ref, found, _partition = _run_it_threaded(conn, monkeypatch, cells=2)
+
+    assert found["status"] == JobStatus.COMPLETED.value, found
+    assert opened, "no worker connection was opened at all, so this asserts nothing"
+    here = conn.execute("PRAGMA database_list").fetchone()[2]
+    assert set(opened) == {here}, (
+        "a worker opened a database that is not the one the job is running against: "
+        f"{sorted(set(opened))} rather than {here!r}")


### PR DESCRIPTION
## What this is for

His muqawil listing crawl was measured at **7 cells of 56 in 198 minutes — 6.6 requests a minute, 14.6 hours for the listing alone** — because `scrapex/directoryjob.py`, the runner behind the panel's crawl button, never passed the `workers` and `connect` arguments `contractors.crawl` has accepted since 2026-08-22. He has no terminal, so `--workers` was reachable only from a surface he does not use.

He gave the instruction while the crawl was running: «ابدا اوقف الزحفة ونفذ التطوير ثم قم باعادة تشغيلها ومن المترض ان النظام قابل لاعادة الاستكمال». The crawl was paused at a cell boundary at 3/56, with 3,138 pages stored and its job ref intact, so a resume skips them.

Closes #420.

## Three, not six — and it is his choice, against a measurement

Issue #367 measured six concurrent writers holding the warehouse past `busy_timeout = 5000`: starting the engine during a six-worker crawl failed with `database is locked`. **He works from the panel while a crawl runs, so that is not theoretical.** Put to him with the arithmetic of each option; he chose three.

| width | remaining | writers against #367 |
|---|---|---|
| 1 (today) | 14.6 h | 1 |
| **3 (chosen)** | **~4.9 h** | 3 — half the load that produced the lock |
| 6 | 2.4 h | 6 — the load that produced it |

**The request rate does not move at any of these.** `HttpFetcher._throttle` holds its lock across its own sleep, so a pool overlaps the waiting and never asks faster.

## Wiring the pool broke three things, none visible in a reading of the diff

Each is a test, and each test fails when its own fix is reverted — five mutations run, five caught.

**1 · The callbacks run in a worker thread.** `crawl_partition` calls `on_cell` — and so `contractors.say`'s sink and `between_cells` — in the thread that closed the cell, and `sqlite3` refuses a connection from a thread it was not created on. Every write in the runner went through the job connection, so the first cell to close inside a worker would have raised `ProgrammingError` **from inside the job log writer**: not a degraded crawl, a dead one, hours into a real run.

**2 · A second connection deadlocks against its own sibling.** Taking a fresh connection whenever the pool was wide made two directory jobs spend **11.75 s doing 0.7 s of work**. A thread dump two seconds in:

```
--- job-0 ---   contractors.py crawl -> say -> directoryjob note -> jobs.append_log
--- job-1 ---   jobs.py lane                     (waiting, correctly)
```

`contractors.crawl` writes `validator_store.save(conn, ...)` on the job connection and commits only after its closing report, so a log line on a **second** connection to the same file waited out the whole `busy_timeout` against an uncommitted write of its own making. It reads as contention with another process and there is no other process. So the connection is chosen **by thread, not by worker count** — which also makes the sequential path identical *by construction* rather than by argument.

**3 · A pause put `running` back over `paused`.** Cells already in flight when a pause is honoured still close, and their progress write overwrote the status. A job that says it is running with nothing running is the state `test_a_killed_engine_does_not_leave_a_job_claiming_to_run` exists for — and from the panel it is a crawl he cannot resume because it never stopped.

## And one in the pool itself

`ThreadPoolExecutor.__exit__` calls `shutdown(wait=True)` **without `cancel_futures`**, so every cell already submitted runs even after a worker raises — and `on_cell` is where the stop is asked. On the shape of his job, **a pause requested at cell 3 of 56 would have fetched the remaining 53** before the `CrawlStopped` was re-raised. The sequential path never had this, which is why nobody looked: `raise` from `on_cell` leaves the `for` loop.

## The pre-merge panel returned three should-fix, and the second commit is them

Per CLAUDE.md's *green is not mergeable*:

- **The shipped default was parsed outside its own fallback guard.** `workers_for` promises a bad value falls back to the shipped width; `int(spec.default)` sat outside the `try`, so a non-numeric literal in our own catalogue would raise at job start-up and kill every directory crawl. A start-up-order defect does not show up in a green suite.
- **The panel clamped the new field with `MAX_PARALLEL_SOURCES`** — a ceiling for a different axis, equal to 8 only by coincidence. One is politeness across sites, the other writer contention inside one warehouse; a change to either would have silently moved the other.
- **`a_connection` claimed to open the job's warehouse and nothing held it up.** `contractors.py` builds its factory from `DatabaseRegistry.defaults()`, which is right for a command line and wrong here.

## Gates

On `3c188070`, fingerprint identical before and after (`DIRTY=0`, `TREE=7cc80b60`):

```
ruff scrapex/                        clean
mutations                            5 written, 5 caught
pytest -q                            exit 0
SCRAPEX_FULL_MIGRATIONS=1 pytest -q  exit 0
pytest -m extension                  exit 0
```

## Filed rather than fixed here

- **#606** — a crawl re-picked after an engine restart reports `0/56` and never says it is re-proving from disk. This is the panel state he asked about: `Requests 0` beside `3/56` is the resume working, and it reads as a stall.
- **#607** — the colour-literal guard reads a three-digit issue number as a colour. `#367` in a comment failed this branch at `extension/app.js:798`; it has cost four sessions today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
